### PR TITLE
feat(delivery): add interactive live map

### DIFF
--- a/apps/delivery/.env.example
+++ b/apps/delivery/.env.example
@@ -4,6 +4,8 @@ GREDICE_JWT_SIGN_SECRET=local-dev-sign-secret
 COOKIE_DOMAIN=
 POSTGRES_URL=
 GREDICE_DELIVERY_HQ_ADDRESS=Ulica Julija Knifera 3, 10000 Zagreb, Hrvatska
+# Restrict this browser key by HTTP referrer and to Maps JavaScript API only.
+NEXT_PUBLIC_GREDICE_GOOGLE_MAPS_API_KEY=
 # Restrict this server key to Geocoding API, Routes API, and Maps Static API.
 GREDICE_GOOGLE_MAPS_SERVER_API_KEY=
 GREDICE_GOOGLE_MAPS_URL_SIGNING_SECRET=

--- a/apps/delivery/app/api/map/[runId]/route.ts
+++ b/apps/delivery/app/api/map/[runId]/route.ts
@@ -4,6 +4,7 @@ import {
     accountCanTrackDeliveryRun,
     resolveDeliveryRunStopGroups,
 } from '../../../../lib/deliveryDashboard';
+import { buildDeliveryMapData } from '../../../../lib/deliveryMapData';
 import { driverDeliveryTrackingLocation } from '../../../../lib/deliveryTracking';
 import {
     buildGoogleStaticMapUrl,
@@ -23,7 +24,7 @@ function unavailableMapResponse() {
 }
 
 export async function GET(
-    _request: Request,
+    request: Request,
     { params }: { params: Promise<{ runId: string }> },
 ) {
     return await withAuth(
@@ -78,7 +79,7 @@ export async function GET(
                     },
                 ];
             });
