### PR TITLE
feat(delivery): add route visibility safeguards

### DIFF
--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -12,6 +12,10 @@ import {
     type DeliveryServerStateExpectation,
     useDeliveryActionSync,
 } from '../hooks/useDeliveryActionSync';
+import {
+    type DriverRouteWakeLockState,
+    useDriverRouteWakeLock,
+} from '../hooks/useDriverRouteWakeLock';
 import { useDriverTracking } from '../hooks/useDriverTracking';
 import { useOfflineRouteCache } from '../hooks/useOfflineRouteCache';
 import { usePickupManifestSync } from '../hooks/usePickupManifestSync';
@@ -259,6 +263,7 @@ type DeliveryActionResult =
 
 function DriverDashboardWithPickupSync({
     dashboard,
+    routeWakeLock,
     trackingState,
     pendingAction,
     onSelectionChange,
@@ -269,6 +274,7 @@ function DriverDashboardWithPickupSync({
     onServerStateChanged,
 }: {
     dashboard: DriverDeliveryDashboard;
+    routeWakeLock: DriverRouteWakeLockState;
     trackingState: ReturnType<typeof useDriverTracking>;
     pendingAction: string | null;
     onSelectionChange: () => void;
@@ -289,6 +295,7 @@ function DriverDashboardWithPickupSync({
         return (
             <DriverDashboard
                 dashboard={dashboard}
+                routeWakeLock={routeWakeLock}
                 trackingState={trackingState}
                 pendingAction={pendingAction}
                 onSelectionChange={onSelectionChange}
@@ -319,6 +326,7 @@ function DriverDashboardWithPickupSync({
         <ActiveDriverDashboardWithPickupSync
             dashboard={dashboard}
             activeRunId={activeRun.id}
+            routeWakeLock={routeWakeLock}
             trackingState={trackingState}
             pendingAction={pendingAction}
             onSelectionChange={onSelectionChange}
@@ -334,6 +342,7 @@ function DriverDashboardWithPickupSync({
 function ActiveDriverDashboardWithPickupSync({
     dashboard,
     activeRunId,
+    routeWakeLock,
     trackingState,
     pendingAction,
     onSelectionChange,
@@ -345,6 +354,7 @@ function ActiveDriverDashboardWithPickupSync({
 }: {
     dashboard: DriverDeliveryDashboard;
     activeRunId: string;
+    routeWakeLock: DriverRouteWakeLockState;
     trackingState: ReturnType<typeof useDriverTracking>;
     pendingAction: string | null;
     onSelectionChange: () => void;
@@ -430,6 +440,7 @@ function ActiveDriverDashboardWithPickupSync({
     return (
         <DriverDashboard
             dashboard={dashboard}
+            routeWakeLock={routeWakeLock}
             trackingState={trackingState}
             pendingAction={pendingAction}
             onSelectionChange={onSelectionChange}
@@ -626,6 +637,13 @@ export function DeliveryDashboard({
             ? dashboardData.activeRun
             : null;
     const activeRunId = activeRun?.id ?? null;
+    const routeWakeLock = useDriverRouteWakeLock({
+        runId: sessionOperational
+            ? dashboardData
+                ? activeRunId
+                : (offlineRoute?.scope.runId ?? null)
+            : null,
+    });
     const trackingState = useDriverTracking({
         runId: sessionOperational ? activeRunId : null,
         serverTracking: sessionOperational
@@ -1073,6 +1091,7 @@ export function DeliveryDashboard({
                     snapshot={offlineRoute}
                     authenticatedUserId={authenticatedDriverUserId}
                     authenticatedRole={authenticatedRole}
+                    routeWakeLock={routeWakeLock}
                     refreshServerState={refreshDriverServerState}
                 />
             );
@@ -1149,6 +1168,7 @@ export function DeliveryDashboard({
             {dashboard.kind === 'driver' ? (
                 <DriverDashboardWithPickupSync
                     dashboard={dashboard}
+                    routeWakeLock={routeWakeLock}
                     trackingState={trackingState}
                     pendingAction={pendingAction}
                     onSelectionChange={() => {

--- a/apps/delivery/components/DriverDashboard.tsx
+++ b/apps/delivery/components/DriverDashboard.tsx
@@ -15,6 +15,7 @@ import {
 } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
 import { useRef, useState } from 'react';
+import type { DriverRouteWakeLockState } from '../hooks/useDriverRouteWakeLock';
 import type { DriverTrackingState } from '../hooks/useDriverTracking';
 import {
     deliveryActionAcknowledgementBlocksRoute,
@@ -67,6 +68,7 @@ import {
     type PickupManifestSyncSummary,
 } from './DeliveryPickupCard';
 import { DeliveryStopCard } from './DeliveryStopCard';
+import { DriverRouteContinuity } from './DriverRouteContinuity';
 import { DriverTrackingStatus } from './DriverTrackingStatus';
 import { HarvestTraceScanner } from './HarvestTraceScanner';
 
@@ -396,6 +398,7 @@ export function DeliveryActionSyncStatus({
 
 export function DriverDashboard({
     dashboard,
+    routeWakeLock,
     trackingState,
     pendingAction,
     onSelectionChange,
@@ -417,6 +420,7 @@ export function DriverDashboard({
     onReconcileDeliverySync,
 }: {
     dashboard: DriverDeliveryDashboard;
+    routeWakeLock: DriverRouteWakeLockState;
     trackingState: DriverTrackingState;
     pendingAction: string | null;
     onSelectionChange: () => void;
@@ -707,6 +711,7 @@ export function DriverDashboard({
 
                 {run ? (
                     <>
+                        <DriverRouteContinuity state={routeWakeLock} />
                         <DriverTrackingStatus tracking={trackingState} />
                         <DeliveryActionSyncStatus
                             snapshot={deliveryQueue}

--- a/apps/delivery/components/DriverRouteContinuity.tsx
+++ b/apps/delivery/components/DriverRouteContinuity.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Device, Reset, Sun, Warning } from '@gredice/ui/icons';
+import { Switch } from '@gredice/ui/Switch';
+import { Typography } from '@gredice/ui/Typography';
+import type { DriverRouteWakeLockState } from '../hooks/useDriverRouteWakeLock';
+
+function continuityMessage(
+    state: DriverRouteWakeLockState,
+    trackingAvailable: boolean,
+) {
+    if (!trackingAvailable) {
+        const screenMessage =
+            state.status === 'unsupported'
+                ? 'Ovaj preglednik ne može spriječiti automatsko gašenje zaslona. Drži izvanmrežnu rutu otvorenom i zaslon uključenim ručno.'
+                : state.status === 'requesting'
+                  ? 'Preglednik obrađuje zahtjev da zaslon ostane uključen za rad s izvanmrežnom rutom.'
+                  : state.status === 'active'
+                    ? 'Zaslon ostaje uključen za rad s izvanmrežnom rutom.'
+                    : state.status === 'paused'
+                      ? 'Održavanje zaslona uključenim je pauzirano jer izvanmrežna ruta nije vidljiva.'
+                      : state.status === 'error'
+                        ? 'Preglednik nije zadržao zaslon uključenim. Drži izvanmrežnu rutu vidljivom i pokušaj ponovno.'
+                        : state.status === 'off'
+                          ? 'Po želji zadrži zaslon uključenim za rad s izvanmrežnom rutom.'
+                          : '';
+        return screenMessage
+            ? `${screenMessage} GPS praćenje nije aktivno dok se ne učita stanje poslužitelja.`
+            : '';
+    }
+    switch (state.status) {
+        case 'unsupported':
+            return 'Ovaj preglednik ne može spriječiti automatsko gašenje zaslona. Drži rutu otvorenom i zaslon uključenim ručno.';
+        case 'off':
+            return 'GPS se može pauzirati kada je ruta skrivena ili je zaslon zaključan. Po želji zadrži zaslon uključenim za ovu rutu.';
+        case 'requesting':
+            return 'Preglednik obrađuje zahtjev da zaslon ostane uključen.';
+        case 'active':
+            return 'Zaslon ostaje uključen dok je ova ruta vidljiva. Prelazak u drugu aplikaciju i dalje može pauzirati GPS.';
+        case 'paused':
+            return 'Održavanje zaslona uključenim je pauzirano jer ruta nije vidljiva. Ponovno će se zatražiti nakon povratka.';
+        case 'error':
+            return 'Preglednik nije zadržao zaslon uključenim. Drži rutu vidljivom i pokušaj ponovno.';
+        case 'inactive':
+            return '';
+    }
+}
+
+export function DriverRouteContinuity({
+    state,
+    trackingAvailable = true,
+}: {
+    state: DriverRouteWakeLockState;
+    trackingAvailable?: boolean;
+}) {
+    if (state.status === 'inactive') return null;
+    const active = state.status === 'active';
+    const unavailable = state.status === 'unsupported';
+    const failed = state.status === 'error';
+    const color =
+        active && trackingAvailable
+            ? 'success'
+            : failed || unavailable
+              ? 'warning'
+              : 'info';
+    const announcement = active
+        ? trackingAvailable
+            ? 'Zaslon ostaje uključen za ovu aktivnu rutu.'
+            : 'Zaslon ostaje uključen za izvanmrežnu rutu. GPS praćenje nije aktivno.'
+        : failed
+          ? 'Zaslon nije zadržan uključenim.'
+          : unavailable
+            ? 'Preglednik ne podržava održavanje zaslona uključenim.'
+            : state.status === 'paused'
+              ? 'Održavanje zaslona uključenim je pauzirano.'
+              : null;
+
+    return (
+        <Alert
+            aria-label="Vidljivost rute i zaslona"
+            color={color}
+            data-wake-lock-status={state.status}
+            role="group"
+            startDecorator={
+                active ? (
+                    <Sun className="size-5" />
+                ) : failed || unavailable ? (
+                    <Warning className="size-5" />
+                ) : (
+                    <Device className="size-5" />
+                )
+            }
+        >
+            <span className="sr-only" aria-live="polite" role="status">
+                {announcement ?? ''}
+            </span>
+            <div className="grid w-full gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+                <div className="min-w-0">
+                    <Typography level="body2" semiBold>
+                        Vidljivost rute
+                    </Typography>
+                    <Typography className="mt-1" level="body2">
+                        {continuityMessage(state, trackingAvailable)}
+                    </Typography>
+                </div>
+                <div className="grid min-w-0 gap-2 sm:w-80">
+                    <div className="min-w-0">
+                        <Switch
+                            checked={state.consented}
+                            description="Vrijedi samo za ovu aktivnu rutu i može povećati potrošnju baterije. Ne omogućuje GPS praćenje u pozadini."
+                            disabled={unavailable}
+                            label="Drži zaslon uključenim"
+                            size="md"
+                            onCheckedChange={(checked) =>
+                                checked ? state.enable() : state.disable()
+                            }
+                        />
+                    </div>
+                    {failed ? (
+                        <Button
+                            className="justify-self-start"
+                            color="warning"
+                            size="sm"
+                            startDecorator={<Reset className="size-4" />}
+                            variant="soft"
+                            onClick={state.retry}
+                        >
+                            Pokušaj ponovno
+                        </Button>
+                    ) : null}
+                </div>
+            </div>
+        </Alert>
+    );
+}

--- a/apps/delivery/components/OfflineRoutePanel.tsx
+++ b/apps/delivery/components/OfflineRoutePanel.tsx
@@ -13,7 +13,7 @@ import {
     Warning,
 } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 import {
     deliveryActionAcknowledgementBlocksRoute,
     deliveryActionCompletionMessage,
@@ -135,6 +135,7 @@ function offlineDeliveryItems(
 export function OfflineRoutePanel({
     snapshot,
     actionQueue,
+    routeContinuity,
     onArrive,
     onDeliver,
     onException,
@@ -145,6 +146,7 @@ export function OfflineRoutePanel({
 }: {
     snapshot: OfflineRouteSnapshot;
     actionQueue: DeliveryActionQueueSnapshot;
+    routeContinuity?: ReactNode;
     onArrive: (stopId: number, routeRevision: number) => void | Promise<void>;
     onDeliver: (
         stopId: number,
@@ -213,6 +215,7 @@ export function OfflineRoutePanel({
     return (
         <main className="min-h-[100dvh] bg-muted/30 p-4">
             <div className="mx-auto max-w-3xl space-y-4">
+                {routeContinuity}
                 <Alert
                     color="warning"
                     startDecorator={<Warning className="size-5" />}

--- a/apps/delivery/components/OfflineRouteRecovery.tsx
+++ b/apps/delivery/components/OfflineRouteRecovery.tsx
@@ -7,19 +7,23 @@ import {
     type DeliveryServerStateExpectation,
     useDeliveryActionSync,
 } from '../hooks/useDeliveryActionSync';
+import type { DriverRouteWakeLockState } from '../hooks/useDriverRouteWakeLock';
 import type { OfflineRouteSnapshot } from '../lib/offlineRouteCache';
 import { DeliveryAppHeader } from './DeliveryAppHeader';
+import { DriverRouteContinuity } from './DriverRouteContinuity';
 import { OfflineRoutePanel } from './OfflineRoutePanel';
 
 export function OfflineRouteRecovery({
     snapshot,
     authenticatedUserId,
     authenticatedRole,
+    routeWakeLock,
     refreshServerState,
 }: {
     snapshot: OfflineRouteSnapshot;
     authenticatedUserId: string;
     authenticatedRole: string;
+    routeWakeLock: DriverRouteWakeLockState;
     refreshServerState: (
         expectation?: DeliveryServerStateExpectation,
     ) => Promise<boolean>;
@@ -71,6 +75,12 @@ export function OfflineRouteRecovery({
             <OfflineRoutePanel
                 snapshot={snapshot}
                 actionQueue={sync.snapshot}
+                routeContinuity={
+                    <DriverRouteContinuity
+                        state={routeWakeLock}
+                        trackingAvailable={false}
+                    />
+                }
                 onArrive={(stopId, routeRevision) =>
                     report(sync.enqueueArrive(stopId, routeRevision))
                 }

--- a/apps/delivery/hooks/useDriverRouteWakeLock.ts
+++ b/apps/delivery/hooks/useDriverRouteWakeLock.ts
@@ -1,0 +1,253 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type DriverRouteWakeLockStatus =
+    | 'inactive'
+    | 'unsupported'
+    | 'off'
+    | 'requesting'
+    | 'active'
+    | 'paused'
+    | 'error';
+
+export type DriverRouteWakeLockState = {
+    status: DriverRouteWakeLockStatus;
+    consented: boolean;
+    documentVisible: boolean;
+    enable: () => void;
+    disable: () => void;
+    retry: () => void;
+};
+
+type WakeLockControls = {
+    runId: string;
+    enable: () => void;
+    disable: () => void;
+    retry: () => void;
+};
+
+type WakeLockViewState = Pick<
+    DriverRouteWakeLockState,
+    'status' | 'consented' | 'documentVisible'
+>;
+
+const inactiveWakeLockState: WakeLockViewState = {
+    status: 'inactive',
+    consented: false,
+    documentVisible: true,
+};
+
+export function useDriverRouteWakeLock({
+    runId,
+}: {
+    runId: string | null;
+}): DriverRouteWakeLockState {
+    const [viewState, setViewState] = useState<WakeLockViewState>(
+        inactiveWakeLockState,
+    );
+    const controlsRef = useRef<WakeLockControls | null>(null);
+
+    const enable = useCallback(() => controlsRef.current?.enable(), []);
+    const disable = useCallback(() => controlsRef.current?.disable(), []);
+    const retry = useCallback(() => controlsRef.current?.retry(), []);
+
+    useEffect(() => {
+        if (!runId) {
+            controlsRef.current = null;
+            setViewState(inactiveWakeLockState);
+            return;
+        }
+
+        let disposed = false;
+        let consented = false;
+        let requesting = false;
+        let requestGeneration = 0;
+        let sentinel: WakeLockSentinel | null = null;
+        let sentinelReleaseListener: (() => void) | null = null;
+        const wakeLock = 'wakeLock' in navigator ? navigator.wakeLock : null;
+        const supported = wakeLock !== null;
+        let state: WakeLockViewState = {
+            status: supported ? 'off' : 'unsupported',
+            consented: false,
+            documentVisible: document.visibilityState === 'visible',
+        };
+        setViewState(state);
+
+        const publish = (patch: Partial<WakeLockViewState>) => {
+            if (disposed) return;
+            state = { ...state, ...patch };
+            setViewState(state);
+        };
+
+        const releaseCurrentSentinel = async () => {
+            const current = sentinel;
+            const releaseListener = sentinelReleaseListener;
+            sentinel = null;
+            sentinelReleaseListener = null;
+            if (!current) return;
+            if (releaseListener) {
+                current.removeEventListener('release', releaseListener);
+            }
+            if (current.released) return;
+            try {
+                await current.release();
+            } catch {
+                // The browser may have released the sentinel concurrently.
+            }
+        };
+
+        const acquire = async () => {
+            if (
+                disposed ||
+                !supported ||
+                !consented ||
+                document.visibilityState !== 'visible'
+            ) {
+                if (consented && document.visibilityState !== 'visible') {
+                    publish({ status: 'paused', documentVisible: false });
+                }
+                return;
+            }
+            if (sentinel && !sentinel.released) {
+                publish({ status: 'active', documentVisible: true });
+                return;
+            }
+            if (requesting) return;
+
+            requesting = true;
+            const generation = ++requestGeneration;
+            publish({ status: 'requesting', documentVisible: true });
+            try {
+                const requestedSentinel = await wakeLock.request('screen');
+                if (
+                    disposed ||
+                    generation !== requestGeneration ||
+                    !consented ||
+                    document.visibilityState !== 'visible'
+                ) {
+                    try {
+                        await requestedSentinel.release();
+                    } catch {
+                        // A stale request must not retain the screen lock.
+                    }
+                    return;
+                }
+                requesting = false;
+
+                const handleRelease = () => {
+                    if (sentinel !== requestedSentinel) return;
+                    sentinel = null;
+                    sentinelReleaseListener = null;
+                    if (disposed || !consented) return;
+                    const documentVisible =
+                        document.visibilityState === 'visible';
+                    if (documentVisible) consented = false;
+                    publish({
+                        status: documentVisible ? 'error' : 'paused',
+                        consented: documentVisible ? false : consented,
+                        documentVisible,
+                    });
+                };
+                sentinel = requestedSentinel;
+                sentinelReleaseListener = handleRelease;
+                requestedSentinel.addEventListener('release', handleRelease, {
+                    once: true,
+                });
+                publish({ status: 'active', documentVisible: true });
+            } catch {
+                if (disposed || generation !== requestGeneration) return;
+                requesting = false;
+                const documentVisible = document.visibilityState === 'visible';
+                if (documentVisible) consented = false;
+                publish({
+                    status: documentVisible ? 'error' : 'paused',
+                    consented: documentVisible ? false : consented,
+                    documentVisible,
+                });
+            }
+        };
+
+        const suspend = () => {
+            requestGeneration += 1;
+            requesting = false;
+            publish({
+                status: consented
+                    ? 'paused'
+                    : supported
+                      ? 'off'
+                      : 'unsupported',
+                documentVisible: false,
+            });
+            void releaseCurrentSentinel();
+        };
+
+        const handleVisibilityChange = () => {
+            if (document.visibilityState !== 'visible') {
+                suspend();
+                return;
+            }
+            publish({
+                status: consented
+                    ? 'requesting'
+                    : supported
+                      ? 'off'
+                      : 'unsupported',
+                documentVisible: true,
+            });
+            if (consented) void acquire();
+        };
+        const handlePageHide = () => suspend();
+        const handlePageShow = () => {
+            if (document.visibilityState !== 'visible') return;
+            publish({ documentVisible: true });
+            if (consented) void acquire();
+        };
+
+        controlsRef.current = {
+            runId,
+            enable: () => {
+                if (!supported) return;
+                consented = true;
+                publish({ consented: true });
+                void acquire();
+            },
+            disable: () => {
+                consented = false;
+                requestGeneration += 1;
+                requesting = false;
+                publish({ status: 'off', consented: false });
+                void releaseCurrentSentinel();
+            },
+            retry: () => {
+                if (!supported) return;
+                consented = true;
+                publish({ consented: true });
+                void acquire();
+            },
+        };
+
+        document.addEventListener('visibilitychange', handleVisibilityChange);
+        window.addEventListener('pagehide', handlePageHide);
+        window.addEventListener('pageshow', handlePageShow);
+
+        return () => {
+            disposed = true;
+            consented = false;
+            requestGeneration += 1;
+            requesting = false;
+            if (controlsRef.current?.runId === runId) {
+                controlsRef.current = null;
+            }
+            document.removeEventListener(
+                'visibilitychange',
+                handleVisibilityChange,
+            );
+            window.removeEventListener('pagehide', handlePageHide);
+            window.removeEventListener('pageshow', handlePageShow);
+            void releaseCurrentSentinel();
+        };
+    }, [runId]);
+
+    return { ...viewState, enable, disable, retry };
+}

--- a/apps/delivery/tests/DriverDashboardOfflineStory.tsx
+++ b/apps/delivery/tests/DriverDashboardOfflineStory.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { DriverDashboard } from '../components/DriverDashboard';
+import type { DriverRouteWakeLockState } from '../hooks/useDriverRouteWakeLock';
 import type { DriverTrackingState } from '../hooks/useDriverTracking';
 import type {
     DeliveryActionQueueEntry,
@@ -155,6 +156,15 @@ const trackingState: DriverTrackingState = {
     recheckPermission: () => undefined,
 };
 
+const routeWakeLock: DriverRouteWakeLockState = {
+    status: 'inactive',
+    consented: false,
+    documentVisible: true,
+    enable: () => undefined,
+    disable: () => undefined,
+    retry: () => undefined,
+};
+
 function DashboardStory({
     deliveryQueue,
 }: {
@@ -163,6 +173,7 @@ function DashboardStory({
     return (
         <DriverDashboard
             dashboard={dashboard}
+            routeWakeLock={routeWakeLock}
             trackingState={trackingState}
             pendingAction={null}
             onSelectionChange={() => undefined}

--- a/apps/delivery/tests/DriverRouteContinuityStory.tsx
+++ b/apps/delivery/tests/DriverRouteContinuityStory.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { DriverRouteContinuity } from '../components/DriverRouteContinuity';
+import { useDriverRouteWakeLock } from '../hooks/useDriverRouteWakeLock';
+
+export function DriverRouteContinuityStory({
+    runId = 'run-one',
+    trackingAvailable = true,
+}: {
+    runId?: string | null;
+    trackingAvailable?: boolean;
+}) {
+    const state = useDriverRouteWakeLock({ runId });
+    return (
+        <DriverRouteContinuity
+            state={state}
+            trackingAvailable={trackingAvailable}
+        />
+    );
+}

--- a/apps/delivery/tests/route-continuity.spec.tsx
+++ b/apps/delivery/tests/route-continuity.spec.tsx
@@ -1,0 +1,387 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Page } from '@playwright/test';
+import { DriverRouteContinuityStory } from './DriverRouteContinuityStory';
+import '../app/globals.css';
+
+async function installWakeLockBrowser(
+    page: Page,
+    options: {
+        supported?: boolean;
+        rejectFirstRequest?: boolean;
+        deferFirstRequest?: boolean;
+        deferRequestCount?: number;
+    } = {},
+) {
+    await page.evaluate(
+        ({
+            supported,
+            rejectFirstRequest,
+            deferFirstRequest,
+            deferRequestCount,
+        }) => {
+            let visibility: DocumentVisibilityState = 'visible';
+            let requestCount = 0;
+            let releaseCount = 0;
+            let shouldReject = rejectFirstRequest;
+            let deferredRequestsRemaining =
+                deferRequestCount ?? (deferFirstRequest ? 1 : 0);
+            const sentinels: Array<{
+                released: boolean;
+                release: () => Promise<void>;
+            }> = [];
+            const deferredResolvers: Array<() => void> = [];
+            const root = document.documentElement;
+
+            const syncMetrics = () => {
+                root.dataset.wakeLockRequestCount = String(requestCount);
+                root.dataset.wakeLockReleaseCount = String(releaseCount);
+            };
+            const createSentinel = () => {
+                let released = false;
+                const target = new EventTarget();
+                const sentinel = {
+                    get released() {
+                        return released;
+                    },
+                    get type() {
+                        return 'screen' as const;
+                    },
+                    onrelease: null,
+                    addEventListener: target.addEventListener.bind(target),
+                    removeEventListener:
+                        target.removeEventListener.bind(target),
+                    dispatchEvent: target.dispatchEvent.bind(target),
+                    async release() {
+                        if (released) return;
+                        released = true;
+                        releaseCount += 1;
+                        syncMetrics();
+                        target.dispatchEvent(new Event('release'));
+                    },
+                };
+                sentinels.push(sentinel);
+                return sentinel;
+            };
+
+            Object.defineProperty(document, 'visibilityState', {
+                configurable: true,
+                get: () => visibility,
+            });
+            if (supported) {
+                Object.defineProperty(navigator, 'wakeLock', {
+                    configurable: true,
+                    value: {
+                        async request() {
+                            requestCount += 1;
+                            syncMetrics();
+                            if (shouldReject) {
+                                shouldReject = false;
+                                throw new DOMException(
+                                    'Wake lock unavailable',
+                                    'NotAllowedError',
+                                );
+                            }
+                            if (deferredRequestsRemaining > 0) {
+                                deferredRequestsRemaining -= 1;
+                                return await new Promise((resolve) => {
+                                    deferredResolvers.push(() =>
+                                        resolve(createSentinel()),
+                                    );
+                                });
+                            }
+                            return createSentinel();
+                        },
+                    },
+                });
+            } else {
+                Reflect.deleteProperty(navigator, 'wakeLock');
+                const prototype: object | null =
+                    Object.getPrototypeOf(navigator);
+                if (prototype) Reflect.deleteProperty(prototype, 'wakeLock');
+            }
+
+            window.addEventListener('wake-lock-test-visibility', (event) => {
+                if (!(event instanceof CustomEvent)) return;
+                visibility = event.detail;
+                document.dispatchEvent(new Event('visibilitychange'));
+            });
+            window.addEventListener('wake-lock-test-browser-release', () => {
+                const sentinel = sentinels.at(-1);
+                if (!sentinel || sentinel.released) return;
+                void sentinel.release();
+            });
+            window.addEventListener('wake-lock-test-resolve', () => {
+                deferredResolvers.shift()?.();
+            });
+            syncMetrics();
+        },
+        {
+            supported: options.supported ?? true,
+            rejectFirstRequest: options.rejectFirstRequest ?? false,
+            deferFirstRequest: options.deferFirstRequest ?? false,
+            deferRequestCount: options.deferRequestCount,
+        },
+    );
+}
+
+test('requests a wake lock only after explicit route consent and releases on opt-out', async ({
+    mount,
+    page,
+}) => {
+    await installWakeLockBrowser(page);
+    const component = await mount(<DriverRouteContinuityStory />);
+    const toggle = component.getByRole('switch', {
+        name: 'Drži zaslon uključenim',
+    });
+
+    await expect(component).toContainText('GPS se može pauzirati');
+    await expect(component.getByRole('status')).toBeEmpty();
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-wake-lock-request-count',
+        '0',
+    );
+
+    await toggle.click();
+    await expect(component).toHaveAttribute('data-wake-lock-status', 'active');
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+    await expect(component).toContainText(
+        'Prelazak u drugu aplikaciju i dalje može pauzirati GPS',
+    );
+    await expect(component.getByRole('status')).toHaveText(
+        'Zaslon ostaje uključen za ovu aktivnu rutu.',
+    );
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-wake-lock-request-count',
+        '1',
+    );
+
+    await toggle.click();
+    await expect(component).toHaveAttribute('data-wake-lock-status', 'off');
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-wake-lock-release-count',
+        '1',
+    );
+});
+
+test('releases while hidden and reacquires only for the consented route', async ({
+    mount,
+    page,
+}) => {
+    await installWakeLockBrowser(page);
+    const component = await mount(<DriverRouteContinuityStory />);
+    await component
+        .getByRole('switch', { name: 'Drži zaslon uključenim' })
+        .click();
+    await expect(component).toHaveAttribute('data-wake-lock-status', 'active');
+
+    await page.evaluate(() => {
+        window.dispatchEvent(
+            new CustomEvent('wake-lock-test-visibility', {
+                detail: 'hidden',
+            }),
+        );
+    });
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-wake-lock-release-count',
+        '1',
+    );
+
+    await page.evaluate(() => {
+        window.dispatchEvent(
+            new CustomEvent('wake-lock-test-visibility', {
+                detail: 'visible',
+            }),
+        );
+    });
+    await expect(component).toHaveAttribute('data-wake-lock-status', 'active');
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-wake-lock-request-count',
+        '2',
+    );
+    await page.evaluate(() => {
+        window.dispatchEvent(
+            new CustomEvent('wake-lock-test-visibility', {
+                detail: 'visible',
+            }),
+        );
+        window.dispatchEvent(new PageTransitionEvent('pageshow'));
+    });
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-wake-lock-request-count',
+        '2',
+    );
+
+    await component.update(<DriverRouteContinuityStory runId="run-two" />);
+    await expect(component).toHaveAttribute('data-wake-lock-status', 'off');
+    await expect(
+        component.getByRole('switch', { name: 'Drži zaslon uključenim' }),
+    ).toHaveAttribute('aria-checked', 'false');
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-wake-lock-release-count',
+        '2',
+    );
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-wake-lock-request-count',
+        '2',
+    );
+});
+
+test('shows unsupported and browser-release recovery states truthfully', async ({
+    mount,
+    page,
+}) => {
+    await installWakeLockBrowser(page, { supported: false });
+    const unsupported = await mount(<DriverRouteContinuityStory />);
+    await expect(unsupported).toHaveAttribute(
+        'data-wake-lock-status',
+        'unsupported',
+    );
+    await expect(
+        unsupported.getByRole('switch', {
+            name: 'Drži zaslon uključenim',
+        }),
+    ).toBeDisabled();
+    await unsupported.unmount();
+
+    await installWakeLockBrowser(page);
+    const released = await mount(<DriverRouteContinuityStory />);
+    await released
+        .getByRole('switch', { name: 'Drži zaslon uključenim' })
+        .click();
+    await page.evaluate(() => {
+        window.dispatchEvent(new Event('wake-lock-test-browser-release'));
+    });
+    await expect(released).toHaveAttribute('data-wake-lock-status', 'error');
+    await expect(
+        released.getByRole('switch', {
+            name: 'Drži zaslon uključenim',
+        }),
+    ).toHaveAttribute('aria-checked', 'false');
+    await expect(released).toContainText('nije zadržao zaslon uključenim');
+    await expect(
+        released.getByRole('button', { name: 'Pokušaj ponovno' }),
+    ).toBeVisible();
+});
+
+test('recovers from a rejected request without claiming GPS is active', async ({
+    mount,
+    page,
+}) => {
+    await installWakeLockBrowser(page, { rejectFirstRequest: true });
+    const component = await mount(<DriverRouteContinuityStory />);
+    await component
+        .getByRole('switch', { name: 'Drži zaslon uključenim' })
+        .click();
+    await expect(component).toHaveAttribute('data-wake-lock-status', 'error');
+    await expect(component).not.toContainText('GPS praćenje je aktivno');
+
+    await component.getByRole('button', { name: 'Pokušaj ponovno' }).click();
+    await expect(component).toHaveAttribute('data-wake-lock-status', 'active');
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-wake-lock-request-count',
+        '2',
+    );
+});
+
+test('releases a late request after consent is withdrawn and cleans up on unmount', async ({
+    mount,
+    page,
+}) => {
+    await installWakeLockBrowser(page, { deferFirstRequest: true });
+    const component = await mount(<DriverRouteContinuityStory />);
+    const toggle = component.getByRole('switch', {
+        name: 'Drži zaslon uključenim',
+    });
+    await toggle.click();
+    await expect(component).toHaveAttribute(
+        'data-wake-lock-status',
+        'requesting',
+    );
+    await toggle.click();
+    await page.evaluate(() => {
+        window.dispatchEvent(new Event('wake-lock-test-resolve'));
+    });
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-wake-lock-release-count',
+        '1',
+    );
+    await expect(component).toHaveAttribute('data-wake-lock-status', 'off');
+
+    await toggle.click();
+    await expect(component).toHaveAttribute('data-wake-lock-status', 'active');
+    await component.unmount();
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-wake-lock-release-count',
+        '2',
+    );
+});
+
+test('a stale hidden-page resolution cannot unlock a newer pending acquisition', async ({
+    mount,
+    page,
+}) => {
+    await installWakeLockBrowser(page, { deferRequestCount: 2 });
+    const component = await mount(<DriverRouteContinuityStory />);
+    await component
+        .getByRole('switch', { name: 'Drži zaslon uključenim' })
+        .click();
+    await page.evaluate(() => {
+        window.dispatchEvent(
+            new CustomEvent('wake-lock-test-visibility', {
+                detail: 'hidden',
+            }),
+        );
+        window.dispatchEvent(
+            new CustomEvent('wake-lock-test-visibility', {
+                detail: 'visible',
+            }),
+        );
+    });
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-wake-lock-request-count',
+        '2',
+    );
+
+    await page.evaluate(() => {
+        window.dispatchEvent(new Event('wake-lock-test-resolve'));
+    });
+    await page.evaluate(() => {
+        window.dispatchEvent(new PageTransitionEvent('pageshow'));
+    });
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-wake-lock-request-count',
+        '2',
+    );
+    await expect(component).toHaveAttribute(
+        'data-wake-lock-status',
+        'requesting',
+    );
+
+    await page.evaluate(() => {
+        window.dispatchEvent(new Event('wake-lock-test-resolve'));
+    });
+    await expect(component).toHaveAttribute('data-wake-lock-status', 'active');
+});
+
+test('cached offline route distinguishes screen continuity from inactive GPS tracking', async ({
+    mount,
+    page,
+}) => {
+    await installWakeLockBrowser(page);
+    const component = await mount(
+        <DriverRouteContinuityStory trackingAvailable={false} />,
+    );
+    await expect(component).toContainText(
+        'GPS praćenje nije aktivno dok se ne učita stanje poslužitelja',
+    );
+    await expect(component).not.toContainText('GPS se može pauzirati');
+
+    await component
+        .getByRole('switch', { name: 'Drži zaslon uključenim' })
+        .click();
+    await expect(component).toHaveAttribute('data-wake-lock-status', 'active');
+    await expect(component.getByRole('status')).toHaveText(
+        'Zaslon ostaje uključen za izvanmrežnu rutu. GPS praćenje nije aktivno.',
+    );
+});

--- a/docs/delivery-tracking-mobile-validation.md
+++ b/docs/delivery-tracking-mobile-validation.md
@@ -1,0 +1,114 @@
+# Delivery mobile tracking validation
+
+This document defines the supported browser envelope for driver tracking in
+`apps/delivery`, the physical-device validation protocol, and the decision gate
+for a wrapped or native driver application.
+
+## Product contract
+
+- Server acknowledgement remains the source of truth. A local GPS callback or
+  an active screen wake lock never makes tracking “live” by itself.
+- A location is live for 30 seconds after server receipt, delayed through 120
+  seconds, and unavailable as an exact customer-visible point after that TTL.
+- The web app can request a **screen** wake lock only after the driver opts in
+  for the current route. It releases the lock when the route is hidden, changed,
+  completed, or unmounted, and when the driver opts out.
+- A screen wake lock keeps a visible screen awake. It does not provide a system
+  wake lock or reliable GPS callbacks after the page is hidden, another app is
+  opened, or the device is explicitly locked.
+- Drivers must keep the active route visible for the supported live-tracking
+  promise. The UI says this before a delay occurs and continues to show the
+  server-confirmed tracking age.
+
+The lifecycle follows the [W3C Screen Wake Lock specification](https://www.w3.org/TR/screen-wake-lock/): only visible documents can acquire the screen lock, the user agent can release it, and an application must release its sentinel when it no longer needs it. Apple also warns that continuous web geolocation can reduce battery life in its [Safari Web Content Guide](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/GettingGeographicalLocations/GettingGeographicalLocations.html).
+
+## Automated observed results
+
+Observed on 2026-07-15 with Playwright 1.61.1 and its bundled desktop Chromium.
+These checks validate application lifecycle behavior; they do not substitute
+for physical iOS or Android evidence.
+
+| Scenario | Observed result | Automated coverage |
+| --- | --- | --- |
+| Route opens without consent | No wake-lock request; proactive foreground guidance is visible | `route-continuity.spec.tsx` |
+| Driver opts in and out | One request after opt-in; sentinel releases after opt-out | `route-continuity.spec.tsx` |
+| Document becomes hidden, then visible | Sentinel releases while hidden and is reacquired only for the same consented route | `route-continuity.spec.tsx` |
+| Browser rejects or releases the lock | UI never calls GPS active; it shows recovery guidance and an explicit retry | `route-continuity.spec.tsx` |
+| Route changes or component unmounts | Consent resets and the previous sentinel releases | `route-continuity.spec.tsx` |
+| A request resolves after opt-out | The stale sentinel is immediately released and cannot reactivate the control | `route-continuity.spec.tsx` |
+| GPS document visibility recovery | A fresh retry runs on return without bypassing the 10-second upload interval | `driver-tracking.spec.tsx` |
+| Stale foreground acknowledgement | UI crosses from live to delayed after 30 seconds and never promotes itself from wake-lock state | `driver-tracking.spec.tsx` |
+
+## Physical-device matrix
+
+Run this matrix on the deployed production build. Do not mark a row passed from
+emulation, a desktop browser, or vendor support tables. Record the device model,
+exact OS and browser versions, installation mode, date, anonymized tester
+role/reference, route duration, and sanitized observations in the result cell.
+Never record a device name, serial number, account ID, or route/run ID.
+
+| Target | Foreground + wake lock | App switch 2 min | Explicit screen lock 2 min | Permission after resume | Network loss/recovery | Battery and thermal result | Sign-off |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Supported iPhone, Safari tab | Not yet observed | Not yet observed | Not yet observed | Not yet observed | Not yet observed | Not yet measured | Pending |
+| Supported iPhone, Home Screen | Not yet observed | Not yet observed | Not yet observed | Not yet observed | Not yet observed | Not yet measured | Pending |
+| Supported Android, Chrome tab | Not yet observed | Not yet observed | Not yet observed | Not yet observed | Not yet observed | Not yet measured | Pending |
+| Supported Android, installed app | Not yet observed | Not yet observed | Not yet observed | Not yet observed | Not yet observed | Not yet measured | Pending |
+
+### Representative route protocol
+
+Use a production-like account and a non-customer test route. Never paste raw
+coordinates, customer data, account/run identifiers, or unsanitized logs into
+this document.
+
+1. Charge the device above 80%, unplug it, disable low-power mode, set brightness
+   to 50%, remove the case, and record ambient temperature.
+2. Run at least 60 minutes with eight or more physical stops, normal navigation,
+   QR use, and the route screen visible with wake lock enabled.
+3. Record the largest gap between server acknowledgements, time to recover after
+   each visibility/network interruption, unexpected permission prompts, and
+   whether a fresh position replaces the pre-suspension sample.
+4. Repeat app switching, explicit screen locking, and a two-minute network loss.
+   Confirm the UI becomes delayed/offline rather than claiming live tracking.
+5. Record battery percentage at start and finish. Report percentage points per
+   hour. On Android, also record the OS-reported battery temperature before and
+   after; on iOS, record any thermal warning, marked dimming, or device heat as
+   none/mild/high because Safari exposes no dependable thermal sensor.
+6. Repeat the foreground run once without wake lock on the same device and
+   comparable route conditions. Record the battery difference and any screen-off
+   tracking gaps.
+
+## Release thresholds
+
+The web/PWA route is approved only when all supported targets meet every
+foreground requirement:
+
+- no server-acknowledgement gap exceeds 30 seconds while the route is visible,
+  connected, and wake-locked;
+- every app-switch, screen-lock, permission, and network test returns to a fresh
+  server acknowledgement within 30 seconds after the route becomes visible;
+- no stale pre-suspension point is uploaded after its 120-second TTL;
+- wake-lock consent and release behave as documented;
+- the representative wake-locked route uses no more than 20 percentage points
+  of battery per hour, adds no more than 8 percentage points per hour versus the
+  comparable foreground control, and produces no OS thermal warning or marked
+  thermal throttling.
+
+These initial battery thresholds are an operational release gate, not a claim
+about device capability. Revisit them only with recorded route evidence.
+
+## Native or wrapped go/no-go
+
+Use a wrapped/native driver application with an OS background-location service
+when either condition is true:
+
+1. Product requires “live” customer tracking while the driver intentionally
+   locks the screen or uses another application. The web build is an immediate
+   **no-go** for that promise because screen wake lock cannot supply background
+   location.
+2. Any supported foreground target misses the acknowledgement, recovery,
+   battery, or thermal release thresholds in two controlled runs after browser
+   and application defects have been excluded.
+
+Until every physical-device row is signed off, the supported promise is
+foreground tracking with truthful delayed/offline recovery—not locked-screen or
+background live tracking.


### PR DESCRIPTION
## Summary

- add an explicit, route-scoped Screen Wake Lock opt-in with guarded async acquisition, release, visibility recovery, and run/logout cleanup
- keep visibility guidance truthful across live and cached offline routes without ever treating wake-lock state as GPS acknowledgement
- document the supported foreground-only browser contract, physical iOS/Android test matrix, battery/thermal protocol, and native/wrapped go/no-go thresholds
- add component coverage for consent, rejection, browser release, visibility changes, stale promises, route changes, unmount, and offline presentation

## Validation

- `corepack pnpm --filter delivery lint`
- `corepack pnpm --filter delivery typecheck`
- `corepack pnpm --filter delivery test:unit` (228 passed)
- `corepack pnpm --filter delivery test:component` (51 passed)
- `corepack pnpm --filter delivery build`
- `git diff --check`

## Physical-device release gate

This PR intentionally references rather than closes #4131. The implementation and validation protocol are ready to deploy, but the documented iPhone/Android lock-screen, app-switch, battery, and thermal rows remain pending real-device runs. The issue must stay open until that evidence is recorded.

Refs #4131