### PR TITLE
feat(delivery): add current-stop command center

### DIFF
--- a/apps/delivery/app/layout.tsx
+++ b/apps/delivery/app/layout.tsx
@@ -19,6 +19,8 @@ export const viewport: Viewport = {
     width: 'device-width',
     initialScale: 1,
     themeColor: '#166534',
+    viewportFit: 'cover',
+    interactiveWidget: 'resizes-content',
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/apps/delivery/components/DeliveryAppHeader.tsx
+++ b/apps/delivery/components/DeliveryAppHeader.tsx
@@ -14,7 +14,7 @@ export function DeliveryAppHeader({
 }) {
     const isDriver = role === 'driver' || role === 'admin';
     return (
-        <header className="sticky top-0 z-20 border-b bg-background/95 px-4 py-3 backdrop-blur">
+        <header className="sticky top-0 z-20 border-b bg-background/95 px-4 pb-3 pt-[calc(env(safe-area-inset-top)+0.75rem)] backdrop-blur">
             <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-3">
                 <div className="flex min-w-0 items-center gap-3">
                     <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground">

--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -41,6 +41,7 @@ import {
     clearDeliveryUserStoredState,
     createBrowserDeliveryUserStoredState,
 } from '../lib/deliveryRunStoredState';
+import type { DriverCommandResult } from '../lib/driverCommandResult';
 import {
     clearOtherOfflineRouteCacheScopes,
     createBrowserOfflineRouteCachePersistence,
@@ -269,8 +270,6 @@ function DriverDashboardWithPickupSync({
     onSelectionChange,
     onStartRun,
     onRetry,
-    onActionError,
-    onActionQueued,
     onServerStateChanged,
 }: {
     dashboard: DriverDeliveryDashboard;
@@ -283,9 +282,7 @@ function DriverDashboardWithPickupSync({
         runId: string,
         stopId: number,
         expectedRouteRevision: number,
-    ) => void;
-    onActionError: (error: unknown) => void;
-    onActionQueued: (message: string) => void;
+    ) => DriverCommandResult | Promise<DriverCommandResult>;
     onServerStateChanged: (
         expectation?: DeliveryServerStateExpectation,
     ) => Promise<boolean>;
@@ -332,8 +329,6 @@ function DriverDashboardWithPickupSync({
             onSelectionChange={onSelectionChange}
             onStartRun={onStartRun}
             onRetry={onRetry}
-            onActionError={onActionError}
-            onActionQueued={onActionQueued}
             onServerStateChanged={onServerStateChanged}
         />
     );
@@ -348,8 +343,6 @@ function ActiveDriverDashboardWithPickupSync({
     onSelectionChange,
     onStartRun,
     onRetry,
-    onActionError,
-    onActionQueued,
     onServerStateChanged,
 }: {
     dashboard: DriverDeliveryDashboard;
@@ -363,9 +356,7 @@ function ActiveDriverDashboardWithPickupSync({
         runId: string,
         stopId: number,
         expectedRouteRevision: number,
-    ) => void;
-    onActionError: (error: unknown) => void;
-    onActionQueued: (message: string) => void;
+    ) => DriverCommandResult | Promise<DriverCommandResult>;
     onServerStateChanged: (
         expectation?: DeliveryServerStateExpectation,
     ) => Promise<boolean>;
@@ -418,25 +409,22 @@ function ActiveDriverDashboardWithPickupSync({
         reconcileDeliveryServerState,
         serverAcknowledgementCount,
     ]);
-    const report = async (action: Promise<unknown>) => {
-        try {
-            await action;
-        } catch (error) {
-            onActionError(error);
-        }
-    };
-    const reportQueued = async (
+    const report = async (
         action: Promise<unknown>,
-        confirmation: string,
-    ) => {
+    ): Promise<DriverCommandResult> => {
         try {
             await action;
-            onActionQueued(confirmation);
+            return { status: 'saved' };
         } catch (error) {
-            onActionError(error);
+            return {
+                status: 'failed',
+                message:
+                    error instanceof Error
+                        ? error.message
+                        : 'Radnju nije moguće sigurno spremiti.',
+            };
         }
     };
-
     return (
         <DriverDashboard
             dashboard={dashboard}
@@ -446,18 +434,16 @@ function ActiveDriverDashboardWithPickupSync({
             onSelectionChange={onSelectionChange}
             onStartRun={onStartRun}
             onRetry={onRetry}
-            onArrive={(runId, stopId, routeRevision) => {
+            onArrive={async (runId, stopId, routeRevision) => {
                 if (runId !== activeRunId) return;
-                void reportQueued(
-                    deliverySync.enqueueArrive(stopId, routeRevision),
-                    'Dolazak je spremljen. Oznaka čekanja nestat će nakon potvrde poslužitelja.',
-                );
+                await deliverySync.enqueueArrive(stopId, routeRevision);
             }}
-            onDeliver={(runId, stopId, routeRevision, notes) => {
+            onDeliver={async (runId, stopId, routeRevision, notes) => {
                 if (runId !== activeRunId) return;
-                void reportQueued(
-                    deliverySync.enqueueDelivery(stopId, routeRevision, notes),
-                    'Dostava je spremljena. Oznaka čekanja nestat će nakon potvrde poslužitelja.',
+                await deliverySync.enqueueDelivery(
+                    stopId,
+                    routeRevision,
+                    notes,
                 );
             }}
             onException={async (runId, stopId, mutation) => {
@@ -470,12 +456,8 @@ function ActiveDriverDashboardWithPickupSync({
                 }
                 try {
                     await deliverySync.enqueueException(stopId, mutation);
-                    onActionQueued(
-                        'Problem je spremljen na uređaju. Ruta se neće nastaviti dok poslužitelj ne potvrdi novi plan.',
-                    );
                     return { status: 'saved' };
                 } catch (error) {
-                    onActionError(error);
                     return deliverySync.isBarrierError(error)
                         ? {
                               status: 'review-required',
@@ -514,9 +496,7 @@ function ActiveDriverDashboardWithPickupSync({
                 report(pickupSync.discardEntry(operationId))
             }
             onVerificationScan={(stopId, tracePath) =>
-                void report(
-                    deliverySync.enqueueVerificationScan(stopId, tracePath),
-                )
+                report(deliverySync.enqueueVerificationScan(stopId, tracePath))
             }
             onRetryDeliverySync={(operationId) =>
                 report(deliverySync.retry(operationId))
@@ -887,7 +867,6 @@ export function DeliveryDashboard({
                 error instanceof Error
                     ? error.message
                     : 'Radnju nije moguće dovršiti.';
-            setActionError(message);
             return { status: 'failed', code, statusCode, message };
         } finally {
             setPendingAction(null);
@@ -1179,24 +1158,12 @@ export function DeliveryDashboard({
                         void startRun(deliveryRequestIds)
                     }
                     onRetry={(runId, stopId, expectedRouteRevision) =>
-                        void perform(
+                        perform(
                             `${stopId}:retry`,
                             `/api/driver/runs/${runId}/stops/${stopId}/retry`,
                             { expectedRouteRevision },
                         )
                     }
-                    onActionError={(error) => {
-                        setActionConfirmation(null);
-                        setActionError(
-                            error instanceof Error
-                                ? error.message
-                                : 'Promjenu dostave nije moguće spremiti.',
-                        );
-                    }}
-                    onActionQueued={(message) => {
-                        setActionError(null);
-                        setActionConfirmation(message);
-                    }}
                     onServerStateChanged={refreshDriverServerState}
                 />
             ) : (

--- a/apps/delivery/components/DeliveryHarvestVerification.tsx
+++ b/apps/delivery/components/DeliveryHarvestVerification.tsx
@@ -6,22 +6,28 @@ import { Check, Info } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
 import { useId, useRef, useState } from 'react';
 import type { DeliveryStopDeliverySummary } from '../lib/deliveryDashboardTypes';
+import { isDriverCommandResult } from '../lib/driverCommandResult';
 import {
     normalizeHarvestTraceScanValue,
     verifyDeliveryStopHarvestTrace,
 } from '../lib/harvestTraceScan';
-import { HarvestTraceScanner } from './HarvestTraceScanner';
+import {
+    type HarvestTraceScanFailureResult,
+    HarvestTraceScanner,
+} from './HarvestTraceScanner';
 
 export function DeliveryHarvestVerification({
     deliveries,
     disabled,
+    compact = false,
     verifiedTracePaths: persistedVerifiedTracePaths = [],
     onVerifiedTrace,
 }: {
     deliveries: DeliveryStopDeliverySummary[];
     disabled: boolean;
+    compact?: boolean;
     verifiedTracePaths?: string[];
-    onVerifiedTrace?: (tracePath: string) => void;
+    onVerifiedTrace?: (tracePath: string) => unknown | Promise<unknown>;
 }) {
     const headingId = useId();
     const [localVerifiedTracePaths, setLocalVerifiedTracePaths] = useState<
@@ -51,7 +57,12 @@ export function DeliveryHarvestVerification({
     const allExpectedTracesVerified =
         expectedTraceCount > 0 && verifiedTraceCount === expectedTraceCount;
 
-    const verifyTrace = (value: string) => {
+    const verifyTrace = async (
+        value: string,
+    ): Promise<
+        | ReturnType<typeof verifyDeliveryStopHarvestTrace>
+        | HarvestTraceScanFailureResult
+    > => {
         const result = verifyDeliveryStopHarvestTrace({
             deliveries,
             verifiedTracePaths: verifiedTracePathsRef.current,
@@ -59,23 +70,37 @@ export function DeliveryHarvestVerification({
         });
 
         if (result.status === 'verified') {
+            const persistenceResult = await onVerifiedTrace?.(result.tracePath);
+            if (
+                isDriverCommandResult(persistenceResult) &&
+                persistenceResult.status === 'failed'
+            ) {
+                return {
+                    status: 'scan-failed',
+                    message: persistenceResult.message,
+                };
+            }
             verifiedTracePathsRef.current = result.nextVerifiedTracePaths;
             setLocalVerifiedTracePaths(result.nextVerifiedTracePaths);
-            onVerifiedTrace?.(result.tracePath);
         }
 
         return result;
     };
 
     return (
-        <section className="space-y-3" aria-labelledby={headingId}>
+        <section
+            className={compact ? 'space-y-2' : 'space-y-3'}
+            aria-labelledby={headingId}
+        >
             <div>
                 <Typography id={headingId} level="body2" semiBold>
                     QR provjera predaje
                 </Typography>
                 <Typography
                     level="body3"
-                    className="mt-0.5 text-muted-foreground"
+                    className={
+                        compact ? 'sr-only' : 'mt-0.5 text-muted-foreground'
+                    }
                 >
                     Provjeri urode dok ih predaješ korisniku kako ništa ne bi
                     ostalo u vozilu.
@@ -109,7 +134,10 @@ export function DeliveryHarvestVerification({
                 />
             ) : null}
 
-            <ul className="space-y-2" aria-label="Urodi na ovoj stanici">
+            <ul
+                className={compact ? 'sr-only' : 'space-y-2'}
+                aria-label="Urodi na ovoj stanici"
+            >
                 {deliveries.map((delivery) => {
                     const tracePath = tracePathByRequestId.get(
                         delivery.requestId,
@@ -154,8 +182,9 @@ export function DeliveryHarvestVerification({
             </ul>
 
             <Typography level="body3" className="text-muted-foreground">
-                Ova provjera nije obavezna. Dostavu možeš potvrditi i ako
-                etiketa nedostaje ili skeniranje nije moguće.
+                {compact
+                    ? 'Provjera nije obavezna i ne blokira potvrdu dostave.'
+                    : 'Ova provjera nije obavezna. Dostavu možeš potvrditi i ako etiketa nedostaje ili skeniranje nije moguće.'}
             </Typography>
         </section>
     );

--- a/apps/delivery/components/DeliveryPickupCard.tsx
+++ b/apps/delivery/components/DeliveryPickupCard.tsx
@@ -28,10 +28,9 @@ import {
     formatDistance,
     formatTravelDuration,
 } from '../lib/deliveryFormatting';
-import {
-    HarvestTraceScanner,
-    type PickupManifestScanResult,
-} from './HarvestTraceScanner';
+import type { PickupManifestScanResult } from '../lib/deliveryPickupScan';
+import { isDriverCommandResult } from '../lib/driverCommandResult';
+import { HarvestTraceScanner } from './HarvestTraceScanner';
 
 export type PickupManifestSyncSummary = {
     state: 'idle' | 'queued' | 'sending' | 'failed' | 'conflicted';
@@ -39,6 +38,7 @@ export type PickupManifestSyncSummary = {
     durability: 'durable' | 'memory';
     coordination: 'coordinated' | 'best-effort';
     blockingOperationId: string | null;
+    blocksCurrentPickup?: boolean;
     message?: string | null;
 };
 
@@ -105,28 +105,32 @@ export function DeliveryPickupCard({
     onConfirmManifest,
     onRetrySync,
     onDiscardSync,
+    showCurrentCommand = true,
 }: {
     pickup: DeliveryPickupStepSummary;
     actionState: 'locked' | 'current' | 'completed';
     pendingAction: string | null;
     sync: PickupManifestSyncSummary;
-    onScan: (value: string) => PickupManifestScanResult;
+    onScan: (
+        value: string,
+    ) => PickupManifestScanResult | Promise<PickupManifestScanResult>;
     onSetItemState: (
         pickupNodeId: string,
         manifestId: string,
         stopId: number,
         state: 'missing-label' | 'not-ready' | 'ready',
-    ) => void;
+    ) => unknown | Promise<unknown>;
     onResolveRemaining: (
         pickupNodeId: string,
         manifest: DeliveryPickupManifestSummary,
-    ) => void;
+    ) => unknown | Promise<unknown>;
     onConfirmManifest: (
         pickupNodeId: string,
         manifestId: string,
-    ) => void | Promise<void>;
-    onRetrySync: (operationId: string) => void | Promise<void>;
-    onDiscardSync: (operationId: string) => void | Promise<void>;
+    ) => unknown | Promise<unknown>;
+    onRetrySync: (operationId: string) => unknown | Promise<unknown>;
+    onDiscardSync: (operationId: string) => unknown | Promise<unknown>;
+    showCurrentCommand?: boolean;
 }) {
     const navigationUrl = `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(pickup.address)}`;
     const current = actionState === 'current';
@@ -146,6 +150,35 @@ export function DeliveryPickupCard({
     const [confirmingManifestIds, setConfirmingManifestIds] = useState(
         () => new Set<string>(),
     );
+    const [syncRecoveryPending, setSyncRecoveryPending] = useState<
+        'retry' | 'discard' | null
+    >(null);
+    const [syncRecoveryError, setSyncRecoveryError] = useState<string | null>(
+        null,
+    );
+
+    async function recoverSync(
+        key: 'retry' | 'discard',
+        action: () => unknown | Promise<unknown>,
+    ) {
+        if (syncRecoveryPending) return;
+        setSyncRecoveryError(null);
+        setSyncRecoveryPending(key);
+        try {
+            const result = await action();
+            if (isDriverCommandResult(result) && result.status === 'failed') {
+                setSyncRecoveryError(result.message);
+            }
+        } catch (error) {
+            setSyncRecoveryError(
+                error instanceof Error
+                    ? error.message
+                    : 'Oporavak nije uspio. Pokušaj ponovno.',
+            );
+        } finally {
+            setSyncRecoveryPending(null);
+        }
+    }
 
     async function confirmManifest(manifestId: string) {
         if (
@@ -292,7 +325,7 @@ export function DeliveryPickupCard({
                     </Chip>
                 </div>
 
-                {syncMessage ? (
+                {syncMessage && (!current || showCurrentCommand) ? (
                     <Alert
                         color={syncMessage.color}
                         startDecorator={<Reset className="size-5" />}
@@ -307,10 +340,18 @@ export function DeliveryPickupCard({
                                         <Button
                                             size="sm"
                                             variant="outlined"
+                                            loading={
+                                                syncRecoveryPending === 'retry'
+                                            }
+                                            disabled={
+                                                syncRecoveryPending !== null
+                                            }
                                             onClick={() =>
-                                                void onRetrySync(
-                                                    sync.blockingOperationId ??
-                                                        '',
+                                                void recoverSync('retry', () =>
+                                                    onRetrySync(
+                                                        sync.blockingOperationId ??
+                                                            '',
+                                                    ),
                                                 )
                                             }
                                         >
@@ -320,9 +361,16 @@ export function DeliveryPickupCard({
                                     <Button
                                         size="sm"
                                         variant="plain"
+                                        loading={
+                                            syncRecoveryPending === 'discard'
+                                        }
+                                        disabled={syncRecoveryPending !== null}
                                         onClick={() =>
-                                            void onDiscardSync(
-                                                sync.blockingOperationId ?? '',
+                                            void recoverSync('discard', () =>
+                                                onDiscardSync(
+                                                    sync.blockingOperationId ??
+                                                        '',
+                                                ),
                                             )
                                         }
                                     >
@@ -330,11 +378,21 @@ export function DeliveryPickupCard({
                                     </Button>
                                 </div>
                             ) : null}
+                            {syncRecoveryError ? (
+                                <Typography
+                                    level="body3"
+                                    className="text-destructive"
+                                >
+                                    {syncRecoveryError}
+                                </Typography>
+                            ) : null}
                         </div>
                     </Alert>
                 ) : null}
 
-                {sync.durability === 'memory' && current ? (
+                {sync.durability === 'memory' &&
+                current &&
+                showCurrentCommand ? (
                     <Alert
                         color="warning"
                         startDecorator={<Warning className="size-5" />}
@@ -344,7 +402,9 @@ export function DeliveryPickupCard({
                     </Alert>
                 ) : null}
 
-                {sync.coordination === 'best-effort' && current ? (
+                {sync.coordination === 'best-effort' &&
+                current &&
+                showCurrentCommand ? (
                     <Alert
                         color="info"
                         startDecorator={<Warning className="size-5" />}
@@ -355,7 +415,7 @@ export function DeliveryPickupCard({
                     </Alert>
                 ) : null}
 
-                {current ? (
+                {current && showCurrentCommand ? (
                     <div className="flex flex-wrap gap-2">
                         <Button
                             href={navigationUrl}
@@ -467,6 +527,7 @@ export function DeliveryPickupCard({
                                                     {itemStateLabel(item.state)}
                                                 </Chip>
                                                 {current &&
+                                                showCurrentCommand &&
                                                 manifest.state === 'pending' &&
                                                 item.state === 'ready' ? (
                                                     <>
@@ -509,6 +570,7 @@ export function DeliveryPickupCard({
                                                     </>
                                                 ) : null}
                                                 {current &&
+                                                showCurrentCommand &&
                                                 manifest.state === 'pending' &&
                                                 item.state === 'not-ready' ? (
                                                     <Button
@@ -534,7 +596,9 @@ export function DeliveryPickupCard({
                                     ))}
                                 </ul>
 
-                                {current && manifest.state === 'pending' ? (
+                                {current &&
+                                showCurrentCommand &&
+                                manifest.state === 'pending' ? (
                                     <div className="space-y-2 border-t pt-3">
                                         {unresolvedReady.length > 0 ? (
                                             <Button

--- a/apps/delivery/components/DeliveryStopCard.tsx
+++ b/apps/delivery/components/DeliveryStopCard.tsx
@@ -74,6 +74,7 @@ export function DeliveryStopCard({
     onRetrySync,
     onDiscardSync,
     routeSyncBlocked = false,
+    showDriverCommand = true,
 }: {
     stop: DeliveryStopSummary;
     mode: 'driver' | 'customer';
@@ -87,10 +88,11 @@ export function DeliveryStopCard({
     ) => Promise<DeliveryExceptionSubmitResult>;
     syncEntry?: DeliveryActionQueueEntry | null;
     verifiedTracePaths?: string[];
-    onVerificationScan?: (tracePath: string) => void;
-    onRetrySync?: (operationId: string) => void | Promise<void>;
-    onDiscardSync?: (operationId: string) => void | Promise<void>;
+    onVerificationScan?: (tracePath: string) => unknown | Promise<unknown>;
+    onRetrySync?: (operationId: string) => unknown | Promise<unknown>;
+    onDiscardSync?: (operationId: string) => unknown | Promise<unknown>;
     routeSyncBlocked?: boolean;
+    showDriverCommand?: boolean;
 }) {
     const [notes, setNotes] = useState('');
     const [syncRecoveryPending, setSyncRecoveryPending] = useState(false);
@@ -133,7 +135,7 @@ export function DeliveryStopCard({
             new Date(stop.estimatedArrivalAt) > new Date(stop.slotEndAt),
     );
     const runSyncRecovery = async (
-        action: (() => void | Promise<void>) | undefined,
+        action: (() => unknown | Promise<unknown>) | undefined,
     ) => {
         if (!action || syncRecoveryPending) return;
         setSyncRecoveryPending(true);
@@ -150,6 +152,7 @@ export function DeliveryStopCard({
     const showRouteEstimates =
         Boolean(stop.estimatedArrivalAt || stop.estimatedTravelSeconds) &&
         !completedDriverException &&
+        (!driverMode || showDriverCommand) &&
         (driverMode ||
             !stop.recovery ||
             stop.recovery.kind === 'retry-planned');
@@ -247,7 +250,7 @@ export function DeliveryStopCard({
                     <DeliveryCustomerRecovery recovery={stop.recovery} />
                 ) : null}
 
-                {driverMode ? (
+                {driverMode && showDriverCommand ? (
                     <div className="space-y-2 text-sm">
                         {stop.slotStartAt && stop.slotEndAt ? (
                             <div className="flex items-start gap-2">
@@ -279,6 +282,7 @@ export function DeliveryStopCard({
                 ) : null}
 
                 {driverMode &&
+                showDriverCommand &&
                 customerActionAvailable &&
                 !delivered &&
                 stop.stopState === 'deferred' ? (
@@ -310,6 +314,7 @@ export function DeliveryStopCard({
                 ) : null}
 
                 {driverMode &&
+                showDriverCommand &&
                 customerActionAvailable &&
                 !delivered &&
                 stop.stopState !== 'deferred' ? (
@@ -527,7 +532,7 @@ export function DeliveryStopCard({
                                         <User className="size-4" />
                                         {delivery.contactName}
                                     </Typography>
-                                    {delivery.phone ? (
+                                    {delivery.phone && showDriverCommand ? (
                                         <a
                                             href={`tel:${delivery.phone}`}
                                             className="flex items-center gap-2 text-primary hover:underline"
@@ -535,6 +540,11 @@ export function DeliveryStopCard({
                                             <Mobile className="size-4" />
                                             {delivery.phone}
                                         </a>
+                                    ) : delivery.phone ? (
+                                        <div className="flex items-center gap-2 text-muted-foreground">
+                                            <Mobile className="size-4" />
+                                            <span>{delivery.phone}</span>
+                                        </div>
                                     ) : null}
                                     <div className="flex items-start gap-2">
                                         <Leaf className="mt-0.5 size-4 shrink-0 text-muted-foreground" />

--- a/apps/delivery/components/DriverCurrentStopCommandCenter.tsx
+++ b/apps/delivery/components/DriverCurrentStopCommandCenter.tsx
@@ -205,7 +205,7 @@ function DeliveryCurrentStopCommandCenter({
     const headingId = useId();
     const syncStatusId = useId();
     const headingRef = useRef<HTMLElement>(null);
-    const actionRef = useRef<HTMLDivElement>(null);
+    const actionRef = useRef<HTMLFieldSetElement>(null);
     const [notes, setNotes] = useState('');
     const [localPendingAction, setLocalPendingAction] = useState<
         'retry' | 'arrive' | 'deliver' | null
@@ -533,7 +533,142 @@ function DeliveryCurrentStopCommandCenter({
                     : ''}
             </span>
 
-            <div className="grid grid-cols-3 gap-1 rounded-lg bg-muted/70 p-2 text-center sm:gap-2 sm:p-3">
+            {deferred ? (
+                <fieldset
+                    aria-label="Radnje trenutačne stanice"
+                    className="m-0 min-w-0 space-y-2 border-0 p-0"
+                >
+                    <Button
+                        className="w-full"
+                        color="warning"
+                        loading={effectivePendingAction === 'retry'}
+                        disabled={
+                            Boolean(effectivePendingAction) ||
+                            routeSyncBlocked ||
+                            !onRetry
+                        }
+                        onClick={() => void runCommand('retry', onRetry)}
+                        startDecorator={<Reset className="size-4" />}
+                    >
+                        {onRetry
+                            ? checkpointPending
+                                ? 'Ponovni pokušaj čeka potvrdu rute'
+                                : 'Pokreni ponovni pokušaj'
+                            : checkpointPending
+                              ? 'Ponovni pokušaj čeka potvrdu rute'
+                              : 'Ponovni pokušaj nakon povratka veze'}
+                    </Button>
+                    {commandStatus}
+                </fieldset>
+            ) : (
+                <fieldset
+                    ref={actionRef}
+                    aria-label="Radnje trenutačne stanice"
+                    className="z-10 -mx-2 min-w-0 space-y-2 border-x-0 border-y bg-background/95 px-2 py-1.5 backdrop-blur sm:mx-0 sm:p-2"
+                    style={stickyActionStyle}
+                >
+                    <div className="grid min-w-0 grid-cols-2 gap-2">
+                        {stop.runId && onException ? (
+                            <DeliveryExceptionSheet
+                                runId={stop.runId}
+                                routeRevision={routeRevision}
+                                stop={stop}
+                                disabled={
+                                    Boolean(effectivePendingAction) ||
+                                    routeCommandBlocked
+                                }
+                                onSubmit={onException}
+                            />
+                        ) : null}
+                        {arrived && (pendingArrival || acknowledgedArrival) ? (
+                            <Button
+                                variant="outlined"
+                                disabled
+                                aria-describedby={
+                                    syncEntry?.command.kind === 'arrive'
+                                        ? syncStatusId
+                                        : undefined
+                                }
+                                startDecorator={
+                                    <MyLocation className="size-4" />
+                                }
+                            >
+                                {pendingArrival
+                                    ? 'Dolazak čeka potvrdu'
+                                    : 'Dolazak potvrđen'}
+                            </Button>
+                        ) : null}
+                        {arrived ? (
+                            <Button
+                                className={
+                                    pendingArrival || acknowledgedArrival
+                                        ? 'col-span-2'
+                                        : undefined
+                                }
+                                color="success"
+                                loading={effectivePendingAction === 'deliver'}
+                                disabled={
+                                    Boolean(effectivePendingAction) ||
+                                    routeCommandBlocked ||
+                                    deliveryQueued ||
+                                    actionableDeliveries.length === 0 ||
+                                    !onDeliver
+                                }
+                                aria-describedby={
+                                    syncEntry?.command.kind === 'deliver'
+                                        ? syncStatusId
+                                        : undefined
+                                }
+                                onClick={() =>
+                                    void runCommand('deliver', () =>
+                                        onDeliver?.(notes || undefined),
+                                    )
+                                }
+                                startDecorator={<Approved className="size-4" />}
+                            >
+                                {syncEntry?.command.kind === 'deliver'
+                                    ? syncEntry.state === 'synced'
+                                        ? 'Dostava potvrđena'
+                                        : 'Dostava čeka potvrdu'
+                                    : groupedDelivery
+                                      ? `Dostavi ${actionableDeliveries.length} · dalje`
+                                      : 'Dostavljeno · dalje'}
+                            </Button>
+                        ) : (
+                            <Button
+                                variant="outlined"
+                                loading={effectivePendingAction === 'arrive'}
+                                disabled={
+                                    Boolean(effectivePendingAction) ||
+                                    routeCommandBlocked ||
+                                    !onArrive
+                                }
+                                aria-describedby={
+                                    syncEntry?.command.kind === 'arrive'
+                                        ? syncStatusId
+                                        : undefined
+                                }
+                                onClick={() =>
+                                    void runCommand('arrive', onArrive)
+                                }
+                                startDecorator={
+                                    <MyLocation className="size-4" />
+                                }
+                            >
+                                {pendingArrival
+                                    ? 'Dolazak čeka potvrdu'
+                                    : 'Stigao sam'}
+                            </Button>
+                        )}
+                    </div>
+                    {commandStatus}
+                </fieldset>
+            )}
+
+            <section
+                aria-label="Procjene trenutačne stanice"
+                className="grid grid-cols-3 gap-1 rounded-lg bg-muted/70 p-2 text-center sm:gap-2 sm:p-3"
+            >
                 <div className="min-w-0">
                     <Typography level="body3" className="text-muted-foreground">
                         Dolazak
@@ -558,7 +693,7 @@ function DeliveryCurrentStopCommandCenter({
                         {formatDistance(stop.estimatedDistanceMeters)}
                     </Typography>
                 </div>
-            </div>
+            </section>
 
             {estimatedOutsideWindow && !stop.deliveredAt ? (
                 <Alert
@@ -589,141 +724,11 @@ function DeliveryCurrentStopCommandCenter({
 
             {deferred ? (
                 <>
-                    <Button
-                        className="w-full"
-                        color="warning"
-                        loading={effectivePendingAction === 'retry'}
-                        disabled={
-                            Boolean(effectivePendingAction) ||
-                            routeSyncBlocked ||
-                            !onRetry
-                        }
-                        onClick={() => void runCommand('retry', onRetry)}
-                        startDecorator={<Reset className="size-4" />}
-                    >
-                        {onRetry
-                            ? checkpointPending
-                                ? 'Ponovni pokušaj čeka potvrdu rute'
-                                : 'Pokreni ponovni pokušaj'
-                            : checkpointPending
-                              ? 'Ponovni pokušaj čeka potvrdu rute'
-                              : 'Ponovni pokušaj nakon povratka veze'}
-                    </Button>
-                    {commandStatus}
                     {secondaryStopDetails}
                     {navigationActions}
                 </>
             ) : (
                 <>
-                    <div
-                        ref={actionRef}
-                        className="z-10 -mx-2 min-w-0 space-y-2 border-y bg-background/95 px-2 py-1.5 backdrop-blur sm:mx-0 sm:p-2"
-                        style={stickyActionStyle}
-                    >
-                        <div className="grid min-w-0 grid-cols-2 gap-2">
-                            {stop.runId && onException ? (
-                                <DeliveryExceptionSheet
-                                    runId={stop.runId}
-                                    routeRevision={routeRevision}
-                                    stop={stop}
-                                    disabled={
-                                        Boolean(effectivePendingAction) ||
-                                        routeCommandBlocked
-                                    }
-                                    onSubmit={onException}
-                                />
-                            ) : null}
-                            {arrived &&
-                            (pendingArrival || acknowledgedArrival) ? (
-                                <Button
-                                    variant="outlined"
-                                    disabled
-                                    aria-describedby={
-                                        syncEntry?.command.kind === 'arrive'
-                                            ? syncStatusId
-                                            : undefined
-                                    }
-                                    startDecorator={
-                                        <MyLocation className="size-4" />
-                                    }
-                                >
-                                    {pendingArrival
-                                        ? 'Dolazak čeka potvrdu'
-                                        : 'Dolazak potvrđen'}
-                                </Button>
-                            ) : null}
-                            {arrived ? (
-                                <Button
-                                    className={
-                                        pendingArrival || acknowledgedArrival
-                                            ? 'col-span-2'
-                                            : undefined
-                                    }
-                                    color="success"
-                                    loading={
-                                        effectivePendingAction === 'deliver'
-                                    }
-                                    disabled={
-                                        Boolean(effectivePendingAction) ||
-                                        routeCommandBlocked ||
-                                        deliveryQueued ||
-                                        actionableDeliveries.length === 0 ||
-                                        !onDeliver
-                                    }
-                                    aria-describedby={
-                                        syncEntry?.command.kind === 'deliver'
-                                            ? syncStatusId
-                                            : undefined
-                                    }
-                                    onClick={() =>
-                                        void runCommand('deliver', () =>
-                                            onDeliver?.(notes || undefined),
-                                        )
-                                    }
-                                    startDecorator={
-                                        <Approved className="size-4" />
-                                    }
-                                >
-                                    {syncEntry?.command.kind === 'deliver'
-                                        ? syncEntry.state === 'synced'
-                                            ? 'Dostava potvrđena'
-                                            : 'Dostava čeka potvrdu'
-                                        : groupedDelivery
-                                          ? `Dostavi ${actionableDeliveries.length} · dalje`
-                                          : 'Dostavljeno · dalje'}
-                                </Button>
-                            ) : (
-                                <Button
-                                    variant="outlined"
-                                    loading={
-                                        effectivePendingAction === 'arrive'
-                                    }
-                                    disabled={
-                                        Boolean(effectivePendingAction) ||
-                                        routeCommandBlocked ||
-                                        !onArrive
-                                    }
-                                    aria-describedby={
-                                        syncEntry?.command.kind === 'arrive'
-                                            ? syncStatusId
-                                            : undefined
-                                    }
-                                    onClick={() =>
-                                        void runCommand('arrive', onArrive)
-                                    }
-                                    startDecorator={
-                                        <MyLocation className="size-4" />
-                                    }
-                                >
-                                    {pendingArrival
-                                        ? 'Dolazak čeka potvrdu'
-                                        : 'Stigao sam'}
-                                </Button>
-                            )}
-                        </div>
-                        {commandStatus}
-                    </div>
-
                     {arrived ? (
                         <DeliveryHarvestVerification
                             compact

--- a/apps/delivery/components/DriverCurrentStopCommandCenter.tsx
+++ b/apps/delivery/components/DriverCurrentStopCommandCenter.tsx
@@ -1,0 +1,1339 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Chip } from '@gredice/ui/Chip';
+import {
+    Approved,
+    Calendar,
+    MapPin,
+    Mobile,
+    MyLocation,
+    Navigate,
+    Reset,
+    Timer,
+    Warning,
+} from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import { type CSSProperties, useEffect, useId, useRef, useState } from 'react';
+import {
+    deliveryActionLocallyCompletesStop,
+    deliveryActionPermanentFailureMessage,
+} from '../lib/deliveryActionPresentation';
+import type { DeliveryActionQueueEntry } from '../lib/deliveryActionQueue';
+import {
+    deliveryCurrentStopCommandDeliveries,
+    deliveryCurrentStopContacts,
+    deliveryCurrentStopCriticalNotes,
+} from '../lib/deliveryCurrentStopPresentation';
+import type {
+    DeliveryPickupManifestSummary,
+    DeliveryPickupStepSummary,
+    DeliveryStopSummary,
+} from '../lib/deliveryDashboardTypes';
+import {
+    actionableDeliveryExceptionItems,
+    type DeliveryExceptionMutation,
+    type DeliveryExceptionSubmitResult,
+} from '../lib/deliveryExceptionPresentation';
+import {
+    formatDeliveryDateTime,
+    formatDeliveryTime,
+    formatDistance,
+    formatTravelDuration,
+} from '../lib/deliveryFormatting';
+import type { PickupManifestScanResult } from '../lib/deliveryPickupScan';
+import { isDriverCommandResult } from '../lib/driverCommandResult';
+import { DeliveryExceptionSheet } from './DeliveryExceptionSheet';
+import { DeliveryHarvestVerification } from './DeliveryHarvestVerification';
+import type { PickupManifestSyncSummary } from './DeliveryPickupCard';
+import { HarvestTraceScanner } from './HarvestTraceScanner';
+
+type DeliveryCommandCenterProps = {
+    kind: 'delivery';
+    stop: DeliveryStopSummary;
+    routeRevision: number;
+    pendingAction?: 'retry' | 'arrive' | 'deliver' | 'exception' | null;
+    syncEntry?: DeliveryActionQueueEntry | null;
+    verifiedTracePaths?: string[];
+    routeSyncBlocked?: boolean;
+    checkpointPending?: boolean;
+    offline?: boolean;
+    focusOnMount?: boolean;
+    onRetry?: () => unknown | Promise<unknown>;
+    onArrive?: () => unknown | Promise<unknown>;
+    onDeliver?: (notes?: string) => unknown | Promise<unknown>;
+    onException?: (
+        mutation: DeliveryExceptionMutation,
+    ) => Promise<DeliveryExceptionSubmitResult>;
+    onVerificationScan?: (tracePath: string) => unknown | Promise<unknown>;
+    onRetrySync?: (operationId: string) => unknown | Promise<unknown>;
+    onDiscardSync?: (operationId: string) => unknown | Promise<unknown>;
+    onReconcileSync?: () => unknown | Promise<unknown>;
+};
+
+type PickupCommandCenterProps = {
+    kind: 'pickup';
+    pickup: DeliveryPickupStepSummary;
+    sync: PickupManifestSyncSummary;
+    pendingAction: string | null;
+    offline?: boolean;
+    routeSyncBlocked?: boolean;
+    checkpointPending?: boolean;
+    focusOnMount?: boolean;
+    onScan?: (
+        value: string,
+    ) => PickupManifestScanResult | Promise<PickupManifestScanResult>;
+    onSetItemState?: (
+        pickupNodeId: string,
+        manifestId: string,
+        stopId: number,
+        state: 'missing-label' | 'not-ready' | 'ready',
+    ) => unknown | Promise<unknown>;
+    onResolveRemaining?: (
+        pickupNodeId: string,
+        manifest: DeliveryPickupManifestSummary,
+    ) => unknown | Promise<unknown>;
+    onConfirmManifest?: (
+        pickupNodeId: string,
+        manifestId: string,
+    ) => unknown | Promise<unknown>;
+    onRetrySync?: (operationId: string) => unknown | Promise<unknown>;
+    onDiscardSync?: (operationId: string) => unknown | Promise<unknown>;
+};
+
+export type DriverCurrentStopCommandCenterProps =
+    | DeliveryCommandCenterProps
+    | PickupCommandCenterProps;
+
+const stickyHeadingStyle: CSSProperties = {
+    position: 'sticky',
+    top: 'calc(env(safe-area-inset-top) + 4rem)',
+    scrollMarginTop: 'calc(env(safe-area-inset-top) + 4rem)',
+};
+function focusCurrentHeading(heading: HTMLElement | null) {
+    if (!heading) return;
+    heading.scrollIntoView({ block: 'start' });
+    heading.focus({ preventScroll: true });
+}
+
+function useElementHeight<Element extends HTMLElement>(
+    ref: { current: Element | null },
+    fallback: number,
+) {
+    const [height, setHeight] = useState(fallback);
+    useEffect(() => {
+        const element = ref.current;
+        if (!element) return;
+        const updateHeight = () =>
+            setHeight(Math.ceil(element.getBoundingClientRect().height));
+        updateHeight();
+        if (typeof ResizeObserver === 'undefined') return;
+        const observer = new ResizeObserver(updateHeight);
+        observer.observe(element);
+        return () => observer.disconnect();
+    }, [ref]);
+    return height;
+}
+
+function useCommandStatusVisibility(identity: string | null) {
+    const statusRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        if (!identity) return;
+        statusRef.current?.scrollIntoView({ block: 'nearest' });
+    }, [identity]);
+    return statusRef;
+}
+
+function commandErrorMessage(error: unknown) {
+    return error instanceof Error
+        ? error.message
+        : 'Radnju nije moguće sigurno spremiti. Pokušaj ponovno.';
+}
+
+function syncEntryMessage(entry: DeliveryActionQueueEntry) {
+    if (entry.state === 'conflicted') {
+        return deliveryActionPermanentFailureMessage(entry.errorCode, 'stop');
+    }
+    if (entry.state === 'failed') {
+        return 'Radnja je spremljena na uređaju, ali slanje nije uspjelo.';
+    }
+    if (entry.state === 'reconciling') {
+        return 'Problem je potvrđen, ali novi plan rute još nije učitan.';
+    }
+    if (entry.state === 'sending') {
+        return 'Radnja se šalje i još nije potvrđena.';
+    }
+    if (entry.state === 'synced') {
+        return 'Poslužitelj je potvrdio radnju. Čeka se osvježeno stanje rute.';
+    }
+    return 'Radnja je spremljena na uređaju i čeka potvrdu.';
+}
+
+function syncCommandLabel(entry: DeliveryActionQueueEntry) {
+    switch (entry.command.kind) {
+        case 'arrive':
+            return 'Dolazak';
+        case 'deliver':
+            return 'Dostava';
+        case 'exception':
+            return 'Prijava problema';
+        case 'verification-scan':
+            return 'QR provjera';
+    }
+}
+
+function DeliveryCurrentStopCommandCenter({
+    stop,
+    routeRevision,
+    pendingAction = null,
+    syncEntry,
+    verifiedTracePaths = [],
+    routeSyncBlocked = false,
+    checkpointPending = false,
+    offline = false,
+    focusOnMount = false,
+    onRetry,
+    onArrive,
+    onDeliver,
+    onException,
+    onVerificationScan,
+    onRetrySync,
+    onDiscardSync,
+    onReconcileSync,
+}: DeliveryCommandCenterProps) {
+    const headingId = useId();
+    const syncStatusId = useId();
+    const headingRef = useRef<HTMLElement>(null);
+    const actionRef = useRef<HTMLDivElement>(null);
+    const [notes, setNotes] = useState('');
+    const [localPendingAction, setLocalPendingAction] = useState<
+        'retry' | 'arrive' | 'deliver' | null
+    >(null);
+    const [localError, setLocalError] = useState<string | null>(null);
+    const [syncRecoveryPending, setSyncRecoveryPending] = useState(false);
+    const stickyHeadingHeight = useElementHeight(headingRef, 96);
+    const stickyActionHeight = useElementHeight(actionRef, 48);
+    const commandStatusRef = useCommandStatusVisibility(
+        localError
+            ? `local:${localError}`
+            : syncEntry?.state === 'failed' || syncEntry?.state === 'conflicted'
+              ? `${syncEntry.command.operationId}:${syncEntry.state}`
+              : null,
+    );
+    const stickyActionStyle: CSSProperties = {
+        position: 'sticky',
+        top: `calc(env(safe-area-inset-top) + 4rem + ${stickyHeadingHeight + 8}px)`,
+    };
+    const textareaScrollStyle: CSSProperties = {
+        scrollMarginTop: `calc(env(safe-area-inset-top) + 4rem + ${stickyHeadingHeight + stickyActionHeight + 24}px)`,
+    };
+    const commandDeliveries = deliveryCurrentStopCommandDeliveries(stop);
+    const actionableDeliveries =
+        actionableDeliveryExceptionItems(commandDeliveries);
+    const commandStop = { ...stop, deliveries: commandDeliveries };
+    const primaryCommandDelivery = commandDeliveries[0];
+    const recipientNames = Array.from(
+        new Set(
+            commandDeliveries
+                .map((delivery) => delivery.contactName.trim())
+                .filter(Boolean),
+        ),
+    );
+    const contacts = deliveryCurrentStopContacts(commandStop);
+    const criticalNotes = deliveryCurrentStopCriticalNotes(commandStop);
+    const groupedDelivery = commandDeliveries.length > 1;
+    const acknowledgedArrival =
+        syncEntry?.command.kind === 'arrive' && syncEntry.state === 'synced';
+    const pendingArrival =
+        syncEntry?.command.kind === 'arrive' &&
+        syncEntry.state !== 'conflicted' &&
+        syncEntry.state !== 'synced';
+    const deliveryQueued = deliveryActionLocallyCompletesStop(
+        syncEntry ?? undefined,
+    );
+    const offlineConflict = syncEntry?.state === 'conflicted';
+    const pendingCompletion =
+        syncEntry?.command.kind === 'deliver' ||
+        syncEntry?.command.kind === 'exception';
+    const routeCommandBlocked =
+        routeSyncBlocked ||
+        checkpointPending ||
+        Boolean(pendingCompletion) ||
+        offlineConflict;
+    const arrived =
+        stop.stopState === 'arrived' || pendingArrival || acknowledgedArrival;
+    const deferred = stop.stopState === 'deferred';
+    const estimatedOutsideWindow = Boolean(
+        stop.estimatedArrivalAt &&
+            stop.slotEndAt &&
+            new Date(stop.estimatedArrivalAt) > new Date(stop.slotEndAt),
+    );
+    const effectivePendingAction = localPendingAction ?? pendingAction;
+    const navigationUrl = `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(stop.address)}`;
+    const runCommand = async (
+        kind: 'retry' | 'arrive' | 'deliver',
+        action: (() => unknown | Promise<unknown>) | undefined,
+    ) => {
+        if (!action || localPendingAction) return;
+        setLocalError(null);
+        setLocalPendingAction(kind);
+        try {
+            const result = await action();
+            if (isDriverCommandResult(result) && result.status === 'failed') {
+                setLocalError(result.message);
+            }
+        } catch (error) {
+            setLocalError(commandErrorMessage(error));
+        } finally {
+            setLocalPendingAction(null);
+        }
+    };
+    const runSyncRecovery = async (
+        action: (() => unknown | Promise<unknown>) | undefined,
+    ) => {
+        if (!action || syncRecoveryPending) return;
+        setLocalError(null);
+        setSyncRecoveryPending(true);
+        try {
+            const result = await action();
+            if (isDriverCommandResult(result) && result.status === 'failed') {
+                setLocalError(result.message);
+            }
+        } catch (error) {
+            setLocalError(commandErrorMessage(error));
+        } finally {
+            setSyncRecoveryPending(false);
+        }
+    };
+
+    useEffect(() => {
+        if (!focusOnMount) return;
+        focusCurrentHeading(headingRef.current);
+    }, [focusOnMount]);
+
+    const commandStatus =
+        localError || syncEntry ? (
+            <div
+                ref={commandStatusRef}
+                className="space-y-2"
+                data-testid="current-command-status"
+            >
+                {syncEntry ? (
+                    <Alert
+                        id={syncStatusId}
+                        aria-label={`Status radnje: ${syncCommandLabel(syncEntry)}`}
+                        color={
+                            syncEntry.state === 'conflicted'
+                                ? 'danger'
+                                : syncEntry.state === 'failed'
+                                  ? 'warning'
+                                  : 'info'
+                        }
+                        startDecorator={<Warning className="size-5" />}
+                    >
+                        <div className="space-y-2">
+                            <Typography level="body3" semiBold>
+                                {syncCommandLabel(syncEntry)}:{' '}
+                                {syncEntryMessage(syncEntry)}
+                            </Typography>
+                            {syncEntry.state === 'failed' ? (
+                                <Button
+                                    size="sm"
+                                    color="warning"
+                                    loading={syncRecoveryPending}
+                                    disabled={
+                                        syncRecoveryPending || !onRetrySync
+                                    }
+                                    onClick={() =>
+                                        void runSyncRecovery(
+                                            onRetrySync
+                                                ? () =>
+                                                      onRetrySync(
+                                                          syncEntry.command
+                                                              .operationId,
+                                                      )
+                                                : undefined,
+                                        )
+                                    }
+                                >
+                                    Pokušaj ponovno
+                                </Button>
+                            ) : null}
+                            {syncEntry.state === 'conflicted' ? (
+                                <Button
+                                    size="sm"
+                                    color="danger"
+                                    variant="outlined"
+                                    loading={syncRecoveryPending}
+                                    disabled={
+                                        syncRecoveryPending || !onDiscardSync
+                                    }
+                                    onClick={() =>
+                                        void runSyncRecovery(
+                                            onDiscardSync
+                                                ? () =>
+                                                      onDiscardSync(
+                                                          syncEntry.command
+                                                              .operationId,
+                                                      )
+                                                : undefined,
+                                        )
+                                    }
+                                >
+                                    Učitaj stanje poslužitelja
+                                </Button>
+                            ) : null}
+                            {syncEntry.state === 'reconciling' ||
+                            syncEntry.acknowledgement?.reroutePending ||
+                            syncEntry.acknowledgement?.runCompleted ? (
+                                <Button
+                                    size="sm"
+                                    color="warning"
+                                    variant="outlined"
+                                    loading={syncRecoveryPending}
+                                    disabled={
+                                        syncRecoveryPending || !onReconcileSync
+                                    }
+                                    onClick={() =>
+                                        void runSyncRecovery(onReconcileSync)
+                                    }
+                                >
+                                    Osvježi novi plan
+                                </Button>
+                            ) : null}
+                        </div>
+                    </Alert>
+                ) : null}
+                {localError ? (
+                    <Alert
+                        color="danger"
+                        startDecorator={<Warning className="size-5" />}
+                    >
+                        {localError}
+                    </Alert>
+                ) : null}
+            </div>
+        ) : null;
+
+    const navigationActions = (
+        <div className="grid min-w-0 grid-cols-2 gap-2 max-[340px]:grid-cols-1">
+            {routeSyncBlocked || stop.reroutePending || deferred ? (
+                <Button
+                    aria-label={
+                        offline
+                            ? 'Navigacija do trenutačne stanice čeka novi plan'
+                            : 'Navigacija čeka novi plan'
+                    }
+                    className="min-w-0"
+                    disabled
+                    variant="outlined"
+                    startDecorator={<Navigate className="size-4" />}
+                >
+                    Navigacija čeka novi plan
+                </Button>
+            ) : (
+                <Button
+                    aria-label="Navigacija do trenutačne stanice"
+                    className="min-w-0"
+                    href={navigationUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    variant="outlined"
+                    startDecorator={<Navigate className="size-4" />}
+                >
+                    Navigacija
+                </Button>
+            )}
+            {contacts.map((contact) => (
+                <Button
+                    key={contact.phone}
+                    aria-label={`Nazovi ${contact.label}`}
+                    className="min-w-0"
+                    href={`tel:${contact.phone}`}
+                    variant="outlined"
+                    startDecorator={<Mobile className="size-4" />}
+                >
+                    Nazovi {contact.label}
+                </Button>
+            ))}
+        </div>
+    );
+    const secondaryStopDetails =
+        (stop.slotStartAt && stop.slotEndAt) ||
+        (groupedDelivery && recipientNames.length) ? (
+            <div className="space-y-1 text-sm">
+                {stop.slotStartAt && stop.slotEndAt ? (
+                    <div className="flex items-start gap-2">
+                        <Calendar className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                        <span>
+                            {formatDeliveryDateTime(stop.slotStartAt)} –{' '}
+                            {formatDeliveryTime(stop.slotEndAt)}
+                        </span>
+                    </div>
+                ) : null}
+                {groupedDelivery && recipientNames.length ? (
+                    <div className="flex items-start gap-2">
+                        <Mobile className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                        <span>Primatelji: {recipientNames.join(', ')}</span>
+                    </div>
+                ) : null}
+            </div>
+        ) : null;
+
+    return (
+        <section
+            aria-labelledby={headingId}
+            className="relative -mx-2 min-w-0 space-y-2.5 rounded-xl border border-primary/30 bg-background/95 p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] shadow-lg sm:mx-0 sm:space-y-3 sm:p-4"
+        >
+            <section
+                aria-label="Sažetak trenutačne stanice"
+                className="z-10 -mx-3 -mt-3 flex min-w-0 items-start justify-between gap-2 rounded-t-xl border-b bg-background/95 p-3 outline-none backdrop-blur sm:-mx-4 sm:-mt-4 sm:p-4"
+                style={stickyHeadingStyle}
+                ref={headingRef}
+                tabIndex={-1}
+            >
+                <div className="min-w-0 space-y-0.5">
+                    <Typography level="body3" className="text-primary">
+                        {offline
+                            ? 'Trenutačna stanica · offline'
+                            : 'Trenutačna stanica'}
+                    </Typography>
+                    <Typography
+                        id={headingId}
+                        level="h3"
+                        component="h2"
+                        semiBold
+                    >
+                        {groupedDelivery
+                            ? `${commandDeliveries.length} ${commandDeliveries.length === 1 ? 'urod' : 'uroda'} · skupna dostava`
+                            : (primaryCommandDelivery?.contactName ??
+                              stop.contactName)}
+                    </Typography>
+                    <Typography
+                        level="body3"
+                        className="truncate text-muted-foreground"
+                        title={stop.address}
+                    >
+                        {stop.address}
+                    </Typography>
+                </div>
+                <Chip color={arrived ? 'info' : 'warning'} size="sm">
+                    {arrived ? 'Na lokaciji' : 'Na redu'}
+                </Chip>
+            </section>
+            <span
+                className="sr-only"
+                role="status"
+                aria-live="polite"
+                aria-label="Promjena trenutačne stanice"
+            >
+                {focusOnMount
+                    ? `Trenutačna stanica je ${groupedDelivery ? stop.address : (primaryCommandDelivery?.contactName ?? stop.contactName)}.`
+                    : ''}
+            </span>
+
+            <div className="grid grid-cols-3 gap-1 rounded-lg bg-muted/70 p-2 text-center sm:gap-2 sm:p-3">
+                <div className="min-w-0">
+                    <Typography level="body3" className="text-muted-foreground">
+                        Dolazak
+                    </Typography>
+                    <Typography level="body2" semiBold className="truncate">
+                        {formatDeliveryTime(stop.estimatedArrivalAt)}
+                    </Typography>
+                </div>
+                <div className="min-w-0 border-x px-1">
+                    <Typography level="body3" className="text-muted-foreground">
+                        Vožnja
+                    </Typography>
+                    <Typography level="body2" semiBold className="truncate">
+                        {formatTravelDuration(stop.estimatedTravelSeconds)}
+                    </Typography>
+                </div>
+                <div className="min-w-0">
+                    <Typography level="body3" className="text-muted-foreground">
+                        Udaljenost
+                    </Typography>
+                    <Typography level="body2" semiBold className="truncate">
+                        {formatDistance(stop.estimatedDistanceMeters)}
+                    </Typography>
+                </div>
+            </div>
+
+            {estimatedOutsideWindow && !stop.deliveredAt ? (
+                <Alert
+                    color="warning"
+                    startDecorator={<Warning className="size-5" />}
+                >
+                    Trenutačna procjena dolaska je nakon završetka termina.
+                    Obavijesti korisnika o kašnjenju.
+                </Alert>
+            ) : null}
+
+            {criticalNotes.length ? (
+                <section
+                    aria-label="Važne napomene za trenutačnu stanicu"
+                    className="space-y-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100"
+                >
+                    {criticalNotes.map((note) => (
+                        <p key={note.id} className="text-sm">
+                            <strong>
+                                {note.label}
+                                {note.context ? ` · ${note.context}` : ''}:
+                            </strong>{' '}
+                            {note.text}
+                        </p>
+                    ))}
+                </section>
+            ) : null}
+
+            {deferred ? (
+                <>
+                    <Button
+                        className="w-full"
+                        color="warning"
+                        loading={effectivePendingAction === 'retry'}
+                        disabled={
+                            Boolean(effectivePendingAction) ||
+                            routeSyncBlocked ||
+                            !onRetry
+                        }
+                        onClick={() => void runCommand('retry', onRetry)}
+                        startDecorator={<Reset className="size-4" />}
+                    >
+                        {onRetry
+                            ? checkpointPending
+                                ? 'Ponovni pokušaj čeka potvrdu rute'
+                                : 'Pokreni ponovni pokušaj'
+                            : checkpointPending
+                              ? 'Ponovni pokušaj čeka potvrdu rute'
+                              : 'Ponovni pokušaj nakon povratka veze'}
+                    </Button>
+                    {commandStatus}
+                    {secondaryStopDetails}
+                    {navigationActions}
+                </>
+            ) : (
+                <>
+                    <div
+                        ref={actionRef}
+                        className="z-10 -mx-2 min-w-0 space-y-2 border-y bg-background/95 px-2 py-1.5 backdrop-blur sm:mx-0 sm:p-2"
+                        style={stickyActionStyle}
+                    >
+                        <div className="grid min-w-0 grid-cols-2 gap-2">
+                            {stop.runId && onException ? (
+                                <DeliveryExceptionSheet
+                                    runId={stop.runId}
+                                    routeRevision={routeRevision}
+                                    stop={stop}
+                                    disabled={
+                                        Boolean(effectivePendingAction) ||
+                                        routeCommandBlocked
+                                    }
+                                    onSubmit={onException}
+                                />
+                            ) : null}
+                            {arrived &&
+                            (pendingArrival || acknowledgedArrival) ? (
+                                <Button
+                                    variant="outlined"
+                                    disabled
+                                    aria-describedby={
+                                        syncEntry?.command.kind === 'arrive'
+                                            ? syncStatusId
+                                            : undefined
+                                    }
+                                    startDecorator={
+                                        <MyLocation className="size-4" />
+                                    }
+                                >
+                                    {pendingArrival
+                                        ? 'Dolazak čeka potvrdu'
+                                        : 'Dolazak potvrđen'}
+                                </Button>
+                            ) : null}
+                            {arrived ? (
+                                <Button
+                                    className={
+                                        pendingArrival || acknowledgedArrival
+                                            ? 'col-span-2'
+                                            : undefined
+                                    }
+                                    color="success"
+                                    loading={
+                                        effectivePendingAction === 'deliver'
+                                    }
+                                    disabled={
+                                        Boolean(effectivePendingAction) ||
+                                        routeCommandBlocked ||
+                                        deliveryQueued ||
+                                        actionableDeliveries.length === 0 ||
+                                        !onDeliver
+                                    }
+                                    aria-describedby={
+                                        syncEntry?.command.kind === 'deliver'
+                                            ? syncStatusId
+                                            : undefined
+                                    }
+                                    onClick={() =>
+                                        void runCommand('deliver', () =>
+                                            onDeliver?.(notes || undefined),
+                                        )
+                                    }
+                                    startDecorator={
+                                        <Approved className="size-4" />
+                                    }
+                                >
+                                    {syncEntry?.command.kind === 'deliver'
+                                        ? syncEntry.state === 'synced'
+                                            ? 'Dostava potvrđena'
+                                            : 'Dostava čeka potvrdu'
+                                        : groupedDelivery
+                                          ? `Dostavi ${actionableDeliveries.length} · dalje`
+                                          : 'Dostavljeno · dalje'}
+                                </Button>
+                            ) : (
+                                <Button
+                                    variant="outlined"
+                                    loading={
+                                        effectivePendingAction === 'arrive'
+                                    }
+                                    disabled={
+                                        Boolean(effectivePendingAction) ||
+                                        routeCommandBlocked ||
+                                        !onArrive
+                                    }
+                                    aria-describedby={
+                                        syncEntry?.command.kind === 'arrive'
+                                            ? syncStatusId
+                                            : undefined
+                                    }
+                                    onClick={() =>
+                                        void runCommand('arrive', onArrive)
+                                    }
+                                    startDecorator={
+                                        <MyLocation className="size-4" />
+                                    }
+                                >
+                                    {pendingArrival
+                                        ? 'Dolazak čeka potvrdu'
+                                        : 'Stigao sam'}
+                                </Button>
+                            )}
+                        </div>
+                        {commandStatus}
+                    </div>
+
+                    {arrived ? (
+                        <DeliveryHarvestVerification
+                            compact
+                            deliveries={actionableDeliveries}
+                            disabled={
+                                Boolean(effectivePendingAction) ||
+                                routeCommandBlocked
+                            }
+                            verifiedTracePaths={verifiedTracePaths}
+                            onVerifiedTrace={onVerificationScan}
+                        />
+                    ) : (
+                        <Typography
+                            level="body3"
+                            className="rounded-md bg-muted/70 p-2 text-muted-foreground"
+                        >
+                            QR provjera otključat će se nakon potvrde dolaska.
+                        </Typography>
+                    )}
+
+                    {secondaryStopDetails}
+                    {navigationActions}
+
+                    <label className="block min-w-0 text-sm font-medium">
+                        Napomena o predaji
+                        <textarea
+                            value={notes}
+                            onChange={(event) => setNotes(event.target.value)}
+                            rows={1}
+                            maxLength={1_000}
+                            placeholder="Npr. predano članu kućanstva"
+                            disabled={routeCommandBlocked}
+                            className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+                            style={textareaScrollStyle}
+                        />
+                    </label>
+                </>
+            )}
+        </section>
+    );
+}
+
+function pickupSyncMessage(sync: PickupManifestSyncSummary) {
+    if (sync.state === 'conflicted') {
+        return (
+            sync.message ?? 'Stanje preuzimanja promijenilo se na poslužitelju.'
+        );
+    }
+    if (sync.state === 'failed') {
+        return (
+            sync.message ??
+            'Preuzimanje je spremljeno, ali slanje nije uspjelo.'
+        );
+    }
+    if (sync.state === 'sending')
+        return sync.message ?? 'Promjene preuzimanja se šalju.';
+    if (sync.state === 'queued')
+        return sync.message ?? 'Preuzimanje čeka potvrdu poslužitelja.';
+    return null;
+}
+
+function PickupCurrentStopCommandCenter({
+    pickup,
+    sync,
+    pendingAction,
+    offline = false,
+    routeSyncBlocked = false,
+    checkpointPending = false,
+    focusOnMount = false,
+    onScan,
+    onSetItemState,
+    onResolveRemaining,
+    onConfirmManifest,
+    onRetrySync,
+    onDiscardSync,
+}: PickupCommandCenterProps) {
+    const headingId = useId();
+    const headingRef = useRef<HTMLElement>(null);
+    const [recoveryPending, setRecoveryPending] = useState(false);
+    const [localPendingAction, setLocalPendingAction] = useState<string | null>(
+        null,
+    );
+    const [localError, setLocalError] = useState<string | null>(null);
+    const stickyHeadingHeight = useElementHeight(headingRef, 96);
+    const commandStatusRef = useCommandStatusVisibility(
+        localError
+            ? `local:${localError}`
+            : sync.state === 'failed' || sync.state === 'conflicted'
+              ? `${sync.blockingOperationId ?? 'pickup'}:${sync.state}`
+              : null,
+    );
+    const collectedCount = pickup.scannedCount + pickup.missingLabelCount;
+    const scannableTraceCount = new Set(
+        pickup.manifests.flatMap((manifest) =>
+            manifest.items.flatMap((item) =>
+                item.tracePath ? [item.tracePath] : [],
+            ),
+        ),
+    ).size;
+    const syncMessage = pickupSyncMessage(sync);
+    const currentManifest = pickup.manifests.find(
+        (manifest) => manifest.state === 'pending',
+    );
+    const unresolvedReady =
+        currentManifest?.items.filter((item) => item.state === 'ready') ?? [];
+    const manuallyResolvableItems =
+        currentManifest?.items.filter(
+            (item) => item.state === 'ready' || item.state === 'not-ready',
+        ) ?? [];
+    const manifestConfirmable = Boolean(
+        currentManifest &&
+            currentManifest.remainingCount === 0 &&
+            currentManifest.notReadyCount === 0,
+    );
+    const effectivePendingAction = localPendingAction ?? pendingAction;
+    const mutationsDisabled =
+        Boolean(effectivePendingAction) ||
+        sync.state === 'conflicted' ||
+        sync.blocksCurrentPickup === true ||
+        offline ||
+        routeSyncBlocked ||
+        checkpointPending;
+    const runPickupCommand = async (
+        key: string,
+        action: (() => unknown | Promise<unknown>) | undefined,
+    ) => {
+        if (!action || effectivePendingAction) return;
+        setLocalError(null);
+        setLocalPendingAction(key);
+        try {
+            const result = await action();
+            if (isDriverCommandResult(result) && result.status === 'failed') {
+                setLocalError(result.message);
+            }
+        } catch (error) {
+            setLocalError(commandErrorMessage(error));
+        } finally {
+            setLocalPendingAction(null);
+        }
+    };
+    const runRecovery = async (
+        action: (() => unknown | Promise<unknown>) | undefined,
+    ) => {
+        if (!action || recoveryPending) return;
+        setLocalError(null);
+        setRecoveryPending(true);
+        try {
+            const result = await action();
+            if (isDriverCommandResult(result) && result.status === 'failed') {
+                setLocalError(result.message);
+            }
+        } catch (error) {
+            setLocalError(commandErrorMessage(error));
+        } finally {
+            setRecoveryPending(false);
+        }
+    };
+
+    useEffect(() => {
+        if (!focusOnMount) return;
+        focusCurrentHeading(headingRef.current);
+    }, [focusOnMount]);
+
+    const commandStatus =
+        localError || syncMessage ? (
+            <div
+                ref={commandStatusRef}
+                className="space-y-2"
+                data-testid="current-command-status"
+                style={{
+                    scrollMarginTop: `calc(env(safe-area-inset-top) + 4rem + ${stickyHeadingHeight + 8}px)`,
+                }}
+            >
+                {syncMessage ? (
+                    <Alert
+                        aria-label="Status radnje: preuzimanje"
+                        color={
+                            sync.state === 'conflicted'
+                                ? 'danger'
+                                : sync.state === 'failed'
+                                  ? 'warning'
+                                  : 'info'
+                        }
+                        startDecorator={<Reset className="size-5" />}
+                    >
+                        <div className="space-y-2">
+                            <Typography level="body3" semiBold>
+                                Preuzimanje: {syncMessage}
+                            </Typography>
+                            {sync.blockingOperationId ? (
+                                <div className="flex flex-wrap gap-2">
+                                    {sync.state === 'failed' ? (
+                                        <Button
+                                            size="sm"
+                                            variant="outlined"
+                                            loading={recoveryPending}
+                                            disabled={
+                                                recoveryPending || !onRetrySync
+                                            }
+                                            onClick={() =>
+                                                void runRecovery(
+                                                    onRetrySync
+                                                        ? () =>
+                                                              onRetrySync(
+                                                                  sync.blockingOperationId ??
+                                                                      '',
+                                                              )
+                                                        : undefined,
+                                                )
+                                            }
+                                        >
+                                            Pokušaj ponovno
+                                        </Button>
+                                    ) : null}
+                                    {sync.state === 'conflicted' ? (
+                                        <Button
+                                            size="sm"
+                                            variant="plain"
+                                            loading={recoveryPending}
+                                            disabled={
+                                                recoveryPending ||
+                                                !onDiscardSync
+                                            }
+                                            onClick={() =>
+                                                void runRecovery(
+                                                    onDiscardSync
+                                                        ? () =>
+                                                              onDiscardSync(
+                                                                  sync.blockingOperationId ??
+                                                                      '',
+                                                              )
+                                                        : undefined,
+                                                )
+                                            }
+                                        >
+                                            Odbaci promjenu i osvježi
+                                        </Button>
+                                    ) : null}
+                                </div>
+                            ) : null}
+                        </div>
+                    </Alert>
+                ) : null}
+                {localError ? (
+                    <Alert
+                        color="danger"
+                        startDecorator={<Warning className="size-5" />}
+                    >
+                        {localError}
+                    </Alert>
+                ) : null}
+            </div>
+        ) : null;
+
+    return (
+        <section
+            aria-labelledby={headingId}
+            className="relative -mx-2 min-w-0 space-y-3 rounded-xl border border-amber-400/60 bg-background/95 p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] shadow-lg sm:mx-0 sm:p-4"
+        >
+            <section
+                aria-label="Sažetak trenutačne stanice"
+                className="z-10 -mx-3 -mt-3 flex min-w-0 items-start justify-between gap-2 rounded-t-xl border-b bg-background/95 p-3 outline-none backdrop-blur sm:-mx-4 sm:-mt-4 sm:p-4"
+                style={stickyHeadingStyle}
+                ref={headingRef}
+                tabIndex={-1}
+            >
+                <div className="min-w-0">
+                    <Typography
+                        level="body3"
+                        className="text-amber-700 dark:text-amber-300"
+                    >
+                        {offline
+                            ? 'Trenutačno preuzimanje · offline'
+                            : 'Trenutačno preuzimanje'}
+                    </Typography>
+                    <Typography
+                        id={headingId}
+                        level="h3"
+                        component="h2"
+                        semiBold
+                    >
+                        {pickup.name}
+                    </Typography>
+                </div>
+                <Chip color="warning" size="sm">
+                    {collectedCount}/{pickup.expectedCount}
+                </Chip>
+            </section>
+            <span
+                className="sr-only"
+                role="status"
+                aria-live="polite"
+                aria-label="Promjena trenutačne stanice"
+            >
+                {focusOnMount
+                    ? currentManifest
+                        ? `Trenutačno preuzimanje je ${pickup.name} za termin ${formatDeliveryDateTime(currentManifest.startAt)}.`
+                        : `Trenutačno preuzimanje je ${pickup.name}.`
+                    : ''}
+            </span>
+
+            {commandStatus}
+
+            <div className="grid grid-cols-3 gap-1 rounded-lg bg-muted/70 p-2 text-center sm:gap-2 sm:p-3">
+                <div className="min-w-0">
+                    <Typography level="body3" className="text-muted-foreground">
+                        Dolazak
+                    </Typography>
+                    <Typography level="body2" semiBold className="truncate">
+                        {formatDeliveryTime(pickup.estimatedArrivalAt)}
+                    </Typography>
+                </div>
+                <div className="min-w-0 border-x px-1">
+                    <Typography level="body3" className="text-muted-foreground">
+                        Vožnja
+                    </Typography>
+                    <Typography level="body2" semiBold className="truncate">
+                        {formatTravelDuration(pickup.estimatedTravelSeconds)}
+                    </Typography>
+                </div>
+                <div className="min-w-0">
+                    <Typography level="body3" className="text-muted-foreground">
+                        Udaljenost
+                    </Typography>
+                    <Typography level="body2" semiBold className="truncate">
+                        {formatDistance(pickup.estimatedDistanceMeters)}
+                    </Typography>
+                </div>
+            </div>
+
+            <div className="flex items-start gap-2 text-sm">
+                <MapPin className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                <span>{pickup.address}</span>
+            </div>
+
+            <div className="grid grid-cols-2 gap-2 max-[340px]:grid-cols-1">
+                {routeSyncBlocked ? (
+                    <Button
+                        aria-label="Navigacija do trenutačne stanice preuzimanja čeka novi plan"
+                        disabled
+                        variant="outlined"
+                        startDecorator={<Navigate className="size-4" />}
+                    >
+                        Navigacija čeka novi plan
+                    </Button>
+                ) : (
+                    <Button
+                        aria-label="Navigacija do trenutačne stanice preuzimanja"
+                        href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(pickup.address)}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        variant="outlined"
+                        startDecorator={<Navigate className="size-4" />}
+                    >
+                        Navigacija
+                    </Button>
+                )}
+                {!offline && scannableTraceCount > 0 && onScan ? (
+                    <HarvestTraceScanner
+                        variant="manifest"
+                        availableTraceCount={pickup.expectedCount}
+                        completedTraceCount={collectedCount}
+                        disabled={mutationsDisabled}
+                        onScan={onScan}
+                    />
+                ) : (
+                    <Button
+                        disabled
+                        startDecorator={<Timer className="size-4" />}
+                    >
+                        Skeniranje nije dostupno
+                    </Button>
+                )}
+            </div>
+
+            {checkpointPending && !offline ? (
+                <Alert color="warning">
+                    Prethodna radnja još čeka potvrdu rute. Preuzimanje će se
+                    otključati čim poslužitelj potvrdi ovu lokaciju.
+                </Alert>
+            ) : null}
+
+            {routeSyncBlocked && !checkpointPending && !offline ? (
+                <Alert color="warning">
+                    Novi plan rute još nije potvrđen. Preuzimanje ostaje
+                    zaključano do sigurnog osvježavanja.
+                </Alert>
+            ) : null}
+
+            {!offline && currentManifest ? (
+                <section
+                    className="space-y-3 rounded-lg border p-3"
+                    aria-label={`Trenutačni manifest ${formatDeliveryDateTime(currentManifest.startAt)}`}
+                >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div>
+                            <Typography level="body2" semiBold>
+                                Sljedeća radnja preuzimanja
+                            </Typography>
+                            <Typography
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                {formatDeliveryDateTime(
+                                    currentManifest.startAt,
+                                )}{' '}
+                                – {formatDeliveryTime(currentManifest.endAt)}
+                            </Typography>
+                        </div>
+                        <Chip size="sm">
+                            {currentManifest.scannedCount +
+                                currentManifest.missingLabelCount}
+                            /{currentManifest.expectedCount}
+                        </Chip>
+                    </div>
+
+                    {manuallyResolvableItems.length ? (
+                        <ul
+                            className="space-y-2"
+                            aria-label="Urodi koji čekaju preuzimanje"
+                        >
+                            {manuallyResolvableItems.map((item) => (
+                                <li
+                                    key={item.id}
+                                    className="space-y-2 rounded-md bg-muted/70 p-2"
+                                >
+                                    <Typography level="body3" semiBold>
+                                        {item.harvest.plantName}
+                                    </Typography>
+                                    {item.state === 'ready' ? (
+                                        <div className="grid gap-2 sm:grid-cols-2">
+                                            <Button
+                                                size="sm"
+                                                variant="outlined"
+                                                loading={
+                                                    effectivePendingAction ===
+                                                    `missing:${item.stopId}`
+                                                }
+                                                disabled={
+                                                    mutationsDisabled ||
+                                                    !onSetItemState
+                                                }
+                                                onClick={() =>
+                                                    void runPickupCommand(
+                                                        `missing:${item.stopId}`,
+                                                        () =>
+                                                            onSetItemState?.(
+                                                                pickup.id,
+                                                                currentManifest.id,
+                                                                item.stopId,
+                                                                'missing-label',
+                                                            ),
+                                                    )
+                                                }
+                                            >
+                                                Preuzeto bez QR etikete
+                                            </Button>
+                                            <Button
+                                                size="sm"
+                                                color="warning"
+                                                variant="outlined"
+                                                loading={
+                                                    effectivePendingAction ===
+                                                    `not-ready:${item.stopId}`
+                                                }
+                                                disabled={
+                                                    mutationsDisabled ||
+                                                    !onSetItemState
+                                                }
+                                                onClick={() =>
+                                                    void runPickupCommand(
+                                                        `not-ready:${item.stopId}`,
+                                                        () =>
+                                                            onSetItemState?.(
+                                                                pickup.id,
+                                                                currentManifest.id,
+                                                                item.stopId,
+                                                                'not-ready',
+                                                            ),
+                                                    )
+                                                }
+                                            >
+                                                Nije spremno
+                                            </Button>
+                                        </div>
+                                    ) : (
+                                        <Button
+                                            size="sm"
+                                            variant="outlined"
+                                            loading={
+                                                effectivePendingAction ===
+                                                `ready:${item.stopId}`
+                                            }
+                                            disabled={
+                                                mutationsDisabled ||
+                                                !onSetItemState
+                                            }
+                                            onClick={() =>
+                                                void runPickupCommand(
+                                                    `ready:${item.stopId}`,
+                                                    () =>
+                                                        onSetItemState?.(
+                                                            pickup.id,
+                                                            currentManifest.id,
+                                                            item.stopId,
+                                                            'ready',
+                                                        ),
+                                                )
+                                            }
+                                        >
+                                            Ponovno spremno
+                                        </Button>
+                                    )}
+                                </li>
+                            ))}
+                        </ul>
+                    ) : null}
+
+                    {unresolvedReady.length > 1 ? (
+                        <Button
+                            variant="outlined"
+                            loading={
+                                effectivePendingAction === 'resolve-remaining'
+                            }
+                            disabled={mutationsDisabled || !onResolveRemaining}
+                            onClick={() =>
+                                void runPickupCommand('resolve-remaining', () =>
+                                    onResolveRemaining?.(
+                                        pickup.id,
+                                        currentManifest,
+                                    ),
+                                )
+                            }
+                        >
+                            Preuzmi preostalih {unresolvedReady.length} bez
+                            etikete
+                        </Button>
+                    ) : null}
+
+                    {currentManifest.notReadyCount > 0 ? (
+                        <Alert color="warning">
+                            Jedan ili više uroda nisu preuzeti. Njihove dostave
+                            ostaju zaključane.
+                        </Alert>
+                    ) : null}
+
+                    <Button
+                        className="w-full"
+                        color="success"
+                        loading={effectivePendingAction === 'confirm-manifest'}
+                        disabled={
+                            !manifestConfirmable ||
+                            mutationsDisabled ||
+                            sync.pendingCount > 0 ||
+                            !onConfirmManifest
+                        }
+                        onClick={() =>
+                            void runPickupCommand('confirm-manifest', () =>
+                                onConfirmManifest?.(
+                                    pickup.id,
+                                    currentManifest.id,
+                                ),
+                            )
+                        }
+                        startDecorator={<Approved className="size-4" />}
+                    >
+                        Potvrdi preuzimanje i nastavi
+                    </Button>
+                    {currentManifest.remainingCount > 0 ? (
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            Prije potvrde skeniraj urode ili označi one bez QR
+                            etikete.
+                        </Typography>
+                    ) : null}
+                </section>
+            ) : null}
+
+            {offline ? (
+                <Alert color="warning">
+                    Skeniranje i potvrda preuzimanja nastavljaju se nakon
+                    povratka veze.
+                </Alert>
+            ) : null}
+
+            {sync.durability === 'memory' ? (
+                <Alert color="warning">
+                    Preglednik ne dopušta trajnu lokalnu pohranu. Ostani na ovoj
+                    stranici dok se promjene ne sinkroniziraju.
+                </Alert>
+            ) : null}
+
+            {sync.coordination === 'best-effort' ? (
+                <Alert color="info">
+                    Ovaj preglednik ne može sigurno uskladiti istodobni rad u
+                    više kartica. Za ovu rutu koristi samo ovu karticu.
+                </Alert>
+            ) : null}
+        </section>
+    );
+}
+
+export function DriverCurrentStopCommandCenter(
+    props: DriverCurrentStopCommandCenterProps,
+) {
+    return props.kind === 'delivery' ? (
+        <DeliveryCurrentStopCommandCenter {...props} />
+    ) : (
+        <PickupCurrentStopCommandCenter {...props} />
+    );
+}

--- a/apps/delivery/components/DriverDashboard.tsx
+++ b/apps/delivery/components/DriverDashboard.tsx
@@ -14,7 +14,7 @@ import {
     Warning,
 } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { DriverRouteWakeLockState } from '../hooks/useDriverRouteWakeLock';
 import type { DriverTrackingState } from '../hooks/useDriverTracking';
 import {
@@ -30,6 +30,10 @@ import {
     deliveryActionPendingEntryForStop,
     deliveryActionVerifiedTracePaths,
 } from '../lib/deliveryActionQueue';
+import {
+    currentDeliveryRouteStep,
+    deliveryCurrentStopCommandDeliveries,
+} from '../lib/deliveryCurrentStopPresentation';
 import type {
     ActiveDeliveryRunSummary,
     DeliveryPickupStepSummary,
@@ -45,6 +49,8 @@ import {
     formatDistance,
     formatTravelDuration,
 } from '../lib/deliveryFormatting';
+import { resolveRemainingPickupManifest } from '../lib/deliveryPickupCommand';
+import { scanPickupManifest } from '../lib/deliveryPickupScan';
 import {
     applyDeliveryRouteSelection,
     deliveryRouteSelectionCandidatesFromBatches,
@@ -52,10 +58,8 @@ import {
 } from '../lib/deliveryRouteSelection';
 import { groupByDeliveryStop } from '../lib/deliveryStopGrouping';
 import { deliveryTrackingMapVersion } from '../lib/deliveryTrackingPresentation';
-import {
-    normalizeHarvestTraceScanValue,
-    selectDeliveryStopFromHarvestTrace,
-} from '../lib/harvestTraceScan';
+import { isDriverCommandResult } from '../lib/driverCommandResult';
+import { selectDeliveryStopFromHarvestTrace } from '../lib/harvestTraceScan';
 import type {
     PickupManifestQueueEntry,
     PickupManifestQueueSnapshot,
@@ -68,6 +72,7 @@ import {
     type PickupManifestSyncSummary,
 } from './DeliveryPickupCard';
 import { DeliveryStopCard } from './DeliveryStopCard';
+import { DriverCurrentStopCommandCenter } from './DriverCurrentStopCommandCenter';
 import { DriverRouteContinuity } from './DriverRouteContinuity';
 import { DriverTrackingStatus } from './DriverTrackingStatus';
 import { HarvestTraceScanner } from './HarvestTraceScanner';
@@ -83,6 +88,36 @@ function routeEstimateSourceLabel(
         case 'legacy':
             return 'Starija procjena';
     }
+}
+
+function pendingStopAction(
+    pendingAction: string | null,
+    stopId: number | null,
+) {
+    if (!stopId || !pendingAction?.startsWith(`${stopId}:`)) return null;
+    if (pendingAction.endsWith(':retry')) return 'retry' as const;
+    if (pendingAction.endsWith(':arrive')) return 'arrive' as const;
+    if (pendingAction.endsWith(':exception')) return 'exception' as const;
+    return 'deliver' as const;
+}
+
+function useCurrentCommandTransitionFocus(identity: string | null) {
+    const previousIdentityRef = useRef<string | null>(null);
+    const [focusIdentity, setFocusIdentity] = useState<string | null>(null);
+
+    useEffect(() => {
+        const previousIdentity = previousIdentityRef.current;
+        previousIdentityRef.current = identity;
+        if (!identity) {
+            setFocusIdentity(null);
+            return;
+        }
+        if (previousIdentity && previousIdentity !== identity) {
+            setFocusIdentity(identity);
+        }
+    }, [identity]);
+
+    return Boolean(identity && focusIdentity === identity);
 }
 
 function queuedPickup(
@@ -171,7 +206,44 @@ function queuedPickup(
 function pickupSyncSummary(
     pickupNodeId: string,
     snapshot: PickupManifestQueueSnapshot | null,
+    includeRunBarrier = false,
 ): PickupManifestSyncSummary {
+    const firstPendingEntry = snapshot?.entries.find(
+        (
+            entry,
+        ): entry is PickupManifestQueueEntry & {
+            state: Exclude<PickupManifestQueueEntry['state'], 'synced'>;
+        } => entry.state !== 'synced',
+    );
+    const blockingEarlierEntry =
+        includeRunBarrier &&
+        firstPendingEntry?.command.pickupNodeId !== pickupNodeId
+            ? firstPendingEntry
+            : null;
+    if (blockingEarlierEntry) {
+        const blockingState = blockingEarlierEntry.state;
+        const retryable = blockingState === 'failed';
+        const terminal = retryable || blockingState === 'conflicted';
+        const message =
+            blockingState === 'sending'
+                ? 'Ranija radnja preuzimanja se šalje. Pričekaj potvrdu prije rada na ovoj lokaciji.'
+                : blockingState === 'queued'
+                  ? 'Ranija radnja preuzimanja čeka slanje. Pričekaj potvrdu prije rada na ovoj lokaciji.'
+                  : `Ranija radnja preuzimanja blokira sinkronizaciju ove rute. ${pickupQueueErrorMessage(blockingEarlierEntry.errorCode, retryable)}`;
+        return {
+            state: blockingState,
+            pendingCount:
+                snapshot?.entries.filter((entry) => entry.state !== 'synced')
+                    .length ?? 0,
+            durability: snapshot?.durability ?? 'durable',
+            coordination: snapshot?.coordination ?? 'coordinated',
+            blockingOperationId: terminal
+                ? blockingEarlierEntry.command.operationId
+                : null,
+            blocksCurrentPickup: true,
+            message,
+        };
+    }
     const entries =
         snapshot?.entries.filter(
             (entry) => entry.command.pickupNodeId === pickupNodeId,
@@ -253,16 +325,22 @@ function pickupQueueErrorMessage(code: string | undefined, retryable: boolean) {
 
 export function DeliveryActionSyncStatus({
     snapshot,
+    currentStopId = null,
     onRetry,
     onRecoverConflict,
     onReconcile,
 }: {
     snapshot: DeliveryActionQueueSnapshot | null;
-    onRetry: (operationId: string) => void | Promise<void>;
-    onRecoverConflict: (operationId: string) => void | Promise<void>;
-    onReconcile: () => void | Promise<void>;
+    currentStopId?: number | null;
+    onRetry: (operationId: string) => unknown | Promise<unknown>;
+    onRecoverConflict: (operationId: string) => unknown | Promise<unknown>;
+    onReconcile: () => unknown | Promise<unknown>;
 }) {
     const [pendingRecovery, setPendingRecovery] = useState<string | null>(null);
+    const [recoveryError, setRecoveryError] = useState<{
+        operationId: string;
+        message: string;
+    } | null>(null);
     const pendingEntries =
         snapshot?.entries.filter(
             (entry) =>
@@ -276,6 +354,8 @@ export function DeliveryActionSyncStatus({
                 entry.state === 'failed' ||
                 entry.state === 'reconciling',
         ) ?? snapshot?.entries.find(deliveryActionAcknowledgementBlocksRoute);
+    const recoveryLivesInCurrentCommand =
+        blockingEntry?.command.stopId === currentStopId;
     const completedRunAcknowledged =
         blockingEntry?.acknowledgement?.kind === 'server' &&
         blockingEntry.acknowledgement.runCompleted === true;
@@ -284,12 +364,25 @@ export function DeliveryActionSyncStatus({
         blockingEntry.acknowledgement.reroutePending === true;
     const runRecovery = async (
         key: string,
-        action: () => void | Promise<void>,
+        operationId: string,
+        action: () => unknown | Promise<unknown>,
     ) => {
         if (pendingRecovery) return;
+        setRecoveryError(null);
         setPendingRecovery(key);
         try {
-            await action();
+            const result = await action();
+            if (isDriverCommandResult(result) && result.status === 'failed') {
+                setRecoveryError({ operationId, message: result.message });
+            }
+        } catch (error) {
+            setRecoveryError({
+                operationId,
+                message:
+                    error instanceof Error
+                        ? error.message
+                        : 'Oporavak nije uspio. Pokušaj ponovno.',
+            });
         } finally {
             setPendingRecovery(null);
         }
@@ -337,24 +430,30 @@ export function DeliveryActionSyncStatus({
                                       ? 'Problem je potvrđen, ali novi plan rute još nije sigurno učitan.'
                                       : 'Prva nesinkronizirana radnja nije poslana. Kasnije radnje čekaju iza nje.'}
                         </Typography>
-                        {blockingEntry.state === 'failed' ? (
+                        {blockingEntry.state === 'failed' &&
+                        !recoveryLivesInCurrentCommand ? (
                             <Button
                                 size="sm"
                                 color="warning"
                                 loading={pendingRecovery === 'retry'}
                                 disabled={pendingRecovery !== null}
                                 onClick={() =>
-                                    void runRecovery('retry', () =>
-                                        onRetry(
-                                            blockingEntry.command.operationId,
-                                        ),
+                                    void runRecovery(
+                                        'retry',
+                                        blockingEntry.command.operationId,
+                                        () =>
+                                            onRetry(
+                                                blockingEntry.command
+                                                    .operationId,
+                                            ),
                                     )
                                 }
                             >
                                 Pokušaj ponovno
                             </Button>
                         ) : null}
-                        {blockingEntry.state === 'conflicted' ? (
+                        {blockingEntry.state === 'conflicted' &&
+                        !recoveryLivesInCurrentCommand ? (
                             <Button
                                 size="sm"
                                 color="danger"
@@ -362,32 +461,50 @@ export function DeliveryActionSyncStatus({
                                 loading={pendingRecovery === 'conflict'}
                                 disabled={pendingRecovery !== null}
                                 onClick={() =>
-                                    void runRecovery('conflict', () =>
-                                        onRecoverConflict(
-                                            blockingEntry.command.operationId,
-                                        ),
+                                    void runRecovery(
+                                        'conflict',
+                                        blockingEntry.command.operationId,
+                                        () =>
+                                            onRecoverConflict(
+                                                blockingEntry.command
+                                                    .operationId,
+                                            ),
                                     )
                                 }
                             >
                                 Učitaj stanje poslužitelja
                             </Button>
                         ) : null}
-                        {blockingEntry.state === 'reconciling' ||
-                        completedRunAcknowledged ||
-                        waitingForReroute ? (
+                        {(blockingEntry.state === 'reconciling' ||
+                            completedRunAcknowledged ||
+                            waitingForReroute) &&
+                        !recoveryLivesInCurrentCommand ? (
                             <Button
                                 size="sm"
                                 color="warning"
                                 loading={pendingRecovery === 'reconcile'}
                                 disabled={pendingRecovery !== null}
                                 onClick={() =>
-                                    void runRecovery('reconcile', onReconcile)
+                                    void runRecovery(
+                                        'reconcile',
+                                        blockingEntry.command.operationId,
+                                        onReconcile,
+                                    )
                                 }
                             >
                                 {completedRunAcknowledged
                                     ? 'Pokušaj ponovno očistiti podatke'
                                     : 'Osvježi novi plan'}
                             </Button>
+                        ) : null}
+                        {recoveryError?.operationId ===
+                        blockingEntry.command.operationId ? (
+                            <Typography
+                                level="body3"
+                                className="text-destructive"
+                            >
+                                {recoveryError.message}
+                            </Typography>
                         ) : null}
                     </div>
                 </Alert>
@@ -429,18 +546,18 @@ export function DriverDashboard({
         runId: string,
         stopId: number,
         expectedRouteRevision: number,
-    ) => void;
+    ) => unknown | Promise<unknown>;
     onArrive: (
         runId: string,
         stopId: number,
         expectedRouteRevision: number,
-    ) => void;
+    ) => unknown | Promise<unknown>;
     onDeliver: (
         runId: string,
         stopId: number,
         expectedRouteRevision: number,
         notes?: string,
-    ) => void;
+    ) => unknown | Promise<unknown>;
     onException: (
         runId: string,
         stopId: number,
@@ -448,28 +565,38 @@ export function DriverDashboard({
     ) => Promise<DeliveryExceptionSubmitResult>;
     pickupQueue: PickupManifestQueueSnapshot | null;
     deliveryQueue: DeliveryActionQueueSnapshot | null;
-    onPickupScan: (pickupNodeId: string, scanValue: string) => void;
+    onPickupScan: (
+        pickupNodeId: string,
+        scanValue: string,
+    ) => unknown | Promise<unknown>;
     onPickupItemState: (
         pickupNodeId: string,
         manifestId: string,
         stopId: number,
         outcome: 'ready' | 'missing-label' | 'not-ready',
-    ) => void;
+    ) => unknown | Promise<unknown>;
     onConfirmPickupManifest: (
         pickupNodeId: string,
         manifestId: string,
-    ) => void | Promise<void>;
-    onRetryPickupSync: (operationId: string) => void | Promise<void>;
-    onDiscardPickupSync: (operationId: string) => void | Promise<void>;
-    onVerificationScan: (stopId: number, tracePath: string) => void;
-    onRetryDeliverySync: (operationId: string) => void | Promise<void>;
-    onDiscardDeliverySync: (operationId: string) => void | Promise<void>;
-    onReconcileDeliverySync: () => void | Promise<void>;
+    ) => unknown | Promise<unknown>;
+    onRetryPickupSync: (operationId: string) => unknown | Promise<unknown>;
+    onDiscardPickupSync: (operationId: string) => unknown | Promise<unknown>;
+    onVerificationScan: (
+        stopId: number,
+        tracePath: string,
+    ) => unknown | Promise<unknown>;
+    onRetryDeliverySync: (operationId: string) => unknown | Promise<unknown>;
+    onDiscardDeliverySync: (operationId: string) => unknown | Promise<unknown>;
+    onReconcileDeliverySync: () => unknown | Promise<unknown>;
 }) {
     const run = dashboard.activeRun;
     const displayedRouteSteps = run
         ? deliveryRouteStepsWithLocalActions(run.routeSteps, deliveryQueue)
         : [];
+    const currentRouteStep = currentDeliveryRouteStep(displayedRouteSteps);
+    const serverCurrentRouteStep = run
+        ? currentDeliveryRouteStep(run.routeSteps)
+        : null;
     const deliveryRouteSyncBlocked = Boolean(
         run?.reroutePending ||
             deliveryQueue?.entries.some(
@@ -480,6 +607,59 @@ export function DriverDashboard({
                     deliveryActionAcknowledgementBlocksRoute(entry),
             ),
     );
+    const currentPickup =
+        currentRouteStep?.kind === 'pickup'
+            ? queuedPickup(currentRouteStep.pickup, pickupQueue?.entries ?? [])
+            : null;
+    const currentDeliveryStop =
+        currentRouteStep?.kind === 'delivery'
+            ? {
+                  ...currentRouteStep.stop,
+                  actionState: currentRouteStep.actionState,
+                  lockedReason: currentRouteStep.lockedReason,
+                  isCurrent: true,
+              }
+            : null;
+    const currentDeliveryCommandRequestIdentity = currentDeliveryStop
+        ? deliveryCurrentStopCommandDeliveries(currentDeliveryStop)
+              .map((delivery) => delivery.requestId)
+              .sort()
+              .join(',') || 'none'
+        : null;
+    const currentRouteStepIdentity = currentRouteStep
+        ? currentRouteStep.kind === 'pickup'
+            ? `pickup:${currentRouteStep.pickup.id}`
+            : `delivery:${currentRouteStep.stop.id ?? currentRouteStep.itinerarySequence}`
+        : null;
+    const serverCurrentRouteStepIdentity = serverCurrentRouteStep
+        ? serverCurrentRouteStep.kind === 'pickup'
+            ? `pickup:${serverCurrentRouteStep.pickup.id}`
+            : `delivery:${serverCurrentRouteStep.stop.id ?? serverCurrentRouteStep.itinerarySequence}`
+        : null;
+    const currentStepAheadOfServer = Boolean(
+        currentRouteStepIdentity &&
+            serverCurrentRouteStepIdentity &&
+            currentRouteStepIdentity !== serverCurrentRouteStepIdentity,
+    );
+    const currentPickupManifestId =
+        currentPickup?.manifests.find(
+            (manifest) => manifest.state === 'pending',
+        )?.id ?? null;
+    const currentCommandIdentity = currentRouteStepIdentity
+        ? currentPickup
+            ? `${currentRouteStepIdentity}:manifest:${currentPickupManifestId ?? 'complete'}`
+            : `${currentRouteStepIdentity}:requests:${currentDeliveryCommandRequestIdentity ?? 'none'}`
+        : null;
+    const focusCurrentCommand = useCurrentCommandTransitionFocus(
+        currentCommandIdentity,
+    );
+    const currentDeliverySyncEntry = currentDeliveryStop?.id
+        ? deliveryActionPendingEntryForStop(
+              deliveryQueue,
+              currentDeliveryStop.id,
+          )
+        : undefined;
+    const currentDeliveryStopId = currentDeliveryStop?.id ?? null;
     const [selectedRequestIds, setSelectedRequestIdsState] = useState<string[]>(
         [],
     );
@@ -698,23 +878,149 @@ export function DriverDashboard({
                 role={dashboard.user.role}
             />
             <main className="mx-auto w-full max-w-6xl space-y-6 px-4 py-5 sm:py-8">
-                <div>
-                    <Typography level="h2" semiBold>
-                        {run ? 'Aktivna ruta' : 'Preuzimanje uroda'}
-                    </Typography>
-                    <Typography className="mt-1 text-muted-foreground">
-                        {run
-                            ? 'Slijedi redoslijed stanica, potvrdi dolazak i nastavi nakon svake dostave.'
-                            : 'Odaberi urode koje je lokacija preuzimanja označila spremnima. Zatim se računa povezana ruta kroz sve lokacije.'}
-                    </Typography>
-                </div>
+                {!run ? (
+                    <div>
+                        <Typography level="h2" semiBold>
+                            Preuzimanje uroda
+                        </Typography>
+                        <Typography className="mt-1 text-muted-foreground">
+                            Odaberi urode koje je lokacija preuzimanja označila
+                            spremnima. Zatim se računa povezana ruta kroz sve
+                            lokacije.
+                        </Typography>
+                    </div>
+                ) : null}
 
                 {run ? (
                     <>
+                        {currentPickup ? (
+                            <DriverCurrentStopCommandCenter
+                                key={`${run.id}:pickup:${currentPickup.id}:${currentPickupManifestId ?? 'complete'}`}
+                                kind="pickup"
+                                pickup={currentPickup}
+                                pendingAction={pendingAction}
+                                focusOnMount={focusCurrentCommand}
+                                routeSyncBlocked={deliveryRouteSyncBlocked}
+                                checkpointPending={currentStepAheadOfServer}
+                                sync={pickupSyncSummary(
+                                    currentPickup.id,
+                                    pickupQueue,
+                                    true,
+                                )}
+                                onScan={(scanValue) =>
+                                    scanPickupManifest(
+                                        currentPickup,
+                                        scanValue,
+                                        onPickupScan,
+                                    )
+                                }
+                                onSetItemState={onPickupItemState}
+                                onResolveRemaining={(pickupNodeId, manifest) =>
+                                    resolveRemainingPickupManifest(
+                                        pickupNodeId,
+                                        manifest,
+                                        onPickupItemState,
+                                    )
+                                }
+                                onConfirmManifest={onConfirmPickupManifest}
+                                onRetrySync={onRetryPickupSync}
+                                onDiscardSync={onDiscardPickupSync}
+                            />
+                        ) : currentDeliveryStop ? (
+                            <DriverCurrentStopCommandCenter
+                                key={`${run.id}:delivery:${currentDeliveryStop.id}:requests:${currentDeliveryCommandRequestIdentity}`}
+                                kind="delivery"
+                                stop={currentDeliveryStop}
+                                routeRevision={run.routeRevision}
+                                focusOnMount={focusCurrentCommand}
+                                pendingAction={pendingStopAction(
+                                    pendingAction,
+                                    currentDeliveryStop.id,
+                                )}
+                                syncEntry={currentDeliverySyncEntry}
+                                verifiedTracePaths={
+                                    currentDeliveryStopId
+                                        ? deliveryActionVerifiedTracePaths(
+                                              deliveryQueue,
+                                              currentDeliveryStopId,
+                                          )
+                                        : []
+                                }
+                                routeSyncBlocked={deliveryRouteSyncBlocked}
+                                checkpointPending={
+                                    currentStepAheadOfServer &&
+                                    currentDeliveryStop.stopState === 'deferred'
+                                }
+                                onRetry={
+                                    currentDeliveryStopId &&
+                                    !currentStepAheadOfServer
+                                        ? () =>
+                                              onRetry(
+                                                  run.id,
+                                                  currentDeliveryStopId,
+                                                  run.routeRevision,
+                                              )
+                                        : undefined
+                                }
+                                onArrive={
+                                    currentDeliveryStopId
+                                        ? () =>
+                                              onArrive(
+                                                  run.id,
+                                                  currentDeliveryStopId,
+                                                  run.routeRevision,
+                                              )
+                                        : undefined
+                                }
+                                onDeliver={
+                                    currentDeliveryStopId
+                                        ? (notes) =>
+                                              onDeliver(
+                                                  run.id,
+                                                  currentDeliveryStopId,
+                                                  run.routeRevision,
+                                                  notes,
+                                              )
+                                        : undefined
+                                }
+                                onException={
+                                    currentDeliveryStopId
+                                        ? (mutation) =>
+                                              onException(
+                                                  run.id,
+                                                  currentDeliveryStopId,
+                                                  mutation,
+                                              )
+                                        : undefined
+                                }
+                                onVerificationScan={
+                                    currentDeliveryStopId
+                                        ? (tracePath) =>
+                                              onVerificationScan(
+                                                  currentDeliveryStopId,
+                                                  tracePath,
+                                              )
+                                        : undefined
+                                }
+                                onRetrySync={onRetryDeliverySync}
+                                onDiscardSync={onDiscardDeliverySync}
+                                onReconcileSync={onReconcileDeliverySync}
+                            />
+                        ) : null}
+                        <div>
+                            <Typography level="h2" semiBold>
+                                Aktivna ruta
+                            </Typography>
+                            <Typography className="mt-1 text-muted-foreground">
+                                Slijedi redoslijed stanica, potvrdi dolazak i
+                                nastavi nakon svake dostave.
+                            </Typography>
+                        </div>
                         <DriverRouteContinuity state={routeWakeLock} />
                         <DriverTrackingStatus tracking={trackingState} />
                         <DeliveryActionSyncStatus
                             snapshot={deliveryQueue}
+                            currentStopId={currentDeliveryStopId}
                             onRetry={onRetryDeliverySync}
                             onRecoverConflict={onDiscardDeliverySync}
                             onReconcile={onReconcileDeliverySync}
@@ -858,108 +1164,13 @@ export function DriverDashboard({
                                                     pickup.id,
                                                     pickupQueue,
                                                 )}
-                                                onScan={(scanValue) => {
-                                                    const tracePath =
-                                                        normalizeHarvestTraceScanValue(
-                                                            scanValue,
-                                                        );
-                                                    if (!tracePath) {
-                                                        return {
-                                                            status: 'pickup-invalid',
-                                                        };
-                                                    }
-                                                    const matchingItems =
-                                                        pickup.manifests.flatMap(
-                                                            (manifest) =>
-                                                                manifest.items.filter(
-                                                                    (item) =>
-                                                                        item.tracePath ===
-                                                                        tracePath,
-                                                                ),
-                                                        );
-                                                    if (
-                                                        matchingItems.length ===
-                                                        0
-                                                    ) {
-                                                        return {
-                                                            status: 'pickup-not-at-location',
-                                                            tracePath,
-                                                        };
-                                                    }
-                                                    if (
-                                                        new Set(
-                                                            matchingItems.map(
-                                                                (item) =>
-                                                                    item.stopKey,
-                                                            ),
-                                                        ).size > 1
-                                                    ) {
-                                                        return {
-                                                            status: 'pickup-ambiguous',
-                                                            tracePath,
-                                                        };
-                                                    }
-                                                    const pendingItems =
-                                                        matchingItems.filter(
-                                                            (item) =>
-                                                                item.state ===
-                                                                    'ready' ||
-                                                                item.state ===
-                                                                    'not-ready',
-                                                        );
-                                                    const firstItem =
-                                                        matchingItems[0];
-                                                    if (!firstItem) {
-                                                        return {
-                                                            status: 'pickup-not-at-location',
-                                                            tracePath,
-                                                        };
-                                                    }
-                                                    if (
-                                                        pendingItems.length >
-                                                            0 &&
-                                                        pendingItems.every(
-                                                            (item) =>
-                                                                item.state ===
-                                                                'not-ready',
-                                                        )
-                                                    ) {
-                                                        return {
-                                                            status: 'pickup-not-ready',
-                                                            tracePath,
-                                                            plantName:
-                                                                firstItem
-                                                                    .harvest
-                                                                    .plantName,
-                                                        };
-                                                    }
-                                                    if (
-                                                        pendingItems.length ===
-                                                        0
-                                                    ) {
-                                                        return {
-                                                            status: 'pickup-already-collected',
-                                                            tracePath,
-                                                            plantName:
-                                                                firstItem
-                                                                    .harvest
-                                                                    .plantName,
-                                                        };
-                                                    }
-                                                    onPickupScan(
-                                                        pickup.id,
-                                                        tracePath,
-                                                    );
-                                                    return {
-                                                        status: 'pickup-queued',
-                                                        tracePath,
-                                                        plantName:
-                                                            firstItem.harvest
-                                                                .plantName,
-                                                        matchedCount:
-                                                            pendingItems.length,
-                                                    };
-                                                }}
+                                                onScan={(scanValue) =>
+                                                    scanPickupManifest(
+                                                        pickup,
+                                                        scanValue,
+                                                        onPickupScan,
+                                                    )
+                                                }
                                                 onSetItemState={(
                                                     pickupNodeId,
                                                     manifestId,
@@ -976,27 +1187,23 @@ export function DriverDashboard({
                                                 onResolveRemaining={(
                                                     pickupNodeId,
                                                     manifest,
-                                                ) => {
-                                                    for (const item of manifest.items) {
-                                                        if (
-                                                            item.state ===
-                                                            'ready'
-                                                        ) {
-                                                            onPickupItemState(
-                                                                pickupNodeId,
-                                                                manifest.id,
-                                                                item.stopId,
-                                                                'missing-label',
-                                                            );
-                                                        }
-                                                    }
-                                                }}
+                                                ) =>
+                                                    resolveRemainingPickupManifest(
+                                                        pickupNodeId,
+                                                        manifest,
+                                                        onPickupItemState,
+                                                    )
+                                                }
                                                 onConfirmManifest={
                                                     onConfirmPickupManifest
                                                 }
                                                 onRetrySync={onRetryPickupSync}
                                                 onDiscardSync={
                                                     onDiscardPickupSync
+                                                }
+                                                showCurrentCommand={
+                                                    step.actionState !==
+                                                    'current'
                                                 }
                                             />
                                         );
@@ -1054,25 +1261,10 @@ export function DriverDashboard({
                                                 routeRevision={
                                                     run.routeRevision
                                                 }
-                                                pendingAction={
-                                                    pendingAction?.startsWith(
-                                                        `${stop.id}:`,
-                                                    )
-                                                        ? pendingAction.endsWith(
-                                                              ':retry',
-                                                          )
-                                                            ? 'retry'
-                                                            : pendingAction.endsWith(
-                                                                    ':arrive',
-                                                                )
-                                                              ? 'arrive'
-                                                              : pendingAction.endsWith(
-                                                                      ':exception',
-                                                                  )
-                                                                ? 'exception'
-                                                                : 'deliver'
-                                                        : null
-                                                }
+                                                pendingAction={pendingStopAction(
+                                                    pendingAction,
+                                                    stop.id,
+                                                )}
                                                 onRetry={() =>
                                                     stop.id &&
                                                     onRetry(
@@ -1137,6 +1329,10 @@ export function DriverDashboard({
                                                 }
                                                 routeSyncBlocked={
                                                     deliveryRouteSyncBlocked
+                                                }
+                                                showDriverCommand={
+                                                    step.actionState !==
+                                                    'current'
                                                 }
                                             />
                                         </div>

--- a/apps/delivery/components/HarvestTraceScanner.tsx
+++ b/apps/delivery/components/HarvestTraceScanner.tsx
@@ -22,6 +22,7 @@ import {
     useRef,
     useState,
 } from 'react';
+import type { PickupManifestScanResult } from '../lib/deliveryPickupScan';
 import type {
     HarvestTraceSelectionResult,
     HarvestTraceVerificationResult,
@@ -44,33 +45,20 @@ type PickupRouteConflict = Extract<
     { status: 'route-conflict' }
 >;
 
-export type PickupManifestScanResult =
-    | { status: 'pickup-invalid' }
-    | { status: 'pickup-not-at-location'; tracePath: string }
-    | { status: 'pickup-ambiguous'; tracePath: string }
-    | {
-          status: 'pickup-already-collected';
-          tracePath: string;
-          plantName: string;
-      }
-    | {
-          status: 'pickup-not-ready';
-          tracePath: string;
-          plantName: string;
-      }
-    | {
-          status: 'pickup-queued';
-          tracePath: string;
-          plantName: string;
-          matchedCount: number;
-      };
+export type HarvestTraceScanFailureResult = {
+    status: 'scan-failed';
+    message: string;
+};
+
+type HarvestTraceScanResult =
+    | HarvestTraceSelectionResult
+    | HarvestTraceVerificationResult
+    | PickupManifestScanResult
+    | HarvestTraceScanFailureResult;
 
 function scanHistoryItem(
     id: number,
-    result:
-        | HarvestTraceSelectionResult
-        | HarvestTraceVerificationResult
-        | PickupManifestScanResult,
+    result: HarvestTraceScanResult,
 ): ScanHistoryItem {
     switch (result.status) {
         case 'selected':
@@ -155,6 +143,18 @@ function scanHistoryItem(
                 color: 'success',
                 message: `${result.plantName} · očitano ${result.matchedCount === 1 ? 'za manifest' : `za ${result.matchedCount} povezana uroda`}.`,
             };
+        case 'pickup-failed':
+            return {
+                id,
+                color: 'danger',
+                message: result.message,
+            };
+        case 'scan-failed':
+            return {
+                id,
+                color: 'danger',
+                message: result.message,
+            };
         case 'pickup-already-collected':
             return {
                 id,
@@ -221,10 +221,7 @@ export function HarvestTraceScanner({
     completedTraceCount: number;
     onScan: (
         value: string,
-    ) =>
-        | HarvestTraceSelectionResult
-        | HarvestTraceVerificationResult
-        | PickupManifestScanResult;
+    ) => HarvestTraceScanResult | Promise<HarvestTraceScanResult>;
     onReplacePickupSelection?: (requestIds: string[]) => boolean;
 }) {
     const [open, setOpen] = useState(false);
@@ -242,6 +239,7 @@ export function HarvestTraceScanner({
     const seenValuesRef = useRef(new Set<string>());
     const pickupRouteConflictScanValueRef = useRef<string | null>(null);
     const historyIdRef = useRef(0);
+    const scanSessionRef = useRef(0);
     const onScanRef = useRef(onScan);
 
     useEffect(() => {
@@ -249,8 +247,17 @@ export function HarvestTraceScanner({
     }, [onScan]);
 
     useEffect(() => {
-        if (disabled) setOpen(false);
+        if (!disabled) return;
+        scanSessionRef.current += 1;
+        setOpen(false);
     }, [disabled]);
+
+    useEffect(
+        () => () => {
+            scanSessionRef.current += 1;
+        },
+        [],
+    );
 
     const pushHistory = useCallback((item: Omit<ScanHistoryItem, 'id'>) => {
         historyIdRef.current += 1;
@@ -261,7 +268,7 @@ export function HarvestTraceScanner({
     }, []);
 
     const processScan = useCallback(
-        (value: string, source: 'camera' | 'manual') => {
+        async (value: string, source: 'camera' | 'manual') => {
             if (disabled) return;
             const normalizedValue = value.trim();
             if (!normalizedValue) return;
@@ -279,40 +286,67 @@ export function HarvestTraceScanner({
             seenValuesRef.current.add(normalizedValue);
             setUniqueScanCount(seenValuesRef.current.size);
             historyIdRef.current += 1;
-            const result = onScanRef.current(normalizedValue);
-            if (result.status === 'route-conflict') {
-                const displacedConflictScanValue =
-                    pickupRouteConflictScanValueRef.current;
+            const historyId = historyIdRef.current;
+            const scanSession = scanSessionRef.current;
+            try {
+                const result = await onScanRef.current(normalizedValue);
+                if (scanSessionRef.current !== scanSession) return;
                 if (
-                    displacedConflictScanValue &&
-                    displacedConflictScanValue !== normalizedValue
+                    result.status === 'pickup-failed' ||
+                    result.status === 'scan-failed'
                 ) {
-                    seenValuesRef.current.delete(displacedConflictScanValue);
+                    seenValuesRef.current.delete(normalizedValue);
                     setUniqueScanCount(seenValuesRef.current.size);
                 }
-                pickupRouteConflictScanValueRef.current = normalizedValue;
-                setPickupRouteConflict(result);
-            } else if (result.status === 'selected') {
-                const resolvedConflictScanValue =
-                    pickupRouteConflictScanValueRef.current;
-                if (resolvedConflictScanValue) {
-                    seenValuesRef.current.delete(resolvedConflictScanValue);
-                    setUniqueScanCount(seenValuesRef.current.size);
+                if (result.status === 'route-conflict') {
+                    const displacedConflictScanValue =
+                        pickupRouteConflictScanValueRef.current;
+                    if (
+                        displacedConflictScanValue &&
+                        displacedConflictScanValue !== normalizedValue
+                    ) {
+                        seenValuesRef.current.delete(
+                            displacedConflictScanValue,
+                        );
+                        setUniqueScanCount(seenValuesRef.current.size);
+                    }
+                    pickupRouteConflictScanValueRef.current = normalizedValue;
+                    setPickupRouteConflict(result);
+                } else if (result.status === 'selected') {
+                    const resolvedConflictScanValue =
+                        pickupRouteConflictScanValueRef.current;
+                    if (resolvedConflictScanValue) {
+                        seenValuesRef.current.delete(resolvedConflictScanValue);
+                        setUniqueScanCount(seenValuesRef.current.size);
+                    }
+                    pickupRouteConflictScanValueRef.current = null;
+                    setPickupRouteConflict(null);
                 }
-                pickupRouteConflictScanValueRef.current = null;
-                setPickupRouteConflict(null);
-            }
-            setHistory((current) => [
-                scanHistoryItem(historyIdRef.current, result),
-                ...current.slice(0, 3),
-            ]);
+                setHistory((current) => [
+                    scanHistoryItem(historyId, result),
+                    ...current.slice(0, 3),
+                ]);
 
-            if (
-                result.status === 'selected' ||
-                result.status === 'verified' ||
-                result.status === 'pickup-queued'
-            ) {
-                navigator.vibrate?.(80);
+                if (
+                    result.status === 'selected' ||
+                    result.status === 'verified' ||
+                    result.status === 'pickup-queued'
+                ) {
+                    navigator.vibrate?.(80);
+                }
+            } catch {
+                if (scanSessionRef.current !== scanSession) return;
+                seenValuesRef.current.delete(normalizedValue);
+                setUniqueScanCount(seenValuesRef.current.size);
+                setHistory((current) => [
+                    {
+                        id: historyId,
+                        color: 'danger',
+                        message:
+                            'Očitavanje nije sigurno spremljeno. Skeniraj QR kod ponovno.',
+                    },
+                    ...current.slice(0, 3),
+                ]);
             }
         },
         [disabled, pushHistory],
@@ -365,7 +399,7 @@ export function HarvestTraceScanner({
                     (result, error) => {
                         if (!active) return;
                         if (result) {
-                            processScan(result.getText(), 'camera');
+                            void processScan(result.getText(), 'camera');
                             return;
                         }
                         if (
@@ -417,6 +451,7 @@ export function HarvestTraceScanner({
     }, [disabled, open, processScan]);
 
     function openScanner() {
+        scanSessionRef.current += 1;
         seenValuesRef.current.clear();
         pickupRouteConflictScanValueRef.current = null;
         historyIdRef.current = 0;
@@ -429,9 +464,14 @@ export function HarvestTraceScanner({
         setOpen(true);
     }
 
+    function changeScannerOpen(nextOpen: boolean) {
+        if (!nextOpen) scanSessionRef.current += 1;
+        setOpen(nextOpen);
+    }
+
     function submitManualValue(event: FormEvent<HTMLFormElement>) {
         event.preventDefault();
-        processScan(manualValue, 'manual');
+        void processScan(manualValue, 'manual');
         setManualValue('');
     }
 
@@ -474,7 +514,7 @@ export function HarvestTraceScanner({
             </Button>
             <Modal
                 open={open}
-                onOpenChange={setOpen}
+                onOpenChange={changeScannerOpen}
                 title={
                     verificationMode
                         ? 'Provjera uroda za dostavu'
@@ -676,7 +716,10 @@ export function HarvestTraceScanner({
                         </Button>
                     </form>
 
-                    <Button className="w-full" onClick={() => setOpen(false)}>
+                    <Button
+                        className="w-full"
+                        onClick={() => changeScannerOpen(false)}
+                    >
                         {verificationMode
                             ? 'Završi provjeru'
                             : 'Završi skeniranje'}

--- a/apps/delivery/components/OfflineRoutePanel.tsx
+++ b/apps/delivery/components/OfflineRoutePanel.tsx
@@ -4,16 +4,9 @@ import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
 import { Chip } from '@gredice/ui/Chip';
-import {
-    Approved,
-    MapPin,
-    Mobile,
-    MyLocation,
-    Navigate,
-    Warning,
-} from '@gredice/ui/icons';
+import { MapPin, Navigate, Warning } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
-import { type ReactNode, useState } from 'react';
+import type { ReactNode } from 'react';
 import {
     deliveryActionAcknowledgementBlocksRoute,
     deliveryActionCompletionMessage,
@@ -24,7 +17,11 @@ import {
     deliveryActionPendingEntryForStop,
     deliveryActionVerifiedTracePaths,
 } from '../lib/deliveryActionQueue';
-import type { DeliveryStopDeliverySummary } from '../lib/deliveryDashboardTypes';
+import type {
+    DeliveryPickupStepSummary,
+    DeliveryStopDeliverySummary,
+    DeliveryStopSummary,
+} from '../lib/deliveryDashboardTypes';
 import type {
     DeliveryExceptionMutation,
     DeliveryExceptionSubmitResult,
@@ -37,11 +34,11 @@ import {
 } from '../lib/deliveryFormatting';
 import type {
     OfflineRouteDeliveryStep,
+    OfflineRoutePickupStep,
     OfflineRouteSnapshot,
     OfflineRouteStep,
 } from '../lib/offlineRouteCache';
-import { DeliveryExceptionSheet } from './DeliveryExceptionSheet';
-import { DeliveryHarvestVerification } from './DeliveryHarvestVerification';
+import { DriverCurrentStopCommandCenter } from './DriverCurrentStopCommandCenter';
 import { DeliveryActionSyncStatus } from './DriverDashboard';
 
 function stepTitle(step: OfflineRouteStep) {
@@ -89,28 +86,6 @@ function hasDeliveryStopId(
     return step.kind === 'delivery' && step.id !== null;
 }
 
-function OfflineDeliveryContacts({ step }: { step: OfflineRouteDeliveryStep }) {
-    const phoneNumbers = Array.from(
-        new Set(step.items.flatMap((item) => (item.phone ? [item.phone] : []))),
-    );
-    if (phoneNumbers.length === 0) return null;
-    return (
-        <div className="flex flex-wrap gap-2">
-            {phoneNumbers.map((phone) => (
-                <Button
-                    key={phone}
-                    href={`tel:${phone}`}
-                    size="sm"
-                    variant="plain"
-                    startDecorator={<Mobile className="size-4" />}
-                >
-                    {phone}
-                </Button>
-            ))}
-        </div>
-    );
-}
-
 function offlineDeliveryItems(
     step: OfflineRouteDeliveryStep,
 ): DeliveryStopDeliverySummary[] {
@@ -132,6 +107,75 @@ function offlineDeliveryItems(
     }));
 }
 
+function offlineDeliveryStop(
+    step: OfflineRouteDeliveryStep & { id: number },
+    runId: string,
+): DeliveryStopSummary & { id: number } {
+    const firstItem = step.items[0];
+    return {
+        id: step.id,
+        requestId: firstItem?.requestId ?? `stop-${step.id}`,
+        sequence: step.itinerarySequence,
+        stopState: step.stopState,
+        requestState: firstItem?.requestState ?? 'in_delivery',
+        statusLabel: step.statusLabel,
+        isCurrent: true,
+        contactName: firstItem?.contactName ?? 'Skupna dostava',
+        phone: firstItem?.phone ?? null,
+        address: step.address,
+        addressLabel: null,
+        requestNotes: firstItem?.requestNotes ?? null,
+        deliveryNotes: null,
+        slotStartAt: step.slotStartAt,
+        slotEndAt: step.slotEndAt,
+        estimatedArrivalAt: step.estimatedArrivalAt,
+        estimatedTravelSeconds: step.estimatedTravelSeconds,
+        estimatedDistanceMeters: step.estimatedDistanceMeters,
+        reroutePending: false,
+        arrivedAt: step.arrivedAt,
+        deliveredAt: step.deliveredAt,
+        harvest: {
+            plantName: firstItem?.harvest.plantName ?? 'Urod za dostavu',
+            operationName: null,
+            raisedBedName: firstItem?.harvest.raisedBedName ?? null,
+            fieldName: firstItem?.harvest.fieldName ?? null,
+            tracePath: firstItem?.harvest.tracePath ?? null,
+        },
+        recovery: null,
+        tracking: null,
+        runId,
+        deliveryCount: step.items.length,
+        deliveries: offlineDeliveryItems(step),
+        actionState: 'current',
+        lockedReason: step.lockedReason,
+    };
+}
+
+function offlinePickup(
+    step: OfflineRoutePickupStep,
+): DeliveryPickupStepSummary {
+    return {
+        id: step.id,
+        pickupLocationId: null,
+        sequence: step.itinerarySequence,
+        itinerarySequence: step.itinerarySequence,
+        name: step.name,
+        address: step.address,
+        estimatedArrivalAt: step.estimatedArrivalAt,
+        estimatedTravelSeconds: step.estimatedTravelSeconds,
+        estimatedDistanceMeters: step.estimatedDistanceMeters,
+        serviceDurationSeconds: null,
+        state: step.state,
+        isCurrent: true,
+        expectedCount: step.expectedCount,
+        scannedCount: step.scannedCount,
+        missingLabelCount: step.missingLabelCount,
+        notReadyCount: step.notReadyCount,
+        remainingCount: step.remainingCount,
+        manifests: [],
+    };
+}
+
 export function OfflineRoutePanel({
     snapshot,
     actionQueue,
@@ -147,22 +191,27 @@ export function OfflineRoutePanel({
     snapshot: OfflineRouteSnapshot;
     actionQueue: DeliveryActionQueueSnapshot;
     routeContinuity?: ReactNode;
-    onArrive: (stopId: number, routeRevision: number) => void | Promise<void>;
+    onArrive: (
+        stopId: number,
+        routeRevision: number,
+    ) => unknown | Promise<unknown>;
     onDeliver: (
         stopId: number,
         routeRevision: number,
         notes?: string,
-    ) => void | Promise<void>;
+    ) => unknown | Promise<unknown>;
     onException: (
         stopId: number,
         mutation: DeliveryExceptionMutation,
     ) => Promise<DeliveryExceptionSubmitResult>;
-    onVerificationScan: (stopId: number, tracePath: string) => void;
-    onRetry: (operationId: string) => void | Promise<void>;
-    onRecoverConflict: (operationId: string) => void | Promise<void>;
-    onReconcile: () => void | Promise<void>;
+    onVerificationScan: (
+        stopId: number,
+        tracePath: string,
+    ) => unknown | Promise<unknown>;
+    onRetry: (operationId: string) => unknown | Promise<unknown>;
+    onRecoverConflict: (operationId: string) => unknown | Promise<unknown>;
+    onReconcile: () => unknown | Promise<unknown>;
 }) {
-    const [notesByStop, setNotesByStop] = useState<Record<number, string>>({});
     const firstStep = snapshot.steps[0];
     const firstStopId = firstStep?.kind === 'delivery' ? firstStep.id : null;
     const firstEntry = firstStopId
@@ -179,16 +228,7 @@ export function OfflineRoutePanel({
     const currentEntry = currentStopId
         ? deliveryActionPendingEntryForStop(actionQueue, currentStopId)
         : undefined;
-    const acknowledgedArrival =
-        currentEntry?.command.kind === 'arrive' &&
-        currentEntry.state === 'synced';
-    const pendingArrival =
-        currentEntry?.command.kind === 'arrive' &&
-        currentEntry.state !== 'conflicted' &&
-        currentEntry.state !== 'synced';
     const deliveryQueued = deliveryActionLocallyCompletesStop(currentEntry);
-    const deliveryAcknowledged =
-        deliveryQueued && currentEntry?.state === 'synced';
     const routeBarrier =
         snapshot.source.reroutePending ||
         actionQueue.entries.some(
@@ -199,22 +239,71 @@ export function OfflineRoutePanel({
                 deliveryActionAcknowledgementBlocksRoute(entry),
         ) ||
         actionQueue.conflictedCount > 0;
-    const currentActionBlocked =
-        routeBarrier ||
-        Boolean(
-            currentEntry &&
-                (currentEntry.command.kind !== 'arrive' ||
-                    currentEntry.state === 'conflicted'),
-        );
-    const currentDeliveryReady = Boolean(
-        currentStep?.kind === 'delivery' &&
-            (currentStep.stopState === 'arrived' ||
-                pendingArrival ||
-                acknowledgedArrival),
-    );
+    const currentDeliveryStop =
+        currentStep && hasDeliveryStopId(currentStep)
+            ? offlineDeliveryStop(currentStep, snapshot.scope.runId)
+            : null;
     return (
         <main className="min-h-[100dvh] bg-muted/30 p-4">
             <div className="mx-auto max-w-3xl space-y-4">
+                {currentDeliveryStop && currentStep?.kind === 'delivery' ? (
+                    <DriverCurrentStopCommandCenter
+                        key={`${snapshot.scope.runId}:delivery:${currentDeliveryStop.id}`}
+                        kind="delivery"
+                        offline
+                        focusOnMount={activeStepIndex > 0}
+                        stop={currentDeliveryStop}
+                        routeRevision={snapshot.source.routeRevision}
+                        syncEntry={currentEntry}
+                        verifiedTracePaths={deliveryActionVerifiedTracePaths(
+                            actionQueue,
+                            currentDeliveryStop.id,
+                        )}
+                        routeSyncBlocked={routeBarrier}
+                        onArrive={() =>
+                            onArrive(
+                                currentDeliveryStop.id,
+                                snapshot.source.routeRevision,
+                            )
+                        }
+                        onDeliver={(notes) =>
+                            onDeliver(
+                                currentDeliveryStop.id,
+                                snapshot.source.routeRevision,
+                                notes,
+                            )
+                        }
+                        onException={(mutation) =>
+                            onException(currentDeliveryStop.id, mutation)
+                        }
+                        onVerificationScan={(tracePath) =>
+                            onVerificationScan(
+                                currentDeliveryStop.id,
+                                tracePath,
+                            )
+                        }
+                        onRetrySync={onRetry}
+                        onDiscardSync={onRecoverConflict}
+                        onReconcileSync={onReconcile}
+                    />
+                ) : currentStep?.kind === 'pickup' ? (
+                    <DriverCurrentStopCommandCenter
+                        key={`${snapshot.scope.runId}:pickup:${currentStep.id}`}
+                        kind="pickup"
+                        offline
+                        focusOnMount={activeStepIndex > 0}
+                        pickup={offlinePickup(currentStep)}
+                        pendingAction={null}
+                        routeSyncBlocked={routeBarrier}
+                        sync={{
+                            state: 'idle',
+                            pendingCount: 0,
+                            durability: actionQueue.durability,
+                            coordination: actionQueue.coordination,
+                            blockingOperationId: null,
+                        }}
+                    />
+                ) : null}
                 {routeContinuity}
                 <Alert
                     color="warning"
@@ -227,6 +316,7 @@ export function OfflineRoutePanel({
                 </Alert>
                 <DeliveryActionSyncStatus
                     snapshot={actionQueue}
+                    currentStopId={currentStopId}
                     onRetry={onRetry}
                     onRecoverConflict={onRecoverConflict}
                     onReconcile={onReconcile}
@@ -291,50 +381,58 @@ export function OfflineRoutePanel({
                                         )}
                                     </Alert>
                                 ) : null}
-                                <Typography className="flex items-start gap-2">
-                                    <MapPin className="mt-0.5 size-4 shrink-0" />
-                                    {step.address}
-                                </Typography>
-                                <div className="flex flex-wrap gap-2">
-                                    {step.kind === 'delivery' &&
-                                    step.slotStartAt ? (
-                                        <Chip size="sm">
-                                            Termin{' '}
-                                            {formatDeliveryTime(
-                                                step.slotStartAt,
-                                            )}
-                                            {step.slotEndAt
-                                                ? `–${formatDeliveryTime(step.slotEndAt)}`
-                                                : ''}
-                                        </Chip>
-                                    ) : null}
-                                    {step.estimatedArrivalAt ? (
-                                        <Chip size="sm">
-                                            Dolazak{' '}
-                                            {formatDeliveryDateTime(
-                                                step.estimatedArrivalAt,
-                                            )}
-                                        </Chip>
-                                    ) : null}
-                                    {step.estimatedTravelSeconds !== null ? (
-                                        <Chip size="sm">
-                                            {formatTravelDuration(
-                                                step.estimatedTravelSeconds,
-                                            )}
-                                        </Chip>
-                                    ) : null}
-                                    {step.estimatedDistanceMeters !== null ? (
-                                        <Chip size="sm">
-                                            {formatDistance(
-                                                step.estimatedDistanceMeters,
-                                            )}
-                                        </Chip>
-                                    ) : null}
-                                </div>
-                                {routeBarrier ||
-                                actionState === 'locked' ||
-                                index < activeStepIndex ||
-                                (index > activeStepIndex && !deliveryQueued) ? (
+                                {index !== activeStepIndex ? (
+                                    <>
+                                        <Typography className="flex items-start gap-2">
+                                            <MapPin className="mt-0.5 size-4 shrink-0" />
+                                            {step.address}
+                                        </Typography>
+                                        <div className="flex flex-wrap gap-2">
+                                            {step.kind === 'delivery' &&
+                                            step.slotStartAt ? (
+                                                <Chip size="sm">
+                                                    Termin{' '}
+                                                    {formatDeliveryTime(
+                                                        step.slotStartAt,
+                                                    )}
+                                                    {step.slotEndAt
+                                                        ? `–${formatDeliveryTime(step.slotEndAt)}`
+                                                        : ''}
+                                                </Chip>
+                                            ) : null}
+                                            {step.estimatedArrivalAt ? (
+                                                <Chip size="sm">
+                                                    Dolazak{' '}
+                                                    {formatDeliveryDateTime(
+                                                        step.estimatedArrivalAt,
+                                                    )}
+                                                </Chip>
+                                            ) : null}
+                                            {step.estimatedTravelSeconds !==
+                                            null ? (
+                                                <Chip size="sm">
+                                                    {formatTravelDuration(
+                                                        step.estimatedTravelSeconds,
+                                                    )}
+                                                </Chip>
+                                            ) : null}
+                                            {step.estimatedDistanceMeters !==
+                                            null ? (
+                                                <Chip size="sm">
+                                                    {formatDistance(
+                                                        step.estimatedDistanceMeters,
+                                                    )}
+                                                </Chip>
+                                            ) : null}
+                                        </div>
+                                    </>
+                                ) : null}
+                                {index ===
+                                activeStepIndex ? null : routeBarrier ||
+                                  actionState === 'locked' ||
+                                  index < activeStepIndex ||
+                                  (index > activeStepIndex &&
+                                      !deliveryQueued) ? (
                                     <Button
                                         disabled
                                         variant="outlined"
@@ -377,135 +475,6 @@ export function OfflineRoutePanel({
                                         Navigacija
                                     </Button>
                                 )}
-                                {step.kind === 'delivery' ? (
-                                    <OfflineDeliveryContacts step={step} />
-                                ) : null}
-                                {hasDeliveryStopId(step) &&
-                                index === activeStepIndex ? (
-                                    <div className="space-y-3 rounded-lg border border-primary/20 bg-primary/5 p-3">
-                                        <label
-                                            className="block text-sm font-medium"
-                                            htmlFor={`offline-notes-${step.id}`}
-                                        >
-                                            Napomena o dostavi
-                                        </label>
-                                        <textarea
-                                            id={`offline-notes-${step.id}`}
-                                            value={notesByStop[step.id] ?? ''}
-                                            onChange={(event) =>
-                                                setNotesByStop((current) => ({
-                                                    ...current,
-                                                    [step.id]:
-                                                        event.target.value,
-                                                }))
-                                            }
-                                            disabled={currentActionBlocked}
-                                            rows={2}
-                                            maxLength={1_000}
-                                            className="w-full rounded-md border bg-background px-3 py-2 text-sm disabled:opacity-60"
-                                        />
-                                        <DeliveryExceptionSheet
-                                            runId={snapshot.scope.runId}
-                                            routeRevision={
-                                                snapshot.source.routeRevision
-                                            }
-                                            stop={{
-                                                id: step.id,
-                                                requestId:
-                                                    step.items[0]?.requestId ??
-                                                    `stop-${step.id}`,
-                                                deliveries:
-                                                    offlineDeliveryItems(step),
-                                            }}
-                                            disabled={currentActionBlocked}
-                                            onSubmit={(mutation) =>
-                                                onException(step.id, mutation)
-                                            }
-                                        />
-                                        {currentDeliveryReady ? (
-                                            <DeliveryHarvestVerification
-                                                deliveries={offlineDeliveryItems(
-                                                    step,
-                                                )}
-                                                disabled={
-                                                    routeBarrier ||
-                                                    deliveryQueued
-                                                }
-                                                verifiedTracePaths={deliveryActionVerifiedTracePaths(
-                                                    actionQueue,
-                                                    step.id,
-                                                )}
-                                                onVerifiedTrace={(tracePath) =>
-                                                    onVerificationScan(
-                                                        step.id,
-                                                        tracePath,
-                                                    )
-                                                }
-                                            />
-                                        ) : null}
-                                        <div className="grid gap-2 sm:grid-cols-2">
-                                            <Button
-                                                variant="outlined"
-                                                disabled={
-                                                    step.stopState ===
-                                                        'arrived' ||
-                                                    acknowledgedArrival ||
-                                                    pendingArrival ||
-                                                    currentActionBlocked
-                                                }
-                                                onClick={() =>
-                                                    onArrive(
-                                                        step.id,
-                                                        snapshot.source
-                                                            .routeRevision,
-                                                    )
-                                                }
-                                                startDecorator={
-                                                    <MyLocation className="size-4" />
-                                                }
-                                            >
-                                                {pendingArrival
-                                                    ? 'Dolazak čeka potvrdu'
-                                                    : step.stopState ===
-                                                            'arrived' ||
-                                                        acknowledgedArrival
-                                                      ? 'Dolazak potvrđen'
-                                                      : 'Stigao sam'}
-                                            </Button>
-                                            <Button
-                                                color="success"
-                                                disabled={
-                                                    currentActionBlocked ||
-                                                    deliveryQueued ||
-                                                    !(
-                                                        step.stopState ===
-                                                            'arrived' ||
-                                                        pendingArrival ||
-                                                        acknowledgedArrival
-                                                    )
-                                                }
-                                                onClick={() =>
-                                                    onDeliver(
-                                                        step.id,
-                                                        snapshot.source
-                                                            .routeRevision,
-                                                        notesByStop[step.id] ||
-                                                            undefined,
-                                                    )
-                                                }
-                                                startDecorator={
-                                                    <Approved className="size-4" />
-                                                }
-                                            >
-                                                {deliveryAcknowledged
-                                                    ? 'Dostava potvrđena'
-                                                    : deliveryQueued
-                                                      ? 'Dostava čeka potvrdu'
-                                                      : 'Dostavljeno · dalje'}
-                                            </Button>
-                                        </div>
-                                    </div>
-                                ) : null}
                                 {step.kind === 'delivery' &&
                                 actionState === 'locked' &&
                                 step.lockedReason ? (

--- a/apps/delivery/components/OfflineRouteRecovery.tsx
+++ b/apps/delivery/components/OfflineRouteRecovery.tsx
@@ -1,13 +1,11 @@
 'use client';
 
-import { Alert } from '@gredice/ui/Alert';
-import { Warning } from '@gredice/ui/icons';
-import { useState } from 'react';
 import {
     type DeliveryServerStateExpectation,
     useDeliveryActionSync,
 } from '../hooks/useDeliveryActionSync';
 import type { DriverRouteWakeLockState } from '../hooks/useDriverRouteWakeLock';
+import type { DriverCommandResult } from '../lib/driverCommandResult';
 import type { OfflineRouteSnapshot } from '../lib/offlineRouteCache';
 import { DeliveryAppHeader } from './DeliveryAppHeader';
 import { DriverRouteContinuity } from './DriverRouteContinuity';
@@ -28,23 +26,24 @@ export function OfflineRouteRecovery({
         expectation?: DeliveryServerStateExpectation,
     ) => Promise<boolean>;
 }) {
-    const [error, setError] = useState<string | null>(null);
     const sync = useDeliveryActionSync({
         userId: authenticatedUserId,
         runId: snapshot.scope.runId,
         refreshServerState,
     });
 
-    const report = async (action: Promise<unknown>) => {
-        setError(null);
+    const report = async (
+        action: Promise<unknown>,
+    ): Promise<DriverCommandResult> => {
         try {
             await action;
+            return { status: 'saved' };
         } catch (cause) {
-            setError(
+            const message =
                 cause instanceof Error
                     ? cause.message
-                    : 'Lokalnu radnju nije moguće sigurno spremiti.',
-            );
+                    : 'Lokalnu radnju nije moguće sigurno spremiti.';
+            return { status: 'failed', message };
         }
     };
     const requireRecovery = async (
@@ -57,16 +56,6 @@ export function OfflineRouteRecovery({
 
     return (
         <>
-            {error ? (
-                <div className="fixed inset-x-4 top-[max(1rem,env(safe-area-inset-top))] z-50 mx-auto max-w-xl">
-                    <Alert
-                        color="danger"
-                        startDecorator={<Warning className="size-5" />}
-                    >
-                        {error}
-                    </Alert>
-                </div>
-            ) : null}
             <DeliveryAppHeader
                 userId={authenticatedUserId}
                 displayName="Izvanmrežna ruta"
@@ -90,20 +79,18 @@ export function OfflineRouteRecovery({
                 onException={async (stopId, mutation) => {
                     try {
                         await sync.enqueueException(stopId, mutation);
-                        setError(null);
                         return { status: 'saved' };
                     } catch (cause) {
                         const message = sync.isBarrierError(cause)
                             ? 'Prethodna promjena još čeka usklađivanje. Učitaj trenutačno stanje prije novog problema.'
                             : 'Problem nije moguće sigurno spremiti na uređaj. Provjeri prostor i pokušaj ponovno.';
-                        setError(message);
                         return sync.isBarrierError(cause)
                             ? { status: 'review-required', message }
                             : { status: 'retryable', message };
                     }
                 }}
                 onVerificationScan={(stopId, tracePath) =>
-                    void report(sync.enqueueVerificationScan(stopId, tracePath))
+                    report(sync.enqueueVerificationScan(stopId, tracePath))
                 }
                 onRetry={(operationId) => report(sync.retry(operationId))}
                 onRecoverConflict={(operationId) =>

--- a/apps/delivery/lib/deliveryCurrentStopPresentation.node.spec.ts
+++ b/apps/delivery/lib/deliveryCurrentStopPresentation.node.spec.ts
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    currentDeliveryRouteStep,
+    deliveryCurrentStopCommandDeliveries,
+    deliveryCurrentStopContacts,
+    deliveryCurrentStopCriticalNotes,
+} from './deliveryCurrentStopPresentation';
+import type { DeliveryStopSummary } from './deliveryDashboardTypes';
+
+const deliveries: DeliveryStopSummary['deliveries'] = [
+    {
+        stopId: 11,
+        stopState: 'pending',
+        requestId: 'request-1',
+        requestState: 'in_delivery',
+        contactName: 'Ana Anic',
+        phone: '+385 91 111 1111',
+        addressLabel: 'Ulaz iz dvorista',
+        requestNotes: 'Pozvoniti dva puta',
+        deliveryNotes: null,
+        harvest: {
+            plantName: 'Rajcica',
+            operationName: null,
+            raisedBedName: null,
+            fieldName: null,
+            tracePath: null,
+        },
+        exception: null,
+    },
+    {
+        stopId: 12,
+        stopState: 'pending',
+        requestId: 'request-2',
+        requestState: 'in_delivery',
+        contactName: 'Borna Babic',
+        phone: '+385 91 111 1111',
+        addressLabel: 'Treci kat bez lifta',
+        requestNotes: 'Pozvoniti dva puta',
+        deliveryNotes: null,
+        harvest: {
+            plantName: 'Bosiljak',
+            operationName: null,
+            raisedBedName: null,
+            fieldName: null,
+            tracePath: null,
+        },
+        exception: null,
+    },
+];
+
+test('selects only the route step derived as current', () => {
+    const steps = [
+        {
+            kind: 'pickup',
+            itinerarySequence: 1,
+            actionState: 'completed' as const,
+        },
+        {
+            kind: 'delivery',
+            itinerarySequence: 2,
+            actionState: 'current' as const,
+        },
+    ];
+
+    assert.equal(currentDeliveryRouteStep(steps), steps[1]);
+    assert.equal(
+        currentDeliveryRouteStep(
+            steps.map((step) => ({
+                ...step,
+                actionState: 'completed' as const,
+            })),
+        ),
+        null,
+    );
+});
+
+test('deduplicates shared phone numbers while preserving every contact name', () => {
+    assert.deepEqual(
+        deliveryCurrentStopContacts({
+            contactName: 'Ana Anic',
+            phone: '+385 91 111 1111',
+            deliveries,
+        }),
+        [
+            {
+                phone: '+385 91 111 1111',
+                label: 'Ana Anic, Borna Babic',
+            },
+        ],
+    );
+});
+
+test('keeps every actionable address instruction and recipient request note', () => {
+    assert.deepEqual(
+        deliveryCurrentStopCriticalNotes({
+            addressLabel: null,
+            requestNotes: null,
+            deliveries,
+        }).map(({ label, context, text }) => ({ label, context, text })),
+        [
+            {
+                label: 'Uputa za adresu',
+                context: 'Ana Anic · Rajcica',
+                text: 'Ulaz iz dvorista',
+            },
+            {
+                label: 'Napomena korisnika',
+                context: 'Ana Anic · Rajcica',
+                text: 'Pozvoniti dva puta',
+            },
+            {
+                label: 'Uputa za adresu',
+                context: 'Borna Babic · Bosiljak',
+                text: 'Treci kat bez lifta',
+            },
+            {
+                label: 'Napomena korisnika',
+                context: 'Borna Babic · Bosiljak',
+                text: 'Pozvoniti dva puta',
+            },
+        ],
+    );
+});
+
+test('limits current commands to actionable or deferred work', () => {
+    const mixedDeliveries: DeliveryStopSummary['deliveries'] = [
+        deliveries[0],
+        {
+            ...deliveries[1],
+            stopState: 'failed',
+            contactName: 'Terminalni kontakt',
+            phone: '+385 99 999 9999',
+            requestNotes: 'Ne prikazuj ovu napomenu',
+        },
+    ];
+    assert.deepEqual(
+        deliveryCurrentStopCommandDeliveries({
+            stopState: 'arrived',
+            deliveries: mixedDeliveries,
+        }).map((delivery) => delivery.requestId),
+        ['request-1'],
+    );
+    assert.equal(
+        deliveryCurrentStopCommandDeliveries({
+            stopState: 'deferred',
+            deliveries: mixedDeliveries.map((delivery) => ({
+                ...delivery,
+                stopState: 'deferred',
+            })),
+        }).length,
+        2,
+    );
+});

--- a/apps/delivery/lib/deliveryCurrentStopPresentation.ts
+++ b/apps/delivery/lib/deliveryCurrentStopPresentation.ts
@@ -1,0 +1,118 @@
+import type { DeliveryStopSummary } from './deliveryDashboardTypes';
+
+export type DeliveryCurrentStopContact = {
+    phone: string;
+    label: string;
+};
+
+export type DeliveryCurrentStopCriticalNote = {
+    id: string;
+    label: 'Uputa za adresu' | 'Napomena korisnika';
+    context: string | null;
+    text: string;
+};
+
+export function currentDeliveryRouteStep<
+    Step extends {
+        actionState: 'locked' | 'upcoming' | 'current' | 'completed';
+    },
+>(steps: readonly Step[]) {
+    return steps.find((step) => step.actionState === 'current') ?? null;
+}
+
+export function deliveryCurrentStopCommandDeliveries(
+    stop: Pick<DeliveryStopSummary, 'stopState' | 'deliveries'>,
+) {
+    return stop.deliveries.filter((delivery) =>
+        stop.stopState === 'deferred'
+            ? delivery.stopState === 'deferred'
+            : delivery.stopState === 'pending' ||
+              delivery.stopState === 'arrived',
+    );
+}
+
+export function deliveryCurrentStopContacts(
+    stop: Pick<DeliveryStopSummary, 'contactName' | 'phone' | 'deliveries'>,
+): DeliveryCurrentStopContact[] {
+    const namesByPhone = new Map<string, Set<string>>();
+    const contacts = stop.deliveries.length
+        ? stop.deliveries
+        : [
+              {
+                  contactName: stop.contactName,
+                  phone: stop.phone,
+              },
+          ];
+
+    for (const contact of contacts) {
+        const phone = contact.phone?.trim();
+        if (!phone) continue;
+        const names = namesByPhone.get(phone) ?? new Set<string>();
+        const name = contact.contactName.trim();
+        if (name) names.add(name);
+        namesByPhone.set(phone, names);
+    }
+
+    return Array.from(namesByPhone, ([phone, names]) => ({
+        phone,
+        label: Array.from(names).join(', ') || phone,
+    }));
+}
+
+export function deliveryCurrentStopCriticalNotes(
+    stop: Pick<
+        DeliveryStopSummary,
+        'addressLabel' | 'requestNotes' | 'deliveries'
+    >,
+): DeliveryCurrentStopCriticalNote[] {
+    const notes: DeliveryCurrentStopCriticalNote[] = [];
+    const seen = new Set<string>();
+    const add = (
+        label: DeliveryCurrentStopCriticalNote['label'],
+        text: string | null,
+        identity: string,
+        context: string | null,
+        dedupeIdentity = context ?? 'shared',
+    ) => {
+        const normalized = text?.trim();
+        if (!normalized) return;
+        const duplicateKey = `${label}\u0000${dedupeIdentity}\u0000${normalized}`;
+        if (seen.has(duplicateKey)) return;
+        seen.add(duplicateKey);
+        notes.push({
+            id: `${identity}:${notes.length}`,
+            label,
+            context,
+            text: normalized,
+        });
+    };
+
+    if (stop.deliveries.length === 0) {
+        add('Uputa za adresu', stop.addressLabel, 'stop-address', null);
+        add('Napomena korisnika', stop.requestNotes, 'stop-request', null);
+    }
+    for (const delivery of stop.deliveries) {
+        const context = [
+            delivery.contactName.trim(),
+            delivery.harvest.plantName.trim(),
+        ]
+            .filter(Boolean)
+            .join(' · ');
+        add(
+            'Uputa za adresu',
+            delivery.addressLabel,
+            `${delivery.requestId}:address`,
+            context || null,
+            delivery.requestId,
+        );
+        add(
+            'Napomena korisnika',
+            delivery.requestNotes,
+            `${delivery.requestId}:request`,
+            context || null,
+            delivery.requestId,
+        );
+    }
+
+    return notes;
+}

--- a/apps/delivery/lib/deliveryPickupCommand.node.spec.ts
+++ b/apps/delivery/lib/deliveryPickupCommand.node.spec.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { DeliveryPickupManifestSummary } from './deliveryDashboardTypes';
+import { resolveRemainingPickupManifest } from './deliveryPickupCommand';
+
+const manifest: DeliveryPickupManifestSummary = {
+    id: 'manifest-bulk-command',
+    timeSlotId: 1,
+    startAt: '2026-07-15T08:00:00.000Z',
+    endAt: '2026-07-15T09:00:00.000Z',
+    state: 'pending',
+    confirmedAt: null,
+    expectedCount: 3,
+    scannedCount: 0,
+    missingLabelCount: 0,
+    notReadyCount: 0,
+    remainingCount: 3,
+    items: [1, 2, 3].map((stopId) => ({
+        id: `pickup-item-${stopId}`,
+        stopId,
+        requestId: `request-${stopId}`,
+        stopKey: `stop-${stopId}`,
+        state: 'ready',
+        resolvedAt: null,
+        tracePath: `/trag/pickup-item-${stopId}`,
+        harvest: {
+            plantName: `Urod ${stopId}`,
+            operationName: null,
+            raisedBedName: null,
+            fieldName: null,
+            tracePath: `/trag/pickup-item-${stopId}`,
+        },
+    })),
+};
+
+test('bulk pickup resolution stops and returns the first durable failure', async () => {
+    const attemptedStopIds: number[] = [];
+    const result = await resolveRemainingPickupManifest(
+        'pickup-node',
+        manifest,
+        (_pickupNodeId, _manifestId, stopId) => {
+            attemptedStopIds.push(stopId);
+            return stopId === 2
+                ? {
+                      status: 'failed' as const,
+                      message: 'Drugi urod nije spremljen.',
+                  }
+                : { status: 'saved' as const };
+        },
+    );
+
+    assert.deepEqual(attemptedStopIds, [1, 2]);
+    assert.deepEqual(result, {
+        status: 'failed',
+        message: 'Drugi urod nije spremljen.',
+    });
+});

--- a/apps/delivery/lib/deliveryPickupCommand.ts
+++ b/apps/delivery/lib/deliveryPickupCommand.ts
@@ -1,0 +1,30 @@
+import type { DeliveryPickupManifestSummary } from './deliveryDashboardTypes';
+import {
+    type DriverCommandResult,
+    isDriverCommandResult,
+} from './driverCommandResult';
+
+export async function resolveRemainingPickupManifest(
+    pickupNodeId: string,
+    manifest: DeliveryPickupManifestSummary,
+    onPickupItemState: (
+        pickupNodeId: string,
+        manifestId: string,
+        stopId: number,
+        outcome: 'ready' | 'missing-label' | 'not-ready',
+    ) => unknown | Promise<unknown>,
+): Promise<DriverCommandResult> {
+    for (const item of manifest.items) {
+        if (item.state !== 'ready') continue;
+        const result = await onPickupItemState(
+            pickupNodeId,
+            manifest.id,
+            item.stopId,
+            'missing-label',
+        );
+        if (isDriverCommandResult(result) && result.status === 'failed') {
+            return result;
+        }
+    }
+    return { status: 'saved' };
+}

--- a/apps/delivery/lib/deliveryPickupScan.node.spec.ts
+++ b/apps/delivery/lib/deliveryPickupScan.node.spec.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { DeliveryPickupStepSummary } from './deliveryDashboardTypes';
+import { scanPickupManifest } from './deliveryPickupScan';
+
+const pickup: DeliveryPickupStepSummary = {
+    id: 'pickup-scan-test',
+    pickupLocationId: 1,
+    sequence: 1,
+    itinerarySequence: 1,
+    name: 'HQ',
+    address: 'HQ 1, Zagreb',
+    estimatedArrivalAt: null,
+    estimatedTravelSeconds: null,
+    estimatedDistanceMeters: null,
+    serviceDurationSeconds: null,
+    state: 'partial',
+    isCurrent: true,
+    expectedCount: 1,
+    scannedCount: 0,
+    missingLabelCount: 0,
+    notReadyCount: 0,
+    remainingCount: 1,
+    manifests: [
+        {
+            id: 'manifest-scan-test',
+            timeSlotId: 1,
+            startAt: '2026-07-15T08:00:00.000Z',
+            endAt: '2026-07-15T09:00:00.000Z',
+            state: 'pending',
+            confirmedAt: null,
+            expectedCount: 1,
+            scannedCount: 0,
+            missingLabelCount: 0,
+            notReadyCount: 0,
+            remainingCount: 1,
+            items: [
+                {
+                    id: 'pickup-scan-item',
+                    stopId: 1,
+                    requestId: 'pickup-scan-request',
+                    stopKey: 'pickup-scan-stop',
+                    state: 'ready',
+                    resolvedAt: null,
+                    tracePath: '/trag/pickup-scan-test',
+                    harvest: {
+                        plantName: 'Rajčica',
+                        operationName: null,
+                        raisedBedName: null,
+                        fieldName: null,
+                        tracePath: '/trag/pickup-scan-test',
+                    },
+                },
+            ],
+        },
+    ],
+};
+
+test('pickup scan reports success only after durable enqueue succeeds', async () => {
+    const calls: string[] = [];
+    const saved = await scanPickupManifest(
+        pickup,
+        '/trag/pickup-scan-test',
+        async (_pickupNodeId, tracePath) => {
+            calls.push(tracePath);
+            return { status: 'saved' as const };
+        },
+    );
+    assert.deepEqual(calls, ['/trag/pickup-scan-test']);
+    assert.equal(saved.status, 'pickup-queued');
+
+    const failed = await scanPickupManifest(
+        pickup,
+        '/trag/pickup-scan-test',
+        async () => ({
+            status: 'failed' as const,
+            message: 'Skeniranje nije spremljeno.',
+        }),
+    );
+    assert.deepEqual(failed, {
+        status: 'pickup-failed',
+        tracePath: '/trag/pickup-scan-test',
+        plantName: 'Rajčica',
+        message: 'Skeniranje nije spremljeno.',
+    });
+});

--- a/apps/delivery/lib/deliveryPickupScan.ts
+++ b/apps/delivery/lib/deliveryPickupScan.ts
@@ -1,0 +1,93 @@
+import type { DeliveryPickupStepSummary } from './deliveryDashboardTypes';
+import { isDriverCommandResult } from './driverCommandResult';
+import { normalizeHarvestTraceScanValue } from './harvestTraceScan';
+
+export type PickupManifestScanResult =
+    | { status: 'pickup-invalid' }
+    | { status: 'pickup-not-at-location'; tracePath: string }
+    | { status: 'pickup-ambiguous'; tracePath: string }
+    | {
+          status: 'pickup-already-collected';
+          tracePath: string;
+          plantName: string;
+      }
+    | {
+          status: 'pickup-not-ready';
+          tracePath: string;
+          plantName: string;
+      }
+    | {
+          status: 'pickup-queued';
+          tracePath: string;
+          plantName: string;
+          matchedCount: number;
+      }
+    | {
+          status: 'pickup-failed';
+          tracePath: string;
+          plantName: string;
+          message: string;
+      };
+
+export async function scanPickupManifest(
+    pickup: DeliveryPickupStepSummary,
+    scanValue: string,
+    onPickupScan: (
+        pickupNodeId: string,
+        scanValue: string,
+    ) => unknown | Promise<unknown>,
+): Promise<PickupManifestScanResult> {
+    const tracePath = normalizeHarvestTraceScanValue(scanValue);
+    if (!tracePath) return { status: 'pickup-invalid' };
+
+    const matchingItems = pickup.manifests.flatMap((manifest) =>
+        manifest.items.filter((item) => item.tracePath === tracePath),
+    );
+    if (matchingItems.length === 0) {
+        return { status: 'pickup-not-at-location', tracePath };
+    }
+    if (new Set(matchingItems.map((item) => item.stopKey)).size > 1) {
+        return { status: 'pickup-ambiguous', tracePath };
+    }
+    const pendingItems = matchingItems.filter(
+        (item) => item.state === 'ready' || item.state === 'not-ready',
+    );
+    const firstItem = matchingItems[0];
+    if (!firstItem) return { status: 'pickup-not-at-location', tracePath };
+    if (
+        pendingItems.length > 0 &&
+        pendingItems.every((item) => item.state === 'not-ready')
+    ) {
+        return {
+            status: 'pickup-not-ready',
+            tracePath,
+            plantName: firstItem.harvest.plantName,
+        };
+    }
+    if (pendingItems.length === 0) {
+        return {
+            status: 'pickup-already-collected',
+            tracePath,
+            plantName: firstItem.harvest.plantName,
+        };
+    }
+
+    const enqueueResult = await onPickupScan(pickup.id, tracePath);
+    if (
+        isDriverCommandResult(enqueueResult) &&
+        enqueueResult.status === 'failed'
+    ) {
+        return {
+            status: 'pickup-failed',
+            tracePath,
+            plantName: firstItem.harvest.plantName,
+            message: enqueueResult.message,
+        };
+    }
+    return {
+        status: 'pickup-queued',
+        tracePath,
+        plantName: firstItem.harvest.plantName,
+        matchedCount: pendingItems.length,
+    };
+}

--- a/apps/delivery/lib/driverCommandResult.ts
+++ b/apps/delivery/lib/driverCommandResult.ts
@@ -1,0 +1,12 @@
+export type DriverCommandResult =
+    | { status: 'saved' }
+    | { status: 'failed'; message: string };
+
+export function isDriverCommandResult(
+    value: unknown,
+): value is DriverCommandResult {
+    if (!value || typeof value !== 'object' || !('status' in value)) {
+        return false;
+    }
+    return value.status === 'saved' || value.status === 'failed';
+}

--- a/apps/delivery/lib/pickupManifestQueue.node.spec.ts
+++ b/apps/delivery/lib/pickupManifestQueue.node.spec.ts
@@ -259,6 +259,45 @@ test('durably enqueues rapid scans while an earlier transport request is in flig
     assert.equal(manifestQueue.getSnapshot().status, 'synced');
 });
 
+test('does not publish or retain a scan whose durable save fails', async () => {
+    const stored = createMemoryPickupManifestQueuePersistence();
+    let rejectSave = true;
+    const persistence: PickupManifestQueuePersistence = {
+        ...stored,
+        durability: 'durable',
+        async save(scope, entries) {
+            if (rejectSave) throw new Error('durable save failed');
+            await stored.save(scope, entries);
+        },
+    };
+    const manifestQueue = queue({ persistence });
+    const publishedStatuses: string[] = [];
+    manifestQueue.subscribe(() => {
+        publishedStatuses.push(manifestQueue.getSnapshot().status);
+    });
+
+    await assert.rejects(
+        manifestQueue.enqueue(scanCommand('failed-durable-scan')),
+        /durable save failed/,
+    );
+
+    assert.equal(manifestQueue.getSnapshot().status, 'idle');
+    assert.equal(manifestQueue.getSnapshot().entries.length, 0);
+    assert.equal(publishedStatuses.includes('queued'), false);
+    assert.equal(await stored.load(defaultScope), undefined);
+
+    rejectSave = false;
+    const saved = await manifestQueue.enqueue(
+        scanCommand('saved-after-failure', { token: `${traceToken}-retry` }),
+    );
+    assert.equal(saved.sequence, 0);
+    assert.equal(manifestQueue.getSnapshot().status, 'queued');
+    assert.equal(
+        manifestQueue.getSnapshot().entries[0]?.command.operationId,
+        'saved-after-failure',
+    );
+});
+
 test('exact duplicate enqueue is harmless and a reused operation ID with another payload is rejected', async () => {
     const persistence = createMemoryPickupManifestQueuePersistence();
     const manifestQueue = queue({

--- a/apps/delivery/lib/pickupManifestQueue.ts
+++ b/apps/delivery/lib/pickupManifestQueue.ts
@@ -744,18 +744,18 @@ export class PickupManifestQueue {
                 return cloneEntry(existing);
             }
 
-            const entry: PickupManifestQueueEntry = {
-                sequence: this.nextSequence,
-                command: { ...command },
-                state: 'queued',
-                attemptCount: 0,
-                updatedAt: this.now().toISOString(),
-            };
-            this.nextSequence += 1;
-            this.entries.push(entry);
-            this.publish();
-            await this.persist();
-            return cloneEntry(entry);
+            return await this.mutateAndPersist(() => {
+                const entry: PickupManifestQueueEntry = {
+                    sequence: this.nextSequence,
+                    command: { ...command },
+                    state: 'queued',
+                    attemptCount: 0,
+                    updatedAt: this.now().toISOString(),
+                };
+                this.nextSequence += 1;
+                this.entries.push(entry);
+                return cloneEntry(entry);
+            });
         });
     }
 
@@ -796,13 +796,13 @@ export class PickupManifestQueue {
             if (entry?.state !== 'failed') {
                 return false;
             }
-            entry.state = 'queued';
-            entry.updatedAt = this.now().toISOString();
-            delete entry.acknowledgement;
-            delete entry.errorCode;
-            this.publish();
-            await this.persist();
-            return true;
+            return await this.mutateAndPersist(() => {
+                entry.state = 'queued';
+                entry.updatedAt = this.now().toISOString();
+                delete entry.acknowledgement;
+                delete entry.errorCode;
+                return true;
+            });
         });
     }
 
@@ -813,10 +813,10 @@ export class PickupManifestQueue {
                 (entry) => entry.command.operationId !== operationId,
             );
             if (nextEntries.length === this.entries.length) return false;
-            this.entries = nextEntries;
-            this.publish();
-            await this.persist();
-            return true;
+            return await this.mutateAndPersist(() => {
+                this.entries = nextEntries;
+                return true;
+            });
         });
     }
 
@@ -834,13 +834,13 @@ export class PickupManifestQueue {
                 (candidate) => candidate.command.operationId === operationId,
             );
             if (!entry || entry.state === 'synced') return false;
-            entry.state = 'synced';
-            entry.acknowledgement = acknowledgement;
-            entry.updatedAt = this.now().toISOString();
-            delete entry.errorCode;
-            this.publish();
-            await this.persist();
-            return true;
+            return await this.mutateAndPersist(() => {
+                entry.state = 'synced';
+                entry.acknowledgement = acknowledgement;
+                entry.updatedAt = this.now().toISOString();
+                delete entry.errorCode;
+                return true;
+            });
         });
     }
 
@@ -915,14 +915,14 @@ export class PickupManifestQueue {
                 );
                 if (!entry || entry.state === 'conflicted') return null;
 
-                entry.state = 'sending';
-                entry.attemptCount += 1;
-                entry.updatedAt = this.now().toISOString();
-                delete entry.acknowledgement;
-                delete entry.errorCode;
-                this.publish();
-                await this.persist();
-                return { ...entry.command };
+                return await this.mutateAndPersist(() => {
+                    entry.state = 'sending';
+                    entry.attemptCount += 1;
+                    entry.updatedAt = this.now().toISOString();
+                    delete entry.acknowledgement;
+                    delete entry.errorCode;
+                    return { ...entry.command };
+                });
             });
             if (!command) break;
 
@@ -948,32 +948,34 @@ export class PickupManifestQueue {
                 if (entry.state === 'synced') return false;
                 if (entry.state === 'conflicted') return true;
 
-                entry.updatedAt = this.now().toISOString();
-                switch (result.status) {
-                    case 'applied':
-                        entry.state = 'synced';
-                        entry.acknowledgement = 'applied';
-                        break;
-                    case 'exact-duplicate':
-                        entry.state = 'synced';
-                        entry.acknowledgement = 'exact-duplicate';
-                        break;
-                    case 'permanent-failure':
-                        entry.state = 'conflicted';
-                        entry.errorCode = validErrorCode(result.code)
-                            ? result.code
-                            : 'pickup-manifest-conflict';
-                        break;
-                    case 'retryable-failure':
-                        entry.state = 'failed';
-                        entry.errorCode = validErrorCode(result.code)
-                            ? result.code
-                            : 'pickup-manifest-sync-failed';
-                        break;
-                }
-                this.publish();
-                await this.persist();
-                return entry.state === 'failed' || entry.state === 'conflicted';
+                return await this.mutateAndPersist(() => {
+                    entry.updatedAt = this.now().toISOString();
+                    switch (result.status) {
+                        case 'applied':
+                            entry.state = 'synced';
+                            entry.acknowledgement = 'applied';
+                            break;
+                        case 'exact-duplicate':
+                            entry.state = 'synced';
+                            entry.acknowledgement = 'exact-duplicate';
+                            break;
+                        case 'permanent-failure':
+                            entry.state = 'conflicted';
+                            entry.errorCode = validErrorCode(result.code)
+                                ? result.code
+                                : 'pickup-manifest-conflict';
+                            break;
+                        case 'retryable-failure':
+                            entry.state = 'failed';
+                            entry.errorCode = validErrorCode(result.code)
+                                ? result.code
+                                : 'pickup-manifest-sync-failed';
+                            break;
+                    }
+                    return (
+                        entry.state === 'failed' || entry.state === 'conflicted'
+                    );
+                });
             });
             if (shouldStop) break;
         }
@@ -992,6 +994,21 @@ export class PickupManifestQueue {
                 : 'best-effort',
         );
         for (const listener of this.listeners) listener();
+    }
+
+    private async mutateAndPersist<Result>(mutation: () => Result) {
+        const previousEntries = this.entries.map(cloneEntry);
+        const previousNextSequence = this.nextSequence;
+        try {
+            const result = mutation();
+            await this.persist();
+            return result;
+        } catch (error) {
+            this.entries = previousEntries;
+            this.nextSequence = previousNextSequence;
+            this.publish();
+            throw error;
+        }
     }
 
     private async persist() {

--- a/apps/delivery/playwright.config.ts
+++ b/apps/delivery/playwright.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import {
     defineConfig,
     devices,
@@ -9,6 +10,7 @@ import {
 } from '../../scripts/app-registry.ts';
 
 const app = getAppByName('delivery');
+const deliveryRoot = fileURLToPath(new URL('.', import.meta.url));
 const reporter: PlaywrightTestConfig['reporter'] = [
     ['list'],
     ['html', { open: 'never' }],
@@ -27,6 +29,9 @@ export const config: PlaywrightTestConfig = {
         trace: 'on-first-retry',
         ctPort: getComponentTestPort(app),
         ctViteConfig: {
+            css: {
+                postcss: deliveryRoot,
+            },
             resolve: {
                 dedupe: ['react', 'react-dom'],
             },

--- a/apps/delivery/playwright/index.tsx
+++ b/apps/delivery/playwright/index.tsx
@@ -1,1 +1,1 @@
-// Component specs import app/globals.css so every mounted journey uses the delivery theme.
+import '../app/globals.css';

--- a/apps/delivery/tests/DriverCurrentStopCommandCenterStory.tsx
+++ b/apps/delivery/tests/DriverCurrentStopCommandCenterStory.tsx
@@ -1,0 +1,392 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { DriverCurrentStopCommandCenter } from '../components/DriverCurrentStopCommandCenter';
+import { HarvestTraceScanner } from '../components/HarvestTraceScanner';
+import type { DeliveryActionQueueEntry } from '../lib/deliveryActionQueue';
+import type {
+    DeliveryPickupStepSummary,
+    DeliveryStopSummary,
+} from '../lib/deliveryDashboardTypes';
+import {
+    bulkExceptionStop,
+    deferredRetryStop,
+} from './deliveryRecoveryFixtures';
+
+const occurredAt = '2026-07-15T08:31:00.000Z';
+const terminalDeliveryFixture = bulkExceptionStop.deliveries[0];
+if (!terminalDeliveryFixture) {
+    throw new Error('Bulk delivery fixture requires one delivery.');
+}
+
+const currentStop: DeliveryStopSummary = {
+    ...bulkExceptionStop,
+    stopState: 'pending',
+    statusLabel: 'U dostavi',
+    arrivedAt: null,
+    addressLabel: 'Ulaz iz dvorišta',
+    requestNotes: null,
+    deliveries: [
+        ...bulkExceptionStop.deliveries.map((delivery, index) => ({
+            ...delivery,
+            stopState: 'pending' as const,
+            phone:
+                index === 0
+                    ? '+385 91 111 1111'
+                    : index === 1
+                      ? '+385 92 222 2222'
+                      : '+385 91 111 1111',
+            addressLabel:
+                index === 0
+                    ? 'Ulaz iz dvorišta'
+                    : index === 1
+                      ? 'Treći kat bez lifta'
+                      : null,
+            requestNotes:
+                index === 0
+                    ? 'Pozvoni dva puta.'
+                    : index === 1
+                      ? 'Sanduk ostavi u hladu.'
+                      : null,
+        })),
+        {
+            ...terminalDeliveryFixture,
+            requestId: 'request-terminal-history',
+            stopId: 99,
+            stopState: 'failed',
+            requestState: 'failed',
+            contactName: 'Zara Završena',
+            phone: '+385 99 999 9999',
+            requestNotes: 'Ne zovi ovaj završeni kontakt.',
+        },
+    ],
+};
+
+const arrivedStop: DeliveryStopSummary = {
+    ...currentStop,
+    stopState: 'arrived',
+    statusLabel: 'Vozač je stigao',
+    arrivedAt: occurredAt,
+    deliveries: currentStop.deliveries.map((delivery) => ({
+        ...delivery,
+        stopState:
+            delivery.requestId === 'request-terminal-history'
+                ? 'failed'
+                : 'arrived',
+    })),
+};
+
+function actionEntry(
+    kind: 'arrive' | 'deliver',
+    state: DeliveryActionQueueEntry['state'],
+): DeliveryActionQueueEntry {
+    return {
+        sequence: 0,
+        command: {
+            kind,
+            operationId: `${kind}-current-stop`,
+            runId: 'run-component-4127',
+            stopId: currentStop.id ?? 41,
+            expectedRouteRevision: 12,
+            occurredAt,
+        },
+        state,
+        attemptCount: state === 'queued' ? 0 : 1,
+        createdAt: occurredAt,
+        updatedAt: occurredAt,
+        ...(state === 'failed' ? { errorCode: 'offline' } : {}),
+        ...(state === 'conflicted'
+            ? { errorCode: 'route-revision-conflict' }
+            : {}),
+    };
+}
+
+export function DriverCurrentDeliveryCommandStory({
+    arrived = false,
+    syncState,
+    syncKind = 'arrive',
+    throwOnArrive = false,
+    late = false,
+}: {
+    arrived?: boolean;
+    syncState?: DeliveryActionQueueEntry['state'];
+    syncKind?: 'arrive' | 'deliver';
+    throwOnArrive?: boolean;
+    late?: boolean;
+}) {
+    const [result, setResult] = useState('none');
+    const selectedStop = arrived ? arrivedStop : currentStop;
+    const stop = late
+        ? {
+              ...selectedStop,
+              estimatedArrivalAt: '2026-07-15T12:30:00.000Z',
+          }
+        : selectedStop;
+    return (
+        <div className="min-h-[150dvh] bg-muted/30">
+            <div className="sticky top-0 z-20 h-16 border-b bg-background" />
+            <main className="space-y-4 px-4 py-5">
+                <output className="sr-only" data-testid="current-stop-result">
+                    {result}
+                </output>
+                <DriverCurrentStopCommandCenter
+                    kind="delivery"
+                    stop={stop}
+                    routeRevision={12}
+                    syncEntry={
+                        syncState ? actionEntry(syncKind, syncState) : undefined
+                    }
+                    onArrive={async () => {
+                        if (throwOnArrive) {
+                            throw new Error(
+                                'Dolazak nije spremljen na uređaj.',
+                            );
+                        }
+                        setResult('arrived');
+                    }}
+                    onDeliver={(notes) => setResult(`delivered:${notes ?? ''}`)}
+                    onException={async () => ({ status: 'saved' })}
+                    onVerificationScan={(tracePath) =>
+                        setResult(`verified:${tracePath}`)
+                    }
+                    onRetrySync={() => setResult('retried')}
+                    onDiscardSync={() => setResult('discarded')}
+                    onReconcileSync={() => setResult('reconciled')}
+                />
+                <div className="h-96" aria-hidden="true" />
+            </main>
+        </div>
+    );
+}
+
+export function DriverCurrentDeferredCommandStory({
+    offline = false,
+    retryAvailable = true,
+}: {
+    offline?: boolean;
+    retryAvailable?: boolean;
+}) {
+    const [result, setResult] = useState('none');
+    return (
+        <div className="min-h-[150dvh] p-4">
+            <output data-testid="current-stop-result">{result}</output>
+            <DriverCurrentStopCommandCenter
+                kind="delivery"
+                stop={deferredRetryStop}
+                routeRevision={13}
+                offline={offline}
+                onRetry={
+                    retryAvailable ? () => setResult('retried') : undefined
+                }
+                onException={async () => ({ status: 'saved' })}
+            />
+        </div>
+    );
+}
+
+const pickup: DeliveryPickupStepSummary = {
+    id: 'pickup-current',
+    pickupLocationId: 1,
+    sequence: 1,
+    itinerarySequence: 1,
+    name: 'Gredice HQ',
+    address: 'HQ ulica 1, Zagreb',
+    estimatedArrivalAt: '2026-07-15T08:20:00.000Z',
+    estimatedTravelSeconds: 480,
+    estimatedDistanceMeters: 2_100,
+    serviceDurationSeconds: 600,
+    state: 'partial',
+    isCurrent: true,
+    expectedCount: 2,
+    scannedCount: 1,
+    missingLabelCount: 0,
+    notReadyCount: 0,
+    remainingCount: 1,
+    manifests: [
+        {
+            id: 'manifest-current',
+            timeSlotId: 1,
+            startAt: '2026-07-15T08:00:00.000Z',
+            endAt: '2026-07-15T09:00:00.000Z',
+            state: 'pending',
+            confirmedAt: null,
+            expectedCount: 2,
+            scannedCount: 1,
+            missingLabelCount: 0,
+            notReadyCount: 0,
+            remainingCount: 1,
+            items: [
+                {
+                    id: 'pickup-item-current',
+                    stopId: 91,
+                    requestId: 'pickup-request-current',
+                    stopKey: 'pickup-stop-current',
+                    state: 'ready',
+                    resolvedAt: null,
+                    tracePath: '/trag/pickup-current-0001',
+                    harvest: {
+                        plantName: 'Rajčica',
+                        operationName: null,
+                        raisedBedName: 'Gredica A',
+                        fieldName: null,
+                        tracePath: '/trag/pickup-current-0001',
+                    },
+                },
+            ],
+        },
+    ],
+};
+
+export const currentPickupFixture = pickup;
+
+export function DriverCurrentPickupCommandStory({
+    offline = false,
+    readyToConfirm = false,
+    routeSyncBlocked = false,
+    syncState = 'idle',
+    failRecovery = false,
+    failScan = false,
+}: {
+    offline?: boolean;
+    readyToConfirm?: boolean;
+    routeSyncBlocked?: boolean;
+    syncState?: 'idle' | 'failed' | 'conflicted';
+    failRecovery?: boolean;
+    failScan?: boolean;
+}) {
+    const [result, setResult] = useState('none');
+    const [scanAttempts, setScanAttempts] = useState(0);
+    const displayedPickup: DeliveryPickupStepSummary = readyToConfirm
+        ? {
+              ...pickup,
+              scannedCount: 2,
+              remainingCount: 0,
+              manifests: pickup.manifests.map((manifest) => ({
+                  ...manifest,
+                  scannedCount: 2,
+                  remainingCount: 0,
+                  items: manifest.items.map((item) => ({
+                      ...item,
+                      state: 'scanned',
+                  })),
+              })),
+          }
+        : pickup;
+    return (
+        <div className="min-h-[150dvh] bg-muted/30">
+            <div className="sticky top-0 z-20 h-16 border-b bg-background" />
+            <main className="space-y-4 px-4 py-5">
+                <output className="sr-only" data-testid="current-stop-result">
+                    {result}
+                </output>
+                <output className="sr-only" data-testid="scan-attempts">
+                    {scanAttempts}
+                </output>
+                <DriverCurrentStopCommandCenter
+                    kind="pickup"
+                    pickup={displayedPickup}
+                    pendingAction={null}
+                    offline={offline}
+                    routeSyncBlocked={routeSyncBlocked}
+                    sync={{
+                        state: syncState,
+                        pendingCount: syncState === 'idle' ? 0 : 1,
+                        durability: 'durable',
+                        coordination: 'coordinated',
+                        blockingOperationId:
+                            syncState === 'idle' ? null : 'pickup-operation',
+                    }}
+                    onScan={() => {
+                        setScanAttempts((count) => count + 1);
+                        if (failScan) {
+                            return {
+                                status: 'pickup-failed',
+                                tracePath: '/trag/pickup-current-0001',
+                                plantName: 'Rajčica',
+                                message:
+                                    'Očitavanje nije sigurno spremljeno. Skeniraj QR kod ponovno.',
+                            };
+                        }
+                        setResult('scanned');
+                        return { status: 'pickup-invalid' };
+                    }}
+                    onSetItemState={(_pickupId, _manifestId, _stopId, state) =>
+                        setResult(`item:${state}`)
+                    }
+                    onResolveRemaining={() => setResult('resolved')}
+                    onConfirmManifest={() => setResult('confirmed')}
+                    onRetrySync={() =>
+                        failRecovery
+                            ? {
+                                  status: 'failed' as const,
+                                  message: 'Pokušaj preuzimanja nije uspio.',
+                              }
+                            : setResult('retried')
+                    }
+                    onDiscardSync={() => setResult('discarded')}
+                />
+                <div className="h-96" aria-hidden="true" />
+            </main>
+        </div>
+    );
+}
+
+function scannerSessionResult(tracePath: string, plantName: string) {
+    return {
+        status: 'pickup-queued' as const,
+        tracePath,
+        plantName,
+        matchedCount: 1,
+    };
+}
+
+type ScannerSessionResult = ReturnType<typeof scannerSessionResult>;
+
+export function HarvestTraceScannerSessionStory({
+    releaseFirstScan = false,
+}: {
+    releaseFirstScan?: boolean;
+}) {
+    const scanNumberRef = useRef(0);
+    const firstScanPromiseRef = useRef<Promise<ScannerSessionResult> | null>(
+        null,
+    );
+    const resolveFirstScanRef = useRef<
+        ((result: ScannerSessionResult) => void) | null
+    >(null);
+
+    useEffect(() => {
+        if (!releaseFirstScan) return;
+        resolveFirstScanRef.current?.(
+            scannerSessionResult('/trag/stari-urod', 'Stari urod'),
+        );
+        resolveFirstScanRef.current = null;
+    }, [releaseFirstScan]);
+
+    return (
+        <main className="p-4">
+            <HarvestTraceScanner
+                variant="manifest"
+                availableTraceCount={2}
+                completedTraceCount={0}
+                disabled={false}
+                onScan={(value) => {
+                    scanNumberRef.current += 1;
+                    if (scanNumberRef.current === 1) {
+                        const firstScanPromise =
+                            new Promise<ScannerSessionResult>((resolve) => {
+                                resolveFirstScanRef.current = resolve;
+                            });
+                        firstScanPromiseRef.current = firstScanPromise;
+                        return firstScanPromise;
+                    }
+
+                    const result = scannerSessionResult(value, 'Novi urod');
+                    return firstScanPromiseRef.current
+                        ? firstScanPromiseRef.current.then(() => result)
+                        : result;
+                }}
+            />
+        </main>
+    );
+}

--- a/apps/delivery/tests/DriverDashboardOfflineStory.tsx
+++ b/apps/delivery/tests/DriverDashboardOfflineStory.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
 import { DriverDashboard } from '../components/DriverDashboard';
 import type { DriverRouteWakeLockState } from '../hooks/useDriverRouteWakeLock';
 import type { DriverTrackingState } from '../hooks/useDriverTracking';
@@ -8,10 +9,19 @@ import type {
     DeliveryActionQueueSnapshot,
 } from '../lib/deliveryActionQueue';
 import type {
+    DeliveryPickupManifestSummary,
+    DeliveryPickupStepSummary,
+    DeliveryRouteStepSummary,
     DeliveryStopSummary,
     DriverDeliveryDashboard,
 } from '../lib/deliveryDashboardTypes';
-import { mixedStatusStop } from './deliveryRecoveryFixtures';
+import type { PickupManifestQueueSnapshot } from '../lib/pickupManifestQueue';
+import { currentPickupFixture } from './DriverCurrentStopCommandCenterStory';
+import {
+    bulkExceptionStop,
+    deferredRetryStop,
+    mixedStatusStop,
+} from './deliveryRecoveryFixtures';
 
 const occurredAt = '2026-07-15T08:32:00.000Z';
 const nextStop: DeliveryStopSummary = {
@@ -166,29 +176,45 @@ const routeWakeLock: DriverRouteWakeLockState = {
 };
 
 function DashboardStory({
+    dashboardData = dashboard,
     deliveryQueue,
+    pickupQueue = null,
+    onDeliver = () => undefined,
+    onRetry = () => undefined,
+    onPickupScan = () => undefined,
+    onPickupItemState = () => undefined,
+    onRetryPickupSync = () => undefined,
+    onDiscardPickupSync = () => undefined,
 }: {
+    dashboardData?: DriverDeliveryDashboard;
     deliveryQueue: DeliveryActionQueueSnapshot;
+    pickupQueue?: PickupManifestQueueSnapshot | null;
+    onDeliver?: () => unknown | Promise<unknown>;
+    onRetry?: () => unknown | Promise<unknown>;
+    onPickupScan?: () => unknown | Promise<unknown>;
+    onPickupItemState?: () => unknown | Promise<unknown>;
+    onRetryPickupSync?: (operationId: string) => unknown | Promise<unknown>;
+    onDiscardPickupSync?: (operationId: string) => unknown | Promise<unknown>;
 }) {
     return (
         <DriverDashboard
-            dashboard={dashboard}
+            dashboard={dashboardData}
             routeWakeLock={routeWakeLock}
             trackingState={trackingState}
             pendingAction={null}
             onSelectionChange={() => undefined}
             onStartRun={() => undefined}
-            onRetry={() => undefined}
+            onRetry={onRetry}
             onArrive={() => undefined}
-            onDeliver={() => undefined}
+            onDeliver={onDeliver}
             onException={async () => ({ status: 'saved' })}
-            pickupQueue={null}
+            pickupQueue={pickupQueue}
             deliveryQueue={deliveryQueue}
-            onPickupScan={() => undefined}
-            onPickupItemState={() => undefined}
+            onPickupScan={onPickupScan}
+            onPickupItemState={onPickupItemState}
             onConfirmPickupManifest={() => undefined}
-            onRetryPickupSync={() => undefined}
-            onDiscardPickupSync={() => undefined}
+            onRetryPickupSync={onRetryPickupSync}
+            onDiscardPickupSync={onDiscardPickupSync}
             onVerificationScan={() => undefined}
             onRetryDeliverySync={() => undefined}
             onDiscardDeliverySync={() => undefined}
@@ -203,4 +229,424 @@ export function DriverDashboardOfflineContinuationStory() {
 
 export function DriverDashboardPendingRerouteStory() {
     return <DashboardStory deliveryQueue={rerouteActionQueue} />;
+}
+
+const emptyActionQueue: DeliveryActionQueueSnapshot = {
+    ...actionQueue,
+    entries: [],
+    queuedCount: 0,
+};
+
+function dashboardWithCurrentBulkStop(
+    stop: DeliveryStopSummary,
+): DriverDeliveryDashboard {
+    if (!dashboard.activeRun) return dashboard;
+    return {
+        ...dashboard,
+        activeRun: {
+            ...dashboard.activeRun,
+            deliveryCount: stop.deliveries.length + nextStop.deliveries.length,
+            stops: [stop, nextStop],
+            routeSteps: dashboard.activeRun.routeSteps.map((step, index) =>
+                index === 0 && step.kind === 'delivery'
+                    ? { ...step, stop }
+                    : step,
+            ),
+        },
+    };
+}
+
+const partialBulkStop: DeliveryStopSummary = {
+    ...bulkExceptionStop,
+    deliveryCount: bulkExceptionStop.deliveries.length,
+    deliveries: bulkExceptionStop.deliveries.map((delivery) =>
+        delivery.requestId === 'request-basil'
+            ? {
+                  ...delivery,
+                  stopState: 'failed',
+                  requestState: 'failed',
+              }
+            : delivery,
+    ),
+};
+
+export function DriverDashboardBulkRecipientAdvanceStory() {
+    const [partial, setPartial] = useState(false);
+    return (
+        <>
+            <button type="button" onClick={() => setPartial(true)}>
+                Simuliraj djelomičnu iznimku
+            </button>
+            <DashboardStory
+                dashboardData={dashboardWithCurrentBulkStop(
+                    partial ? partialBulkStop : bulkExceptionStop,
+                )}
+                deliveryQueue={emptyActionQueue}
+            />
+        </>
+    );
+}
+
+const advancedDashboard: DriverDeliveryDashboard = {
+    ...dashboard,
+    activeRun: dashboard.activeRun
+        ? {
+              ...dashboard.activeRun,
+              routeRevision: 13,
+              routeSteps: dashboard.activeRun.routeSteps.map((step, index) => {
+                  if (step.kind !== 'delivery') return step;
+                  return index === 0
+                      ? { ...step, actionState: 'completed' as const }
+                      : {
+                            ...step,
+                            actionState: 'current' as const,
+                            stop: {
+                                ...step.stop,
+                                isCurrent: true,
+                                actionState: 'current' as const,
+                            },
+                        };
+              }),
+          }
+        : null,
+};
+
+export function DriverDashboardServerAdvanceStory() {
+    const [advanced, setAdvanced] = useState(false);
+    return (
+        <>
+            <button type="button" onClick={() => setAdvanced(true)}>
+                Simuliraj potvrdu poslužitelja
+            </button>
+            <DashboardStory
+                dashboardData={advanced ? advancedDashboard : dashboard}
+                deliveryQueue={emptyActionQueue}
+                onDeliver={() => ({
+                    status: 'failed',
+                    message: 'Dostava nije spremljena.',
+                })}
+            />
+        </>
+    );
+}
+
+const basePickupManifest = currentPickupFixture.manifests[0];
+if (!basePickupManifest) {
+    throw new Error('Current pickup fixture requires one manifest.');
+}
+
+const firstPickupManifest: DeliveryPickupManifestSummary = {
+    ...basePickupManifest,
+    id: 'manifest-first-slot',
+};
+const secondPickupManifest: DeliveryPickupManifestSummary = {
+    ...basePickupManifest,
+    id: 'manifest-second-slot',
+    startAt: '2026-07-15T09:00:00.000Z',
+    endAt: '2026-07-15T10:00:00.000Z',
+    items: basePickupManifest.items.map((item) => ({
+        ...item,
+        id: `${item.id}-second`,
+        stopId: item.stopId + 1,
+        requestId: `${item.requestId}-second`,
+        stopKey: `${item.stopKey}-second`,
+    })),
+};
+
+const pickupWithTwoManifests = {
+    ...currentPickupFixture,
+    manifests: [firstPickupManifest, secondPickupManifest],
+};
+
+function dashboardWithRouteSteps(
+    routeSteps: DeliveryRouteStepSummary[],
+    stops: DeliveryStopSummary[] = [],
+): DriverDeliveryDashboard {
+    if (!dashboard.activeRun) return dashboard;
+    return {
+        ...dashboard,
+        activeRun: {
+            ...dashboard.activeRun,
+            deliveryCount: stops.reduce(
+                (count, stop) => count + stop.deliveries.length,
+                0,
+            ),
+            stops,
+            routeSteps,
+        },
+    };
+}
+
+const pickupManifestDashboard = dashboardWithRouteSteps([
+    {
+        kind: 'pickup',
+        itinerarySequence: 1,
+        actionState: 'current',
+        pickup: pickupWithTwoManifests,
+    },
+]);
+const advancedPickupManifestDashboard = dashboardWithRouteSteps([
+    {
+        kind: 'pickup',
+        itinerarySequence: 1,
+        actionState: 'current',
+        pickup: {
+            ...pickupWithTwoManifests,
+            manifests: [
+                {
+                    ...firstPickupManifest,
+                    state: 'confirmed',
+                    confirmedAt: occurredAt,
+                },
+                secondPickupManifest,
+            ],
+        },
+    },
+]);
+
+export function DriverDashboardPickupManifestAdvanceStory() {
+    const [advanced, setAdvanced] = useState(false);
+    return (
+        <>
+            <button type="button" onClick={() => setAdvanced(true)}>
+                Potvrdi prvi manifest
+            </button>
+            <DashboardStory
+                dashboardData={
+                    advanced
+                        ? advancedPickupManifestDashboard
+                        : pickupManifestDashboard
+                }
+                deliveryQueue={emptyActionQueue}
+                onPickupItemState={() => ({
+                    status: 'failed',
+                    message: 'Ishod preuzimanja nije spremljen.',
+                })}
+            />
+        </>
+    );
+}
+
+const blockedEarlierPickupQueue: PickupManifestQueueSnapshot = {
+    scope: {
+        userId: dashboard.user.id,
+        runId: 'run-component-4127',
+    },
+    status: 'conflicted',
+    durability: 'durable',
+    coordination: 'coordinated',
+    entries: [
+        {
+            sequence: 0,
+            command: {
+                kind: 'scan',
+                operationId: 'pickup-earlier-conflict',
+                runId: 'run-component-4127',
+                pickupNodeId: 'pickup-earlier',
+                occurredAt,
+                tracePath: '/trag/pickup-earlier-0001',
+            },
+            state: 'conflicted',
+            attemptCount: 1,
+            updatedAt: occurredAt,
+            errorCode: 'pickup-trace-not-found',
+        },
+    ],
+    queuedCount: 0,
+    sendingCount: 0,
+    syncedCount: 0,
+    failedCount: 0,
+    conflictedCount: 1,
+};
+
+export function DriverDashboardEarlierPickupConflictStory() {
+    const [discardedOperationId, setDiscardedOperationId] = useState('none');
+    return (
+        <>
+            <output data-testid="pickup-recovery-result">
+                {discardedOperationId}
+            </output>
+            <DashboardStory
+                dashboardData={pickupManifestDashboard}
+                deliveryQueue={emptyActionQueue}
+                pickupQueue={blockedEarlierPickupQueue}
+                onDiscardPickupSync={setDiscardedOperationId}
+            />
+        </>
+    );
+}
+
+const blockedEarlierPickupFailureQueue: PickupManifestQueueSnapshot = {
+    ...blockedEarlierPickupQueue,
+    status: 'failed',
+    entries: blockedEarlierPickupQueue.entries.map((entry) => ({
+        ...entry,
+        command: {
+            ...entry.command,
+            operationId: 'pickup-earlier-failure',
+        },
+        state: 'failed',
+        errorCode: 'transport-error',
+    })),
+    failedCount: 1,
+    conflictedCount: 0,
+};
+
+export function DriverDashboardEarlierPickupFailureStory() {
+    return (
+        <DashboardStory
+            dashboardData={pickupManifestDashboard}
+            deliveryQueue={emptyActionQueue}
+            pickupQueue={blockedEarlierPickupFailureQueue}
+        />
+    );
+}
+
+const readyToConfirmPickup: DeliveryPickupStepSummary = {
+    ...currentPickupFixture,
+    expectedCount: 1,
+    scannedCount: 1,
+    remainingCount: 0,
+    manifests: currentPickupFixture.manifests.map((manifest) => ({
+        ...manifest,
+        expectedCount: 1,
+        scannedCount: 1,
+        remainingCount: 0,
+        items: manifest.items.map((item) => ({
+            ...item,
+            state: 'scanned',
+        })),
+    })),
+};
+
+const readyToConfirmPickupDashboard = dashboardWithRouteSteps([
+    {
+        kind: 'pickup',
+        itinerarySequence: 1,
+        actionState: 'current',
+        pickup: readyToConfirmPickup,
+    },
+]);
+
+function earlierPickupQueue(
+    state: 'failed' | 'queued' | 'sending' | 'synced',
+): PickupManifestQueueSnapshot {
+    return {
+        ...blockedEarlierPickupFailureQueue,
+        status: state,
+        entries: blockedEarlierPickupFailureQueue.entries.map((entry) => ({
+            ...entry,
+            state,
+            ...(state === 'failed'
+                ? { errorCode: 'transport-error' }
+                : { errorCode: undefined }),
+        })),
+        queuedCount: state === 'queued' ? 1 : 0,
+        sendingCount: state === 'sending' ? 1 : 0,
+        syncedCount: state === 'synced' ? 1 : 0,
+        failedCount: state === 'failed' ? 1 : 0,
+    };
+}
+
+export function DriverDashboardEarlierPickupDeferredRetryStory({
+    sendRetry = false,
+    completeRetry = false,
+}: {
+    sendRetry?: boolean;
+    completeRetry?: boolean;
+}) {
+    const [queueState, setQueueState] = useState<
+        'failed' | 'queued' | 'sending' | 'synced'
+    >('failed');
+    const resolveRetryRef = useRef<(() => void) | null>(null);
+
+    useEffect(() => {
+        if (completeRetry) {
+            setQueueState('synced');
+            resolveRetryRef.current?.();
+            resolveRetryRef.current = null;
+            return;
+        }
+        if (sendRetry) setQueueState('sending');
+    }, [completeRetry, sendRetry]);
+
+    return (
+        <>
+            <output data-testid="pickup-queue-state">{queueState}</output>
+            <DashboardStory
+                dashboardData={readyToConfirmPickupDashboard}
+                deliveryQueue={emptyActionQueue}
+                pickupQueue={earlierPickupQueue(queueState)}
+                onRetryPickupSync={() => {
+                    setQueueState('queued');
+                    return new Promise<void>((resolve) => {
+                        resolveRetryRef.current = resolve;
+                    });
+                }}
+            />
+        </>
+    );
+}
+
+const crossQueuePickupDashboard = dashboardWithRouteSteps(
+    [
+        {
+            kind: 'delivery',
+            itinerarySequence: 1,
+            retryLaneRank: null,
+            retryAttempt: 0,
+            actionState: 'current',
+            lockedReason: null,
+            stop: mixedStatusStop,
+        },
+        {
+            kind: 'pickup',
+            itinerarySequence: 2,
+            actionState: 'locked',
+            pickup: currentPickupFixture,
+        },
+    ],
+    [mixedStatusStop],
+);
+
+export function DriverDashboardCrossQueuePickupStory() {
+    return (
+        <DashboardStory
+            dashboardData={crossQueuePickupDashboard}
+            deliveryQueue={actionQueue}
+        />
+    );
+}
+
+const locallyAdvancedDeferredDashboard = dashboardWithRouteSteps(
+    [
+        {
+            kind: 'delivery',
+            itinerarySequence: 1,
+            retryLaneRank: null,
+            retryAttempt: 0,
+            actionState: 'current',
+            lockedReason: null,
+            stop: mixedStatusStop,
+        },
+        {
+            kind: 'delivery',
+            itinerarySequence: 2,
+            retryLaneRank: 1,
+            retryAttempt: 1,
+            actionState: 'upcoming',
+            lockedReason: null,
+            stop: deferredRetryStop,
+        },
+    ],
+    [mixedStatusStop, deferredRetryStop],
+);
+
+export function DriverDashboardLocallyAdvancedDeferredStory() {
+    return (
+        <DashboardStory
+            dashboardData={locallyAdvancedDeferredDashboard}
+            deliveryQueue={actionQueue}
+        />
+    );
 }

--- a/apps/delivery/tests/DriverRecoveryFailureStory.tsx
+++ b/apps/delivery/tests/DriverRecoveryFailureStory.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { DeliveryPickupCard } from '../components/DeliveryPickupCard';
+import { DeliveryActionSyncStatus } from '../components/DriverDashboard';
+import type { DeliveryActionQueueSnapshot } from '../lib/deliveryActionQueue';
+import { currentPickupFixture } from './DriverCurrentStopCommandCenterStory';
+
+const occurredAt = '2026-07-15T08:32:00.000Z';
+
+const failedDeliveryQueue: DeliveryActionQueueSnapshot = {
+    scope: {
+        userId: 'driver-recovery-failure',
+        runId: 'run-recovery-failure',
+    },
+    durability: 'durable',
+    coordination: 'coordinated',
+    entries: [
+        {
+            sequence: 0,
+            command: {
+                kind: 'deliver',
+                operationId: 'operation-non-current-delivery',
+                runId: 'run-recovery-failure',
+                stopId: 42,
+                expectedRouteRevision: 12,
+                occurredAt,
+            },
+            state: 'failed',
+            attemptCount: 1,
+            createdAt: occurredAt,
+            updatedAt: occurredAt,
+            errorCode: 'offline',
+        },
+    ],
+    queuedCount: 0,
+    sendingCount: 0,
+    reconcilingCount: 0,
+    syncedCount: 0,
+    failedCount: 1,
+    conflictedCount: 0,
+};
+
+export function NonCurrentDeliveryRecoveryFailureStory() {
+    return (
+        <main className="p-4">
+            <DeliveryActionSyncStatus
+                snapshot={failedDeliveryQueue}
+                currentStopId={41}
+                onRetry={() => ({
+                    status: 'failed',
+                    message: 'Ponovno slanje dostave nije uspjelo.',
+                })}
+                onRecoverConflict={() => ({ status: 'saved' })}
+                onReconcile={() => ({ status: 'saved' })}
+            />
+        </main>
+    );
+}
+
+export function NonCurrentPickupRecoveryFailureStory() {
+    return (
+        <main className="p-4">
+            <DeliveryPickupCard
+                pickup={currentPickupFixture}
+                actionState="locked"
+                pendingAction={null}
+                showCurrentCommand={false}
+                sync={{
+                    state: 'failed',
+                    pendingCount: 1,
+                    durability: 'durable',
+                    coordination: 'coordinated',
+                    blockingOperationId: 'operation-non-current-pickup',
+                }}
+                onScan={() => ({ status: 'pickup-invalid' })}
+                onSetItemState={() => undefined}
+                onResolveRemaining={() => undefined}
+                onConfirmManifest={() => undefined}
+                onRetrySync={() => ({
+                    status: 'failed',
+                    message: 'Ponovno slanje preuzimanja nije uspjelo.',
+                })}
+                onDiscardSync={() => ({ status: 'saved' })}
+            />
+        </main>
+    );
+}

--- a/apps/delivery/tests/delivery-offline-actions.spec.tsx
+++ b/apps/delivery/tests/delivery-offline-actions.spec.tsx
@@ -4,9 +4,14 @@ import {
     DeliveryQueuedArrivalStory,
 } from './DeliveryStopCardStory';
 import {
+    DriverDashboardBulkRecipientAdvanceStory,
     DriverDashboardOfflineContinuationStory,
     DriverDashboardPendingRerouteStory,
 } from './DriverDashboardOfflineStory';
+import {
+    NonCurrentDeliveryRecoveryFailureStory,
+    NonCurrentPickupRecoveryFailureStory,
+} from './DriverRecoveryFailureStory';
 import {
     OfflineRouteAcknowledgedDeliveryStory,
     OfflineRouteArrivalStory,
@@ -50,7 +55,7 @@ test('already loaded dashboard exposes the next stop after a locally queued deli
             'Dostava je spremljena na uređaju i čeka potvrdu poslužitelja. Možeš nastaviti na sljedeću stanicu.',
         ),
     ).toBeVisible();
-    await expect(page.getByText('Vukovarska 42, Zagreb')).toBeVisible();
+    await expect(page.getByTitle('Vukovarska 42, Zagreb')).toBeVisible();
     await expect(page.getByRole('link', { name: 'Navigacija' })).toHaveCount(1);
     await expect(
         page.getByRole('button', { name: 'Stigao sam' }),
@@ -71,6 +76,22 @@ test('already loaded dashboard blocks its stale next stop while rerouting', asyn
         page.getByRole('button', { name: 'Navigacija čeka novi plan' }),
     ).toBeDisabled();
     await expect(page.getByRole('link', { name: 'Navigacija' })).toHaveCount(0);
+});
+
+test('clears private handoff notes when the actionable bulk recipients change', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverDashboardBulkRecipientAdvanceStory />);
+    const note = page.getByLabel('Napomena o predaji');
+    await note.fill('Privatna napomena za početnu skupinu');
+    await page
+        .getByRole('button', { name: 'Simuliraj djelomičnu iznimku' })
+        .click();
+    await expect(note).toHaveValue('');
+    await expect(
+        page.getByRole('heading', { name: /2 uroda · skupna dostava/ }),
+    ).toBeVisible();
 });
 
 test('offers an explicit retry for a durable failed action', async ({
@@ -106,6 +127,32 @@ test('preserves newer server truth and requires explicit local conflict recovery
     await expect(page.getByTestId('offline-action-result')).toHaveText(
         'discarded',
     );
+});
+
+test('keeps non-current delivery recovery failures beside the recovery command', async ({
+    mount,
+    page,
+}) => {
+    await mount(<NonCurrentDeliveryRecoveryFailureStory />);
+    await page.getByRole('button', { name: 'Pokušaj ponovno' }).click();
+    await expect(
+        page.getByText('Ponovno slanje dostave nije uspjelo.', {
+            exact: true,
+        }),
+    ).toBeVisible();
+});
+
+test('keeps non-current pickup recovery failures beside the recovery command', async ({
+    mount,
+    page,
+}) => {
+    await mount(<NonCurrentPickupRecoveryFailureStory />);
+    await page.getByRole('button', { name: 'Pokušaj ponovno' }).click();
+    await expect(
+        page.getByText('Ponovno slanje preuzimanja nije uspjelo.', {
+            exact: true,
+        }),
+    ).toBeVisible();
 });
 
 test('restored offline route keeps pending actions visible and supports ordered arrival then delivery', async ({

--- a/apps/delivery/tests/driver-current-stop.spec.tsx
+++ b/apps/delivery/tests/driver-current-stop.spec.tsx
@@ -1,0 +1,739 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import {
+    DriverCurrentDeferredCommandStory,
+    DriverCurrentDeliveryCommandStory,
+    DriverCurrentPickupCommandStory,
+    HarvestTraceScannerSessionStory,
+} from './DriverCurrentStopCommandCenterStory';
+import {
+    DriverDashboardCrossQueuePickupStory,
+    DriverDashboardEarlierPickupConflictStory,
+    DriverDashboardEarlierPickupDeferredRetryStory,
+    DriverDashboardEarlierPickupFailureStory,
+    DriverDashboardLocallyAdvancedDeferredStory,
+    DriverDashboardPickupManifestAdvanceStory,
+    DriverDashboardServerAdvanceStory,
+} from './DriverDashboardOfflineStory';
+import { OfflineRouteArrivalStory } from './OfflineRoutePanelStory';
+import '../app/globals.css';
+
+test.describe('320px current-stop command center', () => {
+    test.use({
+        viewport: { width: 320, height: 568 },
+        hasTouch: true,
+        isMobile: true,
+    });
+
+    test('keeps essentials, critical notes, and direct commands visible without horizontal overflow', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<DriverCurrentDeliveryCommandStory />);
+        const command = page.getByRole('region', {
+            name: /skupna dostava/,
+        });
+
+        await expect(command).toContainText('Ilica 42, Zagreb');
+        await expect(command).toContainText('Ulaz iz dvorišta');
+        await expect(command).toContainText('Treći kat bez lifta');
+        await expect(command.getByText(/Uputa za adresu/)).toHaveCount(2);
+        await expect(command).toContainText('Pozvoni dva puta.');
+        await expect(command).toContainText('Sanduk ostavi u hladu.');
+        await expect(
+            command.getByRole('button', { name: 'Stigao sam' }),
+        ).toBeEnabled();
+        await expect(
+            command.getByRole('button', { name: 'Prijavi problem' }),
+        ).toBeEnabled();
+        await expect(
+            command.getByRole('link', {
+                name: 'Navigacija do trenutačne stanice',
+            }),
+        ).toHaveAttribute(
+            'href',
+            'https://www.google.com/maps/dir/?api=1&destination=Ilica%2042%2C%20Zagreb',
+        );
+        const calls = command.getByRole('link', { name: /^Nazovi / });
+        await expect(calls).toHaveCount(2);
+        await expect(calls.first()).toHaveAttribute('href', /^tel:/);
+        await expect(
+            command.getByRole('link', {
+                name: 'Nazovi Ana Anić, Cvita Cvetko',
+            }),
+        ).toBeVisible();
+        await expect(
+            command.getByRole('link', { name: 'Nazovi Borna Babić' }),
+        ).toBeVisible();
+        await expect(command.getByText('Zara Završena')).toHaveCount(0);
+        await expect(
+            command.getByText('Ne zovi ovaj završeni kontakt.'),
+        ).toHaveCount(0);
+        await expect(command).toContainText(
+            'Napomena korisnika · Ana Anić · Rajčica Roma',
+        );
+        await expect(
+            command.getByText(
+                'QR provjera otključat će se nakon potvrde dolaska.',
+            ),
+        ).toBeVisible();
+
+        const arrive = command.getByRole('button', { name: 'Stigao sam' });
+        const arriveBox = await arrive.boundingBox();
+        const heading = command.getByRole('region', {
+            name: 'Sažetak trenutačne stanice',
+        });
+        const geometry = await command.evaluate((element) => ({
+            clientWidth: element.clientWidth,
+            scrollWidth: element.scrollWidth,
+            borderTopWidth: getComputedStyle(element).borderTopWidth,
+        }));
+        expect(geometry.scrollWidth).toBe(geometry.clientWidth);
+        expect(geometry.borderTopWidth).toBe('1px');
+        expect(
+            await heading.evaluate(
+                (element) => getComputedStyle(element).position,
+            ),
+        ).toBe('sticky');
+        expect(arriveBox).not.toBeNull();
+        expect(
+            (arriveBox?.y ?? 568) + (arriveBox?.height ?? 0),
+        ).toBeLessThanOrEqual(568);
+    });
+
+    test('keeps arrived delivery reachable while the note field can scroll above a reduced viewport', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<DriverCurrentDeliveryCommandStory arrived />);
+        const deliver = page.getByRole('button', {
+            name: /Dostavi 3 · dalje/,
+        });
+        const deliverBox = await deliver.boundingBox();
+        expect(deliverBox).not.toBeNull();
+        expect(
+            (deliverBox?.y ?? 568) + (deliverBox?.height ?? 0),
+        ).toBeLessThanOrEqual(568);
+
+        const note = page.getByLabel('Napomena o predaji');
+        await note.focus();
+        await expect(note).toBeFocused();
+        await page.setViewportSize({ width: 320, height: 360 });
+        await note.evaluate((element) =>
+            element.scrollIntoView({ block: 'center' }),
+        );
+        const noteBox = await note.boundingBox();
+        const keyboardDeliverBox = await deliver.boundingBox();
+        const keyboardSummaryBox = await page
+            .getByRole('region', { name: 'Sažetak trenutačne stanice' })
+            .boundingBox();
+        expect(noteBox).not.toBeNull();
+        expect(keyboardDeliverBox).not.toBeNull();
+        expect(keyboardSummaryBox).not.toBeNull();
+        expect(
+            (keyboardDeliverBox?.y ?? 360) + (keyboardDeliverBox?.height ?? 0),
+        ).toBeLessThanOrEqual(360);
+        expect(
+            (noteBox?.y ?? 360) + (noteBox?.height ?? 0),
+        ).toBeLessThanOrEqual(360);
+        expect(noteBox?.y ?? 0).toBeGreaterThanOrEqual(
+            (keyboardDeliverBox?.y ?? 0) + (keyboardDeliverBox?.height ?? 0),
+        );
+        expect(keyboardDeliverBox?.y ?? 0).toBeGreaterThanOrEqual(
+            (keyboardSummaryBox?.y ?? 0) + (keyboardSummaryBox?.height ?? 0),
+        );
+    });
+
+    test('keeps failed delivery recovery attached to the sticky delivery action', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <DriverCurrentDeliveryCommandStory
+                arrived
+                syncKind="deliver"
+                syncState="failed"
+            />,
+        );
+        const action = page.getByRole('button', {
+            name: 'Dostava čeka potvrdu',
+        });
+        const status = page.getByTestId('current-command-status');
+        const retry = page.getByRole('button', { name: 'Pokušaj ponovno' });
+        await expect(action).toBeInViewport();
+        await expect(retry).toBeInViewport();
+
+        const actionBox = await action.boundingBox();
+        const statusBox = await status.boundingBox();
+        expect(actionBox).not.toBeNull();
+        expect(statusBox).not.toBeNull();
+        const actionBottom =
+            (actionBox?.y ?? 0) + (actionBox?.height ?? Number.MAX_VALUE);
+        expect(statusBox?.y ?? 0).toBeGreaterThanOrEqual(actionBottom);
+        expect((statusBox?.y ?? 0) - actionBottom).toBeLessThanOrEqual(12);
+    });
+
+    test('keeps pickup scanning, manual fallback, and confirmation reachable before the route details', async ({
+        mount,
+        page,
+    }) => {
+        const component = await mount(<DriverCurrentPickupCommandStory />);
+        for (const buttonName of [
+            'Skeniraj urode',
+            'Preuzeto bez QR etikete',
+        ]) {
+            const box = await page
+                .getByRole('button', { name: buttonName })
+                .boundingBox();
+            expect(box).not.toBeNull();
+            expect((box?.y ?? 568) + (box?.height ?? 0)).toBeLessThanOrEqual(
+                568,
+            );
+        }
+
+        await component.update(
+            <DriverCurrentPickupCommandStory readyToConfirm />,
+        );
+        const confirmBox = await page
+            .getByRole('button', {
+                name: 'Potvrdi preuzimanje i nastavi',
+            })
+            .boundingBox();
+        expect(confirmBox).not.toBeNull();
+        expect(
+            (confirmBox?.y ?? 568) + (confirmBox?.height ?? 0),
+        ).toBeLessThanOrEqual(568);
+    });
+
+    test('keeps pickup recovery and its failure beside the pickup command', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <DriverCurrentPickupCommandStory syncState="failed" failRecovery />,
+        );
+        const syncAlert = page.getByRole('alert', {
+            name: 'Status radnje: preuzimanje',
+        });
+        const retry = page.getByRole('button', { name: 'Pokušaj ponovno' });
+        await expect(retry).toBeInViewport();
+        await retry.click();
+
+        const recoveryError = page.getByRole('alert').filter({
+            hasText: 'Pokušaj preuzimanja nije uspio.',
+        });
+        await expect(recoveryError).toBeInViewport();
+        const syncBox = await syncAlert.boundingBox();
+        const errorBox = await recoveryError.boundingBox();
+        expect(syncBox).not.toBeNull();
+        expect(errorBox).not.toBeNull();
+        const syncBottom =
+            (syncBox?.y ?? 0) + (syncBox?.height ?? Number.MAX_VALUE);
+        expect(errorBox?.y ?? 0).toBeGreaterThanOrEqual(syncBottom);
+        expect((errorBox?.y ?? 0) - syncBottom).toBeLessThanOrEqual(12);
+    });
+});
+
+test('uses section-level current-command headings in live and offline route views', async ({
+    mount,
+    page,
+}) => {
+    const component = await mount(<DriverDashboardServerAdvanceStory />);
+    const currentSummary = () =>
+        page.getByRole('region', { name: 'Sažetak trenutačne stanice' });
+
+    await expect(
+        currentSummary().getByRole('heading', { level: 2 }),
+    ).toHaveCount(1);
+    await expect(
+        currentSummary().getByRole('heading', { level: 3 }),
+    ).toHaveCount(0);
+
+    await component.update(<OfflineRouteArrivalStory />);
+    await expect(
+        currentSummary().getByRole('heading', { level: 2 }),
+    ).toHaveCount(1);
+    await expect(
+        currentSummary().getByRole('heading', { level: 3 }),
+    ).toHaveCount(0);
+    await expect(
+        page.getByRole('heading', {
+            level: 3,
+            name: 'Sljedeća dostava',
+        }),
+    ).toBeVisible();
+});
+
+test('arrived stop exposes advisory scanning and delivers with its local note', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverCurrentDeliveryCommandStory arrived />);
+    await expect(
+        page.getByRole('button', { name: 'Provjeri QR kodove' }),
+    ).toBeEnabled();
+    await expect(
+        page.getByText('Provjera nije obavezna i ne blokira potvrdu dostave.'),
+    ).toBeVisible();
+    await page.getByLabel('Napomena o predaji').fill('Predano susjedu');
+    await page.getByRole('button', { name: /Dostavi 3 · dalje/ }).click();
+    await expect(page.getByTestId('current-stop-result')).toHaveText(
+        'delivered:Predano susjedu',
+    );
+});
+
+test('queued arrival stays attached to arrival while delivery remains available', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <DriverCurrentDeliveryCommandStory
+            syncState="queued"
+            arrived={false}
+        />,
+    );
+    await expect(
+        page.getByRole('alert', { name: 'Status radnje: Dolazak' }),
+    ).toContainText('Dolazak: Radnja je spremljena na uređaju');
+    await expect(
+        page.getByRole('button', { name: 'Dolazak čeka potvrdu' }),
+    ).toBeDisabled();
+    await expect(
+        page.getByRole('button', { name: /Dostavi 3 · dalje/ }),
+    ).toBeEnabled();
+});
+
+test('sending and acknowledged arrivals keep truthful command-local status', async ({
+    mount,
+    page,
+}) => {
+    const component = await mount(
+        <DriverCurrentDeliveryCommandStory syncState="sending" />,
+    );
+    await expect(
+        page.getByRole('alert', { name: 'Status radnje: Dolazak' }),
+    ).toContainText('Radnja se šalje i još nije potvrđena.');
+
+    await component.update(
+        <DriverCurrentDeliveryCommandStory syncState="synced" />,
+    );
+    await expect(
+        page.getByRole('button', { name: 'Dolazak potvrđen' }),
+    ).toBeDisabled();
+    await expect(
+        page.getByRole('alert', { name: 'Status radnje: Dolazak' }),
+    ).toContainText('Poslužitelj je potvrdio radnju');
+});
+
+test('failed and conflicted commands recover beside the command that failed', async ({
+    mount,
+    page,
+}) => {
+    const component = await mount(
+        <DriverCurrentDeliveryCommandStory
+            arrived
+            syncKind="deliver"
+            syncState="failed"
+        />,
+    );
+    await expect(
+        page.getByRole('alert', { name: 'Status radnje: Dostava' }),
+    ).toContainText('Dostava: Radnja je spremljena na uređaju');
+    await page.getByRole('button', { name: 'Pokušaj ponovno' }).click();
+    await expect(page.getByTestId('current-stop-result')).toHaveText('retried');
+
+    await component.update(
+        <DriverCurrentDeliveryCommandStory
+            arrived
+            syncKind="deliver"
+            syncState="conflicted"
+        />,
+    );
+    await expect(
+        page.getByRole('alert', { name: 'Status radnje: Dostava' }),
+    ).toContainText('Poslužitelj ima noviju verziju rute.');
+    await page
+        .getByRole('button', { name: 'Učitaj stanje poslužitelja' })
+        .click();
+    await expect(page.getByTestId('current-stop-result')).toHaveText(
+        'discarded',
+    );
+
+    await component.update(
+        <DriverCurrentDeliveryCommandStory
+            arrived
+            syncKind="deliver"
+            syncState="reconciling"
+        />,
+    );
+    await expect(
+        page.getByRole('alert', { name: 'Status radnje: Dostava' }),
+    ).toContainText('novi plan rute još nije učitan');
+    await page.getByRole('button', { name: 'Osvježi novi plan' }).click();
+    await expect(page.getByTestId('current-stop-result')).toHaveText(
+        'reconciled',
+    );
+});
+
+test('enqueue failure remains local to the arrival command', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverCurrentDeliveryCommandStory throwOnArrive />);
+    await page.getByRole('button', { name: 'Stigao sam' }).click();
+    await expect(page.getByRole('alert')).toContainText(
+        'Dolazak nije spremljen na uređaj.',
+    );
+});
+
+test('deferred stop presents retry as its only route mutation', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverCurrentDeferredCommandStory />);
+    await expect(
+        page.getByRole('heading', { name: '2 uroda · skupna dostava' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Navigacija čeka novi plan' }),
+    ).toBeDisabled();
+    await expect(
+        page.getByRole('button', { name: 'Pokreni ponovni pokušaj' }),
+    ).toBeEnabled();
+    await expect(page.getByRole('button', { name: 'Stigao sam' })).toHaveCount(
+        0,
+    );
+    await page.getByRole('button', { name: 'Pokreni ponovni pokušaj' }).click();
+    await expect(page.getByTestId('current-stop-result')).toHaveText('retried');
+});
+
+test('offline deferred stop does not present an actionable no-op retry', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <DriverCurrentDeferredCommandStory offline retryAvailable={false} />,
+    );
+    await expect(
+        page.getByRole('button', {
+            name: 'Ponovni pokušaj nakon povratka veze',
+        }),
+    ).toBeDisabled();
+    await expect(
+        page.getByRole('button', {
+            name: 'Navigacija do trenutačne stanice čeka novi plan',
+        }),
+    ).toBeDisabled();
+});
+
+test('late current-stop estimate remains visible beside the command', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverCurrentDeliveryCommandStory late />);
+    await expect(page.getByRole('alert')).toContainText(
+        'Trenutačna procjena dolaska je nakon završetka termina.',
+    );
+});
+
+test('dashboard advancement clears private state and focuses every server-driven current command', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverDashboardServerAdvanceStory />);
+    await page.getByLabel('Napomena o predaji').fill('Privatna napomena A');
+    await page.getByRole('button', { name: /Dostavljeno · dalje/ }).click();
+    await expect(
+        page.getByRole('alert').filter({
+            hasText: 'Dostava nije spremljena.',
+        }),
+    ).toBeVisible();
+
+    await page
+        .getByRole('button', { name: 'Simuliraj potvrdu poslužitelja' })
+        .click();
+
+    await expect(page.getByLabel('Napomena o predaji')).toHaveValue('');
+    await expect(page.getByText('Dostava nije spremljena.')).toHaveCount(0);
+    const summary = page.getByRole('region', {
+        name: 'Sažetak trenutačne stanice',
+    });
+    await expect(summary).toBeFocused();
+    const summaryBox = await summary.boundingBox();
+    expect(summaryBox).not.toBeNull();
+    expect(summaryBox?.y ?? 0).toBeGreaterThanOrEqual(64);
+    await expect(
+        page.getByRole('status', {
+            name: 'Promjena trenutačne stanice',
+        }),
+    ).toContainText('Trenutačna stanica je Vukovarska 42, Zagreb.');
+});
+
+test('pickup manifest advancement resets local state and announces the new slot', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverDashboardPickupManifestAdvanceStory />);
+    await page
+        .getByRole('button', { name: 'Preuzeto bez QR etikete' })
+        .first()
+        .click();
+    await expect(page.getByRole('alert')).toContainText(
+        'Ishod preuzimanja nije spremljen.',
+    );
+
+    await page.getByRole('button', { name: 'Potvrdi prvi manifest' }).click();
+    await expect(
+        page.getByText('Ishod preuzimanja nije spremljen.'),
+    ).toHaveCount(0);
+    await expect(
+        page.getByRole('region', { name: 'Sažetak trenutačne stanice' }),
+    ).toBeFocused();
+    await expect(
+        page.getByRole('status', {
+            name: 'Promjena trenutačne stanice',
+        }),
+    ).toContainText('11:00');
+});
+
+test('locally projected pickup waits for the server checkpoint before accepting mutations', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverDashboardCrossQueuePickupStory />);
+    await expect(
+        page.getByText(
+            'Prethodna radnja još čeka potvrdu rute. Preuzimanje će se otključati čim poslužitelj potvrdi ovu lokaciju.',
+        ),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Skeniraj urode' }),
+    ).toBeDisabled();
+    await expect(
+        page.getByRole('button', { name: 'Preuzeto bez QR etikete' }),
+    ).toBeDisabled();
+    await expect(
+        page.getByRole('link', {
+            name: 'Navigacija do trenutačne stanice preuzimanja',
+        }),
+    ).toBeEnabled();
+});
+
+test('earlier pickup conflict blocks current mutations and exposes recovery without blocking navigation', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverDashboardEarlierPickupConflictStory />);
+    await expect(
+        page.getByText(
+            /Ranija radnja preuzimanja blokira sinkronizaciju ove rute/,
+        ),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Skeniraj urode' }),
+    ).toBeDisabled();
+    await expect(
+        page.getByRole('button', { name: 'Preuzeto bez QR etikete' }),
+    ).toBeDisabled();
+    await expect(
+        page.getByRole('link', {
+            name: 'Navigacija do trenutačne stanice preuzimanja',
+        }),
+    ).toBeEnabled();
+
+    await page
+        .getByRole('button', { name: 'Odbaci promjenu i osvježi' })
+        .click();
+    await expect(page.getByTestId('pickup-recovery-result')).toHaveText(
+        'pickup-earlier-conflict',
+    );
+});
+
+test('earlier retryable pickup failure also blocks current mutations until recovery', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverDashboardEarlierPickupFailureStory />);
+    await expect(
+        page.getByRole('button', { name: 'Pokušaj ponovno' }),
+    ).toBeEnabled();
+    await expect(
+        page.getByRole('button', { name: 'Skeniraj urode' }),
+    ).toBeDisabled();
+    await expect(
+        page.getByRole('button', { name: 'Preuzeto bez QR etikete' }),
+    ).toBeDisabled();
+    await expect(
+        page.getByRole('link', {
+            name: 'Navigacija do trenutačne stanice preuzimanja',
+        }),
+    ).toBeEnabled();
+});
+
+test('earlier pickup retry keeps current mutations blocked while the old command is sending', async ({
+    mount,
+    page,
+}) => {
+    const component = await mount(
+        <DriverDashboardEarlierPickupDeferredRetryStory />,
+    );
+    const scan = page.getByRole('button', { name: 'Skeniraj urode' });
+    const confirm = page.getByRole('button', {
+        name: 'Potvrdi preuzimanje i nastavi',
+    });
+
+    await expect(scan).toBeDisabled();
+    await expect(confirm).toBeDisabled();
+    await page.getByRole('button', { name: 'Pokušaj ponovno' }).click();
+
+    await expect(page.getByTestId('pickup-queue-state')).toHaveText('queued');
+    await expect(
+        page.getByText(/Ranija radnja preuzimanja čeka slanje/),
+    ).toBeVisible();
+    await expect(scan).toBeDisabled();
+    await expect(confirm).toBeDisabled();
+    await expect(
+        page.getByRole('button', { name: 'Pokušaj ponovno' }),
+    ).toHaveCount(0);
+
+    await component.update(
+        <DriverDashboardEarlierPickupDeferredRetryStory sendRetry />,
+    );
+    await expect(page.getByTestId('pickup-queue-state')).toHaveText('sending');
+    await expect(
+        page.getByText(/Ranija radnja preuzimanja se šalje/),
+    ).toBeVisible();
+    await expect(scan).toBeDisabled();
+    await expect(confirm).toBeDisabled();
+    await expect(
+        page.getByRole('button', { name: 'Pokušaj ponovno' }),
+    ).toHaveCount(0);
+
+    await component.update(
+        <DriverDashboardEarlierPickupDeferredRetryStory completeRetry />,
+    );
+    await expect(page.getByTestId('pickup-queue-state')).toHaveText('synced');
+    await expect(scan).toBeEnabled();
+    await expect(confirm).toBeEnabled();
+});
+
+test('locally projected deferred stop withholds direct retry until server confirmation', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverDashboardLocallyAdvancedDeferredStory />);
+    await expect(
+        page.getByRole('button', {
+            name: 'Ponovni pokušaj čeka potvrdu rute',
+        }),
+    ).toBeDisabled();
+});
+
+test('pickup command owns navigation and live scanning with an offline fallback', async ({
+    mount,
+    page,
+}) => {
+    const component = await mount(<DriverCurrentPickupCommandStory />);
+    await expect(
+        page.getByRole('link', {
+            name: 'Navigacija do trenutačne stanice preuzimanja',
+        }),
+    ).toBeEnabled();
+    await expect(
+        page.getByRole('button', { name: 'Skeniraj urode' }),
+    ).toBeEnabled();
+    await page.getByRole('button', { name: 'Preuzeto bez QR etikete' }).click();
+    await expect(page.getByTestId('current-stop-result')).toHaveText(
+        'item:missing-label',
+    );
+
+    await component.update(<DriverCurrentPickupCommandStory readyToConfirm />);
+    await page
+        .getByRole('button', { name: 'Potvrdi preuzimanje i nastavi' })
+        .click();
+    await expect(page.getByTestId('current-stop-result')).toHaveText(
+        'confirmed',
+    );
+
+    await component.update(
+        <DriverCurrentPickupCommandStory offline routeSyncBlocked />,
+    );
+    await expect(
+        page.getByRole('button', { name: 'Skeniranje nije dostupno' }),
+    ).toBeDisabled();
+    await expect(
+        page.getByText(
+            'Skeniranje i potvrda preuzimanja nastavljaju se nakon povratka veze.',
+        ),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', {
+            name: 'Navigacija do trenutačne stanice preuzimanja čeka novi plan',
+        }),
+    ).toBeDisabled();
+});
+
+test('pickup recovery failure remains inside the pickup command', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <DriverCurrentPickupCommandStory syncState="failed" failRecovery />,
+    );
+    await page.getByRole('button', { name: 'Pokušaj ponovno' }).click();
+    await expect(
+        page.getByRole('alert').filter({
+            hasText: 'Pokušaj preuzimanja nije uspio.',
+        }),
+    ).toBeVisible();
+});
+
+test('failed durable pickup scan stays retryable and never reports success', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverCurrentPickupCommandStory failScan />);
+    await page.getByRole('button', { name: 'Skeniraj urode' }).click();
+    const manualInput = page.getByLabel('Ručni unos');
+    for (const attempt of [1, 2]) {
+        await manualInput.fill('/trag/pickup-current-0001');
+        await page.getByRole('button', { name: 'Dodaj kod' }).click();
+        await expect(page.getByTestId('scan-attempts')).toHaveText(
+            String(attempt),
+        );
+        await expect(
+            page
+                .getByText(
+                    'Očitavanje nije sigurno spremljeno. Skeniraj QR kod ponovno.',
+                )
+                .first(),
+        ).toBeVisible();
+        await expect(page.getByText('0 očitano')).toBeVisible();
+    }
+});
+
+test('late durable scan completion cannot leak into a reopened scanner session', async ({
+    mount,
+    page,
+}) => {
+    const component = await mount(<HarvestTraceScannerSessionStory />);
+    const openScanner = page.getByRole('button', { name: 'Skeniraj urode' });
+
+    await openScanner.click();
+    await page.getByLabel('Ručni unos').fill('/trag/stari-urod');
+    await page.getByRole('button', { name: 'Dodaj kod' }).click();
+    await expect(page.getByText('1 očitano')).toBeVisible();
+    await page.getByRole('button', { name: 'Završi skeniranje' }).click();
+
+    await openScanner.click();
+    await expect(page.getByText('0 očitano')).toBeVisible();
+    await page.getByLabel('Ručni unos').fill('/trag/novi-urod');
+    await page.getByRole('button', { name: 'Dodaj kod' }).click();
+    await expect(page.getByText('1 očitano')).toBeVisible();
+
+    await component.update(
+        <HarvestTraceScannerSessionStory releaseFirstScan />,
+    );
+    await expect(page.getByText(/Novi urod · očitano/)).toBeVisible();
+    await expect(page.getByText(/Stari urod · očitano/)).toHaveCount(0);
+    await expect(page.getByText('1 očitano')).toBeVisible();
+});

--- a/apps/delivery/tests/driver-current-stop.spec.tsx
+++ b/apps/delivery/tests/driver-current-stop.spec.tsx
@@ -32,6 +32,15 @@ test.describe('320px current-stop command center', () => {
         const command = page.getByRole('region', {
             name: /skupna dostava/,
         });
+        const actionGroup = command.getByRole('group', {
+            name: 'Radnje trenutačne stanice',
+        });
+        const estimateGroup = command.getByRole('region', {
+            name: 'Procjene trenutačne stanice',
+        });
+        const criticalNotes = command.getByRole('region', {
+            name: 'Važne napomene za trenutačnu stanicu',
+        });
 
         await expect(command).toContainText('Ilica 42, Zagreb');
         await expect(command).toContainText('Ulaz iz dvorišta');
@@ -70,6 +79,20 @@ test.describe('320px current-stop command center', () => {
         ).toHaveCount(0);
         await expect(command).toContainText(
             'Napomena korisnika · Ana Anić · Rajčica Roma',
+        );
+        await expect(actionGroup).toBeVisible();
+        await expect(estimateGroup).toBeVisible();
+        await expect(criticalNotes).toBeVisible();
+        const orderedLabels = await command
+            .locator(':scope > [aria-label]')
+            .evaluateAll((elements) =>
+                elements.map((element) => element.getAttribute('aria-label')),
+            );
+        expect(orderedLabels.indexOf('Radnje trenutačne stanice')).toBeLessThan(
+            orderedLabels.indexOf('Procjene trenutačne stanice'),
+        );
+        expect(orderedLabels.indexOf('Radnje trenutačne stanice')).toBeLessThan(
+            orderedLabels.indexOf('Važne napomene za trenutačnu stanicu'),
         );
         await expect(
             command.getByText(


### PR DESCRIPTION
## Summary

- add mobile-first sticky pickup and delivery command centers with one-tap navigation, recipient contact, ETA, critical notes, and the next safe action
- keep queued, sending, failed, conflicted, and reconciliation state beside the command that caused it across live and offline routes
- harden live QR scanning, durable pickup persistence, bulk-recipient state resets, and run-level pickup ordering barriers
- cover 320px/PWA safe areas, keyboard/focus behavior, semantic headings, async scanner sessions, and queue recovery

## Validation

- `corepack pnpm --filter delivery lint`
- `corepack pnpm --filter delivery typecheck`
- `corepack pnpm --filter delivery test:unit` (239 passed)
- `corepack pnpm --filter delivery test:component` (80 passed)
- `corepack pnpm --filter delivery build`
- `git diff --check`

Closes #4132