-            const url = buildGoogleStaticMapUrl({
+            const mapData = buildDeliveryMapData({
                 driverLocation: location
                     ? {
                           latitude: location.latitude,
@@ -100,6 +101,17 @@ export async function GET(
                     : [],
                 stops,
                 encodedPolyline: run.encodedPolyline,
+                customerView,
+            });
+            if (new URL(request.url).searchParams.get('format') === 'json') {
+                return Response.json(mapData, {
+                    status: 200,
+                    headers: noStoreHeaders,
+                });
+            }
+
+            const url = buildGoogleStaticMapUrl({
+                ...mapData,
                 customerView,
             });
             if (!url) return unavailableMapResponse();

--- a/apps/delivery/components/DeliveryInteractiveMap.tsx
+++ b/apps/delivery/components/DeliveryInteractiveMap.tsx
@@ -1,0 +1,366 @@
+/// <reference types="google.maps" />
+
+'use client';
+
+import { importLibrary, setOptions } from '@googlemaps/js-api-loader';
+import { Button } from '@gredice/ui/Button';
+import { MyLocation } from '@gredice/ui/icons';
+import Image from 'next/image';
+import { useEffect, useRef, useState } from 'react';
+import {
+    type DeliveryMapCoordinate,
+    type DeliveryMapData,
+    type DeliveryMapPosition,
+    decodeDeliveryMapPolyline,
+    parseDeliveryMapData,
+} from '../lib/deliveryMapData';
+
+type MapState = 'loading' | 'ready' | 'fallback';
+
+type MapLayers = {
+    markers: google.maps.Marker[];
+    polyline: google.maps.Polyline | null;
+};
+
+type GoogleMapsClient = {
+    LatLngBounds: typeof google.maps.LatLngBounds;
+    Map: typeof google.maps.Map;
+    Marker: typeof google.maps.Marker;
+    Polyline: typeof google.maps.Polyline;
+    SymbolPath: typeof google.maps.SymbolPath;
+};
+
+declare global {
+    interface Window {
+        gm_authFailure?: () => void;
+    }
+}
+
+const googleMapsAuthFailureEvent = 'gredice-google-maps-auth-failure';
+let configuredApiKey: string | null = null;
+let mapsAuthFailed = false;
+let mapsPromise: Promise<GoogleMapsClient> | null = null;
+
+function loadGoogleMaps(apiKey: string) {
+    if (mapsAuthFailed) {
+        return Promise.reject(
+            new Error('Google Maps JavaScript API authorization failed'),
+        );
+    }
+    if (configuredApiKey && configuredApiKey !== apiKey) {
+        return Promise.reject(
+            new Error('Google Maps JavaScript API key changed after loading'),
+        );
+    }
+    if (mapsPromise) return mapsPromise;
+
+    window.gm_authFailure = () => {
+        mapsAuthFailed = true;
+        window.dispatchEvent(new Event(googleMapsAuthFailureEvent));
+    };
+    configuredApiKey = apiKey;
+    setOptions({
+        key: apiKey,
+        v: 'quarterly',
+        language: 'hr',
+        region: 'HR',
+        authReferrerPolicy: 'origin',
+    });
+    const load = Promise.all([
+        importLibrary('maps'),
+        importLibrary('marker'),
+        importLibrary('core'),
+    ]).then(([maps, marker, core]) => ({
+        Map: maps.Map,
+        Marker: marker.Marker,
+        Polyline: maps.Polyline,
+        LatLngBounds: core.LatLngBounds,
+        SymbolPath: core.SymbolPath,
+    }));
+    mapsPromise = load.catch((error: unknown) => {
+        mapsPromise = null;
+        throw error;
+    });
+    return mapsPromise;
+}
+
+function versionedMapUrl(
+    mapUrl: string,
+    version: string | null,
+    format?: 'json',
+) {
+    const separator = mapUrl.includes('?') ? '&' : '?';
+    const versionQuery = `v=${encodeURIComponent(version ?? 'initial')}`;
+    return `${mapUrl}${separator}${versionQuery}${format ? `&format=${format}` : ''}`;
+}
+
+function position(coordinate: DeliveryMapCoordinate): DeliveryMapPosition {
+    return { lat: coordinate.latitude, lng: coordinate.longitude };
+}
+
+function markerIcon(maps: GoogleMapsClient, fillColor: string, scale: number) {
+    return {
+        path: maps.SymbolPath.CIRCLE,
+        fillColor,
+        fillOpacity: 1,
+        strokeColor: '#ffffff',
+        strokeWeight: 2,
+        scale,
+    };
+}
+
+function clearLayers(layers: MapLayers) {
+    for (const marker of layers.markers) marker.setMap(null);
+    layers.polyline?.setMap(null);
+}
+
+function drawMapData(
+    map: google.maps.Map,
+    maps: GoogleMapsClient,
+    data: DeliveryMapData,
+): { layers: MapLayers; positions: DeliveryMapPosition[] } {
+    const markers: google.maps.Marker[] = [];
+    const positions: DeliveryMapPosition[] = [];
+
+    if (data.driverLocation) {
+        const driverPosition = position(data.driverLocation);
+        positions.push(driverPosition);
+        markers.push(
+            new maps.Marker({
+                map,
+                position: driverPosition,
+                title: 'Vozač',
+                icon: markerIcon(maps, '#166534', 10),
+                zIndex: 1000,
+            }),
+        );
+    }
+
+    data.pickupNodes.forEach((pickupNode, index) => {
+        const pickupPosition = position(pickupNode);
+        positions.push(pickupPosition);
+        markers.push(
+            new maps.Marker({
+                map,
+                position: pickupPosition,
+                title: `Lokacija preuzimanja ${index + 1}`,
+                label: {
+                    text: 'P',
+                    color: '#ffffff',
+                    fontSize: '11px',
+                    fontWeight: '700',
+                },
+                icon: markerIcon(maps, '#d97706', 10),
+            }),
+        );
+    });
+
+    for (const stop of data.stops) {
+        const stopPosition = position(stop);
+        positions.push(stopPosition);
+        markers.push(
+            new maps.Marker({
+                map,
+                position: stopPosition,
+                title: `Dostavna stanica ${stop.sequence}`,
+                label: {
+                    text: String(stop.sequence),
+                    color: '#ffffff',
+                    fontSize: '11px',
+                    fontWeight: '700',
+                },
+                icon: markerIcon(maps, '#0f766e', 10),
+            }),
+        );
+    }
+
+    const routePositions = data.encodedPolyline
+        ? decodeDeliveryMapPolyline(data.encodedPolyline)
+        : [];
+    positions.push(...routePositions);
+    const polyline =
+        routePositions.length > 1
+            ? new maps.Polyline({
+                  map,
+                  path: routePositions,
+                  geodesic: true,
+                  strokeColor: '#166534',
+                  strokeOpacity: 0.85,
+                  strokeWeight: 5,
+              })
+            : null;
+
+    return { layers: { markers, polyline }, positions };
+}
+
+function fitMap(
+    map: google.maps.Map,
+    maps: GoogleMapsClient,
+    positions: DeliveryMapPosition[],
+) {
+    const firstPosition = positions[0];
+    if (!firstPosition) return;
+    if (positions.length === 1) {
+        map.setCenter(firstPosition);
+        map.setZoom(15);
+        return;
+    }
+    const bounds = new maps.LatLngBounds();
+    for (const mapPosition of positions) bounds.extend(mapPosition);
+    map.fitBounds(bounds, 48);
+}
+
+export function DeliveryInteractiveMap({
+    apiKey,
+    mapUrl,
+    version,
+    title,
+}: {
+    apiKey: string;
+    mapUrl: string;
+    version: string | null;
+    title: string;
+}) {
+    const containerRef = useRef<HTMLElement>(null);
+    const mapRef = useRef<google.maps.Map>(null);
+    const mapsRef = useRef<GoogleMapsClient>(null);
+    const layersRef = useRef<MapLayers>({ markers: [], polyline: null });
+    const positionsRef = useRef<DeliveryMapPosition[]>([]);
+    const fittedMapUrlRef = useRef<string>(null);
+    const [state, setState] = useState<MapState>(
+        apiKey ? 'loading' : 'fallback',
+    );
+    const staticMapUrl = versionedMapUrl(mapUrl, version);
+
+    useEffect(() => {
+        if (!apiKey) return;
+        const controller = new AbortController();
+        let active = true;
+        const handleAuthFailure = () => {
+            if (active) setState('fallback');
+        };
+        window.addEventListener(googleMapsAuthFailureEvent, handleAuthFailure);
+
+        async function refreshMap() {
+            const element = containerRef.current;
+            if (!element) return;
+            try {
+                const [maps, response] = await Promise.all([
+                    loadGoogleMaps(apiKey),
+                    fetch(versionedMapUrl(mapUrl, version, 'json'), {
+                        cache: 'no-store',
+                        headers: { Accept: 'application/json' },
+                        signal: controller.signal,
+                    }),
+                ]);
+                if (!response.ok) throw new Error('Delivery map data failed');
+                const payload: unknown = await response.json();
+                const data = parseDeliveryMapData(payload);
+                if (!data) throw new Error('Delivery map data is invalid');
+                if (!active) return;
+
+                let map = mapRef.current;
+                if (!map) {
+                    map = new maps.Map(element, {
+                        center: { lat: 45.815, lng: 15.982 },
+                        zoom: 12,
+                        clickableIcons: false,
+                        fullscreenControl: true,
+                        gestureHandling: 'cooperative',
+                        mapTypeControl: false,
+                        streetViewControl: false,
+                    });
+                    mapRef.current = map;
+                    mapsRef.current = maps;
+                }
+
+                clearLayers(layersRef.current);
+                const rendered = drawMapData(map, maps, data);
+                layersRef.current = rendered.layers;
+                positionsRef.current = rendered.positions;
+                if (
+                    fittedMapUrlRef.current !== mapUrl &&
+                    rendered.positions.length > 0
+                ) {
+                    fitMap(map, maps, rendered.positions);
+                    fittedMapUrlRef.current = mapUrl;
+                }
+                setState('ready');
+            } catch (error) {
+                if (
+                    !active ||
+                    (error instanceof DOMException &&
+                        error.name === 'AbortError')
+                ) {
+                    return;
+                }
+                setState('fallback');
+            }
+        }
+
+        void refreshMap();
+        return () => {
+            active = false;
+            controller.abort();
+            window.removeEventListener(
+                googleMapsAuthFailureEvent,
+                handleAuthFailure,
+            );
+        };
+    }, [apiKey, mapUrl, version]);
+
+    useEffect(
+        () => () => {
+            clearLayers(layersRef.current);
+        },
+        [],
+    );
+
+    const recenter = () => {
+        const map = mapRef.current;
+        const maps = mapsRef.current;
+        if (map && maps) fitMap(map, maps, positionsRef.current);
+    };
+
+    return (
+        <div className="relative aspect-[16/10] w-full overflow-hidden rounded-lg border bg-muted">
+            <section
+                ref={containerRef}
+                aria-label={title}
+                aria-hidden={state !== 'ready'}
+                className={`absolute inset-0 transition-opacity ${state === 'ready' ? 'opacity-100' : 'pointer-events-none opacity-0'}`}
+            />
+            {state === 'loading' ? (
+                <div
+                    role="status"
+                    className="absolute inset-0 flex items-center justify-center bg-muted text-sm text-muted-foreground"
+                >
+                    Učitavanje interaktivne karte…
+                </div>
+            ) : null}
+            {state === 'fallback' ? (
+                <Image
+                    src={staticMapUrl}
+                    alt={title}
+                    fill
+                    sizes="(max-width: 768px) 100vw, 720px"
+                    className="object-cover"
+                    unoptimized
+                    priority
+                />
+            ) : null}
+            {state === 'ready' ? (
+                <Button
+                    type="button"
+                    variant="outlined"
+                    size="sm"
+                    className="absolute bottom-3 right-3 bg-background/95 shadow-sm backdrop-blur"
+                    startDecorator={<MyLocation className="size-4" />}
+                    onClick={recenter}
+                >
+                    Centriraj kartu
+                </Button>
+            ) : null}
+        </div>
+    );
+}

--- a/apps/delivery/components/DeliveryMap.tsx
+++ b/apps/delivery/components/DeliveryMap.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import Image from 'next/image';
+import { DeliveryInteractiveMap } from './DeliveryInteractiveMap';
+
+const browserApiKey =
+    process.env.NEXT_PUBLIC_GREDICE_GOOGLE_MAPS_API_KEY?.trim() ?? '';
 
 export function DeliveryMap({
     mapUrl,
@@ -11,19 +14,12 @@ export function DeliveryMap({
     version: string | null;
     title: string;
 }) {
-    const separator = mapUrl.includes('?') ? '&' : '?';
-    const src = `${mapUrl}${separator}v=${encodeURIComponent(version ?? 'initial')}`;
     return (
-        <div className="relative aspect-[16/10] w-full overflow-hidden rounded-lg border bg-muted">
-            <Image
-                src={src}
-                alt={title}
-                fill
-                sizes="(max-width: 768px) 100vw, 720px"
-                className="object-cover"
-                unoptimized
-                priority
-            />
-        </div>
+        <DeliveryInteractiveMap
+            apiKey={browserApiKey}
+            mapUrl={mapUrl}
+            version={version}
+            title={title}
+        />
     );
 }

--- a/apps/delivery/lib/deliveryMapData.node.spec.ts
+++ b/apps/delivery/lib/deliveryMapData.node.spec.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    buildDeliveryMapData,
+    decodeDeliveryMapPolyline,
+    parseDeliveryMapData,
+} from './deliveryMapData';
+
+const driverLocation = { latitude: 45.801, longitude: 15.981 };
+const pickupNodes = [{ latitude: 45.79, longitude: 15.97 }];
+const stops = [{ latitude: 45.81, longitude: 16.01, sequence: 2 }];
+
+test('keeps the complete route data in the driver map projection', () => {
+    assert.deepEqual(
+        buildDeliveryMapData({
+            driverLocation,
+            pickupNodes,
+            stops,
+            encodedPolyline: 'private-route',
+            customerView: false,
+        }),
+        {
+            driverLocation,
+            pickupNodes,
+            stops,
+            encodedPolyline: 'private-route',
+        },
+    );
+});
+
+test('removes pickup checkpoints and the complete route from customer map data', () => {
+    assert.deepEqual(
+        buildDeliveryMapData({
+            driverLocation,
+            pickupNodes,
+            stops,
+            encodedPolyline: 'private-route',
+            customerView: true,
+        }),
+        {
+            driverLocation,
+            pickupNodes: [],
+            stops,
+            encodedPolyline: null,
+        },
+    );
+});
+
+test('validates map data received by the interactive client', () => {
+    assert.deepEqual(
+        parseDeliveryMapData({
+            driverLocation,
+            pickupNodes,
+            stops,
+            encodedPolyline: null,
+        }),
+        { driverLocation, pickupNodes, stops, encodedPolyline: null },
+    );
+    assert.equal(
+        parseDeliveryMapData({
+            driverLocation: { latitude: 120, longitude: 15.981 },
+            pickupNodes,
+            stops,
+            encodedPolyline: null,
+        }),
+        null,
+    );
+    assert.equal(
+        parseDeliveryMapData({
+            driverLocation,
+            pickupNodes,
+            stops: [{ latitude: 45.81, longitude: 16.01, sequence: 0 }],
+            encodedPolyline: null,
+        }),
+        null,
+    );
+});
+
+test('decodes Google encoded route polylines and rejects truncated input', () => {
+    assert.deepEqual(decodeDeliveryMapPolyline('_p~iF~ps|U_ulLnnqC_mqNvxq`@'), [
+        { lat: 38.5, lng: -120.2 },
+        { lat: 40.7, lng: -120.95 },
+        { lat: 43.252, lng: -126.453 },
+    ]);
+    assert.deepEqual(decodeDeliveryMapPolyline('_p~i'), []);
+});

--- a/apps/delivery/lib/deliveryMapData.ts
+++ b/apps/delivery/lib/deliveryMapData.ts
@@ -1,0 +1,159 @@
+export type DeliveryMapCoordinate = {
+    latitude: number;
+    longitude: number;
+};
+
+export type DeliveryMapStop = DeliveryMapCoordinate & {
+    sequence: number;
+};
+
+export type DeliveryMapData = {
+    driverLocation: DeliveryMapCoordinate | null;
+    pickupNodes: DeliveryMapCoordinate[];
+    stops: DeliveryMapStop[];
+    encodedPolyline: string | null;
+};
+
+export type DeliveryMapPosition = {
+    lat: number;
+    lng: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function parseCoordinate(value: unknown): DeliveryMapCoordinate | null {
+    if (!isRecord(value)) return null;
+    const { latitude, longitude } = value;
+    if (
+        typeof latitude !== 'number' ||
+        !Number.isFinite(latitude) ||
+        latitude < -90 ||
+        latitude > 90 ||
+        typeof longitude !== 'number' ||
+        !Number.isFinite(longitude) ||
+        longitude < -180 ||
+        longitude > 180
+    ) {
+        return null;
+    }
+    return { latitude, longitude };
+}
+
+function parseStop(value: unknown): DeliveryMapStop | null {
+    const coordinate = parseCoordinate(value);
+    if (!coordinate || !isRecord(value)) return null;
+    const { sequence } = value;
+    if (
+        typeof sequence !== 'number' ||
+        !Number.isInteger(sequence) ||
+        sequence < 1
+    ) {
+        return null;
+    }
+    return { ...coordinate, sequence };
+}
+
+function parseArray<T>(
+    value: unknown,
+    parseItem: (item: unknown) => T | null,
+): T[] | null {
+    if (!Array.isArray(value)) return null;
+    const result: T[] = [];
+    for (const item of value) {
+        const parsed = parseItem(item);
+        if (!parsed) return null;
+        result.push(parsed);
+    }
+    return result;
+}
+
+export function parseDeliveryMapData(value: unknown): DeliveryMapData | null {
+    if (!isRecord(value)) return null;
+    const driverLocation =
+        value.driverLocation === null
+            ? null
+            : parseCoordinate(value.driverLocation);
+    const pickupNodes = parseArray(value.pickupNodes, parseCoordinate);
+    const stops = parseArray(value.stops, parseStop);
+    const encodedPolyline = value.encodedPolyline;
+    if (
+        (value.driverLocation !== null && !driverLocation) ||
+        !pickupNodes ||
+        !stops ||
+        (typeof encodedPolyline !== 'string' && encodedPolyline !== null)
+    ) {
+        return null;
+    }
+    return { driverLocation, pickupNodes, stops, encodedPolyline };
+}
+
+export function buildDeliveryMapData({
+    driverLocation,
+    pickupNodes,
+    stops,
+    encodedPolyline,
+    customerView,
+}: {
+    driverLocation: DeliveryMapCoordinate | null;
+    pickupNodes: DeliveryMapCoordinate[];
+    stops: DeliveryMapStop[];
+    encodedPolyline?: string | null;
+    customerView: boolean;
+}): DeliveryMapData {
+    return {
+        driverLocation,
+        pickupNodes: customerView ? [] : pickupNodes,
+        stops,
+        encodedPolyline: customerView ? null : (encodedPolyline ?? null),
+    };
+}
+
+function decodePolylineValue(
+    encodedPolyline: string,
+    startIndex: number,
+): { value: number; nextIndex: number } | null {
+    let index = startIndex;
+    let result = 0;
+    let shift = 0;
+    let byte = 0;
+    do {
+        if (index >= encodedPolyline.length || shift > 30) return null;
+        byte = encodedPolyline.charCodeAt(index) - 63;
+        if (byte < 0 || byte > 63) return null;
+        result |= (byte & 0x1f) << shift;
+        shift += 5;
+        index += 1;
+    } while (byte >= 0x20);
+    return {
+        value: result & 1 ? ~(result >> 1) : result >> 1,
+        nextIndex: index,
+    };
+}
+
+export function decodeDeliveryMapPolyline(
+    encodedPolyline: string,
+): DeliveryMapPosition[] {
+    const positions: DeliveryMapPosition[] = [];
+    let index = 0;
+    let latitude = 0;
+    let longitude = 0;
+    while (index < encodedPolyline.length) {
+        const latitudeDelta = decodePolylineValue(encodedPolyline, index);
+        if (!latitudeDelta) return [];
+        const longitudeDelta = decodePolylineValue(
+            encodedPolyline,
+            latitudeDelta.nextIndex,
+        );
+        if (!longitudeDelta) return [];
+        latitude += latitudeDelta.value;
+        longitude += longitudeDelta.value;
+        positions.push({
+            lat: latitude / 1e5,
+            lng: longitude / 1e5,
+        });
+        index = longitudeDelta.nextIndex;
+    }
+    return positions;
+}

--- a/apps/delivery/package.json
+++ b/apps/delivery/package.json
@@ -19,6 +19,7 @@
         "test:local": "pnpm run test:run"
     },
     "dependencies": {
+        "@googlemaps/js-api-loader": "2.1.1",
         "next": "16.2.10",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -36,6 +37,7 @@
         "@tailwindcss/postcss": "4.3.2",
         "@tailwindcss/typography": "0.5.20",
         "@tanstack/react-query": "5.101.2",
+        "@types/google.maps": "3.65.2",
         "@types/node": "24.12.4",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",

--- a/apps/delivery/tests/delivery-interactive-map.spec.tsx
+++ b/apps/delivery/tests/delivery-interactive-map.spec.tsx
@@ -1,0 +1,90 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { DeliveryInteractiveMap } from '../components/DeliveryInteractiveMap';
+import '../app/globals.css';
+
+const googleMapsStub = `
+class TestMap {
+  constructor(element) {
+    this.element = element;
+    element.dataset.googleMapReady = 'true';
+  }
+  fitBounds() {
+    const count = Number(this.element.dataset.fitBoundsCalls || '0') + 1;
+    this.element.dataset.fitBoundsCalls = String(count);
+  }
+  setCenter() {}
+  setZoom() {}
+}
+class TestMarker {
+  constructor({ map }) {
+    const count = Number(map.element.dataset.markerCount || '0') + 1;
+    map.element.dataset.markerCount = String(count);
+  }
+  setMap() {}
+}
+class TestPolyline {
+  constructor({ map }) {
+    map.element.dataset.polylineReady = 'true';
+  }
+  setMap() {}
+}
+class TestLatLngBounds {
+  extend() { return this; }
+}
+window.google.maps.importLibrary = async (name) => {
+  if (name === 'maps') return { Map: TestMap, Polyline: TestPolyline };
+  if (name === 'marker') return { Marker: TestMarker };
+  if (name === 'core') {
+    return { LatLngBounds: TestLatLngBounds, SymbolPath: { CIRCLE: 0 } };
+  }
+  throw new Error('Unexpected library: ' + name);
+};
+window.google.maps.__ib__();
+`;
+
+test('loads authorized map data into a live interactive map', async ({
+    mount,
+    page,
+}) => {
+    await page.route('https://maps.googleapis.com/maps/api/js?**', (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: googleMapsStub,
+        }),
+    );
+    await page.route('**/api/map/run-interactive?**', (route) => {
+        const url = new URL(route.request().url());
+        expect(url.searchParams.get('format')).toBe('json');
+        return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                driverLocation: { latitude: 45.801, longitude: 15.981 },
+                pickupNodes: [{ latitude: 45.79, longitude: 15.97 }],
+                stops: [{ latitude: 45.81, longitude: 16.01, sequence: 1 }],
+                encodedPolyline: '_p~iF~ps|U_ulLnnqC_mqNvxq`@',
+            }),
+        });
+    });
+
+    await mount(
+        <DeliveryInteractiveMap
+            apiKey="browser-test-key"
+            mapUrl="/api/map/run-interactive"
+            version="2026-07-15T14:00:00.000Z"
+            title="Interaktivna karta dostave"
+        />,
+    );
+
+    const map = page.getByRole('region', {
+        name: 'Interaktivna karta dostave',
+    });
+    await expect(map).toHaveAttribute('data-google-map-ready', 'true');
+    await expect(map).toHaveAttribute('data-marker-count', '3');
+    await expect(map).toHaveAttribute('data-polyline-ready', 'true');
+    await expect(map).toHaveAttribute('data-fit-bounds-calls', '1');
+
+    await page.getByRole('button', { name: 'Centriraj kartu' }).click();
+    await expect(map).toHaveAttribute('data-fit-bounds-calls', '2');
+});

--- a/apps/delivery/turbo.json
+++ b/apps/delivery/turbo.json
@@ -12,6 +12,7 @@
                 "GREDICE_JWT_SIGN_SECRET",
                 "NEXT_PUBLIC_GREDICE_API_ORIGIN",
                 "NEXT_PUBLIC_GREDICE_DELIVERY_ORIGIN",
+                "NEXT_PUBLIC_GREDICE_GOOGLE_MAPS_API_KEY",
                 "POSTGRES_DATABASE",
                 "POSTGRES_HOST",
                 "POSTGRES_PASSWORD",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,6 +400,9 @@ importers:
 
   apps/delivery:
     dependencies:
+      '@googlemaps/js-api-loader':
+        specifier: 2.1.1
+        version: 2.1.1
       next:
         specifier: 16.2.10
         version: 16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
@@ -446,6 +449,9 @@ importers:
       '@tanstack/react-query':
         specifier: 5.101.2
         version: 5.101.2(react@19.2.7)
+      '@types/google.maps':
+        specifier: 3.65.2
+        version: 3.65.2
       '@types/node':
         specifier: 24.12.4
         version: 24.12.4
@@ -2934,6 +2940,9 @@ packages:
 
   '@fontsource/spicy-rice@5.2.8':
     resolution: {integrity: sha512-nVBsLFNhm3rRN/d4HjavzJP/cGoKA3pyZ+EVTnrEqZHWtvxKUdBxaD8imYWTTVEm4FJklVz8tvADPH8Fii2TYw==}
+
+  '@googlemaps/js-api-loader@2.1.1':
+    resolution: {integrity: sha512-yUpAwksbHrlZIWD49JmveNSfBG4oAK0AwMknfSaPMnP5N7UT8oFRVCqwjGb1XQovi//7KLbPQKZpbofiLGzpDw==}
 
   '@headlessui/tailwindcss@0.2.2':
     resolution: {integrity: sha512-xNe42KjdyA4kfUKLLPGzME9zkH7Q3rOZ5huFihWNWOQFxnItxPB3/67yBI8/qBfY8nwBRx5GHn4VprsoluVMGw==}
@@ -5845,6 +5854,9 @@ packages:
 
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/google.maps@3.65.2':
+    resolution: {integrity: sha512-e52bmOhGCQSNabFpL48iQlwJybq6rfns8NUVJ20MR7CdPlHQ2RmSCnPbJfrUYJfogrE4OiHQTZ4LXpop+eer1w==}
 
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
@@ -12020,6 +12032,10 @@ snapshots:
 
   '@fontsource/spicy-rice@5.2.8': {}
 
+  '@googlemaps/js-api-loader@2.1.1':
+    dependencies:
+      '@types/google.maps': 3.65.2
+
   '@headlessui/tailwindcss@0.2.2(tailwindcss@4.3.2)':
     dependencies:
       tailwindcss: 4.3.2
@@ -15156,6 +15172,8 @@ snapshots:
       '@types/node': 24.12.4
 
   '@types/geojson@7946.0.16': {}
+
+  '@types/google.maps@3.65.2': {}
 
   '@types/har-format@1.2.16': {}
 


### PR DESCRIPTION
## What changed

- replace the static-only delivery map with a live Google Maps JavaScript view
- reuse the authenticated map route for a privacy-filtered JSON representation
- keep the existing static map as a load/authentication fallback
- update the driver marker on existing dashboard refreshes without resetting the user's viewport
- add a keyboard-accessible recenter control

## Privacy and security

- customers receive only the driver location and their own current delivery stop
- pickup nodes and the complete encoded route remain limited to the assigned driver/admin view
- the browser key is a separate `NEXT_PUBLIC_` variable and remains API/referrer restricted

## Validation

- `pnpm lint --filter delivery`
- `pnpm typecheck --filter delivery`
- `pnpm test --filter delivery` (178 unit + 34 component tests)
- delivery production build through the test task
