### PR TITLE
feat(delivery): cache routes and queue offline actions

### DIFF
--- a/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/arrive/route.ts
+++ b/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/arrive/route.ts
@@ -1,10 +1,14 @@
+import { DeliveryRunStopOperationKinds } from '@gredice/storage';
 import { withAuth } from '../../../../../../../../lib/auth/auth';
 import { arriveAtDeliveryStop } from '../../../../../../../../lib/deliveryDashboard';
 import {
     DeliveryMutationRequestError,
-    expectedRouteRevision,
+    parseDeliveryStopMutation,
 } from '../../../../../../../../lib/deliveryMutationRequest';
-import { deliveryRunExecutionErrorDetails } from '../../../../../../../../lib/deliveryRunExecutionError';
+import {
+    deliveryRunExecutionErrorDetails,
+    deliveryRunExecutionErrorStatus,
+} from '../../../../../../../../lib/deliveryRunExecutionError';
 
 const privateNoStore = { 'Cache-Control': 'private, no-store' };
 
@@ -15,16 +19,19 @@ export async function POST(
     return await withAuth(['driver', 'admin'], async ({ userId }) => {
         const { runId, stopId: stopIdValue } = await params;
         const stopId = Number(stopIdValue);
-        if (!Number.isInteger(stopId)) {
+        if (!Number.isInteger(stopId) || stopId <= 0) {
             return Response.json(
                 { error: 'Neispravna stanica.' },
                 { status: 400, headers: privateNoStore },
             );
         }
         const body: unknown = await request.json().catch(() => null);
-        let routeRevision: number;
+        let mutation: ReturnType<typeof parseDeliveryStopMutation>;
         try {
-            routeRevision = expectedRouteRevision(body);
+            mutation = parseDeliveryStopMutation(
+                body,
+                DeliveryRunStopOperationKinds.ARRIVE,
+            );
         } catch (error) {
             return Response.json(
                 {
@@ -42,12 +49,11 @@ export async function POST(
                 driverUserId: userId,
                 runId,
                 stopId,
-                expectedRouteRevision: routeRevision,
+                expectedRouteRevision: mutation.expectedRouteRevision,
+                clientOperationId: mutation.clientOperationId,
+                occurredAt: mutation.occurredAt,
             });
-            return Response.json(
-                { success: true, ...result },
-                { headers: privateNoStore },
-            );
+            return Response.json(result, { headers: privateNoStore });
         } catch (error) {
             const executionError = deliveryRunExecutionErrorDetails(error);
             const logContext = { runId, stopId, userId };
@@ -68,9 +74,12 @@ export async function POST(
                     error:
                         executionError?.message ??
                         'Dolazak trenutačno nije moguće potvrditi.',
-                    code: executionError?.code,
+                    code: executionError?.code ?? 'delivery-mutation-failed',
                 },
-                { status: 409, headers: privateNoStore },
+                {
+                    status: deliveryRunExecutionErrorStatus(error),
+                    headers: privateNoStore,
+                },
             );
         }
     });

--- a/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/deliver/route.ts
+++ b/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/deliver/route.ts
@@ -1,10 +1,14 @@
+import { DeliveryRunStopOperationKinds } from '@gredice/storage';
 import { withAuth } from '../../../../../../../../lib/auth/auth';
 import { deliverDeliveryStop } from '../../../../../../../../lib/deliveryDashboard';
 import {
     DeliveryMutationRequestError,
-    expectedRouteRevision,
+    parseDeliveryStopMutation,
 } from '../../../../../../../../lib/deliveryMutationRequest';
-import { deliveryRunExecutionErrorDetails } from '../../../../../../../../lib/deliveryRunExecutionError';
+import {
+    deliveryRunExecutionErrorDetails,
+    deliveryRunExecutionErrorStatus,
+} from '../../../../../../../../lib/deliveryRunExecutionError';
 
 const privateNoStore = { 'Cache-Control': 'private, no-store' };
 
@@ -15,16 +19,19 @@ export async function POST(
     return await withAuth(['driver', 'admin'], async ({ userId }) => {
         const { runId, stopId: stopIdValue } = await params;
         const stopId = Number(stopIdValue);
-        if (!Number.isInteger(stopId)) {
+        if (!Number.isInteger(stopId) || stopId <= 0) {
             return Response.json(
                 { error: 'Neispravna stanica.' },
                 { status: 400, headers: privateNoStore },
             );
         }
         const body: unknown = await request.json().catch(() => null);
-        let routeRevision: number;
+        let mutation: ReturnType<typeof parseDeliveryStopMutation>;
         try {
-            routeRevision = expectedRouteRevision(body);
+            mutation = parseDeliveryStopMutation(
+                body,
+                DeliveryRunStopOperationKinds.DELIVER,
+            );
         } catch (error) {
             return Response.json(
                 {
@@ -37,26 +44,17 @@ export async function POST(
                 { status: 400, headers: privateNoStore },
             );
         }
-        const notes =
-            typeof body === 'object' &&
-            body !== null &&
-            'notes' in body &&
-            typeof body.notes === 'string' &&
-            body.notes.trim()
-                ? body.notes.trim().slice(0, 1_000)
-                : undefined;
         try {
             const result = await deliverDeliveryStop({
                 driverUserId: userId,
                 runId,
                 stopId,
-                notes,
-                expectedRouteRevision: routeRevision,
+                notes: mutation.notes,
+                expectedRouteRevision: mutation.expectedRouteRevision,
+                clientOperationId: mutation.clientOperationId,
+                occurredAt: mutation.occurredAt,
             });
-            return Response.json(
-                { success: true, ...result },
-                { headers: privateNoStore },
-            );
+            return Response.json(result, { headers: privateNoStore });
         } catch (error) {
             const executionError = deliveryRunExecutionErrorDetails(error);
             const logContext = { runId, stopId, userId };
@@ -77,9 +75,12 @@ export async function POST(
                     error:
                         executionError?.message ??
                         'Dostavu trenutačno nije moguće potvrditi.',
-                    code: executionError?.code,
+                    code: executionError?.code ?? 'delivery-mutation-failed',
                 },
-                { status: 409, headers: privateNoStore },
+                {
+                    status: deliveryRunExecutionErrorStatus(error),
+                    headers: privateNoStore,
+                },
             );
         }
     });

--- a/apps/delivery/app/page.tsx
+++ b/apps/delivery/app/page.tsx
@@ -1,19 +1,39 @@
 import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
-import { Suspense } from 'react';
+import { cache, Suspense } from 'react';
 import { LoginPanel } from '../components/auth/LoginPanel';
 import { DeliveryDashboard } from '../components/DeliveryDashboard';
 import { auth } from '../lib/auth/auth';
 
 export const dynamic = 'force-dynamic';
 
+type DeliveryAuth = () => ReturnType<typeof auth>;
+
+async function AuthenticatedDeliveryDashboard({
+    deliveryAuth,
+}: {
+    deliveryAuth: DeliveryAuth;
+}) {
+    const session = await deliveryAuth();
+    return (
+        <DeliveryDashboard
+            authenticatedUserId={session.userId}
+            authenticatedRole={session.user.role}
+        />
+    );
+}
+
 export default function Home() {
-    const deliveryAuth = auth.bind(null, ['user', 'farmer', 'driver', 'admin']);
+    const deliveryAuth = cache(() =>
+        auth(['user', 'farmer', 'driver', 'admin']),
+    );
 
     return (
         <div className="min-h-[100dvh] w-full bg-background">
             <AuthProtectedSection auth={deliveryAuth}>
                 <Suspense>
-                    <DeliveryDashboard />
+                    <AuthenticatedDeliveryDashboard
+                        deliveryAuth={deliveryAuth}
+                    />
                 </Suspense>
             </AuthProtectedSection>
             <SignedOut auth={deliveryAuth}>

--- a/apps/delivery/app/prijava/UrlAuthForward.tsx
+++ b/apps/delivery/app/prijava/UrlAuthForward.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
+import { publishDeliverySessionResumed } from '../../lib/deliveryOfflineEvents';
 
 export function UrlAuthForward() {
     const router = useRouter();
@@ -34,6 +35,9 @@ export function UrlAuthForward() {
                     router.replace('/');
                     return;
                 }
+                publishDeliverySessionResumed();
+                window.location.replace('/');
+                return;
             }
             router.replace('/');
             router.refresh();

--- a/apps/delivery/components/CustomerDashboard.tsx
+++ b/apps/delivery/components/CustomerDashboard.tsx
@@ -21,6 +21,7 @@ export function CustomerDashboard({
     return (
         <div className="min-h-[100dvh] bg-background">
             <DeliveryAppHeader
+                userId={dashboard.user.id}
                 displayName={dashboard.user.displayName}
                 role={dashboard.user.role}
             />

--- a/apps/delivery/components/DeliveryAppHeader.tsx
+++ b/apps/delivery/components/DeliveryAppHeader.tsx
@@ -4,9 +4,11 @@ import { Typography } from '@gredice/ui/Typography';
 import { LogoutButton } from './auth/LogoutButton';
 
 export function DeliveryAppHeader({
+    userId,
     displayName,
     role,
 }: {
+    userId: string;
     displayName: string;
     role: string;
 }) {
@@ -50,7 +52,7 @@ export function DeliveryAppHeader({
                               ? 'Vozač'
                               : 'Korisnik'}
                     </Chip>
-                    <LogoutButton />
+                    <LogoutButton userId={userId} />
                 </div>
             </div>
         </header>

--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -7,7 +7,7 @@ import { LoaderSpinner, Reset, Warning } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
     type DeliveryServerStateExpectation,
     useDeliveryActionSync,
@@ -25,9 +25,11 @@ import type {
 } from '../lib/deliveryDashboardTypes';
 import { performDeliveryLogout } from '../lib/deliveryLogout';
 import {
+    assertDeliveryOfflineWritesAllowed,
     deliveryLogoutCompletedEvent,
     deliveryLogoutEvent,
     deliveryLogoutFailedEvent,
+    deliveryOfflineWriteBlockReason,
     deliveryRunCompletedEvent,
     subscribeToRemoteDeliveryLogout,
 } from '../lib/deliveryOfflineEvents';
@@ -81,12 +83,17 @@ async function clearOtherStoredDriverRuns(userId: string, activeRunId: string) {
     }
 }
 
-async function readDashboard() {
-    const response = await fetch('/api/dashboard', { cache: 'no-store' });
+async function readDashboard({ signal }: { signal: AbortSignal }) {
+    assertDeliveryOfflineWritesAllowed();
+    const response = await fetch('/api/dashboard', {
+        cache: 'no-store',
+        signal,
+    });
+    const data: unknown = await response.json().catch(() => null);
+    assertDeliveryOfflineWritesAllowed();
     if (!response.ok) {
         throw new Error('Podatke o dostavama trenutačno nije moguće učitati.');
     }
-    const data: unknown = await response.json();
     if (!isDeliveryDashboard(data)) {
         throw new Error(
             'Poslužitelj je vratio neispravne podatke o dostavama.',
@@ -181,12 +188,14 @@ function isSafeActiveRun(value: unknown) {
 }
 
 async function postAction(path: string, body?: object) {
+    assertDeliveryOfflineWritesAllowed();
     const response = await fetch(path, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body ?? {}),
     });
     const data: unknown = await response.json().catch(() => null);
+    assertDeliveryOfflineWritesAllowed();
     if (!response.ok) {
         const message =
             typeof data === 'object' &&
@@ -551,9 +560,15 @@ export function DeliveryDashboard({
         'idle' | 'pending' | 'failed'
     >('idle');
     const [completedRunId, setCompletedRunId] = useState<string | null>(null);
+    const [offlineSessionUserId, setOfflineSessionUserId] = useState<
+        string | null
+    >(null);
+    const offlineSessionReady = offlineSessionUserId === authenticatedUserId;
+    const sessionOperational = offlineSessionReady && logoutState === 'idle';
     const query = useQuery({
         queryKey: ['delivery-dashboard'],
         queryFn: readDashboard,
+        enabled: sessionOperational,
         refetchInterval: 10_000,
     });
     const refetchDashboard = query.refetch;
@@ -564,9 +579,47 @@ export function DeliveryDashboard({
         authenticatedRole === 'driver' || authenticatedRole === 'admin'
             ? authenticatedUserId
             : null;
+    const verifyOfflineSession = useCallback(() => {
+        const blockReason = deliveryOfflineWriteBlockReason();
+        if (blockReason === 'stale-session') {
+            window.location.reload();
+            return false;
+        }
+        if (blockReason === 'logout') {
+            setOfflineSessionUserId(null);
+            setLogoutState((current) =>
+                current === 'pending' ? current : 'failed',
+            );
+            queryClient.removeQueries({ queryKey: ['delivery-dashboard'] });
+            return false;
+        }
+        setOfflineSessionUserId(authenticatedUserId);
+        return true;
+    }, [authenticatedUserId, queryClient]);
+    useEffect(() => {
+        const verify = () => void verifyOfflineSession();
+        const verifyVisibleSession = () => {
+            if (document.visibilityState === 'visible') verify();
+        };
+        verify();
+        window.addEventListener('focus', verify);
+        window.addEventListener('pageshow', verify);
+        document.addEventListener('visibilitychange', verifyVisibleSession);
+        return () => {
+            window.removeEventListener('focus', verify);
+            window.removeEventListener('pageshow', verify);
+            document.removeEventListener(
+                'visibilitychange',
+                verifyVisibleSession,
+            );
+        };
+    }, [verifyOfflineSession]);
+    useEffect(() => {
+        if (query.isError) verifyOfflineSession();
+    }, [query.isError, verifyOfflineSession]);
     const offlineRoute = useOfflineRouteCache(
-        authenticatedDriverUserId,
-        driverDashboard,
+        sessionOperational ? authenticatedDriverUserId : null,
+        sessionOperational ? driverDashboard : null,
     );
     const activeRun =
         dashboardData && 'activeRun' in dashboardData
@@ -574,10 +627,14 @@ export function DeliveryDashboard({
             : null;
     const activeRunId = activeRun?.id ?? null;
     const trackingState = useDriverTracking({
-        runId: activeRunId,
-        serverTracking: activeRun?.tracking ?? null,
+        runId: sessionOperational ? activeRunId : null,
+        serverTracking: sessionOperational
+            ? (activeRun?.tracking ?? null)
+            : null,
         dashboardRefreshedAt:
-            dashboardData?.kind === 'driver' ? dashboardData.refreshedAt : null,
+            sessionOperational && dashboardData?.kind === 'driver'
+                ? dashboardData.refreshedAt
+                : null,
         onDashboardRefresh: async () => {
             await query.refetch();
         },
@@ -636,6 +693,7 @@ export function DeliveryDashboard({
                 window.dispatchEvent(new Event(deliveryLogoutCompletedEvent)),
             onFailed: () =>
                 window.dispatchEvent(new Event(deliveryLogoutFailedEvent)),
+            onResumed: () => window.location.reload(),
         });
         return () => {
             window.removeEventListener(deliveryLogoutEvent, handleLocalLogout);
@@ -976,6 +1034,20 @@ export function DeliveryDashboard({
                         </Button>
                     </CardContent>
                 </Card>
+            </main>
+        );
+    }
+
+    if (!offlineSessionReady) {
+        return (
+            <main className="flex min-h-[100dvh] items-center justify-center bg-background p-4">
+                <div
+                    className="flex items-center gap-3 text-muted-foreground"
+                    role="status"
+                >
+                    <LoaderSpinner className="size-5 animate-spin" />
+                    <Typography>Učitavanje dostava…</Typography>
+                </div>
             </main>
         );
     }

--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -5,34 +5,79 @@ import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
 import { LoaderSpinner, Reset, Warning } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
+import {
+    type DeliveryServerStateExpectation,
+    useDeliveryActionSync,
+} from '../hooks/useDeliveryActionSync';
 import { useDriverTracking } from '../hooks/useDriverTracking';
+import { useOfflineRouteCache } from '../hooks/useOfflineRouteCache';
 import { usePickupManifestSync } from '../hooks/usePickupManifestSync';
+import {
+    clearOtherDeliveryActionQueueScopes,
+    createBrowserDeliveryActionQueuePersistence,
+} from '../lib/deliveryActionQueue';
 import type {
     DeliveryDashboard as DeliveryDashboardData,
     DriverDeliveryDashboard,
 } from '../lib/deliveryDashboardTypes';
+import { performDeliveryLogout } from '../lib/deliveryLogout';
 import {
-    type DeliveryExceptionMutation,
-    type DeliveryExceptionSubmitResult,
-    deliveryExceptionConfirmation,
-} from '../lib/deliveryExceptionPresentation';
+    deliveryLogoutCompletedEvent,
+    deliveryLogoutEvent,
+    deliveryLogoutFailedEvent,
+    deliveryRunCompletedEvent,
+    subscribeToRemoteDeliveryLogout,
+} from '../lib/deliveryOfflineEvents';
 import {
-    clearPickupManifestQueueScope,
+    clearDeliveryUserStoredState,
+    createBrowserDeliveryUserStoredState,
+} from '../lib/deliveryRunStoredState';
+import {
+    clearOtherOfflineRouteCacheScopes,
+    createBrowserOfflineRouteCachePersistence,
+} from '../lib/offlineRouteCache';
+import {
+    clearOtherPickupManifestQueueScopes,
     createWebStoragePickupManifestQueuePersistence,
 } from '../lib/pickupManifestQueue';
 import { CustomerDashboard } from './CustomerDashboard';
 import { DriverDashboard } from './DriverDashboard';
+import { OfflineRouteRecovery } from './OfflineRouteRecovery';
 
-async function clearStoredPickupQueues(userId: string) {
+async function clearStoredDriverState(userId: string, runId?: string) {
     try {
-        await clearPickupManifestQueueScope(
-            createWebStoragePickupManifestQueuePersistence(window.localStorage),
-            { userId },
+        await clearDeliveryUserStoredState(
+            createBrowserDeliveryUserStoredState(),
+            { userId, runId },
         );
+        return true;
     } catch {
         // Storage may be unavailable in private/restricted browser contexts.
+        return false;
+    }
+}
+
+async function clearOtherStoredDriverRuns(userId: string, activeRunId: string) {
+    try {
+        await clearOtherOfflineRouteCacheScopes(
+            createBrowserOfflineRouteCachePersistence(),
+            { userId, activeRunId },
+        );
+        await clearOtherPickupManifestQueueScopes(
+            createWebStoragePickupManifestQueuePersistence(window.localStorage),
+            { userId, activeRunId },
+        );
+        await clearOtherDeliveryActionQueueScopes(
+            createBrowserDeliveryActionQueuePersistence(),
+            { userId, activeRunId },
+        );
+        return true;
+    } catch {
+        // A completion marker is retained when supporting cleanup is uncertain.
+        return false;
     }
 }
 
@@ -194,12 +239,6 @@ const refreshPreparationCodes = new Set([
     'preparation-not-found',
 ]);
 
-type DeliveryExceptionAction = (
-    runId: string,
-    stopId: number,
-    mutation: DeliveryExceptionMutation,
-) => Promise<DeliveryExceptionSubmitResult>;
-
 type DeliveryActionResult =
     | { status: 'saved' }
     | {
@@ -216,11 +255,9 @@ function DriverDashboardWithPickupSync({
     onSelectionChange,
     onStartRun,
     onRetry,
-    onArrive,
-    onDeliver,
-    onException,
-    onPickupError,
-    onPickupAcknowledged,
+    onActionError,
+    onActionQueued,
+    onServerStateChanged,
 }: {
     dashboard: DriverDeliveryDashboard;
     trackingState: ReturnType<typeof useDriverTracking>;
@@ -232,20 +269,11 @@ function DriverDashboardWithPickupSync({
         stopId: number,
         expectedRouteRevision: number,
     ) => void;
-    onArrive: (
-        runId: string,
-        stopId: number,
-        expectedRouteRevision: number,
-    ) => void;
-    onDeliver: (
-        runId: string,
-        stopId: number,
-        expectedRouteRevision: number,
-        notes?: string,
-    ) => void;
-    onException: DeliveryExceptionAction;
-    onPickupError: (error: unknown) => void;
-    onPickupAcknowledged: () => void | Promise<void>;
+    onActionError: (error: unknown) => void;
+    onActionQueued: (message: string) => void;
+    onServerStateChanged: (
+        expectation?: DeliveryServerStateExpectation,
+    ) => Promise<boolean>;
 }) {
     const activeRun = dashboard.activeRun;
     if (!activeRun) {
@@ -257,15 +285,23 @@ function DriverDashboardWithPickupSync({
                 onSelectionChange={onSelectionChange}
                 onStartRun={onStartRun}
                 onRetry={onRetry}
-                onArrive={onArrive}
-                onDeliver={onDeliver}
-                onException={onException}
+                onArrive={() => undefined}
+                onDeliver={() => undefined}
+                onException={async () => ({
+                    status: 'review-required',
+                    message: 'Nema aktivne rute.',
+                })}
                 pickupQueue={null}
+                deliveryQueue={null}
                 onPickupScan={() => undefined}
                 onPickupItemState={() => undefined}
                 onConfirmPickupManifest={() => undefined}
                 onRetryPickupSync={() => undefined}
                 onDiscardPickupSync={() => undefined}
+                onVerificationScan={() => undefined}
+                onRetryDeliverySync={() => undefined}
+                onDiscardDeliverySync={() => undefined}
+                onReconcileDeliverySync={() => undefined}
             />
         );
     }
@@ -279,11 +315,9 @@ function DriverDashboardWithPickupSync({
             onSelectionChange={onSelectionChange}
             onStartRun={onStartRun}
             onRetry={onRetry}
-            onArrive={onArrive}
-            onDeliver={onDeliver}
-            onException={onException}
-            onPickupError={onPickupError}
-            onPickupAcknowledged={onPickupAcknowledged}
+            onActionError={onActionError}
+            onActionQueued={onActionQueued}
+            onServerStateChanged={onServerStateChanged}
         />
     );
 }
@@ -296,11 +330,9 @@ function ActiveDriverDashboardWithPickupSync({
     onSelectionChange,
     onStartRun,
     onRetry,
-    onArrive,
-    onDeliver,
-    onException,
-    onPickupError,
-    onPickupAcknowledged,
+    onActionError,
+    onActionQueued,
+    onServerStateChanged,
 }: {
     dashboard: DriverDeliveryDashboard;
     activeRunId: string;
@@ -313,31 +345,76 @@ function ActiveDriverDashboardWithPickupSync({
         stopId: number,
         expectedRouteRevision: number,
     ) => void;
-    onArrive: (
-        runId: string,
-        stopId: number,
-        expectedRouteRevision: number,
-    ) => void;
-    onDeliver: (
-        runId: string,
-        stopId: number,
-        expectedRouteRevision: number,
-        notes?: string,
-    ) => void;
-    onException: DeliveryExceptionAction;
-    onPickupError: (error: unknown) => void;
-    onPickupAcknowledged: () => void | Promise<void>;
+    onActionError: (error: unknown) => void;
+    onActionQueued: (message: string) => void;
+    onServerStateChanged: (
+        expectation?: DeliveryServerStateExpectation,
+    ) => Promise<boolean>;
 }) {
     const pickupSync = usePickupManifestSync({
         userId: dashboard.user.id,
         runId: activeRunId,
-        onAcknowledged: onPickupAcknowledged,
+        onAcknowledged: async () => {
+            await onServerStateChanged();
+        },
     });
+    const deliverySync = useDeliveryActionSync({
+        userId: dashboard.user.id,
+        runId: activeRunId,
+        refreshServerState: onServerStateChanged,
+    });
+    const serverAcknowledgementCount = deliverySync.snapshot.entries.filter(
+        (entry) =>
+            entry.command.kind !== 'verification-scan' &&
+            entry.acknowledgement?.kind === 'server',
+    ).length;
+    const minimumAcknowledgedRouteRevision = Math.max(
+        -1,
+        ...deliverySync.snapshot.entries.flatMap((entry) =>
+            entry.acknowledgement?.kind === 'server' &&
+            entry.acknowledgement.routeRevision !== undefined
+                ? [entry.acknowledgement.routeRevision]
+                : [],
+        ),
+    );
+    const reconcileDeliveryServerState =
+        deliverySync.reconcilePendingServerState;
+    useEffect(() => {
+        if (
+            dashboard.activeRun?.id !== activeRunId ||
+            dashboard.activeRun.reroutePending ||
+            dashboard.activeRun.routeRevision <
+                minimumAcknowledgedRouteRevision ||
+            serverAcknowledgementCount === 0
+        ) {
+            return;
+        }
+        void reconcileDeliveryServerState().catch(() => undefined);
+    }, [
+        activeRunId,
+        dashboard.activeRun?.id,
+        dashboard.activeRun?.reroutePending,
+        dashboard.activeRun?.routeRevision,
+        minimumAcknowledgedRouteRevision,
+        reconcileDeliveryServerState,
+        serverAcknowledgementCount,
+    ]);
     const report = async (action: Promise<unknown>) => {
         try {
             await action;
         } catch (error) {
-            onPickupError(error);
+            onActionError(error);
+        }
+    };
+    const reportQueued = async (
+        action: Promise<unknown>,
+        confirmation: string,
+    ) => {
+        try {
+            await action;
+            onActionQueued(confirmation);
+        } catch (error) {
+            onActionError(error);
         }
     };
 
@@ -349,10 +426,51 @@ function ActiveDriverDashboardWithPickupSync({
             onSelectionChange={onSelectionChange}
             onStartRun={onStartRun}
             onRetry={onRetry}
-            onArrive={onArrive}
-            onDeliver={onDeliver}
-            onException={onException}
+            onArrive={(runId, stopId, routeRevision) => {
+                if (runId !== activeRunId) return;
+                void reportQueued(
+                    deliverySync.enqueueArrive(stopId, routeRevision),
+                    'Dolazak je spremljen. Oznaka čekanja nestat će nakon potvrde poslužitelja.',
+                );
+            }}
+            onDeliver={(runId, stopId, routeRevision, notes) => {
+                if (runId !== activeRunId) return;
+                void reportQueued(
+                    deliverySync.enqueueDelivery(stopId, routeRevision, notes),
+                    'Dostava je spremljena. Oznaka čekanja nestat će nakon potvrde poslužitelja.',
+                );
+            }}
+            onException={async (runId, stopId, mutation) => {
+                if (runId !== activeRunId) {
+                    return {
+                        status: 'review-required',
+                        message:
+                            'Aktivna ruta se promijenila. Provjeri stanicu.',
+                    };
+                }
+                try {
+                    await deliverySync.enqueueException(stopId, mutation);
+                    onActionQueued(
+                        'Problem je spremljen na uređaju. Ruta se neće nastaviti dok poslužitelj ne potvrdi novi plan.',
+                    );
+                    return { status: 'saved' };
+                } catch (error) {
+                    onActionError(error);
+                    return deliverySync.isBarrierError(error)
+                        ? {
+                              status: 'review-required',
+                              message:
+                                  'Prethodni problem još čeka sinkronizaciju. Pričekaj potvrdu nove rute.',
+                          }
+                        : {
+                              status: 'retryable',
+                              message:
+                                  'Promjenu nije moguće sigurno spremiti na uređaj. Provjeri prostor i pokušaj ponovno.',
+                          };
+                }
+            }}
             pickupQueue={pickupSync.snapshot}
+            deliveryQueue={deliverySync.snapshot}
             onPickupScan={(pickupNodeId, scanValue) =>
                 report(pickupSync.enqueueScan(pickupNodeId, scanValue))
             }
@@ -375,22 +493,81 @@ function ActiveDriverDashboardWithPickupSync({
             onDiscardPickupSync={(operationId) =>
                 report(pickupSync.discardEntry(operationId))
             }
+            onVerificationScan={(stopId, tracePath) =>
+                void report(
+                    deliverySync.enqueueVerificationScan(stopId, tracePath),
+                )
+            }
+            onRetryDeliverySync={(operationId) =>
+                report(deliverySync.retry(operationId))
+            }
+            onDiscardDeliverySync={(operationId) =>
+                report(
+                    deliverySync
+                        .recoverConflict(operationId)
+                        .then((changed) => {
+                            if (!changed) {
+                                throw new Error(
+                                    'Novo stanje rute nije moguće potvrditi. Lokalna radnja ostaje spremljena.',
+                                );
+                            }
+                        }),
+                )
+            }
+            onReconcileDeliverySync={() =>
+                report(
+                    deliverySync
+                        .reconcilePendingServerState()
+                        .then((reconciled) => {
+                            if (!reconciled) {
+                                throw new Error(
+                                    'Novi plan rute još nije moguće potvrditi. Iznimka ostaje blokirajuća.',
+                                );
+                            }
+                        }),
+                )
+            }
         />
     );
 }
 
-export function DeliveryDashboard() {
+export function DeliveryDashboard({
+    authenticatedUserId,
+    authenticatedRole,
+}: {
+    authenticatedUserId: string;
+    authenticatedRole: string;
+}) {
+    const router = useRouter();
+    const queryClient = useQueryClient();
     const [pendingAction, setPendingAction] = useState<string | null>(null);
     const [actionError, setActionError] = useState<string | null>(null);
     const [actionConfirmation, setActionConfirmation] = useState<string | null>(
         null,
     );
+    const [networkOnline, setNetworkOnline] = useState(true);
+    const [offlineFallbackReady, setOfflineFallbackReady] = useState(false);
+    const [logoutState, setLogoutState] = useState<
+        'idle' | 'pending' | 'failed'
+    >('idle');
+    const [completedRunId, setCompletedRunId] = useState<string | null>(null);
     const query = useQuery({
         queryKey: ['delivery-dashboard'],
         queryFn: readDashboard,
         refetchInterval: 10_000,
     });
+    const refetchDashboard = query.refetch;
     const dashboardData = query.data;
+    const driverDashboard: DriverDeliveryDashboard | null =
+        dashboardData?.kind === 'driver' ? dashboardData : null;
+    const authenticatedDriverUserId =
+        authenticatedRole === 'driver' || authenticatedRole === 'admin'
+            ? authenticatedUserId
+            : null;
+    const offlineRoute = useOfflineRouteCache(
+        authenticatedDriverUserId,
+        driverDashboard,
+    );
     const activeRun =
         dashboardData && 'activeRun' in dashboardData
             ? dashboardData.activeRun
@@ -411,20 +588,202 @@ export function DeliveryDashboard() {
             : null;
     const currentDriverUserId =
         query.data?.kind === 'driver' ? query.data.user.id : null;
+    const currentDriverRunId = driverDashboard?.activeRun?.id ?? null;
     const previousDriverUserIdRef = useRef<string | null>(null);
+    const previousDriverRunScopeRef = useRef<{
+        userId: string;
+        runId: string;
+    } | null>(null);
+    const prunedDriverRunScopeRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        const timeout = window.setTimeout(
+            () => setOfflineFallbackReady(true),
+            1_500,
+        );
+        return () => window.clearTimeout(timeout);
+    }, []);
+
+    useEffect(() => {
+        const update = () => setNetworkOnline(navigator.onLine);
+        update();
+        window.addEventListener('online', update);
+        window.addEventListener('offline', update);
+        return () => {
+            window.removeEventListener('online', update);
+            window.removeEventListener('offline', update);
+        };
+    }, []);
+
+    useEffect(() => {
+        const clearVisibleSession = () => {
+            setLogoutState('pending');
+            queryClient.removeQueries({ queryKey: ['delivery-dashboard'] });
+        };
+        const handleLocalLogout = () => clearVisibleSession();
+        const handleLogoutCompleted = () => router.refresh();
+        const handleLogoutFailed = () => setLogoutState('failed');
+        window.addEventListener(deliveryLogoutEvent, handleLocalLogout);
+        window.addEventListener(
+            deliveryLogoutCompletedEvent,
+            handleLogoutCompleted,
+        );
+        window.addEventListener(deliveryLogoutFailedEvent, handleLogoutFailed);
+        const unsubscribeRemote = subscribeToRemoteDeliveryLogout({
+            onLogout: () =>
+                window.dispatchEvent(new Event(deliveryLogoutEvent)),
+            onCompleted: () =>
+                window.dispatchEvent(new Event(deliveryLogoutCompletedEvent)),
+            onFailed: () =>
+                window.dispatchEvent(new Event(deliveryLogoutFailedEvent)),
+        });
+        return () => {
+            window.removeEventListener(deliveryLogoutEvent, handleLocalLogout);
+            window.removeEventListener(
+                deliveryLogoutCompletedEvent,
+                handleLogoutCompleted,
+            );
+            window.removeEventListener(
+                deliveryLogoutFailedEvent,
+                handleLogoutFailed,
+            );
+            unsubscribeRemote();
+        };
+    }, [queryClient, router]);
+
+    useEffect(() => {
+        const handleRunCompleted = (event: Event) => {
+            if (!(event instanceof CustomEvent)) return;
+            const detail: unknown = event.detail;
+            if (
+                typeof detail !== 'object' ||
+                detail === null ||
+                !('userId' in detail) ||
+                detail.userId !== authenticatedUserId ||
+                !('runId' in detail) ||
+                typeof detail.runId !== 'string'
+            ) {
+                return;
+            }
+            setCompletedRunId(detail.runId);
+            queryClient.removeQueries({ queryKey: ['delivery-dashboard'] });
+            void refetchDashboard();
+        };
+        window.addEventListener(deliveryRunCompletedEvent, handleRunCompleted);
+        return () =>
+            window.removeEventListener(
+                deliveryRunCompletedEvent,
+                handleRunCompleted,
+            );
+    }, [authenticatedUserId, queryClient, refetchDashboard]);
+
+    useEffect(() => {
+        if (!completedRunId || query.data?.kind !== 'driver') return;
+        if (query.data.activeRun?.id !== completedRunId) {
+            setCompletedRunId(null);
+        }
+    }, [completedRunId, query.data]);
+
+    useEffect(() => {
+        if (authenticatedDriverUserId) return;
+        void clearStoredDriverState(authenticatedUserId);
+    }, [authenticatedDriverUserId, authenticatedUserId]);
 
     useEffect(() => {
         if (!driverWithoutActiveRun) return;
-        void clearStoredPickupQueues(driverWithoutActiveRun);
+        let active = true;
+        let running = false;
+        let retryTimer: number | null = null;
+        const cleanup = async () => {
+            if (running) return;
+            if (retryTimer) {
+                window.clearTimeout(retryTimer);
+                retryTimer = null;
+            }
+            running = true;
+            const cleared = await clearStoredDriverState(
+                driverWithoutActiveRun,
+            );
+            running = false;
+            if (active && !cleared) {
+                retryTimer = window.setTimeout(() => void cleanup(), 10_000);
+            }
+        };
+        const handleOnline = () => void cleanup();
+        void cleanup();
+        window.addEventListener('online', handleOnline);
+        return () => {
+            active = false;
+            if (retryTimer) window.clearTimeout(retryTimer);
+            window.removeEventListener('online', handleOnline);
+        };
     }, [driverWithoutActiveRun]);
 
     useEffect(() => {
         const previousUserId = previousDriverUserIdRef.current;
         if (previousUserId && previousUserId !== currentDriverUserId) {
-            void clearStoredPickupQueues(previousUserId);
+            void clearStoredDriverState(previousUserId);
         }
         previousDriverUserIdRef.current = currentDriverUserId;
     }, [currentDriverUserId]);
+
+    useEffect(() => {
+        const currentScope =
+            currentDriverRunId && currentDriverUserId
+                ? {
+                      userId: currentDriverUserId,
+                      runId: currentDriverRunId,
+                  }
+                : null;
+        const previousScope = previousDriverRunScopeRef.current;
+        if (
+            previousScope &&
+            (!currentScope ||
+                previousScope.userId !== currentScope.userId ||
+                previousScope.runId !== currentScope.runId)
+        ) {
+            void clearStoredDriverState(
+                previousScope.userId,
+                previousScope.runId,
+            );
+        }
+        previousDriverRunScopeRef.current = currentScope;
+        if (!currentScope) return;
+
+        const scopeKey = `${currentScope.userId}\u0000${currentScope.runId}`;
+        if (prunedDriverRunScopeRef.current === scopeKey) return;
+
+        let active = true;
+        let running = false;
+        let retryTimer: number | null = null;
+        const prune = async () => {
+            if (running || prunedDriverRunScopeRef.current === scopeKey) return;
+            if (retryTimer) {
+                window.clearTimeout(retryTimer);
+                retryTimer = null;
+            }
+            running = true;
+            const cleared = await clearOtherStoredDriverRuns(
+                currentScope.userId,
+                currentScope.runId,
+            );
+            running = false;
+            if (!active) return;
+            if (cleared) {
+                prunedDriverRunScopeRef.current = scopeKey;
+                return;
+            }
+            retryTimer = window.setTimeout(() => void prune(), 10_000);
+        };
+        const handleOnline = () => void prune();
+        void prune();
+        window.addEventListener('online', handleOnline);
+        return () => {
+            active = false;
+            if (retryTimer) window.clearTimeout(retryTimer);
+            window.removeEventListener('online', handleOnline);
+        };
+    }, [currentDriverRunId, currentDriverUserId]);
 
     const perform = async (
         key: string,
@@ -457,6 +816,32 @@ export function DeliveryDashboard() {
         } finally {
             setPendingAction(null);
         }
+    };
+
+    const refreshDriverServerState = async (
+        expectation?: DeliveryServerStateExpectation,
+    ) => {
+        const refreshed = await query.refetch();
+        if (!refreshed.isSuccess || refreshed.data?.kind !== 'driver') {
+            return false;
+        }
+        if (!expectation) {
+            setActionConfirmation(null);
+            return true;
+        }
+        const refreshedRun = refreshed.data.activeRun;
+        if (!refreshedRun || refreshedRun.id !== expectation.runId) {
+            setActionConfirmation(null);
+            return true;
+        }
+        if (expectation.runCompleted) return false;
+        const minimumRouteRevision = expectation.minimumRouteRevision;
+        const reconciled =
+            !refreshedRun.reroutePending &&
+            (minimumRouteRevision === undefined ||
+                refreshedRun.routeRevision >= minimumRouteRevision);
+        if (reconciled) setActionConfirmation(null);
+        return reconciled;
     };
 
     const startRun = async (deliveryRequestIds: string[]) => {
@@ -520,7 +905,85 @@ export function DeliveryDashboard() {
         }
     };
 
-    if (query.isPending) {
+    if (logoutState !== 'idle') {
+        return (
+            <main className="flex min-h-[100dvh] items-center justify-center bg-background p-4">
+                {logoutState === 'pending' ? (
+                    <div
+                        className="flex items-center gap-3 text-muted-foreground"
+                        role="status"
+                    >
+                        <LoaderSpinner className="size-5 animate-spin" />
+                        <Typography>Odjava…</Typography>
+                    </div>
+                ) : (
+                    <Card
+                        aria-atomic="true"
+                        className="w-full max-w-md"
+                        role="alert"
+                    >
+                        <CardContent
+                            noHeader
+                            className="space-y-4 p-6 text-center"
+                        >
+                            <Warning className="mx-auto size-9 text-warning" />
+                            <Typography level="h3" semiBold>
+                                Odjava nije potvrđena
+                            </Typography>
+                            <Typography className="text-muted-foreground">
+                                Sigurno brisanje lokalnih podataka ili odjava na
+                                poslužitelju nije potvrđena. Provjeri vezu i
+                                pokušaj ponovno.
+                            </Typography>
+                            <Button
+                                onClick={() =>
+                                    void performDeliveryLogout(
+                                        authenticatedUserId,
+                                    )
+                                }
+                            >
+                                Pokušaj odjavu ponovno
+                            </Button>
+                        </CardContent>
+                    </Card>
+                )}
+            </main>
+        );
+    }
+
+    if (completedRunId) {
+        return (
+            <main className="flex min-h-[100dvh] items-center justify-center bg-background p-4">
+                <Card
+                    aria-atomic="true"
+                    aria-live="polite"
+                    className="w-full max-w-md"
+                    role="status"
+                >
+                    <CardContent noHeader className="space-y-4 p-6 text-center">
+                        <Typography level="h3" semiBold>
+                            Ruta je završena
+                        </Typography>
+                        <Typography className="text-muted-foreground">
+                            Završena ruta uklonjena je s ovog uređaja. Novo
+                            stanje prikazat će se nakon potvrde poslužitelja.
+                        </Typography>
+                        <Button
+                            startDecorator={<Reset className="size-4" />}
+                            onClick={() => void refetchDashboard()}
+                        >
+                            Učitaj novo stanje
+                        </Button>
+                    </CardContent>
+                </Card>
+            </main>
+        );
+    }
+
+    if (
+        query.isPending &&
+        !(offlineRoute && (!networkOnline || offlineFallbackReady))
+    ) {
         return (
             <main className="flex min-h-[100dvh] items-center justify-center bg-background p-4">
                 <div className="flex items-center gap-3 text-muted-foreground">
@@ -531,7 +994,17 @@ export function DeliveryDashboard() {
         );
     }
 
-    if (query.isError || !query.data) {
+    if (!query.data) {
+        if (offlineRoute && authenticatedDriverUserId) {
+            return (
+                <OfflineRouteRecovery
+                    snapshot={offlineRoute}
+                    authenticatedUserId={authenticatedDriverUserId}
+                    authenticatedRole={authenticatedRole}
+                    refreshServerState={refreshDriverServerState}
+                />
+            );
+        }
         return (
             <main className="flex min-h-[100dvh] items-center justify-center bg-background p-4">
                 <Card className="w-full max-w-md">
@@ -560,8 +1033,19 @@ export function DeliveryDashboard() {
     const dashboard = query.data;
     return (
         <>
+            {!networkOnline || query.isError ? (
+                <div className="fixed inset-x-4 bottom-[max(1rem,env(safe-area-inset-bottom))] z-50 mx-auto max-w-xl">
+                    <Alert
+                        color="warning"
+                        startDecorator={<Warning className="size-5" />}
+                    >
+                        Veza nije dostupna. Trenutačni i sljedeći korak ostaju
+                        na uređaju, a spremljene radnje čekaju potvrdu.
+                    </Alert>
+                </div>
+            ) : null}
             {actionError ? (
-                <div className="fixed inset-x-4 top-4 z-50 mx-auto max-w-xl">
+                <div className="fixed inset-x-4 top-[max(1rem,env(safe-area-inset-top))] z-50 mx-auto max-w-xl">
                     <Alert
                         color="danger"
                         startDecorator={<Warning className="size-5" />}
@@ -571,13 +1055,13 @@ export function DeliveryDashboard() {
                 </div>
             ) : null}
             {actionConfirmation ? (
-                <div className="fixed inset-x-4 top-4 z-50 mx-auto max-w-xl">
+                <div className="fixed inset-x-4 top-[max(1rem,env(safe-area-inset-top))] z-50 mx-auto max-w-xl">
                     <Alert
-                        color="success"
+                        color="info"
                         endDecorator={
                             <Button
                                 aria-label="Zatvori potvrdu"
-                                color="success"
+                                color="info"
                                 size="sm"
                                 variant="plain"
                                 onClick={() => setActionConfirmation(null)}
@@ -609,63 +1093,26 @@ export function DeliveryDashboard() {
                             { expectedRouteRevision },
                         )
                     }
-                    onArrive={(runId, stopId, expectedRouteRevision) =>
-                        void perform(
-                            `${stopId}:arrive`,
-                            `/api/driver/runs/${runId}/stops/${stopId}/arrive`,
-                            {
-                                expectedRouteRevision,
-                            },
-                        )
-                    }
-                    onDeliver={(runId, stopId, expectedRouteRevision, notes) =>
-                        void perform(
-                            `${stopId}:deliver`,
-                            `/api/driver/runs/${runId}/stops/${stopId}/deliver`,
-                            {
-                                notes,
-                                expectedRouteRevision,
-                            },
-                        )
-                    }
-                    onException={async (runId, stopId, mutation) => {
-                        const result = await perform(
-                            `${stopId}:exception`,
-                            `/api/driver/runs/${runId}/exceptions`,
-                            mutation,
-                            deliveryExceptionConfirmation(mutation),
-                        );
-                        if (result.status === 'saved') {
-                            return result;
-                        }
-                        if (result.statusCode === 409) {
-                            return {
-                                status: 'review-required',
-                                message:
-                                    'Ruta ili odabrani urodi promijenili su se. Provjeri osvježeni odabir i ponovno potvrdi spremanje.',
-                            };
-                        }
-                        return {
-                            status: 'retryable',
-                            message:
-                                'Promjena možda nije potvrđena. Provjeri vezu i pokušaj ponovno bez izmjene odabira.',
-                        };
-                    }}
-                    onPickupError={(error) => {
+                    onActionError={(error) => {
                         setActionConfirmation(null);
                         setActionError(
                             error instanceof Error
                                 ? error.message
-                                : 'Promjenu preuzimanja nije moguće spremiti.',
+                                : 'Promjenu dostave nije moguće spremiti.',
                         );
                     }}
-                    onPickupAcknowledged={async () => {
-                        await query.refetch();
+                    onActionQueued={(message) => {
+                        setActionError(null);
+                        setActionConfirmation(message);
                     }}
+                    onServerStateChanged={refreshDriverServerState}
                 />
             ) : (
                 <CustomerDashboard dashboard={dashboard} />
             )}
+            {!networkOnline || query.isError ? (
+                <div aria-hidden="true" className="h-32 sm:h-24" />
+            ) : null}
         </>
     );
 }

--- a/apps/delivery/components/DeliveryExceptionSheet.tsx
+++ b/apps/delivery/components/DeliveryExceptionSheet.tsx
@@ -33,7 +33,7 @@ export function DeliveryExceptionSheet({
 }: {
     runId: string;
     routeRevision: number;
-    stop: DeliveryStopSummary;
+    stop: Pick<DeliveryStopSummary, 'id' | 'requestId' | 'deliveries'>;
     disabled: boolean;
     onSubmit: (
         mutation: DeliveryExceptionMutation,

--- a/apps/delivery/components/DeliveryHarvestVerification.tsx
+++ b/apps/delivery/components/DeliveryHarvestVerification.tsx
@@ -15,13 +15,23 @@ import { HarvestTraceScanner } from './HarvestTraceScanner';
 export function DeliveryHarvestVerification({
     deliveries,
     disabled,
+    verifiedTracePaths: persistedVerifiedTracePaths = [],
+    onVerifiedTrace,
 }: {
     deliveries: DeliveryStopDeliverySummary[];
     disabled: boolean;
+    verifiedTracePaths?: string[];
+    onVerifiedTrace?: (tracePath: string) => void;
 }) {
     const headingId = useId();
-    const [verifiedTracePaths, setVerifiedTracePaths] = useState<string[]>([]);
+    const [localVerifiedTracePaths, setLocalVerifiedTracePaths] = useState<
+        string[]
+    >([]);
     const verifiedTracePathsRef = useRef<string[]>([]);
+    const verifiedTracePaths = Array.from(
+        new Set([...persistedVerifiedTracePaths, ...localVerifiedTracePaths]),
+    );
+    verifiedTracePathsRef.current = verifiedTracePaths;
     const tracePathByRequestId = new Map(
         deliveries.flatMap((delivery) => {
             const tracePath = delivery.harvest.tracePath
@@ -50,7 +60,8 @@ export function DeliveryHarvestVerification({
 
         if (result.status === 'verified') {
             verifiedTracePathsRef.current = result.nextVerifiedTracePaths;
-            setVerifiedTracePaths(result.nextVerifiedTracePaths);
+            setLocalVerifiedTracePaths(result.nextVerifiedTracePaths);
+            onVerifiedTrace?.(result.tracePath);
         }
 
         return result;

--- a/apps/delivery/components/DeliveryStopCard.tsx
+++ b/apps/delivery/components/DeliveryStopCard.tsx
@@ -20,6 +20,8 @@ import {
 } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
 import { useState } from 'react';
+import { deliveryActionPermanentFailureMessage } from '../lib/deliveryActionPresentation';
+import type { DeliveryActionQueueEntry } from '../lib/deliveryActionQueue';
 import type { DeliveryStopSummary } from '../lib/deliveryDashboardTypes';
 import {
     actionableDeliveryExceptionItems,
@@ -66,6 +68,12 @@ export function DeliveryStopCard({
     onArrive,
     onDeliver,
     onException,
+    syncEntry,
+    verifiedTracePaths = [],
+    onVerificationScan,
+    onRetrySync,
+    onDiscardSync,
+    routeSyncBlocked = false,
 }: {
     stop: DeliveryStopSummary;
     mode: 'driver' | 'customer';
@@ -77,8 +85,15 @@ export function DeliveryStopCard({
     onException?: (
         mutation: DeliveryExceptionMutation,
     ) => Promise<DeliveryExceptionSubmitResult>;
+    syncEntry?: DeliveryActionQueueEntry | null;
+    verifiedTracePaths?: string[];
+    onVerificationScan?: (tracePath: string) => void;
+    onRetrySync?: (operationId: string) => void | Promise<void>;
+    onDiscardSync?: (operationId: string) => void | Promise<void>;
+    routeSyncBlocked?: boolean;
 }) {
     const [notes, setNotes] = useState('');
+    const [syncRecoveryPending, setSyncRecoveryPending] = useState(false);
     const navigationUrl = `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(stop.address)}`;
     const driverMode = mode === 'driver';
     const delivered = stop.statusLabel === 'Dostavljeno';
@@ -86,6 +101,20 @@ export function DeliveryStopCard({
         stop.actionState ??
         (delivered ? 'completed' : stop.isCurrent ? 'current' : 'upcoming');
     const customerActionAvailable = driverActionState === 'current';
+    const acknowledgedOfflineArrival =
+        syncEntry?.command.kind === 'arrive' && syncEntry.state === 'synced';
+    const pendingOfflineArrival =
+        syncEntry?.command.kind === 'arrive' &&
+        syncEntry.state !== 'conflicted' &&
+        syncEntry.state !== 'synced';
+    const pendingOfflineCompletion =
+        syncEntry?.command.kind === 'deliver' ||
+        syncEntry?.command.kind === 'exception';
+    const offlineConflict = syncEntry?.state === 'conflicted';
+    const routeCommandBlocking =
+        routeSyncBlocked ||
+        Boolean(pendingOfflineCompletion) ||
+        Boolean(offlineConflict);
     const actionableDeliveries = actionableDeliveryExceptionItems(
         stop.deliveries,
     );
@@ -103,6 +132,17 @@ export function DeliveryStopCard({
             stop.slotEndAt &&
             new Date(stop.estimatedArrivalAt) > new Date(stop.slotEndAt),
     );
+    const runSyncRecovery = async (
+        action: (() => void | Promise<void>) | undefined,
+    ) => {
+        if (!action || syncRecoveryPending) return;
+        setSyncRecoveryPending(true);
+        try {
+            await action();
+        } finally {
+            setSyncRecoveryPending(false);
+        }
+    };
     const completedDriverException =
         driverMode &&
         driverActionState === 'completed' &&
@@ -256,7 +296,11 @@ export function DeliveryStopCard({
                         <Button
                             color="warning"
                             loading={pendingAction === 'retry'}
-                            disabled={Boolean(pendingAction)}
+                            disabled={
+                                Boolean(pendingAction) ||
+                                routeSyncBlocked ||
+                                stop.reroutePending
+                            }
                             onClick={onRetry}
                             startDecorator={<Reset className="size-4" />}
                         >
@@ -271,15 +315,29 @@ export function DeliveryStopCard({
                 stop.stopState !== 'deferred' ? (
                     <div className="space-y-3 rounded-lg border border-primary/20 bg-primary/5 p-3">
                         <div className="flex flex-wrap gap-2">
-                            <Button
-                                href={navigationUrl}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                variant="outlined"
-                                startDecorator={<Navigate className="size-4" />}
-                            >
-                                Navigacija
-                            </Button>
+                            {routeSyncBlocked || stop.reroutePending ? (
+                                <Button
+                                    disabled
+                                    variant="outlined"
+                                    startDecorator={
+                                        <Navigate className="size-4" />
+                                    }
+                                >
+                                    Navigacija čeka novi plan
+                                </Button>
+                            ) : (
+                                <Button
+                                    href={navigationUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    variant="outlined"
+                                    startDecorator={
+                                        <Navigate className="size-4" />
+                                    }
+                                >
+                                    Navigacija
+                                </Button>
+                            )}
                             {stop.runId &&
                             routeRevision !== undefined &&
                             onException ? (
@@ -287,15 +345,24 @@ export function DeliveryStopCard({
                                     runId={stop.runId}
                                     routeRevision={routeRevision}
                                     stop={stop}
-                                    disabled={Boolean(pendingAction)}
+                                    disabled={
+                                        Boolean(pendingAction) ||
+                                        routeCommandBlocking
+                                    }
                                     onSubmit={onException}
                                 />
                             ) : null}
                         </div>
-                        {stop.stopState === 'arrived' ? (
+                        {stop.stopState === 'arrived' ||
+                        pendingOfflineArrival ? (
                             <DeliveryHarvestVerification
                                 deliveries={actionableDeliveries}
-                                disabled={Boolean(pendingAction)}
+                                disabled={
+                                    Boolean(pendingAction) ||
+                                    routeCommandBlocking
+                                }
+                                verifiedTracePaths={verifiedTracePaths}
+                                onVerifiedTrace={onVerificationScan}
                             />
                         ) : (
                             <Typography
@@ -321,38 +388,124 @@ export function DeliveryStopCard({
                             rows={2}
                             maxLength={1_000}
                             placeholder="Npr. predano članu kućanstva"
-                            className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+                            disabled={routeCommandBlocking}
+                            className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
                         />
+                        {syncEntry ? (
+                            <Alert
+                                color={
+                                    syncEntry.state === 'conflicted'
+                                        ? 'danger'
+                                        : syncEntry.state === 'failed'
+                                          ? 'warning'
+                                          : 'info'
+                                }
+                                startDecorator={<Warning className="size-5" />}
+                            >
+                                <div className="space-y-2">
+                                    <Typography level="body3" semiBold>
+                                        {syncEntry.state === 'conflicted'
+                                            ? deliveryActionPermanentFailureMessage(
+                                                  syncEntry.errorCode,
+                                                  'stop',
+                                              )
+                                            : syncEntry.state === 'failed'
+                                              ? 'Radnja je spremljena na uređaju, ali slanje nije uspjelo.'
+                                              : syncEntry.state ===
+                                                  'reconciling'
+                                                ? 'Problem je potvrđen, ali novi plan rute još nije učitan.'
+                                                : syncEntry.state === 'sending'
+                                                  ? 'Radnja se šalje i još nije potvrđena.'
+                                                  : syncEntry.state === 'synced'
+                                                    ? 'Poslužitelj je potvrdio radnju. Čeka se osvježeno stanje rute.'
+                                                    : 'Radnja je spremljena na uređaju i čeka potvrdu.'}
+                                    </Typography>
+                                    {syncEntry.state === 'failed' ? (
+                                        <Button
+                                            size="sm"
+                                            color="warning"
+                                            loading={syncRecoveryPending}
+                                            disabled={syncRecoveryPending}
+                                            onClick={() =>
+                                                void runSyncRecovery(() =>
+                                                    onRetrySync?.(
+                                                        syncEntry.command
+                                                            .operationId,
+                                                    ),
+                                                )
+                                            }
+                                        >
+                                            Pokušaj ponovno
+                                        </Button>
+                                    ) : null}
+                                    {syncEntry.state === 'conflicted' ? (
+                                        <Button
+                                            size="sm"
+                                            color="danger"
+                                            variant="outlined"
+                                            loading={syncRecoveryPending}
+                                            disabled={syncRecoveryPending}
+                                            onClick={() =>
+                                                void runSyncRecovery(() =>
+                                                    onDiscardSync?.(
+                                                        syncEntry.command
+                                                            .operationId,
+                                                    ),
+                                                )
+                                            }
+                                        >
+                                            Učitaj stanje poslužitelja
+                                        </Button>
+                                    ) : null}
+                                </div>
+                            </Alert>
+                        ) : null}
                         <div className="grid gap-2 sm:grid-cols-2">
                             <Button
                                 variant="outlined"
                                 loading={pendingAction === 'arrive'}
                                 disabled={
                                     Boolean(pendingAction) ||
-                                    stop.stopState === 'arrived'
+                                    stop.stopState === 'arrived' ||
+                                    acknowledgedOfflineArrival ||
+                                    pendingOfflineArrival ||
+                                    routeCommandBlocking
                                 }
                                 onClick={onArrive}
                                 startDecorator={
                                     <MyLocation className="size-4" />
                                 }
                             >
-                                {stop.stopState === 'arrived'
-                                    ? 'Dolazak potvrđen'
-                                    : 'Stigao sam'}
+                                {pendingOfflineArrival
+                                    ? 'Dolazak čeka potvrdu'
+                                    : stop.stopState === 'arrived' ||
+                                        acknowledgedOfflineArrival
+                                      ? 'Dolazak potvrđen'
+                                      : 'Stigao sam'}
                             </Button>
                             <Button
                                 color="success"
                                 loading={pendingAction === 'deliver'}
                                 disabled={
                                     Boolean(pendingAction) ||
-                                    actionableDeliveries.length === 0
+                                    routeCommandBlocking ||
+                                    actionableDeliveries.length === 0 ||
+                                    !(
+                                        stop.stopState === 'arrived' ||
+                                        pendingOfflineArrival ||
+                                        acknowledgedOfflineArrival
+                                    )
                                 }
                                 onClick={() => onDeliver?.(notes || undefined)}
                                 startDecorator={<Approved className="size-4" />}
                             >
-                                {groupedDelivery
-                                    ? `Dostavi ${actionableDeliveries.length} ${actionableDeliveries.length === 1 ? 'urod' : 'uroda'} · dalje`
-                                    : 'Dostavljeno · dalje'}
+                                {syncEntry?.command.kind === 'deliver'
+                                    ? syncEntry.state === 'synced'
+                                        ? 'Dostava potvrđena'
+                                        : 'Dostava čeka potvrdu'
+                                    : groupedDelivery
+                                      ? `Dostavi ${actionableDeliveries.length} ${actionableDeliveries.length === 1 ? 'urod' : 'uroda'} · dalje`
+                                      : 'Dostavljeno · dalje'}
                             </Button>
                         </div>
                     </div>

--- a/apps/delivery/components/DriverDashboard.tsx
+++ b/apps/delivery/components/DriverDashboard.tsx
@@ -16,6 +16,19 @@ import {
 import { Typography } from '@gredice/ui/Typography';
 import { useRef, useState } from 'react';
 import type { DriverTrackingState } from '../hooks/useDriverTracking';
+import {
+    deliveryActionAcknowledgementBlocksRoute,
+    deliveryActionCompletionMessage,
+    deliveryActionLocallyCompletesStop,
+    deliveryActionPermanentFailureMessage,
+    deliveryRouteStepsWithLocalActions,
+} from '../lib/deliveryActionPresentation';
+import {
+    type DeliveryActionQueueEntry,
+    type DeliveryActionQueueSnapshot,
+    deliveryActionPendingEntryForStop,
+    deliveryActionVerifiedTracePaths,
+} from '../lib/deliveryActionQueue';
 import type {
     ActiveDeliveryRunSummary,
     DeliveryPickupStepSummary,
@@ -236,6 +249,151 @@ function pickupQueueErrorMessage(code: string | undefined, retryable: boolean) {
     }
 }
 
+export function DeliveryActionSyncStatus({
+    snapshot,
+    onRetry,
+    onRecoverConflict,
+    onReconcile,
+}: {
+    snapshot: DeliveryActionQueueSnapshot | null;
+    onRetry: (operationId: string) => void | Promise<void>;
+    onRecoverConflict: (operationId: string) => void | Promise<void>;
+    onReconcile: () => void | Promise<void>;
+}) {
+    const [pendingRecovery, setPendingRecovery] = useState<string | null>(null);
+    const pendingEntries =
+        snapshot?.entries.filter(
+            (entry) =>
+                entry.command.kind !== 'verification-scan' &&
+                entry.state !== 'synced',
+        ) ?? [];
+    const blockingEntry: DeliveryActionQueueEntry | undefined =
+        pendingEntries.find(
+            (entry) =>
+                entry.state === 'conflicted' ||
+                entry.state === 'failed' ||
+                entry.state === 'reconciling',
+        ) ?? snapshot?.entries.find(deliveryActionAcknowledgementBlocksRoute);
+    const completedRunAcknowledged =
+        blockingEntry?.acknowledgement?.kind === 'server' &&
+        blockingEntry.acknowledgement.runCompleted === true;
+    const waitingForReroute =
+        blockingEntry?.acknowledgement?.kind === 'server' &&
+        blockingEntry.acknowledgement.reroutePending === true;
+    const runRecovery = async (
+        key: string,
+        action: () => void | Promise<void>,
+    ) => {
+        if (pendingRecovery) return;
+        setPendingRecovery(key);
+        try {
+            await action();
+        } finally {
+            setPendingRecovery(null);
+        }
+    };
+    return (
+        <div className="space-y-3">
+            {snapshot?.durability === 'memory' ? (
+                <Alert
+                    color="warning"
+                    startDecorator={<Warning className="size-5" />}
+                >
+                    Preglednik ne dopušta trajnu pohranu. Radnje su spremljene
+                    samo dok je ova stranica otvorena; nemoj je zatvarati prije
+                    sinkronizacije.
+                </Alert>
+            ) : null}
+            {snapshot?.coordination === 'best-effort' ? (
+                <Alert color="info">
+                    Sinkronizacija između više kartica nije podržana u ovom
+                    pregledniku. Drži dostavnu rutu otvorenu u samo jednoj
+                    kartici.
+                </Alert>
+            ) : null}
+            {blockingEntry ? (
+                <Alert
+                    color={
+                        blockingEntry.state === 'conflicted'
+                            ? 'danger'
+                            : 'warning'
+                    }
+                    startDecorator={<Warning className="size-5" />}
+                >
+                    <div className="space-y-2">
+                        <Typography level="body3" semiBold>
+                            {completedRunAcknowledged
+                                ? 'Poslužitelj je potvrdio završetak rute. Sigurno lokalno čišćenje još nije dovršeno.'
+                                : waitingForReroute
+                                  ? 'Poslužitelj je potvrdio radnju, ali novi plan rute još nije sigurno učitan.'
+                                  : blockingEntry.state === 'conflicted'
+                                    ? deliveryActionPermanentFailureMessage(
+                                          blockingEntry.errorCode,
+                                          'global',
+                                      )
+                                    : blockingEntry.state === 'reconciling'
+                                      ? 'Problem je potvrđen, ali novi plan rute još nije sigurno učitan.'
+                                      : 'Prva nesinkronizirana radnja nije poslana. Kasnije radnje čekaju iza nje.'}
+                        </Typography>
+                        {blockingEntry.state === 'failed' ? (
+                            <Button
+                                size="sm"
+                                color="warning"
+                                loading={pendingRecovery === 'retry'}
+                                disabled={pendingRecovery !== null}
+                                onClick={() =>
+                                    void runRecovery('retry', () =>
+                                        onRetry(
+                                            blockingEntry.command.operationId,
+                                        ),
+                                    )
+                                }
+                            >
+                                Pokušaj ponovno
+                            </Button>
+                        ) : null}
+                        {blockingEntry.state === 'conflicted' ? (
+                            <Button
+                                size="sm"
+                                color="danger"
+                                variant="outlined"
+                                loading={pendingRecovery === 'conflict'}
+                                disabled={pendingRecovery !== null}
+                                onClick={() =>
+                                    void runRecovery('conflict', () =>
+                                        onRecoverConflict(
+                                            blockingEntry.command.operationId,
+                                        ),
+                                    )
+                                }
+                            >
+                                Učitaj stanje poslužitelja
+                            </Button>
+                        ) : null}
+                        {blockingEntry.state === 'reconciling' ||
+                        completedRunAcknowledged ||
+                        waitingForReroute ? (
+                            <Button
+                                size="sm"
+                                color="warning"
+                                loading={pendingRecovery === 'reconcile'}
+                                disabled={pendingRecovery !== null}
+                                onClick={() =>
+                                    void runRecovery('reconcile', onReconcile)
+                                }
+                            >
+                                {completedRunAcknowledged
+                                    ? 'Pokušaj ponovno očistiti podatke'
+                                    : 'Osvježi novi plan'}
+                            </Button>
+                        ) : null}
+                    </div>
+                </Alert>
+            ) : null}
+        </div>
+    );
+}
+
 export function DriverDashboard({
     dashboard,
     trackingState,
@@ -247,11 +405,16 @@ export function DriverDashboard({
     onDeliver,
     onException,
     pickupQueue,
+    deliveryQueue,
     onPickupScan,
     onPickupItemState,
     onConfirmPickupManifest,
     onRetryPickupSync,
     onDiscardPickupSync,
+    onVerificationScan,
+    onRetryDeliverySync,
+    onDiscardDeliverySync,
+    onReconcileDeliverySync,
 }: {
     dashboard: DriverDeliveryDashboard;
     trackingState: DriverTrackingState;
@@ -280,6 +443,7 @@ export function DriverDashboard({
         mutation: DeliveryExceptionMutation,
     ) => Promise<DeliveryExceptionSubmitResult>;
     pickupQueue: PickupManifestQueueSnapshot | null;
+    deliveryQueue: DeliveryActionQueueSnapshot | null;
     onPickupScan: (pickupNodeId: string, scanValue: string) => void;
     onPickupItemState: (
         pickupNodeId: string,
@@ -293,8 +457,25 @@ export function DriverDashboard({
     ) => void | Promise<void>;
     onRetryPickupSync: (operationId: string) => void | Promise<void>;
     onDiscardPickupSync: (operationId: string) => void | Promise<void>;
+    onVerificationScan: (stopId: number, tracePath: string) => void;
+    onRetryDeliverySync: (operationId: string) => void | Promise<void>;
+    onDiscardDeliverySync: (operationId: string) => void | Promise<void>;
+    onReconcileDeliverySync: () => void | Promise<void>;
 }) {
     const run = dashboard.activeRun;
+    const displayedRouteSteps = run
+        ? deliveryRouteStepsWithLocalActions(run.routeSteps, deliveryQueue)
+        : [];
+    const deliveryRouteSyncBlocked = Boolean(
+        run?.reroutePending ||
+            deliveryQueue?.entries.some(
+                (entry) =>
+                    entry.state === 'failed' ||
+                    entry.state === 'conflicted' ||
+                    entry.state === 'reconciling' ||
+                    deliveryActionAcknowledgementBlocksRoute(entry),
+            ),
+    );
     const [selectedRequestIds, setSelectedRequestIdsState] = useState<string[]>(
         [],
     );
@@ -508,6 +689,7 @@ export function DriverDashboard({
     return (
         <div className="min-h-[100dvh] bg-background">
             <DeliveryAppHeader
+                userId={dashboard.user.id}
                 displayName={dashboard.user.displayName}
                 role={dashboard.user.role}
             />
@@ -526,6 +708,12 @@ export function DriverDashboard({
                 {run ? (
                     <>
                         <DriverTrackingStatus tracking={trackingState} />
+                        <DeliveryActionSyncStatus
+                            snapshot={deliveryQueue}
+                            onRetry={onRetryDeliverySync}
+                            onRecoverConflict={onDiscardDeliverySync}
+                            onReconcile={onReconcileDeliverySync}
+                        />
                         {run.reroutePending ? (
                             <Alert
                                 color="warning"
@@ -649,7 +837,7 @@ export function DriverDashboard({
                                 </Typography>
                             </div>
                             <div className="grid gap-3 lg:grid-cols-2">
-                                {run.routeSteps.map((step) => {
+                                {displayedRouteSteps.map((step, stepIndex) => {
                                     if (step.kind === 'pickup') {
                                         const pickup = queuedPickup(
                                             step.pickup,
@@ -815,6 +1003,12 @@ export function DriverDashboard({
                                         isCurrent:
                                             step.actionState === 'current',
                                     };
+                                    const deliverySyncEntry = stop.id
+                                        ? deliveryActionPendingEntryForStop(
+                                              deliveryQueue,
+                                              stop.id,
+                                          )
+                                        : undefined;
                                     return (
                                         <div
                                             key={`delivery:${stop.id ?? stop.requestId}`}
@@ -828,6 +1022,26 @@ export function DriverDashboard({
                                                         ? ` · pokušaj ${step.retryAttempt}`
                                                         : null}
                                                 </Chip>
+                                            ) : null}
+                                            {deliveryActionLocallyCompletesStop(
+                                                deliverySyncEntry,
+                                            ) ? (
+                                                <Alert color="info">
+                                                    {deliveryActionCompletionMessage(
+                                                        deliverySyncEntry,
+                                                        !deliveryRouteSyncBlocked &&
+                                                            displayedRouteSteps.some(
+                                                                (
+                                                                    candidate,
+                                                                    candidateIndex,
+                                                                ) =>
+                                                                    candidateIndex >
+                                                                        stepIndex &&
+                                                                    candidate.actionState ===
+                                                                        'current',
+                                                            ),
+                                                    )}
+                                                </Alert>
                                             ) : null}
                                             <DeliveryStopCard
                                                 stop={stop}
@@ -891,6 +1105,33 @@ export function DriverDashboard({
                                                               message:
                                                                   'Stanica više nije dostupna. Osvježi rutu i provjeri odabir.',
                                                           })
+                                                }
+                                                syncEntry={deliverySyncEntry}
+                                                verifiedTracePaths={
+                                                    stop.id
+                                                        ? deliveryActionVerifiedTracePaths(
+                                                              deliveryQueue,
+                                                              stop.id,
+                                                          )
+                                                        : []
+                                                }
+                                                onVerificationScan={(
+                                                    tracePath,
+                                                ) =>
+                                                    stop.id &&
+                                                    onVerificationScan(
+                                                        stop.id,
+                                                        tracePath,
+                                                    )
+                                                }
+                                                onRetrySync={
+                                                    onRetryDeliverySync
+                                                }
+                                                onDiscardSync={
+                                                    onDiscardDeliverySync
+                                                }
+                                                routeSyncBlocked={
+                                                    deliveryRouteSyncBlocked
                                                 }
                                             />
                                         </div>

--- a/apps/delivery/components/OfflineRoutePanel.tsx
+++ b/apps/delivery/components/OfflineRoutePanel.tsx
@@ -1,0 +1,553 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Card, CardContent } from '@gredice/ui/Card';
+import { Chip } from '@gredice/ui/Chip';
+import {
+    Approved,
+    MapPin,
+    Mobile,
+    MyLocation,
+    Navigate,
+    Warning,
+} from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import { useState } from 'react';
+import {
+    deliveryActionAcknowledgementBlocksRoute,
+    deliveryActionCompletionMessage,
+    deliveryActionLocallyCompletesStop,
+} from '../lib/deliveryActionPresentation';
+import {
+    type DeliveryActionQueueSnapshot,
+    deliveryActionPendingEntryForStop,
+    deliveryActionVerifiedTracePaths,
+} from '../lib/deliveryActionQueue';
+import type { DeliveryStopDeliverySummary } from '../lib/deliveryDashboardTypes';
+import type {
+    DeliveryExceptionMutation,
+    DeliveryExceptionSubmitResult,
+} from '../lib/deliveryExceptionPresentation';
+import {
+    formatDeliveryDateTime,
+    formatDeliveryTime,
+    formatDistance,
+    formatTravelDuration,
+} from '../lib/deliveryFormatting';
+import type {
+    OfflineRouteDeliveryStep,
+    OfflineRouteSnapshot,
+    OfflineRouteStep,
+} from '../lib/offlineRouteCache';
+import { DeliveryExceptionSheet } from './DeliveryExceptionSheet';
+import { DeliveryHarvestVerification } from './DeliveryHarvestVerification';
+import { DeliveryActionSyncStatus } from './DriverDashboard';
+
+function stepTitle(step: OfflineRouteStep) {
+    return step.kind === 'pickup' ? step.name : step.statusLabel;
+}
+
+function stepItems(step: OfflineRouteStep) {
+    return step.kind === 'pickup'
+        ? step.items.map((item) => ({
+              id: item.requestId,
+              label: [
+                  item.harvest.plantName,
+                  item.harvest.raisedBedName,
+                  item.harvest.fieldName,
+              ]
+                  .filter(Boolean)
+                  .join(' · '),
+              detail:
+                  item.state === 'not-ready'
+                      ? 'Nije spremno'
+                      : item.state === 'scanned'
+                        ? 'Skenirano'
+                        : item.state === 'missing-label'
+                          ? 'Bez etikete'
+                          : 'Spremno',
+              note: null,
+          }))
+        : step.items.map((item) => ({
+              id: item.requestId,
+              label: [
+                  item.harvest.plantName,
+                  item.harvest.raisedBedName,
+                  item.harvest.fieldName,
+              ]
+                  .filter(Boolean)
+                  .join(' · '),
+              detail: item.contactName,
+              note: item.requestNotes,
+          }));
+}
+
+function hasDeliveryStopId(
+    step: OfflineRouteStep,
+): step is OfflineRouteDeliveryStep & { id: number } {
+    return step.kind === 'delivery' && step.id !== null;
+}
+
+function OfflineDeliveryContacts({ step }: { step: OfflineRouteDeliveryStep }) {
+    const phoneNumbers = Array.from(
+        new Set(step.items.flatMap((item) => (item.phone ? [item.phone] : []))),
+    );
+    if (phoneNumbers.length === 0) return null;
+    return (
+        <div className="flex flex-wrap gap-2">
+            {phoneNumbers.map((phone) => (
+                <Button
+                    key={phone}
+                    href={`tel:${phone}`}
+                    size="sm"
+                    variant="plain"
+                    startDecorator={<Mobile className="size-4" />}
+                >
+                    {phone}
+                </Button>
+            ))}
+        </div>
+    );
+}
+
+function offlineDeliveryItems(
+    step: OfflineRouteDeliveryStep,
+): DeliveryStopDeliverySummary[] {
+    return step.items.map((item) => ({
+        stopId: item.stopId,
+        stopState: item.stopState,
+        requestId: item.requestId,
+        requestState: item.requestState,
+        contactName: item.contactName,
+        phone: item.phone,
+        addressLabel: null,
+        requestNotes: item.requestNotes,
+        deliveryNotes: null,
+        harvest: {
+            ...item.harvest,
+            operationName: null,
+        },
+        exception: null,
+    }));
+}
+
+export function OfflineRoutePanel({
+    snapshot,
+    actionQueue,
+    onArrive,
+    onDeliver,
+    onException,
+    onVerificationScan,
+    onRetry,
+    onRecoverConflict,
+    onReconcile,
+}: {
+    snapshot: OfflineRouteSnapshot;
+    actionQueue: DeliveryActionQueueSnapshot;
+    onArrive: (stopId: number, routeRevision: number) => void | Promise<void>;
+    onDeliver: (
+        stopId: number,
+        routeRevision: number,
+        notes?: string,
+    ) => void | Promise<void>;
+    onException: (
+        stopId: number,
+        mutation: DeliveryExceptionMutation,
+    ) => Promise<DeliveryExceptionSubmitResult>;
+    onVerificationScan: (stopId: number, tracePath: string) => void;
+    onRetry: (operationId: string) => void | Promise<void>;
+    onRecoverConflict: (operationId: string) => void | Promise<void>;
+    onReconcile: () => void | Promise<void>;
+}) {
+    const [notesByStop, setNotesByStop] = useState<Record<number, string>>({});
+    const firstStep = snapshot.steps[0];
+    const firstStopId = firstStep?.kind === 'delivery' ? firstStep.id : null;
+    const firstEntry = firstStopId
+        ? deliveryActionPendingEntryForStop(actionQueue, firstStopId)
+        : undefined;
+    const activeStepIndex =
+        deliveryActionLocallyCompletesStop(firstEntry) &&
+        snapshot.steps.length > 1
+            ? 1
+            : 0;
+    const currentStep = snapshot.steps[activeStepIndex];
+    const currentStopId =
+        currentStep?.kind === 'delivery' ? currentStep.id : null;
+    const currentEntry = currentStopId
+        ? deliveryActionPendingEntryForStop(actionQueue, currentStopId)
+        : undefined;
+    const acknowledgedArrival =
+        currentEntry?.command.kind === 'arrive' &&
+        currentEntry.state === 'synced';
+    const pendingArrival =
+        currentEntry?.command.kind === 'arrive' &&
+        currentEntry.state !== 'conflicted' &&
+        currentEntry.state !== 'synced';
+    const deliveryQueued = deliveryActionLocallyCompletesStop(currentEntry);
+    const deliveryAcknowledged =
+        deliveryQueued && currentEntry?.state === 'synced';
+    const routeBarrier =
+        snapshot.source.reroutePending ||
+        actionQueue.entries.some(
+            (entry) =>
+                (entry.command.kind === 'exception' &&
+                    entry.state !== 'synced') ||
+                entry.state === 'failed' ||
+                deliveryActionAcknowledgementBlocksRoute(entry),
+        ) ||
+        actionQueue.conflictedCount > 0;
+    const currentActionBlocked =
+        routeBarrier ||
+        Boolean(
+            currentEntry &&
+                (currentEntry.command.kind !== 'arrive' ||
+                    currentEntry.state === 'conflicted'),
+        );
+    const currentDeliveryReady = Boolean(
+        currentStep?.kind === 'delivery' &&
+            (currentStep.stopState === 'arrived' ||
+                pendingArrival ||
+                acknowledgedArrival),
+    );
+    return (
+        <main className="min-h-[100dvh] bg-muted/30 p-4">
+            <div className="mx-auto max-w-3xl space-y-4">
+                <Alert
+                    color="warning"
+                    startDecorator={<Warning className="size-5" />}
+                >
+                    Prikazana je zaštićena izvanmrežna kopija trenutačnog i
+                    sljedećeg koraka. Radnje na čekanju nisu potvrđene na
+                    poslužitelju. Kopija je osvježena{' '}
+                    {formatDeliveryDateTime(snapshot.source.refreshedAt)}.
+                </Alert>
+                <DeliveryActionSyncStatus
+                    snapshot={actionQueue}
+                    onRetry={onRetry}
+                    onRecoverConflict={onRecoverConflict}
+                    onReconcile={onReconcile}
+                />
+                {routeBarrier ? (
+                    <Alert color="warning">
+                        Ruta čeka novi plan. Nemoj nastaviti na sljedeću stanicu
+                        dok se veza ne vrati i plan ne osvježi.
+                    </Alert>
+                ) : null}
+                {snapshot.steps.map((step, index) => {
+                    const actionState =
+                        index < activeStepIndex
+                            ? 'completed'
+                            : index === activeStepIndex
+                              ? 'current'
+                              : step.actionState;
+                    return (
+                        <Card
+                            key={`${step.kind}:${step.id}`}
+                            className={
+                                index === activeStepIndex
+                                    ? 'border-primary'
+                                    : undefined
+                            }
+                        >
+                            <CardContent noHeader className="space-y-3 p-4">
+                                <div className="flex items-start justify-between gap-3">
+                                    <div>
+                                        <Typography
+                                            level="body3"
+                                            className="text-muted-foreground"
+                                        >
+                                            {index < activeStepIndex
+                                                ? firstEntry?.state === 'synced'
+                                                    ? 'Dovršeni korak čeka osvježenu rutu'
+                                                    : 'Dovršeni korak čeka potvrdu'
+                                                : index === activeStepIndex
+                                                  ? 'Trenutačni korak'
+                                                  : 'Sljedeći korak'}
+                                        </Typography>
+                                        <Typography level="h3" semiBold>
+                                            {stepTitle(step)}
+                                        </Typography>
+                                    </div>
+                                    <Chip
+                                        color={
+                                            index === activeStepIndex
+                                                ? 'info'
+                                                : 'neutral'
+                                        }
+                                        size="sm"
+                                    >
+                                        #{step.itinerarySequence}
+                                    </Chip>
+                                </div>
+                                {index < activeStepIndex ? (
+                                    <Alert color="info">
+                                        {deliveryActionCompletionMessage(
+                                            firstEntry,
+                                            !routeBarrier,
+                                        )}
+                                    </Alert>
+                                ) : null}
+                                <Typography className="flex items-start gap-2">
+                                    <MapPin className="mt-0.5 size-4 shrink-0" />
+                                    {step.address}
+                                </Typography>
+                                <div className="flex flex-wrap gap-2">
+                                    {step.kind === 'delivery' &&
+                                    step.slotStartAt ? (
+                                        <Chip size="sm">
+                                            Termin{' '}
+                                            {formatDeliveryTime(
+                                                step.slotStartAt,
+                                            )}
+                                            {step.slotEndAt
+                                                ? `–${formatDeliveryTime(step.slotEndAt)}`
+                                                : ''}
+                                        </Chip>
+                                    ) : null}
+                                    {step.estimatedArrivalAt ? (
+                                        <Chip size="sm">
+                                            Dolazak{' '}
+                                            {formatDeliveryDateTime(
+                                                step.estimatedArrivalAt,
+                                            )}
+                                        </Chip>
+                                    ) : null}
+                                    {step.estimatedTravelSeconds !== null ? (
+                                        <Chip size="sm">
+                                            {formatTravelDuration(
+                                                step.estimatedTravelSeconds,
+                                            )}
+                                        </Chip>
+                                    ) : null}
+                                    {step.estimatedDistanceMeters !== null ? (
+                                        <Chip size="sm">
+                                            {formatDistance(
+                                                step.estimatedDistanceMeters,
+                                            )}
+                                        </Chip>
+                                    ) : null}
+                                </div>
+                                {routeBarrier ||
+                                actionState === 'locked' ||
+                                index < activeStepIndex ||
+                                (index > activeStepIndex && !deliveryQueued) ? (
+                                    <Button
+                                        disabled
+                                        variant="outlined"
+                                        aria-label={
+                                            index < activeStepIndex
+                                                ? 'Navigacija do prethodne stanice nije potrebna'
+                                                : index === activeStepIndex
+                                                  ? 'Navigacija do trenutačne stanice čeka novi plan'
+                                                  : routeBarrier
+                                                    ? 'Navigacija do sljedeće stanice čeka novi plan'
+                                                    : 'Navigacija do sljedeće stanice čeka završetak trenutačne dostave'
+                                        }
+                                        startDecorator={
+                                            <Navigate className="size-4" />
+                                        }
+                                    >
+                                        {index < activeStepIndex
+                                            ? 'Prethodna dostava je spremljena'
+                                            : index === activeStepIndex
+                                              ? 'Navigacija čeka novi plan'
+                                              : routeBarrier
+                                                ? 'Navigacija čeka novi plan'
+                                                : 'Navigacija čeka završetak dostave'}
+                                    </Button>
+                                ) : (
+                                    <Button
+                                        href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(step.address)}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        variant="outlined"
+                                        aria-label={
+                                            index === activeStepIndex
+                                                ? 'Navigacija do trenutačne stanice'
+                                                : 'Navigacija do sljedeće stanice'
+                                        }
+                                        startDecorator={
+                                            <Navigate className="size-4" />
+                                        }
+                                    >
+                                        Navigacija
+                                    </Button>
+                                )}
+                                {step.kind === 'delivery' ? (
+                                    <OfflineDeliveryContacts step={step} />
+                                ) : null}
+                                {hasDeliveryStopId(step) &&
+                                index === activeStepIndex ? (
+                                    <div className="space-y-3 rounded-lg border border-primary/20 bg-primary/5 p-3">
+                                        <label
+                                            className="block text-sm font-medium"
+                                            htmlFor={`offline-notes-${step.id}`}
+                                        >
+                                            Napomena o dostavi
+                                        </label>
+                                        <textarea
+                                            id={`offline-notes-${step.id}`}
+                                            value={notesByStop[step.id] ?? ''}
+                                            onChange={(event) =>
+                                                setNotesByStop((current) => ({
+                                                    ...current,
+                                                    [step.id]:
+                                                        event.target.value,
+                                                }))
+                                            }
+                                            disabled={currentActionBlocked}
+                                            rows={2}
+                                            maxLength={1_000}
+                                            className="w-full rounded-md border bg-background px-3 py-2 text-sm disabled:opacity-60"
+                                        />
+                                        <DeliveryExceptionSheet
+                                            runId={snapshot.scope.runId}
+                                            routeRevision={
+                                                snapshot.source.routeRevision
+                                            }
+                                            stop={{
+                                                id: step.id,
+                                                requestId:
+                                                    step.items[0]?.requestId ??
+                                                    `stop-${step.id}`,
+                                                deliveries:
+                                                    offlineDeliveryItems(step),
+                                            }}
+                                            disabled={currentActionBlocked}
+                                            onSubmit={(mutation) =>
+                                                onException(step.id, mutation)
+                                            }
+                                        />
+                                        {currentDeliveryReady ? (
+                                            <DeliveryHarvestVerification
+                                                deliveries={offlineDeliveryItems(
+                                                    step,
+                                                )}
+                                                disabled={
+                                                    routeBarrier ||
+                                                    deliveryQueued
+                                                }
+                                                verifiedTracePaths={deliveryActionVerifiedTracePaths(
+                                                    actionQueue,
+                                                    step.id,
+                                                )}
+                                                onVerifiedTrace={(tracePath) =>
+                                                    onVerificationScan(
+                                                        step.id,
+                                                        tracePath,
+                                                    )
+                                                }
+                                            />
+                                        ) : null}
+                                        <div className="grid gap-2 sm:grid-cols-2">
+                                            <Button
+                                                variant="outlined"
+                                                disabled={
+                                                    step.stopState ===
+                                                        'arrived' ||
+                                                    acknowledgedArrival ||
+                                                    pendingArrival ||
+                                                    currentActionBlocked
+                                                }
+                                                onClick={() =>
+                                                    onArrive(
+                                                        step.id,
+                                                        snapshot.source
+                                                            .routeRevision,
+                                                    )
+                                                }
+                                                startDecorator={
+                                                    <MyLocation className="size-4" />
+                                                }
+                                            >
+                                                {pendingArrival
+                                                    ? 'Dolazak čeka potvrdu'
+                                                    : step.stopState ===
+                                                            'arrived' ||
+                                                        acknowledgedArrival
+                                                      ? 'Dolazak potvrđen'
+                                                      : 'Stigao sam'}
+                                            </Button>
+                                            <Button
+                                                color="success"
+                                                disabled={
+                                                    currentActionBlocked ||
+                                                    deliveryQueued ||
+                                                    !(
+                                                        step.stopState ===
+                                                            'arrived' ||
+                                                        pendingArrival ||
+                                                        acknowledgedArrival
+                                                    )
+                                                }
+                                                onClick={() =>
+                                                    onDeliver(
+                                                        step.id,
+                                                        snapshot.source
+                                                            .routeRevision,
+                                                        notesByStop[step.id] ||
+                                                            undefined,
+                                                    )
+                                                }
+                                                startDecorator={
+                                                    <Approved className="size-4" />
+                                                }
+                                            >
+                                                {deliveryAcknowledged
+                                                    ? 'Dostava potvrđena'
+                                                    : deliveryQueued
+                                                      ? 'Dostava čeka potvrdu'
+                                                      : 'Dostavljeno · dalje'}
+                                            </Button>
+                                        </div>
+                                    </div>
+                                ) : null}
+                                {step.kind === 'delivery' &&
+                                actionState === 'locked' &&
+                                step.lockedReason ? (
+                                    <Typography
+                                        level="body3"
+                                        className="text-muted-foreground"
+                                    >
+                                        {step.lockedReason}
+                                    </Typography>
+                                ) : null}
+                                <ul className="space-y-2">
+                                    {stepItems(step).map((item) => (
+                                        <li
+                                            key={item.id}
+                                            className="rounded-md bg-muted px-3 py-2"
+                                        >
+                                            <Typography level="body3" semiBold>
+                                                {item.label}
+                                            </Typography>
+                                            <Typography
+                                                level="body3"
+                                                className="text-muted-foreground"
+                                            >
+                                                {item.detail}
+                                            </Typography>
+                                            {item.note ? (
+                                                <Typography
+                                                    level="body3"
+                                                    className="mt-1 text-amber-800 dark:text-amber-200"
+                                                >
+                                                    Napomena: {item.note}
+                                                </Typography>
+                                            ) : null}
+                                        </li>
+                                    ))}
+                                </ul>
+                            </CardContent>
+                        </Card>
+                    );
+                })}
+                <Typography level="body3" className="text-muted-foreground">
+                    Kopija vrijedi najviše 24 sata i briše se završetkom rute,
+                    promjenom korisnika ili odjavom.
+                </Typography>
+            </div>
+        </main>
+    );
+}

--- a/apps/delivery/components/OfflineRouteRecovery.tsx
+++ b/apps/delivery/components/OfflineRouteRecovery.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Warning } from '@gredice/ui/icons';
+import { useState } from 'react';
+import {
+    type DeliveryServerStateExpectation,
+    useDeliveryActionSync,
+} from '../hooks/useDeliveryActionSync';
+import type { OfflineRouteSnapshot } from '../lib/offlineRouteCache';
+import { DeliveryAppHeader } from './DeliveryAppHeader';
+import { OfflineRoutePanel } from './OfflineRoutePanel';
+
+export function OfflineRouteRecovery({
+    snapshot,
+    authenticatedUserId,
+    authenticatedRole,
+    refreshServerState,
+}: {
+    snapshot: OfflineRouteSnapshot;
+    authenticatedUserId: string;
+    authenticatedRole: string;
+    refreshServerState: (
+        expectation?: DeliveryServerStateExpectation,
+    ) => Promise<boolean>;
+}) {
+    const [error, setError] = useState<string | null>(null);
+    const sync = useDeliveryActionSync({
+        userId: authenticatedUserId,
+        runId: snapshot.scope.runId,
+        refreshServerState,
+    });
+
+    const report = async (action: Promise<unknown>) => {
+        setError(null);
+        try {
+            await action;
+        } catch (cause) {
+            setError(
+                cause instanceof Error
+                    ? cause.message
+                    : 'Lokalnu radnju nije moguće sigurno spremiti.',
+            );
+        }
+    };
+    const requireRecovery = async (
+        action: Promise<boolean>,
+        message: string,
+    ) => {
+        const recovered = await action;
+        if (!recovered) throw new Error(message);
+    };
+
+    return (
+        <>
+            {error ? (
+                <div className="fixed inset-x-4 top-[max(1rem,env(safe-area-inset-top))] z-50 mx-auto max-w-xl">
+                    <Alert
+                        color="danger"
+                        startDecorator={<Warning className="size-5" />}
+                    >
+                        {error}
+                    </Alert>
+                </div>
+            ) : null}
+            <DeliveryAppHeader
+                userId={authenticatedUserId}
+                displayName="Izvanmrežna ruta"
+                role={authenticatedRole}
+            />
+            <OfflineRoutePanel
+                snapshot={snapshot}
+                actionQueue={sync.snapshot}
+                onArrive={(stopId, routeRevision) =>
+                    report(sync.enqueueArrive(stopId, routeRevision))
+                }
+                onDeliver={(stopId, routeRevision, notes) =>
+                    report(sync.enqueueDelivery(stopId, routeRevision, notes))
+                }
+                onException={async (stopId, mutation) => {
+                    try {
+                        await sync.enqueueException(stopId, mutation);
+                        setError(null);
+                        return { status: 'saved' };
+                    } catch (cause) {
+                        const message = sync.isBarrierError(cause)
+                            ? 'Prethodna promjena još čeka usklađivanje. Učitaj trenutačno stanje prije novog problema.'
+                            : 'Problem nije moguće sigurno spremiti na uređaj. Provjeri prostor i pokušaj ponovno.';
+                        setError(message);
+                        return sync.isBarrierError(cause)
+                            ? { status: 'review-required', message }
+                            : { status: 'retryable', message };
+                    }
+                }}
+                onVerificationScan={(stopId, tracePath) =>
+                    void report(sync.enqueueVerificationScan(stopId, tracePath))
+                }
+                onRetry={(operationId) => report(sync.retry(operationId))}
+                onRecoverConflict={(operationId) =>
+                    report(
+                        requireRecovery(
+                            sync.recoverConflict(operationId),
+                            'Novo stanje rute nije moguće potvrditi. Lokalna radnja ostaje spremljena.',
+                        ),
+                    )
+                }
+                onReconcile={() =>
+                    report(
+                        requireRecovery(
+                            sync.reconcilePendingServerState(),
+                            'Novi plan rute još nije moguće potvrditi. Iznimka ostaje blokirajuća.',
+                        ),
+                    )
+                }
+            />
+        </>
+    );
+}

--- a/apps/delivery/components/auth/LoginPanel.tsx
+++ b/apps/delivery/components/auth/LoginPanel.tsx
@@ -13,11 +13,10 @@ import { Input } from '@gredice/ui/Input';
 import { Mail, Truck, Warning } from '@gredice/ui/icons';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import { useRouter } from 'next/navigation';
 import { useActionState, useCallback, useState } from 'react';
+import { publishDeliverySessionResumed } from '../../lib/deliveryOfflineEvents';
 
 export function LoginPanel() {
-    const router = useRouter();
     const [emailExpanded, setEmailExpanded] = useState(false);
     const fetchLastLogin = useCallback(
         () => fetch('/api/gredice/api/auth/last-login'),
@@ -42,7 +41,8 @@ export function LoginPanel() {
             if (!response.ok) {
                 return 'Prijava nije uspjela. Provjeri podatke i pokušaj ponovno.';
             }
-            router.refresh();
+            publishDeliverySessionResumed();
+            window.location.replace('/');
             return null;
         } catch {
             return 'Aplikacija za prijavu trenutačno nije dostupna.';

--- a/apps/delivery/components/auth/LogoutButton.tsx
+++ b/apps/delivery/components/auth/LogoutButton.tsx
@@ -2,11 +2,10 @@
 
 import { IconButton } from '@gredice/ui/IconButton';
 import { LogOut } from '@gredice/ui/icons';
-import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { performDeliveryLogout } from '../../lib/deliveryLogout';
 
-export function LogoutButton() {
-    const router = useRouter();
+export function LogoutButton({ userId }: { userId: string }) {
     const [loading, setLoading] = useState(false);
     return (
         <IconButton
@@ -16,8 +15,7 @@ export function LogoutButton() {
             onClick={async () => {
                 setLoading(true);
                 try {
-                    await fetch('/api/logout', { method: 'POST' });
-                    router.refresh();
+                    await performDeliveryLogout(userId);
                 } finally {
                     setLoading(false);
                 }

--- a/apps/delivery/hooks/useDeliveryActionSync.ts
+++ b/apps/delivery/hooks/useDeliveryActionSync.ts
@@ -1,0 +1,484 @@
+'use client';
+
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useSyncExternalStore,
+} from 'react';
+import {
+    type DeliveryRunCompletion,
+    deliveryActionChangedMessage,
+    deliveryRunCompletedMessage,
+    deliveryRunCompletionFromSnapshot,
+    parseDeliveryActionChannelMessage,
+} from '../lib/deliveryActionCompletion';
+import {
+    createBrowserDeliveryActionQueuePersistence,
+    createDeliveryArriveCommand,
+    createDeliveryCompleteCommand,
+    createDeliveryExceptionCommand,
+    createDeliveryVerificationScanCommand,
+    DeliveryActionBarrierError,
+    type DeliveryActionCommand,
+    DeliveryActionQueue,
+    type DeliveryActionQueueCoordinator,
+    type DeliveryActionQueueSnapshot,
+    type DeliveryServerActionCommand,
+    deliveryActionQueueCanReplay,
+} from '../lib/deliveryActionQueue';
+import { sendDeliveryAction } from '../lib/deliveryActionTransport';
+import type { DeliveryExceptionMutation } from '../lib/deliveryExceptionPresentation';
+import { deliveryRunCompletedEvent } from '../lib/deliveryOfflineEvents';
+import {
+    clearDeliveryRunSupportingStores,
+    createBrowserDeliveryRunSupportingStores,
+    finalizeDeliveryRunStoredState,
+} from '../lib/deliveryRunStoredState';
+
+export type DeliveryServerStateExpectation = {
+    runId: string;
+    minimumRouteRevision?: number;
+    runCompleted?: boolean;
+};
+
+function operationId(prefix: string) {
+    return (
+        globalThis.crypto?.randomUUID?.() ??
+        `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+}
+
+function deliveryActionLockCoordinator(
+    lockManager: LockManager,
+    purpose: 'state' | 'replay',
+): DeliveryActionQueueCoordinator {
+    return {
+        runExclusive: async (scope, task) =>
+            await lockManager.request(
+                `gredice:delivery:actions:${purpose}:${encodeURIComponent(scope.userId)}:${encodeURIComponent(scope.runId)}`,
+                { mode: 'exclusive' },
+                async () => await task(),
+            ),
+    };
+}
+
+function deliveryActionQueueResources() {
+    const persistence = createBrowserDeliveryActionQueuePersistence();
+    if (typeof navigator === 'undefined' || !navigator.locks) {
+        return { persistence };
+    }
+    return {
+        persistence,
+        coordinator: deliveryActionLockCoordinator(navigator.locks, 'state'),
+        replayCoordinator: deliveryActionLockCoordinator(
+            navigator.locks,
+            'replay',
+        ),
+    };
+}
+
+export function useDeliveryActionSync({
+    userId,
+    runId,
+    refreshServerState,
+}: {
+    userId: string;
+    runId: string;
+    refreshServerState: (
+        expectation?: DeliveryServerStateExpectation,
+    ) => Promise<boolean>;
+}) {
+    const refreshServerStateRef = useRef(refreshServerState);
+    useEffect(() => {
+        refreshServerStateRef.current = refreshServerState;
+    }, [refreshServerState]);
+
+    const channel = useMemo(() => {
+        if (
+            typeof window === 'undefined' ||
+            typeof BroadcastChannel === 'undefined'
+        ) {
+            return null;
+        }
+        try {
+            return new BroadcastChannel(
+                `gredice:delivery:actions:${encodeURIComponent(userId)}:${encodeURIComponent(runId)}`,
+            );
+        } catch {
+            return null;
+        }
+    }, [runId, userId]);
+    const resources = useMemo(deliveryActionQueueResources, []);
+    const queue = useMemo(
+        () =>
+            new DeliveryActionQueue({
+                scope: { userId, runId },
+                persistence: resources.persistence,
+                transport: sendDeliveryAction,
+                coordinator: resources.coordinator,
+                replayCoordinator: resources.replayCoordinator,
+                crossTabNotifications: channel !== null,
+            }),
+        [channel, resources, runId, userId],
+    );
+    const announceChange = useCallback(() => {
+        try {
+            channel?.postMessage(deliveryActionChangedMessage());
+        } catch {
+            // The local queue remains usable when cross-tab signaling closes.
+        }
+    }, [channel]);
+    const snapshot = useSyncExternalStore(
+        queue.subscribe,
+        queue.getSnapshot,
+        queue.getServerSnapshot,
+    );
+
+    const finishCompletedRun = useCallback(
+        async (completion: DeliveryRunCompletion, broadcast: boolean) => {
+            if (completion.userId !== userId || completion.runId !== runId) {
+                return false;
+            }
+            try {
+                await finalizeDeliveryRunStoredState({
+                    clearSupportingStores: async () =>
+                        await clearDeliveryRunSupportingStores(
+                            createBrowserDeliveryRunSupportingStores(),
+                            { userId, runId },
+                        ),
+                    clearActionMarker: async () => await queue.clear(),
+                    publishCompleted: () => {
+                        if (broadcast) {
+                            try {
+                                channel?.postMessage(
+                                    deliveryRunCompletedMessage(completion),
+                                );
+                            } catch {
+                                // The local completion event remains authoritative.
+                            }
+                        }
+                        window.dispatchEvent(
+                            new CustomEvent(deliveryRunCompletedEvent, {
+                                detail: { userId, runId },
+                            }),
+                        );
+                    },
+                });
+            } catch {
+                throw new Error(
+                    'Završenu rutu nije moguće sigurno ukloniti s uređaja. Provjeri prostor i pokušaj ponovno.',
+                );
+            }
+            return true;
+        },
+        [channel, queue, runId, userId],
+    );
+
+    const replay =
+        useCallback(async (): Promise<DeliveryActionQueueSnapshot> => {
+            const before = queue.getSnapshot();
+            const next = await queue.replay();
+            announceChange();
+            const changedServerEntries = next.entries.filter((entry) => {
+                if (entry.command.kind === 'verification-scan') return false;
+                const previous = before.entries.find(
+                    (candidate) =>
+                        candidate.command.operationId ===
+                        entry.command.operationId,
+                );
+                return (
+                    previous?.state !== entry.state &&
+                    (entry.state === 'synced' ||
+                        entry.state === 'reconciling' ||
+                        entry.state === 'conflicted')
+                );
+            });
+            const completion = deliveryRunCompletionFromSnapshot(next);
+            const completed = completion
+                ? next.entries.find(
+                      (entry) =>
+                          entry.command.operationId === completion.operationId,
+                  )
+                : undefined;
+            if (completion && completed) {
+                await finishCompletedRun(completion, true);
+                await refreshServerStateRef.current({
+                    runId,
+                    minimumRouteRevision:
+                        completed.acknowledgement?.routeRevision,
+                    runCompleted: true,
+                });
+                return queue.getSnapshot();
+            }
+            if (changedServerEntries.length === 0) return next;
+            const acknowledgedEntries = next.entries.filter(
+                (entry) =>
+                    entry.command.kind !== 'verification-scan' &&
+                    entry.acknowledgement?.kind === 'server',
+            );
+            const highestRevision = Math.max(
+                -1,
+                ...acknowledgedEntries.flatMap((entry) =>
+                    entry.acknowledgement?.routeRevision === undefined
+                        ? []
+                        : [entry.acknowledgement.routeRevision],
+                ),
+            );
+            const refreshed = await refreshServerStateRef.current({
+                runId,
+                ...(highestRevision >= 0
+                    ? { minimumRouteRevision: highestRevision }
+                    : {}),
+            });
+            if (refreshed) {
+                for (const entry of acknowledgedEntries) {
+                    await queue.completeServerReconciliation(
+                        entry.command.operationId,
+                    );
+                }
+                announceChange();
+            }
+            const reconciled = queue.getSnapshot();
+            if (
+                refreshed &&
+                navigator.onLine &&
+                deliveryActionQueueCanReplay(reconciled)
+            ) {
+                return await replay();
+            }
+            return reconciled;
+        }, [announceChange, finishCompletedRun, queue, runId]);
+
+    const reconcilePendingServerState = useCallback(async () => {
+        const completion = deliveryRunCompletionFromSnapshot(
+            queue.getSnapshot(),
+        );
+        if (completion) {
+            await finishCompletedRun(completion, true);
+            await refreshServerStateRef.current({
+                runId,
+                runCompleted: true,
+            });
+            return true;
+        }
+        const entries = queue
+            .getSnapshot()
+            .entries.filter(
+                (entry) =>
+                    entry.command.kind !== 'verification-scan' &&
+                    entry.acknowledgement?.kind === 'server' &&
+                    !entry.acknowledgement.runCompleted,
+            );
+        if (entries.length === 0) return true;
+        const highestRevision = Math.max(
+            ...entries.flatMap((entry) =>
+                entry.acknowledgement?.routeRevision === undefined
+                    ? []
+                    : [entry.acknowledgement.routeRevision],
+            ),
+        );
+        const refreshed = await refreshServerStateRef.current({
+            runId,
+            ...(Number.isFinite(highestRevision)
+                ? { minimumRouteRevision: highestRevision }
+                : {}),
+        });
+        if (!refreshed) return false;
+        for (const entry of entries) {
+            await queue.completeServerReconciliation(entry.command.operationId);
+        }
+        announceChange();
+        if (
+            navigator.onLine &&
+            deliveryActionQueueCanReplay(queue.getSnapshot())
+        ) {
+            await replay();
+        }
+        return true;
+    }, [announceChange, finishCompletedRun, queue, replay, runId]);
+
+    const processRestoredSnapshot = useCallback(
+        async (restored: DeliveryActionQueueSnapshot) => {
+            const completion = deliveryRunCompletionFromSnapshot(restored);
+            if (completion) {
+                await finishCompletedRun(completion, true);
+                await refreshServerStateRef.current({
+                    runId,
+                    runCompleted: true,
+                });
+                return;
+            }
+            const hasServerAcknowledgement = restored.entries.some(
+                (entry) =>
+                    entry.command.kind !== 'verification-scan' &&
+                    entry.acknowledgement?.kind === 'server',
+            );
+            if (hasServerAcknowledgement) {
+                const reconciled = await reconcilePendingServerState();
+                if (!reconciled) return;
+            }
+            if (
+                navigator.onLine &&
+                deliveryActionQueueCanReplay(queue.getSnapshot())
+            ) {
+                await replay();
+            }
+        },
+        [finishCompletedRun, queue, reconcilePendingServerState, replay, runId],
+    );
+
+    useEffect(() => {
+        let active = true;
+        void queue
+            .restore()
+            .then((restored) =>
+                active ? processRestoredSnapshot(restored) : undefined,
+            )
+            .catch(() => undefined);
+        const handleOnline = () => {
+            void queue
+                .restore()
+                .then(processRestoredSnapshot)
+                .catch(() => undefined);
+        };
+        window.addEventListener('online', handleOnline);
+        return () => {
+            active = false;
+            window.removeEventListener('online', handleOnline);
+        };
+    }, [processRestoredSnapshot, queue]);
+
+    useEffect(() => {
+        if (!channel) return;
+        const handleMessage = (event: MessageEvent<unknown>) => {
+            const message = parseDeliveryActionChannelMessage(event.data);
+            if (!message) return;
+            if (message.kind === 'run-completed') {
+                void finishCompletedRun(message.completion, false).catch(
+                    () => undefined,
+                );
+                return;
+            }
+            void queue
+                .restore()
+                .then(processRestoredSnapshot)
+                .catch(() => undefined);
+        };
+        channel.addEventListener('message', handleMessage);
+        return () => {
+            channel.removeEventListener('message', handleMessage);
+            channel.close();
+        };
+    }, [channel, finishCompletedRun, processRestoredSnapshot, queue]);
+
+    const enqueue = useCallback(
+        async (command: DeliveryActionCommand) => {
+            const entry = await queue.enqueue(command);
+            announceChange();
+            if (navigator.onLine && command.kind !== 'verification-scan') {
+                void replay().catch(() => undefined);
+            }
+            return entry;
+        },
+        [announceChange, queue, replay],
+    );
+
+    const enqueueRouteAction = useCallback(
+        async (
+            serverRouteRevision: number,
+            createCommand: (
+                expectedRouteRevision: number,
+            ) => DeliveryServerActionCommand,
+        ) => {
+            const entry = await queue.enqueueRouteAction(
+                serverRouteRevision,
+                createCommand,
+            );
+            announceChange();
+            if (navigator.onLine) void replay().catch(() => undefined);
+            return entry;
+        },
+        [announceChange, queue, replay],
+    );
+
+    const retry = useCallback(
+        async (operationIdValue: string) => {
+            const changed = await queue.retry(operationIdValue);
+            if (changed) announceChange();
+            if (changed && navigator.onLine) await replay();
+            return changed;
+        },
+        [announceChange, queue, replay],
+    );
+    const recoverConflict = useCallback(
+        async (operationIdValue: string) => {
+            const refreshed = await refreshServerStateRef.current({ runId });
+            if (!refreshed) return false;
+            const recovered =
+                await queue.discardConflictAndDependents(operationIdValue);
+            if (recovered) announceChange();
+            return recovered;
+        },
+        [announceChange, queue, runId],
+    );
+
+    return {
+        snapshot,
+        enqueueArrive: (stopId: number, serverRouteRevision: number) =>
+            enqueueRouteAction(serverRouteRevision, (expectedRouteRevision) =>
+                createDeliveryArriveCommand({
+                    operationId: operationId('arrival'),
+                    runId,
+                    stopId,
+                    expectedRouteRevision,
+                }),
+            ),
+        enqueueDelivery: (
+            stopId: number,
+            serverRouteRevision: number,
+            notes?: string,
+        ) =>
+            enqueueRouteAction(serverRouteRevision, (expectedRouteRevision) =>
+                createDeliveryCompleteCommand({
+                    operationId: operationId('delivery'),
+                    runId,
+                    stopId,
+                    expectedRouteRevision,
+                    notes,
+                }),
+            ),
+        enqueueException: (
+            stopId: number,
+            mutation: DeliveryExceptionMutation,
+        ) =>
+            enqueueRouteAction(
+                mutation.expectedRouteRevision,
+                (expectedRouteRevision) =>
+                    createDeliveryExceptionCommand({
+                        operationId: mutation.clientOperationId,
+                        runId,
+                        stopId,
+                        expectedRouteRevision,
+                        occurredAt: mutation.occurredAt,
+                        exceptions: mutation.exceptions,
+                    }),
+            ),
+        enqueueVerificationScan: (stopId: number, tracePath: string) =>
+            enqueue(
+                createDeliveryVerificationScanCommand({
+                    operationId: operationId('verification'),
+                    runId,
+                    stopId,
+                    tracePath,
+                }),
+            ),
+        retry,
+        recoverConflict,
+        reconcilePendingServerState,
+        clear: () => queue.clear(),
+        isBarrierError: (error: unknown) =>
+            error instanceof DeliveryActionBarrierError,
+    };
+}

--- a/apps/delivery/hooks/useDriverTracking.ts
+++ b/apps/delivery/hooks/useDriverTracking.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { DeliveryTrackingFreshnessSummary } from '../lib/deliveryDashboardTypes';
+import { assertDeliveryOfflineWritesAllowed } from '../lib/deliveryOfflineEvents';
 import {
     classifyDriverLocationResponse,
     type DriverLocationAcknowledgement,
@@ -330,6 +331,7 @@ export function useDriverTracking({
                 driverTrackingUploadTimeoutMs,
             );
             try {
+                assertDeliveryOfflineWritesAllowed();
                 const response = await fetch(
                     `/api/driver/runs/${runId}/location`,
                     {
@@ -347,6 +349,7 @@ export function useDriverTracking({
                     },
                 );
                 const body: unknown = await response.json().catch(() => null);
+                assertDeliveryOfflineWritesAllowed();
                 result = classifyDriverLocationResponse({
                     status: response.status,
                     body,

--- a/apps/delivery/hooks/useOfflineRouteCache.ts
+++ b/apps/delivery/hooks/useOfflineRouteCache.ts
@@ -1,0 +1,129 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { DriverDeliveryDashboard } from '../lib/deliveryDashboardTypes';
+import {
+    deliveryLogoutEvent,
+    deliveryRunCompletedEvent,
+} from '../lib/deliveryOfflineEvents';
+import {
+    createBrowserOfflineRouteCachePersistence,
+    createOfflineRouteSnapshot,
+    type OfflineRouteSnapshot,
+} from '../lib/offlineRouteCache';
+
+export function useOfflineRouteCache(
+    authenticatedUserId: string | null,
+    dashboard: DriverDeliveryDashboard | null,
+) {
+    const persistence = useMemo(createBrowserOfflineRouteCachePersistence, []);
+    const [snapshot, setSnapshot] = useState<OfflineRouteSnapshot | null>(null);
+    const previousScopeRef = useRef<{
+        userId: string;
+        runId: string;
+    } | null>(null);
+
+    useEffect(() => {
+        const handleLogout = () => {
+            previousScopeRef.current = null;
+            setSnapshot(null);
+        };
+        const handleRunCompleted = (event: Event) => {
+            const detail = (event as CustomEvent<unknown>).detail;
+            if (
+                typeof detail !== 'object' ||
+                detail === null ||
+                !('userId' in detail) ||
+                typeof detail.userId !== 'string' ||
+                detail.userId !== authenticatedUserId ||
+                !('runId' in detail) ||
+                typeof detail.runId !== 'string'
+            ) {
+                return;
+            }
+            void persistence
+                .clear({
+                    userId: detail.userId,
+                    runId: detail.runId,
+                })
+                .catch(() => undefined);
+            previousScopeRef.current = null;
+            setSnapshot(null);
+        };
+        window.addEventListener(deliveryLogoutEvent, handleLogout);
+        window.addEventListener(deliveryRunCompletedEvent, handleRunCompleted);
+        return () => {
+            window.removeEventListener(deliveryLogoutEvent, handleLogout);
+            window.removeEventListener(
+                deliveryRunCompletedEvent,
+                handleRunCompleted,
+            );
+        };
+    }, [authenticatedUserId, persistence]);
+
+    useEffect(() => {
+        if (!authenticatedUserId) {
+            setSnapshot(null);
+            return;
+        }
+        if (!dashboard) {
+            let active = true;
+            void persistence
+                .load({ userId: authenticatedUserId })
+                .then((stored) => {
+                    if (active) {
+                        previousScopeRef.current = stored?.scope ?? null;
+                        setSnapshot(stored);
+                    }
+                })
+                .catch(() => {
+                    if (active) setSnapshot(null);
+                });
+            return () => {
+                active = false;
+            };
+        }
+        const run = dashboard.activeRun;
+        if (!run) {
+            void persistence
+                .clear({ userId: dashboard.user.id })
+                .catch(() => undefined);
+            previousScopeRef.current = null;
+            setSnapshot(null);
+            return;
+        }
+        const scope = { userId: dashboard.user.id, runId: run.id };
+        const previousScope = previousScopeRef.current;
+        if (
+            previousScope &&
+            (previousScope.userId !== scope.userId ||
+                previousScope.runId !== scope.runId)
+        ) {
+            void persistence.clear(previousScope).catch(() => undefined);
+        }
+        previousScopeRef.current = scope;
+        let active = true;
+        const projected = createOfflineRouteSnapshot({
+            authenticatedUserId: dashboard.user.id,
+            dashboard,
+        });
+        if (projected) {
+            setSnapshot(projected);
+            void persistence.save(projected).catch(() => undefined);
+            return;
+        }
+        void persistence
+            .load(scope)
+            .then((stored) => {
+                if (active) setSnapshot(stored);
+            })
+            .catch(() => {
+                if (active) setSnapshot(null);
+            });
+        return () => {
+            active = false;
+        };
+    }, [authenticatedUserId, dashboard, persistence]);
+
+    return snapshot;
+}

--- a/apps/delivery/hooks/usePickupManifestSync.ts
+++ b/apps/delivery/hooks/usePickupManifestSync.ts
@@ -7,7 +7,10 @@ import {
     useRef,
     useSyncExternalStore,
 } from 'react';
-import { deliveryRunCompletedEvent } from '../lib/deliveryOfflineEvents';
+import {
+    assertDeliveryOfflineWritesAllowed,
+    deliveryRunCompletedEvent,
+} from '../lib/deliveryOfflineEvents';
 import {
     createMemoryPickupManifestQueuePersistence,
     createPickupManifestConfirmCommand,
@@ -66,6 +69,7 @@ function mutationForCommand(command: PickupManifestCommand) {
 async function sendPickupManifestCommand(
     command: PickupManifestCommand,
 ): Promise<PickupManifestTransportResult> {
+    assertDeliveryOfflineWritesAllowed();
     let response: Response;
     try {
         response = await fetch(
@@ -82,6 +86,7 @@ async function sendPickupManifestCommand(
         return { status: 'retryable-failure', code: 'offline' };
     }
     const data: unknown = await response.json().catch(() => null);
+    assertDeliveryOfflineWritesAllowed();
     if (!response.ok) {
         return pickupManifestHttpFailure(response.status, data);
     }

--- a/apps/delivery/hooks/usePickupManifestSync.ts
+++ b/apps/delivery/hooks/usePickupManifestSync.ts
@@ -7,6 +7,7 @@ import {
     useRef,
     useSyncExternalStore,
 } from 'react';
+import { deliveryRunCompletedEvent } from '../lib/deliveryOfflineEvents';
 import {
     createMemoryPickupManifestQueuePersistence,
     createPickupManifestConfirmCommand,
@@ -192,6 +193,19 @@ export function usePickupManifestSync({
             })
             .catch(() => undefined);
         const handleOnline = () => void replay().catch(() => undefined);
+        const handleRunCompleted = (event: Event) => {
+            const detail = (event as CustomEvent<unknown>).detail;
+            if (
+                typeof detail === 'object' &&
+                detail !== null &&
+                'userId' in detail &&
+                detail.userId === userId &&
+                'runId' in detail &&
+                detail.runId === runId
+            ) {
+                void queue.clear().catch(() => undefined);
+            }
+        };
         const handleStorage = (event: StorageEvent) => {
             let storage: Storage;
             try {
@@ -222,10 +236,15 @@ export function usePickupManifestSync({
         };
         window.addEventListener('online', handleOnline);
         window.addEventListener('storage', handleStorage);
+        window.addEventListener(deliveryRunCompletedEvent, handleRunCompleted);
         return () => {
             active = false;
             window.removeEventListener('online', handleOnline);
             window.removeEventListener('storage', handleStorage);
+            window.removeEventListener(
+                deliveryRunCompletedEvent,
+                handleRunCompleted,
+            );
         };
     }, [queue, replay, runId, userId]);
 

--- a/apps/delivery/lib/deliveryActionCompletion.ts
+++ b/apps/delivery/lib/deliveryActionCompletion.ts
@@ -1,0 +1,90 @@
+import type { DeliveryActionQueueSnapshot } from './deliveryActionQueue';
+
+const channelMessageVersion = 1;
+
+export type DeliveryRunCompletion = {
+    userId: string;
+    runId: string;
+    operationId: string;
+};
+
+export type DeliveryActionChannelMessage =
+    | { version: typeof channelMessageVersion; kind: 'changed' }
+    | {
+          version: typeof channelMessageVersion;
+          kind: 'run-completed';
+          completion: DeliveryRunCompletion;
+      };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function validIdentifier(value: unknown): value is string {
+    return (
+        typeof value === 'string' &&
+        value.length > 0 &&
+        value.length <= 256 &&
+        Array.from(value).every((character) => {
+            const code = character.charCodeAt(0);
+            return code > 31 && code !== 127;
+        })
+    );
+}
+
+export function deliveryRunCompletionFromSnapshot(
+    snapshot: DeliveryActionQueueSnapshot,
+): DeliveryRunCompletion | null {
+    const completed = snapshot.entries.find(
+        (entry) =>
+            entry.command.kind !== 'verification-scan' &&
+            entry.acknowledgement?.kind === 'server' &&
+            entry.acknowledgement.runCompleted,
+    );
+    return completed
+        ? {
+              userId: snapshot.scope.userId,
+              runId: snapshot.scope.runId,
+              operationId: completed.command.operationId,
+          }
+        : null;
+}
+
+export function deliveryActionChangedMessage(): DeliveryActionChannelMessage {
+    return { version: channelMessageVersion, kind: 'changed' };
+}
+
+export function deliveryRunCompletedMessage(
+    completion: DeliveryRunCompletion,
+): DeliveryActionChannelMessage {
+    return {
+        version: channelMessageVersion,
+        kind: 'run-completed',
+        completion,
+    };
+}
+
+export function parseDeliveryActionChannelMessage(
+    value: unknown,
+): DeliveryActionChannelMessage | null {
+    if (
+        !isRecord(value) ||
+        value.version !== channelMessageVersion ||
+        (value.kind !== 'changed' && value.kind !== 'run-completed')
+    ) {
+        return null;
+    }
+    if (value.kind === 'changed') {
+        return deliveryActionChangedMessage();
+    }
+    if (!isRecord(value.completion)) return null;
+    const { userId, runId, operationId } = value.completion;
+    if (
+        !validIdentifier(userId) ||
+        !validIdentifier(runId) ||
+        !validIdentifier(operationId)
+    ) {
+        return null;
+    }
+    return deliveryRunCompletedMessage({ userId, runId, operationId });
+}

--- a/apps/delivery/lib/deliveryActionPresentation.node.spec.ts
+++ b/apps/delivery/lib/deliveryActionPresentation.node.spec.ts
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    deliveryActionCompletionMessage,
+    deliveryRouteStepsWithLocalActions,
+} from './deliveryActionPresentation';
+import type {
+    DeliveryActionCommandState,
+    DeliveryActionQueueEntry,
+    DeliveryActionQueueSnapshot,
+} from './deliveryActionQueue';
+import type {
+    DeliveryRouteStepSummary,
+    DeliveryStopSummary,
+} from './deliveryDashboardTypes';
+
+const occurredAt = '2026-07-15T12:00:00.000Z';
+
+function stop(id: number, isCurrent: boolean): DeliveryStopSummary {
+    return {
+        id,
+        requestId: `request-${id}`,
+        sequence: id,
+        stopState: 'pending',
+        requestState: 'in_delivery',
+        statusLabel: 'U dostavi',
+        isCurrent,
+        contactName: `Kontakt ${id}`,
+        phone: null,
+        address: `Adresa ${id}, Zagreb`,
+        addressLabel: null,
+        requestNotes: null,
+        deliveryNotes: null,
+        slotStartAt: null,
+        slotEndAt: null,
+        estimatedArrivalAt: null,
+        estimatedTravelSeconds: null,
+        estimatedDistanceMeters: null,
+        reroutePending: false,
+        arrivedAt: null,
+        deliveredAt: null,
+        harvest: {
+            plantName: 'Rajčica',
+            operationName: null,
+            raisedBedName: 'Gredica A',
+            fieldName: null,
+            tracePath: `/trag/route-${id}`,
+        },
+        recovery: null,
+        tracking: null,
+        runId: 'run-route-projection',
+        deliveryCount: 1,
+        deliveries: [],
+    };
+}
+
+function deliveryStep(
+    id: number,
+    actionState: 'locked' | 'upcoming' | 'current' | 'completed',
+): DeliveryRouteStepSummary {
+    return {
+        kind: 'delivery',
+        itinerarySequence: id,
+        retryLaneRank: null,
+        retryAttempt: 0,
+        actionState,
+        lockedReason: actionState === 'locked' ? 'Prethodni korak' : null,
+        stop: stop(id, actionState === 'current'),
+    };
+}
+
+function deliverEntry(
+    stopId: number,
+    sequence: number,
+    state: DeliveryActionCommandState,
+    reroutePending = false,
+): DeliveryActionQueueEntry {
+    const acknowledgement: DeliveryActionQueueEntry['acknowledgement'] =
+        state === 'synced'
+            ? {
+                  kind: 'server',
+                  replayed: false,
+                  routeRevision: 11 + sequence,
+                  reroutePending,
+                  runCompleted: false,
+              }
+            : undefined;
+    return {
+        sequence,
+        command: {
+            kind: 'deliver',
+            operationId: `deliver-${stopId}`,
+            runId: 'run-route-projection',
+            stopId,
+            expectedRouteRevision: 10 + sequence,
+            occurredAt,
+        },
+        state,
+        attemptCount: state === 'queued' ? 0 : 1,
+        createdAt: occurredAt,
+        updatedAt: occurredAt,
+        ...(acknowledgement ? { acknowledgement } : {}),
+    };
+}
+
+function queue(
+    entries: readonly DeliveryActionQueueEntry[],
+): DeliveryActionQueueSnapshot {
+    return {
+        scope: {
+            userId: 'driver-route-projection',
+            runId: 'run-route-projection',
+        },
+        durability: 'durable',
+        coordination: 'coordinated',
+        entries,
+        queuedCount: entries.filter((entry) => entry.state === 'queued').length,
+        sendingCount: entries.filter((entry) => entry.state === 'sending')
+            .length,
+        reconcilingCount: entries.filter(
+            (entry) => entry.state === 'reconciling',
+        ).length,
+        syncedCount: entries.filter((entry) => entry.state === 'synced').length,
+        failedCount: entries.filter((entry) => entry.state === 'failed').length,
+        conflictedCount: entries.filter((entry) => entry.state === 'conflicted')
+            .length,
+    };
+}
+
+test('queued completion locally advances the already loaded route to its next stop', () => {
+    const projected = deliveryRouteStepsWithLocalActions(
+        [deliveryStep(1, 'current'), deliveryStep(2, 'upcoming')],
+        queue([deliverEntry(1, 0, 'queued')]),
+    );
+
+    assert.equal(projected[0]?.actionState, 'completed');
+    assert.equal(projected[0]?.kind, 'delivery');
+    if (projected[0]?.kind === 'delivery') {
+        assert.equal(projected[0].stop.isCurrent, false);
+    }
+    assert.equal(projected[1]?.actionState, 'current');
+    assert.equal(projected[1]?.kind, 'delivery');
+    if (projected[1]?.kind === 'delivery') {
+        assert.equal(projected[1].stop.isCurrent, true);
+        assert.equal(projected[1].lockedReason, null);
+    }
+});
+
+test('ordered local completions advance repeatedly but a failed action remains a barrier', () => {
+    const steps = [
+        deliveryStep(1, 'current'),
+        deliveryStep(2, 'upcoming'),
+        deliveryStep(3, 'locked'),
+    ];
+    const advanced = deliveryRouteStepsWithLocalActions(
+        steps,
+        queue([deliverEntry(1, 0, 'synced'), deliverEntry(2, 1, 'sending')]),
+    );
+    assert.deepEqual(
+        advanced.map((step) => step.actionState),
+        ['completed', 'completed', 'current'],
+    );
+
+    const blocked = deliveryRouteStepsWithLocalActions(
+        steps,
+        queue([deliverEntry(1, 0, 'failed')]),
+    );
+    assert.equal(blocked, steps);
+});
+
+test('server acknowledgement that requires a reroute never advances the stale route', () => {
+    const steps = [deliveryStep(1, 'current'), deliveryStep(2, 'upcoming')];
+    const projected = deliveryRouteStepsWithLocalActions(
+        steps,
+        queue([deliverEntry(1, 0, 'synced', true)]),
+    );
+
+    assert.equal(projected, steps);
+});
+
+test('completion copy distinguishes device-pending from server-acknowledged state', () => {
+    assert.match(
+        deliveryActionCompletionMessage(deliverEntry(1, 0, 'queued')),
+        /čeka potvrdu poslužitelja/,
+    );
+    assert.match(
+        deliveryActionCompletionMessage(deliverEntry(1, 0, 'synced'), true),
+        /Poslužitelj je potvrdio dostavu.*Možeš nastaviti/,
+    );
+});

--- a/apps/delivery/lib/deliveryActionPresentation.ts
+++ b/apps/delivery/lib/deliveryActionPresentation.ts
@@ -1,0 +1,114 @@
+import {
+    type DeliveryActionQueueEntry,
+    type DeliveryActionQueueSnapshot,
+    deliveryActionPendingEntryForStop,
+    deliveryActionAcknowledgementBlocksRoute as queueAcknowledgementBlocksRoute,
+} from './deliveryActionQueue';
+import type { DeliveryRouteStepSummary } from './deliveryDashboardTypes';
+
+const changedRouteCodes = new Set([
+    'active-run-not-found',
+    'route-order',
+    'route-revision-conflict',
+    'run-driver-conflict',
+]);
+
+export function deliveryActionPermanentFailureMessage(
+    errorCode: string | undefined,
+    scope: 'global' | 'stop',
+) {
+    if (changedRouteCodes.has(errorCode ?? '')) {
+        return scope === 'global'
+            ? 'Ruta na poslužitelju se promijenila. Lokalna radnja i sve ovisne radnje ostaju blokirane.'
+            : 'Poslužitelj ima noviju verziju rute.';
+    }
+    return scope === 'global'
+        ? 'Poslužitelj nije prihvatio lokalnu radnju. Ona i sve ovisne radnje ostaju blokirane dok se ne učita trenutačno stanje.'
+        : 'Poslužitelj nije prihvatio ovu radnju. Učitaj trenutačno stanje prije nastavka.';
+}
+
+export function deliveryActionLocallyCompletesStop(
+    entry: DeliveryActionQueueEntry | undefined,
+) {
+    return (
+        entry?.command.kind === 'deliver' &&
+        !deliveryActionAcknowledgementBlocksRoute(entry) &&
+        (entry.state === 'queued' ||
+            entry.state === 'sending' ||
+            entry.state === 'synced')
+    );
+}
+
+export function deliveryActionAcknowledgementBlocksRoute(
+    entry: DeliveryActionQueueEntry | undefined,
+) {
+    return queueAcknowledgementBlocksRoute(entry);
+}
+
+export function deliveryActionCompletionMessage(
+    entry: DeliveryActionQueueEntry | undefined,
+    canContinue = false,
+) {
+    const message =
+        entry?.state === 'synced'
+            ? 'Poslužitelj je potvrdio dostavu. Čeka se osvježeno stanje rute.'
+            : 'Dostava je spremljena na uređaju i čeka potvrdu poslužitelja.';
+    return canContinue
+        ? `${message} Možeš nastaviti na sljedeću stanicu.`
+        : message;
+}
+
+export function deliveryRouteStepsWithLocalActions(
+    routeSteps: readonly DeliveryRouteStepSummary[],
+    actionQueue: DeliveryActionQueueSnapshot | null,
+): readonly DeliveryRouteStepSummary[] {
+    const serverCurrentIndex = routeSteps.findIndex(
+        (step) => step.actionState === 'current',
+    );
+    if (serverCurrentIndex < 0) return routeSteps;
+
+    let localCurrentIndex = serverCurrentIndex;
+    while (localCurrentIndex < routeSteps.length) {
+        const step = routeSteps[localCurrentIndex];
+        if (step?.kind !== 'delivery' || step.stop.id === null) break;
+        const entry = deliveryActionPendingEntryForStop(
+            actionQueue,
+            step.stop.id,
+        );
+        if (!deliveryActionLocallyCompletesStop(entry)) break;
+        localCurrentIndex += 1;
+    }
+    if (localCurrentIndex === serverCurrentIndex) return routeSteps;
+
+    return routeSteps.map((step, index) => {
+        if (index >= serverCurrentIndex && index < localCurrentIndex) {
+            if (step.kind === 'pickup') {
+                return {
+                    ...step,
+                    actionState: 'completed',
+                    pickup: { ...step.pickup, isCurrent: false },
+                };
+            }
+            return {
+                ...step,
+                actionState: 'completed',
+                lockedReason: null,
+                stop: { ...step.stop, isCurrent: false },
+            };
+        }
+        if (index !== localCurrentIndex) return step;
+        if (step.kind === 'pickup') {
+            return {
+                ...step,
+                actionState: 'current',
+                pickup: { ...step.pickup, isCurrent: true },
+            };
+        }
+        return {
+            ...step,
+            actionState: 'current',
+            lockedReason: null,
+            stop: { ...step.stop, isCurrent: true },
+        };
+    });
+}

--- a/apps/delivery/lib/deliveryActionQueue.node.spec.ts
+++ b/apps/delivery/lib/deliveryActionQueue.node.spec.ts
@@ -1,0 +1,693 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    deliveryRunCompletedMessage,
+    deliveryRunCompletionFromSnapshot,
+    parseDeliveryActionChannelMessage,
+} from './deliveryActionCompletion';
+import {
+    clearOtherDeliveryActionQueueScopes,
+    createDeliveryArriveCommand,
+    createDeliveryCompleteCommand,
+    createDeliveryExceptionCommand,
+    createDeliveryVerificationScanCommand,
+    createMemoryDeliveryActionQueuePersistence,
+    DeliveryActionBarrierError,
+    DeliveryActionOperationConflictError,
+    DeliveryActionQueue,
+    type DeliveryActionQueueCoordinator,
+    type DeliveryActionQueuePersistence,
+    type DeliveryActionTransport,
+    deliveryActionPendingEntryForStop,
+    deliveryActionQueueCanReplay,
+    deliveryActionVerifiedTracePaths,
+    nextDeliveryActionRouteRevision,
+} from './deliveryActionQueue';
+
+const scope = { userId: 'driver-1', runId: 'run-1' };
+const now = () => new Date('2026-07-15T12:00:00.000Z');
+
+function arrive(operationId = 'arrive-1', revision = 4) {
+    return createDeliveryArriveCommand({
+        operationId,
+        runId: scope.runId,
+        stopId: 101,
+        expectedRouteRevision: revision,
+        now,
+    });
+}
+
+function complete(operationId = 'deliver-1', revision = 5) {
+    return createDeliveryCompleteCommand({
+        operationId,
+        runId: scope.runId,
+        stopId: 101,
+        expectedRouteRevision: revision,
+        notes: '  Predano susjedi  ',
+        now,
+    });
+}
+
+function queue({
+    persistence = createMemoryDeliveryActionQueuePersistence(),
+    transport = async () => ({
+        status: 'applied' as const,
+        routeRevision: 5,
+        reroutePending: false,
+        runCompleted: false,
+    }),
+    clock = now,
+    coordinator,
+    replayCoordinator,
+}: {
+    persistence?: DeliveryActionQueuePersistence;
+    transport?: DeliveryActionTransport;
+    clock?: () => Date;
+    coordinator?: DeliveryActionQueueCoordinator;
+    replayCoordinator?: DeliveryActionQueueCoordinator;
+} = {}) {
+    return new DeliveryActionQueue({
+        scope,
+        persistence,
+        transport,
+        now: clock,
+        coordinator,
+        replayCoordinator,
+    });
+}
+
+function serialCoordinator(): DeliveryActionQueueCoordinator {
+    let tail = Promise.resolve();
+    return {
+        async runExclusive(_scope, task) {
+            const previous = tail;
+            let release: (() => void) | undefined;
+            tail = new Promise<void>((resolve) => {
+                release = resolve;
+            });
+            await previous;
+            try {
+                return await task();
+            } finally {
+                release?.();
+            }
+        },
+    };
+}
+
+test('normalizes immutable route commands and rejects malformed payloads', () => {
+    assert.deepEqual(complete(), {
+        operationId: 'deliver-1',
+        runId: 'run-1',
+        stopId: 101,
+        expectedRouteRevision: 5,
+        kind: 'deliver',
+        notes: 'Predano susjedi',
+        occurredAt: '2026-07-15T12:00:00.000Z',
+    });
+    assert.throws(
+        () =>
+            createDeliveryArriveCommand({
+                operationId: '',
+                runId: scope.runId,
+                stopId: 101,
+                expectedRouteRevision: 4,
+                now,
+            }),
+        TypeError,
+    );
+});
+
+test('replays arrival and delivery strictly in order with explicit acknowledgements', async () => {
+    const sent: string[] = [];
+    let revision = 4;
+    const actionQueue = queue({
+        transport: async (command) => {
+            sent.push(command.operationId);
+            revision += 1;
+            return {
+                status:
+                    command.operationId === 'deliver-1'
+                        ? ('exact-duplicate' as const)
+                        : ('applied' as const),
+                routeRevision: revision,
+                reroutePending: false,
+                runCompleted: command.kind === 'deliver',
+            };
+        },
+    });
+
+    await actionQueue.enqueue(arrive());
+    assert.equal(
+        nextDeliveryActionRouteRevision(actionQueue.getSnapshot(), 4),
+        5,
+    );
+    await actionQueue.enqueue(complete());
+    assert.equal(
+        nextDeliveryActionRouteRevision(actionQueue.getSnapshot(), 4),
+        6,
+    );
+    const replayed = await actionQueue.replay();
+
+    assert.deepEqual(sent, ['arrive-1', 'deliver-1']);
+    assert.equal(replayed.entries[0]?.state, 'synced');
+    assert.equal(replayed.entries[0]?.acknowledgement?.routeRevision, 5);
+    assert.equal(replayed.entries[1]?.acknowledgement?.replayed, true);
+    assert.equal(replayed.entries[1]?.acknowledgement?.runCompleted, true);
+});
+
+test('a retryable failure stays visibly pending and blocks later route work', async () => {
+    const sent: string[] = [];
+    let fail = true;
+    const actionQueue = queue({
+        transport: async (command) => {
+            sent.push(command.operationId);
+            if (fail) return { status: 'retryable-failure', code: 'offline' };
+            return {
+                status: 'applied',
+                routeRevision: command.kind === 'arrive' ? 5 : 6,
+                reroutePending: false,
+                runCompleted: false,
+            };
+        },
+    });
+    await actionQueue.enqueue(arrive());
+    await actionQueue.enqueue(complete());
+
+    const failed = await actionQueue.replay();
+    assert.deepEqual(sent, ['arrive-1']);
+    assert.equal(failed.entries[0]?.state, 'failed');
+    assert.equal(failed.entries[1]?.state, 'queued');
+    assert.equal(
+        deliveryActionPendingEntryForStop(failed, 101)?.errorCode,
+        'offline',
+    );
+    await assert.rejects(
+        actionQueue.enqueue(
+            createDeliveryArriveCommand({
+                operationId: 'arrive-later-stop',
+                runId: scope.runId,
+                stopId: 102,
+                expectedRouteRevision: 6,
+                now,
+            }),
+        ),
+        DeliveryActionBarrierError,
+    );
+
+    fail = false;
+    assert.equal(await actionQueue.retry('arrive-1'), true);
+    await actionQueue.replay();
+    assert.deepEqual(sent, ['arrive-1', 'arrive-1', 'deliver-1']);
+});
+
+test('a server-required reroute stops replay before dependent route work', async () => {
+    const transported: string[] = [];
+    const actions = queue({
+        transport: async (command) => {
+            transported.push(command.operationId);
+            return {
+                status: 'applied',
+                routeRevision: command.expectedRouteRevision + 1,
+                reroutePending: true,
+                runCompleted: false,
+            };
+        },
+    });
+    await actions.enqueue(complete('reroute-delivery', 4));
+    await actions.enqueue(
+        createDeliveryArriveCommand({
+            operationId: 'dependent-next-arrival',
+            runId: scope.runId,
+            stopId: 102,
+            expectedRouteRevision: 5,
+            now,
+        }),
+    );
+
+    const replayed = await actions.replay();
+
+    assert.deepEqual(transported, ['reroute-delivery']);
+    assert.equal(replayed.entries[0]?.state, 'synced');
+    assert.equal(replayed.entries[0]?.acknowledgement?.reroutePending, true);
+    assert.equal(replayed.entries[1]?.state, 'queued');
+    await actions.replay();
+    assert.deepEqual(transported, ['reroute-delivery']);
+    await assert.rejects(
+        actions.enqueueRouteAction(5, (expectedRouteRevision) =>
+            createDeliveryArriveCommand({
+                operationId: 'blocked-during-reroute',
+                runId: scope.runId,
+                stopId: 103,
+                expectedRouteRevision,
+                now,
+            }),
+        ),
+        DeliveryActionBarrierError,
+    );
+
+    await actions.completeServerReconciliation('reroute-delivery');
+    assert.equal(deliveryActionQueueCanReplay(actions.getSnapshot()), true);
+    await actions.replay();
+    assert.deepEqual(transported, [
+        'reroute-delivery',
+        'dependent-next-arrival',
+    ]);
+});
+
+test('restores an interrupted send as queued without mutating its operation ID', async () => {
+    const persistence = createMemoryDeliveryActionQueuePersistence();
+    let release: (() => void) | undefined;
+    const inFlight = new Promise<void>((resolve) => {
+        release = resolve;
+    });
+    const first = queue({
+        persistence,
+        transport: async () => {
+            await inFlight;
+            return {
+                status: 'applied',
+                routeRevision: 5,
+                reroutePending: false,
+                runCompleted: false,
+            };
+        },
+    });
+    await first.enqueue(arrive());
+    const replayPromise = first.replay();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const restored = queue({ persistence });
+    const snapshot = await restored.restore();
+    assert.equal(snapshot.entries[0]?.state, 'queued');
+    assert.equal(snapshot.entries[0]?.command.operationId, 'arrive-1');
+    release?.();
+    await replayPromise;
+});
+
+test('computes a new command revision after restoring durable predecessors atomically', async () => {
+    const persistence = createMemoryDeliveryActionQueuePersistence();
+    const first = queue({ persistence });
+    await first.enqueue(arrive());
+
+    const reloaded = queue({ persistence });
+    await reloaded.enqueueRouteAction(4, (expectedRouteRevision) =>
+        complete('deliver-after-reload', expectedRouteRevision),
+    );
+
+    const commands = reloaded
+        .getSnapshot()
+        .entries.map((entry) => entry.command);
+    const firstCommand = commands[0];
+    const secondCommand = commands[1];
+    if (
+        !firstCommand ||
+        firstCommand.kind === 'verification-scan' ||
+        !secondCommand ||
+        secondCommand.kind === 'verification-scan'
+    ) {
+        throw new Error('Expected two route-changing commands');
+    }
+    assert.equal(firstCommand.expectedRouteRevision, 4);
+    assert.equal(secondCommand.expectedRouteRevision, 5);
+});
+
+test('an exception is a reconciliation barrier for later route commands', async () => {
+    let transportCalls = 0;
+    const actionQueue = queue({
+        transport: async () => {
+            transportCalls += 1;
+            return {
+                status: 'applied',
+                routeRevision: 5,
+                reroutePending: false,
+                runCompleted: false,
+            };
+        },
+    });
+    const exception = createDeliveryExceptionCommand({
+        operationId: 'exception-1',
+        runId: scope.runId,
+        stopId: 101,
+        expectedRouteRevision: 4,
+        exceptions: [
+            {
+                stopId: 101,
+                outcome: 'deferred',
+                reason: 'customer-unavailable',
+            },
+        ],
+        now,
+    });
+    await actionQueue.enqueue(exception);
+    await assert.rejects(
+        actionQueue.enqueue(complete()),
+        DeliveryActionBarrierError,
+    );
+    const acknowledged = await actionQueue.replay();
+    assert.equal(acknowledged.entries[0]?.state, 'reconciling');
+    assert.equal(transportCalls, 1);
+    await actionQueue.replay();
+    assert.equal(transportCalls, 1);
+    await assert.rejects(
+        actionQueue.enqueue(complete()),
+        DeliveryActionBarrierError,
+    );
+    assert.equal(
+        await actionQueue.completeServerReconciliation(exception.operationId),
+        true,
+    );
+    await actionQueue.enqueue(complete());
+});
+
+test('a stale server conflict preserves the blocking command until explicit recovery', async () => {
+    const sent: string[] = [];
+    const actionQueue = queue({
+        transport: async (command) => {
+            sent.push(command.operationId);
+            return command.operationId === 'arrive-1'
+                ? {
+                      status: 'permanent-failure',
+                      code: 'route-revision-conflict',
+                  }
+                : {
+                      status: 'applied',
+                      routeRevision: 6,
+                      reroutePending: false,
+                      runCompleted: false,
+                  };
+        },
+    });
+    await actionQueue.enqueue(arrive());
+    await actionQueue.enqueue(complete());
+
+    const conflicted = await actionQueue.replay();
+    assert.deepEqual(sent, ['arrive-1']);
+    assert.equal(conflicted.entries[0]?.state, 'conflicted');
+    assert.equal(conflicted.entries[0]?.errorCode, 'route-revision-conflict');
+    assert.equal(conflicted.entries[1]?.state, 'queued');
+    await assert.rejects(
+        actionQueue.enqueue(
+            createDeliveryArriveCommand({
+                operationId: 'arrive-after-conflict',
+                runId: scope.runId,
+                stopId: 102,
+                expectedRouteRevision: 6,
+                now,
+            }),
+        ),
+        DeliveryActionBarrierError,
+    );
+
+    assert.equal(
+        await actionQueue.discardConflictAndDependents('arrive-1'),
+        true,
+    );
+    await actionQueue.replay();
+    assert.deepEqual(sent, ['arrive-1']);
+    assert.equal(actionQueue.getSnapshot().entries.length, 0);
+});
+
+test('rapid repeated route taps reuse the durable pending operation', async () => {
+    const actionQueue = queue();
+    const first = await actionQueue.enqueue(arrive());
+    const duplicate = await actionQueue.enqueue(arrive('arrival-new-id'));
+
+    assert.equal(duplicate.command.operationId, first.command.operationId);
+    assert.equal(actionQueue.getSnapshot().entries.length, 1);
+});
+
+test('advisory verification scans persist locally, deduplicate, and never call transport', async () => {
+    const persistence = createMemoryDeliveryActionQueuePersistence();
+    let transportCalls = 0;
+    const actionQueue = queue({
+        persistence,
+        transport: async () => {
+            transportCalls += 1;
+            return {
+                status: 'applied',
+                routeRevision: 5,
+                reroutePending: false,
+                runCompleted: false,
+            };
+        },
+    });
+    const scan = createDeliveryVerificationScanCommand({
+        operationId: 'scan-1',
+        runId: scope.runId,
+        stopId: 101,
+        tracePath: '/trag/plant-trace-token-0001',
+        now,
+    });
+    await actionQueue.enqueue(scan);
+    await actionQueue.enqueue({ ...scan, operationId: 'scan-duplicate' });
+    await actionQueue.enqueue(arrive());
+    await actionQueue.replay();
+
+    assert.equal(transportCalls, 1);
+    assert.deepEqual(
+        deliveryActionVerifiedTracePaths(actionQueue.getSnapshot(), 101),
+        ['/trag/plant-trace-token-0001'],
+    );
+    const restored = queue({ persistence });
+    await restored.restore();
+    assert.deepEqual(
+        deliveryActionVerifiedTracePaths(restored.getSnapshot(), 101),
+        ['/trag/plant-trace-token-0001'],
+    );
+});
+
+test('rejects operation ID reuse with a changed payload and expires old device data', async () => {
+    const persistence = createMemoryDeliveryActionQueuePersistence();
+    const first = queue({ persistence });
+    await first.enqueue(arrive());
+    await assert.rejects(
+        first.enqueue({ ...arrive(), expectedRouteRevision: 9 }),
+        DeliveryActionOperationConflictError,
+    );
+
+    const afterTtl = queue({
+        persistence,
+        clock: () => new Date('2026-07-16T12:00:00.001Z'),
+    });
+    const restored = await afterTtl.restore();
+    assert.equal(restored.entries.length, 0);
+});
+
+test('keeps persisted actions isolated by authenticated user and run scope', async () => {
+    const persistence = createMemoryDeliveryActionQueuePersistence();
+    const first = queue({ persistence });
+    await first.enqueue(arrive());
+
+    const otherUser = new DeliveryActionQueue({
+        scope: { userId: 'driver-2', runId: scope.runId },
+        persistence,
+        transport: async () => ({
+            status: 'applied',
+            routeRevision: 5,
+            reroutePending: false,
+            runCompleted: false,
+        }),
+        now,
+    });
+    const otherRun = new DeliveryActionQueue({
+        scope: { userId: scope.userId, runId: 'run-2' },
+        persistence,
+        transport: async () => ({
+            status: 'applied',
+            routeRevision: 5,
+            reroutePending: false,
+            runCompleted: false,
+        }),
+        now,
+    });
+    assert.equal((await otherUser.restore()).entries.length, 0);
+    assert.equal((await otherRun.restore()).entries.length, 0);
+
+    await persistence.clear({ userId: 'driver-2' });
+    assert.equal((await first.restore()).entries.length, 1);
+    await persistence.clear({ userId: scope.userId });
+    assert.equal((await first.restore()).entries.length, 0);
+});
+
+test('prunes stale run scopes while preserving the authenticated active run', async () => {
+    const persistence = createMemoryDeliveryActionQueuePersistence();
+    const current = queue({ persistence });
+    await current.enqueue(arrive());
+    const stale = new DeliveryActionQueue({
+        scope: { userId: scope.userId, runId: 'run-stale' },
+        persistence,
+        transport: async () => ({
+            status: 'applied',
+            routeRevision: 1,
+            reroutePending: false,
+            runCompleted: false,
+        }),
+        now,
+    });
+    await stale.enqueue(
+        createDeliveryArriveCommand({
+            operationId: 'stale-arrival',
+            runId: 'run-stale',
+            stopId: 102,
+            expectedRouteRevision: 0,
+            now,
+        }),
+    );
+
+    await clearOtherDeliveryActionQueueScopes(persistence, {
+        userId: scope.userId,
+        activeRunId: scope.runId,
+    });
+
+    assert.equal((await current.restore()).entries.length, 1);
+    assert.equal((await stale.restore()).entries.length, 0);
+});
+
+test('restores a durable completion marker and validates its cross-tab signal', async () => {
+    const persistence = createMemoryDeliveryActionQueuePersistence();
+    const first = queue({
+        persistence,
+        transport: async () => ({
+            status: 'applied',
+            routeRevision: 5,
+            reroutePending: false,
+            runCompleted: true,
+        }),
+    });
+    await first.enqueue(arrive('final-arrival'));
+    await first.replay();
+
+    const restored = queue({ persistence });
+    const snapshot = await restored.restore();
+    const completion = deliveryRunCompletionFromSnapshot(snapshot);
+    if (!completion) throw new Error('Expected a durable completion marker');
+    assert.deepEqual(completion, {
+        userId: scope.userId,
+        runId: scope.runId,
+        operationId: 'final-arrival',
+    });
+    assert.deepEqual(
+        parseDeliveryActionChannelMessage(
+            deliveryRunCompletedMessage(completion),
+        ),
+        deliveryRunCompletedMessage(completion),
+    );
+    assert.equal(
+        parseDeliveryActionChannelMessage({
+            version: 1,
+            kind: 'run-completed',
+            completion: { ...completion, runId: '' },
+        }),
+        null,
+    );
+});
+
+test('keeps the completion marker when durable queue deletion cannot be confirmed', async () => {
+    let durability: 'durable' | 'memory' = 'durable';
+    let stored: unknown;
+    const persistence: DeliveryActionQueuePersistence = {
+        get durability() {
+            return durability;
+        },
+        async load() {
+            return stored;
+        },
+        async save(_scope, entries) {
+            stored = { version: 1, entries };
+        },
+        async clear() {
+            durability = 'memory';
+        },
+    };
+    const actions = queue({
+        persistence,
+        transport: async () => ({
+            status: 'applied',
+            routeRevision: 5,
+            reroutePending: false,
+            runCompleted: true,
+        }),
+    });
+    await actions.enqueue(arrive('durable-completion'));
+    const completed = await actions.replay();
+    assert.ok(deliveryRunCompletionFromSnapshot(completed));
+
+    await assert.rejects(
+        actions.clear(),
+        /Durable delivery action cleanup could not be confirmed/,
+    );
+    assert.ok(deliveryRunCompletionFromSnapshot(actions.getSnapshot()));
+    assert.equal(actions.getSnapshot().durability, 'memory');
+});
+
+test('keeps the completion marker after an earlier durable-store degradation', async () => {
+    let stored: unknown;
+    const persistence: DeliveryActionQueuePersistence = {
+        durability: 'memory',
+        durableCleanupRequired: true,
+        async load() {
+            return stored;
+        },
+        async save(_scope, entries) {
+            stored = { version: 1, entries };
+        },
+        async clear() {
+            stored = undefined;
+        },
+    };
+    const actions = queue({
+        persistence,
+        transport: async () => ({
+            status: 'applied',
+            routeRevision: 5,
+            reroutePending: false,
+            runCompleted: true,
+        }),
+    });
+    await actions.enqueue(arrive('degraded-completion'));
+    await actions.replay();
+
+    await assert.rejects(
+        actions.clear(),
+        /Durable delivery action cleanup could not be confirmed/,
+    );
+    assert.ok(deliveryRunCompletionFromSnapshot(actions.getSnapshot()));
+});
+
+test('shared state and replay locks preserve concurrent cross-tab actions', async () => {
+    const persistence = createMemoryDeliveryActionQueuePersistence();
+    const coordinator = serialCoordinator();
+    const replayCoordinator = serialCoordinator();
+    const first = queue({ persistence, coordinator, replayCoordinator });
+    const second = queue({ persistence, coordinator, replayCoordinator });
+
+    await Promise.all([
+        first.enqueue(arrive('cross-tab-arrival')),
+        second.enqueue(
+            createDeliveryVerificationScanCommand({
+                operationId: 'cross-tab-scan',
+                runId: scope.runId,
+                stopId: 101,
+                tracePath: '/trag/cross-tab-trace-0001',
+                now,
+            }),
+        ),
+    ]);
+
+    const restored = queue({
+        persistence,
+        coordinator,
+        replayCoordinator,
+    });
+    const snapshot = await restored.restore();
+    assert.equal(snapshot.coordination, 'best-effort');
+    assert.deepEqual(
+        snapshot.entries.map((entry) => entry.command.operationId),
+        ['cross-tab-arrival', 'cross-tab-scan'],
+    );
+    assert.deepEqual(
+        snapshot.entries.map((entry) => entry.sequence),
+        [0, 1],
+    );
+});

--- a/apps/delivery/lib/deliveryActionQueue.ts
+++ b/apps/delivery/lib/deliveryActionQueue.ts
@@ -1,0 +1,1262 @@
+import type {
+    DeliveryExceptionOutcome,
+    DeliveryExceptionReason,
+} from './deliveryDashboardTypes';
+import { normalizeHarvestTraceScanValue } from './harvestTraceScan';
+
+export type DeliveryActionQueueScope = {
+    userId: string;
+    runId: string;
+};
+
+type DeliveryRouteCommandBase = {
+    operationId: string;
+    runId: string;
+    stopId: number;
+    occurredAt: string;
+    expectedRouteRevision: number;
+};
+
+export type DeliveryArriveCommand = DeliveryRouteCommandBase & {
+    kind: 'arrive';
+};
+
+export type DeliveryCompleteCommand = DeliveryRouteCommandBase & {
+    kind: 'deliver';
+    notes?: string;
+};
+
+export type DeliveryExceptionCommand = DeliveryRouteCommandBase & {
+    kind: 'exception';
+    exceptions: Array<{
+        stopId: number;
+        outcome: DeliveryExceptionOutcome;
+        reason: DeliveryExceptionReason;
+        note?: string;
+    }>;
+};
+
+export type DeliveryVerificationScanCommand = {
+    kind: 'verification-scan';
+    operationId: string;
+    runId: string;
+    stopId: number;
+    occurredAt: string;
+    tracePath: string;
+};
+
+export type DeliveryActionCommand =
+    | DeliveryArriveCommand
+    | DeliveryCompleteCommand
+    | DeliveryExceptionCommand
+    | DeliveryVerificationScanCommand;
+
+export type DeliveryServerActionCommand = Exclude<
+    DeliveryActionCommand,
+    DeliveryVerificationScanCommand
+>;
+
+export type DeliveryActionCommandState =
+    | 'queued'
+    | 'sending'
+    | 'reconciling'
+    | 'synced'
+    | 'failed'
+    | 'conflicted';
+
+export type DeliveryActionAcknowledgement = {
+    kind: 'server' | 'device';
+    replayed: boolean;
+    routeRevision?: number;
+    reroutePending?: boolean;
+    runCompleted?: boolean;
+};
+
+export type DeliveryActionQueueEntry = {
+    sequence: number;
+    command: DeliveryActionCommand;
+    state: DeliveryActionCommandState;
+    attemptCount: number;
+    createdAt: string;
+    updatedAt: string;
+    acknowledgement?: DeliveryActionAcknowledgement;
+    errorCode?: string;
+};
+
+export type DeliveryActionQueueDurability = 'durable' | 'memory';
+export type DeliveryActionQueueCoordination = 'coordinated' | 'best-effort';
+
+export type DeliveryActionQueueSnapshot = {
+    scope: DeliveryActionQueueScope;
+    durability: DeliveryActionQueueDurability;
+    coordination: DeliveryActionQueueCoordination;
+    entries: readonly DeliveryActionQueueEntry[];
+    queuedCount: number;
+    sendingCount: number;
+    reconcilingCount: number;
+    syncedCount: number;
+    failedCount: number;
+    conflictedCount: number;
+};
+
+export type DeliveryActionTransportResult =
+    | {
+          status: 'applied';
+          routeRevision: number;
+          reroutePending: boolean;
+          runCompleted: boolean;
+      }
+    | {
+          status: 'exact-duplicate';
+          routeRevision: number;
+          reroutePending: boolean;
+          runCompleted: boolean;
+      }
+    | { status: 'retryable-failure'; code?: string }
+    | { status: 'permanent-failure'; code?: string };
+
+export type DeliveryActionTransport = (
+    command: DeliveryServerActionCommand,
+) => Promise<DeliveryActionTransportResult>;
+
+export type DeliveryActionQueuePersistence = {
+    readonly durability: DeliveryActionQueueDurability;
+    readonly durableCleanupRequired?: boolean;
+    load: (scope: DeliveryActionQueueScope) => Promise<unknown>;
+    save: (
+        scope: DeliveryActionQueueScope,
+        entries: readonly DeliveryActionQueueEntry[],
+    ) => Promise<void>;
+    clear: (scope: { userId: string; runId?: string }) => Promise<void>;
+    clearOtherRuns?: (scope: {
+        userId: string;
+        activeRunId: string;
+    }) => Promise<void>;
+};
+
+export type DeliveryActionQueueCoordinator = {
+    runExclusive: <Result>(
+        scope: DeliveryActionQueueScope,
+        task: () => Promise<Result>,
+    ) => Promise<Result>;
+};
+
+type DeliveryActionQueueOptions = {
+    scope: DeliveryActionQueueScope;
+    persistence: DeliveryActionQueuePersistence;
+    transport: DeliveryActionTransport;
+    coordinator?: DeliveryActionQueueCoordinator;
+    replayCoordinator?: DeliveryActionQueueCoordinator;
+    crossTabNotifications?: boolean;
+    now?: () => Date;
+};
+
+type DeliveryRouteCommandInput = {
+    operationId: string;
+    runId: string;
+    stopId: number;
+    expectedRouteRevision: number;
+    occurredAt?: string;
+    now?: () => Date;
+};
+
+const persistenceVersion = 1;
+export const deliveryActionQueueTtlMs = 24 * 60 * 60 * 1_000;
+const maximumPersistedEntries = 200;
+const databaseName = 'gredice-delivery-actions-v1';
+const storeName = 'run-actions';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function validIdentifier(value: unknown): value is string {
+    return (
+        typeof value === 'string' &&
+        value.trim() === value &&
+        value.length > 0 &&
+        value.length <= 256
+    );
+}
+
+function validStopId(value: unknown): value is number {
+    return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}
+
+function validRevision(value: unknown): value is number {
+    return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+function validDate(value: unknown): value is string {
+    return typeof value === 'string' && Number.isFinite(Date.parse(value));
+}
+
+function validErrorCode(value: unknown): value is string {
+    return (
+        typeof value === 'string' &&
+        value.length > 0 &&
+        value.length <= 128 &&
+        /^[a-z0-9-]+$/.test(value)
+    );
+}
+
+function validNote(value: unknown): value is string | undefined {
+    return (
+        value === undefined ||
+        (typeof value === 'string' && value.length <= 1_000)
+    );
+}
+
+function validReason(value: unknown): value is DeliveryExceptionReason {
+    return (
+        value === 'customer-unavailable' ||
+        value === 'address-inaccessible' ||
+        value === 'address-wrong' ||
+        value === 'harvest-damaged' ||
+        value === 'harvest-missing' ||
+        value === 'cancellation' ||
+        value === 'operational-other'
+    );
+}
+
+function validOutcome(value: unknown): value is DeliveryExceptionOutcome {
+    return value === 'deferred' || value === 'failed' || value === 'cancelled';
+}
+
+function validTracePath(value: unknown): value is string {
+    return (
+        typeof value === 'string' &&
+        normalizeHarvestTraceScanValue(value) === value
+    );
+}
+
+function validException(value: unknown) {
+    return (
+        isRecord(value) &&
+        validStopId(value.stopId) &&
+        validOutcome(value.outcome) &&
+        validReason(value.reason) &&
+        validNote(value.note)
+    );
+}
+
+function isDeliveryActionCommand(
+    value: unknown,
+): value is DeliveryActionCommand {
+    if (
+        !isRecord(value) ||
+        !validIdentifier(value.operationId) ||
+        !validIdentifier(value.runId) ||
+        !validStopId(value.stopId) ||
+        !validDate(value.occurredAt)
+    ) {
+        return false;
+    }
+    if (value.kind === 'verification-scan') {
+        return validTracePath(value.tracePath);
+    }
+    if (!validRevision(value.expectedRouteRevision)) return false;
+    if (value.kind === 'arrive') return true;
+    if (value.kind === 'deliver') return validNote(value.notes);
+    return (
+        value.kind === 'exception' &&
+        Array.isArray(value.exceptions) &&
+        value.exceptions.length > 0 &&
+        value.exceptions.length <= 100 &&
+        value.exceptions.every(validException)
+    );
+}
+
+function isAcknowledgement(
+    value: unknown,
+): value is DeliveryActionAcknowledgement {
+    if (
+        !isRecord(value) ||
+        !(value.kind === 'server' || value.kind === 'device') ||
+        typeof value.replayed !== 'boolean'
+    ) {
+        return false;
+    }
+    return (
+        (value.routeRevision === undefined ||
+            validRevision(value.routeRevision)) &&
+        (value.reroutePending === undefined ||
+            typeof value.reroutePending === 'boolean') &&
+        (value.runCompleted === undefined ||
+            typeof value.runCompleted === 'boolean')
+    );
+}
+
+function isEntry(value: unknown): value is DeliveryActionQueueEntry {
+    return (
+        isRecord(value) &&
+        typeof value.sequence === 'number' &&
+        Number.isInteger(value.sequence) &&
+        value.sequence >= 0 &&
+        isDeliveryActionCommand(value.command) &&
+        (value.state === 'queued' ||
+            value.state === 'sending' ||
+            value.state === 'reconciling' ||
+            value.state === 'synced' ||
+            value.state === 'failed' ||
+            value.state === 'conflicted') &&
+        typeof value.attemptCount === 'number' &&
+        Number.isInteger(value.attemptCount) &&
+        value.attemptCount >= 0 &&
+        validDate(value.createdAt) &&
+        validDate(value.updatedAt) &&
+        (value.acknowledgement === undefined ||
+            isAcknowledgement(value.acknowledgement)) &&
+        (value.errorCode === undefined || validErrorCode(value.errorCode))
+    );
+}
+
+function cloneValue<Value>(value: Value): Value {
+    if (value === undefined) return value;
+    return JSON.parse(JSON.stringify(value)) as Value;
+}
+
+function cloneEntry(entry: DeliveryActionQueueEntry) {
+    return cloneValue(entry);
+}
+
+function fingerprint(command: DeliveryActionCommand) {
+    return JSON.stringify(command);
+}
+
+function resolvedOccurredAt(value: string | undefined, now: () => Date) {
+    const result = value ?? now().toISOString();
+    if (!validDate(result)) {
+        throw new TypeError('Delivery action has an invalid occurredAt value');
+    }
+    return new Date(result).toISOString();
+}
+
+function validatedCommand<Command extends DeliveryActionCommand>(
+    command: Command,
+) {
+    if (!isDeliveryActionCommand(command)) {
+        throw new TypeError('Delivery action command is invalid');
+    }
+    return command;
+}
+
+export function createDeliveryArriveCommand({
+    occurredAt,
+    now = () => new Date(),
+    ...input
+}: DeliveryRouteCommandInput): DeliveryArriveCommand {
+    return validatedCommand({
+        ...input,
+        kind: 'arrive',
+        occurredAt: resolvedOccurredAt(occurredAt, now),
+    });
+}
+
+export function createDeliveryCompleteCommand({
+    notes,
+    occurredAt,
+    now = () => new Date(),
+    ...input
+}: DeliveryRouteCommandInput & { notes?: string }): DeliveryCompleteCommand {
+    const normalizedNotes = notes?.trim();
+    return validatedCommand({
+        ...input,
+        kind: 'deliver',
+        occurredAt: resolvedOccurredAt(occurredAt, now),
+        ...(normalizedNotes ? { notes: normalizedNotes } : {}),
+    });
+}
+
+export function createDeliveryExceptionCommand({
+    exceptions,
+    occurredAt,
+    now = () => new Date(),
+    ...input
+}: DeliveryRouteCommandInput & {
+    exceptions: DeliveryExceptionCommand['exceptions'];
+}): DeliveryExceptionCommand {
+    return validatedCommand({
+        ...input,
+        kind: 'exception',
+        occurredAt: resolvedOccurredAt(occurredAt, now),
+        exceptions: cloneValue(exceptions),
+    });
+}
+
+export function createDeliveryVerificationScanCommand({
+    operationId,
+    runId,
+    stopId,
+    tracePath,
+    occurredAt,
+    now = () => new Date(),
+}: Omit<DeliveryRouteCommandInput, 'expectedRouteRevision'> & {
+    tracePath: string;
+}): DeliveryVerificationScanCommand {
+    return validatedCommand({
+        kind: 'verification-scan',
+        operationId,
+        runId,
+        stopId,
+        tracePath,
+        occurredAt: resolvedOccurredAt(occurredAt, now),
+    });
+}
+
+export class DeliveryActionOperationConflictError extends Error {
+    override name = 'DeliveryActionOperationConflictError';
+
+    constructor(readonly operationId: string) {
+        super(`Delivery action ${operationId} has conflicting payloads`);
+    }
+}
+
+export class DeliveryActionBarrierError extends Error {
+    override name = 'DeliveryActionBarrierError';
+
+    constructor() {
+        super(
+            'An offline delivery exception must synchronize before continuing',
+        );
+    }
+}
+
+function persistenceKey(scope: DeliveryActionQueueScope) {
+    return `${encodeURIComponent(scope.userId)}:${encodeURIComponent(scope.runId)}`;
+}
+
+function persistenceUserPrefix(userId: string) {
+    return `${encodeURIComponent(userId)}:`;
+}
+
+function persistedPayload(entries: readonly DeliveryActionQueueEntry[]) {
+    return { version: persistenceVersion, entries };
+}
+
+function restoredEntries(
+    value: unknown,
+    scope: DeliveryActionQueueScope,
+    now: Date,
+) {
+    if (
+        !isRecord(value) ||
+        value.version !== persistenceVersion ||
+        !Array.isArray(value.entries)
+    ) {
+        return [];
+    }
+    const minimumCreatedAt = now.getTime() - deliveryActionQueueTtlMs;
+    const byOperationId = new Map<string, DeliveryActionQueueEntry>();
+    for (const candidate of value.entries) {
+        if (
+            !isEntry(candidate) ||
+            candidate.command.runId !== scope.runId ||
+            Date.parse(candidate.createdAt) < minimumCreatedAt ||
+            Date.parse(candidate.createdAt) > now.getTime() + 5 * 60 * 1_000
+        ) {
+            continue;
+        }
+        const restored = cloneEntry(candidate);
+        if (restored.state === 'sending') restored.state = 'queued';
+        const existing = byOperationId.get(restored.command.operationId);
+        if (
+            existing &&
+            fingerprint(existing.command) !== fingerprint(restored.command)
+        ) {
+            throw new DeliveryActionOperationConflictError(
+                restored.command.operationId,
+            );
+        }
+        byOperationId.set(restored.command.operationId, restored);
+    }
+    return Array.from(byOperationId.values())
+        .sort((first, second) => first.sequence - second.sequence)
+        .slice(-maximumPersistedEntries);
+}
+
+function snapshotFor(
+    scope: DeliveryActionQueueScope,
+    entries: readonly DeliveryActionQueueEntry[],
+    durability: DeliveryActionQueueDurability,
+    coordination: DeliveryActionQueueCoordination,
+): DeliveryActionQueueSnapshot {
+    const cloned = entries.map(cloneEntry);
+    return {
+        scope: { ...scope },
+        durability,
+        coordination,
+        entries: cloned,
+        queuedCount: entries.filter((entry) => entry.state === 'queued').length,
+        sendingCount: entries.filter((entry) => entry.state === 'sending')
+            .length,
+        reconcilingCount: entries.filter(
+            (entry) => entry.state === 'reconciling',
+        ).length,
+        syncedCount: entries.filter((entry) => entry.state === 'synced').length,
+        failedCount: entries.filter((entry) => entry.state === 'failed').length,
+        conflictedCount: entries.filter((entry) => entry.state === 'conflicted')
+            .length,
+    };
+}
+
+export function deliveryActionPendingEntryForStop(
+    snapshot: DeliveryActionQueueSnapshot | null,
+    stopId: number,
+) {
+    const entries =
+        snapshot?.entries.filter(
+            (entry) =>
+                entry.command.kind !== 'verification-scan' &&
+                entry.command.stopId === stopId &&
+                (entry.state !== 'synced' ||
+                    entry.acknowledgement?.kind === 'server'),
+        ) ?? [];
+    return (
+        entries.find(
+            (entry) => entry.state === 'failed' || entry.state === 'conflicted',
+        ) ?? entries.at(-1)
+    );
+}
+
+export function deliveryActionAcknowledgementBlocksRoute(
+    entry: DeliveryActionQueueEntry | undefined,
+) {
+    return (
+        entry?.acknowledgement?.kind === 'server' &&
+        (entry.acknowledgement.reroutePending === true ||
+            entry.acknowledgement.runCompleted === true)
+    );
+}
+
+export function deliveryActionQueueCanReplay(
+    snapshot: DeliveryActionQueueSnapshot,
+) {
+    return (
+        snapshot.queuedCount > 0 &&
+        snapshot.failedCount === 0 &&
+        snapshot.conflictedCount === 0 &&
+        snapshot.reconcilingCount === 0 &&
+        !snapshot.entries.some(deliveryActionAcknowledgementBlocksRoute)
+    );
+}
+
+export function deliveryActionVerifiedTracePaths(
+    snapshot: DeliveryActionQueueSnapshot | null,
+    stopId: number,
+) {
+    return (
+        snapshot?.entries.flatMap((entry) =>
+            entry.command.kind === 'verification-scan' &&
+            entry.command.stopId === stopId &&
+            entry.state === 'synced'
+                ? [entry.command.tracePath]
+                : [],
+        ) ?? []
+    );
+}
+
+export function nextDeliveryActionRouteRevision(
+    snapshot: DeliveryActionQueueSnapshot | null,
+    serverRouteRevision: number,
+) {
+    let revision = serverRouteRevision;
+    for (const entry of snapshot?.entries ?? []) {
+        if (
+            entry.command.kind === 'verification-scan' ||
+            entry.state === 'conflicted'
+        ) {
+            continue;
+        }
+        const acknowledgedRevision = entry.acknowledgement?.routeRevision;
+        if (acknowledgedRevision !== undefined) {
+            revision = Math.max(revision, acknowledgedRevision);
+        } else if (entry.state !== 'synced') {
+            revision += 1;
+        }
+    }
+    return revision;
+}
+
+export function createMemoryDeliveryActionQueuePersistence(): DeliveryActionQueuePersistence {
+    const values = new Map<string, unknown>();
+    return {
+        durability: 'memory',
+        durableCleanupRequired: false,
+        async load(scope) {
+            return cloneValue(values.get(persistenceKey(scope)));
+        },
+        async save(scope, entries) {
+            values.set(
+                persistenceKey(scope),
+                cloneValue(persistedPayload(entries)),
+            );
+        },
+        async clear(scope) {
+            if (scope.runId) {
+                values.delete(
+                    persistenceKey({
+                        userId: scope.userId,
+                        runId: scope.runId,
+                    }),
+                );
+                return;
+            }
+            for (const key of values.keys()) {
+                if (key.startsWith(persistenceUserPrefix(scope.userId))) {
+                    values.delete(key);
+                }
+            }
+        },
+        async clearOtherRuns({ userId, activeRunId }) {
+            const prefix = persistenceUserPrefix(userId);
+            const activeKey = persistenceKey({ userId, runId: activeRunId });
+            for (const key of values.keys()) {
+                if (key.startsWith(prefix) && key !== activeKey) {
+                    values.delete(key);
+                }
+            }
+        },
+    };
+}
+
+function requestResult<Result>(request: IDBRequest<Result>) {
+    return new Promise<Result>((resolve, reject) => {
+        request.addEventListener('success', () => resolve(request.result), {
+            once: true,
+        });
+        request.addEventListener('error', () => reject(request.error), {
+            once: true,
+        });
+    });
+}
+
+function transactionResult(transaction: IDBTransaction) {
+    return new Promise<void>((resolve, reject) => {
+        transaction.addEventListener('complete', () => resolve(), {
+            once: true,
+        });
+        transaction.addEventListener('abort', () => reject(transaction.error), {
+            once: true,
+        });
+        transaction.addEventListener('error', () => reject(transaction.error), {
+            once: true,
+        });
+    });
+}
+
+function openDatabase(factory: IDBFactory) {
+    return new Promise<IDBDatabase>((resolve, reject) => {
+        const request = factory.open(databaseName, 1);
+        request.addEventListener('upgradeneeded', () => {
+            if (!request.result.objectStoreNames.contains(storeName)) {
+                request.result.createObjectStore(storeName);
+            }
+        });
+        request.addEventListener('success', () => resolve(request.result), {
+            once: true,
+        });
+        request.addEventListener('error', () => reject(request.error), {
+            once: true,
+        });
+    });
+}
+
+export function createIndexedDbDeliveryActionQueuePersistence(
+    factory: IDBFactory,
+): DeliveryActionQueuePersistence {
+    const memory = createMemoryDeliveryActionQueuePersistence();
+    let durable = true;
+    let databasePromise: Promise<IDBDatabase> | null = null;
+    const database = () => (databasePromise ??= openDatabase(factory));
+    const markDurableStoreUnavailable = () => {
+        durable = false;
+        if (databasePromise) {
+            void databasePromise
+                .then((openDatabase) => openDatabase.close())
+                .catch(() => undefined);
+        }
+        databasePromise = null;
+    };
+    const fallback = async <Result>(
+        durableTask: () => Promise<Result>,
+        memoryTask: () => Promise<Result>,
+    ) => {
+        if (!durable) return await memoryTask();
+        try {
+            return await durableTask();
+        } catch {
+            markDurableStoreUnavailable();
+            return await memoryTask();
+        }
+    };
+    return {
+        get durability() {
+            return durable ? 'durable' : 'memory';
+        },
+        durableCleanupRequired: true,
+        async load(scope) {
+            return await fallback(
+                async () => {
+                    const db = await database();
+                    const transaction = db.transaction(storeName, 'readonly');
+                    const completed = transactionResult(transaction);
+                    const value: unknown = await requestResult(
+                        transaction
+                            .objectStore(storeName)
+                            .get(persistenceKey(scope)),
+                    );
+                    await completed;
+                    if (value !== undefined) {
+                        const rawEntries =
+                            isRecord(value) && Array.isArray(value.entries)
+                                ? value.entries.filter(isEntry)
+                                : [];
+                        await memory.save(scope, rawEntries);
+                    }
+                    return value;
+                },
+                async () => await memory.load(scope),
+            );
+        },
+        async save(scope, entries) {
+            await memory.save(scope, entries);
+            await fallback(
+                async () => {
+                    const db = await database();
+                    const transaction = db.transaction(storeName, 'readwrite');
+                    const completed = transactionResult(transaction);
+                    transaction
+                        .objectStore(storeName)
+                        .put(persistedPayload(entries), persistenceKey(scope));
+                    await completed;
+                },
+                async () => undefined,
+            );
+        },
+        async clear(scope) {
+            try {
+                const db = await database();
+                const transaction = db.transaction(storeName, 'readwrite');
+                const completed = transactionResult(transaction);
+                const store = transaction.objectStore(storeName);
+                if (scope.runId) {
+                    store.delete(
+                        persistenceKey({
+                            userId: scope.userId,
+                            runId: scope.runId,
+                        }),
+                    );
+                } else {
+                    const keys = await requestResult(store.getAllKeys());
+                    for (const key of keys) {
+                        if (
+                            typeof key === 'string' &&
+                            key.startsWith(persistenceUserPrefix(scope.userId))
+                        ) {
+                            store.delete(key);
+                        }
+                    }
+                }
+                await completed;
+                await memory.clear(scope);
+                durable = true;
+            } catch {
+                markDurableStoreUnavailable();
+                throw new Error(
+                    'Durable delivery action cleanup could not be confirmed',
+                );
+            }
+        },
+        async clearOtherRuns({ userId, activeRunId }) {
+            try {
+                const db = await database();
+                const transaction = db.transaction(storeName, 'readwrite');
+                const completed = transactionResult(transaction);
+                const store = transaction.objectStore(storeName);
+                const keys = await requestResult(store.getAllKeys());
+                const prefix = persistenceUserPrefix(userId);
+                const activeKey = persistenceKey({
+                    userId,
+                    runId: activeRunId,
+                });
+                for (const key of keys) {
+                    if (
+                        typeof key === 'string' &&
+                        key.startsWith(prefix) &&
+                        key !== activeKey
+                    ) {
+                        store.delete(key);
+                    }
+                }
+                await completed;
+                await memory.clearOtherRuns?.({ userId, activeRunId });
+                durable = true;
+            } catch {
+                markDurableStoreUnavailable();
+                throw new Error(
+                    'Durable delivery action cleanup could not be confirmed',
+                );
+            }
+        },
+    };
+}
+
+export function createBrowserDeliveryActionQueuePersistence() {
+    try {
+        return typeof indexedDB === 'undefined'
+            ? createMemoryDeliveryActionQueuePersistence()
+            : createIndexedDbDeliveryActionQueuePersistence(indexedDB);
+    } catch {
+        const memory = createMemoryDeliveryActionQueuePersistence();
+        return {
+            ...memory,
+            durableCleanupRequired: true,
+            async clear() {
+                throw new Error(
+                    'Durable delivery action cleanup could not be confirmed',
+                );
+            },
+            async clearOtherRuns() {
+                throw new Error(
+                    'Durable delivery action cleanup could not be confirmed',
+                );
+            },
+        };
+    }
+}
+
+export async function clearOtherDeliveryActionQueueScopes(
+    persistence: DeliveryActionQueuePersistence,
+    scope: { userId: string; activeRunId: string },
+) {
+    await persistence.clearOtherRuns?.(scope);
+}
+
+export class DeliveryActionQueue {
+    private entries: DeliveryActionQueueEntry[] = [];
+    private snapshot: DeliveryActionQueueSnapshot;
+    private readonly serverSnapshot: DeliveryActionQueueSnapshot;
+    private readonly listeners = new Set<() => void>();
+    private operationChain: Promise<void> = Promise.resolve();
+    private replayPromise: Promise<DeliveryActionQueueSnapshot> | null = null;
+    private nextSequence = 0;
+    private generation = 0;
+    private readonly now: () => Date;
+
+    constructor(private readonly options: DeliveryActionQueueOptions) {
+        if (
+            !validIdentifier(options.scope.userId) ||
+            !validIdentifier(options.scope.runId)
+        ) {
+            throw new TypeError('Delivery action queue scope is invalid');
+        }
+        this.now = options.now ?? (() => new Date());
+        this.snapshot = snapshotFor(
+            options.scope,
+            [],
+            options.persistence.durability,
+            options.persistence.durability === 'durable' &&
+                options.coordinator &&
+                options.replayCoordinator &&
+                options.crossTabNotifications
+                ? 'coordinated'
+                : 'best-effort',
+        );
+        this.serverSnapshot = snapshotFor(
+            options.scope,
+            [],
+            'memory',
+            'best-effort',
+        );
+    }
+
+    getSnapshot = () => this.snapshot;
+    getServerSnapshot = () => this.serverSnapshot;
+
+    subscribe = (listener: () => void) => {
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    };
+
+    async restore() {
+        return await this.runExclusive(async () => {
+            await this.load();
+            await this.persist();
+            return this.snapshot;
+        });
+    }
+
+    async enqueue(command: DeliveryActionCommand) {
+        if (
+            !isDeliveryActionCommand(command) ||
+            command.runId !== this.options.scope.runId
+        ) {
+            throw new TypeError('Delivery action does not match its queue');
+        }
+        return await this.runExclusive(async () => {
+            await this.load();
+            return await this.enqueueLoaded(command);
+        });
+    }
+
+    async enqueueRouteAction(
+        serverRouteRevision: number,
+        createCommand: (
+            expectedRouteRevision: number,
+        ) => DeliveryServerActionCommand,
+    ) {
+        if (!validRevision(serverRouteRevision)) {
+            throw new TypeError('Server route revision is invalid');
+        }
+        return await this.runExclusive(async () => {
+            await this.load();
+            const command = createCommand(
+                nextDeliveryActionRouteRevision(
+                    this.snapshot,
+                    serverRouteRevision,
+                ),
+            );
+            if (
+                !isDeliveryActionCommand(command) ||
+                command.runId !== this.options.scope.runId
+            ) {
+                throw new TypeError('Delivery action does not match its queue');
+            }
+            return await this.enqueueLoaded(command);
+        });
+    }
+
+    private async enqueueLoaded(command: DeliveryActionCommand) {
+        const exact = this.entries.find(
+            (entry) => entry.command.operationId === command.operationId,
+        );
+        if (exact) {
+            if (fingerprint(exact.command) !== fingerprint(command)) {
+                throw new DeliveryActionOperationConflictError(
+                    command.operationId,
+                );
+            }
+            return cloneEntry(exact);
+        }
+        if (command.kind === 'verification-scan') {
+            const existingScan = this.entries.find(
+                (entry) =>
+                    entry.command.kind === 'verification-scan' &&
+                    entry.command.stopId === command.stopId &&
+                    entry.command.tracePath === command.tracePath,
+            );
+            if (existingScan) return cloneEntry(existingScan);
+        } else {
+            if (
+                this.entries.some(
+                    (entry) =>
+                        entry.state === 'failed' ||
+                        entry.state === 'conflicted' ||
+                        entry.state === 'reconciling' ||
+                        deliveryActionAcknowledgementBlocksRoute(entry),
+                )
+            ) {
+                throw new DeliveryActionBarrierError();
+            }
+            if (command.kind === 'arrive' || command.kind === 'deliver') {
+                const existingRouteAction = this.entries.find(
+                    (entry) =>
+                        entry.command.kind === command.kind &&
+                        entry.command.stopId === command.stopId &&
+                        entry.state !== 'synced' &&
+                        entry.state !== 'conflicted',
+                );
+                if (existingRouteAction) {
+                    return cloneEntry(existingRouteAction);
+                }
+            }
+            if (
+                this.entries.some((entry) => entry.command.kind === 'exception')
+            ) {
+                throw new DeliveryActionBarrierError();
+            }
+        }
+        const timestamp = this.now().toISOString();
+        const localOnly = command.kind === 'verification-scan';
+        const entry: DeliveryActionQueueEntry = {
+            sequence: this.nextSequence,
+            command: cloneValue(command),
+            state: localOnly ? 'synced' : 'queued',
+            attemptCount: 0,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+            ...(localOnly
+                ? {
+                      acknowledgement: {
+                          kind: 'device' as const,
+                          replayed: false,
+                      },
+                  }
+                : {}),
+        };
+        this.nextSequence += 1;
+        this.entries.push(entry);
+        this.trim();
+        await this.persist();
+        return cloneEntry(entry);
+    }
+
+    async replay() {
+        if (this.replayPromise) return await this.replayPromise;
+        const generation = this.generation;
+        const task = () => this.replayEntries(generation);
+        this.replayPromise = (
+            this.options.replayCoordinator
+                ? this.options.replayCoordinator.runExclusive(
+                      this.options.scope,
+                      task,
+                  )
+                : task()
+        ).finally(() => {
+            this.replayPromise = null;
+        });
+        return await this.replayPromise;
+    }
+
+    async retry(operationId: string) {
+        return await this.runExclusive(async () => {
+            await this.load();
+            const entry = this.entries.find(
+                (candidate) => candidate.command.operationId === operationId,
+            );
+            if (entry?.state !== 'failed') return false;
+            entry.state = 'queued';
+            entry.updatedAt = this.now().toISOString();
+            delete entry.errorCode;
+            delete entry.acknowledgement;
+            await this.persist();
+            return true;
+        });
+    }
+
+    async completeServerReconciliation(operationId: string) {
+        return await this.runExclusive(async () => {
+            await this.load();
+            const entry = this.entries.find(
+                (candidate) => candidate.command.operationId === operationId,
+            );
+            if (
+                !entry ||
+                entry.command.kind === 'verification-scan' ||
+                entry.acknowledgement?.kind !== 'server'
+            ) {
+                return false;
+            }
+            this.entries = this.entries.filter(
+                (candidate) => candidate.command.operationId !== operationId,
+            );
+            await this.persist();
+            return true;
+        });
+    }
+
+    async discardConflictAndDependents(operationId: string) {
+        return await this.runExclusive(async () => {
+            await this.load();
+            const conflicted = this.entries.find(
+                (entry) => entry.command.operationId === operationId,
+            );
+            if (conflicted?.state !== 'conflicted') return false;
+            this.entries = this.entries.filter(
+                (entry) =>
+                    entry.command.kind === 'verification-scan' ||
+                    entry.sequence < conflicted.sequence,
+            );
+            await this.persist();
+            return true;
+        });
+    }
+
+    async clear() {
+        return await this.runExclusive(async () => {
+            const requiredDurability =
+                this.options.persistence.durableCleanupRequired ??
+                this.options.persistence.durability === 'durable';
+            try {
+                await this.options.persistence.clear(this.options.scope);
+            } catch (error) {
+                this.publish();
+                throw error;
+            }
+            if (
+                requiredDurability &&
+                this.options.persistence.durability !== 'durable'
+            ) {
+                this.publish();
+                throw new Error(
+                    'Durable delivery action cleanup could not be confirmed',
+                );
+            }
+            this.generation += 1;
+            this.entries = [];
+            this.nextSequence = 0;
+            this.publish();
+        });
+    }
+
+    private runExclusive<Result>(task: () => Promise<Result>) {
+        const coordinatedTask = () =>
+            this.options.coordinator
+                ? this.options.coordinator.runExclusive(
+                      this.options.scope,
+                      task,
+                  )
+                : task();
+        const result = this.operationChain.then(
+            coordinatedTask,
+            coordinatedTask,
+        );
+        this.operationChain = result.then(
+            () => undefined,
+            () => undefined,
+        );
+        return result;
+    }
+
+    private async load() {
+        this.entries = restoredEntries(
+            await this.options.persistence.load(this.options.scope),
+            this.options.scope,
+            this.now(),
+        );
+        this.nextSequence =
+            Math.max(-1, ...this.entries.map((entry) => entry.sequence)) + 1;
+        this.publish();
+    }
+
+    private async replayEntries(generation: number) {
+        while (generation === this.generation) {
+            const command = await this.runExclusive(async () => {
+                await this.load();
+                if (
+                    this.entries.some(deliveryActionAcknowledgementBlocksRoute)
+                ) {
+                    return null;
+                }
+                const entry = this.entries.find(
+                    (candidate) =>
+                        candidate.command.kind !== 'verification-scan' &&
+                        candidate.state !== 'synced',
+                );
+                if (
+                    !entry ||
+                    entry.state === 'failed' ||
+                    entry.state === 'conflicted' ||
+                    entry.state === 'reconciling'
+                ) {
+                    return null;
+                }
+                entry.state = 'sending';
+                entry.attemptCount += 1;
+                entry.updatedAt = this.now().toISOString();
+                delete entry.errorCode;
+                delete entry.acknowledgement;
+                await this.persist();
+                return cloneValue(entry.command) as Exclude<
+                    DeliveryActionCommand,
+                    DeliveryVerificationScanCommand
+                >;
+            });
+            if (!command) break;
+            let result: DeliveryActionTransportResult;
+            try {
+                result = await this.options.transport(command);
+            } catch {
+                result = {
+                    status: 'retryable-failure',
+                    code: 'transport-error',
+                };
+            }
+            const stop = await this.runExclusive(async () => {
+                await this.load();
+                const entry = this.entries.find(
+                    (candidate) =>
+                        candidate.command.operationId === command.operationId,
+                );
+                if (!entry || entry.state === 'synced') return false;
+                entry.updatedAt = this.now().toISOString();
+                if (
+                    result.status === 'applied' ||
+                    result.status === 'exact-duplicate'
+                ) {
+                    entry.state =
+                        command.kind === 'exception' ? 'reconciling' : 'synced';
+                    entry.acknowledgement = {
+                        kind: 'server',
+                        replayed: result.status === 'exact-duplicate',
+                        routeRevision: result.routeRevision,
+                        reroutePending: result.reroutePending,
+                        runCompleted: result.runCompleted,
+                    };
+                    delete entry.errorCode;
+                } else if (result.status === 'retryable-failure') {
+                    entry.state = 'failed';
+                    entry.errorCode = validErrorCode(result.code)
+                        ? result.code
+                        : 'delivery-action-sync-failed';
+                } else {
+                    entry.state = 'conflicted';
+                    entry.errorCode = validErrorCode(result.code)
+                        ? result.code
+                        : 'delivery-action-conflict';
+                }
+                await this.persist();
+                return (
+                    entry.state === 'failed' ||
+                    entry.state === 'conflicted' ||
+                    entry.state === 'reconciling' ||
+                    entry.acknowledgement?.reroutePending === true ||
+                    entry.acknowledgement?.runCompleted === true
+                );
+            });
+            if (stop) break;
+        }
+        return this.snapshot;
+    }
+
+    private trim() {
+        if (this.entries.length <= maximumPersistedEntries) return;
+        const removable = this.entries
+            .filter((entry) => entry.state === 'synced')
+            .sort((first, second) => first.sequence - second.sequence);
+        for (const entry of removable) {
+            if (this.entries.length <= maximumPersistedEntries) break;
+            this.entries = this.entries.filter(
+                (candidate) =>
+                    candidate.command.operationId !== entry.command.operationId,
+            );
+        }
+        if (this.entries.length > maximumPersistedEntries) {
+            throw new RangeError('Too many unsynchronized delivery actions');
+        }
+    }
+
+    private publish() {
+        this.snapshot = snapshotFor(
+            this.options.scope,
+            this.entries,
+            this.options.persistence.durability,
+            this.options.persistence.durability === 'durable' &&
+                this.options.coordinator &&
+                this.options.replayCoordinator &&
+                this.options.crossTabNotifications
+                ? 'coordinated'
+                : 'best-effort',
+        );
+        for (const listener of this.listeners) listener();
+    }
+
+    private async persist() {
+        await this.options.persistence.save(
+            this.options.scope,
+            this.entries.map(cloneEntry),
+        );
+        this.publish();
+    }
+}

--- a/apps/delivery/lib/deliveryActionQueue.ts
+++ b/apps/delivery/lib/deliveryActionQueue.ts
@@ -2,6 +2,7 @@ import type {
     DeliveryExceptionOutcome,
     DeliveryExceptionReason,
 } from './deliveryDashboardTypes';
+import { assertDeliveryOfflineWritesAllowed } from './deliveryOfflineEvents';
 import { normalizeHarvestTraceScanValue } from './harvestTraceScan';
 
 export type DeliveryActionQueueScope = {
@@ -587,6 +588,7 @@ export function createMemoryDeliveryActionQueuePersistence(): DeliveryActionQueu
             return cloneValue(values.get(persistenceKey(scope)));
         },
         async save(scope, entries) {
+            assertDeliveryOfflineWritesAllowed();
             values.set(
                 persistenceKey(scope),
                 cloneValue(persistedPayload(entries)),
@@ -724,6 +726,7 @@ export function createIndexedDbDeliveryActionQueuePersistence(
             await fallback(
                 async () => {
                     const db = await database();
+                    assertDeliveryOfflineWritesAllowed();
                     const transaction = db.transaction(storeName, 'readwrite');
                     const completed = transactionResult(transaction);
                     transaction

--- a/apps/delivery/lib/deliveryActionTransport.node.spec.ts
+++ b/apps/delivery/lib/deliveryActionTransport.node.spec.ts
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    createDeliveryArriveCommand,
+    createDeliveryExceptionCommand,
+} from './deliveryActionQueue';
+import {
+    deliveryActionAcknowledgement,
+    deliveryActionHttpFailure,
+} from './deliveryActionTransport';
+
+const arrive = createDeliveryArriveCommand({
+    operationId: 'arrival-1',
+    runId: 'run-1',
+    stopId: 22,
+    expectedRouteRevision: 3,
+    occurredAt: '2026-07-15T12:00:00.000Z',
+});
+
+test('accepts only the exact route-operation receipt contract', () => {
+    assert.deepEqual(
+        deliveryActionAcknowledgement(
+            {
+                clientOperationId: 'arrival-1',
+                replayed: true,
+                result: {
+                    kind: 'arrive',
+                    targetStopId: 22,
+                    affectedStopIds: [22, 23],
+                    routeRevision: 4,
+                    reroutePending: false,
+                    runCompleted: false,
+                },
+            },
+            arrive,
+        ),
+        {
+            status: 'exact-duplicate',
+            routeRevision: 4,
+            reroutePending: false,
+            runCompleted: false,
+        },
+    );
+    assert.deepEqual(
+        deliveryActionAcknowledgement(
+            {
+                clientOperationId: 'another-operation',
+                replayed: false,
+                result: {
+                    kind: 'arrive',
+                    targetStopId: 22,
+                    affectedStopIds: [22],
+                    routeRevision: 4,
+                    reroutePending: false,
+                    runCompleted: false,
+                },
+            },
+            arrive,
+        ),
+        {
+            status: 'retryable-failure',
+            code: 'invalid-acknowledgement',
+        },
+    );
+});
+
+test('validates the existing idempotent exception acknowledgement', () => {
+    const command = createDeliveryExceptionCommand({
+        operationId: 'exception-1',
+        runId: 'run-1',
+        stopId: 22,
+        expectedRouteRevision: 3,
+        occurredAt: '2026-07-15T12:00:00.000Z',
+        exceptions: [
+            {
+                stopId: 22,
+                outcome: 'deferred',
+                reason: 'customer-unavailable',
+            },
+        ],
+    });
+    assert.deepEqual(
+        deliveryActionAcknowledgement(
+            {
+                clientOperationId: 'exception-1',
+                replayed: false,
+                outcomes: [
+                    {
+                        stopId: 22,
+                        outcome: 'deferred',
+                        reason: 'customer-unavailable',
+                    },
+                ],
+                routeRevision: 4,
+                reroutePending: false,
+                runCompleted: false,
+            },
+            command,
+        ),
+        {
+            status: 'applied',
+            routeRevision: 4,
+            reroutePending: false,
+            runCompleted: false,
+        },
+    );
+    assert.deepEqual(
+        deliveryActionAcknowledgement(
+            {
+                clientOperationId: 'exception-1',
+                replayed: false,
+                outcomes: [
+                    {
+                        stopId: 999,
+                        outcome: 'failed',
+                        reason: 'address-wrong',
+                    },
+                ],
+                routeRevision: 4,
+                reroutePending: false,
+                runCompleted: false,
+            },
+            command,
+        ),
+        {
+            status: 'retryable-failure',
+            code: 'invalid-acknowledgement',
+        },
+    );
+});
+
+test('classifies transport failures without turning infrastructure errors into conflicts', () => {
+    assert.deepEqual(
+        deliveryActionHttpFailure(503, { code: 'database-down' }),
+        {
+            status: 'retryable-failure',
+            code: 'database-down',
+        },
+    );
+    assert.deepEqual(
+        deliveryActionHttpFailure(409, { code: 'route-revision-conflict' }),
+        {
+            status: 'permanent-failure',
+            code: 'route-revision-conflict',
+        },
+    );
+});

--- a/apps/delivery/lib/deliveryActionTransport.ts
+++ b/apps/delivery/lib/deliveryActionTransport.ts
@@ -1,0 +1,158 @@
+import type {
+    DeliveryActionCommand,
+    DeliveryActionTransportResult,
+    DeliveryVerificationScanCommand,
+} from './deliveryActionQueue';
+
+type ServerDeliveryActionCommand = Exclude<
+    DeliveryActionCommand,
+    DeliveryVerificationScanCommand
+>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function validRevision(value: unknown): value is number {
+    return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+function validStopId(value: unknown): value is number {
+    return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}
+
+function responseCode(value: unknown) {
+    if (
+        isRecord(value) &&
+        typeof value.code === 'string' &&
+        /^[a-z0-9-]{1,128}$/.test(value.code)
+    ) {
+        return value.code;
+    }
+    return undefined;
+}
+
+export function deliveryActionHttpFailure(
+    status: number,
+    value: unknown,
+): DeliveryActionTransportResult {
+    const code = responseCode(value);
+    return status === 408 || status === 425 || status === 429 || status >= 500
+        ? { status: 'retryable-failure', code }
+        : { status: 'permanent-failure', code };
+}
+
+export function deliveryActionAcknowledgement(
+    value: unknown,
+    command: ServerDeliveryActionCommand,
+): DeliveryActionTransportResult {
+    if (
+        !isRecord(value) ||
+        value.clientOperationId !== command.operationId ||
+        typeof value.replayed !== 'boolean'
+    ) {
+        return {
+            status: 'retryable-failure',
+            code: 'invalid-acknowledgement',
+        };
+    }
+    if (command.kind === 'exception') {
+        const outcomes = Array.isArray(value.outcomes) ? value.outcomes : null;
+        const outcomesMatch =
+            outcomes?.length === command.exceptions.length &&
+            command.exceptions.every((exception) =>
+                outcomes.some(
+                    (outcome) =>
+                        isRecord(outcome) &&
+                        outcome.stopId === exception.stopId &&
+                        outcome.outcome === exception.outcome &&
+                        outcome.reason === exception.reason,
+                ),
+            );
+        if (
+            !validRevision(value.routeRevision) ||
+            typeof value.reroutePending !== 'boolean' ||
+            typeof value.runCompleted !== 'boolean' ||
+            !outcomesMatch
+        ) {
+            return {
+                status: 'retryable-failure',
+                code: 'invalid-acknowledgement',
+            };
+        }
+        return {
+            status: value.replayed ? 'exact-duplicate' : 'applied',
+            routeRevision: value.routeRevision,
+            reroutePending: value.reroutePending,
+            runCompleted: value.runCompleted,
+        };
+    }
+    const result = value.result;
+    if (
+        !isRecord(result) ||
+        result.kind !== command.kind ||
+        result.targetStopId !== command.stopId ||
+        !Array.isArray(result.affectedStopIds) ||
+        result.affectedStopIds.length === 0 ||
+        !result.affectedStopIds.every(validStopId) ||
+        !validRevision(result.routeRevision) ||
+        typeof result.reroutePending !== 'boolean' ||
+        typeof result.runCompleted !== 'boolean'
+    ) {
+        return {
+            status: 'retryable-failure',
+            code: 'invalid-acknowledgement',
+        };
+    }
+    return {
+        status: value.replayed ? 'exact-duplicate' : 'applied',
+        routeRevision: result.routeRevision,
+        reroutePending: result.reroutePending,
+        runCompleted: result.runCompleted,
+    };
+}
+
+function endpoint(command: ServerDeliveryActionCommand) {
+    const runId = encodeURIComponent(command.runId);
+    if (command.kind === 'exception') {
+        return `/api/driver/runs/${runId}/exceptions`;
+    }
+    return `/api/driver/runs/${runId}/stops/${command.stopId}/${command.kind}`;
+}
+
+function requestBody(command: ServerDeliveryActionCommand) {
+    const common = {
+        clientOperationId: command.operationId,
+        occurredAt: command.occurredAt,
+        expectedRouteRevision: command.expectedRouteRevision,
+    };
+    if (command.kind === 'exception') {
+        return { ...common, exceptions: command.exceptions };
+    }
+    if (command.kind === 'deliver') {
+        return {
+            ...common,
+            ...(command.notes ? { notes: command.notes } : {}),
+        };
+    }
+    return common;
+}
+
+export async function sendDeliveryAction(
+    command: ServerDeliveryActionCommand,
+): Promise<DeliveryActionTransportResult> {
+    let response: Response;
+    try {
+        response = await fetch(endpoint(command), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(requestBody(command)),
+        });
+    } catch {
+        return { status: 'retryable-failure', code: 'offline' };
+    }
+    const value: unknown = await response.json().catch(() => null);
+    return response.ok
+        ? deliveryActionAcknowledgement(value, command)
+        : deliveryActionHttpFailure(response.status, value);
+}

--- a/apps/delivery/lib/deliveryActionTransport.ts
+++ b/apps/delivery/lib/deliveryActionTransport.ts
@@ -3,6 +3,7 @@ import type {
     DeliveryActionTransportResult,
     DeliveryVerificationScanCommand,
 } from './deliveryActionQueue';
+import { assertDeliveryOfflineWritesAllowed } from './deliveryOfflineEvents';
 
 type ServerDeliveryActionCommand = Exclude<
     DeliveryActionCommand,
@@ -141,6 +142,7 @@ function requestBody(command: ServerDeliveryActionCommand) {
 export async function sendDeliveryAction(
     command: ServerDeliveryActionCommand,
 ): Promise<DeliveryActionTransportResult> {
+    assertDeliveryOfflineWritesAllowed();
     let response: Response;
     try {
         response = await fetch(endpoint(command), {
@@ -152,6 +154,7 @@ export async function sendDeliveryAction(
         return { status: 'retryable-failure', code: 'offline' };
     }
     const value: unknown = await response.json().catch(() => null);
+    assertDeliveryOfflineWritesAllowed();
     return response.ok
         ? deliveryActionAcknowledgement(value, command)
         : deliveryActionHttpFailure(response.status, value);

--- a/apps/delivery/lib/deliveryDashboard.node.spec.ts
+++ b/apps/delivery/lib/deliveryDashboard.node.spec.ts
@@ -413,7 +413,7 @@ test('exception receipt replay returns current revision without rerouting a stal
             { routeRevision: 8, rerouteRequiredAt: null },
             7,
         ),
-        { routeRevision: 8, reroutePending: false },
+        { routeRevision: 8, reroutePending: false, runCompleted: false },
     );
     assert.equal(
         recordedExceptionNeedsReroute({

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -6,8 +6,8 @@ import {
     DeliveryRunManifestItemStates,
     DeliveryRunManifestStates,
     DeliveryRunStates,
+    DeliveryRunStopOperationKinds,
     DeliveryRunStopStates,
-    fulfillDeliveryRunStops,
     getActiveDeliveryRunForDriver,
     getActiveDeliveryRunStopsForRequestIds,
     getDeliveryRequest,
@@ -18,10 +18,10 @@ import {
     getUser,
     isDeliveryRunStopActionable,
     isDeliveryRunStopTerminal,
-    markDeliveryRunStopsArrived,
     type RecordDeliveryRunStopExceptionsInput,
     reassignDeliveryRun,
     recordDeliveryRunStopExceptions,
+    recordDeliveryRunStopOperation,
     recoverDeliveryRunStop,
     retryDeliveryRunStop,
     updateDeliveryRunEstimates,
@@ -1123,80 +1123,30 @@ export async function arriveAtDeliveryStop({
     runId,
     stopId,
     expectedRouteRevision,
+    clientOperationId,
+    occurredAt,
 }: {
     driverUserId: string;
     runId: string;
     stopId: number;
     expectedRouteRevision: number;
+    clientOperationId: string;
+    occurredAt: Date;
 }) {
-    const group = await getOwnedDeliveryRunStopGroup({
+    const recorded = await recordDeliveryRunStopOperation({
+        kind: DeliveryRunStopOperationKinds.ARRIVE,
         driverUserId,
         runId,
-        stopId,
-    });
-    await markDeliveryRunStopsArrived({
-        driverUserId,
-        runId,
-        stopIds: group.items.map(({ stop }) => stop.id),
+        targetStopId: stopId,
         expectedRouteRevision,
+        clientOperationId,
+        occurredAt,
     });
-    return await currentDeliveryRunMutationResult({
-        runId,
-        fallbackRouteRevision: expectedRouteRevision + 1,
-    });
-}
-
-async function getOwnedDeliveryRunStopGroup({
-    driverUserId,
-    runId,
-    stopId,
-}: {
-    driverUserId: string;
-    runId: string;
-    stopId: number;
-}) {
-    const run = await getDeliveryRun(runId);
-    if (!run || run.driverUserId !== driverUserId) {
-        throw new Error('Aktivna dostava nije pronađena.');
-    }
-    const groups = await resolveDeliveryRunStopGroups(run);
-    const targetGroup = groups.find((group) =>
-        group.items.some(({ stop }) => stop.id === stopId),
-    );
-    if (!targetGroup) {
-        throw new Error('Aktivna dostava nije pronađena.');
-    }
-    const targetIsDelivered = targetGroup.items.every(
-        ({ stop }) => stop.state === DeliveryRunStopStates.DELIVERED,
-    );
-    if (targetIsDelivered) {
-        return targetGroup;
-    }
-    if (
-        targetGroup.items.every(({ stop }) =>
-            isDeliveryRunStopTerminal(stop.state),
-        )
-    ) {
-        throw new Error('Dostava ima zabilježen završni ishod.');
-    }
-    if (run.state !== DeliveryRunStates.ACTIVE) {
-        throw new Error('Aktivna dostava nije pronađena.');
-    }
-    if (run.routePlanVersion < 2) {
-        const currentGroup = groups.find((group) =>
-            group.items.some(
-                ({ stop }) => !isDeliveryRunStopTerminal(stop.state),
-            ),
-        );
-        if (currentGroup?.executionKey !== targetGroup.executionKey) {
-            throw new Error('Dostave se moraju završiti redoslijedom rute.');
-        }
-    }
-    if (targetGroup.items.some(({ request }) => !request)) {
-        throw new Error('Dostava u ruti nije pronađena.');
-    }
-
-    return targetGroup;
+    return {
+        clientOperationId: recorded.clientOperationId,
+        replayed: recorded.replayed,
+        result: recorded.result,
+    };
 }
 
 export async function deliverDeliveryStop({
@@ -1205,37 +1155,44 @@ export async function deliverDeliveryStop({
     stopId,
     notes,
     expectedRouteRevision,
+    clientOperationId,
+    occurredAt,
 }: {
     driverUserId: string;
     runId: string;
     stopId: number;
     notes?: string;
     expectedRouteRevision: number;
+    clientOperationId: string;
+    occurredAt: Date;
 }) {
-    const group = await getOwnedDeliveryRunStopGroup({
+    const recorded = await recordDeliveryRunStopOperation({
+        kind: DeliveryRunStopOperationKinds.DELIVER,
         driverUserId,
         runId,
-        stopId,
-    });
-    const requestIds = await fulfillDeliveryRunStops({
-        driverUserId,
-        runId,
-        stopIds: group.items.map(({ stop }) => stop.id),
+        targetStopId: stopId,
         deliveryNotes: notes,
         expectedRouteRevision,
+        clientOperationId,
+        occurredAt,
     });
-    await Promise.all(
-        requestIds.map((requestId) =>
-            notifyDeliveryRequestEvent(requestId, 'updated', {
-                status: DeliveryRequestStates.FULFILLED,
-                note: notes,
-            }),
-        ),
-    );
-    return await currentDeliveryRunMutationResult({
-        runId,
-        fallbackRouteRevision: expectedRouteRevision + 1,
-    });
+    if (!recorded.replayed) {
+        // Receipts suppress replay duplicates; a post-commit crash can still
+        // lose this notification until delivery notifications use an outbox.
+        await Promise.all(
+            recorded.newlyFulfilledRequestIds.map((requestId) =>
+                notifyDeliveryRequestEvent(requestId, 'updated', {
+                    status: DeliveryRequestStates.FULFILLED,
+                    note: notes,
+                }),
+            ),
+        );
+    }
+    return {
+        clientOperationId: recorded.clientOperationId,
+        replayed: recorded.replayed,
+        result: recorded.result,
+    };
 }
 
 async function currentDeliveryRunMutationResult({

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -1208,7 +1208,11 @@ async function currentDeliveryRunMutationResult({
 
 export function deliveryMutationRouteState(
     run:
-        | { routeRevision: number; rerouteRequiredAt: Date | null }
+        | {
+              routeRevision: number;
+              rerouteRequiredAt: Date | null;
+              state?: string;
+          }
         | null
         | undefined,
     fallbackRouteRevision: number,
@@ -1216,6 +1220,7 @@ export function deliveryMutationRouteState(
     return {
         routeRevision: run?.routeRevision ?? fallbackRouteRevision,
         reroutePending: Boolean(run?.rerouteRequiredAt),
+        runCompleted: run?.state === DeliveryRunStates.COMPLETED,
     };
 }
 

--- a/apps/delivery/lib/deliveryLogout.node.spec.ts
+++ b/apps/delivery/lib/deliveryLogout.node.spec.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { executeDeliveryLogout } from './deliveryLogout';
+
+function lifecycle({
+    clearFails = false,
+    serverOk = true,
+}: {
+    clearFails?: boolean;
+    serverOk?: boolean;
+} = {}) {
+    const events: string[] = [];
+    return {
+        events,
+        lifecycle: {
+            publishStarted() {
+                events.push('started');
+                return 'logout-test';
+            },
+            async clearLocalState() {
+                events.push('cleared');
+                if (clearFails) throw new Error('cleanup failed');
+            },
+            async requestServerLogout() {
+                events.push('requested');
+                return { ok: serverOk };
+            },
+            publishCompleted() {
+                events.push('completed');
+            },
+            publishFailed() {
+                events.push('failed');
+            },
+        },
+    };
+}
+
+test('publishes logout completion only after durable local cleanup and server logout', async () => {
+    const fixture = lifecycle();
+    assert.equal(await executeDeliveryLogout(fixture.lifecycle), true);
+    assert.deepEqual(fixture.events, [
+        'started',
+        'cleared',
+        'requested',
+        'completed',
+    ]);
+});
+
+test('cleanup failure prevents server logout and publishes a retryable failure', async () => {
+    const fixture = lifecycle({ clearFails: true });
+    assert.equal(await executeDeliveryLogout(fixture.lifecycle), false);
+    assert.deepEqual(fixture.events, ['started', 'cleared', 'failed']);
+});
+
+test('server failure is published only after local data was cleared', async () => {
+    const fixture = lifecycle({ serverOk: false });
+    assert.equal(await executeDeliveryLogout(fixture.lifecycle), false);
+    assert.deepEqual(fixture.events, [
+        'started',
+        'cleared',
+        'requested',
+        'failed',
+    ]);
+});

--- a/apps/delivery/lib/deliveryLogout.node.spec.ts
+++ b/apps/delivery/lib/deliveryLogout.node.spec.ts
@@ -42,6 +42,7 @@ test('publishes logout completion only after durable local cleanup and server lo
         'started',
         'cleared',
         'requested',
+        'cleared',
         'completed',
     ]);
 });
@@ -49,7 +50,12 @@ test('publishes logout completion only after durable local cleanup and server lo
 test('cleanup failure prevents server logout and publishes a retryable failure', async () => {
     const fixture = lifecycle({ clearFails: true });
     assert.equal(await executeDeliveryLogout(fixture.lifecycle), false);
-    assert.deepEqual(fixture.events, ['started', 'cleared', 'failed']);
+    assert.deepEqual(fixture.events, [
+        'started',
+        'cleared',
+        'cleared',
+        'failed',
+    ]);
 });
 
 test('server failure is published only after local data was cleared', async () => {
@@ -59,6 +65,7 @@ test('server failure is published only after local data was cleared', async () =
         'started',
         'cleared',
         'requested',
+        'cleared',
         'failed',
     ]);
 });

--- a/apps/delivery/lib/deliveryLogout.ts
+++ b/apps/delivery/lib/deliveryLogout.ts
@@ -24,9 +24,15 @@ export async function executeDeliveryLogout(
         await lifecycle.clearLocalState();
         const response = await lifecycle.requestServerLogout();
         if (!response.ok) throw new Error('Logout failed');
+        await lifecycle.clearLocalState();
         lifecycle.publishCompleted(logoutId);
         return true;
     } catch {
+        try {
+            await lifecycle.clearLocalState();
+        } catch {
+            // The logout guard remains active so a later retry can finish.
+        }
         lifecycle.publishFailed(logoutId);
         return false;
     }

--- a/apps/delivery/lib/deliveryLogout.ts
+++ b/apps/delivery/lib/deliveryLogout.ts
@@ -1,0 +1,48 @@
+import {
+    publishDeliveryLogout,
+    publishDeliveryLogoutCompleted,
+    publishDeliveryLogoutFailed,
+} from './deliveryOfflineEvents';
+import {
+    clearDeliveryUserStoredState,
+    createBrowserDeliveryUserStoredState,
+} from './deliveryRunStoredState';
+
+export type DeliveryLogoutLifecycle = {
+    clearLocalState: () => Promise<void>;
+    requestServerLogout: () => Promise<{ ok: boolean }>;
+    publishStarted: () => string;
+    publishCompleted: (logoutId: string) => void;
+    publishFailed: (logoutId: string) => void;
+};
+
+export async function executeDeliveryLogout(
+    lifecycle: DeliveryLogoutLifecycle,
+) {
+    const logoutId = lifecycle.publishStarted();
+    try {
+        await lifecycle.clearLocalState();
+        const response = await lifecycle.requestServerLogout();
+        if (!response.ok) throw new Error('Logout failed');
+        lifecycle.publishCompleted(logoutId);
+        return true;
+    } catch {
+        lifecycle.publishFailed(logoutId);
+        return false;
+    }
+}
+
+export async function performDeliveryLogout(userId: string) {
+    return await executeDeliveryLogout({
+        clearLocalState: async () =>
+            await clearDeliveryUserStoredState(
+                createBrowserDeliveryUserStoredState(),
+                { userId },
+            ),
+        requestServerLogout: async () =>
+            await fetch('/api/logout', { method: 'POST' }),
+        publishStarted: publishDeliveryLogout,
+        publishCompleted: publishDeliveryLogoutCompleted,
+        publishFailed: publishDeliveryLogoutFailed,
+    });
+}

--- a/apps/delivery/lib/deliveryMutationRequest.node.spec.ts
+++ b/apps/delivery/lib/deliveryMutationRequest.node.spec.ts
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { DeliveryRunStopOperationKinds } from '@gredice/storage';
 import {
     DeliveryMutationRequestError,
     expectedRouteRevision,
     parseDeliveryExceptionMutation,
+    parseDeliveryStopMutation,
 } from './deliveryMutationRequest';
 
 test('requires a nonnegative integer route revision on delivery mutations', () => {
@@ -56,4 +58,79 @@ test('parses a deterministic bulk delivery exception mutation', () => {
             reason: 'harvest-damaged',
         },
     ]);
+});
+
+test('parses strict arrive and deliver stop operation payloads', () => {
+    const arrived = parseDeliveryStopMutation(
+        {
+            expectedRouteRevision: 8,
+            clientOperationId: ' arrive-1 ',
+            occurredAt: '2026-07-15T10:00:00.000Z',
+        },
+        DeliveryRunStopOperationKinds.ARRIVE,
+    );
+    assert.deepEqual(arrived, {
+        kind: DeliveryRunStopOperationKinds.ARRIVE,
+        expectedRouteRevision: 8,
+        clientOperationId: 'arrive-1',
+        occurredAt: new Date('2026-07-15T10:00:00.000Z'),
+    });
+
+    const delivered = parseDeliveryStopMutation(
+        {
+            expectedRouteRevision: 9,
+            clientOperationId: ' deliver-1 ',
+            occurredAt: '2026-07-15T10:05:00.000Z',
+            notes: '  Predano susjedu  ',
+        },
+        DeliveryRunStopOperationKinds.DELIVER,
+    );
+    assert.deepEqual(delivered, {
+        kind: DeliveryRunStopOperationKinds.DELIVER,
+        expectedRouteRevision: 9,
+        clientOperationId: 'deliver-1',
+        occurredAt: new Date('2026-07-15T10:05:00.000Z'),
+        notes: 'Predano susjedu',
+    });
+});
+
+test('rejects incomplete or unsupported stop operation payloads', () => {
+    const valid = {
+        expectedRouteRevision: 8,
+        clientOperationId: 'operation-1',
+        occurredAt: '2026-07-15T10:00:00.000Z',
+    };
+    for (const value of [
+        null,
+        { ...valid, expectedRouteRevision: undefined },
+        { ...valid, clientOperationId: '' },
+        { ...valid, clientOperationId: 'x'.repeat(129) },
+        { ...valid, occurredAt: 'not-a-date' },
+        { ...valid, extra: true },
+        { ...valid, notes: 'not allowed' },
+    ]) {
+        assert.throws(
+            () =>
+                parseDeliveryStopMutation(
+                    value,
+                    DeliveryRunStopOperationKinds.ARRIVE,
+                ),
+            DeliveryMutationRequestError,
+        );
+    }
+
+    for (const value of [
+        { ...valid, notes: 42 },
+        { ...valid, notes: 'x'.repeat(1_001) },
+        { ...valid, unexpected: 'field' },
+    ]) {
+        assert.throws(
+            () =>
+                parseDeliveryStopMutation(
+                    value,
+                    DeliveryRunStopOperationKinds.DELIVER,
+                ),
+            DeliveryMutationRequestError,
+        );
+    }
 });

--- a/apps/delivery/lib/deliveryMutationRequest.ts
+++ b/apps/delivery/lib/deliveryMutationRequest.ts
@@ -3,6 +3,8 @@ import {
     DeliveryRunExceptionOutcomes,
     type DeliveryRunExceptionReason,
     DeliveryRunExceptionReasons,
+    type DeliveryRunStopOperationKind,
+    DeliveryRunStopOperationKinds,
 } from '@gredice/storage';
 
 export class DeliveryMutationRequestError extends Error {
@@ -25,6 +27,75 @@ export function expectedRouteRevision(value: unknown) {
         );
     }
     return value.expectedRouteRevision;
+}
+
+export function parseDeliveryStopMutation(
+    value: unknown,
+    kind: DeliveryRunStopOperationKind,
+) {
+    if (!isRecord(value)) {
+        throw new DeliveryMutationRequestError('Neispravna promjena dostave.');
+    }
+    const routeRevision = expectedRouteRevision(value);
+    if (
+        typeof value.clientOperationId !== 'string' ||
+        value.clientOperationId.trim().length === 0 ||
+        value.clientOperationId.trim().length > 128
+    ) {
+        throw new DeliveryMutationRequestError(
+            'Nedostaje identifikator promjene.',
+        );
+    }
+    if (typeof value.occurredAt !== 'string') {
+        throw new DeliveryMutationRequestError('Nedostaje vrijeme promjene.');
+    }
+    const occurredAt = new Date(value.occurredAt);
+    if (!Number.isFinite(occurredAt.getTime())) {
+        throw new DeliveryMutationRequestError(
+            'Vrijeme promjene nije valjano.',
+        );
+    }
+    if (
+        kind !== DeliveryRunStopOperationKinds.ARRIVE &&
+        kind !== DeliveryRunStopOperationKinds.DELIVER
+    ) {
+        throw new DeliveryMutationRequestError('Neispravna vrsta promjene.');
+    }
+    const allowedKeys = new Set([
+        'clientOperationId',
+        'expectedRouteRevision',
+        'occurredAt',
+        ...(kind === DeliveryRunStopOperationKinds.DELIVER ? ['notes'] : []),
+    ]);
+    if (Object.keys(value).some((key) => !allowedKeys.has(key))) {
+        throw new DeliveryMutationRequestError(
+            'Promjena dostave sadrži nepodržane podatke.',
+        );
+    }
+    if (kind === DeliveryRunStopOperationKinds.ARRIVE && 'notes' in value) {
+        throw new DeliveryMutationRequestError(
+            'Napomena nije dopuštena za potvrdu dolaska.',
+        );
+    }
+    let notes: string | undefined;
+    if (kind === DeliveryRunStopOperationKinds.DELIVER && 'notes' in value) {
+        if (typeof value.notes !== 'string') {
+            throw new DeliveryMutationRequestError('Napomena nije valjana.');
+        }
+        notes = value.notes.trim() || undefined;
+        if (notes && notes.length > 1_000) {
+            throw new DeliveryMutationRequestError(
+                'Napomena smije imati najviše 1000 znakova.',
+            );
+        }
+    }
+    return {
+        kind,
+        expectedRouteRevision: routeRevision,
+        clientOperationId: value.clientOperationId.trim(),
+        occurredAt,
+        ...(notes ? { notes } : {}),
+    };
 }
 
 function exceptionOutcome(value: unknown): DeliveryRunExceptionOutcome {

--- a/apps/delivery/lib/deliveryOfflineEvents.node.spec.ts
+++ b/apps/delivery/lib/deliveryOfflineEvents.node.spec.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    assertDeliveryOfflineWritesAllowed,
+    blockDeliveryOfflineWritesForLogout,
+    deliveryOfflineWritesBlocked,
+    publishDeliverySessionResumed,
+    resetDeliveryOfflineWritesForFreshDocument,
+} from './deliveryOfflineEvents';
+
+test('session resume keeps old-document writers blocked until replacement', () => {
+    blockDeliveryOfflineWritesForLogout('logout-generation-one');
+    publishDeliverySessionResumed();
+
+    assert.equal(deliveryOfflineWritesBlocked(), true);
+    assert.throws(
+        assertDeliveryOfflineWritesAllowed,
+        /Delivery logout is in progress/,
+    );
+
+    resetDeliveryOfflineWritesForFreshDocument();
+    assert.equal(deliveryOfflineWritesBlocked(), false);
+    assert.doesNotThrow(assertDeliveryOfflineWritesAllowed);
+});
+
+test('session generation invalidates a document that missed logout signaling', () => {
+    resetDeliveryOfflineWritesForFreshDocument();
+    publishDeliverySessionResumed();
+
+    assert.equal(deliveryOfflineWritesBlocked(), true);
+    assert.throws(
+        assertDeliveryOfflineWritesAllowed,
+        /Delivery logout is in progress/,
+    );
+
+    resetDeliveryOfflineWritesForFreshDocument();
+    assert.equal(deliveryOfflineWritesBlocked(), false);
+});

--- a/apps/delivery/lib/deliveryOfflineEvents.ts
+++ b/apps/delivery/lib/deliveryOfflineEvents.ts
@@ -2,15 +2,103 @@ export const deliveryLogoutEvent = 'gredice:delivery:logout';
 export const deliveryLogoutCompletedEvent = 'gredice:delivery:logout-completed';
 export const deliveryLogoutFailedEvent = 'gredice:delivery:logout-failed';
 export const deliveryRunCompletedEvent = 'gredice:delivery:run-completed';
+export const deliverySessionResumedEvent = 'gredice:delivery:session-resumed';
 
 const deliverySessionChannelName = 'gredice:delivery:session';
 const deliveryLogoutStorageKey = 'gredice:delivery:logout-signal';
+const deliveryLogoutWriteGuardKey = 'gredice:delivery:logout-write-guard';
+const deliverySessionGenerationKey = 'gredice:delivery:session-generation';
+let activeDeliveryLogoutId: string | null = null;
+let documentDeliverySessionGeneration: string | null = null;
+let sharedDeliverySessionGeneration: string | null = null;
 
 type DeliveryLogoutSignal = {
     version: 1;
-    kind: 'logout' | 'logout-completed' | 'logout-failed';
+    kind: 'logout' | 'logout-completed' | 'logout-failed' | 'session-resumed';
     id: string;
 };
+
+function deliverySessionStorage() {
+    if (typeof window === 'undefined') return null;
+    try {
+        return window.localStorage;
+    } catch {
+        return null;
+    }
+}
+
+function deliverySessionStorageValue(key: string) {
+    try {
+        return deliverySessionStorage()?.getItem(key) ?? null;
+    } catch {
+        return null;
+    }
+}
+
+documentDeliverySessionGeneration = deliverySessionStorageValue(
+    deliverySessionGenerationKey,
+);
+sharedDeliverySessionGeneration = documentDeliverySessionGeneration;
+
+export function blockDeliveryOfflineWritesForLogout(id: string) {
+    if (!id || id.length > 256) {
+        throw new TypeError('Delivery logout guard ID is invalid');
+    }
+    activeDeliveryLogoutId = id;
+    try {
+        deliverySessionStorage()?.setItem(deliveryLogoutWriteGuardKey, id);
+    } catch {
+        // The module guard still protects this browser context.
+    }
+}
+
+export function deliveryOfflineWriteBlockReason():
+    | 'logout'
+    | 'stale-session'
+    | null {
+    const currentGeneration =
+        deliverySessionStorageValue(deliverySessionGenerationKey) ??
+        sharedDeliverySessionGeneration;
+    if (
+        currentGeneration !== null &&
+        currentGeneration !== documentDeliverySessionGeneration
+    ) {
+        return 'stale-session';
+    }
+    if (activeDeliveryLogoutId) return 'logout';
+    try {
+        const stored = deliverySessionStorage()?.getItem(
+            deliveryLogoutWriteGuardKey,
+        );
+        if (!stored) return null;
+        activeDeliveryLogoutId = stored;
+        return 'logout';
+    } catch {
+        return null;
+    }
+}
+
+export function deliveryOfflineWritesBlocked() {
+    return deliveryOfflineWriteBlockReason() !== null;
+}
+
+export function assertDeliveryOfflineWritesAllowed() {
+    if (deliveryOfflineWritesBlocked()) {
+        throw new Error('Delivery logout is in progress');
+    }
+}
+
+export function resetDeliveryOfflineWritesForFreshDocument() {
+    activeDeliveryLogoutId = null;
+    documentDeliverySessionGeneration =
+        deliverySessionStorageValue(deliverySessionGenerationKey) ??
+        sharedDeliverySessionGeneration;
+    try {
+        deliverySessionStorage()?.removeItem(deliveryLogoutWriteGuardKey);
+    } catch {
+        // An unavailable storage guard cannot contain durable delivery data.
+    }
+}
 
 function isDeliveryLogoutSignal(value: unknown): value is DeliveryLogoutSignal {
     return (
@@ -21,7 +109,8 @@ function isDeliveryLogoutSignal(value: unknown): value is DeliveryLogoutSignal {
         'kind' in value &&
         (value.kind === 'logout' ||
             value.kind === 'logout-completed' ||
-            value.kind === 'logout-failed') &&
+            value.kind === 'logout-failed' ||
+            value.kind === 'session-resumed') &&
         'id' in value &&
         typeof value.id === 'string' &&
         value.id.length > 0 &&
@@ -51,10 +140,13 @@ function localEventForSignal(kind: DeliveryLogoutSignal['kind']) {
             return deliveryLogoutCompletedEvent;
         case 'logout-failed':
             return deliveryLogoutFailedEvent;
+        case 'session-resumed':
+            return deliverySessionResumedEvent;
     }
 }
 
 function publishDeliverySessionSignal(signal: DeliveryLogoutSignal) {
+    if (typeof window === 'undefined') return;
     window.dispatchEvent(new Event(localEventForSignal(signal.kind)));
     try {
         if (typeof BroadcastChannel !== 'undefined') {
@@ -78,6 +170,7 @@ function publishDeliverySessionSignal(signal: DeliveryLogoutSignal) {
 
 export function publishDeliveryLogout() {
     const signal = logoutSignal('logout');
+    blockDeliveryOfflineWritesForLogout(signal.id);
     publishDeliverySessionSignal(signal);
     return signal.id;
 }
@@ -90,14 +183,30 @@ export function publishDeliveryLogoutFailed(id: string) {
     publishDeliverySessionSignal(logoutSignal('logout-failed', id));
 }
 
+export function publishDeliverySessionResumed() {
+    const signal = logoutSignal('session-resumed');
+    sharedDeliverySessionGeneration = signal.id;
+    try {
+        const storage = deliverySessionStorage();
+        storage?.setItem(deliverySessionGenerationKey, signal.id);
+        storage?.removeItem(deliveryLogoutWriteGuardKey);
+    } catch {
+        // The full-page login transition replaces this guarded document.
+    }
+    publishDeliverySessionSignal(signal);
+    return signal.id;
+}
+
 export function subscribeToRemoteDeliveryLogout({
     onLogout,
     onCompleted,
     onFailed,
+    onResumed,
 }: {
     onLogout: () => void;
     onCompleted: () => void;
     onFailed: () => void;
+    onResumed: () => void;
 }) {
     let lastSignalKey: string | null = null;
     const receive = (value: unknown) => {
@@ -105,9 +214,15 @@ export function subscribeToRemoteDeliveryLogout({
         const signalKey = `${value.kind}:${value.id}`;
         if (signalKey === lastSignalKey) return;
         lastSignalKey = signalKey;
-        if (value.kind === 'logout') onLogout();
-        else if (value.kind === 'logout-completed') onCompleted();
-        else onFailed();
+        if (value.kind === 'logout') {
+            blockDeliveryOfflineWritesForLogout(value.id);
+            onLogout();
+        } else if (value.kind === 'logout-completed') onCompleted();
+        else if (value.kind === 'logout-failed') onFailed();
+        else {
+            sharedDeliverySessionGeneration = value.id;
+            onResumed();
+        }
     };
     let channel: BroadcastChannel | null = null;
     try {
@@ -121,6 +236,15 @@ export function subscribeToRemoteDeliveryLogout({
     const handleChannelMessage = (event: MessageEvent<unknown>) =>
         receive(event.data);
     const handleStorage = (event: StorageEvent) => {
+        if (
+            event.key === deliverySessionGenerationKey &&
+            event.newValue &&
+            event.newValue !== documentDeliverySessionGeneration
+        ) {
+            sharedDeliverySessionGeneration = event.newValue;
+            onResumed();
+            return;
+        }
         if (event.key !== deliveryLogoutStorageKey || !event.newValue) return;
         try {
             receive(JSON.parse(event.newValue));

--- a/apps/delivery/lib/deliveryOfflineEvents.ts
+++ b/apps/delivery/lib/deliveryOfflineEvents.ts
@@ -1,0 +1,138 @@
+export const deliveryLogoutEvent = 'gredice:delivery:logout';
+export const deliveryLogoutCompletedEvent = 'gredice:delivery:logout-completed';
+export const deliveryLogoutFailedEvent = 'gredice:delivery:logout-failed';
+export const deliveryRunCompletedEvent = 'gredice:delivery:run-completed';
+
+const deliverySessionChannelName = 'gredice:delivery:session';
+const deliveryLogoutStorageKey = 'gredice:delivery:logout-signal';
+
+type DeliveryLogoutSignal = {
+    version: 1;
+    kind: 'logout' | 'logout-completed' | 'logout-failed';
+    id: string;
+};
+
+function isDeliveryLogoutSignal(value: unknown): value is DeliveryLogoutSignal {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'version' in value &&
+        value.version === 1 &&
+        'kind' in value &&
+        (value.kind === 'logout' ||
+            value.kind === 'logout-completed' ||
+            value.kind === 'logout-failed') &&
+        'id' in value &&
+        typeof value.id === 'string' &&
+        value.id.length > 0 &&
+        value.id.length <= 256
+    );
+}
+
+function logoutSignal(
+    kind: DeliveryLogoutSignal['kind'],
+    id?: string,
+): DeliveryLogoutSignal {
+    return {
+        version: 1,
+        kind,
+        id:
+            id ??
+            globalThis.crypto?.randomUUID?.() ??
+            `logout-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    };
+}
+
+function localEventForSignal(kind: DeliveryLogoutSignal['kind']) {
+    switch (kind) {
+        case 'logout':
+            return deliveryLogoutEvent;
+        case 'logout-completed':
+            return deliveryLogoutCompletedEvent;
+        case 'logout-failed':
+            return deliveryLogoutFailedEvent;
+    }
+}
+
+function publishDeliverySessionSignal(signal: DeliveryLogoutSignal) {
+    window.dispatchEvent(new Event(localEventForSignal(signal.kind)));
+    try {
+        if (typeof BroadcastChannel !== 'undefined') {
+            const channel = new BroadcastChannel(deliverySessionChannelName);
+            channel.postMessage(signal);
+            channel.close();
+        }
+    } catch {
+        // The storage signal remains available when channel creation is blocked.
+    }
+    try {
+        window.localStorage.setItem(
+            deliveryLogoutStorageKey,
+            JSON.stringify(signal),
+        );
+        window.localStorage.removeItem(deliveryLogoutStorageKey);
+    } catch {
+        // BroadcastChannel still propagates the signal when storage is blocked.
+    }
+}
+
+export function publishDeliveryLogout() {
+    const signal = logoutSignal('logout');
+    publishDeliverySessionSignal(signal);
+    return signal.id;
+}
+
+export function publishDeliveryLogoutCompleted(id: string) {
+    publishDeliverySessionSignal(logoutSignal('logout-completed', id));
+}
+
+export function publishDeliveryLogoutFailed(id: string) {
+    publishDeliverySessionSignal(logoutSignal('logout-failed', id));
+}
+
+export function subscribeToRemoteDeliveryLogout({
+    onLogout,
+    onCompleted,
+    onFailed,
+}: {
+    onLogout: () => void;
+    onCompleted: () => void;
+    onFailed: () => void;
+}) {
+    let lastSignalKey: string | null = null;
+    const receive = (value: unknown) => {
+        if (!isDeliveryLogoutSignal(value)) return;
+        const signalKey = `${value.kind}:${value.id}`;
+        if (signalKey === lastSignalKey) return;
+        lastSignalKey = signalKey;
+        if (value.kind === 'logout') onLogout();
+        else if (value.kind === 'logout-completed') onCompleted();
+        else onFailed();
+    };
+    let channel: BroadcastChannel | null = null;
+    try {
+        channel =
+            typeof BroadcastChannel === 'undefined'
+                ? null
+                : new BroadcastChannel(deliverySessionChannelName);
+    } catch {
+        // The storage event remains available when channels are blocked.
+    }
+    const handleChannelMessage = (event: MessageEvent<unknown>) =>
+        receive(event.data);
+    const handleStorage = (event: StorageEvent) => {
+        if (event.key !== deliveryLogoutStorageKey || !event.newValue) return;
+        try {
+            receive(JSON.parse(event.newValue));
+        } catch {
+            // Ignore malformed cross-tab signals.
+        }
+    };
+    channel?.addEventListener('message', handleChannelMessage);
+    window.addEventListener('storage', handleStorage);
+    return () => {
+        channel?.removeEventListener('message', handleChannelMessage);
+        channel?.close();
+        window.removeEventListener('storage', handleStorage);
+    };
+}

--- a/apps/delivery/lib/deliveryRunExecutionError.node.spec.ts
+++ b/apps/delivery/lib/deliveryRunExecutionError.node.spec.ts
@@ -13,6 +13,7 @@ test('maps typed stop operation failures to conflict responses', () => {
     for (const code of [
         DeliveryRunExecutionErrorCodes.STOP_OPERATION_CONFLICT,
         DeliveryRunExecutionErrorCodes.STOP_OPERATION_INVALID,
+        DeliveryRunExecutionErrorCodes.STOP_OPERATION_STATE_CONFLICT,
     ]) {
         const error = new DeliveryRunExecutionError(code, 'internal detail');
         const details = deliveryRunExecutionErrorDetails(error);

--- a/apps/delivery/lib/deliveryRunExecutionError.node.spec.ts
+++ b/apps/delivery/lib/deliveryRunExecutionError.node.spec.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    DeliveryRunExecutionError,
+    DeliveryRunExecutionErrorCodes,
+} from '@gredice/storage';
+import {
+    deliveryRunExecutionErrorDetails,
+    deliveryRunExecutionErrorStatus,
+} from './deliveryRunExecutionError';
+
+test('maps typed stop operation failures to conflict responses', () => {
+    for (const code of [
+        DeliveryRunExecutionErrorCodes.STOP_OPERATION_CONFLICT,
+        DeliveryRunExecutionErrorCodes.STOP_OPERATION_INVALID,
+    ]) {
+        const error = new DeliveryRunExecutionError(code, 'internal detail');
+        const details = deliveryRunExecutionErrorDetails(error);
+
+        assert.equal(details?.code, code);
+        assert.ok(details?.message);
+        assert.equal(deliveryRunExecutionErrorStatus(error), 409);
+    }
+});
+
+test('maps unknown failures to internal server errors without details', () => {
+    const error = new Error('database unavailable');
+
+    assert.equal(deliveryRunExecutionErrorDetails(error), null);
+    assert.equal(deliveryRunExecutionErrorStatus(error), 500);
+});

--- a/apps/delivery/lib/deliveryRunExecutionError.ts
+++ b/apps/delivery/lib/deliveryRunExecutionError.ts
@@ -57,6 +57,12 @@ export function deliveryRunExecutionErrorDetails(
                 message:
                     'Vrijeme ili podaci potvrde dostave nisu valjani. Osvježi rutu i pokušaj ponovno.',
             };
+        case 'stop-operation-state-conflict':
+            return {
+                code: error.code,
+                message:
+                    'Stanje dostave promijenilo se. Osvježi rutu prije nastavka.',
+            };
         default:
             return {
                 code: error.code,

--- a/apps/delivery/lib/deliveryRunExecutionError.ts
+++ b/apps/delivery/lib/deliveryRunExecutionError.ts
@@ -45,10 +45,26 @@ export function deliveryRunExecutionErrorDetails(
                 message:
                     'Stanje odabranog uroda promijenilo se. Provjeri osvježenu rutu i ponovno potvrdi odabir.',
             };
+        case 'stop-operation-conflict':
+            return {
+                code: error.code,
+                message:
+                    'Ova potvrda dostave već je korištena s drugim podacima. Osvježi rutu i pokušaj ponovno.',
+            };
+        case 'stop-operation-invalid':
+            return {
+                code: error.code,
+                message:
+                    'Vrijeme ili podaci potvrde dostave nisu valjani. Osvježi rutu i pokušaj ponovno.',
+            };
         default:
             return {
                 code: error.code,
                 message: 'Radnju nije moguće primijeniti na trenutačnu rutu.',
             };
     }
+}
+
+export function deliveryRunExecutionErrorStatus(error: unknown): 409 | 500 {
+    return error instanceof DeliveryRunExecutionError ? 409 : 500;
 }

--- a/apps/delivery/lib/deliveryRunStoredState.node.spec.ts
+++ b/apps/delivery/lib/deliveryRunStoredState.node.spec.ts
@@ -1,0 +1,208 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createMemoryDeliveryActionQueuePersistence } from './deliveryActionQueue';
+import {
+    clearDeliveryRunSupportingStores,
+    clearDeliveryUserStoredState,
+    type DeliveryRunSupportingStores,
+    finalizeDeliveryRunStoredState,
+} from './deliveryRunStoredState';
+import {
+    createMemoryOfflineRouteCachePersistence,
+    type OfflineRouteSnapshot,
+} from './offlineRouteCache';
+import { createMemoryPickupManifestQueuePersistence } from './pickupManifestQueue';
+
+const now = '2026-07-15T12:00:00.000Z';
+const scope = { userId: 'driver-cleanup', runId: 'run-completed' };
+
+function offlineSnapshot(): OfflineRouteSnapshot {
+    return {
+        version: 1,
+        scope,
+        source: {
+            routeRevision: 4,
+            refreshedAt: now,
+            reroutePending: false,
+        },
+        cachedAt: now,
+        expiresAt: '2026-07-16T12:00:00.000Z',
+        steps: [
+            {
+                kind: 'delivery',
+                id: 101,
+                itinerarySequence: 1,
+                actionState: 'current',
+                address: 'Ilica 101, Zagreb',
+                estimatedArrivalAt: null,
+                estimatedTravelSeconds: null,
+                estimatedDistanceMeters: null,
+                stopState: 'arrived',
+                statusLabel: 'Vozač je stigao',
+                slotStartAt: null,
+                slotEndAt: null,
+                arrivedAt: now,
+                deliveredAt: null,
+                retryLaneRank: null,
+                retryAttempt: 0,
+                lockedReason: null,
+                items: [
+                    {
+                        stopId: 101,
+                        requestId: 'request-cleanup',
+                        stopState: 'arrived',
+                        requestState: 'in_delivery',
+                        contactName: 'Kontakt za brisanje',
+                        phone: '+385990000000',
+                        requestNotes: 'Obriši nakon završetka',
+                        harvest: {
+                            plantName: 'Rajčica',
+                            raisedBedName: 'Gredica A',
+                            fieldName: null,
+                            tracePath: '/trag/cleanup-trace-0001',
+                        },
+                        exception: null,
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+test('completion cleanup removes exact pickup and route stores but preserves another run', async () => {
+    const pickupManifest = createMemoryPickupManifestQueuePersistence();
+    const offlineRoute = createMemoryOfflineRouteCachePersistence();
+    const otherScope = { userId: scope.userId, runId: 'run-other' };
+    await pickupManifest.save(scope, []);
+    await pickupManifest.save(otherScope, []);
+    await offlineRoute.save(offlineSnapshot());
+
+    await clearDeliveryRunSupportingStores(
+        { pickupManifest, offlineRoute },
+        scope,
+    );
+
+    assert.equal(await pickupManifest.load(scope), undefined);
+    assert.notEqual(await pickupManifest.load(otherScope), undefined);
+    assert.equal(await offlineRoute.load(scope), null);
+});
+
+test('user cleanup removes pickup, route, and action data together', async () => {
+    const pickupManifest = createMemoryPickupManifestQueuePersistence();
+    const offlineRoute = createMemoryOfflineRouteCachePersistence();
+    const deliveryActions = createMemoryDeliveryActionQueuePersistence();
+    await pickupManifest.save(scope, []);
+    await offlineRoute.save(offlineSnapshot());
+    await deliveryActions.save(scope, []);
+
+    await clearDeliveryUserStoredState(
+        { pickupManifest, offlineRoute, deliveryActions },
+        { userId: scope.userId },
+    );
+
+    assert.equal(await pickupManifest.load(scope), undefined);
+    assert.equal(await offlineRoute.load(scope), null);
+    assert.equal(await deliveryActions.load(scope), undefined);
+});
+
+test('user cleanup retains the action marker until every supporting store is cleared', async () => {
+    let actionClearCalled = false;
+    const stores = {
+        pickupManifest: createMemoryPickupManifestQueuePersistence(),
+        offlineRoute: {
+            ...createMemoryOfflineRouteCachePersistence(),
+            async clear() {
+                throw new Error('route cleanup failed');
+            },
+        },
+        deliveryActions: {
+            ...createMemoryDeliveryActionQueuePersistence(),
+            async clear() {
+                actionClearCalled = true;
+            },
+        },
+    };
+
+    await assert.rejects(
+        clearDeliveryUserStoredState(stores, { userId: scope.userId }),
+        /Durable delivery cleanup could not be confirmed/,
+    );
+    assert.equal(actionClearCalled, false);
+});
+
+test('completion marker must remain when a formerly durable store cannot confirm deletion', async () => {
+    let pickupDurability: 'durable' | 'memory' = 'durable';
+    const stores: DeliveryRunSupportingStores = {
+        pickupManifest: {
+            get durability() {
+                return pickupDurability;
+            },
+            async load() {
+                return undefined;
+            },
+            async save() {},
+            async clear() {
+                pickupDurability = 'memory';
+            },
+        },
+        offlineRoute: createMemoryOfflineRouteCachePersistence(),
+    };
+
+    await assert.rejects(
+        clearDeliveryRunSupportingStores(stores, scope),
+        /Durable delivery cleanup could not be confirmed/,
+    );
+});
+
+test('completion marker must remain when a degraded store may still have an older durable copy', async () => {
+    const stores: DeliveryRunSupportingStores = {
+        pickupManifest: {
+            durability: 'memory',
+            durableCleanupRequired: true,
+            async load() {
+                return undefined;
+            },
+            async save() {},
+            async clear() {},
+        },
+        offlineRoute: createMemoryOfflineRouteCachePersistence(),
+    };
+
+    await assert.rejects(
+        clearDeliveryRunSupportingStores(stores, scope),
+        /Durable delivery cleanup could not be confirmed/,
+    );
+});
+
+test('completion is published only after supporting data and the durable marker are cleared', async () => {
+    const events: string[] = [];
+    await finalizeDeliveryRunStoredState({
+        clearSupportingStores: async () => {
+            events.push('supporting-cleared');
+        },
+        clearActionMarker: async () => {
+            events.push('marker-cleared');
+        },
+        publishCompleted: () => events.push('published'),
+    });
+    assert.deepEqual(events, [
+        'supporting-cleared',
+        'marker-cleared',
+        'published',
+    ]);
+
+    await assert.rejects(
+        finalizeDeliveryRunStoredState({
+            clearSupportingStores: async () => {
+                throw new Error('cleanup failed');
+            },
+            clearActionMarker: async () => {
+                events.push('unexpected-marker-clear');
+            },
+            publishCompleted: () => events.push('unexpected-publish'),
+        }),
+        /cleanup failed/,
+    );
+    assert.equal(events.includes('unexpected-marker-clear'), false);
+    assert.equal(events.includes('unexpected-publish'), false);
+});

--- a/apps/delivery/lib/deliveryRunStoredState.ts
+++ b/apps/delivery/lib/deliveryRunStoredState.ts
@@ -1,0 +1,104 @@
+import {
+    createBrowserDeliveryActionQueuePersistence,
+    type DeliveryActionQueuePersistence,
+} from './deliveryActionQueue';
+import {
+    createBrowserOfflineRouteCachePersistence,
+    type OfflineRouteCachePersistence,
+} from './offlineRouteCache';
+import {
+    createWebStoragePickupManifestQueuePersistence,
+    type PickupManifestQueuePersistence,
+} from './pickupManifestQueue';
+
+export type DeliveryRunSupportingStores = {
+    pickupManifest: PickupManifestQueuePersistence;
+    offlineRoute: OfflineRouteCachePersistence;
+};
+
+export type DeliveryUserStoredState = DeliveryRunSupportingStores & {
+    deliveryActions: DeliveryActionQueuePersistence;
+};
+
+export function createBrowserDeliveryRunSupportingStores(): DeliveryRunSupportingStores {
+    return {
+        pickupManifest: createWebStoragePickupManifestQueuePersistence(
+            window.localStorage,
+        ),
+        offlineRoute: createBrowserOfflineRouteCachePersistence(),
+    };
+}
+
+export function createBrowserDeliveryUserStoredState(): DeliveryUserStoredState {
+    return {
+        ...createBrowserDeliveryRunSupportingStores(),
+        deliveryActions: createBrowserDeliveryActionQueuePersistence(),
+    };
+}
+
+async function clearStoreDurably(
+    persistence: {
+        readonly durability: 'durable' | 'memory';
+        readonly durableCleanupRequired?: boolean;
+    },
+    clear: () => Promise<void>,
+) {
+    const requiredDurability =
+        persistence.durableCleanupRequired ??
+        persistence.durability === 'durable';
+    await clear();
+    if (requiredDurability && persistence.durability !== 'durable') {
+        throw new Error('Durable delivery cleanup could not be confirmed');
+    }
+}
+
+export async function clearDeliveryRunSupportingStores(
+    stores: DeliveryRunSupportingStores,
+    scope: { userId: string; runId: string },
+) {
+    const results = await Promise.allSettled([
+        clearStoreDurably(stores.pickupManifest, async () =>
+            stores.pickupManifest.clear(scope),
+        ),
+        clearStoreDurably(stores.offlineRoute, async () =>
+            stores.offlineRoute.clear(scope),
+        ),
+    ]);
+    if (results.some((result) => result.status === 'rejected')) {
+        throw new Error('Durable delivery cleanup could not be confirmed');
+    }
+}
+
+export async function clearDeliveryUserStoredState(
+    stores: DeliveryUserStoredState,
+    scope: { userId: string; runId?: string },
+) {
+    const supportingResults = await Promise.allSettled([
+        clearStoreDurably(stores.pickupManifest, async () =>
+            stores.pickupManifest.clear(scope),
+        ),
+        clearStoreDurably(stores.offlineRoute, async () =>
+            stores.offlineRoute.clear(scope),
+        ),
+    ]);
+    if (supportingResults.some((result) => result.status === 'rejected')) {
+        throw new Error('Durable delivery cleanup could not be confirmed');
+    }
+    await clearStoreDurably(stores.deliveryActions, async () =>
+        stores.deliveryActions.clear(scope),
+    );
+}
+
+export async function finalizeDeliveryRunStoredState({
+    clearSupportingStores,
+    clearActionMarker,
+    publishCompleted,
+}: {
+    clearSupportingStores: () => Promise<void>;
+    clearActionMarker: () => Promise<void>;
+    publishCompleted: () => void;
+}) {
+    await clearSupportingStores();
+    await clearActionMarker();
+    publishCompleted();
+}

--- a/apps/delivery/lib/offlineRouteCache.node.spec.ts
+++ b/apps/delivery/lib/offlineRouteCache.node.spec.ts
@@ -6,6 +6,7 @@ import type {
     DriverDeliveryDashboard,
 } from './deliveryDashboardTypes';
 import {
+    clearOtherOfflineRouteCacheScopes,
     createBrowserOfflineRouteCachePersistence,
     createIndexedDbOfflineRouteCachePersistence,
     createMemoryOfflineRouteCachePersistence,
@@ -558,6 +559,51 @@ test('user and run scopes cannot read or clear each other', async () => {
     assert.equal(backing.has('driver-one'), false);
 });
 
+test('old-run pruning clears a stale route before preserving the active run', async () => {
+    const backing = new Map<string, unknown>();
+    const persistence = createMemoryOfflineRouteCachePersistence(backing);
+    await persistence.save(snapshot());
+
+    await clearOtherOfflineRouteCacheScopes(persistence, {
+        userId: 'driver-one',
+        activeRunId: 'run-two',
+    });
+    assert.equal(await persistence.load({ userId: 'driver-one', now }), null);
+
+    const active = snapshot(dashboard({ runId: 'run-two' }));
+    await persistence.save(active);
+    await clearOtherOfflineRouteCacheScopes(persistence, {
+        userId: 'driver-one',
+        activeRunId: 'run-two',
+    });
+    assert.deepEqual(
+        await persistence.load({ userId: 'driver-one', now }),
+        active,
+    );
+});
+
+test('old-run pruning keeps action cleanup blocked after route storage degradation', async () => {
+    const persistence = createIndexedDbOfflineRouteCachePersistence({
+        open() {
+            throw new Error('IndexedDB denied');
+        },
+    });
+    const stale = snapshot();
+    await persistence.save(stale);
+
+    await assert.rejects(
+        clearOtherOfflineRouteCacheScopes(persistence, {
+            userId: 'driver-one',
+            activeRunId: 'run-two',
+        }),
+        /Durable offline route cleanup could not be confirmed/,
+    );
+    assert.deepEqual(
+        await persistence.load({ userId: 'driver-one', now }),
+        stale,
+    );
+});
+
 test('clear uses raw scope even when TTL or version data is corrupt', async () => {
     const backing = new Map<string, unknown>();
     const persistence = createMemoryOfflineRouteCachePersistence(backing);
@@ -606,6 +652,18 @@ test('IndexedDB open failure falls back to the mirrored memory cache', async () 
     assert.equal(persistence.durability, 'durable');
     await persistence.save(result);
     assert.equal(persistence.durability, 'memory');
+    assert.deepEqual(
+        await persistence.load({
+            userId: 'driver-one',
+            runId: 'run-one',
+            now,
+        }),
+        result,
+    );
+    await assert.rejects(
+        persistence.clear({ userId: 'driver-one', runId: 'run-one' }),
+        /Durable offline route cleanup could not be confirmed/,
+    );
     assert.deepEqual(
         await persistence.load({
             userId: 'driver-one',

--- a/apps/delivery/lib/offlineRouteCache.node.spec.ts
+++ b/apps/delivery/lib/offlineRouteCache.node.spec.ts
@@ -1,0 +1,667 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type {
+    DeliveryRouteStepSummary,
+    DeliveryStopSummary,
+    DriverDeliveryDashboard,
+} from './deliveryDashboardTypes';
+import {
+    createBrowserOfflineRouteCachePersistence,
+    createIndexedDbOfflineRouteCachePersistence,
+    createMemoryOfflineRouteCachePersistence,
+    createOfflineRouteSnapshot,
+    type OfflineRouteSnapshot,
+    offlineRouteCacheTtlMs,
+    offlineRouteCacheVersion,
+    parseOfflineRouteSnapshot,
+} from './offlineRouteCache';
+
+const now = new Date('2026-07-15T12:00:00.000Z');
+
+type DeliveryStep = Extract<DeliveryRouteStepSummary, { kind: 'delivery' }>;
+type PickupStep = Extract<DeliveryRouteStepSummary, { kind: 'pickup' }>;
+
+function harvest(marker: string) {
+    return {
+        plantName: `${marker} plant`,
+        operationName: `${marker} OPERATION_NAME_PRIVATE`,
+        raisedBedName: `${marker} raised bed`,
+        fieldName: `${marker} field`,
+        tracePath: `/trag/${marker.padEnd(16, 'x')}`,
+    };
+}
+
+function deliveryStep({
+    actionState,
+    id,
+    marker,
+}: {
+    actionState: DeliveryStep['actionState'];
+    id: number;
+    marker: string;
+}): DeliveryStep {
+    const stopState = actionState === 'completed' ? 'delivered' : 'pending';
+    const stop: DeliveryStopSummary = {
+        id,
+        requestId: `${marker}-request`,
+        sequence: id,
+        stopState,
+        requestState: stopState,
+        statusLabel: actionState === 'completed' ? 'Dostavljeno' : 'U dostavi',
+        isCurrent: actionState === 'current',
+        contactName: `${marker} contact`,
+        phone: `+38599${String(id).padStart(6, '0')}`,
+        address: `${marker} door address`,
+        addressLabel: `${marker} ADDRESS_LABEL_PRIVATE`,
+        requestNotes: `${marker} essential door note`,
+        deliveryNotes: `${marker} DELIVERY_NOTES_PRIVATE`,
+        slotStartAt: '2026-07-15T12:30:00.000Z',
+        slotEndAt: '2026-07-15T13:30:00.000Z',
+        estimatedArrivalAt: '2026-07-15T12:45:00.000Z',
+        estimatedTravelSeconds: 900,
+        estimatedDistanceMeters: 4_200,
+        reroutePending: false,
+        arrivedAt: null,
+        deliveredAt:
+            actionState === 'completed' ? '2026-07-15T12:40:00.000Z' : null,
+        harvest: harvest(marker),
+        recovery: null,
+        tracking: null,
+        runId: 'run-one',
+        deliveryCount: 1,
+        deliveries: [
+            {
+                stopId: id,
+                stopState,
+                requestId: `${marker}-request`,
+                requestState: stopState,
+                contactName: `${marker} contact`,
+                phone: `+38599${String(id).padStart(6, '0')}`,
+                addressLabel: `${marker} ITEM_ADDRESS_LABEL_PRIVATE`,
+                requestNotes: `${marker} essential door note`,
+                deliveryNotes: `${marker} ITEM_DELIVERY_NOTES_PRIVATE`,
+                harvest: harvest(marker),
+                exception: {
+                    outcome: 'deferred',
+                    reason: 'customer-unavailable',
+                    note: `${marker} EXCEPTION_NOTE_PRIVATE`,
+                    occurredAt: '2026-07-15T12:35:00.000Z',
+                },
+            },
+        ],
+    };
+    return {
+        kind: 'delivery',
+        itinerarySequence: id,
+        retryLaneRank: null,
+        retryAttempt: 0,
+        actionState,
+        lockedReason:
+            actionState === 'locked' ? 'Čeka prethodnu stanicu' : null,
+        stop,
+    };
+}
+
+function pickupStep({
+    actionState = 'locked',
+    marker = 'NEXT_PICKUP',
+}: {
+    actionState?: PickupStep['actionState'];
+    marker?: string;
+} = {}): PickupStep {
+    return {
+        kind: 'pickup',
+        itinerarySequence: 3,
+        actionState,
+        pickup: {
+            id: `${marker}-node`,
+            pickupLocationId: 17,
+            sequence: 1,
+            itinerarySequence: 3,
+            name: `${marker} pickup name`,
+            address: `${marker} pickup address`,
+            estimatedArrivalAt: '2026-07-15T13:00:00.000Z',
+            estimatedTravelSeconds: 600,
+            estimatedDistanceMeters: 3_100,
+            serviceDurationSeconds: 300,
+            state: 'pending',
+            isCurrent: actionState === 'current',
+            expectedCount: 1,
+            scannedCount: 0,
+            missingLabelCount: 0,
+            notReadyCount: 0,
+            remainingCount: 1,
+            manifests: [
+                {
+                    id: `${marker}-manifest`,
+                    timeSlotId: 12,
+                    startAt: '2026-07-15T13:00:00.000Z',
+                    endAt: '2026-07-15T14:00:00.000Z',
+                    state: 'pending',
+                    confirmedAt: null,
+                    expectedCount: 1,
+                    scannedCount: 0,
+                    missingLabelCount: 0,
+                    notReadyCount: 0,
+                    remainingCount: 1,
+                    items: [
+                        {
+                            id: `${marker}-item`,
+                            stopId: 31,
+                            requestId: `${marker}-request`,
+                            stopKey: `${marker}-stop-key`,
+                            state: 'ready',
+                            resolvedAt: null,
+                            tracePath: `/trag/${marker.padEnd(16, 'x')}`,
+                            harvest: harvest(marker),
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+function dashboard({
+    runId = 'run-one',
+    userId = 'driver-one',
+}: {
+    runId?: string;
+    userId?: string;
+} = {}): DriverDeliveryDashboard {
+    const completed = deliveryStep({
+        actionState: 'completed',
+        id: 10,
+        marker: 'COMPLETED_PRIVATE',
+    });
+    const current = deliveryStep({
+        actionState: 'current',
+        id: 20,
+        marker: 'CURRENT_ESSENTIAL',
+    });
+    const completedBetween = deliveryStep({
+        actionState: 'completed',
+        id: 25,
+        marker: 'COMPLETED_BETWEEN_PRIVATE',
+    });
+    const next = pickupStep();
+    const later = deliveryStep({
+        actionState: 'locked',
+        id: 40,
+        marker: 'LATER_PRIVATE',
+    });
+    const userWithPrivateFields = {
+        id: userId,
+        displayName: 'Driver Visible',
+        role: 'driver',
+        email: 'EMAIL_PRIVATE@example.test',
+        avatarUrl: 'AVATAR_URL_PRIVATE',
+    };
+    const runWithPrivateFields = {
+        id: runId,
+        state: 'active',
+        startedAt: '2026-07-15T11:00:00.000Z',
+        completedAt: null,
+        totalDistanceMeters: 12_000,
+        totalDurationSeconds: 3_600,
+        routePlanVersion: 2,
+        routeRevision: 7,
+        reroutePending: false,
+        estimateSource: 'google' as const,
+        tracking: {
+            status: 'live' as const,
+            lastAcceptedAt: '2026-07-15T11:59:00.000Z',
+            mapAvailable: true,
+        },
+        location: {
+            latitude: 45.815_399,
+            longitude: 15.966_568,
+            accuracy: 4,
+            heading: 180,
+            speed: 8,
+            capturedAt: '2026-07-15T11:59:00.000Z',
+            acceptedAt: '2026-07-15T11:59:01.000Z',
+            gpsCanary: 'GPS_PRIVATE',
+        },
+        estimatesUpdatedAt: '2026-07-15T11:58:00.000Z',
+        mapUrl: 'https://maps.example/MAP_URL_PRIVATE',
+        deliveryCount: 4,
+        stops: [completed.stop, current.stop, later.stop],
+        routeSteps: [completed, current, completedBetween, next, later],
+    };
+    return {
+        kind: 'driver',
+        user: userWithPrivateFields,
+        activeRun: runWithPrivateFields,
+        batches: [
+            {
+                slotId: 99,
+                startAt: '2026-07-16T10:00:00.000Z',
+                endAt: '2026-07-16T11:00:00.000Z',
+                pickupLocationId: 1,
+                pickupLocationName: 'BATCH_PRIVATE',
+                pickupAddress: 'BATCH_ADDRESS_PRIVATE',
+                deliveryCount: 1,
+                stopCount: 1,
+                orders: [
+                    {
+                        requestId: 'BATCH_REQUEST_PRIVATE',
+                        stopKey: 'BATCH_STOP_PRIVATE',
+                        readyForPickup: true,
+                        pickupStatusLabel: 'Spremno',
+                        contactName: 'BATCH_CONTACT_PRIVATE',
+                        address: 'BATCH_DOOR_PRIVATE',
+                        addressLabel: 'BATCH_LABEL_PRIVATE',
+                        requestNotes: 'BATCH_NOTE_PRIVATE',
+                        harvest: harvest('BATCH_PRIVATE'),
+                    },
+                ],
+            },
+        ],
+        maximumRouteStops: 10,
+        maximumRouteWindowHours: 12,
+        refreshedAt: '2026-07-15T12:00:00.000Z',
+    };
+}
+
+function snapshot(input = dashboard()) {
+    const result = createOfflineRouteSnapshot({
+        authenticatedUserId: input.user.id,
+        dashboard: input,
+        now,
+    });
+    assert.ok(result);
+    return result;
+}
+
+function jsonRecord(value: unknown): Record<string, unknown> {
+    const parsed: unknown = JSON.parse(JSON.stringify(value));
+    assert.ok(isRecord(parsed));
+    return parsed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function record(value: unknown): Record<string, unknown> {
+    assert.ok(isRecord(value));
+    return value;
+}
+
+function firstStep(value: Record<string, unknown>) {
+    assert.ok(Array.isArray(value.steps));
+    return record(value.steps[0]);
+}
+
+test('projects only the current and immediate next non-completed route steps', () => {
+    const result = snapshot();
+
+    assert.deepEqual(
+        result.steps.map((step) => [step.kind, step.actionState]),
+        [
+            ['delivery', 'current'],
+            ['pickup', 'locked'],
+        ],
+    );
+    assert.equal(result.scope.userId, 'driver-one');
+    assert.equal(result.scope.runId, 'run-one');
+    assert.equal(result.source.routeRevision, 7);
+    assert.equal(
+        Date.parse(result.expiresAt) - Date.parse(result.cachedAt),
+        offlineRouteCacheTtlMs,
+    );
+
+    const current = result.steps[0];
+    assert.equal(current?.kind, 'delivery');
+    if (current?.kind === 'delivery') {
+        assert.equal(current.address, 'CURRENT_ESSENTIAL door address');
+        assert.equal(
+            current.items[0]?.contactName,
+            'CURRENT_ESSENTIAL contact',
+        );
+        assert.equal(
+            current.items[0]?.requestNotes,
+            'CURRENT_ESSENTIAL essential door note',
+        );
+    }
+    const next = result.steps[1];
+    assert.equal(next?.kind, 'pickup');
+    if (next?.kind === 'pickup') {
+        assert.equal(next.name, 'NEXT_PICKUP pickup name');
+        assert.equal(next.address, 'NEXT_PICKUP pickup address');
+        assert.equal(next.items[0]?.manifestId, 'NEXT_PICKUP-manifest');
+    }
+});
+
+test('serialized projection is an allowlist and excludes privacy canaries', () => {
+    const serialized = JSON.stringify(snapshot());
+    const excludedValues = [
+        'EMAIL_PRIVATE',
+        'AVATAR_URL_PRIVATE',
+        'GPS_PRIVATE',
+        'MAP_URL_PRIVATE',
+        'COMPLETED_PRIVATE',
+        'COMPLETED_BETWEEN_PRIVATE',
+        'LATER_PRIVATE',
+        'DELIVERY_NOTES_PRIVATE',
+        'EXCEPTION_NOTE_PRIVATE',
+        'OPERATION_NAME_PRIVATE',
+        'ADDRESS_LABEL_PRIVATE',
+        'BATCH_PRIVATE',
+    ];
+    for (const canary of excludedValues) {
+        assert.equal(serialized.includes(canary), false, canary);
+    }
+    for (const forbiddenKey of [
+        'email',
+        'avatarUrl',
+        'location',
+        'latitude',
+        'longitude',
+        'tracking',
+        'mapUrl',
+        'batches',
+        'deliveryNotes',
+        'operationName',
+        'addressLabel',
+    ]) {
+        assert.equal(serialized.includes(`"${forbiddenKey}"`), false);
+    }
+    assert.match(serialized, /CURRENT_ESSENTIAL/);
+    assert.match(serialized, /NEXT_PICKUP/);
+});
+
+test('parser validates every cached nullable time as a timestamp', () => {
+    for (const key of [
+        'estimatedArrivalAt',
+        'slotStartAt',
+        'slotEndAt',
+        'arrivedAt',
+        'deliveredAt',
+    ]) {
+        const raw = jsonRecord(snapshot());
+        firstStep(raw)[key] = 'not-a-timestamp';
+        assert.equal(
+            parseOfflineRouteSnapshot(raw, {
+                userId: 'driver-one',
+                runId: 'run-one',
+                now,
+            }),
+            null,
+            key,
+        );
+    }
+
+    const nullable = jsonRecord(snapshot());
+    const step = firstStep(nullable);
+    for (const key of [
+        'estimatedArrivalAt',
+        'slotStartAt',
+        'slotEndAt',
+        'arrivedAt',
+        'deliveredAt',
+    ]) {
+        step[key] = null;
+    }
+    assert.ok(
+        parseOfflineRouteSnapshot(nullable, {
+            userId: 'driver-one',
+            runId: 'run-one',
+            now,
+        }),
+    );
+
+    const invalidExceptionTime = jsonRecord(snapshot());
+    const delivery = firstStep(invalidExceptionTime);
+    assert.ok(Array.isArray(delivery.items));
+    const item = record(delivery.items[0]);
+    const exception = record(item.exception);
+    exception.occurredAt = 'tomorrow-ish';
+    assert.equal(
+        parseOfflineRouteSnapshot(invalidExceptionTime, {
+            userId: 'driver-one',
+            runId: 'run-one',
+            now,
+        }),
+        null,
+    );
+});
+
+test('parser enforces positive bounded lifetime and expiry', () => {
+    const result = snapshot();
+    assert.ok(
+        parseOfflineRouteSnapshot(result, {
+            userId: 'driver-one',
+            runId: 'run-one',
+            now,
+        }),
+    );
+
+    const nonPositive = jsonRecord(result);
+    nonPositive.expiresAt = result.cachedAt;
+    assert.equal(
+        parseOfflineRouteSnapshot(nonPositive, {
+            userId: 'driver-one',
+            now,
+        }),
+        null,
+    );
+
+    const tooLong = jsonRecord(result);
+    tooLong.expiresAt = new Date(
+        Date.parse(result.cachedAt) + offlineRouteCacheTtlMs + 1,
+    ).toISOString();
+    assert.equal(
+        parseOfflineRouteSnapshot(tooLong, {
+            userId: 'driver-one',
+            now,
+        }),
+        null,
+    );
+
+    assert.equal(
+        parseOfflineRouteSnapshot(result, {
+            userId: 'driver-one',
+            now: new Date(result.expiresAt),
+        }),
+        null,
+    );
+});
+
+test('memory persistence survives recreation with shared backing and clones values', async () => {
+    const backing = new Map<string, unknown>();
+    const first = createMemoryOfflineRouteCachePersistence(backing);
+    const result = snapshot();
+    await first.save(result);
+
+    const loaded = await first.load({
+        userId: 'driver-one',
+        runId: 'run-one',
+        now,
+    });
+    assert.ok(loaded);
+    loaded.steps[0] = { ...loaded.steps[0], address: 'mutated in caller' };
+
+    const recreated = createMemoryOfflineRouteCachePersistence(backing);
+    const restored = await recreated.load({
+        userId: 'driver-one',
+        runId: 'run-one',
+        now,
+    });
+    assert.equal(restored?.steps[0]?.address, 'CURRENT_ESSENTIAL door address');
+});
+
+test('load purges expired, versioned, malformed, and extra-field records', async () => {
+    const backing = new Map<string, unknown>();
+    const persistence = createMemoryOfflineRouteCachePersistence(backing);
+    const result = snapshot();
+
+    await persistence.save(result);
+    assert.equal(
+        await persistence.load({
+            userId: 'driver-one',
+            now: new Date(result.expiresAt),
+        }),
+        null,
+    );
+    assert.equal(backing.has('driver-one'), false);
+
+    const wrongVersion = jsonRecord(result);
+    wrongVersion.version = offlineRouteCacheVersion + 1;
+    backing.set('driver-one', wrongVersion);
+    assert.equal(await persistence.load({ userId: 'driver-one', now }), null);
+    assert.equal(backing.has('driver-one'), false);
+
+    const malformed = jsonRecord(result);
+    malformed.cachedAt = 'invalid';
+    backing.set('driver-one', malformed);
+    assert.equal(await persistence.load({ userId: 'driver-one', now }), null);
+    assert.equal(backing.has('driver-one'), false);
+
+    const extraPrivateField = jsonRecord(result);
+    extraPrivateField.email = 'must-not-survive@example.test';
+    backing.set('driver-one', extraPrivateField);
+    assert.equal(await persistence.load({ userId: 'driver-one', now }), null);
+    assert.equal(backing.has('driver-one'), false);
+});
+
+test('user and run scopes cannot read or clear each other', async () => {
+    const backing = new Map<string, unknown>();
+    const persistence = createMemoryOfflineRouteCachePersistence(backing);
+    const runOne = snapshot();
+    await persistence.save(runOne);
+
+    assert.equal(await persistence.load({ userId: 'driver-two', now }), null);
+    assert.equal(backing.has('driver-one'), true);
+    assert.equal(
+        await persistence.load({
+            userId: 'driver-one',
+            runId: 'run-two',
+            now,
+        }),
+        null,
+    );
+    assert.equal(backing.has('driver-one'), true);
+
+    const runTwo = snapshot(dashboard({ runId: 'run-two' }));
+    await persistence.save(runTwo);
+    await persistence.clear({ userId: 'driver-one', runId: 'run-one' });
+    assert.ok(
+        await persistence.load({
+            userId: 'driver-one',
+            runId: 'run-two',
+            now,
+        }),
+    );
+    await persistence.clear({ userId: 'driver-one', runId: 'run-two' });
+    assert.equal(backing.has('driver-one'), false);
+});
+
+test('clear uses raw scope even when TTL or version data is corrupt', async () => {
+    const backing = new Map<string, unknown>();
+    const persistence = createMemoryOfflineRouteCachePersistence(backing);
+    backing.set('driver-one', {
+        version: 999,
+        scope: { userId: 'driver-one', runId: 'run-one' },
+        cachedAt: 'corrupt',
+        expiresAt: 'corrupt',
+    });
+
+    await persistence.clear({ userId: 'driver-one', runId: 'run-two' });
+    assert.equal(backing.has('driver-one'), true);
+    await persistence.clear({ userId: 'driver-one', runId: 'run-one' });
+    assert.equal(backing.has('driver-one'), false);
+
+    backing.set('driver-one', { entirely: 'corrupt' });
+    await persistence.clear({ userId: 'driver-one' });
+    assert.equal(backing.has('driver-one'), false);
+
+    backing.set('driver-one', { entirely: 'corrupt-again' });
+    await persistence.clearUser('driver-one');
+    assert.equal(backing.has('driver-one'), false);
+});
+
+test('invalid snapshots are rejected on save', async () => {
+    const persistence = createMemoryOfflineRouteCachePersistence();
+    const result = snapshot();
+    const invalid: OfflineRouteSnapshot = {
+        ...result,
+        expiresAt: result.cachedAt,
+    };
+    await assert.rejects(
+        persistence.save(invalid),
+        /Offline route snapshot is invalid/,
+    );
+});
+
+test('IndexedDB open failure falls back to the mirrored memory cache', async () => {
+    const persistence = createIndexedDbOfflineRouteCachePersistence({
+        open() {
+            throw new Error('IndexedDB denied');
+        },
+    });
+    const result = snapshot();
+
+    assert.equal(persistence.durability, 'durable');
+    await persistence.save(result);
+    assert.equal(persistence.durability, 'memory');
+    assert.deepEqual(
+        await persistence.load({
+            userId: 'driver-one',
+            runId: 'run-one',
+            now,
+        }),
+        result,
+    );
+});
+
+test('browser factory is a memory cache when IndexedDB is unavailable', () => {
+    const persistence = createBrowserOfflineRouteCachePersistence();
+    assert.equal(persistence.durability, 'memory');
+});
+
+test('projection declines inactive shapes without a current step', () => {
+    const withoutRun = dashboard();
+    withoutRun.activeRun = null;
+    assert.equal(
+        createOfflineRouteSnapshot({
+            authenticatedUserId: 'driver-one',
+            dashboard: withoutRun,
+            now,
+        }),
+        null,
+    );
+
+    const withoutCurrent = dashboard();
+    assert.ok(withoutCurrent.activeRun);
+    withoutCurrent.activeRun.routeSteps =
+        withoutCurrent.activeRun.routeSteps.map((step) => ({
+            ...step,
+            actionState: 'completed',
+        }));
+    assert.equal(
+        createOfflineRouteSnapshot({
+            authenticatedUserId: 'driver-one',
+            dashboard: withoutCurrent,
+            now,
+        }),
+        null,
+    );
+    assert.equal(
+        createOfflineRouteSnapshot({
+            authenticatedUserId: 'driver-one',
+            dashboard: dashboard(),
+            now: new Date('invalid'),
+        }),
+        null,
+    );
+    assert.equal(
+        createOfflineRouteSnapshot({
+            authenticatedUserId: 'another-driver',
+            dashboard: dashboard(),
+            now,
+        }),
+        null,
+    );
+});

--- a/apps/delivery/lib/offlineRouteCache.ts
+++ b/apps/delivery/lib/offlineRouteCache.ts
@@ -4,6 +4,7 @@ import type {
     DeliveryStopSummary,
     DriverDeliveryDashboard,
 } from './deliveryDashboardTypes';
+import { assertDeliveryOfflineWritesAllowed } from './deliveryOfflineEvents';
 
 export const offlineRouteCacheVersion = 1;
 export const offlineRouteCacheTtlMs = 24 * 60 * 60 * 1_000;
@@ -718,6 +719,7 @@ export function createMemoryOfflineRouteCachePersistence(
             return parsed ? cloneSnapshot(parsed) : null;
         },
         async save(snapshot) {
+            assertDeliveryOfflineWritesAllowed();
             const parsed = parseOfflineRouteSnapshot(snapshot, {
                 userId: snapshot.scope.userId,
                 runId: snapshot.scope.runId,
@@ -900,6 +902,7 @@ export function createIndexedDbOfflineRouteCachePersistence(
                     }
                     await memory.save(parsed);
                     const db = await database();
+                    assertDeliveryOfflineWritesAllowed();
                     const transaction = db.transaction(
                         offlineRouteStoreName,
                         'readwrite',

--- a/apps/delivery/lib/offlineRouteCache.ts
+++ b/apps/delivery/lib/offlineRouteCache.ts
@@ -111,6 +111,7 @@ export type OfflineRouteCacheDurability = 'durable' | 'memory';
 
 export type OfflineRouteCachePersistence = {
     readonly durability: OfflineRouteCacheDurability;
+    readonly durableCleanupRequired?: boolean;
     load: (scope: {
         userId: string;
         runId?: string;
@@ -699,6 +700,7 @@ export function createMemoryOfflineRouteCachePersistence(
 ): OfflineRouteCachePersistence {
     return {
         durability: 'memory',
+        durableCleanupRequired: false,
         async load({ userId, runId, now }) {
             const stored = snapshots.get(userId);
             if (stored === undefined) return null;
@@ -823,6 +825,15 @@ export function createIndexedDbOfflineRouteCachePersistence(
         databasePromise ??= openOfflineRouteDatabase(factory);
         return databasePromise;
     };
+    const markDurableStoreUnavailable = () => {
+        durable = false;
+        if (databasePromise) {
+            void databasePromise
+                .then((openDatabase) => openDatabase.close())
+                .catch(() => undefined);
+        }
+        databasePromise = null;
+    };
     const withFallback = async <Result>(
         durableTask: () => Promise<Result>,
         fallbackTask: () => Promise<Result>,
@@ -831,13 +842,7 @@ export function createIndexedDbOfflineRouteCachePersistence(
         try {
             return await durableTask();
         } catch {
-            durable = false;
-            if (databasePromise) {
-                void databasePromise
-                    .then((openDatabase) => openDatabase.close())
-                    .catch(() => undefined);
-            }
-            databasePromise = null;
+            markDurableStoreUnavailable();
             return await fallbackTask();
         }
     };
@@ -845,6 +850,7 @@ export function createIndexedDbOfflineRouteCachePersistence(
         get durability() {
             return durable ? 'durable' : 'memory';
         },
+        durableCleanupRequired: true,
         async load({ userId, runId, now }) {
             return await withFallback(
                 async () => {
@@ -910,52 +916,54 @@ export function createIndexedDbOfflineRouteCachePersistence(
             );
         },
         async clear({ userId, runId }) {
-            await withFallback(
-                async () => {
-                    const db = await database();
-                    const transaction = db.transaction(
-                        offlineRouteStoreName,
-                        'readwrite',
-                    );
-                    const completed = transactionCompleted(transaction);
-                    const store = transaction.objectStore(
-                        offlineRouteStoreName,
-                    );
-                    if (!runId) {
+            try {
+                const db = await database();
+                const transaction = db.transaction(
+                    offlineRouteStoreName,
+                    'readwrite',
+                );
+                const completed = transactionCompleted(transaction);
+                const store = transaction.objectStore(offlineRouteStoreName);
+                if (!runId) {
+                    await requestResult(store.delete(userId));
+                } else {
+                    const raw: unknown = await requestResult(store.get(userId));
+                    if (rawScopeMatches(raw, { userId, runId })) {
                         await requestResult(store.delete(userId));
-                    } else {
-                        const raw: unknown = await requestResult(
-                            store.get(userId),
-                        );
-                        if (rawScopeMatches(raw, { userId, runId })) {
-                            await requestResult(store.delete(userId));
-                        }
                     }
-                    await completed;
-                    await memory.clear({ userId, runId });
-                },
-                async () => await memory.clear({ userId, runId }),
-            );
+                }
+                await completed;
+                await memory.clear({ userId, runId });
+                durable = true;
+            } catch {
+                markDurableStoreUnavailable();
+                throw new Error(
+                    'Durable offline route cleanup could not be confirmed',
+                );
+            }
         },
         async clearUser(userId) {
-            await withFallback(
-                async () => {
-                    const db = await database();
-                    const transaction = db.transaction(
-                        offlineRouteStoreName,
-                        'readwrite',
-                    );
-                    const completed = transactionCompleted(transaction);
-                    await requestResult(
-                        transaction
-                            .objectStore(offlineRouteStoreName)
-                            .delete(userId),
-                    );
-                    await completed;
-                    await memory.clearUser(userId);
-                },
-                async () => await memory.clearUser(userId),
-            );
+            try {
+                const db = await database();
+                const transaction = db.transaction(
+                    offlineRouteStoreName,
+                    'readwrite',
+                );
+                const completed = transactionCompleted(transaction);
+                await requestResult(
+                    transaction
+                        .objectStore(offlineRouteStoreName)
+                        .delete(userId),
+                );
+                await completed;
+                await memory.clearUser(userId);
+                durable = true;
+            } catch {
+                markDurableStoreUnavailable();
+                throw new Error(
+                    'Durable offline route cleanup could not be confirmed',
+                );
+            }
         },
     };
 }
@@ -966,6 +974,44 @@ export function createBrowserOfflineRouteCachePersistence(): OfflineRouteCachePe
             ? createMemoryOfflineRouteCachePersistence()
             : createIndexedDbOfflineRouteCachePersistence(indexedDB);
     } catch {
-        return createMemoryOfflineRouteCachePersistence();
+        const memory = createMemoryOfflineRouteCachePersistence();
+        return {
+            ...memory,
+            durableCleanupRequired: true,
+            async clear() {
+                throw new Error(
+                    'Durable offline route cleanup could not be confirmed',
+                );
+            },
+            async clearUser() {
+                throw new Error(
+                    'Durable offline route cleanup could not be confirmed',
+                );
+            },
+        };
+    }
+}
+
+export async function clearOtherOfflineRouteCacheScopes(
+    persistence: OfflineRouteCachePersistence,
+    scope: { userId: string; activeRunId: string },
+) {
+    const stored = await persistence.load({ userId: scope.userId });
+    if (
+        persistence.durableCleanupRequired &&
+        persistence.durability !== 'durable'
+    ) {
+        throw new Error('Durable offline route cleanup could not be confirmed');
+    }
+    if (!stored || stored.scope.runId === scope.activeRunId) return;
+    await persistence.clear({
+        userId: scope.userId,
+        runId: stored.scope.runId,
+    });
+    if (
+        persistence.durableCleanupRequired &&
+        persistence.durability !== 'durable'
+    ) {
+        throw new Error('Durable offline route cleanup could not be confirmed');
     }
 }

--- a/apps/delivery/lib/offlineRouteCache.ts
+++ b/apps/delivery/lib/offlineRouteCache.ts
@@ -1,0 +1,971 @@
+import type {
+    DeliveryPickupStepSummary,
+    DeliveryRouteStepSummary,
+    DeliveryStopSummary,
+    DriverDeliveryDashboard,
+} from './deliveryDashboardTypes';
+
+export const offlineRouteCacheVersion = 1;
+export const offlineRouteCacheTtlMs = 24 * 60 * 60 * 1_000;
+
+type OfflineRouteActionState = 'locked' | 'upcoming' | 'current';
+
+function projectActionState(
+    actionState: DeliveryRouteStepSummary['actionState'],
+): OfflineRouteActionState {
+    if (actionState === 'completed') {
+        throw new TypeError('Completed route steps cannot be cached');
+    }
+    return actionState;
+}
+
+export type OfflineRouteHarvest = {
+    plantName: string;
+    raisedBedName: string | null;
+    fieldName: string | null;
+    tracePath: string | null;
+};
+
+export type OfflineRoutePickupItem = {
+    manifestId: string;
+    stopId: number;
+    requestId: string;
+    state: 'ready' | 'scanned' | 'missing-label' | 'not-ready';
+    harvest: OfflineRouteHarvest;
+};
+
+export type OfflineRouteDeliveryItem = {
+    stopId: number;
+    requestId: string;
+    stopState: string | null;
+    requestState: string;
+    contactName: string;
+    phone: string | null;
+    requestNotes: string | null;
+    harvest: OfflineRouteHarvest;
+    exception: {
+        outcome: string;
+        reason: string;
+        occurredAt: string;
+    } | null;
+};
+
+type OfflineRouteStepBase = {
+    itinerarySequence: number;
+    actionState: OfflineRouteActionState;
+    address: string;
+    estimatedArrivalAt: string | null;
+    estimatedTravelSeconds: number | null;
+    estimatedDistanceMeters: number | null;
+};
+
+export type OfflineRoutePickupStep = OfflineRouteStepBase & {
+    kind: 'pickup';
+    id: string;
+    name: string;
+    state: 'pending' | 'partial' | 'confirmed';
+    expectedCount: number;
+    scannedCount: number;
+    missingLabelCount: number;
+    notReadyCount: number;
+    remainingCount: number;
+    items: OfflineRoutePickupItem[];
+};
+
+export type OfflineRouteDeliveryStep = OfflineRouteStepBase & {
+    kind: 'delivery';
+    id: number | null;
+    stopState: string | null;
+    statusLabel: string;
+    slotStartAt: string | null;
+    slotEndAt: string | null;
+    arrivedAt: string | null;
+    deliveredAt: string | null;
+    retryLaneRank: number | null;
+    retryAttempt: number;
+    lockedReason: string | null;
+    items: OfflineRouteDeliveryItem[];
+};
+
+export type OfflineRouteStep =
+    | OfflineRoutePickupStep
+    | OfflineRouteDeliveryStep;
+
+export type OfflineRouteSnapshot = {
+    version: typeof offlineRouteCacheVersion;
+    scope: {
+        userId: string;
+        runId: string;
+    };
+    source: {
+        routeRevision: number;
+        refreshedAt: string;
+        reroutePending: boolean;
+    };
+    cachedAt: string;
+    expiresAt: string;
+    steps: OfflineRouteStep[];
+};
+
+export type OfflineRouteCacheDurability = 'durable' | 'memory';
+
+export type OfflineRouteCachePersistence = {
+    readonly durability: OfflineRouteCacheDurability;
+    load: (scope: {
+        userId: string;
+        runId?: string;
+        now?: Date;
+    }) => Promise<OfflineRouteSnapshot | null>;
+    save: (snapshot: OfflineRouteSnapshot) => Promise<void>;
+    clear: (scope: { userId: string; runId?: string }) => Promise<void>;
+    clearUser: (userId: string) => Promise<void>;
+};
+
+function projectHarvest({
+    plantName,
+    raisedBedName,
+    fieldName,
+    tracePath,
+}: {
+    plantName: string;
+    raisedBedName: string | null;
+    fieldName: string | null;
+    tracePath: string | null;
+}): OfflineRouteHarvest {
+    return { plantName, raisedBedName, fieldName, tracePath };
+}
+
+function projectPickupStep(
+    step: Extract<DeliveryRouteStepSummary, { kind: 'pickup' }>,
+): OfflineRoutePickupStep {
+    const pickup: DeliveryPickupStepSummary = step.pickup;
+    return {
+        kind: 'pickup',
+        id: pickup.id,
+        itinerarySequence: step.itinerarySequence,
+        actionState: projectActionState(step.actionState),
+        name: pickup.name,
+        address: pickup.address,
+        estimatedArrivalAt: pickup.estimatedArrivalAt,
+        estimatedTravelSeconds: pickup.estimatedTravelSeconds,
+        estimatedDistanceMeters: pickup.estimatedDistanceMeters,
+        state: pickup.state,
+        expectedCount: pickup.expectedCount,
+        scannedCount: pickup.scannedCount,
+        missingLabelCount: pickup.missingLabelCount,
+        notReadyCount: pickup.notReadyCount,
+        remainingCount: pickup.remainingCount,
+        items: pickup.manifests.flatMap((manifest) =>
+            manifest.items.map((item) => ({
+                manifestId: manifest.id,
+                stopId: item.stopId,
+                requestId: item.requestId,
+                state: item.state,
+                harvest: projectHarvest(item.harvest),
+            })),
+        ),
+    };
+}
+
+function projectDeliveryStep(
+    step: Extract<DeliveryRouteStepSummary, { kind: 'delivery' }>,
+): OfflineRouteDeliveryStep {
+    const stop: DeliveryStopSummary = step.stop;
+    return {
+        kind: 'delivery',
+        id: stop.id,
+        itinerarySequence: step.itinerarySequence,
+        actionState: projectActionState(step.actionState),
+        address: stop.address,
+        estimatedArrivalAt: stop.estimatedArrivalAt,
+        estimatedTravelSeconds: stop.estimatedTravelSeconds,
+        estimatedDistanceMeters: stop.estimatedDistanceMeters,
+        stopState: stop.stopState,
+        statusLabel: stop.statusLabel,
+        slotStartAt: stop.slotStartAt,
+        slotEndAt: stop.slotEndAt,
+        arrivedAt: stop.arrivedAt,
+        deliveredAt: stop.deliveredAt,
+        retryLaneRank: step.retryLaneRank,
+        retryAttempt: step.retryAttempt,
+        lockedReason: step.lockedReason,
+        items: stop.deliveries.flatMap((delivery) =>
+            delivery.stopId === null
+                ? []
+                : [
+                      {
+                          stopId: delivery.stopId,
+                          requestId: delivery.requestId,
+                          stopState: delivery.stopState,
+                          requestState: delivery.requestState,
+                          contactName: delivery.contactName,
+                          phone: delivery.phone,
+                          requestNotes: delivery.requestNotes,
+                          harvest: projectHarvest(delivery.harvest),
+                          exception: delivery.exception
+                              ? {
+                                    outcome: delivery.exception.outcome,
+                                    reason: delivery.exception.reason,
+                                    occurredAt: delivery.exception.occurredAt,
+                                }
+                              : null,
+                      },
+                  ],
+        ),
+    };
+}
+
+function projectRouteStep(step: DeliveryRouteStepSummary): OfflineRouteStep {
+    return step.kind === 'pickup'
+        ? projectPickupStep(step)
+        : projectDeliveryStep(step);
+}
+
+export function createOfflineRouteSnapshot({
+    authenticatedUserId,
+    dashboard,
+    now = new Date(),
+}: {
+    authenticatedUserId: string;
+    dashboard: DriverDeliveryDashboard;
+    now?: Date;
+}): OfflineRouteSnapshot | null {
+    const run = dashboard.activeRun;
+    if (
+        !validIdentifier(authenticatedUserId) ||
+        dashboard.user.id !== authenticatedUserId ||
+        !run ||
+        !Number.isFinite(now.getTime())
+    ) {
+        return null;
+    }
+    const currentIndex = run.routeSteps.findIndex(
+        (step) => step.actionState === 'current',
+    );
+    if (currentIndex < 0) return null;
+    const current = run.routeSteps[currentIndex];
+    if (!current) return null;
+    const next = run.routeSteps
+        .slice(currentIndex + 1)
+        .find((step) => step.actionState !== 'completed');
+    const cachedAt = now.toISOString();
+    return {
+        version: offlineRouteCacheVersion,
+        scope: { userId: authenticatedUserId, runId: run.id },
+        source: {
+            routeRevision: run.routeRevision,
+            refreshedAt: dashboard.refreshedAt,
+            reroutePending: run.reroutePending,
+        },
+        cachedAt,
+        expiresAt: new Date(
+            now.getTime() + offlineRouteCacheTtlMs,
+        ).toISOString(),
+        steps: [current, ...(next ? [next] : [])].map(projectRouteStep),
+    };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function hasOnlyKeys(
+    value: Record<string, unknown>,
+    allowedKeys: readonly string[],
+) {
+    const allowed = new Set(allowedKeys);
+    return Object.keys(value).every((key) => allowed.has(key));
+}
+
+function validIdentifier(value: unknown): value is string {
+    return (
+        typeof value === 'string' &&
+        value.trim() === value &&
+        value.length > 0 &&
+        value.length <= 256
+    );
+}
+
+function validString(value: unknown): value is string {
+    return typeof value === 'string' && value.length <= 2_000;
+}
+
+function nullableString(value: unknown): value is string | null {
+    return value === null || validString(value);
+}
+
+function validDateString(value: unknown): value is string {
+    return typeof value === 'string' && Number.isFinite(Date.parse(value));
+}
+
+function nullableDateString(value: unknown): value is string | null {
+    return value === null || validDateString(value);
+}
+
+function validNonNegativeInteger(value: unknown): value is number {
+    return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+function nullableNonNegativeNumber(value: unknown): value is number | null {
+    return (
+        value === null ||
+        (typeof value === 'number' && Number.isFinite(value) && value >= 0)
+    );
+}
+
+function parseHarvest(value: unknown): OfflineRouteHarvest | null {
+    if (
+        !isRecord(value) ||
+        !hasOnlyKeys(value, [
+            'plantName',
+            'raisedBedName',
+            'fieldName',
+            'tracePath',
+        ]) ||
+        !validString(value.plantName) ||
+        !nullableString(value.raisedBedName) ||
+        !nullableString(value.fieldName) ||
+        !nullableString(value.tracePath)
+    ) {
+        return null;
+    }
+    return {
+        plantName: value.plantName,
+        raisedBedName: value.raisedBedName,
+        fieldName: value.fieldName,
+        tracePath: value.tracePath,
+    };
+}
+
+function parseActionState(value: unknown): OfflineRouteActionState | null {
+    return value === 'locked' || value === 'upcoming' || value === 'current'
+        ? value
+        : null;
+}
+
+function parseCommonStep(value: Record<string, unknown>) {
+    const actionState = parseActionState(value.actionState);
+    if (
+        !validNonNegativeInteger(value.itinerarySequence) ||
+        !actionState ||
+        !validString(value.address) ||
+        !nullableDateString(value.estimatedArrivalAt) ||
+        !nullableNonNegativeNumber(value.estimatedTravelSeconds) ||
+        !nullableNonNegativeNumber(value.estimatedDistanceMeters)
+    ) {
+        return null;
+    }
+    return {
+        itinerarySequence: value.itinerarySequence,
+        actionState,
+        address: value.address,
+        estimatedArrivalAt: value.estimatedArrivalAt,
+        estimatedTravelSeconds: value.estimatedTravelSeconds,
+        estimatedDistanceMeters: value.estimatedDistanceMeters,
+    };
+}
+
+function parsePickupItem(value: unknown): OfflineRoutePickupItem | null {
+    if (
+        !isRecord(value) ||
+        !hasOnlyKeys(value, [
+            'manifestId',
+            'stopId',
+            'requestId',
+            'state',
+            'harvest',
+        ]) ||
+        !validIdentifier(value.manifestId) ||
+        !validNonNegativeInteger(value.stopId) ||
+        value.stopId === 0 ||
+        !validIdentifier(value.requestId) ||
+        !(
+            value.state === 'ready' ||
+            value.state === 'scanned' ||
+            value.state === 'missing-label' ||
+            value.state === 'not-ready'
+        )
+    ) {
+        return null;
+    }
+    const harvest = parseHarvest(value.harvest);
+    return harvest
+        ? {
+              manifestId: value.manifestId,
+              stopId: value.stopId,
+              requestId: value.requestId,
+              state: value.state,
+              harvest,
+          }
+        : null;
+}
+
+function parsePickupState(
+    value: unknown,
+): OfflineRoutePickupStep['state'] | null {
+    return value === 'pending' || value === 'partial' || value === 'confirmed'
+        ? value
+        : null;
+}
+
+function parseDeliveryItem(value: unknown): OfflineRouteDeliveryItem | null {
+    if (
+        !isRecord(value) ||
+        !hasOnlyKeys(value, [
+            'stopId',
+            'requestId',
+            'stopState',
+            'requestState',
+            'contactName',
+            'phone',
+            'requestNotes',
+            'harvest',
+            'exception',
+        ]) ||
+        !validNonNegativeInteger(value.stopId) ||
+        value.stopId === 0 ||
+        !validIdentifier(value.requestId) ||
+        !nullableString(value.stopState) ||
+        !validString(value.requestState) ||
+        !validString(value.contactName) ||
+        !nullableString(value.phone) ||
+        !nullableString(value.requestNotes)
+    ) {
+        return null;
+    }
+    const harvest = parseHarvest(value.harvest);
+    if (!harvest) return null;
+    let exception: OfflineRouteDeliveryItem['exception'] = null;
+    if (value.exception !== null) {
+        if (
+            !isRecord(value.exception) ||
+            !hasOnlyKeys(value.exception, [
+                'outcome',
+                'reason',
+                'occurredAt',
+            ]) ||
+            !validString(value.exception.outcome) ||
+            !validString(value.exception.reason) ||
+            !validDateString(value.exception.occurredAt)
+        ) {
+            return null;
+        }
+        exception = {
+            outcome: value.exception.outcome,
+            reason: value.exception.reason,
+            occurredAt: value.exception.occurredAt,
+        };
+    }
+    return {
+        stopId: value.stopId,
+        requestId: value.requestId,
+        stopState: value.stopState,
+        requestState: value.requestState,
+        contactName: value.contactName,
+        phone: value.phone,
+        requestNotes: value.requestNotes,
+        harvest,
+        exception,
+    };
+}
+
+function parsePickupStep(value: Record<string, unknown>) {
+    const common = parseCommonStep(value);
+    const state = parsePickupState(value.state);
+    if (
+        !hasOnlyKeys(value, [
+            'kind',
+            'id',
+            'itinerarySequence',
+            'actionState',
+            'name',
+            'address',
+            'estimatedArrivalAt',
+            'estimatedTravelSeconds',
+            'estimatedDistanceMeters',
+            'state',
+            'expectedCount',
+            'scannedCount',
+            'missingLabelCount',
+            'notReadyCount',
+            'remainingCount',
+            'items',
+        ]) ||
+        !common ||
+        !validIdentifier(value.id) ||
+        !validString(value.name) ||
+        !state ||
+        !validNonNegativeInteger(value.expectedCount) ||
+        !validNonNegativeInteger(value.scannedCount) ||
+        !validNonNegativeInteger(value.missingLabelCount) ||
+        !validNonNegativeInteger(value.notReadyCount) ||
+        !validNonNegativeInteger(value.remainingCount) ||
+        !Array.isArray(value.items)
+    ) {
+        return null;
+    }
+    const items = value.items.map(parsePickupItem);
+    if (items.some((item) => item === null)) return null;
+    return {
+        kind: 'pickup' as const,
+        ...common,
+        id: value.id,
+        name: value.name,
+        state,
+        expectedCount: value.expectedCount,
+        scannedCount: value.scannedCount,
+        missingLabelCount: value.missingLabelCount,
+        notReadyCount: value.notReadyCount,
+        remainingCount: value.remainingCount,
+        items: items.flatMap((item) => (item ? [item] : [])),
+    };
+}
+
+function parseDeliveryStep(value: Record<string, unknown>) {
+    const common = parseCommonStep(value);
+    if (
+        !hasOnlyKeys(value, [
+            'kind',
+            'id',
+            'itinerarySequence',
+            'actionState',
+            'address',
+            'estimatedArrivalAt',
+            'estimatedTravelSeconds',
+            'estimatedDistanceMeters',
+            'stopState',
+            'statusLabel',
+            'slotStartAt',
+            'slotEndAt',
+            'arrivedAt',
+            'deliveredAt',
+            'retryLaneRank',
+            'retryAttempt',
+            'lockedReason',
+            'items',
+        ]) ||
+        !common ||
+        !(
+            value.id === null ||
+            (validNonNegativeInteger(value.id) && value.id > 0)
+        ) ||
+        !nullableString(value.stopState) ||
+        !validString(value.statusLabel) ||
+        !nullableDateString(value.slotStartAt) ||
+        !nullableDateString(value.slotEndAt) ||
+        !nullableDateString(value.arrivedAt) ||
+        !nullableDateString(value.deliveredAt) ||
+        !(
+            value.retryLaneRank === null ||
+            (validNonNegativeInteger(value.retryLaneRank) &&
+                value.retryLaneRank > 0)
+        ) ||
+        !validNonNegativeInteger(value.retryAttempt) ||
+        !nullableString(value.lockedReason) ||
+        !Array.isArray(value.items)
+    ) {
+        return null;
+    }
+    const items = value.items.map(parseDeliveryItem);
+    if (items.some((item) => item === null)) return null;
+    return {
+        kind: 'delivery' as const,
+        ...common,
+        id: value.id,
+        stopState: value.stopState,
+        statusLabel: value.statusLabel,
+        slotStartAt: value.slotStartAt,
+        slotEndAt: value.slotEndAt,
+        arrivedAt: value.arrivedAt,
+        deliveredAt: value.deliveredAt,
+        retryLaneRank: value.retryLaneRank,
+        retryAttempt: value.retryAttempt,
+        lockedReason: value.lockedReason,
+        items: items.flatMap((item) => (item ? [item] : [])),
+    };
+}
+
+function parseStep(value: unknown): OfflineRouteStep | null {
+    if (!isRecord(value)) return null;
+    if (value.kind === 'pickup') return parsePickupStep(value);
+    if (value.kind === 'delivery') return parseDeliveryStep(value);
+    return null;
+}
+
+export function parseOfflineRouteSnapshot(
+    value: unknown,
+    {
+        userId,
+        runId,
+        now = new Date(),
+    }: {
+        userId: string;
+        runId?: string;
+        now?: Date;
+    },
+): OfflineRouteSnapshot | null {
+    const cachedAt =
+        isRecord(value) && validDateString(value.cachedAt)
+            ? Date.parse(value.cachedAt)
+            : Number.NaN;
+    const expiresAt =
+        isRecord(value) && validDateString(value.expiresAt)
+            ? Date.parse(value.expiresAt)
+            : Number.NaN;
+    if (
+        !isRecord(value) ||
+        !hasOnlyKeys(value, [
+            'version',
+            'scope',
+            'source',
+            'cachedAt',
+            'expiresAt',
+            'steps',
+        ]) ||
+        value.version !== offlineRouteCacheVersion ||
+        !isRecord(value.scope) ||
+        !hasOnlyKeys(value.scope, ['userId', 'runId']) ||
+        value.scope.userId !== userId ||
+        !validIdentifier(value.scope.runId) ||
+        (runId !== undefined && value.scope.runId !== runId) ||
+        !isRecord(value.source) ||
+        !hasOnlyKeys(value.source, [
+            'routeRevision',
+            'refreshedAt',
+            'reroutePending',
+        ]) ||
+        !validNonNegativeInteger(value.source.routeRevision) ||
+        !validDateString(value.source.refreshedAt) ||
+        typeof value.source.reroutePending !== 'boolean' ||
+        !validDateString(value.cachedAt) ||
+        !validDateString(value.expiresAt) ||
+        !Array.isArray(value.steps) ||
+        value.steps.length < 1 ||
+        value.steps.length > 2 ||
+        !Number.isFinite(now.getTime()) ||
+        expiresAt <= now.getTime() ||
+        expiresAt <= cachedAt ||
+        expiresAt - cachedAt > offlineRouteCacheTtlMs
+    ) {
+        return null;
+    }
+    const steps = value.steps.map(parseStep);
+    if (
+        steps.some((step) => step === null) ||
+        steps[0]?.actionState !== 'current' ||
+        steps.slice(1).some((step) => step?.actionState === 'current')
+    ) {
+        return null;
+    }
+    return {
+        version: offlineRouteCacheVersion,
+        scope: { userId, runId: value.scope.runId },
+        source: {
+            routeRevision: value.source.routeRevision,
+            refreshedAt: value.source.refreshedAt,
+            reroutePending: value.source.reroutePending,
+        },
+        cachedAt: value.cachedAt,
+        expiresAt: value.expiresAt,
+        steps: steps.flatMap((step) => (step ? [step] : [])),
+    };
+}
+
+function cloneSnapshot(value: OfflineRouteSnapshot) {
+    const serialized: unknown = JSON.parse(JSON.stringify(value));
+    const clone = parseOfflineRouteSnapshot(serialized, {
+        userId: value.scope.userId,
+        runId: value.scope.runId,
+        now: new Date(value.cachedAt),
+    });
+    if (!clone) throw new TypeError('Offline route snapshot is invalid');
+    return clone;
+}
+
+function rawScopeMatches(
+    value: unknown,
+    { userId, runId }: { userId: string; runId?: string },
+) {
+    return (
+        isRecord(value) &&
+        isRecord(value.scope) &&
+        value.scope.userId === userId &&
+        (runId === undefined || value.scope.runId === runId)
+    );
+}
+
+export function createMemoryOfflineRouteCachePersistence(
+    snapshots: Map<string, unknown> = new Map(),
+): OfflineRouteCachePersistence {
+    return {
+        durability: 'memory',
+        async load({ userId, runId, now }) {
+            const stored = snapshots.get(userId);
+            if (stored === undefined) return null;
+            const parsed = parseOfflineRouteSnapshot(stored, {
+                userId,
+                now,
+            });
+            if (!parsed) {
+                snapshots.delete(userId);
+                return null;
+            }
+            if (runId !== undefined && parsed.scope.runId !== runId) {
+                return null;
+            }
+            return parsed ? cloneSnapshot(parsed) : null;
+        },
+        async save(snapshot) {
+            const parsed = parseOfflineRouteSnapshot(snapshot, {
+                userId: snapshot.scope.userId,
+                runId: snapshot.scope.runId,
+                now: new Date(snapshot.cachedAt),
+            });
+            if (!parsed)
+                throw new TypeError('Offline route snapshot is invalid');
+            snapshots.set(snapshot.scope.userId, cloneSnapshot(parsed));
+        },
+        async clear({ userId, runId }) {
+            if (
+                runId === undefined ||
+                rawScopeMatches(snapshots.get(userId), { userId, runId })
+            ) {
+                snapshots.delete(userId);
+            }
+        },
+        async clearUser(userId) {
+            snapshots.delete(userId);
+        },
+    };
+}
+
+function requestResult<Result>(request: IDBRequest<Result>) {
+    return new Promise<Result>((resolve, reject) => {
+        request.addEventListener('success', () => resolve(request.result), {
+            once: true,
+        });
+        request.addEventListener('error', () => reject(request.error), {
+            once: true,
+        });
+    });
+}
+
+function transactionCompleted(transaction: IDBTransaction) {
+    const completed = new Promise<void>((resolve, reject) => {
+        transaction.addEventListener('complete', () => resolve(), {
+            once: true,
+        });
+        transaction.addEventListener('abort', () => reject(transaction.error), {
+            once: true,
+        });
+        transaction.addEventListener('error', () => reject(transaction.error), {
+            once: true,
+        });
+    });
+    // Request failures often abort the transaction before the request promise
+    // reaches its caller. Attach a handler immediately, while still returning
+    // the rejecting promise for the normal awaited control flow.
+    void completed.catch(() => undefined);
+    return completed;
+}
+
+const offlineRouteDatabaseName = 'gredice-delivery-offline-route-v1';
+const offlineRouteStoreName = 'active-routes';
+
+type OfflineRouteIndexedDbFactory = Pick<IDBFactory, 'open'>;
+
+function openOfflineRouteDatabase(factory: OfflineRouteIndexedDbFactory) {
+    return new Promise<IDBDatabase>((resolve, reject) => {
+        const request = factory.open(offlineRouteDatabaseName, 1);
+        request.addEventListener(
+            'upgradeneeded',
+            () => {
+                const database = request.result;
+                if (
+                    !database.objectStoreNames.contains(offlineRouteStoreName)
+                ) {
+                    database.createObjectStore(offlineRouteStoreName);
+                }
+            },
+            { once: true },
+        );
+        request.addEventListener(
+            'success',
+            () => {
+                request.result.addEventListener(
+                    'versionchange',
+                    () => request.result.close(),
+                    { once: true },
+                );
+                resolve(request.result);
+            },
+            { once: true },
+        );
+        request.addEventListener('error', () => reject(request.error), {
+            once: true,
+        });
+        request.addEventListener(
+            'blocked',
+            () =>
+                reject(new Error('Offline route database upgrade is blocked')),
+            { once: true },
+        );
+    });
+}
+
+export function createIndexedDbOfflineRouteCachePersistence(
+    factory: OfflineRouteIndexedDbFactory,
+): OfflineRouteCachePersistence {
+    const memory = createMemoryOfflineRouteCachePersistence();
+    let durable = true;
+    let databasePromise: Promise<IDBDatabase> | null = null;
+    const database = () => {
+        databasePromise ??= openOfflineRouteDatabase(factory);
+        return databasePromise;
+    };
+    const withFallback = async <Result>(
+        durableTask: () => Promise<Result>,
+        fallbackTask: () => Promise<Result>,
+    ) => {
+        if (!durable) return await fallbackTask();
+        try {
+            return await durableTask();
+        } catch {
+            durable = false;
+            if (databasePromise) {
+                void databasePromise
+                    .then((openDatabase) => openDatabase.close())
+                    .catch(() => undefined);
+            }
+            databasePromise = null;
+            return await fallbackTask();
+        }
+    };
+    return {
+        get durability() {
+            return durable ? 'durable' : 'memory';
+        },
+        async load({ userId, runId, now }) {
+            return await withFallback(
+                async () => {
+                    const db = await database();
+                    const transaction = db.transaction(
+                        offlineRouteStoreName,
+                        'readwrite',
+                    );
+                    const completed = transactionCompleted(transaction);
+                    const store = transaction.objectStore(
+                        offlineRouteStoreName,
+                    );
+                    const raw: unknown = await requestResult(store.get(userId));
+                    const parsed = parseOfflineRouteSnapshot(raw, {
+                        userId,
+                        now,
+                    });
+                    if (raw !== undefined && !parsed) {
+                        await requestResult(store.delete(userId));
+                    }
+                    await completed;
+                    if (!parsed) {
+                        await memory.clearUser(userId);
+                        return null;
+                    }
+                    await memory.save(parsed);
+                    if (runId !== undefined && parsed.scope.runId !== runId) {
+                        return null;
+                    }
+                    return cloneSnapshot(parsed);
+                },
+                async () => await memory.load({ userId, runId, now }),
+            );
+        },
+        async save(snapshot) {
+            await withFallback(
+                async () => {
+                    const parsed = parseOfflineRouteSnapshot(snapshot, {
+                        userId: snapshot.scope.userId,
+                        runId: snapshot.scope.runId,
+                        now: new Date(snapshot.cachedAt),
+                    });
+                    if (!parsed) {
+                        throw new TypeError(
+                            'Offline route snapshot is invalid',
+                        );
+                    }
+                    await memory.save(parsed);
+                    const db = await database();
+                    const transaction = db.transaction(
+                        offlineRouteStoreName,
+                        'readwrite',
+                    );
+                    const completed = transactionCompleted(transaction);
+                    await requestResult(
+                        transaction
+                            .objectStore(offlineRouteStoreName)
+                            .put(parsed, snapshot.scope.userId),
+                    );
+                    await completed;
+                },
+                async () => await memory.save(snapshot),
+            );
+        },
+        async clear({ userId, runId }) {
+            await withFallback(
+                async () => {
+                    const db = await database();
+                    const transaction = db.transaction(
+                        offlineRouteStoreName,
+                        'readwrite',
+                    );
+                    const completed = transactionCompleted(transaction);
+                    const store = transaction.objectStore(
+                        offlineRouteStoreName,
+                    );
+                    if (!runId) {
+                        await requestResult(store.delete(userId));
+                    } else {
+                        const raw: unknown = await requestResult(
+                            store.get(userId),
+                        );
+                        if (rawScopeMatches(raw, { userId, runId })) {
+                            await requestResult(store.delete(userId));
+                        }
+                    }
+                    await completed;
+                    await memory.clear({ userId, runId });
+                },
+                async () => await memory.clear({ userId, runId }),
+            );
+        },
+        async clearUser(userId) {
+            await withFallback(
+                async () => {
+                    const db = await database();
+                    const transaction = db.transaction(
+                        offlineRouteStoreName,
+                        'readwrite',
+                    );
+                    const completed = transactionCompleted(transaction);
+                    await requestResult(
+                        transaction
+                            .objectStore(offlineRouteStoreName)
+                            .delete(userId),
+                    );
+                    await completed;
+                    await memory.clearUser(userId);
+                },
+                async () => await memory.clearUser(userId),
+            );
+        },
+    };
+}
+
+export function createBrowserOfflineRouteCachePersistence(): OfflineRouteCachePersistence {
+    try {
+        return typeof indexedDB === 'undefined'
+            ? createMemoryOfflineRouteCachePersistence()
+            : createIndexedDbOfflineRouteCachePersistence(indexedDB);
+    } catch {
+        return createMemoryOfflineRouteCachePersistence();
+    }
+}

--- a/apps/delivery/lib/pickupManifestQueue.node.spec.ts
+++ b/apps/delivery/lib/pickupManifestQueue.node.spec.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    blockDeliveryOfflineWritesForLogout,
+    resetDeliveryOfflineWritesForFreshDocument,
+} from './deliveryOfflineEvents';
+import {
     clearPickupManifestQueueScope,
     createMemoryPickupManifestQueuePersistence,
     createPickupManifestConfirmCommand,
@@ -607,4 +611,37 @@ test('web storage failures fall back to surfaced non-durable memory persistence'
         /Durable pickup cleanup could not be confirmed/,
     );
     assert.equal(manifestQueue.getSnapshot().entries.length, 1);
+});
+
+test('a logout guard rejects a late write that resumed after the final clear', async (context) => {
+    context.after(resetDeliveryOfflineWritesForFreshDocument);
+    const base = createMemoryPickupManifestQueuePersistence();
+    let releaseLoad: () => void = () => undefined;
+    let markLoadStarted: () => void = () => undefined;
+    const loadStarted = new Promise<void>((resolve) => {
+        markLoadStarted = resolve;
+    });
+    const loadGate = new Promise<void>((resolve) => {
+        releaseLoad = resolve;
+    });
+    const persistence: PickupManifestQueuePersistence = {
+        ...base,
+        async load(scope) {
+            markLoadStarted();
+            await loadGate;
+            return await base.load(scope);
+        },
+    };
+    const manifestQueue = queue({ persistence });
+    const pendingEnqueue = manifestQueue.enqueue(
+        scanCommand('late-after-logout'),
+    );
+    await loadStarted;
+
+    blockDeliveryOfflineWritesForLogout('logout-race-test');
+    await base.clear({ userId: defaultScope.userId });
+    releaseLoad();
+
+    await assert.rejects(pendingEnqueue, /Delivery logout is in progress/);
+    assert.equal(await base.load(defaultScope), undefined);
 });

--- a/apps/delivery/lib/pickupManifestQueue.node.spec.ts
+++ b/apps/delivery/lib/pickupManifestQueue.node.spec.ts
@@ -257,7 +257,11 @@ test('durably enqueues rapid scans while an earlier transport request is in flig
 
 test('exact duplicate enqueue is harmless and a reused operation ID with another payload is rejected', async () => {
     const persistence = createMemoryPickupManifestQueuePersistence();
-    const manifestQueue = queue({ persistence });
+    const manifestQueue = queue({
+        persistence,
+        coordinator: serialCoordinator(),
+        replayCoordinator: serialCoordinator(),
+    });
     const command = scanCommand('same-operation');
 
     await manifestQueue.enqueue(command);
@@ -592,9 +596,15 @@ test('web storage failures fall back to surfaced non-durable memory persistence'
     await manifestQueue.enqueue(scanCommand('memory-fallback'));
     assert.equal((await manifestQueue.replay()).status, 'synced');
     assert.equal(manifestQueue.getSnapshot().durability, 'memory');
+    assert.equal(manifestQueue.getSnapshot().coordination, 'best-effort');
     assert.equal(
         (await queue({ persistence }).restore()).entries[0]?.command
             .operationId,
         'memory-fallback',
     );
+    await assert.rejects(
+        manifestQueue.clear(),
+        /Durable pickup cleanup could not be confirmed/,
+    );
+    assert.equal(manifestQueue.getSnapshot().entries.length, 1);
 });

--- a/apps/delivery/lib/pickupManifestQueue.ts
+++ b/apps/delivery/lib/pickupManifestQueue.ts
@@ -94,12 +94,17 @@ export type PickupManifestTransport = (
 
 export type PickupManifestQueuePersistence = {
     readonly durability: PickupManifestQueueDurability;
+    readonly durableCleanupRequired?: boolean;
     load: (scope: PickupManifestQueueScope) => Promise<unknown>;
     save: (
         scope: PickupManifestQueueScope,
         entries: readonly PickupManifestQueueEntry[],
     ) => Promise<void>;
     clear: (scope: { userId: string; runId?: string }) => Promise<void>;
+    clearOtherRuns?: (scope: {
+        userId: string;
+        activeRunId: string;
+    }) => Promise<void>;
 };
 
 export type PickupManifestQueueCoordinator = {
@@ -479,6 +484,7 @@ export function createMemoryPickupManifestQueuePersistence(): PickupManifestQueu
     const values = new Map<string, unknown>();
     return {
         durability: 'memory',
+        durableCleanupRequired: false,
         async load(scope) {
             return clonePersistedValue(
                 values.get(pickupManifestQueueStorageKey(scope)),
@@ -505,6 +511,18 @@ export function createMemoryPickupManifestQueuePersistence(): PickupManifestQueu
                 if (key.startsWith(prefix)) values.delete(key);
             }
         },
+        async clearOtherRuns({ userId, activeRunId }) {
+            const prefix = storageUserPrefix(userId);
+            const activeKey = pickupManifestQueueStorageKey({
+                userId,
+                runId: activeRunId,
+            });
+            for (const key of values.keys()) {
+                if (key.startsWith(prefix) && key !== activeKey) {
+                    values.delete(key);
+                }
+            }
+        },
     };
 }
 
@@ -527,6 +545,7 @@ export function createWebStoragePickupManifestQueuePersistence(
         get durability() {
             return durable ? 'durable' : 'memory';
         },
+        durableCleanupRequired: true,
         async load(scope) {
             const key = pickupManifestQueueStorageKey(scope);
             if (durable) {
@@ -558,20 +577,19 @@ export function createWebStoragePickupManifestQueuePersistence(
                     userId: scope.userId,
                     runId: scope.runId,
                 });
-                fallbackValues.delete(key);
-                if (!durable) return;
                 try {
                     storage.removeItem(key);
+                    fallbackValues.delete(key);
+                    durable = true;
                 } catch {
                     durable = false;
+                    throw new Error(
+                        'Durable pickup cleanup could not be confirmed',
+                    );
                 }
                 return;
             }
             const prefix = storageUserPrefix(scope.userId);
-            for (const key of fallbackValues.keys()) {
-                if (key.startsWith(prefix)) fallbackValues.delete(key);
-            }
-            if (!durable) return;
             try {
                 const keys = Array.from(
                     { length: storage.length },
@@ -580,8 +598,44 @@ export function createWebStoragePickupManifestQueuePersistence(
                 for (const key of keys) {
                     if (key?.startsWith(prefix)) storage.removeItem(key);
                 }
+                for (const key of fallbackValues.keys()) {
+                    if (key.startsWith(prefix)) fallbackValues.delete(key);
+                }
+                durable = true;
             } catch {
                 durable = false;
+                throw new Error(
+                    'Durable pickup cleanup could not be confirmed',
+                );
+            }
+        },
+        async clearOtherRuns({ userId, activeRunId }) {
+            const prefix = storageUserPrefix(userId);
+            const activeKey = pickupManifestQueueStorageKey({
+                userId,
+                runId: activeRunId,
+            });
+            try {
+                const keys = Array.from(
+                    { length: storage.length },
+                    (_, index) => storage.key(index),
+                );
+                for (const key of keys) {
+                    if (key?.startsWith(prefix) && key !== activeKey) {
+                        storage.removeItem(key);
+                    }
+                }
+                for (const key of fallbackValues.keys()) {
+                    if (key.startsWith(prefix) && key !== activeKey) {
+                        fallbackValues.delete(key);
+                    }
+                }
+                durable = true;
+            } catch {
+                durable = false;
+                throw new Error(
+                    'Durable pickup cleanup could not be confirmed',
+                );
             }
         },
     };
@@ -592,6 +646,13 @@ export async function clearPickupManifestQueueScope(
     scope: { userId: string; runId?: string },
 ) {
     await persistence.clear(scope);
+}
+
+export async function clearOtherPickupManifestQueueScopes(
+    persistence: PickupManifestQueuePersistence,
+    scope: { userId: string; activeRunId: string },
+) {
+    await persistence.clearOtherRuns?.(scope);
 }
 
 export class PickupManifestQueue {
@@ -783,11 +844,27 @@ export class PickupManifestQueue {
     async clear() {
         await this.runExclusive(async () => {
             await this.synchronizeFromPersistence(false);
+            const requiredDurability =
+                this.options.persistence.durableCleanupRequired ??
+                this.options.persistence.durability === 'durable';
+            try {
+                await this.options.persistence.clear(this.options.scope);
+            } catch (error) {
+                this.publish();
+                throw error;
+            }
+            if (
+                requiredDurability &&
+                this.options.persistence.durability !== 'durable'
+            ) {
+                this.publish();
+                throw new Error(
+                    'Durable pickup cleanup could not be confirmed',
+                );
+            }
             this.generation += 1;
             this.entries = [];
             this.nextSequence = 0;
-            this.publish();
-            await this.options.persistence.clear(this.options.scope);
             this.publish();
         });
     }
@@ -905,7 +982,9 @@ export class PickupManifestQueue {
             this.options.scope,
             this.entries,
             this.options.persistence.durability,
-            this.options.coordinator && this.options.replayCoordinator
+            this.options.persistence.durability === 'durable' &&
+                this.options.coordinator &&
+                this.options.replayCoordinator
                 ? 'coordinated'
                 : 'best-effort',
         );

--- a/apps/delivery/lib/pickupManifestQueue.ts
+++ b/apps/delivery/lib/pickupManifestQueue.ts
@@ -1,3 +1,4 @@
+import { assertDeliveryOfflineWritesAllowed } from './deliveryOfflineEvents';
 import { normalizeHarvestTraceScanValue } from './harvestTraceScan';
 
 export type PickupManifestQueueScope = {
@@ -491,6 +492,7 @@ export function createMemoryPickupManifestQueuePersistence(): PickupManifestQueu
             );
         },
         async save(scope, entries) {
+            assertDeliveryOfflineWritesAllowed();
             values.set(
                 pickupManifestQueueStorageKey(scope),
                 clonePersistedValue(persistencePayload(entries)),
@@ -561,6 +563,7 @@ export function createWebStoragePickupManifestQueuePersistence(
             return parsedValue(fallbackValues.get(key) ?? null);
         },
         async save(scope, entries) {
+            assertDeliveryOfflineWritesAllowed();
             const key = pickupManifestQueueStorageKey(scope);
             const value = JSON.stringify(persistencePayload(entries));
             fallbackValues.set(key, value);

--- a/apps/delivery/tests/DeliveryStopCardStory.tsx
+++ b/apps/delivery/tests/DeliveryStopCardStory.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useState } from 'react';
 import { DeliveryStopCard } from '../components/DeliveryStopCard';
+import type { DeliveryActionQueueEntry } from '../lib/deliveryActionQueue';
 import {
     customerFailedStop,
     deferredRetryStop,
@@ -46,6 +48,89 @@ export function DeliveryDriverTerminalStopCardStory() {
     return (
         <div className="max-w-2xl p-4">
             <DeliveryStopCard stop={driverFailedStop} mode="driver" />
+        </div>
+    );
+}
+
+const pendingStop = {
+    ...mixedStatusStop,
+    stopState: 'pending',
+    statusLabel: 'U dostavi',
+    arrivedAt: null,
+    deliveries: mixedStatusStop.deliveries.map((delivery) =>
+        delivery.stopState === 'arrived'
+            ? { ...delivery, stopState: 'pending' }
+            : delivery,
+    ),
+};
+
+function actionEntry({
+    kind,
+    state,
+}: {
+    kind: 'arrive' | 'deliver';
+    state: DeliveryActionQueueEntry['state'];
+}): DeliveryActionQueueEntry {
+    return {
+        sequence: 0,
+        command: {
+            kind,
+            operationId: `${kind}-component`,
+            runId: 'run-component-4127',
+            stopId: 41,
+            expectedRouteRevision: 12,
+            occurredAt: '2026-07-15T08:31:00.000Z',
+        },
+        state,
+        attemptCount: state === 'queued' ? 0 : 1,
+        createdAt: '2026-07-15T08:31:00.000Z',
+        updatedAt: '2026-07-15T08:31:00.000Z',
+        ...(state === 'failed' ? { errorCode: 'offline' } : {}),
+        ...(state === 'conflicted'
+            ? { errorCode: 'route-revision-conflict' }
+            : {}),
+    };
+}
+
+export function DeliveryQueuedArrivalStory() {
+    return (
+        <div className="max-w-2xl p-4">
+            <DeliveryStopCard
+                stop={pendingStop}
+                mode="driver"
+                routeRevision={12}
+                pendingAction={null}
+                syncEntry={actionEntry({ kind: 'arrive', state: 'queued' })}
+                verifiedTracePaths={['/trag/active-tomato-trace-0001']}
+                onArrive={() => undefined}
+                onDeliver={() => undefined}
+                onException={async () => ({ status: 'saved' })}
+            />
+        </div>
+    );
+}
+
+export function DeliveryFailedActionStory({
+    state = 'failed',
+}: {
+    state?: 'failed' | 'conflicted';
+}) {
+    const [action, setAction] = useState('none');
+    return (
+        <div className="max-w-2xl p-4">
+            <output data-testid="offline-action-result">{action}</output>
+            <DeliveryStopCard
+                stop={mixedStatusStop}
+                mode="driver"
+                routeRevision={12}
+                pendingAction={null}
+                syncEntry={actionEntry({ kind: 'deliver', state })}
+                onArrive={() => undefined}
+                onDeliver={() => undefined}
+                onException={async () => ({ status: 'saved' })}
+                onRetrySync={() => setAction('retried')}
+                onDiscardSync={() => setAction('discarded')}
+            />
         </div>
     );
 }

--- a/apps/delivery/tests/DriverDashboardOfflineStory.tsx
+++ b/apps/delivery/tests/DriverDashboardOfflineStory.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { DriverDashboard } from '../components/DriverDashboard';
+import type { DriverTrackingState } from '../hooks/useDriverTracking';
+import type {
+    DeliveryActionQueueEntry,
+    DeliveryActionQueueSnapshot,
+} from '../lib/deliveryActionQueue';
+import type {
+    DeliveryStopSummary,
+    DriverDeliveryDashboard,
+} from '../lib/deliveryDashboardTypes';
+import { mixedStatusStop } from './deliveryRecoveryFixtures';
+
+const occurredAt = '2026-07-15T08:32:00.000Z';
+const nextStop: DeliveryStopSummary = {
+    ...mixedStatusStop,
+    id: 42,
+    requestId: 'request-next-offline',
+    sequence: 3,
+    stopState: 'pending',
+    statusLabel: 'Sljedeća dostava',
+    isCurrent: false,
+    contactName: 'Nika Sljedeća',
+    address: 'Vukovarska 42, Zagreb',
+    arrivedAt: null,
+    estimatedArrivalAt: '2026-07-15T09:00:00.000Z',
+    actionState: 'upcoming',
+    deliveries: mixedStatusStop.deliveries.map((delivery, index) => ({
+        ...delivery,
+        stopId: 42,
+        requestId: `request-next-offline-${index}`,
+        stopState: 'pending',
+        contactName: 'Nika Sljedeća',
+        exception: null,
+    })),
+};
+
+const dashboard: DriverDeliveryDashboard = {
+    kind: 'driver',
+    user: {
+        id: 'driver-live-offline',
+        displayName: 'Vozač Offline',
+        role: 'delivery',
+    },
+    activeRun: {
+        id: 'run-component-4127',
+        state: 'active',
+        startedAt: '2026-07-15T08:00:00.000Z',
+        completedAt: null,
+        totalDistanceMeters: 8_000,
+        totalDurationSeconds: 1_800,
+        routePlanVersion: 3,
+        routeRevision: 12,
+        reroutePending: false,
+        estimateSource: 'local',
+        tracking: {
+            status: 'offline',
+            lastAcceptedAt: null,
+            mapAvailable: false,
+        },
+        location: null,
+        estimatesUpdatedAt: occurredAt,
+        mapUrl: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
+        deliveryCount: 4,
+        stops: [mixedStatusStop, nextStop],
+        routeSteps: [
+            {
+                kind: 'delivery',
+                itinerarySequence: 2,
+                retryLaneRank: null,
+                retryAttempt: 0,
+                actionState: 'current',
+                lockedReason: null,
+                stop: mixedStatusStop,
+            },
+            {
+                kind: 'delivery',
+                itinerarySequence: 3,
+                retryLaneRank: null,
+                retryAttempt: 0,
+                actionState: 'upcoming',
+                lockedReason: null,
+                stop: nextStop,
+            },
+        ],
+    },
+    batches: [],
+    maximumRouteStops: 24,
+    maximumRouteWindowHours: 12,
+    refreshedAt: occurredAt,
+};
+
+const completion: DeliveryActionQueueEntry = {
+    sequence: 0,
+    command: {
+        kind: 'deliver',
+        operationId: 'deliver-live-offline-current',
+        runId: 'run-component-4127',
+        stopId: 41,
+        expectedRouteRevision: 12,
+        occurredAt,
+    },
+    state: 'queued',
+    attemptCount: 0,
+    createdAt: occurredAt,
+    updatedAt: occurredAt,
+};
+
+const actionQueue: DeliveryActionQueueSnapshot = {
+    scope: {
+        userId: dashboard.user.id,
+        runId: 'run-component-4127',
+    },
+    durability: 'durable',
+    coordination: 'coordinated',
+    entries: [completion],
+    queuedCount: 1,
+    sendingCount: 0,
+    reconcilingCount: 0,
+    syncedCount: 0,
+    failedCount: 0,
+    conflictedCount: 0,
+};
+
+const rerouteActionQueue: DeliveryActionQueueSnapshot = {
+    ...actionQueue,
+    entries: [
+        {
+            ...completion,
+            state: 'synced',
+            attemptCount: 1,
+            acknowledgement: {
+                kind: 'server',
+                replayed: false,
+                routeRevision: 13,
+                reroutePending: true,
+                runCompleted: false,
+            },
+        },
+    ],
+    queuedCount: 0,
+    syncedCount: 1,
+};
+
+const trackingState: DriverTrackingState = {
+    status: 'retrying',
+    lastAttemptAt: occurredAt,
+    lastAcceptedAt: null,
+    nextRetryAt: null,
+    retryAttempt: 1,
+    sampleQueued: false,
+    reason: 'offline',
+    retryNow: () => undefined,
+    recheckPermission: () => undefined,
+};
+
+function DashboardStory({
+    deliveryQueue,
+}: {
+    deliveryQueue: DeliveryActionQueueSnapshot;
+}) {
+    return (
+        <DriverDashboard
+            dashboard={dashboard}
+            trackingState={trackingState}
+            pendingAction={null}
+            onSelectionChange={() => undefined}
+            onStartRun={() => undefined}
+            onRetry={() => undefined}
+            onArrive={() => undefined}
+            onDeliver={() => undefined}
+            onException={async () => ({ status: 'saved' })}
+            pickupQueue={null}
+            deliveryQueue={deliveryQueue}
+            onPickupScan={() => undefined}
+            onPickupItemState={() => undefined}
+            onConfirmPickupManifest={() => undefined}
+            onRetryPickupSync={() => undefined}
+            onDiscardPickupSync={() => undefined}
+            onVerificationScan={() => undefined}
+            onRetryDeliverySync={() => undefined}
+            onDiscardDeliverySync={() => undefined}
+            onReconcileDeliverySync={() => undefined}
+        />
+    );
+}
+
+export function DriverDashboardOfflineContinuationStory() {
+    return <DashboardStory deliveryQueue={actionQueue} />;
+}
+
+export function DriverDashboardPendingRerouteStory() {
+    return <DashboardStory deliveryQueue={rerouteActionQueue} />;
+}

--- a/apps/delivery/tests/OfflineRoutePanelStory.tsx
+++ b/apps/delivery/tests/OfflineRoutePanelStory.tsx
@@ -1,0 +1,317 @@
+'use client';
+
+import { useState } from 'react';
+import { OfflineRoutePanel } from '../components/OfflineRoutePanel';
+import type {
+    DeliveryActionQueueEntry,
+    DeliveryActionQueueSnapshot,
+} from '../lib/deliveryActionQueue';
+import type { OfflineRouteSnapshot } from '../lib/offlineRouteCache';
+
+const cachedAt = '2026-07-15T10:00:00.000Z';
+
+const routeSnapshot: OfflineRouteSnapshot = {
+    version: 1,
+    scope: { userId: 'driver-offline', runId: 'run-offline' },
+    source: {
+        routeRevision: 7,
+        refreshedAt: cachedAt,
+        reroutePending: false,
+    },
+    cachedAt,
+    expiresAt: '2026-07-16T10:00:00.000Z',
+    steps: [
+        {
+            kind: 'delivery',
+            id: 71,
+            itinerarySequence: 2,
+            actionState: 'current',
+            address: 'Ilica 71, Zagreb',
+            estimatedArrivalAt: '2026-07-15T10:15:00.000Z',
+            estimatedTravelSeconds: 600,
+            estimatedDistanceMeters: 3_200,
+            stopState: 'pending',
+            statusLabel: 'U dostavi',
+            slotStartAt: '2026-07-15T10:00:00.000Z',
+            slotEndAt: '2026-07-15T11:00:00.000Z',
+            arrivedAt: null,
+            deliveredAt: null,
+            retryLaneRank: null,
+            retryAttempt: 0,
+            lockedReason: null,
+            items: [
+                {
+                    stopId: 71,
+                    requestId: 'request-71',
+                    stopState: 'pending',
+                    requestState: 'in_delivery',
+                    contactName: 'Ana Offline',
+                    phone: '+385991234567',
+                    requestNotes: 'Pozvoniti na drugi kat',
+                    harvest: {
+                        plantName: 'Rajčica',
+                        raisedBedName: 'Gredica A',
+                        fieldName: null,
+                        tracePath: '/trag/offline-tomato-0001',
+                    },
+                    exception: null,
+                },
+            ],
+        },
+        {
+            kind: 'delivery',
+            id: 72,
+            itinerarySequence: 3,
+            actionState: 'locked',
+            address: 'Vukovarska 72, Zagreb',
+            estimatedArrivalAt: '2026-07-15T10:45:00.000Z',
+            estimatedTravelSeconds: 900,
+            estimatedDistanceMeters: 5_100,
+            stopState: 'pending',
+            statusLabel: 'Sljedeća dostava',
+            slotStartAt: '2026-07-15T10:30:00.000Z',
+            slotEndAt: '2026-07-15T11:30:00.000Z',
+            arrivedAt: null,
+            deliveredAt: null,
+            retryLaneRank: null,
+            retryAttempt: 0,
+            lockedReason: 'Dovrši prethodnu dostavu.',
+            items: [
+                {
+                    stopId: 72,
+                    requestId: 'request-72',
+                    stopState: 'pending',
+                    requestState: 'in_delivery',
+                    contactName: 'Borna Sljedeći',
+                    phone: null,
+                    requestNotes: null,
+                    harvest: {
+                        plantName: 'Bosiljak',
+                        raisedBedName: 'Gredica B',
+                        fieldName: null,
+                        tracePath: '/trag/offline-basil-00001',
+                    },
+                    exception: null,
+                },
+            ],
+        },
+    ],
+};
+
+function queueSnapshot(
+    entries: DeliveryActionQueueEntry[],
+    durability: DeliveryActionQueueSnapshot['durability'] = 'durable',
+): DeliveryActionQueueSnapshot {
+    return {
+        scope: routeSnapshot.scope,
+        durability,
+        coordination: durability === 'durable' ? 'coordinated' : 'best-effort',
+        entries,
+        queuedCount: entries.filter((entry) => entry.state === 'queued').length,
+        sendingCount: entries.filter((entry) => entry.state === 'sending')
+            .length,
+        reconcilingCount: entries.filter(
+            (entry) => entry.state === 'reconciling',
+        ).length,
+        syncedCount: entries.filter((entry) => entry.state === 'synced').length,
+        failedCount: entries.filter((entry) => entry.state === 'failed').length,
+        conflictedCount: entries.filter((entry) => entry.state === 'conflicted')
+            .length,
+    };
+}
+
+function routeEntry(
+    kind: 'arrive' | 'deliver',
+    sequence: number,
+    stopId = 71,
+    state: DeliveryActionQueueEntry['state'] = 'queued',
+    reroutePending = false,
+): DeliveryActionQueueEntry {
+    const acknowledgement: DeliveryActionQueueEntry['acknowledgement'] =
+        state === 'synced'
+            ? {
+                  kind: 'server',
+                  replayed: false,
+                  routeRevision: 8,
+                  reroutePending,
+                  runCompleted: false,
+              }
+            : undefined;
+    return {
+        sequence,
+        command: {
+            kind,
+            operationId: `${kind}-offline-${sequence}`,
+            runId: routeSnapshot.scope.runId,
+            stopId,
+            expectedRouteRevision: 7 + sequence,
+            occurredAt: cachedAt,
+        },
+        state,
+        attemptCount: state === 'queued' ? 0 : 1,
+        createdAt: cachedAt,
+        updatedAt: cachedAt,
+        ...(acknowledgement ? { acknowledgement } : {}),
+    };
+}
+
+export function OfflineRouteAcknowledgedDeliveryStory() {
+    return (
+        <OfflineRoutePanel
+            snapshot={routeSnapshot}
+            actionQueue={queueSnapshot([
+                routeEntry('deliver', 0, 71, 'synced'),
+            ])}
+            onArrive={() => undefined}
+            onDeliver={() => undefined}
+            onException={async () => ({ status: 'saved' })}
+            onVerificationScan={() => undefined}
+            onRetry={() => undefined}
+            onRecoverConflict={() => undefined}
+            onReconcile={() => undefined}
+        />
+    );
+}
+
+export function OfflineRoutePendingRerouteStory() {
+    const [reconciled, setReconciled] = useState(false);
+    return (
+        <>
+            <output data-testid="offline-reroute-reconciled">
+                {reconciled ? 'yes' : 'no'}
+            </output>
+            <OfflineRoutePanel
+                snapshot={routeSnapshot}
+                actionQueue={queueSnapshot([
+                    routeEntry('deliver', 0, 71, 'synced', true),
+                ])}
+                onArrive={() => undefined}
+                onDeliver={() => undefined}
+                onException={async () => ({ status: 'saved' })}
+                onVerificationScan={() => undefined}
+                onRetry={() => undefined}
+                onRecoverConflict={() => undefined}
+                onReconcile={() => setReconciled(true)}
+            />
+        </>
+    );
+}
+
+export function OfflineRouteBlockedContinuationStory() {
+    return (
+        <OfflineRoutePanel
+            snapshot={routeSnapshot}
+            actionQueue={queueSnapshot([
+                routeEntry('deliver', 0),
+                {
+                    ...routeEntry('arrive', 1, 72, 'failed'),
+                    errorCode: 'offline',
+                },
+            ])}
+            onArrive={() => undefined}
+            onDeliver={() => undefined}
+            onException={async () => ({ status: 'saved' })}
+            onVerificationScan={() => undefined}
+            onRetry={() => undefined}
+            onRecoverConflict={() => undefined}
+            onReconcile={() => undefined}
+        />
+    );
+}
+
+export function OfflineRouteArrivalStory() {
+    const [entries, setEntries] = useState<DeliveryActionQueueEntry[]>([]);
+    const [exceptionQueued, setExceptionQueued] = useState(false);
+    const [verifiedTrace, setVerifiedTrace] = useState('');
+    return (
+        <>
+            <output data-testid="offline-operations">
+                {entries.map((entry) => entry.command.kind).join(',')}
+            </output>
+            <output data-testid="offline-exception">
+                {exceptionQueued ? 'queued' : 'none'}
+            </output>
+            <output data-testid="offline-verification">{verifiedTrace}</output>
+            <OfflineRoutePanel
+                snapshot={routeSnapshot}
+                actionQueue={queueSnapshot(entries)}
+                onArrive={(stopId) =>
+                    setEntries((current) => [
+                        ...current,
+                        routeEntry('arrive', current.length, stopId),
+                    ])
+                }
+                onDeliver={(stopId) =>
+                    setEntries((current) => [
+                        ...current,
+                        routeEntry('deliver', current.length, stopId),
+                    ])
+                }
+                onException={async () => {
+                    setExceptionQueued(true);
+                    return { status: 'saved' };
+                }}
+                onVerificationScan={(_, tracePath) =>
+                    setVerifiedTrace(tracePath)
+                }
+                onRetry={() => undefined}
+                onRecoverConflict={() => undefined}
+                onReconcile={() => undefined}
+            />
+        </>
+    );
+}
+
+export function OfflineRouteExceptionBarrierStory() {
+    const [reconciled, setReconciled] = useState(false);
+    const exception: DeliveryActionQueueEntry = {
+        sequence: 0,
+        command: {
+            kind: 'exception',
+            operationId: 'exception-offline',
+            runId: routeSnapshot.scope.runId,
+            stopId: 71,
+            expectedRouteRevision: 7,
+            occurredAt: cachedAt,
+            exceptions: [
+                {
+                    stopId: 71,
+                    outcome: 'deferred',
+                    reason: 'customer-unavailable',
+                },
+            ],
+        },
+        state: 'reconciling',
+        attemptCount: 1,
+        createdAt: cachedAt,
+        updatedAt: cachedAt,
+        acknowledgement: {
+            kind: 'server',
+            replayed: false,
+            routeRevision: 8,
+            reroutePending: false,
+            runCompleted: false,
+        },
+    };
+    return (
+        <>
+            <output data-testid="offline-reconciled">
+                {reconciled ? 'yes' : 'no'}
+            </output>
+            <OfflineRoutePanel
+                snapshot={routeSnapshot}
+                actionQueue={queueSnapshot([exception], 'memory')}
+                onArrive={() => undefined}
+                onDeliver={() => undefined}
+                onException={async () => ({
+                    status: 'review-required',
+                    message: 'Ruta čeka novi plan.',
+                })}
+                onVerificationScan={() => undefined}
+                onRetry={() => undefined}
+                onRecoverConflict={() => undefined}
+                onReconcile={() => setReconciled(true)}
+            />
+        </>
+    );
+}

--- a/apps/delivery/tests/delivery-offline-actions.spec.tsx
+++ b/apps/delivery/tests/delivery-offline-actions.spec.tsx
@@ -1,0 +1,242 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import {
+    DeliveryFailedActionStory,
+    DeliveryQueuedArrivalStory,
+} from './DeliveryStopCardStory';
+import {
+    DriverDashboardOfflineContinuationStory,
+    DriverDashboardPendingRerouteStory,
+} from './DriverDashboardOfflineStory';
+import {
+    OfflineRouteAcknowledgedDeliveryStory,
+    OfflineRouteArrivalStory,
+    OfflineRouteBlockedContinuationStory,
+    OfflineRouteExceptionBarrierStory,
+    OfflineRoutePendingRerouteStory,
+} from './OfflineRoutePanelStory';
+import '../app/globals.css';
+
+test('keeps an offline arrival visibly pending while allowing advisory verification and delivery', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryQueuedArrivalStory />);
+    await expect(
+        page.getByText('Radnja je spremljena na uređaju i čeka potvrdu.'),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Dolazak čeka potvrdu' }),
+    ).toBeDisabled();
+    await expect(page.getByText('QR provjera predaje')).toBeVisible();
+    await expect(
+        page.getByText(
+            'Svi urodi s dostupnim QR kodom provjereni su za ovu stanicu.',
+        ),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', {
+            name: /Dostavi .* dalje|Dostavljeno · dalje/,
+        }),
+    ).toBeEnabled();
+});
+
+test('already loaded dashboard exposes the next stop after a locally queued delivery', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverDashboardOfflineContinuationStory />);
+    await expect(
+        page.getByText(
+            'Dostava je spremljena na uređaju i čeka potvrdu poslužitelja. Možeš nastaviti na sljedeću stanicu.',
+        ),
+    ).toBeVisible();
+    await expect(page.getByText('Vukovarska 42, Zagreb')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Navigacija' })).toHaveCount(1);
+    await expect(
+        page.getByRole('button', { name: 'Stigao sam' }),
+    ).toBeEnabled();
+});
+
+test('already loaded dashboard blocks its stale next stop while rerouting', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverDashboardPendingRerouteStory />);
+    await expect(
+        page.getByText(
+            'Poslužitelj je potvrdio radnju, ali novi plan rute još nije sigurno učitan.',
+        ),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Navigacija čeka novi plan' }),
+    ).toBeDisabled();
+    await expect(page.getByRole('link', { name: 'Navigacija' })).toHaveCount(0);
+});
+
+test('offers an explicit retry for a durable failed action', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryFailedActionStory />);
+    await expect(
+        page.getByText(
+            'Radnja je spremljena na uređaju, ali slanje nije uspjelo.',
+        ),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Pokušaj ponovno' }).click();
+    await expect(page.getByTestId('offline-action-result')).toHaveText(
+        'retried',
+    );
+});
+
+test('preserves newer server truth and requires explicit local conflict recovery', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryFailedActionStory state="conflicted" />);
+    await expect(
+        page.getByText('Poslužitelj ima noviju verziju rute.'),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: /Dostava čeka potvrdu/ }),
+    ).toBeDisabled();
+    await page
+        .getByRole('button', { name: 'Učitaj stanje poslužitelja' })
+        .click();
+    await expect(page.getByTestId('offline-action-result')).toHaveText(
+        'discarded',
+    );
+});
+
+test('restored offline route keeps pending actions visible and supports ordered arrival then delivery', async ({
+    mount,
+    page,
+}) => {
+    await mount(<OfflineRouteArrivalStory />);
+    await expect(
+        page.getByRole('button', {
+            name: 'Navigacija do sljedeće stanice čeka završetak trenutačne dostave',
+        }),
+    ).toBeDisabled();
+    await page.getByRole('button', { name: 'Stigao sam' }).click();
+    await expect(
+        page.getByRole('button', { name: 'Dolazak čeka potvrdu' }),
+    ).toBeDisabled();
+    await expect(
+        page.getByRole('button', { name: 'Dostavljeno · dalje' }),
+    ).toBeEnabled();
+    await page.getByRole('button', { name: 'Provjeri QR kodove' }).click();
+    await page
+        .getByLabel('Ručni unos')
+        .fill('https://www.gredice.com/trag/offline-tomato-0001');
+    await page.getByRole('button', { name: 'Dodaj kod' }).click();
+    await expect(page.getByTestId('offline-verification')).toHaveText(
+        '/trag/offline-tomato-0001',
+    );
+    await page.getByRole('button', { name: 'Završi provjeru' }).click();
+    await page.getByRole('button', { name: 'Dostavljeno · dalje' }).click();
+    await expect(page.getByTestId('offline-operations')).toHaveText(
+        'arrive,deliver',
+    );
+    await expect(
+        page.getByRole('link', { name: 'Navigacija do trenutačne stanice' }),
+    ).toBeEnabled();
+    await page.getByRole('button', { name: 'Stigao sam' }).click();
+    await page.getByRole('button', { name: 'Dostavljeno · dalje' }).click();
+    await expect(page.getByTestId('offline-operations')).toHaveText(
+        'arrive,deliver,arrive,deliver',
+    );
+});
+
+test('restored server acknowledgement is not mislabeled as waiting for confirmation', async ({
+    mount,
+    page,
+}) => {
+    await mount(<OfflineRouteAcknowledgedDeliveryStory />);
+    await expect(
+        page.getByText(
+            'Poslužitelj je potvrdio dostavu. Čeka se osvježeno stanje rute. Možeš nastaviti na sljedeću stanicu.',
+        ),
+    ).toBeVisible();
+    await expect(
+        page.getByText(/Dostava je spremljena.*čeka potvrdu poslužitelja/),
+    ).toHaveCount(0);
+    await expect(
+        page.getByRole('link', { name: 'Navigacija do trenutačne stanice' }),
+    ).toBeEnabled();
+});
+
+test('server-required reroute blocks stale cached continuation until reconciliation', async ({
+    mount,
+    page,
+}) => {
+    await mount(<OfflineRoutePendingRerouteStory />);
+    await expect(
+        page.getByText(
+            'Poslužitelj je potvrdio radnju, ali novi plan rute još nije sigurno učitan.',
+        ),
+    ).toBeVisible();
+    await expect(page.getByText('Trenutačni korak')).toBeVisible();
+    await expect(
+        page.getByRole('button', {
+            name: 'Navigacija do trenutačne stanice čeka novi plan',
+        }),
+    ).toBeDisabled();
+    await page.getByRole('button', { name: 'Osvježi novi plan' }).click();
+    await expect(page.getByTestId('offline-reroute-reconciled')).toHaveText(
+        'yes',
+    );
+});
+
+test('completed-stop copy never tells the driver to continue through a queue barrier', async ({
+    mount,
+    page,
+}) => {
+    await mount(<OfflineRouteBlockedContinuationStory />);
+    await expect(
+        page.getByText(
+            'Dostava je spremljena na uređaju i čeka potvrdu poslužitelja.',
+            { exact: true },
+        ),
+    ).toBeVisible();
+    await expect(page.getByText(/Možeš nastaviti/)).toHaveCount(0);
+    await expect(
+        page.getByText(
+            'Prva nesinkronizirana radnja nije poslana. Kasnije radnje čekaju iza nje.',
+        ),
+    ).toBeVisible();
+});
+
+test('restored route can safely queue a delivery exception', async ({
+    mount,
+    page,
+}) => {
+    await mount(<OfflineRouteArrivalStory />);
+    await page.getByRole('button', { name: 'Prijavi problem' }).click();
+    await page.getByRole('button', { name: 'Spremi i nastavi rutu' }).click();
+    await expect(page.getByTestId('offline-exception')).toHaveText('queued');
+});
+
+test('restored exception remains a route barrier and memory fallback is truthful', async ({
+    mount,
+    page,
+}) => {
+    await mount(<OfflineRouteExceptionBarrierStory />);
+    await expect(
+        page.getByText(
+            'Problem je potvrđen, ali novi plan rute još nije sigurno učitan.',
+        ),
+    ).toBeVisible();
+    await expect(
+        page.getByText(
+            /Radnje su spremljene samo dok je ova stranica otvorena/,
+        ),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', {
+            name: 'Navigacija do sljedeće stanice čeka novi plan',
+        }),
+    ).toBeDisabled();
+    await page.getByRole('button', { name: 'Osvježi novi plan' }).click();
+    await expect(page.getByTestId('offline-reconciled')).toHaveText('yes');
+});

--- a/packages/storage/src/migrations/0074_strong_morlun.sql
+++ b/packages/storage/src/migrations/0074_strong_morlun.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "delivery_run_stop_operations" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"run_id" text NOT NULL,
+	"target_stop_id" integer NOT NULL,
+	"driver_user_id" text NOT NULL,
+	"client_operation_id" text NOT NULL,
+	"kind" text NOT NULL,
+	"payload_hash" text NOT NULL,
+	"result" jsonb NOT NULL,
+	"occurred_at" timestamp NOT NULL,
+	"applied_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "delivery_run_stop_operations_kind_check" CHECK ("delivery_run_stop_operations"."kind" in ('arrive', 'deliver'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "delivery_run_stops_run_id_id_unique" ON "delivery_run_stops" USING btree ("run_id","id");--> statement-breakpoint
+ALTER TABLE "delivery_run_stop_operations" ADD CONSTRAINT "delivery_run_stop_operations_run_id_delivery_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."delivery_runs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "delivery_run_stop_operations" ADD CONSTRAINT "delivery_run_stop_operations_driver_user_id_users_id_fk" FOREIGN KEY ("driver_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "delivery_run_stop_operations" ADD CONSTRAINT "delivery_run_stop_operations_run_target_stop_fk" FOREIGN KEY ("run_id","target_stop_id") REFERENCES "public"."delivery_run_stops"("run_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "delivery_run_stop_operations_run_client_unique" ON "delivery_run_stop_operations" USING btree ("run_id","client_operation_id");--> statement-breakpoint
+CREATE INDEX "delivery_run_stop_operations_run_id_idx" ON "delivery_run_stop_operations" USING btree ("run_id");--> statement-breakpoint
+CREATE INDEX "delivery_run_stop_operations_target_stop_id_idx" ON "delivery_run_stop_operations" USING btree ("target_stop_id");--> statement-breakpoint
+CREATE INDEX "delivery_run_stop_operations_driver_user_id_idx" ON "delivery_run_stop_operations" USING btree ("driver_user_id");

--- a/packages/storage/src/migrations/meta/0074_snapshot.json
+++ b/packages/storage/src/migrations/meta/0074_snapshot.json
@@ -1,0 +1,18189 @@
+{
+  "id": "051ec58c-1aae-4856-8a4a-18bb42bf9581",
+  "prevId": "d2e6be6e-54db-4dc9-80dd-e8577569db99",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_achievements": {
+      "name": "account_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_key": {
+          "name": "achievement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "achievement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reward_sunflowers": {
+          "name": "reward_sunflowers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress_value": {
+          "name": "progress_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_granted_at": {
+          "name": "reward_granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_by_user_id": {
+          "name": "denied_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_achievements_account_id_idx": {
+          "name": "account_achievements_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_achievements_status_idx": {
+          "name": "account_achievements_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_achievements_account_key_uq": {
+          "name": "account_achievements_account_key_uq",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "achievement_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_achievements_account_id_accounts_id_fk": {
+          "name": "account_achievements_account_id_accounts_id_fk",
+          "tableFrom": "account_achievements",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_achievements_approved_by_user_id_users_id_fk": {
+          "name": "account_achievements_approved_by_user_id_users_id_fk",
+          "tableFrom": "account_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_achievements_denied_by_user_id_users_id_fk": {
+          "name": "account_achievements_denied_by_user_id_users_id_fk",
+          "tableFrom": "account_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "denied_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_account_limit_overrides": {
+      "name": "ai_account_limit_overrides",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active_daily_limit_micro_usd": {
+          "name": "active_daily_limit_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_daily_limit_micro_usd": {
+          "name": "trial_daily_limit_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_chat_days": {
+          "name": "trial_chat_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ai_account_limit_overrides_disabled_idx": {
+          "name": "ai_account_limit_overrides_disabled_idx",
+          "columns": [
+            {
+              "expression": "disabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_account_limit_overrides_account_id_accounts_id_fk": {
+          "name": "ai_account_limit_overrides_account_id_accounts_id_fk",
+          "tableFrom": "ai_account_limit_overrides",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_account_limit_overrides_updated_by_user_id_users_id_fk": {
+          "name": "ai_account_limit_overrides_updated_by_user_id_users_id_fk",
+          "tableFrom": "ai_account_limit_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_conversations": {
+      "name": "ai_chat_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_chat_conversations_account_idx": {
+          "name": "ai_chat_conversations_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_conversations_user_idx": {
+          "name": "ai_chat_conversations_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_conversations_last_message_idx": {
+          "name": "ai_chat_conversations_last_message_idx",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_conversations_account_id_accounts_id_fk": {
+          "name": "ai_chat_conversations_account_id_accounts_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_chat_conversations_user_id_users_id_fk": {
+          "name": "ai_chat_conversations_user_id_users_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_chat_conversations_garden_id_gardens_id_fk": {
+          "name": "ai_chat_conversations_garden_id_gardens_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_chat_conversations_raised_bed_id_raised_beds_id_fk": {
+          "name": "ai_chat_conversations_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_messages": {
+      "name": "ai_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_chat_messages_conversation_idx": {
+          "name": "ai_chat_messages_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_messages_created_at_idx": {
+          "name": "ai_chat_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_messages_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_chat_messages_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_chat_messages",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_tool_calls": {
+      "name": "ai_chat_tool_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_approval": {
+          "name": "needs_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_correlation_id": {
+          "name": "mcp_correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ai_chat_tool_calls_conversation_idx": {
+          "name": "ai_chat_tool_calls_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_tool_calls_tool_name_idx": {
+          "name": "ai_chat_tool_calls_tool_name_idx",
+          "columns": [
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_tool_calls_created_at_idx": {
+          "name": "ai_chat_tool_calls_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_tool_calls_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_chat_tool_calls_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_chat_tool_calls",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_chat_tool_calls_message_id_ai_chat_messages_id_fk": {
+          "name": "ai_chat_tool_calls_message_id_ai_chat_messages_id_fk",
+          "tableFrom": "ai_chat_tool_calls",
+          "tableTo": "ai_chat_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_chat_tool_calls_approved_by_user_id_users_id_fk": {
+          "name": "ai_chat_tool_calls_approved_by_user_id_users_id_fk",
+          "tableFrom": "ai_chat_tool_calls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_usage_ledger": {
+      "name": "ai_usage_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'suncokret-chat'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_date": {
+          "name": "usage_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reserved_micro_usd": {
+          "name": "reserved_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_micro_usd": {
+          "name": "input_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_micro_usd": {
+          "name": "output_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_micro_usd": {
+          "name": "total_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_usage_ledger_request_unique": {
+          "name": "ai_usage_ledger_request_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_ledger_account_date_idx": {
+          "name": "ai_usage_ledger_account_date_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usage_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_ledger_conversation_idx": {
+          "name": "ai_usage_ledger_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_ledger_status_idx": {
+          "name": "ai_usage_ledger_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_ledger_created_at_idx": {
+          "name": "ai_usage_ledger_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_usage_ledger_account_id_accounts_id_fk": {
+          "name": "ai_usage_ledger_account_id_accounts_id_fk",
+          "tableFrom": "ai_usage_ledger",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_usage_ledger_user_id_users_id_fk": {
+          "name": "ai_usage_ledger_user_id_users_id_fk",
+          "tableFrom": "ai_usage_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_usage_ledger_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_usage_ledger_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_usage_ledger",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_definitions": {
+      "name": "automation_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_definition_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "max_concurrent_runs": {
+          "name": "max_concurrent_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "trigger_module_key": {
+          "name": "trigger_module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_event_type": {
+          "name": "trigger_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":[],\"edges\":[]}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_definitions_key_idx": {
+          "name": "automation_definitions_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_definitions_status_idx": {
+          "name": "automation_definitions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_definitions_trigger_event_type_idx": {
+          "name": "automation_definitions_trigger_event_type_idx",
+          "columns": [
+            {
+              "expression": "trigger_event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_definitions_updated_at_idx": {
+          "name": "automation_definitions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_definitions_created_by_user_id_users_id_fk": {
+          "name": "automation_definitions_created_by_user_id_users_id_fk",
+          "tableFrom": "automation_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "automation_definitions_updated_by_user_id_users_id_fk": {
+          "name": "automation_definitions_updated_by_user_id_users_id_fk",
+          "tableFrom": "automation_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_event_cursors": {
+      "name": "automation_event_cursors",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_run_steps": {
+      "name": "automation_run_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_key": {
+          "name": "module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_kind": {
+          "name": "module_kind",
+          "type": "automation_module_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_run_steps_run_node_idx": {
+          "name": "automation_run_steps_run_node_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_run_steps_run_id_idx": {
+          "name": "automation_run_steps_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_run_steps_status_idx": {
+          "name": "automation_run_steps_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_run_steps_run_id_automation_runs_id_fk": {
+          "name": "automation_run_steps_run_id_automation_runs_id_fk",
+          "tableFrom": "automation_run_steps",
+          "tableTo": "automation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_runs": {
+      "name": "automation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "automation_definition_id": {
+          "name": "automation_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_definition_key": {
+          "name": "automation_definition_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_definition_name": {
+          "name": "automation_definition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "automation_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_type": {
+          "name": "source_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_aggregate_id": {
+          "name": "source_aggregate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_run_id": {
+          "name": "parent_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_requested_by_user_id": {
+          "name": "manual_requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph_snapshot": {
+          "name": "graph_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":[],\"edges\":[]}'::jsonb"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_runs_definition_source_event_idx": {
+          "name": "automation_runs_definition_source_event_idx",
+          "columns": [
+            {
+              "expression": "automation_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"automation_runs\".\"source\" = 'event'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_definition_source_schedule_idx": {
+          "name": "automation_runs_definition_source_schedule_idx",
+          "columns": [
+            {
+              "expression": "automation_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_aggregate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"automation_runs\".\"source_event_type\" in ('automation.schedule', 'automation.schedule.monthly')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_definition_id_idx": {
+          "name": "automation_runs_definition_id_idx",
+          "columns": [
+            {
+              "expression": "automation_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_status_next_run_at_idx": {
+          "name": "automation_runs_status_next_run_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_source_event_type_idx": {
+          "name": "automation_runs_source_event_type_idx",
+          "columns": [
+            {
+              "expression": "source_event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_source_event_id_idx": {
+          "name": "automation_runs_source_event_id_idx",
+          "columns": [
+            {
+              "expression": "source_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_created_at_idx": {
+          "name": "automation_runs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_runs_automation_definition_id_automation_definitions_id_fk": {
+          "name": "automation_runs_automation_definition_id_automation_definitions_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "automation_definitions",
+          "columnsFrom": [
+            "automation_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "automation_runs_source_event_id_events_id_fk": {
+          "name": "automation_runs_source_event_id_events_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "automation_runs_manual_requested_by_user_id_users_id_fk": {
+          "name": "automation_runs_manual_requested_by_user_id_users_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "manual_requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_definition_categories": {
+      "name": "attribute_definition_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_adc_entity_type_name_idx": {
+          "name": "cms_adc_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_adc_order_idx": {
+          "name": "cms_adc_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_adc_is_deleted_idx": {
+          "name": "cms_adc_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_definitions": {
+      "name": "attribute_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multiple": {
+          "name": "multiple",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display": {
+          "name": "display",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_ad_category_idx": {
+          "name": "cms_ad_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_entity_type_name_idx": {
+          "name": "cms_ad_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_order_idx": {
+          "name": "cms_ad_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_is_deleted_idx": {
+          "name": "cms_ad_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_values": {
+      "name": "attribute_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attribute_definition_id": {
+          "name": "attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_av_attribute_definition_id_idx": {
+          "name": "cms_av_attribute_definition_id_idx",
+          "columns": [
+            {
+              "expression": "attribute_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_entity_type_name_idx": {
+          "name": "cms_av_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_entity_id_idx": {
+          "name": "cms_av_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_order_idx": {
+          "name": "cms_av_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_is_deleted_idx": {
+          "name": "cms_av_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attribute_values_attribute_definition_id_attribute_definitions_id_fk": {
+          "name": "attribute_values_attribute_definition_id_attribute_definitions_id_fk",
+          "tableFrom": "attribute_values",
+          "tableTo": "attribute_definitions",
+          "columnsFrom": [
+            "attribute_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attribute_values_entity_id_entities_id_fk": {
+          "name": "attribute_values_entity_id_entities_id_fk",
+          "tableFrom": "attribute_values",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cms_page_revisions": {
+      "name": "cms_page_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cms_page_id": {
+          "name": "cms_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_slug": {
+          "name": "previous_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_slug": {
+          "name": "next_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_title": {
+          "name": "previous_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_title": {
+          "name": "next_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_content": {
+          "name": "previous_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_content": {
+          "name": "next_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_content_kind": {
+          "name": "previous_content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_content_kind": {
+          "name": "next_content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category": {
+          "name": "previous_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_category": {
+          "name": "next_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_tags": {
+          "name": "previous_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_tags": {
+          "name": "next_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_state": {
+          "name": "next_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_title": {
+          "name": "previous_meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_title": {
+          "name": "next_meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_description": {
+          "name": "previous_meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_description": {
+          "name": "next_meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_image_url": {
+          "name": "previous_meta_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_image_url": {
+          "name": "next_meta_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_seo_image_url": {
+          "name": "previous_seo_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_seo_image_url": {
+          "name": "next_seo_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_canonical_path": {
+          "name": "previous_canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_canonical_path": {
+          "name": "next_canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_no_index": {
+          "name": "previous_no_index",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_no_index": {
+          "name": "next_no_index",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_published_at": {
+          "name": "previous_published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_published_at": {
+          "name": "next_published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cms_page_revisions_page_id_idx": {
+          "name": "cms_page_revisions_page_id_idx",
+          "columns": [
+            {
+              "expression": "cms_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_page_revisions_action_idx": {
+          "name": "cms_page_revisions_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_page_revisions_created_at_idx": {
+          "name": "cms_page_revisions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cms_page_revisions_cms_page_id_cms_pages_id_fk": {
+          "name": "cms_page_revisions_cms_page_id_cms_pages_id_fk",
+          "tableFrom": "cms_page_revisions",
+          "tableTo": "cms_pages",
+          "columnsFrom": [
+            "cms_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cms_pages": {
+      "name": "cms_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_kind": {
+          "name": "content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_image_url": {
+          "name": "meta_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_image_url": {
+          "name": "seo_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_path": {
+          "name": "canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_index": {
+          "name": "no_index",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_pages_slug_active_uq": {
+          "name": "cms_pages_slug_active_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cms_pages\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_state_idx": {
+          "name": "cms_pages_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_content_kind_idx": {
+          "name": "cms_pages_content_kind_idx",
+          "columns": [
+            {
+              "expression": "content_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_category_idx": {
+          "name": "cms_pages_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_published_at_idx": {
+          "name": "cms_pages_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_is_deleted_idx": {
+          "name": "cms_pages_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchy_order": {
+          "name": "hierarchy_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_e_entity_type_name_idx": {
+          "name": "cms_e_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_parent_id_idx": {
+          "name": "cms_e_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_hierarchy_order_idx": {
+          "name": "cms_e_hierarchy_order_idx",
+          "columns": [
+            {
+              "expression": "hierarchy_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_state_idx": {
+          "name": "cms_e_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_is_deleted_idx": {
+          "name": "cms_e_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_parent_id_entities_id_fk": {
+          "name": "entities_parent_id_entities_id_fk",
+          "tableFrom": "entities",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_revisions": {
+      "name": "entity_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_value_id": {
+          "name": "attribute_value_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_definition_id": {
+          "name": "attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_value": {
+          "name": "next_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_state": {
+          "name": "next_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cms_er_entity_id_idx": {
+          "name": "cms_er_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_er_entity_type_name_idx": {
+          "name": "cms_er_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_er_action_idx": {
+          "name": "cms_er_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_revisions_entity_id_entities_id_fk": {
+          "name": "entity_revisions_entity_id_entities_id_fk",
+          "tableFrom": "entity_revisions",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_search_documents": {
+      "name": "entity_search_documents",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_category": {
+          "name": "public_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_category_label": {
+          "name": "public_category_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cms_esd_entity_type_idx": {
+          "name": "cms_esd_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_public_category_idx": {
+          "name": "cms_esd_public_category_idx",
+          "columns": [
+            {
+              "expression": "public_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_state_idx": {
+          "name": "cms_esd_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_published_at_idx": {
+          "name": "cms_esd_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_search_vector_idx": {
+          "name": "cms_esd_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_search_documents_entity_id_entities_id_fk": {
+          "name": "entity_search_documents_entity_id_entities_id_fk",
+          "tableFrom": "entity_search_documents",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_type_categories": {
+      "name": "entity_type_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_etc_order_idx": {
+          "name": "cms_etc_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_etc_is_deleted_idx": {
+          "name": "cms_etc_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_types": {
+      "name": "entity_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchy_order": {
+          "name": "hierarchy_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_root": {
+          "name": "is_root",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "inventory_source_attribute_definition_id": {
+          "name": "inventory_source_attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_et_category_id_idx": {
+          "name": "cms_et_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_order_idx": {
+          "name": "cms_et_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_parent_id_idx": {
+          "name": "cms_et_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_hierarchy_order_idx": {
+          "name": "cms_et_hierarchy_order_idx",
+          "columns": [
+            {
+              "expression": "hierarchy_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_is_deleted_idx": {
+          "name": "cms_et_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_is_root_idx": {
+          "name": "cms_et_is_root_idx",
+          "columns": [
+            {
+              "expression": "is_root",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_inventory_source_attr_def_idx": {
+          "name": "cms_et_inventory_source_attr_def_idx",
+          "columns": [
+            {
+              "expression": "inventory_source_attribute_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_types_category_id_entity_type_categories_id_fk": {
+          "name": "entity_types_category_id_entity_type_categories_id_fk",
+          "tableFrom": "entity_types",
+          "tableTo": "entity_type_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_types_parent_id_entity_types_id_fk": {
+          "name": "entity_types_parent_id_entity_types_id_fk",
+          "tableFrom": "entity_types",
+          "tableTo": "entity_types",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_types_inventory_source_attribute_definition_id_attribute_definitions_id_fk": {
+          "name": "entity_types_inventory_source_attribute_definition_id_attribute_definitions_id_fk",
+          "tableFrom": "entity_types",
+          "tableTo": "attribute_definitions",
+          "columnsFrom": [
+            "inventory_source_attribute_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_edit_request_changes": {
+      "name": "community_edit_request_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_key": {
+          "name": "section_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_definition_id": {
+          "name": "attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribute_value_id": {
+          "name": "attribute_value_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_path": {
+          "name": "attribute_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_value": {
+          "name": "proposed_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_value_hash": {
+          "name": "base_value_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_patch": {
+          "name": "value_patch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_diff": {
+          "name": "review_diff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_edit_changes_request_id_idx": {
+          "name": "community_edit_changes_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_changes_field_key_idx": {
+          "name": "community_edit_changes_field_key_idx",
+          "columns": [
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_changes_attribute_definition_idx": {
+          "name": "community_edit_changes_attribute_definition_idx",
+          "columns": [
+            {
+              "expression": "attribute_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_edit_request_changes_request_id_community_edit_requests_id_fk": {
+          "name": "community_edit_request_changes_request_id_community_edit_requests_id_fk",
+          "tableFrom": "community_edit_request_changes",
+          "tableTo": "community_edit_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_edit_request_changes_attribute_definition_id_attribute_definitions_id_fk": {
+          "name": "community_edit_request_changes_attribute_definition_id_attribute_definitions_id_fk",
+          "tableFrom": "community_edit_request_changes",
+          "tableTo": "attribute_definitions",
+          "columnsFrom": [
+            "attribute_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_edit_request_changes_attribute_value_id_attribute_values_id_fk": {
+          "name": "community_edit_request_changes_attribute_value_id_attribute_values_id_fk",
+          "tableFrom": "community_edit_request_changes",
+          "tableTo": "attribute_values",
+          "columnsFrom": [
+            "attribute_value_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_edit_requests": {
+      "name": "community_edit_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_path": {
+          "name": "public_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_key": {
+          "name": "section_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_user_id": {
+          "name": "submitter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitter_name": {
+          "name": "submitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_email": {
+          "name": "submitter_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_note": {
+          "name": "submitter_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_user_id": {
+          "name": "reviewer_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_name": {
+          "name": "reviewer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_note": {
+          "name": "reviewer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_failure_reason": {
+          "name": "application_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "community_edit_requests_status_idx": {
+          "name": "community_edit_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_requests_entity_type_idx": {
+          "name": "community_edit_requests_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_requests_entity_id_idx": {
+          "name": "community_edit_requests_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_requests_submitter_idx": {
+          "name": "community_edit_requests_submitter_idx",
+          "columns": [
+            {
+              "expression": "submitter_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_requests_created_at_idx": {
+          "name": "community_edit_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_edit_requests_entity_id_entities_id_fk": {
+          "name": "community_edit_requests_entity_id_entities_id_fk",
+          "tableFrom": "community_edit_requests",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_edit_requests_submitter_user_id_users_id_fk": {
+          "name": "community_edit_requests_submitter_user_id_users_id_fk",
+          "tableFrom": "community_edit_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_edit_requests_reviewer_user_id_users_id_fk": {
+          "name": "community_edit_requests_reviewer_user_id_users_id_fk",
+          "tableFrom": "community_edit_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_addresses": {
+      "name": "delivery_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street1": {
+          "name": "street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street2": {
+          "name": "street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'HR'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_addresses_account_id_idx": {
+          "name": "delivery_addresses_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_addresses_is_default_idx": {
+          "name": "delivery_addresses_is_default_idx",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_addresses_deleted_at_idx": {
+          "name": "delivery_addresses_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_addresses_account_id_accounts_id_fk": {
+          "name": "delivery_addresses_account_id_accounts_id_fk",
+          "tableFrom": "delivery_addresses",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_requests": {
+      "name": "delivery_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_requests_operation_id_idx": {
+          "name": "delivery_requests_operation_id_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_requests_created_at_idx": {
+          "name": "delivery_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_requests_operation_id_operations_id_fk": {
+          "name": "delivery_requests_operation_id_operations_id_fk",
+          "tableFrom": "delivery_requests",
+          "tableTo": "operations",
+          "columnsFrom": [
+            "operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_exception_operations": {
+      "name": "delivery_run_exception_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_operation_id": {
+          "name": "client_operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_run_exception_operations_run_client_unique": {
+          "name": "delivery_run_exception_operations_run_client_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_exception_operations_run_id_idx": {
+          "name": "delivery_run_exception_operations_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_exception_operations_driver_user_id_idx": {
+          "name": "delivery_run_exception_operations_driver_user_id_idx",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_exception_operations_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_exception_operations_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_exception_operations",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_exception_operations_driver_user_id_users_id_fk": {
+          "name": "delivery_run_exception_operations_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_run_exception_operations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_pickup_nodes": {
+      "name": "delivery_run_pickup_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_location_id": {
+          "name": "pickup_location_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "itinerary_sequence": {
+          "name": "itinerary_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_arrival_at": {
+          "name": "estimated_arrival_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_travel_seconds": {
+          "name": "incoming_travel_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_distance_meters": {
+          "name": "incoming_distance_meters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_duration_seconds": {
+          "name": "service_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street1": {
+          "name": "street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street2": {
+          "name": "street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_run_pickup_nodes_run_sequence_unique": {
+          "name": "delivery_run_pickup_nodes_run_sequence_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_nodes_run_location_unique": {
+          "name": "delivery_run_pickup_nodes_run_location_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pickup_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_nodes_run_id_id_unique": {
+          "name": "delivery_run_pickup_nodes_run_id_id_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_nodes_run_itinerary_sequence_unique": {
+          "name": "delivery_run_pickup_nodes_run_itinerary_sequence_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "itinerary_sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"delivery_run_pickup_nodes\".\"itinerary_sequence\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_nodes_run_id_idx": {
+          "name": "delivery_run_pickup_nodes_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_pickup_nodes_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_pickup_nodes_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_pickup_nodes",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_pickup_nodes_pickup_location_id_pickup_locations_id_fk": {
+          "name": "delivery_run_pickup_nodes_pickup_location_id_pickup_locations_id_fk",
+          "tableFrom": "delivery_run_pickup_nodes",
+          "tableTo": "pickup_locations",
+          "columnsFrom": [
+            "pickup_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_pickup_nodes_itinerary_shape_check": {
+          "name": "delivery_run_pickup_nodes_itinerary_shape_check",
+          "value": "(\n                \"delivery_run_pickup_nodes\".\"itinerary_sequence\" is null\n                and \"delivery_run_pickup_nodes\".\"estimated_arrival_at\" is null\n                and \"delivery_run_pickup_nodes\".\"incoming_travel_seconds\" is null\n                and \"delivery_run_pickup_nodes\".\"incoming_distance_meters\" is null\n                and \"delivery_run_pickup_nodes\".\"service_duration_seconds\" is null\n            ) or (\n                \"delivery_run_pickup_nodes\".\"itinerary_sequence\" is not null\n                and \"delivery_run_pickup_nodes\".\"itinerary_sequence\" > 0\n                and \"delivery_run_pickup_nodes\".\"estimated_arrival_at\" is not null\n                and \"delivery_run_pickup_nodes\".\"incoming_travel_seconds\" is not null\n                and \"delivery_run_pickup_nodes\".\"incoming_travel_seconds\" >= 0\n                and \"delivery_run_pickup_nodes\".\"incoming_distance_meters\" is not null\n                and \"delivery_run_pickup_nodes\".\"incoming_distance_meters\" >= 0\n                and \"delivery_run_pickup_nodes\".\"service_duration_seconds\" is not null\n                and \"delivery_run_pickup_nodes\".\"service_duration_seconds\" >= 0\n            )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_pickup_operations": {
+      "name": "delivery_run_pickup_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_node_id": {
+          "name": "pickup_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_operation_id": {
+          "name": "client_operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_run_pickup_operations_run_client_unique": {
+          "name": "delivery_run_pickup_operations_run_client_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_operations_run_id_idx": {
+          "name": "delivery_run_pickup_operations_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_operations_pickup_node_id_idx": {
+          "name": "delivery_run_pickup_operations_pickup_node_id_idx",
+          "columns": [
+            {
+              "expression": "pickup_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_pickup_operations_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_pickup_operations_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_pickup_operations",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_pickup_operations_driver_user_id_users_id_fk": {
+          "name": "delivery_run_pickup_operations_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_run_pickup_operations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_pickup_operations_run_pickup_node_fk": {
+          "name": "delivery_run_pickup_operations_run_pickup_node_fk",
+          "tableFrom": "delivery_run_pickup_operations",
+          "tableTo": "delivery_run_pickup_nodes",
+          "columnsFrom": [
+            "run_id",
+            "pickup_node_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_pickup_operations_kind_check": {
+          "name": "delivery_run_pickup_operations_kind_check",
+          "value": "\"delivery_run_pickup_operations\".\"kind\" in ('scan', 'mark-item', 'confirm-manifest')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_preparations": {
+      "name": "delivery_run_preparations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selection_hash": {
+          "name": "selection_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_run_id": {
+          "name": "delivery_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_run_preparations_driver_user_id_idx": {
+          "name": "delivery_run_preparations_driver_user_id_idx",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_preparations_expires_at_idx": {
+          "name": "delivery_run_preparations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_preparations_consumed_at_idx": {
+          "name": "delivery_run_preparations_consumed_at_idx",
+          "columns": [
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_preparations_delivery_run_id_unique": {
+          "name": "delivery_run_preparations_delivery_run_id_unique",
+          "columns": [
+            {
+              "expression": "delivery_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_preparations_driver_user_id_users_id_fk": {
+          "name": "delivery_run_preparations_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_run_preparations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_preparations_delivery_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_preparations_delivery_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_preparations",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "delivery_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_preparations_consumption_shape_check": {
+          "name": "delivery_run_preparations_consumption_shape_check",
+          "value": "(\"delivery_run_preparations\".\"consumed_at\" is null and \"delivery_run_preparations\".\"delivery_run_id\" is null) or (\"delivery_run_preparations\".\"consumed_at\" is not null and \"delivery_run_preparations\".\"delivery_run_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_slots": {
+      "name": "delivery_run_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_node_id": {
+          "name": "pickup_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot_id": {
+          "name": "time_slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_id": {
+          "name": "manifest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_state": {
+          "name": "manifest_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'confirmed'"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by_user_id": {
+          "name": "confirmed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_run_slots_manifest_id_unique": {
+          "name": "delivery_run_slots_manifest_id_unique",
+          "columns": [
+            {
+              "expression": "manifest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_run_sequence_unique": {
+          "name": "delivery_run_slots_run_sequence_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_run_time_slot_unique": {
+          "name": "delivery_run_slots_run_time_slot_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_run_id_id_unique": {
+          "name": "delivery_run_slots_run_id_id_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_run_id_idx": {
+          "name": "delivery_run_slots_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_pickup_node_id_idx": {
+          "name": "delivery_run_slots_pickup_node_id_idx",
+          "columns": [
+            {
+              "expression": "pickup_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_slots_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_slots_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_slots",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_slots_time_slot_id_time_slots_id_fk": {
+          "name": "delivery_run_slots_time_slot_id_time_slots_id_fk",
+          "tableFrom": "delivery_run_slots",
+          "tableTo": "time_slots",
+          "columnsFrom": [
+            "time_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "delivery_run_slots_confirmed_by_user_id_users_id_fk": {
+          "name": "delivery_run_slots_confirmed_by_user_id_users_id_fk",
+          "tableFrom": "delivery_run_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "delivery_run_slots_run_pickup_node_fk": {
+          "name": "delivery_run_slots_run_pickup_node_fk",
+          "tableFrom": "delivery_run_slots",
+          "tableTo": "delivery_run_pickup_nodes",
+          "columnsFrom": [
+            "run_id",
+            "pickup_node_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_slots_manifest_state_check": {
+          "name": "delivery_run_slots_manifest_state_check",
+          "value": "\"delivery_run_slots\".\"manifest_state\" in ('pending', 'confirmed')"
+        },
+        "delivery_run_slots_manifest_confirmation_shape_check": {
+          "name": "delivery_run_slots_manifest_confirmation_shape_check",
+          "value": "\"delivery_run_slots\".\"manifest_state\" = 'confirmed' or (\"delivery_run_slots\".\"confirmed_at\" is null and \"delivery_run_slots\".\"confirmed_by_user_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_stop_operations": {
+      "name": "delivery_run_stop_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_stop_id": {
+          "name": "target_stop_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_operation_id": {
+          "name": "client_operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_run_stop_operations_run_client_unique": {
+          "name": "delivery_run_stop_operations_run_client_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stop_operations_run_id_idx": {
+          "name": "delivery_run_stop_operations_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stop_operations_target_stop_id_idx": {
+          "name": "delivery_run_stop_operations_target_stop_id_idx",
+          "columns": [
+            {
+              "expression": "target_stop_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stop_operations_driver_user_id_idx": {
+          "name": "delivery_run_stop_operations_driver_user_id_idx",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_stop_operations_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_stop_operations_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_stop_operations",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stop_operations_driver_user_id_users_id_fk": {
+          "name": "delivery_run_stop_operations_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_run_stop_operations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stop_operations_run_target_stop_fk": {
+          "name": "delivery_run_stop_operations_run_target_stop_fk",
+          "tableFrom": "delivery_run_stop_operations",
+          "tableTo": "delivery_run_stops",
+          "columnsFrom": [
+            "run_id",
+            "target_stop_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_stop_operations_kind_check": {
+          "name": "delivery_run_stop_operations_kind_check",
+          "value": "\"delivery_run_stop_operations\".\"kind\" in ('arrive', 'deliver')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_stops": {
+      "name": "delivery_run_stops",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_request_id": {
+          "name": "delivery_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_slot_id": {
+          "name": "run_slot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "itinerary_sequence": {
+          "name": "itinerary_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_duration_seconds": {
+          "name": "service_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_lane_rank": {
+          "name": "retry_lane_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_attempt": {
+          "name": "retry_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stop_key": {
+          "name": "stop_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_dispatch_event_id": {
+          "name": "request_dispatch_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address_id": {
+          "name": "delivery_address_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address_updated_at": {
+          "name": "delivery_address_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address_label": {
+          "name": "delivery_address_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_contact_name": {
+          "name": "delivery_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_phone": {
+          "name": "delivery_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street1": {
+          "name": "delivery_street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street2": {
+          "name": "delivery_street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_city": {
+          "name": "delivery_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_postal_code": {
+          "name": "delivery_postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_country_code": {
+          "name": "delivery_country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_item_state": {
+          "name": "pickup_item_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_trace_link_id": {
+          "name": "pickup_trace_link_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_trace_token": {
+          "name": "pickup_trace_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_resolved_at": {
+          "name": "pickup_resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_resolved_by_user_id": {
+          "name": "pickup_resolved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_arrival_at": {
+          "name": "estimated_arrival_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_travel_seconds": {
+          "name": "estimated_travel_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_distance_meters": {
+          "name": "estimated_distance_meters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_reason": {
+          "name": "exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_note": {
+          "name": "exception_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_occurred_at": {
+          "name": "exception_occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_recorded_by_user_id": {
+          "name": "exception_recorded_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_run_stops_delivery_request_active_unique": {
+          "name": "delivery_run_stops_delivery_request_active_unique",
+          "columns": [
+            {
+              "expression": "delivery_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"delivery_run_stops\".\"released_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_sequence_unique": {
+          "name": "delivery_run_stops_run_sequence_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_id_id_unique": {
+          "name": "delivery_run_stops_run_id_id_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_id_idx": {
+          "name": "delivery_run_stops_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_itinerary_sequence_idx": {
+          "name": "delivery_run_stops_run_itinerary_sequence_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "itinerary_sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_slot_id_idx": {
+          "name": "delivery_run_stops_run_slot_id_idx",
+          "columns": [
+            {
+              "expression": "run_slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_state_idx": {
+          "name": "delivery_run_stops_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_retry_lane_rank_idx": {
+          "name": "delivery_run_stops_run_retry_lane_rank_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retry_lane_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_released_at_idx": {
+          "name": "delivery_run_stops_released_at_idx",
+          "columns": [
+            {
+              "expression": "released_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_pickup_trace_token_idx": {
+          "name": "delivery_run_stops_pickup_trace_token_idx",
+          "columns": [
+            {
+              "expression": "pickup_trace_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_pickup_item_state_idx": {
+          "name": "delivery_run_stops_pickup_item_state_idx",
+          "columns": [
+            {
+              "expression": "pickup_item_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_stops_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_stops_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_delivery_request_id_delivery_requests_id_fk": {
+          "name": "delivery_run_stops_delivery_request_id_delivery_requests_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "delivery_requests",
+          "columnsFrom": [
+            "delivery_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_pickup_trace_link_id_harvest_trace_links_id_fk": {
+          "name": "delivery_run_stops_pickup_trace_link_id_harvest_trace_links_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "harvest_trace_links",
+          "columnsFrom": [
+            "pickup_trace_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_pickup_resolved_by_user_id_users_id_fk": {
+          "name": "delivery_run_stops_pickup_resolved_by_user_id_users_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "users",
+          "columnsFrom": [
+            "pickup_resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_exception_recorded_by_user_id_users_id_fk": {
+          "name": "delivery_run_stops_exception_recorded_by_user_id_users_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "users",
+          "columnsFrom": [
+            "exception_recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_run_slot_fk": {
+          "name": "delivery_run_stops_run_slot_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "delivery_run_slots",
+          "columnsFrom": [
+            "run_id",
+            "run_slot_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_stops_snapshot_shape_check": {
+          "name": "delivery_run_stops_snapshot_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"run_slot_id\" is null\n                and \"delivery_run_stops\".\"stop_key\" is null\n                and \"delivery_run_stops\".\"request_dispatch_event_id\" is null\n                and \"delivery_run_stops\".\"delivery_address_id\" is null\n                and \"delivery_run_stops\".\"delivery_address_updated_at\" is null\n                and \"delivery_run_stops\".\"delivery_address_label\" is null\n                and \"delivery_run_stops\".\"delivery_contact_name\" is null\n                and \"delivery_run_stops\".\"delivery_phone\" is null\n                and \"delivery_run_stops\".\"delivery_street1\" is null\n                and \"delivery_run_stops\".\"delivery_street2\" is null\n                and \"delivery_run_stops\".\"delivery_city\" is null\n                and \"delivery_run_stops\".\"delivery_postal_code\" is null\n                and \"delivery_run_stops\".\"delivery_country_code\" is null\n            ) or (\n                \"delivery_run_stops\".\"run_slot_id\" is not null\n                and \"delivery_run_stops\".\"stop_key\" is not null\n                and \"delivery_run_stops\".\"request_dispatch_event_id\" is not null\n                and \"delivery_run_stops\".\"delivery_address_id\" is not null\n                and \"delivery_run_stops\".\"delivery_address_updated_at\" is not null\n                and \"delivery_run_stops\".\"delivery_address_label\" is not null\n                and \"delivery_run_stops\".\"delivery_contact_name\" is not null\n                and \"delivery_run_stops\".\"delivery_phone\" is not null\n                and \"delivery_run_stops\".\"delivery_street1\" is not null\n                and \"delivery_run_stops\".\"delivery_city\" is not null\n                and \"delivery_run_stops\".\"delivery_postal_code\" is not null\n                and \"delivery_run_stops\".\"delivery_country_code\" is not null\n            )"
+        },
+        "delivery_run_stops_itinerary_shape_check": {
+          "name": "delivery_run_stops_itinerary_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"itinerary_sequence\" is null\n                and \"delivery_run_stops\".\"service_duration_seconds\" is null\n            ) or (\n                \"delivery_run_stops\".\"itinerary_sequence\" is not null\n                and \"delivery_run_stops\".\"itinerary_sequence\" > 0\n                and \"delivery_run_stops\".\"service_duration_seconds\" is not null\n                and \"delivery_run_stops\".\"service_duration_seconds\" >= 0\n            )"
+        },
+        "delivery_run_stops_retry_shape_check": {
+          "name": "delivery_run_stops_retry_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"retry_lane_rank\" is null\n                and \"delivery_run_stops\".\"retry_attempt\" = 0\n            ) or (\n                \"delivery_run_stops\".\"retry_lane_rank\" is not null\n                and \"delivery_run_stops\".\"retry_lane_rank\" > 0\n                and \"delivery_run_stops\".\"retry_attempt\" > 0\n            )"
+        },
+        "delivery_run_stops_pickup_item_state_check": {
+          "name": "delivery_run_stops_pickup_item_state_check",
+          "value": "\"delivery_run_stops\".\"pickup_item_state\" is null or \"delivery_run_stops\".\"pickup_item_state\" in ('ready', 'scanned', 'missing-label', 'not-ready')"
+        },
+        "delivery_run_stops_pickup_item_resolution_shape_check": {
+          "name": "delivery_run_stops_pickup_item_resolution_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"pickup_item_state\" is null\n                and \"delivery_run_stops\".\"pickup_trace_link_id\" is null\n                and \"delivery_run_stops\".\"pickup_trace_token\" is null\n                and \"delivery_run_stops\".\"pickup_resolved_at\" is null\n                and \"delivery_run_stops\".\"pickup_resolved_by_user_id\" is null\n            ) or (\n                \"delivery_run_stops\".\"pickup_item_state\" = 'ready'\n                and \"delivery_run_stops\".\"pickup_resolved_at\" is null\n                and \"delivery_run_stops\".\"pickup_resolved_by_user_id\" is null\n            ) or (\n                \"delivery_run_stops\".\"pickup_item_state\" in ('scanned', 'missing-label', 'not-ready')\n                and \"delivery_run_stops\".\"pickup_resolved_at\" is not null\n            )"
+        },
+        "delivery_run_stops_state_check": {
+          "name": "delivery_run_stops_state_check",
+          "value": "\"delivery_run_stops\".\"state\" in ('pending', 'arrived', 'delivered', 'deferred', 'failed', 'cancelled')"
+        },
+        "delivery_run_stops_exception_reason_check": {
+          "name": "delivery_run_stops_exception_reason_check",
+          "value": "\"delivery_run_stops\".\"exception_reason\" is null or \"delivery_run_stops\".\"exception_reason\" in ('customer-unavailable', 'address-inaccessible', 'address-wrong', 'harvest-damaged', 'harvest-missing', 'cancellation', 'operational-other')"
+        },
+        "delivery_run_stops_cancellation_pair_check": {
+          "name": "delivery_run_stops_cancellation_pair_check",
+          "value": "(\"delivery_run_stops\".\"state\" = 'cancelled') = coalesce(\"delivery_run_stops\".\"exception_reason\" = 'cancellation', false)"
+        },
+        "delivery_run_stops_outcome_shape_check": {
+          "name": "delivery_run_stops_outcome_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"state\" in ('pending', 'arrived')\n                and \"delivery_run_stops\".\"delivered_at\" is null\n                and \"delivery_run_stops\".\"exception_reason\" is null\n                and \"delivery_run_stops\".\"exception_note\" is null\n                and \"delivery_run_stops\".\"exception_occurred_at\" is null\n                and \"delivery_run_stops\".\"exception_recorded_by_user_id\" is null\n            ) or (\n                \"delivery_run_stops\".\"state\" = 'delivered'\n                and \"delivery_run_stops\".\"delivered_at\" is not null\n                and \"delivery_run_stops\".\"exception_reason\" is null\n                and \"delivery_run_stops\".\"exception_note\" is null\n                and \"delivery_run_stops\".\"exception_occurred_at\" is null\n                and \"delivery_run_stops\".\"exception_recorded_by_user_id\" is null\n            ) or (\n                \"delivery_run_stops\".\"state\" in ('deferred', 'failed')\n                and \"delivery_run_stops\".\"delivered_at\" is null\n                and \"delivery_run_stops\".\"exception_reason\" is not null\n                and \"delivery_run_stops\".\"exception_occurred_at\" is not null\n                and \"delivery_run_stops\".\"exception_recorded_by_user_id\" is not null\n            ) or (\n                \"delivery_run_stops\".\"state\" = 'cancelled'\n                and \"delivery_run_stops\".\"delivered_at\" is null\n                and \"delivery_run_stops\".\"exception_reason\" = 'cancellation'\n                and \"delivery_run_stops\".\"exception_occurred_at\" is not null\n            )"
+        },
+        "delivery_run_stops_release_shape_check": {
+          "name": "delivery_run_stops_release_shape_check",
+          "value": "\"delivery_run_stops\".\"released_at\" is null or \"delivery_run_stops\".\"state\" in ('delivered', 'failed', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_runs": {
+      "name": "delivery_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot_id": {
+          "name": "time_slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "encoded_polyline": {
+          "name": "encoded_polyline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_distance_meters": {
+          "name": "total_distance_meters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_seconds": {
+          "name": "total_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_plan_version": {
+          "name": "route_plan_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "route_revision": {
+          "name": "route_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reroute_required_at": {
+          "name": "reroute_required_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reroute_attempted_at": {
+          "name": "reroute_attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimate_source": {
+          "name": "estimate_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy'"
+        },
+        "current_latitude": {
+          "name": "current_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_longitude": {
+          "name": "current_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_accuracy": {
+          "name": "current_location_accuracy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_heading": {
+          "name": "current_location_heading",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_speed": {
+          "name": "current_location_speed",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_recorded_at": {
+          "name": "current_location_recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_received_at": {
+          "name": "current_location_received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimates_updated_at": {
+          "name": "estimates_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_runs_driver_user_id_idx": {
+          "name": "delivery_runs_driver_user_id_idx",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_time_slot_id_idx": {
+          "name": "delivery_runs_time_slot_id_idx",
+          "columns": [
+            {
+              "expression": "time_slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_state_idx": {
+          "name": "delivery_runs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_driver_active_unique": {
+          "name": "delivery_runs_driver_active_unique",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"delivery_runs\".\"state\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_location_recorded_at_idx": {
+          "name": "delivery_runs_location_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "current_location_recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_runs_driver_user_id_users_id_fk": {
+          "name": "delivery_runs_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_runs_time_slot_id_time_slots_id_fk": {
+          "name": "delivery_runs_time_slot_id_time_slots_id_fk",
+          "tableFrom": "delivery_runs",
+          "tableTo": "time_slots",
+          "columnsFrom": [
+            "time_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_runs_route_plan_provenance_check": {
+          "name": "delivery_runs_route_plan_provenance_check",
+          "value": "(\n                \"delivery_runs\".\"route_plan_version\" = 1\n                and \"delivery_runs\".\"estimate_source\" = 'legacy'\n            ) or (\n                \"delivery_runs\".\"route_plan_version\" >= 2\n                and \"delivery_runs\".\"estimate_source\" in ('google', 'local')\n            )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pickup_locations": {
+      "name": "pickup_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street1": {
+          "name": "street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street2": {
+          "name": "street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'HR'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pickup_locations_is_active_idx": {
+          "name": "pickup_locations_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_slots": {
+      "name": "time_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "time_slots_location_id_idx": {
+          "name": "time_slots_location_id_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_type_idx": {
+          "name": "time_slots_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_start_at_idx": {
+          "name": "time_slots_start_at_idx",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_closes_at_idx": {
+          "name": "time_slots_closes_at_idx",
+          "columns": [
+            {
+              "expression": "closes_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_status_idx": {
+          "name": "time_slots_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_unique_slot_idx": {
+          "name": "time_slots_unique_slot_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_slots_location_id_pickup_locations_id_fk": {
+          "name": "time_slots_location_id_pickup_locations_id_fk",
+          "tableFrom": "time_slots",
+          "tableTo": "pickup_locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_messages": {
+      "name": "email_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'acs'"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "email_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_name": {
+          "name": "template_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounced_at": {
+          "name": "bounced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_messages_status_idx": {
+          "name": "email_messages_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_messages_created_idx": {
+          "name": "email_messages_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_messages_provider_message_idx": {
+          "name": "email_messages_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_e_type_idx": {
+          "name": "events_e_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_e_aggregate_id_idx": {
+          "name": "events_e_aggregate_id_idx",
+          "columns": [
+            {
+              "expression": "aggregate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_e_created_at_idx": {
+          "name": "events_e_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farms": {
+      "name": "farms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snow_accumulation": {
+          "name": "snow_accumulation",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "farms_f_is_deleted_idx": {
+          "name": "farms_f_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedbacks": {
+      "name": "feedbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fiscalization_pos_settings": {
+      "name": "fiscalization_pos_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos_id": {
+          "name": "pos_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "premise_id": {
+          "name": "premise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "fiscalization_pos_settings_pos_id_idx": {
+          "name": "fiscalization_pos_settings_pos_id_idx",
+          "columns": [
+            {
+              "expression": "pos_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_pos_settings_is_active_idx": {
+          "name": "fiscalization_pos_settings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_pos_settings_is_deleted_idx": {
+          "name": "fiscalization_pos_settings_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fiscalization_user_settings": {
+      "name": "fiscalization_user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pin": {
+          "name": "pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "use_vat": {
+          "name": "use_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "receipt_number_on_device": {
+          "name": "receipt_number_on_device",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'educ'"
+        },
+        "cert_base64": {
+          "name": "cert_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cert_password": {
+          "name": "cert_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "fiscalization_user_settings_is_active_idx": {
+          "name": "fiscalization_user_settings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_user_settings_is_deleted_idx": {
+          "name": "fiscalization_user_settings_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_blocks": {
+      "name": "garden_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_gb_garden_id_idx": {
+          "name": "garden_gb_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_gb_is_deleted_idx": {
+          "name": "garden_gb_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_blocks_garden_id_gardens_id_fk": {
+          "name": "garden_blocks_garden_id_gardens_id_fk",
+          "tableFrom": "garden_blocks",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_likes": {
+      "name": "garden_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "garden_likes_user_garden_uq": {
+          "name": "garden_likes_user_garden_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_likes_user_id_idx": {
+          "name": "garden_likes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_likes_garden_id_idx": {
+          "name": "garden_likes_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_likes_user_id_users_id_fk": {
+          "name": "garden_likes_user_id_users_id_fk",
+          "tableFrom": "garden_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "garden_likes_garden_id_gardens_id_fk": {
+          "name": "garden_likes_garden_id_gardens_id_fk",
+          "tableFrom": "garden_likes",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_preview_blob_deletions": {
+      "name": "garden_preview_blob_deletions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pathname": {
+          "name": "pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "garden_preview_blob_deletions_pathname_uq": {
+          "name": "garden_preview_blob_deletions_pathname_uq",
+          "columns": [
+            {
+              "expression": "pathname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_preview_blob_deletions_next_attempt_at_idx": {
+          "name": "garden_preview_blob_deletions_next_attempt_at_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_preview_blob_deletions_claim_expires_at_idx": {
+          "name": "garden_preview_blob_deletions_claim_expires_at_idx",
+          "columns": [
+            {
+              "expression": "claim_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_preview_blob_scan_states": {
+      "name": "garden_preview_blob_scan_states",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_preview_capture_leases": {
+      "name": "garden_preview_capture_leases",
+      "schema": "",
+      "columns": {
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "garden_preview_capture_leases_expires_at_idx": {
+          "name": "garden_preview_capture_leases_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_preview_capture_leases_garden_id_gardens_id_fk": {
+          "name": "garden_preview_capture_leases_garden_id_gardens_id_fk",
+          "tableFrom": "garden_preview_capture_leases",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_previews": {
+      "name": "garden_previews",
+      "schema": "",
+      "columns": {
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "capture_request_id": {
+          "name": "capture_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pathname": {
+          "name": "pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renderer_version": {
+          "name": "renderer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_requested_at": {
+          "name": "capture_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "garden_previews_capture_request_id_uq": {
+          "name": "garden_previews_capture_request_id_uq",
+          "columns": [
+            {
+              "expression": "capture_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_previews_pathname_uq": {
+          "name": "garden_previews_pathname_uq",
+          "columns": [
+            {
+              "expression": "pathname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_previews_captured_at_idx": {
+          "name": "garden_previews_captured_at_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_previews_garden_id_gardens_id_fk": {
+          "name": "garden_previews_garden_id_gardens_id_fk",
+          "tableFrom": "garden_previews",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_stacks": {
+      "name": "garden_stacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_x": {
+          "name": "position_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_y": {
+          "name": "position_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocks": {
+          "name": "blocks",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_gs_garden_id_idx": {
+          "name": "garden_gs_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_gs_is_deleted_idx": {
+          "name": "garden_gs_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_stacks_garden_id_gardens_id_fk": {
+          "name": "garden_stacks_garden_id_gardens_id_fk",
+          "tableFrom": "garden_stacks",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_visit_states": {
+      "name": "garden_visit_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_summary_seen_at": {
+          "name": "last_summary_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_summary_facts_hash": {
+          "name": "last_summary_facts_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "garden_visit_states_user_account_garden_unique": {
+          "name": "garden_visit_states_user_account_garden_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_visit_states_account_garden_idx": {
+          "name": "garden_visit_states_account_garden_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_visit_states_garden_id_idx": {
+          "name": "garden_visit_states_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_visit_states_user_id_users_id_fk": {
+          "name": "garden_visit_states_user_id_users_id_fk",
+          "tableFrom": "garden_visit_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "garden_visit_states_account_id_accounts_id_fk": {
+          "name": "garden_visit_states_account_id_accounts_id_fk",
+          "tableFrom": "garden_visit_states",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "garden_visit_states_garden_id_gardens_id_fk": {
+          "name": "garden_visit_states_garden_id_gardens_id_fk",
+          "tableFrom": "garden_visit_states",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gardens": {
+      "name": "gardens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background_palette": {
+          "name": "background_palette",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'current'"
+        },
+        "home_camera": {
+          "name": "home_camera",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_sandbox": {
+          "name": "is_sandbox",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_g_account_id_idx": {
+          "name": "garden_g_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_farm_id_idx": {
+          "name": "garden_g_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_is_deleted_idx": {
+          "name": "garden_g_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_is_public_idx": {
+          "name": "garden_g_is_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_is_sandbox_idx": {
+          "name": "garden_g_is_sandbox_idx",
+          "columns": [
+            {
+              "expression": "is_sandbox",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gardens_account_id_accounts_id_fk": {
+          "name": "gardens_account_id_accounts_id_fk",
+          "tableFrom": "gardens",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gardens_farm_id_farms_id_fk": {
+          "name": "gardens_farm_id_farms_id_fk",
+          "tableFrom": "gardens",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_bed_fields": {
+      "name": "raised_bed_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_bed_fields_raised_bed_id_idx": {
+          "name": "raised_bed_fields_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_bed_fields_is_deleted_idx": {
+          "name": "raised_bed_fields_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_bed_fields_raised_bed_id_raised_beds_id_fk": {
+          "name": "raised_bed_fields_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "raised_bed_fields",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_bed_sensors": {
+      "name": "raised_bed_sensors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "sensor_signalco_id": {
+          "name": "sensor_signalco_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_bed_sensors_raised_bed_id_idx": {
+          "name": "raised_bed_sensors_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_bed_sensors_is_deleted_idx": {
+          "name": "raised_bed_sensors_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_bed_sensors_raised_bed_id_raised_beds_id_fk": {
+          "name": "raised_bed_sensors_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "raised_bed_sensors",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_beds": {
+      "name": "raised_beds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orientation": {
+          "name": "orientation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vertical'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "physical_id": {
+          "name": "physical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_beds_account_id_idx": {
+          "name": "raised_beds_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_garden_id_idx": {
+          "name": "raised_beds_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_block_id_idx": {
+          "name": "raised_beds_block_id_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_is_deleted_idx": {
+          "name": "raised_beds_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_beds_account_id_accounts_id_fk": {
+          "name": "raised_beds_account_id_accounts_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "raised_beds_garden_id_gardens_id_fk": {
+          "name": "raised_beds_garden_id_gardens_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "raised_beds_block_id_garden_blocks_id_fk": {
+          "name": "raised_beds_block_id_garden_blocks_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "garden_blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harvest_trace_links": {
+      "name": "harvest_trace_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_token": {
+          "name": "public_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raised_bed_field_id": {
+          "name": "raised_bed_field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_position_index": {
+          "name": "field_position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_label": {
+          "name": "field_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plant_place_event_id": {
+          "name": "plant_place_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plant_sort_id": {
+          "name": "plant_sort_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harvest_operation_id": {
+          "name": "harvest_operation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_path": {
+          "name": "trace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "printed_at": {
+          "name": "printed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harvest_trace_links_public_token_unique": {
+          "name": "harvest_trace_links_public_token_unique",
+          "columns": [
+            {
+              "expression": "public_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_target_unique": {
+          "name": "harvest_trace_links_target_unique",
+          "columns": [
+            {
+              "expression": "harvest_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raised_bed_field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plant_place_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_status_idx": {
+          "name": "harvest_trace_links_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_target_idx": {
+          "name": "harvest_trace_links_target_idx",
+          "columns": [
+            {
+              "expression": "harvest_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raised_bed_field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plant_place_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_raised_bed_idx": {
+          "name": "harvest_trace_links_raised_bed_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_plant_sort_idx": {
+          "name": "harvest_trace_links_plant_sort_idx",
+          "columns": [
+            {
+              "expression": "plant_sort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_created_at_idx": {
+          "name": "harvest_trace_links_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harvest_trace_links_account_id_accounts_id_fk": {
+          "name": "harvest_trace_links_account_id_accounts_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_garden_id_gardens_id_fk": {
+          "name": "harvest_trace_links_garden_id_gardens_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_raised_bed_id_raised_beds_id_fk": {
+          "name": "harvest_trace_links_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_raised_bed_field_id_raised_bed_fields_id_fk": {
+          "name": "harvest_trace_links_raised_bed_field_id_raised_bed_fields_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "raised_bed_fields",
+          "columnsFrom": [
+            "raised_bed_field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_plant_place_event_id_events_id_fk": {
+          "name": "harvest_trace_links_plant_place_event_id_events_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "events",
+          "columnsFrom": [
+            "plant_place_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_plant_sort_id_entities_id_fk": {
+          "name": "harvest_trace_links_plant_sort_id_entities_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "plant_sort_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_harvest_operation_id_operations_id_fk": {
+          "name": "harvest_trace_links_harvest_operation_id_operations_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "operations",
+          "columnsFrom": [
+            "harvest_operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harvest_trace_scans": {
+      "name": "harvest_trace_scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "harvest_trace_link_id": {
+          "name": "harvest_trace_link_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_agent_family": {
+          "name": "user_agent_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harvest_trace_scans_link_id_idx": {
+          "name": "harvest_trace_scans_link_id_idx",
+          "columns": [
+            {
+              "expression": "harvest_trace_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_scans_scanned_at_idx": {
+          "name": "harvest_trace_scans_scanned_at_idx",
+          "columns": [
+            {
+              "expression": "scanned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harvest_trace_scans_harvest_trace_link_id_harvest_trace_links_id_fk": {
+          "name": "harvest_trace_scans_harvest_trace_link_id_harvest_trace_links_id_fk",
+          "tableFrom": "harvest_trace_scans",
+          "tableTo": "harvest_trace_links",
+          "columnsFrom": [
+            "harvest_trace_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_configs": {
+      "name": "inventory_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_tracking_type": {
+          "name": "default_tracking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pieces'"
+        },
+        "status_attribute_name": {
+          "name": "status_attribute_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "empty_status_value": {
+          "name": "empty_status_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_attribute_name": {
+          "name": "amount_attribute_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "low_count_threshold": {
+          "name": "low_count_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_configs_entity_type_name_idx": {
+          "name": "inv_configs_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_configs_is_deleted_idx": {
+          "name": "inv_configs_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_item_events": {
+      "name": "inventory_item_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_item_id": {
+          "name": "inventory_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_quantity": {
+          "name": "previous_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_quantity": {
+          "name": "new_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_state": {
+          "name": "new_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_item_events_inventory_item_id_idx": {
+          "name": "inv_item_events_inventory_item_id_idx",
+          "columns": [
+            {
+              "expression": "inventory_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_item_events_is_deleted_idx": {
+          "name": "inv_item_events_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_item_events_inventory_item_id_inventory_items_id_fk": {
+          "name": "inventory_item_events_inventory_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_item_events",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "inventory_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_item_field_definitions": {
+      "name": "inventory_item_field_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_config_id": {
+          "name": "inventory_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_field_defs_inventory_config_id_idx": {
+          "name": "inv_field_defs_inventory_config_id_idx",
+          "columns": [
+            {
+              "expression": "inventory_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_field_defs_is_deleted_idx": {
+          "name": "inv_field_defs_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_item_field_definitions_inventory_config_id_inventory_configs_id_fk": {
+          "name": "inventory_item_field_definitions_inventory_config_id_inventory_configs_id_fk",
+          "tableFrom": "inventory_item_field_definitions",
+          "tableTo": "inventory_configs",
+          "columnsFrom": [
+            "inventory_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_items": {
+      "name": "inventory_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_config_id": {
+          "name": "inventory_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_type": {
+          "name": "tracking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pieces'"
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "low_count_threshold": {
+          "name": "low_count_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_fields": {
+          "name": "additional_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_items_inventory_config_id_idx": {
+          "name": "inv_items_inventory_config_id_idx",
+          "columns": [
+            {
+              "expression": "inventory_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_items_entity_id_idx": {
+          "name": "inv_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_items_is_deleted_idx": {
+          "name": "inv_items_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_items_tracking_type_idx": {
+          "name": "inv_items_tracking_type_idx",
+          "columns": [
+            {
+              "expression": "tracking_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_items_inventory_config_id_inventory_configs_id_fk": {
+          "name": "inventory_items_inventory_config_id_inventory_configs_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "inventory_configs",
+          "columnsFrom": [
+            "inventory_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_items_entity_id_entities_id_fk": {
+          "name": "inventory_items_entity_id_entities_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.00'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_id_idx": {
+          "name": "invoice_items_invoice_id_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_entity_id_idx": {
+          "name": "invoice_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_entity_type_idx": {
+          "name": "invoice_items_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_date": {
+          "name": "paid_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_name": {
+          "name": "bill_to_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_email": {
+          "name": "bill_to_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bill_to_address": {
+          "name": "bill_to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_city": {
+          "name": "bill_to_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_state": {
+          "name": "bill_to_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_zip": {
+          "name": "bill_to_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_country": {
+          "name": "bill_to_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_invoice_number_idx": {
+          "name": "invoices_invoice_number_idx",
+          "columns": [
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_account_id_idx": {
+          "name": "invoices_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_transaction_id_idx": {
+          "name": "invoices_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_status_idx": {
+          "name": "invoices_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_issue_date_idx": {
+          "name": "invoices_issue_date_idx",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_due_date_idx": {
+          "name": "invoices_due_date_idx",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_is_deleted_idx": {
+          "name": "invoices_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_account_id_accounts_id_fk": {
+          "name": "invoices_account_id_accounts_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_transaction_id_transactions_id_fk": {
+          "name": "invoices_transaction_id_transactions_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_invoice_number_unique": {
+          "name": "invoices_invoice_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receipts": {
+      "name": "receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_number": {
+          "name": "receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_receipt_number": {
+          "name": "year_receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_reference": {
+          "name": "payment_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jir": {
+          "name": "jir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zki": {
+          "name": "zki",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_status": {
+          "name": "cis_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "cis_reference": {
+          "name": "cis_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_error_message": {
+          "name": "cis_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_timestamp": {
+          "name": "cis_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_response": {
+          "name": "cis_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "business_pin": {
+          "name": "business_pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_name": {
+          "name": "business_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_address": {
+          "name": "business_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_pin": {
+          "name": "customer_pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_address": {
+          "name": "customer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "receipts_invoice_id_idx": {
+          "name": "receipts_invoice_id_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_receipt_number_idx": {
+          "name": "receipts_receipt_number_idx",
+          "columns": [
+            {
+              "expression": "receipt_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_jir_idx": {
+          "name": "receipts_jir_idx",
+          "columns": [
+            {
+              "expression": "jir",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_zki_idx": {
+          "name": "receipts_zki_idx",
+          "columns": [
+            {
+              "expression": "zki",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_cis_status_idx": {
+          "name": "receipts_cis_status_idx",
+          "columns": [
+            {
+              "expression": "cis_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_issued_at_idx": {
+          "name": "receipts_issued_at_idx",
+          "columns": [
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_business_pin_idx": {
+          "name": "receipts_business_pin_idx",
+          "columns": [
+            {
+              "expression": "business_pin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_is_deleted_idx": {
+          "name": "receipts_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "receipts_invoice_id_invoices_id_fk": {
+          "name": "receipts_invoice_id_invoices_id_fk",
+          "tableFrom": "receipts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "receipts_year_receipt_number_unique": {
+          "name": "receipts_year_receipt_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "year_receipt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "newsletter_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscribed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_subscribers_email_idx": {
+          "name": "newsletter_subscribers_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_subscribers_status_idx": {
+          "name": "newsletter_subscribers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_type": {
+          "name": "integration_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'true'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_campaigns": {
+      "name": "notification_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_campaign_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_policy": {
+          "name": "channel_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_label": {
+          "name": "action_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_image_url": {
+          "name": "safe_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_link_url": {
+          "name": "safe_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_action_url": {
+          "name": "safe_action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_channel": {
+          "name": "primary_channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_app'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "notification_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "collapse_key": {
+          "name": "collapse_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "delivery_metadata": {
+          "name": "delivery_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "failures": {
+          "name": "failures",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "target_count": {
+          "name": "target_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "queued_count": {
+          "name": "queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_count": {
+          "name": "sent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "suppressed_count": {
+          "name": "suppressed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enqueued_at": {
+          "name": "enqueued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_from_account_id": {
+          "name": "created_from_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_user_id": {
+          "name": "cancelled_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_campaigns_status_idx": {
+          "name": "notification_campaigns_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_scheduled_at_idx": {
+          "name": "notification_campaigns_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_created_by_user_id_idx": {
+          "name": "notification_campaigns_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_category_idx": {
+          "name": "notification_campaigns_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_event_type_idx": {
+          "name": "notification_campaigns_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_campaigns_created_by_user_id_users_id_fk": {
+          "name": "notification_campaigns_created_by_user_id_users_id_fk",
+          "tableFrom": "notification_campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "notification_campaigns_created_from_account_id_accounts_id_fk": {
+          "name": "notification_campaigns_created_from_account_id_accounts_id_fk",
+          "tableFrom": "notification_campaigns",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "created_from_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_campaigns_cancelled_by_user_id_users_id_fk": {
+          "name": "notification_campaigns_cancelled_by_user_id_users_id_fk",
+          "tableFrom": "notification_campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "cancelled_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery_attempts": {
+      "name": "notification_delivery_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_response_code": {
+          "name": "provider_response_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_response_body": {
+          "name": "provider_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bulk_id": {
+          "name": "bulk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_subscription_id": {
+          "name": "push_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_attempts_notification_id_idx": {
+          "name": "notification_delivery_attempts_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_delivery_attempts_status_idx": {
+          "name": "notification_delivery_attempts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_attempts_notification_id_notifications_id_fk": {
+          "name": "notification_delivery_attempts_notification_id_notifications_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_attempts_user_id_users_id_fk": {
+          "name": "notification_delivery_attempts_user_id_users_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_attempts_account_id_accounts_id_fk": {
+          "name": "notification_delivery_attempts_account_id_accounts_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_attempts_push_subscription_id_web_push_subscriptions_id_fk": {
+          "name": "notification_delivery_attempts_push_subscription_id_web_push_subscriptions_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "web_push_subscriptions",
+          "columnsFrom": [
+            "push_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery_events": {
+      "name": "notification_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "delivery_attempt_id": {
+          "name": "delivery_attempt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_delivery_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_events_attempt_id_idx": {
+          "name": "notification_delivery_events_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "delivery_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_events_delivery_attempt_id_notification_delivery_attempts_id_fk": {
+          "name": "notification_delivery_events_delivery_attempt_id_notification_delivery_attempts_id_fk",
+          "tableFrom": "notification_delivery_events",
+          "tableTo": "notification_delivery_attempts",
+          "columnsFrom": [
+            "delivery_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_events_notification_id_notifications_id_fk": {
+          "name": "notification_delivery_events_notification_id_notifications_id_fk",
+          "tableFrom": "notification_delivery_events",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_email_log": {
+      "name": "notification_email_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailed_at": {
+          "name": "emailed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_email_log_user_id_users_id_fk": {
+          "name": "notification_email_log_user_id_users_id_fk",
+          "tableFrom": "notification_email_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_email_log_notification_id_notifications_id_fk": {
+          "name": "notification_email_log_notification_id_notifications_id_fk",
+          "tableFrom": "notification_email_log",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_user_channel_preferences": {
+      "name": "notification_user_channel_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "notification_preference_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "quiet_hours_start_minute": {
+          "name": "quiet_hours_start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end_minute": {
+          "name": "quiet_hours_end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_window_start_minute": {
+          "name": "delivery_window_start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_window_end_minute": {
+          "name": "delivery_window_end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_frequency": {
+          "name": "digest_frequency",
+          "type": "notification_digest_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_channel_preferences_global_unique_idx": {
+          "name": "notification_user_channel_preferences_global_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification_user_channel_preferences\".\"scope\" = 'global'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_channel_preferences_account_unique_idx": {
+          "name": "notification_user_channel_preferences_account_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification_user_channel_preferences\".\"scope\" = 'account'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_channel_preferences_user_id_users_id_fk": {
+          "name": "notification_user_channel_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_user_channel_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_user_channel_preferences_account_id_accounts_id_fk": {
+          "name": "notification_user_channel_preferences_account_id_accounts_id_fk",
+          "tableFrom": "notification_user_channel_preferences",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_user_channel_preferences_scope_account_id_check": {
+          "name": "notification_user_channel_preferences_scope_account_id_check",
+          "value": "(scope = 'global' and account_id is null) or (scope = 'account' and account_id is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "primary_channel": {
+          "name": "primary_channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_app'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "notification_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bulk_id": {
+          "name": "bulk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collapse_key": {
+          "name": "collapse_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_label": {
+          "name": "action_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_image_url": {
+          "name": "safe_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_link_url": {
+          "name": "safe_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_where": {
+          "name": "read_where",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_account_id_idx": {
+          "name": "notifications_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_readAt_idx": {
+          "name": "notifications_readAt_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_category_idx": {
+          "name": "notifications_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_campaign_id_idx": {
+          "name": "notifications_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_account_id_accounts_id_fk": {
+          "name": "notifications_account_id_accounts_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_garden_id_gardens_id_fk": {
+          "name": "notifications_garden_id_gardens_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_raised_bed_id_raised_beds_id_fk": {
+          "name": "notifications_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_block_id_garden_blocks_id_fk": {
+          "name": "notifications_block_id_garden_blocks_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "garden_blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_digest": {
+          "name": "daily_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.web_push_subscriptions": {
+      "name": "web_push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_label": {
+          "name": "device_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_name": {
+          "name": "browser_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_version": {
+          "name": "browser_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission_state": {
+          "name": "permission_state",
+          "type": "push_permission_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "fail_count": {
+          "name": "fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_at": {
+          "name": "last_failure_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_code": {
+          "name": "last_failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "web_push_subscriptions_endpoint_unique_idx": {
+          "name": "web_push_subscriptions_endpoint_unique_idx",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "web_push_subscriptions_user_id_idx": {
+          "name": "web_push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "web_push_subscriptions_account_id_idx": {
+          "name": "web_push_subscriptions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "web_push_subscriptions_device_id_idx": {
+          "name": "web_push_subscriptions_device_id_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "web_push_subscriptions_account_id_accounts_id_fk": {
+          "name": "web_push_subscriptions_account_id_accounts_id_fk",
+          "tableFrom": "web_push_subscriptions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "web_push_subscriptions_user_id_users_id_fk": {
+          "name": "web_push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "web_push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operations": {
+      "name": "operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_field_id": {
+          "name": "raised_bed_field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_accepted": {
+          "name": "is_accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "operations_entity_id_idx": {
+          "name": "operations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_entity_type_name_idx": {
+          "name": "operations_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_account_id_idx": {
+          "name": "operations_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_farm_id_idx": {
+          "name": "operations_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_garden_id_idx": {
+          "name": "operations_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_raised_bed_id_idx": {
+          "name": "operations_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_raised_bed_field_id_idx": {
+          "name": "operations_raised_bed_field_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_timestamp_idx": {
+          "name": "operations_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_is_deleted_idx": {
+          "name": "operations_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_is_accepted_idx": {
+          "name": "operations_is_accepted_idx",
+          "columns": [
+            {
+              "expression": "is_accepted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outlet_offer_reservations": {
+      "name": "outlet_offer_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "outlet_offer_id": {
+          "name": "outlet_offer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cart_id": {
+          "name": "cart_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cart_item_id": {
+          "name": "cart_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_expires_at": {
+          "name": "hold_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'held'"
+        },
+        "held_outlet_price_cents": {
+          "name": "held_outlet_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_compare_price_cents": {
+          "name": "held_compare_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "held_sowing_date": {
+          "name": "held_sowing_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_initial_plant_status": {
+          "name": "held_initial_plant_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sprouted'"
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "converted_at": {
+          "name": "converted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "outlet_reservations_offer_id_idx": {
+          "name": "outlet_reservations_offer_id_idx",
+          "columns": [
+            {
+              "expression": "outlet_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_account_id_idx": {
+          "name": "outlet_reservations_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_cart_id_idx": {
+          "name": "outlet_reservations_cart_id_idx",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_cart_item_id_idx": {
+          "name": "outlet_reservations_cart_item_id_idx",
+          "columns": [
+            {
+              "expression": "cart_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_status_idx": {
+          "name": "outlet_reservations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_hold_expires_at_idx": {
+          "name": "outlet_reservations_hold_expires_at_idx",
+          "columns": [
+            {
+              "expression": "hold_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outlet_offer_reservations_outlet_offer_id_outlet_offers_id_fk": {
+          "name": "outlet_offer_reservations_outlet_offer_id_outlet_offers_id_fk",
+          "tableFrom": "outlet_offer_reservations",
+          "tableTo": "outlet_offers",
+          "columnsFrom": [
+            "outlet_offer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "outlet_offer_reservations_account_id_accounts_id_fk": {
+          "name": "outlet_offer_reservations_account_id_accounts_id_fk",
+          "tableFrom": "outlet_offer_reservations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "outlet_offer_reservations_cart_id_shopping_carts_id_fk": {
+          "name": "outlet_offer_reservations_cart_id_shopping_carts_id_fk",
+          "tableFrom": "outlet_offer_reservations",
+          "tableTo": "shopping_carts",
+          "columnsFrom": [
+            "cart_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "outlet_offer_reservations_cart_item_id_shopping_cart_items_id_fk": {
+          "name": "outlet_offer_reservations_cart_item_id_shopping_cart_items_id_fk",
+          "tableFrom": "outlet_offer_reservations",
+          "tableTo": "shopping_cart_items",
+          "columnsFrom": [
+            "cart_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outlet_offers": {
+      "name": "outlet_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plant_sort_id": {
+          "name": "plant_sort_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sowing_date": {
+          "name": "sowing_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_plant_status": {
+          "name": "initial_plant_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sprouted'"
+        },
+        "image_urls": {
+          "name": "image_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "outlet_price_cents": {
+          "name": "outlet_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compare_price_cents": {
+          "name": "compare_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "admin_notes": {
+          "name": "admin_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "outlet_offers_plant_sort_id_idx": {
+          "name": "outlet_offers_plant_sort_id_idx",
+          "columns": [
+            {
+              "expression": "plant_sort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_offers_status_idx": {
+          "name": "outlet_offers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_offers_start_at_idx": {
+          "name": "outlet_offers_start_at_idx",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_offers_end_at_idx": {
+          "name": "outlet_offers_end_at_idx",
+          "columns": [
+            {
+              "expression": "end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_offers_is_deleted_idx": {
+          "name": "outlet_offers_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outlet_offers_plant_sort_id_entities_id_fk": {
+          "name": "outlet_offers_plant_sort_id_entities_id_fk",
+          "tableFrom": "outlet_offers",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "plant_sort_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farmer_payout_request_adjustments": {
+      "name": "farmer_payout_request_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payout_request_id": {
+          "name": "payout_request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "farmer_payout_adjustments_request_id_idx": {
+          "name": "farmer_payout_adjustments_request_id_idx",
+          "columns": [
+            {
+              "expression": "payout_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farmer_payout_request_adjustments_payout_request_id_farmer_payout_requests_id_fk": {
+          "name": "farmer_payout_request_adjustments_payout_request_id_farmer_payout_requests_id_fk",
+          "tableFrom": "farmer_payout_request_adjustments",
+          "tableTo": "farmer_payout_requests",
+          "columnsFrom": [
+            "payout_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_request_adjustments_created_by_user_id_users_id_fk": {
+          "name": "farmer_payout_request_adjustments_created_by_user_id_users_id_fk",
+          "tableFrom": "farmer_payout_request_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farmer_payout_request_items": {
+      "name": "farmer_payout_request_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payout_request_id": {
+          "name": "payout_request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_count": {
+          "name": "operation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration_minutes": {
+          "name": "total_duration_minutes",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_per_unit": {
+          "name": "price_per_unit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "farmer_payout_items_request_id_idx": {
+          "name": "farmer_payout_items_request_id_idx",
+          "columns": [
+            {
+              "expression": "payout_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farmer_payout_request_items_payout_request_id_farmer_payout_requests_id_fk": {
+          "name": "farmer_payout_request_items_payout_request_id_farmer_payout_requests_id_fk",
+          "tableFrom": "farmer_payout_request_items",
+          "tableTo": "farmer_payout_requests",
+          "columnsFrom": [
+            "payout_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farmer_payout_requests": {
+      "name": "farmer_payout_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_amount": {
+          "name": "requested_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "farmer_note": {
+          "name": "farmer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_reference": {
+          "name": "bank_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_id": {
+          "name": "receipt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "farmer_payout_requests_farm_id_idx": {
+          "name": "farmer_payout_requests_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farmer_payout_requests_user_id_idx": {
+          "name": "farmer_payout_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farmer_payout_requests_status_idx": {
+          "name": "farmer_payout_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farmer_payout_requests_farm_id_farms_id_fk": {
+          "name": "farmer_payout_requests_farm_id_farms_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_requests_user_id_users_id_fk": {
+          "name": "farmer_payout_requests_user_id_users_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_requests_receipt_id_receipts_id_fk": {
+          "name": "farmer_payout_requests_receipt_id_receipts_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "receipts",
+          "columnsFrom": [
+            "receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_requests_approved_by_user_id_users_id_fk": {
+          "name": "farmer_payout_requests_approved_by_user_id_users_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operation_prices": {
+      "name": "operation_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_per_unit": {
+          "name": "price_per_unit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "operation_prices_farm_type_null_unique": {
+          "name": "operation_prices_farm_type_null_unique",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"operation_prices\".\"entity_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operation_prices_farm_type_entity_unique": {
+          "name": "operation_prices_farm_type_entity_unique",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"operation_prices\".\"entity_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operation_prices_farm_id_idx": {
+          "name": "operation_prices_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operation_prices_farm_id_farms_id_fk": {
+          "name": "operation_prices_farm_id_farms_id_fk",
+          "tableFrom": "operation_prices",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_id_idx": {
+          "name": "refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_at_idx": {
+          "name": "refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_token_hash_idx": {
+          "name": "refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopping_cart_items": {
+      "name": "shopping_cart_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cart_id": {
+          "name": "cart_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": null
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        }
+      },
+      "indexes": {
+        "shopping_cart_items_cart_id_idx": {
+          "name": "shopping_cart_items_cart_id_idx",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_entity_id_idx": {
+          "name": "shopping_cart_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_garden_id_idx": {
+          "name": "shopping_cart_items_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_raised_bed_id_idx": {
+          "name": "shopping_cart_items_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_is_deleted_idx": {
+          "name": "shopping_cart_items_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_status_idx": {
+          "name": "shopping_cart_items_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopping_cart_items_cart_id_shopping_carts_id_fk": {
+          "name": "shopping_cart_items_cart_id_shopping_carts_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "shopping_carts",
+          "columnsFrom": [
+            "cart_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shopping_cart_items_garden_id_gardens_id_fk": {
+          "name": "shopping_cart_items_garden_id_gardens_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shopping_cart_items_raised_bed_id_raised_beds_id_fk": {
+          "name": "shopping_cart_items_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopping_carts": {
+      "name": "shopping_carts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        }
+      },
+      "indexes": {
+        "shopping_carts_account_id_idx": {
+          "name": "shopping_carts_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_carts_is_deleted_idx": {
+          "name": "shopping_carts_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_carts_status_idx": {
+          "name": "shopping_carts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopping_carts_account_id_accounts_id_fk": {
+          "name": "shopping_carts_account_id_accounts_id_fk",
+          "tableFrom": "shopping_carts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_accounts": {
+      "name": "social_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "social_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_key": {
+          "name": "provider_account_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "social_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "default_destination": {
+          "name": "default_destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_destinations": {
+          "name": "allowed_destinations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_reference": {
+          "name": "credential_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_accounts_provider_account_key_idx": {
+          "name": "social_accounts_provider_account_key_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_accounts_provider_idx": {
+          "name": "social_accounts_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_accounts_status_idx": {
+          "name": "social_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_posts": {
+      "name": "social_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "social_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_key": {
+          "name": "provider_account_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "social_post_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "post_type": {
+          "name": "post_type",
+          "type": "social_post_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_urls": {
+          "name": "media_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_submission_id": {
+          "name": "provider_submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_permalink": {
+          "name": "provider_permalink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_metadata": {
+          "name": "failure_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_posts_provider_idx": {
+          "name": "social_posts_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_status_idx": {
+          "name": "social_posts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_scheduled_at_idx": {
+          "name": "social_posts_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_queued_at_idx": {
+          "name": "social_posts_queued_at_idx",
+          "columns": [
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_created_at_idx": {
+          "name": "social_posts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_provider_destination_idx": {
+          "name": "social_posts_provider_destination_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sunflower_ledger_entries": {
+      "name": "sunflower_ledger_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_delta": {
+          "name": "available_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reserved_delta": {
+          "name": "reserved_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_balance_after": {
+          "name": "available_balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reserved_balance_after": {
+          "name": "reserved_balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_balance_after": {
+          "name": "total_balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_eur": {
+          "name": "amount_eur",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sunflower'"
+        },
+        "package_code": {
+          "name": "package_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_entity_id": {
+          "name": "package_entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_id": {
+          "name": "receipt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reservation_key": {
+          "name": "reservation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sunflower_ledger_account_id_idx": {
+          "name": "sunflower_ledger_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_entry_type_idx": {
+          "name": "sunflower_ledger_entry_type_idx",
+          "columns": [
+            {
+              "expression": "entry_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_package_code_idx": {
+          "name": "sunflower_ledger_package_code_idx",
+          "columns": [
+            {
+              "expression": "package_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_package_entity_id_idx": {
+          "name": "sunflower_ledger_package_entity_id_idx",
+          "columns": [
+            {
+              "expression": "package_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_operation_id_idx": {
+          "name": "sunflower_ledger_operation_id_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_transaction_id_idx": {
+          "name": "sunflower_ledger_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_invoice_id_idx": {
+          "name": "sunflower_ledger_invoice_id_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_receipt_id_idx": {
+          "name": "sunflower_ledger_receipt_id_idx",
+          "columns": [
+            {
+              "expression": "receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_reservation_key_idx": {
+          "name": "sunflower_ledger_reservation_key_idx",
+          "columns": [
+            {
+              "expression": "reservation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_source_idx": {
+          "name": "sunflower_ledger_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_created_at_idx": {
+          "name": "sunflower_ledger_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_is_deleted_idx": {
+          "name": "sunflower_ledger_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_account_idempotency_unique": {
+          "name": "sunflower_ledger_account_idempotency_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sunflower_ledger_entries_account_id_accounts_id_fk": {
+          "name": "sunflower_ledger_entries_account_id_accounts_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_package_entity_id_entities_id_fk": {
+          "name": "sunflower_ledger_entries_package_entity_id_entities_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "package_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_operation_id_operations_id_fk": {
+          "name": "sunflower_ledger_entries_operation_id_operations_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "operations",
+          "columnsFrom": [
+            "operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_transaction_id_transactions_id_fk": {
+          "name": "sunflower_ledger_entries_transaction_id_transactions_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_invoice_id_invoices_id_fk": {
+          "name": "sunflower_ledger_entries_invoice_id_invoices_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_receipt_id_receipts_id_fk": {
+          "name": "sunflower_ledger_entries_receipt_id_receipts_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "receipts",
+          "columnsFrom": [
+            "receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_answers": {
+      "name": "survey_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_key": {
+          "name": "question_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "survey_question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "numeric_value": {
+          "name": "numeric_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_value": {
+          "name": "text_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_value": {
+          "name": "contact_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_answers_response_question_unique": {
+          "name": "survey_answers_response_question_unique",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answers_response_idx": {
+          "name": "survey_answers_response_idx",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answers_question_idx": {
+          "name": "survey_answers_question_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answers_question_key_idx": {
+          "name": "survey_answers_question_key_idx",
+          "columns": [
+            {
+              "expression": "question_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_answers_response_id_survey_responses_id_fk": {
+          "name": "survey_answers_response_id_survey_responses_id_fk",
+          "tableFrom": "survey_answers",
+          "tableTo": "survey_responses",
+          "columnsFrom": [
+            "response_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "survey_answers_question_id_survey_questions_id_fk": {
+          "name": "survey_answers_question_id_survey_questions_id_fk",
+          "tableFrom": "survey_answers",
+          "tableTo": "survey_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_assignments": {
+      "name": "survey_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "send_id": {
+          "name": "send_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_assignments_version_target_context_unique": {
+          "name": "survey_assignments_version_target_context_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_survey_idx": {
+          "name": "survey_assignments_survey_idx",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_version_idx": {
+          "name": "survey_assignments_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_account_idx": {
+          "name": "survey_assignments_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_user_idx": {
+          "name": "survey_assignments_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_status_idx": {
+          "name": "survey_assignments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_send_idx": {
+          "name": "survey_assignments_send_idx",
+          "columns": [
+            {
+              "expression": "send_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_assignments_survey_id_surveys_id_fk": {
+          "name": "survey_assignments_survey_id_surveys_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_assignments_version_id_survey_versions_id_fk": {
+          "name": "survey_assignments_version_id_survey_versions_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "survey_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_assignments_send_id_survey_sends_id_fk": {
+          "name": "survey_assignments_send_id_survey_sends_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "survey_sends",
+          "columnsFrom": [
+            "send_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_assignments_account_id_accounts_id_fk": {
+          "name": "survey_assignments_account_id_accounts_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_assignments_user_id_users_id_fk": {
+          "name": "survey_assignments_user_id_users_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_questions": {
+      "name": "survey_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "survey_question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_metadata": {
+          "name": "score_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_questions_version_key_unique": {
+          "name": "survey_questions_version_key_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_questions_version_order_unique": {
+          "name": "survey_questions_version_order_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_questions_version_idx": {
+          "name": "survey_questions_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_questions_version_id_survey_versions_id_fk": {
+          "name": "survey_questions_version_id_survey_versions_id_fk",
+          "tableFrom": "survey_questions",
+          "tableTo": "survey_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_responses": {
+      "name": "survey_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "survey_response_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_app'"
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "imported_external_id": {
+          "name": "imported_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_responses_assignment_unique": {
+          "name": "survey_responses_assignment_unique",
+          "columns": [
+            {
+              "expression": "assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_imported_external_unique": {
+          "name": "survey_responses_imported_external_unique",
+          "columns": [
+            {
+              "expression": "imported_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_survey_idx": {
+          "name": "survey_responses_survey_idx",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_version_idx": {
+          "name": "survey_responses_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_account_idx": {
+          "name": "survey_responses_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_user_idx": {
+          "name": "survey_responses_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_source_idx": {
+          "name": "survey_responses_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_submitted_at_idx": {
+          "name": "survey_responses_submitted_at_idx",
+          "columns": [
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_responses_assignment_id_survey_assignments_id_fk": {
+          "name": "survey_responses_assignment_id_survey_assignments_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "survey_assignments",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_responses_survey_id_surveys_id_fk": {
+          "name": "survey_responses_survey_id_surveys_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_responses_version_id_survey_versions_id_fk": {
+          "name": "survey_responses_version_id_survey_versions_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "survey_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_responses_account_id_accounts_id_fk": {
+          "name": "survey_responses_account_id_accounts_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_responses_user_id_users_id_fk": {
+          "name": "survey_responses_user_id_users_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_send_deliveries": {
+      "name": "survey_send_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "send_id": {
+          "name": "send_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "survey_send_delivery_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_send_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_send_deliveries_send_idx": {
+          "name": "survey_send_deliveries_send_idx",
+          "columns": [
+            {
+              "expression": "send_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_send_deliveries_assignment_idx": {
+          "name": "survey_send_deliveries_assignment_idx",
+          "columns": [
+            {
+              "expression": "assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_send_deliveries_status_idx": {
+          "name": "survey_send_deliveries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_send_deliveries_notification_idx": {
+          "name": "survey_send_deliveries_notification_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_send_deliveries_send_id_survey_sends_id_fk": {
+          "name": "survey_send_deliveries_send_id_survey_sends_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "survey_sends",
+          "columnsFrom": [
+            "send_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "survey_send_deliveries_assignment_id_survey_assignments_id_fk": {
+          "name": "survey_send_deliveries_assignment_id_survey_assignments_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "survey_assignments",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_send_deliveries_account_id_accounts_id_fk": {
+          "name": "survey_send_deliveries_account_id_accounts_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_send_deliveries_user_id_users_id_fk": {
+          "name": "survey_send_deliveries_user_id_users_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_send_deliveries_notification_id_notifications_id_fk": {
+          "name": "survey_send_deliveries_notification_id_notifications_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_sends": {
+      "name": "survey_sends",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_policy": {
+          "name": "channel_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "target_count": {
+          "name": "target_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "assigned_count": {
+          "name": "assigned_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_duplicate_count": {
+          "name": "skipped_duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from_account_id": {
+          "name": "created_from_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_sends_survey_idx": {
+          "name": "survey_sends_survey_idx",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_sends_version_idx": {
+          "name": "survey_sends_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_sends_status_idx": {
+          "name": "survey_sends_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_sends_context_key_idx": {
+          "name": "survey_sends_context_key_idx",
+          "columns": [
+            {
+              "expression": "context_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_sends_survey_id_surveys_id_fk": {
+          "name": "survey_sends_survey_id_surveys_id_fk",
+          "tableFrom": "survey_sends",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_sends_version_id_survey_versions_id_fk": {
+          "name": "survey_sends_version_id_survey_versions_id_fk",
+          "tableFrom": "survey_sends",
+          "tableTo": "survey_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_sends_created_by_user_id_users_id_fk": {
+          "name": "survey_sends_created_by_user_id_users_id_fk",
+          "tableFrom": "survey_sends",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_sends_created_from_account_id_accounts_id_fk": {
+          "name": "survey_sends_created_from_account_id_accounts_id_fk",
+          "tableFrom": "survey_sends",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "created_from_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_versions": {
+      "name": "survey_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_title": {
+          "name": "intro_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_description": {
+          "name": "intro_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thank_you_title": {
+          "name": "thank_you_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thank_you_description": {
+          "name": "thank_you_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_versions_survey_number_unique": {
+          "name": "survey_versions_survey_number_unique",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_versions_survey_status_idx": {
+          "name": "survey_versions_survey_status_idx",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_versions_survey_id_surveys_id_fk": {
+          "name": "survey_versions_survey_id_surveys_id_fk",
+          "tableFrom": "survey_versions",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.surveys": {
+      "name": "surveys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "surveys_key_unique": {
+          "name": "surveys_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "surveys_status_idx": {
+          "name": "surveys_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "surveys_category_idx": {
+          "name": "surveys_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "surveys_created_by_user_id_users_id_fk": {
+          "name": "surveys_created_by_user_id_users_id_fk",
+          "tableFrom": "surveys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "transactions_account_id_idx": {
+          "name": "transactions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_garden_id_idx": {
+          "name": "transactions_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_stripe_payment_id_idx": {
+          "name": "transactions_stripe_payment_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_is_deleted_idx": {
+          "name": "transactions_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_garden_id_gardens_id_fk": {
+          "name": "transactions_garden_id_gardens_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tutorial_checklist_task_claims": {
+      "name": "tutorial_checklist_task_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_key": {
+          "name": "task_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_sunflowers": {
+          "name": "reward_sunflowers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tutorial_checklist_claims_account_id_idx": {
+          "name": "tutorial_checklist_claims_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tutorial_checklist_claims_task_key_idx": {
+          "name": "tutorial_checklist_claims_task_key_idx",
+          "columns": [
+            {
+              "expression": "task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tutorial_checklist_claims_account_task_uq": {
+          "name": "tutorial_checklist_claims_account_task_uq",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tutorial_checklist_task_claims_account_id_accounts_id_fk": {
+          "name": "tutorial_checklist_task_claims_account_id_accounts_id_fk",
+          "tableFrom": "tutorial_checklist_task_claims",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "user_favorite_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_favorites_user_entity_uq": {
+          "name": "user_favorites_user_entity_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_user_id_idx": {
+          "name": "user_favorites_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_entity_type_idx": {
+          "name": "user_favorites_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_entity_id_idx": {
+          "name": "user_favorites_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_favorites_entity_id_entities_id_fk": {
+          "name": "user_favorites_entity_id_entities_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_invitations": {
+      "name": "account_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "account_invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_invitations_account_id_idx": {
+          "name": "account_invitations_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_invitations_email_idx": {
+          "name": "account_invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_invitations_token_idx": {
+          "name": "account_invitations_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_invitations_account_id_accounts_id_fk": {
+          "name": "account_invitations_account_id_accounts_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_invitations_invited_by_user_id_users_id_fk": {
+          "name": "account_invitations_invited_by_user_id_users_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_users": {
+      "name": "account_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_au_account_id_idx": {
+          "name": "users_au_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_au_user_id_idx": {
+          "name": "users_au_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_users_account_id_accounts_id_fk": {
+          "name": "account_users_account_id_accounts_id_fk",
+          "tableFrom": "account_users",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_users_user_id_users_id_fk": {
+          "name": "account_users_user_id_users_id_fk",
+          "tableFrom": "account_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_street1": {
+          "name": "address_street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_street2": {
+          "name": "address_street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_city": {
+          "name": "address_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_zip": {
+          "name": "address_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Europe/Paris'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farm_users": {
+      "name": "farm_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "farm_users_farm_id_idx": {
+          "name": "farm_users_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farm_users_user_id_idx": {
+          "name": "farm_users_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farm_users_farm_user_unique": {
+          "name": "farm_users_farm_user_unique",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farm_users_farm_id_farms_id_fk": {
+          "name": "farm_users_farm_id_farms_id_fk",
+          "tableFrom": "farm_users",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farm_users_user_id_users_id_fk": {
+          "name": "farm_users_user_id_users_id_fk",
+          "tableFrom": "farm_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_logins": {
+      "name": "user_logins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_type": {
+          "name": "login_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_id": {
+          "name": "login_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_data": {
+          "name": "login_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_attempts": {
+          "name": "failed_attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failed_attempt": {
+          "name": "last_failed_attempt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_until": {
+          "name": "blocked_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_ul_user_id_idx": {
+          "name": "users_ul_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_ul_login_type_idx": {
+          "name": "users_ul_login_type_idx",
+          "columns": [
+            {
+              "expression": "login_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_ul_login_id_idx": {
+          "name": "users_ul_login_id_idx",
+          "columns": [
+            {
+              "expression": "login_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_logins_user_id_users_id_fk": {
+          "name": "user_logins_user_id_users_id_fk",
+          "tableFrom": "user_logins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday_day": {
+          "name": "birthday_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday_month": {
+          "name": "birthday_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday_year": {
+          "name": "birthday_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday_last_updated_at": {
+          "name": "birthday_last_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whats_new_last_seen_at": {
+          "name": "whats_new_last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whats_new_popup_disabled": {
+          "name": "whats_new_popup_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "farm_schedule_grouped_watering_enabled": {
+          "name": "farm_schedule_grouped_watering_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_u_username_idx": {
+          "name": "users_u_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_history": {
+      "name": "weather_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rain": {
+          "name": "rain",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wind_direction": {
+          "name": "wind_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wind_speed": {
+          "name": "wind_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rainy": {
+          "name": "rainy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "snowy": {
+          "name": "snowy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cloudy": {
+          "name": "cloudy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "foggy": {
+          "name": "foggy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "thundery": {
+          "name": "thundery",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "weather_history_recorded_at_idx": {
+          "name": "weather_history_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_status": {
+      "name": "achievement_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.automation_definition_status": {
+      "name": "automation_definition_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "enabled",
+        "disabled",
+        "archived"
+      ]
+    },
+    "public.automation_module_kind": {
+      "name": "automation_module_kind",
+      "schema": "public",
+      "values": [
+        "trigger",
+        "filter",
+        "condition",
+        "action"
+      ]
+    },
+    "public.automation_run_source": {
+      "name": "automation_run_source",
+      "schema": "public",
+      "values": [
+        "event",
+        "manual",
+        "schedule",
+        "test",
+        "replay"
+      ]
+    },
+    "public.automation_run_status": {
+      "name": "automation_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "skipped",
+        "failed",
+        "retrying",
+        "canceled"
+      ]
+    },
+    "public.automation_step_status": {
+      "name": "automation_step_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "succeeded",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.email_status": {
+      "name": "email_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sending",
+        "sent",
+        "failed",
+        "bounced"
+      ]
+    },
+    "public.newsletter_status": {
+      "name": "newsletter_status",
+      "schema": "public",
+      "values": [
+        "subscribed",
+        "unsubscribed",
+        "pending"
+      ]
+    },
+    "public.notification_delivery_status": {
+      "name": "notification_delivery_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "accepted",
+        "sent",
+        "failed",
+        "dropped"
+      ]
+    },
+    "public.notification_delivery_event_type": {
+      "name": "notification_delivery_event_type",
+      "schema": "public",
+      "values": [
+        "queued",
+        "accepted",
+        "sent",
+        "failed",
+        "opened",
+        "clicked",
+        "dismissed",
+        "unsubscribed"
+      ]
+    },
+    "public.notification_digest_frequency": {
+      "name": "notification_digest_frequency",
+      "schema": "public",
+      "values": [
+        "off",
+        "hourly",
+        "daily",
+        "weekly"
+      ]
+    },
+    "public.notification_campaign_status": {
+      "name": "notification_campaign_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "scheduled",
+        "queued",
+        "sending",
+        "sent",
+        "cancelled",
+        "failed"
+      ]
+    },
+    "public.notification_channel": {
+      "name": "notification_channel",
+      "schema": "public",
+      "values": [
+        "in_app",
+        "email",
+        "push",
+        "sms"
+      ]
+    },
+    "public.notification_preference_scope": {
+      "name": "notification_preference_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "account"
+      ]
+    },
+    "public.notification_priority": {
+      "name": "notification_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "critical"
+      ]
+    },
+    "public.push_permission_state": {
+      "name": "push_permission_state",
+      "schema": "public",
+      "values": [
+        "default",
+        "granted",
+        "denied"
+      ]
+    },
+    "public.social_account_status": {
+      "name": "social_account_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "disabled",
+        "needs_reauth"
+      ]
+    },
+    "public.social_post_status": {
+      "name": "social_post_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "queued",
+        "scheduled",
+        "submitting",
+        "submitted",
+        "published",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.social_post_type": {
+      "name": "social_post_type",
+      "schema": "public",
+      "values": [
+        "text",
+        "link",
+        "image",
+        "video",
+        "reel",
+        "story",
+        "carousel",
+        "other"
+      ]
+    },
+    "public.social_provider": {
+      "name": "social_provider",
+      "schema": "public",
+      "values": [
+        "reddit",
+        "instagram",
+        "facebook",
+        "google_business",
+        "x",
+        "tiktok",
+        "threads",
+        "linkedin",
+        "whatsapp"
+      ]
+    },
+    "public.survey_assignment_status": {
+      "name": "survey_assignment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "started",
+        "submitted",
+        "expired",
+        "canceled"
+      ]
+    },
+    "public.survey_question_type": {
+      "name": "survey_question_type",
+      "schema": "public",
+      "values": [
+        "opinion_scale",
+        "long_text",
+        "contact_info"
+      ]
+    },
+    "public.survey_response_source": {
+      "name": "survey_response_source",
+      "schema": "public",
+      "values": [
+        "in_app",
+        "typeform",
+        "admin_import"
+      ]
+    },
+    "public.survey_send_delivery_channel": {
+      "name": "survey_send_delivery_channel",
+      "schema": "public",
+      "values": [
+        "in_app",
+        "email"
+      ]
+    },
+    "public.survey_send_delivery_status": {
+      "name": "survey_send_delivery_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.survey_send_status": {
+      "name": "survey_send_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "scheduled",
+        "sent",
+        "canceled",
+        "failed"
+      ]
+    },
+    "public.survey_status": {
+      "name": "survey_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.survey_version_status": {
+      "name": "survey_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.user_favorite_entity_type": {
+      "name": "user_favorite_entity_type",
+      "schema": "public",
+      "values": [
+        "plant",
+        "plantSort",
+        "operation"
+      ]
+    },
+    "public.account_invitation_status": {
+      "name": "account_invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage/src/migrations/meta/_journal.json
+++ b/packages/storage/src/migrations/meta/_journal.json
@@ -519,6 +519,13 @@
       "when": 1784117004059,
       "tag": "0073_overrated_sleepwalker",
       "breakpoints": true
+    },
+    {
+      "idx": 74,
+      "version": "7",
+      "when": 1784138271972,
+      "tag": "0074_strong_morlun",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage/src/repositories/deliveryRequestsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRequestsRepo.ts
@@ -74,6 +74,25 @@ type DeliveryRaisedBedField = Partial<
     Pick<RaisedBedFieldWithEvents, 'plantCycles' | 'plantSortId'>
 >;
 
+export const DeliveryRequestFulfillmentErrorCodes = {
+    NOT_FOUND: 'delivery-request-not-found',
+    STATE_CONFLICT: 'delivery-request-state-conflict',
+} as const;
+
+export type DeliveryRequestFulfillmentErrorCode =
+    (typeof DeliveryRequestFulfillmentErrorCodes)[keyof typeof DeliveryRequestFulfillmentErrorCodes];
+
+export class DeliveryRequestFulfillmentError extends Error {
+    override name = 'DeliveryRequestFulfillmentError';
+
+    constructor(
+        readonly code: DeliveryRequestFulfillmentErrorCode,
+        message: string,
+    ) {
+        super(message);
+    }
+}
+
 // TODO: Should use types from union of payloads for delivery events
 interface DeliveryEventData {
     slotId?: number;
@@ -1776,7 +1795,10 @@ export async function fulfillDeliveryRequest(
     const request = await getDeliveryRequest(requestId, db);
 
     if (!request) {
-        throw new Error('Delivery request not found');
+        throw new DeliveryRequestFulfillmentError(
+            DeliveryRequestFulfillmentErrorCodes.NOT_FOUND,
+            'Delivery request not found',
+        );
     }
 
     if (request.state === DeliveryRequestStates.FULFILLED) {
@@ -1785,13 +1807,17 @@ export async function fulfillDeliveryRequest(
     }
 
     if (request.state === DeliveryRequestStates.CANCELLED) {
-        throw new Error('Cannot fulfill a cancelled delivery request');
+        throw new DeliveryRequestFulfillmentError(
+            DeliveryRequestFulfillmentErrorCodes.STATE_CONFLICT,
+            'Cannot fulfill a cancelled delivery request',
+        );
     }
     if (
         request.state === DeliveryRequestStates.DEFERRED ||
         request.state === DeliveryRequestStates.FAILED
     ) {
-        throw new Error(
+        throw new DeliveryRequestFulfillmentError(
+            DeliveryRequestFulfillmentErrorCodes.STATE_CONFLICT,
             'Cannot fulfill a delivery request with an exception outcome',
         );
     }

--- a/packages/storage/src/repositories/deliveryRunsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRunsRepo.ts
@@ -39,6 +39,9 @@ import {
     type DeliveryRunPreparationPlanPayloadV2,
     type DeliveryRunPreparationPlanPayloadV3,
     DeliveryRunStates,
+    type DeliveryRunStopOperationKind,
+    DeliveryRunStopOperationKinds,
+    type DeliveryRunStopOperationStoredResult,
     type DeliveryRunStopState,
     DeliveryRunStopStates,
     deliveryAddresses,
@@ -48,6 +51,7 @@ import {
     deliveryRunPickupOperations,
     deliveryRunPreparations,
     deliveryRunSlots,
+    deliveryRunStopOperations,
     deliveryRunStops,
     deliveryRuns,
     events,
@@ -282,6 +286,8 @@ export const DeliveryRunExecutionErrorCodes = {
     EXCEPTION_OPERATION_CONFLICT: 'exception-operation-conflict',
     EXCEPTION_INVALID: 'exception-invalid',
     EXCEPTION_TRANSITION_INVALID: 'exception-transition-invalid',
+    STOP_OPERATION_CONFLICT: 'stop-operation-conflict',
+    STOP_OPERATION_INVALID: 'stop-operation-invalid',
     RUN_DRIVER_CONFLICT: 'run-driver-conflict',
     RUN_MUTATION_INVALID: 'run-mutation-invalid',
     LOCATION_CONFLICT: 'location-conflict',
@@ -371,6 +377,30 @@ export type RecordDeliveryRunStopExceptionsResult = {
     clientOperationId: string;
     replayed: boolean;
     result: DeliveryRunExceptionOperationStoredResult;
+};
+
+type RecordDeliveryRunStopOperationBase = {
+    driverUserId: string;
+    runId: string;
+    targetStopId: number;
+    expectedRouteRevision: number;
+    clientOperationId: string;
+    occurredAt: Date;
+};
+
+export type RecordDeliveryRunStopOperationInput =
+    | (RecordDeliveryRunStopOperationBase & {
+          kind: 'arrive';
+      })
+    | (RecordDeliveryRunStopOperationBase & {
+          kind: 'deliver';
+          deliveryNotes?: string;
+      });
+
+export type RecordDeliveryRunStopOperationResult = {
+    clientOperationId: string;
+    replayed: boolean;
+    result: DeliveryRunStopOperationStoredResult;
 };
 
 export type SaveDeliveryRunPreparationInput = {
@@ -4628,17 +4658,127 @@ export async function updateDeliveryRunEstimates({
     });
 }
 
+const deliveryRunStopOperationMaximumAgeMs = 36 * 60 * 60 * 1000;
+const deliveryRunStopOperationMaximumFutureSkewMs = 5 * 60 * 1000;
+
+type NormalizedRecordDeliveryRunStopOperationInput =
+    RecordDeliveryRunStopOperationBase & {
+        kind: DeliveryRunStopOperationKind;
+        deliveryNotes?: string;
+    };
+
+function invalidDeliveryRunStopOperation(message: string): never {
+    throw new DeliveryRunExecutionError(
+        DeliveryRunExecutionErrorCodes.STOP_OPERATION_INVALID,
+        message,
+    );
+}
+
+export function deliveryRunStopOperationOccurredAtIsAcceptable(
+    occurredAt: Date,
+    appliedAt = new Date(),
+) {
+    const occurredAtMs = occurredAt.getTime();
+    const appliedAtMs = appliedAt.getTime();
+    if (!Number.isFinite(occurredAtMs) || !Number.isFinite(appliedAtMs)) {
+        return false;
+    }
+    const ageMs = appliedAtMs - occurredAtMs;
+    return (
+        ageMs <= deliveryRunStopOperationMaximumAgeMs &&
+        ageMs >= -deliveryRunStopOperationMaximumFutureSkewMs
+    );
+}
+
+function normalizeDeliveryRunStopOperationInput(
+    input: RecordDeliveryRunStopOperationInput,
+): NormalizedRecordDeliveryRunStopOperationInput {
+    const clientOperationId = input.clientOperationId.trim();
+    if (clientOperationId.length === 0 || clientOperationId.length > 128) {
+        invalidDeliveryRunStopOperation(
+            'Delivery stop operation ID must contain 1 to 128 characters',
+        );
+    }
+    if (
+        input.kind !== DeliveryRunStopOperationKinds.ARRIVE &&
+        input.kind !== DeliveryRunStopOperationKinds.DELIVER
+    ) {
+        invalidDeliveryRunStopOperation(
+            'Delivery stop operation kind is invalid',
+        );
+    }
+    if (!Number.isInteger(input.targetStopId) || input.targetStopId <= 0) {
+        invalidDeliveryRunStopOperation('Delivery stop selection is invalid');
+    }
+    if (
+        !Number.isInteger(input.expectedRouteRevision) ||
+        input.expectedRouteRevision < 0
+    ) {
+        invalidDeliveryRunStopOperation('Delivery route revision is invalid');
+    }
+    if (
+        !(input.occurredAt instanceof Date) ||
+        !Number.isFinite(input.occurredAt.getTime())
+    ) {
+        invalidDeliveryRunStopOperation(
+            'Delivery stop operation occurrence time is invalid',
+        );
+    }
+    const deliveryNotes =
+        input.kind === DeliveryRunStopOperationKinds.DELIVER
+            ? input.deliveryNotes?.trim()
+            : undefined;
+    if (deliveryNotes && deliveryNotes.length > 1_000) {
+        invalidDeliveryRunStopOperation(
+            'Delivery notes must not exceed 1000 characters',
+        );
+    }
+    return {
+        driverUserId: input.driverUserId,
+        runId: input.runId,
+        targetStopId: input.targetStopId,
+        expectedRouteRevision: input.expectedRouteRevision,
+        clientOperationId,
+        occurredAt: input.occurredAt,
+        kind: input.kind,
+        ...(deliveryNotes ? { deliveryNotes } : {}),
+    };
+}
+
+function deliveryRunStopOperationPayloadHash(
+    input: NormalizedRecordDeliveryRunStopOperationInput,
+) {
+    return hashValue(
+        JSON.stringify({
+            clientOperationId: input.clientOperationId,
+            kind: input.kind,
+            targetStopId: input.targetStopId,
+            expectedRouteRevision: input.expectedRouteRevision,
+            occurredAt: input.occurredAt.toISOString(),
+            deliveryNotes: input.deliveryNotes ?? null,
+        }),
+    );
+}
+
+async function lockDeliveryRun(runId: string, db: TransactionClient) {
+    await db.execute(
+        sql`select ${deliveryRuns.id} from ${deliveryRuns} where ${deliveryRuns.id} = ${runId} for update`,
+    );
+}
+
 async function ensureOwnedDeliveryRunStops({
     driverUserId,
     runId,
     stopIds,
     expectedRouteRevision,
+    runAlreadyLocked = false,
     db,
 }: {
     driverUserId: string;
     runId: string;
     stopIds: number[];
     expectedRouteRevision?: number;
+    runAlreadyLocked?: boolean;
     db: TransactionClient;
 }) {
     const uniqueStopIds = Array.from(new Set(stopIds));
@@ -4649,9 +4789,7 @@ async function ensureOwnedDeliveryRunStops({
     // Serialize every arrival/delivery transition for this run before reading
     // stop state. Without this lock, a late arrival write can overwrite a
     // concurrently committed delivered state.
-    await db.execute(
-        sql`select ${deliveryRuns.id} from ${deliveryRuns} where ${deliveryRuns.id} = ${runId} for update`,
-    );
+    if (!runAlreadyLocked) await lockDeliveryRun(runId, db);
 
     const stops = await db.query.deliveryRunStops.findMany({
         where: and(
@@ -4762,6 +4900,64 @@ async function ensureOwnedDeliveryRunStops({
     return stops;
 }
 
+async function applyDeliveryRunStopsArrivedInDatabase({
+    runId,
+    stops,
+    occurredAt,
+    db,
+}: {
+    runId: string;
+    stops: Awaited<ReturnType<typeof ensureOwnedDeliveryRunStops>>;
+    occurredAt: Date;
+    db: TransactionClient;
+}) {
+    const advancesExecution = stops.some(
+        (stop) => stop.state === DeliveryRunStopStates.PENDING,
+    );
+
+    for (const stop of stops) {
+        if (!isDeliveryRunStopActionable(stop.state)) continue;
+        const [updatedStop] = await db
+            .update(deliveryRunStops)
+            .set({
+                state: DeliveryRunStopStates.ARRIVED,
+                arrivedAt: stop.arrivedAt ?? occurredAt,
+            })
+            .where(
+                and(
+                    eq(deliveryRunStops.id, stop.id),
+                    inArray(deliveryRunStops.state, [
+                        DeliveryRunStopStates.PENDING,
+                        DeliveryRunStopStates.ARRIVED,
+                    ]),
+                ),
+            )
+            .returning({ id: deliveryRunStops.id });
+        if (!updatedStop) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.EXCEPTION_TRANSITION_INVALID,
+                `Delivery stop ${stop.id} changed before arrival could be recorded`,
+            );
+        }
+    }
+
+    if (advancesExecution) {
+        await db
+            .update(deliveryRuns)
+            .set({
+                routeRevision: sql`${deliveryRuns.routeRevision} + 1`,
+                rerouteAttemptedAt: null,
+            })
+            .where(
+                and(
+                    eq(deliveryRuns.id, runId),
+                    eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+                ),
+            );
+    }
+    return stops;
+}
+
 export async function markDeliveryRunStopsArrived({
     driverUserId,
     runId,
@@ -4781,55 +4977,12 @@ export async function markDeliveryRunStopsArrived({
             expectedRouteRevision,
             db: tx,
         });
-        const now = new Date();
-        const advancesExecution = stops.some(
-            (stop) => stop.state === DeliveryRunStopStates.PENDING,
-        );
-
-        for (const stop of stops) {
-            if (!isDeliveryRunStopActionable(stop.state)) {
-                continue;
-            }
-            const [updatedStop] = await tx
-                .update(deliveryRunStops)
-                .set({
-                    state: DeliveryRunStopStates.ARRIVED,
-                    arrivedAt: stop.arrivedAt ?? now,
-                })
-                .where(
-                    and(
-                        eq(deliveryRunStops.id, stop.id),
-                        inArray(deliveryRunStops.state, [
-                            DeliveryRunStopStates.PENDING,
-                            DeliveryRunStopStates.ARRIVED,
-                        ]),
-                    ),
-                )
-                .returning({ id: deliveryRunStops.id });
-            if (!updatedStop) {
-                throw new DeliveryRunExecutionError(
-                    DeliveryRunExecutionErrorCodes.EXCEPTION_TRANSITION_INVALID,
-                    `Delivery stop ${stop.id} changed before arrival could be recorded`,
-                );
-            }
-        }
-
-        if (advancesExecution) {
-            await tx
-                .update(deliveryRuns)
-                .set({
-                    routeRevision: sql`${deliveryRuns.routeRevision} + 1`,
-                    rerouteAttemptedAt: null,
-                })
-                .where(
-                    and(
-                        eq(deliveryRuns.id, runId),
-                        eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
-                    ),
-                );
-        }
-
-        return stops;
+        return await applyDeliveryRunStopsArrivedInDatabase({
+            runId,
+            stops,
+            occurredAt: new Date(),
+            db: tx,
+        });
     });
 }
 
@@ -4897,6 +5050,28 @@ async function markDeliveryRunStopsDeliveredInDatabase({
         db,
     });
     const now = new Date();
+    return await applyDeliveryRunStopsDeliveredInDatabase({
+        runId,
+        stops,
+        occurredAt: now,
+        appliedAt: now,
+        db,
+    });
+}
+
+async function applyDeliveryRunStopsDeliveredInDatabase({
+    runId,
+    stops,
+    occurredAt,
+    appliedAt,
+    db,
+}: {
+    runId: string;
+    stops: Awaited<ReturnType<typeof ensureOwnedDeliveryRunStops>>;
+    occurredAt: Date;
+    appliedAt: Date;
+    db: TransactionClient;
+}) {
     const advancesExecution = stops.some((stop) =>
         isDeliveryRunStopActionable(stop.state),
     );
@@ -4909,8 +5084,8 @@ async function markDeliveryRunStopsDeliveredInDatabase({
             .update(deliveryRunStops)
             .set({
                 state: DeliveryRunStopStates.DELIVERED,
-                arrivedAt: stop.arrivedAt ?? now,
-                deliveredAt: now,
+                arrivedAt: stop.arrivedAt ?? occurredAt,
+                deliveredAt: occurredAt,
             })
             .where(
                 and(
@@ -4946,7 +5121,11 @@ async function markDeliveryRunStopsDeliveredInDatabase({
             );
     }
 
-    await completeDeliveryRunIfEligible({ runId, completedAt: now, db });
+    await completeDeliveryRunIfEligible({
+        runId,
+        completedAt: appliedAt,
+        db,
+    });
 
     return stops.flatMap((stop) =>
         stop.state === DeliveryRunStopStates.DELIVERED ||
@@ -4985,11 +5164,12 @@ export async function fulfillDeliveryRunStops({
                 tx,
             );
         }
-        return await markDeliveryRunStopsDeliveredInDatabase({
-            driverUserId,
+        const appliedAt = new Date();
+        return await applyDeliveryRunStopsDeliveredInDatabase({
             runId,
-            stopIds,
-            expectedRouteRevision,
+            stops,
+            occurredAt: appliedAt,
+            appliedAt,
             db: tx,
         });
     });
@@ -5016,4 +5196,255 @@ export async function fulfillDeliveryRunStop({
         expectedRouteRevision,
     });
     return requestIds[0];
+}
+
+async function currentDeliveryRunStopIdsForOperation({
+    driverUserId,
+    runId,
+    targetStopId,
+    expectedRouteRevision,
+    db,
+}: {
+    driverUserId: string;
+    runId: string;
+    targetStopId: number;
+    expectedRouteRevision: number;
+    db: TransactionClient;
+}) {
+    const run = await db.query.deliveryRuns.findFirst({
+        where: eq(deliveryRuns.id, runId),
+    });
+    if (
+        !run ||
+        run.driverUserId !== driverUserId ||
+        run.state !== DeliveryRunStates.ACTIVE
+    ) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND,
+            'Active delivery run was not found',
+        );
+    }
+    if (run.routeRevision !== expectedRouteRevision) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+            'Delivery route changed. Refresh the active run and retry.',
+        );
+    }
+
+    const progress = await getDeliveryRunExecutionProgressFromDb(runId, db);
+    const current = progress.find((step) => step.state === 'current');
+    if (current?.kind === 'pickup') {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.PICKUP_DEPENDENCY_PENDING,
+            'Delivery pickup dependency is pending',
+        );
+    }
+    if (
+        current?.kind !== 'delivery' ||
+        !current.stopIds.includes(targetStopId)
+    ) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.ROUTE_ORDER,
+            'Delivery operation must target the current delivery checkpoint',
+        );
+    }
+    if (!current.pickupConfirmed) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.PICKUP_DEPENDENCY_PENDING,
+            'Delivery pickup dependency is pending',
+        );
+    }
+    return current.stopIds;
+}
+
+function deliveryRunStopOperationReceiptResult({
+    receipt,
+    driverUserId,
+    payloadHash,
+}: {
+    receipt: typeof deliveryRunStopOperations.$inferSelect;
+    driverUserId: string;
+    payloadHash: string;
+}): RecordDeliveryRunStopOperationResult & {
+    newlyFulfilledRequestIds: string[];
+} {
+    if (
+        receipt.driverUserId !== driverUserId ||
+        receipt.payloadHash !== payloadHash
+    ) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.STOP_OPERATION_CONFLICT,
+            'Delivery stop operation ID was reused with different content',
+        );
+    }
+    return {
+        clientOperationId: receipt.clientOperationId,
+        replayed: true,
+        result: receipt.result,
+        newlyFulfilledRequestIds: [],
+    };
+}
+
+async function recordDeliveryRunStopOperationInDatabase(
+    input: NormalizedRecordDeliveryRunStopOperationInput,
+    db: TransactionClient,
+): Promise<
+    RecordDeliveryRunStopOperationResult & {
+        newlyFulfilledRequestIds: string[];
+    }
+> {
+    const payloadHash = deliveryRunStopOperationPayloadHash(input);
+    const existingReceipt = await db.query.deliveryRunStopOperations.findFirst({
+        where: and(
+            eq(deliveryRunStopOperations.runId, input.runId),
+            eq(
+                deliveryRunStopOperations.clientOperationId,
+                input.clientOperationId,
+            ),
+        ),
+    });
+    if (existingReceipt) {
+        return deliveryRunStopOperationReceiptResult({
+            receipt: existingReceipt,
+            driverUserId: input.driverUserId,
+            payloadHash,
+        });
+    }
+
+    await lockDeliveryRun(input.runId, db);
+    const receiptAfterLock = await db.query.deliveryRunStopOperations.findFirst(
+        {
+            where: and(
+                eq(deliveryRunStopOperations.runId, input.runId),
+                eq(
+                    deliveryRunStopOperations.clientOperationId,
+                    input.clientOperationId,
+                ),
+            ),
+        },
+    );
+    if (receiptAfterLock) {
+        return deliveryRunStopOperationReceiptResult({
+            receipt: receiptAfterLock,
+            driverUserId: input.driverUserId,
+            payloadHash,
+        });
+    }
+
+    const appliedAt = new Date();
+    if (
+        !deliveryRunStopOperationOccurredAtIsAcceptable(
+            input.occurredAt,
+            appliedAt,
+        )
+    ) {
+        invalidDeliveryRunStopOperation(
+            'Delivery stop operation occurrence time is outside the accepted range',
+        );
+    }
+    const stopIds = await currentDeliveryRunStopIdsForOperation({
+        driverUserId: input.driverUserId,
+        runId: input.runId,
+        targetStopId: input.targetStopId,
+        expectedRouteRevision: input.expectedRouteRevision,
+        db,
+    });
+    const stops = await ensureOwnedDeliveryRunStops({
+        driverUserId: input.driverUserId,
+        runId: input.runId,
+        stopIds,
+        expectedRouteRevision: input.expectedRouteRevision,
+        runAlreadyLocked: true,
+        db,
+    });
+    if (
+        input.kind === DeliveryRunStopOperationKinds.DELIVER &&
+        stops.some(
+            (stop) =>
+                isDeliveryRunStopActionable(stop.state) &&
+                stop.arrivedAt &&
+                stop.arrivedAt > input.occurredAt,
+        )
+    ) {
+        invalidDeliveryRunStopOperation(
+            'Delivery cannot occur before the recorded arrival',
+        );
+    }
+
+    const newlyFulfilledRequestIds =
+        input.kind === DeliveryRunStopOperationKinds.DELIVER
+            ? stops
+                  .filter((stop) => isDeliveryRunStopActionable(stop.state))
+                  .map((stop) => stop.deliveryRequestId)
+            : [];
+    if (input.kind === DeliveryRunStopOperationKinds.DELIVER) {
+        for (const requestId of newlyFulfilledRequestIds) {
+            await fulfillDeliveryRequest(requestId, input.deliveryNotes, db);
+        }
+        await applyDeliveryRunStopsDeliveredInDatabase({
+            runId: input.runId,
+            stops,
+            occurredAt: input.occurredAt,
+            appliedAt,
+            db,
+        });
+    } else {
+        await applyDeliveryRunStopsArrivedInDatabase({
+            runId: input.runId,
+            stops,
+            occurredAt: input.occurredAt,
+            db,
+        });
+    }
+
+    const runAfterMutation = await db.query.deliveryRuns.findFirst({
+        columns: {
+            routeRevision: true,
+            rerouteRequiredAt: true,
+            state: true,
+        },
+        where: eq(deliveryRuns.id, input.runId),
+    });
+    if (!runAfterMutation) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND,
+            'Delivery run was not found after applying the operation',
+        );
+    }
+    const runCompleted = runAfterMutation.state === DeliveryRunStates.COMPLETED;
+    const result: DeliveryRunStopOperationStoredResult = {
+        kind: input.kind,
+        targetStopId: input.targetStopId,
+        affectedStopIds: stops.map((stop) => stop.id),
+        routeRevision: runAfterMutation.routeRevision,
+        reroutePending:
+            !runCompleted && Boolean(runAfterMutation.rerouteRequiredAt),
+        runCompleted,
+    };
+    await db.insert(deliveryRunStopOperations).values({
+        runId: input.runId,
+        targetStopId: input.targetStopId,
+        driverUserId: input.driverUserId,
+        clientOperationId: input.clientOperationId,
+        kind: input.kind,
+        payloadHash,
+        result,
+        occurredAt: input.occurredAt,
+        appliedAt,
+    });
+    return {
+        clientOperationId: input.clientOperationId,
+        replayed: false,
+        result,
+        newlyFulfilledRequestIds,
+    };
+}
+
+export async function recordDeliveryRunStopOperation(
+    input: RecordDeliveryRunStopOperationInput,
+) {
+    const normalized = normalizeDeliveryRunStopOperationInput(input);
+    return await withDeliveryDispatchTransaction(async (tx) =>
+        recordDeliveryRunStopOperationInDatabase(normalized, tx),
+    );
 }

--- a/packages/storage/src/repositories/deliveryRunsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRunsRepo.ts
@@ -70,6 +70,7 @@ import {
     withDeliveryDispatchTransaction,
 } from './deliveryDispatchRepo';
 import {
+    DeliveryRequestFulfillmentError,
     deliveryDispatchEventTypes,
     fulfillDeliveryRequest,
     getDeliveryRequest,
@@ -288,6 +289,7 @@ export const DeliveryRunExecutionErrorCodes = {
     EXCEPTION_TRANSITION_INVALID: 'exception-transition-invalid',
     STOP_OPERATION_CONFLICT: 'stop-operation-conflict',
     STOP_OPERATION_INVALID: 'stop-operation-invalid',
+    STOP_OPERATION_STATE_CONFLICT: 'stop-operation-state-conflict',
     RUN_DRIVER_CONFLICT: 'run-driver-conflict',
     RUN_MUTATION_INVALID: 'run-mutation-invalid',
     LOCATION_CONFLICT: 'location-conflict',
@@ -5379,7 +5381,21 @@ async function recordDeliveryRunStopOperationInDatabase(
             : [];
     if (input.kind === DeliveryRunStopOperationKinds.DELIVER) {
         for (const requestId of newlyFulfilledRequestIds) {
-            await fulfillDeliveryRequest(requestId, input.deliveryNotes, db);
+            try {
+                await fulfillDeliveryRequest(
+                    requestId,
+                    input.deliveryNotes,
+                    db,
+                );
+            } catch (error) {
+                if (error instanceof DeliveryRequestFulfillmentError) {
+                    throw new DeliveryRunExecutionError(
+                        DeliveryRunExecutionErrorCodes.STOP_OPERATION_STATE_CONFLICT,
+                        'Delivery request state changed before stop completion',
+                    );
+                }
+                throw error;
+            }
         }
         await applyDeliveryRunStopsDeliveredInDatabase({
             runId: input.runId,

--- a/packages/storage/src/schema/deliverySchema.ts
+++ b/packages/storage/src/schema/deliverySchema.ts
@@ -244,6 +244,23 @@ export type DeliveryRunExceptionOperationStoredResult = {
     reroutePending: boolean;
 };
 
+export const DeliveryRunStopOperationKinds = {
+    ARRIVE: 'arrive',
+    DELIVER: 'deliver',
+} as const;
+
+export type DeliveryRunStopOperationKind =
+    (typeof DeliveryRunStopOperationKinds)[keyof typeof DeliveryRunStopOperationKinds];
+
+export type DeliveryRunStopOperationStoredResult = {
+    kind: DeliveryRunStopOperationKind;
+    targetStopId: number;
+    affectedStopIds: number[];
+    routeRevision: number;
+    reroutePending: boolean;
+    runCompleted: boolean;
+};
+
 // Delivery Runs - one optimized route picked up and driven by a driver/admin.
 export const deliveryRuns = pgTable(
     'delivery_runs',
@@ -838,6 +855,10 @@ export const deliveryRunStops = pgTable(
             table.runId,
             table.sequence,
         ),
+        uniqueIndex('delivery_run_stops_run_id_id_unique').on(
+            table.runId,
+            table.id,
+        ),
         index('delivery_run_stops_run_id_idx').on(table.runId),
         index('delivery_run_stops_run_itinerary_sequence_idx').on(
             table.runId,
@@ -937,6 +958,52 @@ export const deliveryRunExceptionOperations = pgTable(
     ],
 );
 
+// Durable, data-minimized receipts for arrival and delivery commands.
+// Customer details are excluded; notes are represented only by the payload digest.
+export const deliveryRunStopOperations = pgTable(
+    'delivery_run_stop_operations',
+    {
+        id: serial('id').primaryKey(),
+        runId: text('run_id')
+            .notNull()
+            .references(() => deliveryRuns.id, { onDelete: 'cascade' }),
+        targetStopId: integer('target_stop_id').notNull(),
+        driverUserId: text('driver_user_id')
+            .notNull()
+            .references(() => users.id),
+        clientOperationId: text('client_operation_id').notNull(),
+        kind: text('kind').$type<DeliveryRunStopOperationKind>().notNull(),
+        payloadHash: text('payload_hash').notNull(),
+        result: jsonb('result')
+            .$type<DeliveryRunStopOperationStoredResult>()
+            .notNull(),
+        occurredAt: timestamp('occurred_at').notNull(),
+        appliedAt: timestamp('applied_at').notNull().defaultNow(),
+    },
+    (table) => [
+        foreignKey({
+            columns: [table.runId, table.targetStopId],
+            foreignColumns: [deliveryRunStops.runId, deliveryRunStops.id],
+            name: 'delivery_run_stop_operations_run_target_stop_fk',
+        }).onDelete('cascade'),
+        uniqueIndex('delivery_run_stop_operations_run_client_unique').on(
+            table.runId,
+            table.clientOperationId,
+        ),
+        check(
+            'delivery_run_stop_operations_kind_check',
+            sql`${table.kind} in ('arrive', 'deliver')`,
+        ),
+        index('delivery_run_stop_operations_run_id_idx').on(table.runId),
+        index('delivery_run_stop_operations_target_stop_id_idx').on(
+            table.targetStopId,
+        ),
+        index('delivery_run_stop_operations_driver_user_id_idx').on(
+            table.driverUserId,
+        ),
+    ],
+);
+
 export const deliveryRunsRelations = relations(
     deliveryRuns,
     ({ many, one }) => ({
@@ -967,6 +1034,9 @@ export const deliveryRunsRelations = relations(
         }),
         exceptionOperations: many(deliveryRunExceptionOperations, {
             relationName: 'deliveryRunExceptionOperations',
+        }),
+        stopOperations: many(deliveryRunStopOperations, {
+            relationName: 'deliveryRunStopOperations',
         }),
     }),
 );
@@ -1038,7 +1108,7 @@ export const deliveryRunSlotsRelations = relations(
 
 export const deliveryRunStopsRelations = relations(
     deliveryRunStops,
-    ({ one }) => ({
+    ({ many, one }) => ({
         run: one(deliveryRuns, {
             fields: [deliveryRunStops.runId],
             references: [deliveryRuns.id],
@@ -1053,6 +1123,9 @@ export const deliveryRunStopsRelations = relations(
             fields: [deliveryRunStops.runId, deliveryRunStops.runSlotId],
             references: [deliveryRunSlots.runId, deliveryRunSlots.id],
             relationName: 'deliveryRunSlotStops',
+        }),
+        operations: many(deliveryRunStopOperations, {
+            relationName: 'deliveryRunStopOperationsTarget',
         }),
     }),
 );
@@ -1096,6 +1169,27 @@ export const deliveryRunExceptionOperationsRelations = relations(
             fields: [deliveryRunExceptionOperations.driverUserId],
             references: [users.id],
             relationName: 'driverDeliveryRunExceptionOperations',
+        }),
+    }),
+);
+
+export const deliveryRunStopOperationsRelations = relations(
+    deliveryRunStopOperations,
+    ({ one }) => ({
+        run: one(deliveryRuns, {
+            fields: [deliveryRunStopOperations.runId],
+            references: [deliveryRuns.id],
+            relationName: 'deliveryRunStopOperations',
+        }),
+        targetStop: one(deliveryRunStops, {
+            fields: [deliveryRunStopOperations.targetStopId],
+            references: [deliveryRunStops.id],
+            relationName: 'deliveryRunStopOperationsTarget',
+        }),
+        driver: one(users, {
+            fields: [deliveryRunStopOperations.driverUserId],
+            references: [users.id],
+            relationName: 'driverDeliveryRunStopOperations',
         }),
     }),
 );
@@ -1154,6 +1248,8 @@ export type SelectDeliveryRunPickupOperation =
     typeof deliveryRunPickupOperations.$inferSelect;
 export type SelectDeliveryRunExceptionOperation =
     typeof deliveryRunExceptionOperations.$inferSelect;
+export type SelectDeliveryRunStopOperation =
+    typeof deliveryRunStopOperations.$inferSelect;
 
 // Enums for type safety
 export const DeliveryModes = {

--- a/packages/storage/tests/deliveryRunsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRunsRepo.node.spec.ts
@@ -33,6 +33,7 @@ import {
     type DeliveryRunPreparationPlanPayloadV3,
     type DeliveryRunRequestSnapshotInput,
     DeliveryRunStates,
+    DeliveryRunStopOperationKinds,
     DeliveryRunStopStates,
     deleteDeliveryAddress,
     deliveryRequests,
@@ -42,6 +43,8 @@ import {
     deliveryRunPickupOperations,
     deliveryRunPreparations,
     deliveryRunRerouteLeaseMs,
+    deliveryRunStopOperationOccurredAtIsAcceptable,
+    deliveryRunStopOperations,
     deliveryRunStops,
     deliveryRunStopsAllowCompletion,
     deliveryRuns,
@@ -70,6 +73,7 @@ import {
     readyDeliveryRequest,
     reassignDeliveryRun,
     recordDeliveryRunStopExceptions,
+    recordDeliveryRunStopOperation,
     recoverDeliveryRunStop,
     retryDeliveryRunStop,
     saveDeliveryRunPreparation,
@@ -4993,5 +4997,393 @@ test('a partially cancelled stop is released for explicit admin reactivation', a
             ])
         )[0]?.run.id,
         nextRun.id,
+    );
+});
+
+test('stop operation receipts replay exact bulk arrival and delivery results after completion', async () => {
+    const { run, driverUserId } =
+        await startPreparedBulkRunWithConfirmedPickup();
+    const initialRun = await getDeliveryRun(run.id);
+    const [firstStop, secondStop] = run.stops;
+    assert.ok(initialRun);
+    assert.ok(firstStop);
+    assert.ok(secondStop);
+
+    const arrivalOccurredAt = new Date(Date.now() - 2_000);
+    const arrivalInput = {
+        kind: DeliveryRunStopOperationKinds.ARRIVE,
+        driverUserId,
+        runId: run.id,
+        targetStopId: firstStop.id,
+        expectedRouteRevision: initialRun.routeRevision,
+        clientOperationId: 'offline-bulk-arrival',
+        occurredAt: arrivalOccurredAt,
+    } as const;
+    const arrival = await recordDeliveryRunStopOperation(arrivalInput);
+    assert.equal(arrival.replayed, false);
+    assert.deepEqual(arrival.result, {
+        kind: DeliveryRunStopOperationKinds.ARRIVE,
+        targetStopId: firstStop.id,
+        affectedStopIds: [firstStop.id, secondStop.id],
+        routeRevision: initialRun.routeRevision + 1,
+        reroutePending: false,
+        runCompleted: false,
+    });
+    const arrivedRun = await getDeliveryRun(run.id);
+    assert.deepEqual(
+        arrivedRun?.stops.map((stop) => stop.state),
+        [DeliveryRunStopStates.ARRIVED, DeliveryRunStopStates.ARRIVED],
+    );
+    assert.ok(
+        arrivedRun?.stops.every(
+            (stop) => stop.arrivedAt?.getTime() === arrivalOccurredAt.getTime(),
+        ),
+    );
+
+    const deliveryOccurredAt = new Date(Date.now() - 1_000);
+    const privateNote = 'Kupac je preuzeo obje gredice na stražnjem ulazu.';
+    const deliveryInput = {
+        kind: DeliveryRunStopOperationKinds.DELIVER,
+        driverUserId,
+        runId: run.id,
+        targetStopId: secondStop.id,
+        expectedRouteRevision: arrival.result.routeRevision,
+        clientOperationId: 'offline-bulk-delivery',
+        occurredAt: deliveryOccurredAt,
+        deliveryNotes: privateNote,
+    } as const;
+    const deliveryAttempts = await Promise.all([
+        recordDeliveryRunStopOperation(deliveryInput),
+        recordDeliveryRunStopOperation(deliveryInput),
+    ]);
+    assert.deepEqual(
+        deliveryAttempts.map((attempt) => attempt.replayed).sort(),
+        [false, true],
+    );
+    const appliedDelivery = deliveryAttempts.find(
+        (attempt) => !attempt.replayed,
+    );
+    const concurrentReplay = deliveryAttempts.find(
+        (attempt) => attempt.replayed,
+    );
+    assert.ok(appliedDelivery);
+    assert.ok(concurrentReplay);
+    assert.deepEqual(concurrentReplay.result, appliedDelivery.result);
+    assert.deepEqual(
+        [...appliedDelivery.newlyFulfilledRequestIds].sort(),
+        [firstStop.deliveryRequestId, secondStop.deliveryRequestId].sort(),
+    );
+    assert.deepEqual(concurrentReplay.newlyFulfilledRequestIds, []);
+    assert.deepEqual(appliedDelivery.result, {
+        kind: DeliveryRunStopOperationKinds.DELIVER,
+        targetStopId: secondStop.id,
+        affectedStopIds: [firstStop.id, secondStop.id],
+        routeRevision: arrival.result.routeRevision + 1,
+        reroutePending: false,
+        runCompleted: true,
+    });
+
+    const completedRun = await getDeliveryRun(run.id);
+    assert.equal(completedRun?.state, DeliveryRunStates.COMPLETED);
+    assert.ok(
+        completedRun?.stops.every(
+            (stop) =>
+                stop.state === DeliveryRunStopStates.DELIVERED &&
+                stop.deliveredAt?.getTime() === deliveryOccurredAt.getTime(),
+        ),
+    );
+    assert.ok(
+        completedRun?.completedAt &&
+            completedRun.completedAt.getTime() >= deliveryOccurredAt.getTime(),
+    );
+
+    const fulfillmentEventsBeforeReplay = await storage()
+        .select({ aggregateId: events.aggregateId })
+        .from(events)
+        .where(
+            and(
+                eq(events.type, knownEventTypes.delivery.requestFulfilled),
+                inArray(events.aggregateId, [
+                    firstStop.deliveryRequestId,
+                    secondStop.deliveryRequestId,
+                ]),
+            ),
+        );
+    assert.equal(fulfillmentEventsBeforeReplay.length, 2);
+
+    const arrivalReplay = await recordDeliveryRunStopOperation(arrivalInput);
+    const deliveryReplay = await recordDeliveryRunStopOperation(deliveryInput);
+    assert.equal(arrivalReplay.replayed, true);
+    assert.equal(deliveryReplay.replayed, true);
+    assert.deepEqual(arrivalReplay.result, arrival.result);
+    assert.deepEqual(deliveryReplay.result, appliedDelivery.result);
+    assert.deepEqual(deliveryReplay.newlyFulfilledRequestIds, []);
+
+    const fulfillmentEventsAfterReplay = await storage()
+        .select({ aggregateId: events.aggregateId })
+        .from(events)
+        .where(
+            and(
+                eq(events.type, knownEventTypes.delivery.requestFulfilled),
+                inArray(events.aggregateId, [
+                    firstStop.deliveryRequestId,
+                    secondStop.deliveryRequestId,
+                ]),
+            ),
+        );
+    assert.deepEqual(
+        fulfillmentEventsAfterReplay,
+        fulfillmentEventsBeforeReplay,
+    );
+    const receipts = await storage()
+        .select()
+        .from(deliveryRunStopOperations)
+        .where(eq(deliveryRunStopOperations.runId, run.id));
+    assert.equal(receipts.length, 2);
+    assert.ok(!JSON.stringify(receipts).includes(privateNote));
+});
+
+test('stop operation IDs reject changed payloads and stale new commands without side effects', async () => {
+    const { prepared, run, driverUserId } =
+        await startPreparedBulkRunWithConfirmedPickup({ driverCount: 2 });
+    const [targetStop] = run.stops;
+    const otherDriverUserId = prepared.fixture.driverUserIds[1];
+    assert.ok(targetStop);
+    assert.ok(otherDriverUserId);
+    const occurredAt = new Date(Date.now() - 1_000);
+    const input = {
+        kind: DeliveryRunStopOperationKinds.ARRIVE,
+        driverUserId,
+        runId: run.id,
+        targetStopId: targetStop.id,
+        expectedRouteRevision: run.routeRevision,
+        clientOperationId: 'conflict-checked-arrival',
+        occurredAt,
+    } as const;
+    const applied = await recordDeliveryRunStopOperation(input);
+    assert.equal(applied.replayed, false);
+
+    await assertExecutionError(
+        recordDeliveryRunStopOperation({
+            ...input,
+            occurredAt: new Date(occurredAt.getTime() + 1),
+        }),
+        DeliveryRunExecutionErrorCodes.STOP_OPERATION_CONFLICT,
+    );
+    await assertExecutionError(
+        recordDeliveryRunStopOperation({
+            ...input,
+            kind: DeliveryRunStopOperationKinds.DELIVER,
+            deliveryNotes: 'Promijenjen sadržaj',
+        }),
+        DeliveryRunExecutionErrorCodes.STOP_OPERATION_CONFLICT,
+    );
+    await assertExecutionError(
+        recordDeliveryRunStopOperation({
+            ...input,
+            driverUserId: otherDriverUserId,
+        }),
+        DeliveryRunExecutionErrorCodes.STOP_OPERATION_CONFLICT,
+    );
+    await assertExecutionError(
+        recordDeliveryRunStopOperation({
+            ...input,
+            clientOperationId: 'stale-new-arrival',
+        }),
+        DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+    );
+    await assertExecutionError(
+        recordDeliveryRunStopOperation({
+            ...input,
+            clientOperationId: 'future-new-arrival',
+            expectedRouteRevision: applied.result.routeRevision,
+            occurredAt: new Date(Date.now() + 5 * 60 * 1_000 + 1_000),
+        }),
+        DeliveryRunExecutionErrorCodes.STOP_OPERATION_INVALID,
+    );
+    await assertExecutionError(
+        recordDeliveryRunStopOperation({
+            ...input,
+            kind: DeliveryRunStopOperationKinds.DELIVER,
+            clientOperationId: 'delivery-before-arrival',
+            expectedRouteRevision: applied.result.routeRevision,
+            occurredAt: new Date(occurredAt.getTime() - 1),
+        }),
+        DeliveryRunExecutionErrorCodes.STOP_OPERATION_INVALID,
+    );
+
+    assert.equal(
+        (
+            await storage()
+                .select()
+                .from(deliveryRunStopOperations)
+                .where(eq(deliveryRunStopOperations.runId, run.id))
+        ).length,
+        1,
+    );
+    const persisted = await getDeliveryRun(run.id);
+    assert.equal(persisted?.routeRevision, applied.result.routeRevision);
+    assert.ok(
+        persisted?.stops.every(
+            (stop) => stop.state === DeliveryRunStopStates.ARRIVED,
+        ),
+    );
+});
+
+test('bulk delivery command rolls back fulfillment events, stop state, and receipt together', async () => {
+    const fixture = await createDeliveryRunFixture({
+        accountIndexes: [0, 0, 0],
+    });
+    await createRequestEvents(fixture);
+    const [driverUserId] = fixture.driverUserIds;
+    const [firstRequestId, secondRequestId] = fixture.requestIds;
+    assert.ok(driverUserId);
+    assert.ok(firstRequestId);
+    assert.ok(secondRequestId);
+    await cancelDeliveryRequest(
+        secondRequestId,
+        'admin',
+        'Otkazano prije skupne dostave',
+    );
+    const run = await createRun({
+        fixture,
+        driverUserId,
+        requestIds: fixture.requestIds,
+    });
+    const [firstStop] = run.stops;
+    assert.ok(firstStop);
+
+    await assert.rejects(
+        recordDeliveryRunStopOperation({
+            kind: DeliveryRunStopOperationKinds.DELIVER,
+            driverUserId,
+            runId: run.id,
+            targetStopId: firstStop.id,
+            expectedRouteRevision: run.routeRevision,
+            clientOperationId: 'rollback-bulk-delivery',
+            occurredAt: new Date(),
+        }),
+        /Cannot fulfill a cancelled delivery request/,
+    );
+
+    const unchangedRun = await getDeliveryRun(run.id);
+    assert.deepEqual(
+        unchangedRun?.stops.map((stop) => stop.state),
+        [
+            DeliveryRunStopStates.PENDING,
+            DeliveryRunStopStates.PENDING,
+            DeliveryRunStopStates.PENDING,
+        ],
+    );
+    assert.equal(
+        (
+            await storage()
+                .select()
+                .from(deliveryRunStopOperations)
+                .where(eq(deliveryRunStopOperations.runId, run.id))
+        ).length,
+        0,
+    );
+    assert.equal(
+        (
+            await storage()
+                .select()
+                .from(events)
+                .where(
+                    and(
+                        eq(
+                            events.type,
+                            knownEventTypes.delivery.requestFulfilled,
+                        ),
+                        eq(events.aggregateId, firstRequestId),
+                    ),
+                )
+        ).length,
+        0,
+    );
+    assert.notEqual(
+        (await getDeliveryRequest(firstRequestId))?.state,
+        'fulfilled',
+    );
+});
+
+test('stop operation occurrence bounds and run-target integrity are enforced', async () => {
+    const appliedAt = new Date('2026-07-15T12:00:00.000Z');
+    assert.equal(
+        deliveryRunStopOperationOccurredAtIsAcceptable(
+            new Date(appliedAt.getTime() - 36 * 60 * 60 * 1_000),
+            appliedAt,
+        ),
+        true,
+    );
+    assert.equal(
+        deliveryRunStopOperationOccurredAtIsAcceptable(
+            new Date(appliedAt.getTime() - 36 * 60 * 60 * 1_000 - 1),
+            appliedAt,
+        ),
+        false,
+    );
+    assert.equal(
+        deliveryRunStopOperationOccurredAtIsAcceptable(
+            new Date(appliedAt.getTime() + 5 * 60 * 1_000),
+            appliedAt,
+        ),
+        true,
+    );
+    assert.equal(
+        deliveryRunStopOperationOccurredAtIsAcceptable(
+            new Date(appliedAt.getTime() + 5 * 60 * 1_000 + 1),
+            appliedAt,
+        ),
+        false,
+    );
+
+    const fixture = await createDeliveryRunFixture({
+        accountIndexes: [0, 0],
+        driverCount: 2,
+    });
+    const [firstDriverUserId, secondDriverUserId] = fixture.driverUserIds;
+    const [firstRequestId, secondRequestId] = fixture.requestIds;
+    assert.ok(firstDriverUserId);
+    assert.ok(secondDriverUserId);
+    assert.ok(firstRequestId);
+    assert.ok(secondRequestId);
+    const firstRun = await createRun({
+        fixture,
+        driverUserId: firstDriverUserId,
+        requestIds: [firstRequestId],
+    });
+    const secondRun = await createRun({
+        fixture,
+        driverUserId: secondDriverUserId,
+        requestIds: [secondRequestId],
+    });
+    const [foreignTargetStop] = secondRun.stops;
+    assert.ok(foreignTargetStop);
+    await assert.rejects(
+        storage()
+            .insert(deliveryRunStopOperations)
+            .values({
+                runId: firstRun.id,
+                targetStopId: foreignTargetStop.id,
+                driverUserId: firstDriverUserId,
+                clientOperationId: 'cross-run-target',
+                kind: DeliveryRunStopOperationKinds.ARRIVE,
+                payloadHash: '0'.repeat(64),
+                result: {
+                    kind: DeliveryRunStopOperationKinds.ARRIVE,
+                    targetStopId: foreignTargetStop.id,
+                    affectedStopIds: [foreignTargetStop.id],
+                    routeRevision: 0,
+                    reroutePending: false,
+                    runCompleted: false,
+                },
+                occurredAt: new Date(),
+            }),
+        (error) =>
+            error instanceof Error &&
+            `${error.message} ${
+                error.cause instanceof Error ? error.cause.message : ''
+            }`.includes('delivery_run_stop_operations_run_target_stop_fk'),
     );
 });

--- a/packages/storage/tests/deliveryRunsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRunsRepo.node.spec.ts
@@ -5253,7 +5253,7 @@ test('bulk delivery command rolls back fulfillment events, stop state, and recei
     const [firstStop] = run.stops;
     assert.ok(firstStop);
 
-    await assert.rejects(
+    await assertExecutionError(
         recordDeliveryRunStopOperation({
             kind: DeliveryRunStopOperationKinds.DELIVER,
             driverUserId,
@@ -5263,7 +5263,7 @@ test('bulk delivery command rolls back fulfillment events, stop state, and recei
             clientOperationId: 'rollback-bulk-delivery',
             occurredAt: new Date(),
         }),
-        /Cannot fulfill a cancelled delivery request/,
+        DeliveryRunExecutionErrorCodes.STOP_OPERATION_STATE_CONFLICT,
     );
 
     const unchangedRun = await getDeliveryRun(run.id);
@@ -5305,6 +5305,93 @@ test('bulk delivery command rolls back fulfillment events, stop state, and recei
         (await getDeliveryRequest(firstRequestId))?.state,
         'fulfilled',
     );
+});
+
+test('bulk delivery command treats deferred and failed request races as state conflicts', async () => {
+    for (const outcome of [
+        DeliveryRunExceptionOutcomes.DEFERRED,
+        DeliveryRunExceptionOutcomes.FAILED,
+    ]) {
+        const fixture = await createDeliveryRunFixture({
+            accountIndexes: [0, 0, 0],
+        });
+        await createRequestEvents(fixture);
+        const [driverUserId] = fixture.driverUserIds;
+        const [firstRequestId, secondRequestId] = fixture.requestIds;
+        assert.ok(driverUserId);
+        assert.ok(firstRequestId);
+        assert.ok(secondRequestId);
+        const run = await createRun({
+            fixture,
+            driverUserId,
+            requestIds: fixture.requestIds,
+        });
+        const [firstStop, secondStop] = run.stops;
+        assert.ok(firstStop);
+        assert.ok(secondStop);
+        await createEvent(
+            knownEvents.delivery.requestExceptionRecordedV1(secondRequestId, {
+                runId: run.id,
+                stopId: secondStop.id,
+                clientOperationId: `external-${outcome}`,
+                outcome,
+                reason:
+                    outcome === DeliveryRunExceptionOutcomes.DEFERRED
+                        ? DeliveryRunExceptionReasons.CUSTOMER_UNAVAILABLE
+                        : DeliveryRunExceptionReasons.HARVEST_MISSING,
+                retryable: outcome === DeliveryRunExceptionOutcomes.DEFERRED,
+                occurredAt: new Date().toISOString(),
+                recordedByUserId: driverUserId,
+                routeRevision: run.routeRevision,
+            }),
+        );
+
+        await assertExecutionError(
+            recordDeliveryRunStopOperation({
+                kind: DeliveryRunStopOperationKinds.DELIVER,
+                driverUserId,
+                runId: run.id,
+                targetStopId: firstStop.id,
+                expectedRouteRevision: run.routeRevision,
+                clientOperationId: `rollback-bulk-${outcome}`,
+                occurredAt: new Date(),
+            }),
+            DeliveryRunExecutionErrorCodes.STOP_OPERATION_STATE_CONFLICT,
+        );
+
+        const unchangedRun = await getDeliveryRun(run.id);
+        assert.ok(
+            unchangedRun?.stops.every(
+                (stop) => stop.state === DeliveryRunStopStates.PENDING,
+            ),
+        );
+        assert.equal(
+            (
+                await storage()
+                    .select()
+                    .from(deliveryRunStopOperations)
+                    .where(eq(deliveryRunStopOperations.runId, run.id))
+            ).length,
+            0,
+        );
+        assert.equal(
+            (
+                await storage()
+                    .select()
+                    .from(events)
+                    .where(
+                        and(
+                            eq(
+                                events.type,
+                                knownEventTypes.delivery.requestFulfilled,
+                            ),
+                            eq(events.aggregateId, firstRequestId),
+                        ),
+                    )
+            ).length,
+            0,
+        );
+    }
 });
 
 test('stop operation occurrence bounds and run-target integrity are enforced', async () => {


### PR DESCRIPTION
## Summary

- cache a strict, minimized 24-hour projection of the current and immediate next route step for the authenticated driver
- queue arrival, delivery, exception, and advisory verification actions with immutable operation IDs, FIFO replay, conflict barriers, and cross-tab coordination
- persist exact server operation receipts so duplicate replays return the original acknowledgement without repeating mutations or notifications
- map cancelled, deferred, and failed request races to permanent replay conflicts while retaining atomic rollback
- reconcile reroutes and newer server truth before allowing dependent route work to continue
- clear route, manifest, and action data with supporting-store-first durable guarantees on completion, logout, user changes, and run changes
- block late writes and in-flight responses across logout with a persisted session generation, including missed cross-tab signals and bfcache recovery
- add Croatian offline/recovery states, pending acknowledgements, retry actions, and accessible terminal announcements

## Validation

- `corepack pnpm --filter delivery lint`
- `corepack pnpm --filter @gredice/storage lint`
- `corepack pnpm --filter delivery typecheck`
- `corepack pnpm --filter delivery test:unit` — 228 passed
- `corepack pnpm --filter delivery test:component` — 44 passed
- `corepack pnpm --filter @gredice/storage test:node deliveryRunsRepo.node.spec.ts` — 61 passed
- `corepack pnpm --filter delivery build`
- `git diff --check`
- three independent final reviews: client durability/replay, server idempotency/privacy, and UX/accessibility

## Explicit boundaries

- Restored route data is available after the authenticated application shell loads when `/api/dashboard` is unavailable or hangs. A completely cold origin navigation without a network connection still requires a future service worker/PWA shell.
- Stop mutations are committed atomically with their idempotency receipts. Slack delivery notifications remain best-effort after commit; a durable notification outbox is a separate reliability improvement.

Closes #4130