### PR TITLE
feat(delivery): add compact route progress timeline

### DIFF
--- a/apps/delivery/app/api/map/[runId]/route.ts
+++ b/apps/delivery/app/api/map/[runId]/route.ts
@@ -4,7 +4,10 @@ import {
     accountCanTrackDeliveryRun,
     resolveDeliveryRunStopGroups,
 } from '../../../../lib/deliveryDashboard';
-import { buildDeliveryMapData } from '../../../../lib/deliveryMapData';
+import {
+    buildDeliveryMapData,
+    deliveryMapStopGroupSelectionId,
+} from '../../../../lib/deliveryMapData';
 import { driverDeliveryTrackingLocation } from '../../../../lib/deliveryTracking';
 import {
     buildGoogleStaticMapUrl,
@@ -76,6 +79,11 @@ export async function GET(
                         latitude: representative.latitude,
                         longitude: representative.longitude,
                         sequence: index + 1,
+                        selectionId: driverView
+                            ? deliveryMapStopGroupSelectionId(
+                                  group.items.map(({ stop }) => stop.id),
+                              )
+                            : null,
                     },
                 ];
             });
@@ -94,6 +102,7 @@ export async function GET(
                                     {
                                         latitude: pickupNode.latitude,
                                         longitude: pickupNode.longitude,
+                                        selectionId: pickupNode.id,
                                     },
                                 ]
                               : [],

--- a/apps/delivery/components/DeliveryInteractiveMap.tsx
+++ b/apps/delivery/components/DeliveryInteractiveMap.tsx
@@ -11,7 +11,9 @@ import {
     type DeliveryMapCoordinate,
     type DeliveryMapData,
     type DeliveryMapPosition,
+    type DeliveryMapSelection,
     decodeDeliveryMapPolyline,
+    deliveryMapSelectionKey,
     parseDeliveryMapData,
 } from '../lib/deliveryMapData';
 
@@ -20,6 +22,12 @@ type MapState = 'loading' | 'ready' | 'fallback';
 type MapLayers = {
     markers: google.maps.Marker[];
     polyline: google.maps.Polyline | null;
+};
+
+type RenderedMapData = {
+    layers: MapLayers;
+    positions: DeliveryMapPosition[];
+    selectionPositions: Map<string, DeliveryMapPosition>;
 };
 
 type GoogleMapsClient = {
@@ -118,9 +126,13 @@ function drawMapData(
     map: google.maps.Map,
     maps: GoogleMapsClient,
     data: DeliveryMapData,
-): { layers: MapLayers; positions: DeliveryMapPosition[] } {
+    selectedNode: DeliveryMapSelection | null,
+    onSelectedNodeChange: (selection: DeliveryMapSelection) => void,
+): RenderedMapData {
     const markers: google.maps.Marker[] = [];
     const positions: DeliveryMapPosition[] = [];
+    const selectionPositions = new Map<string, DeliveryMapPosition>();
+    const selectedKey = deliveryMapSelectionKey(selectedNode);
 
     if (data.driverLocation) {
         const driverPosition = position(data.driverLocation);
@@ -138,40 +150,70 @@ function drawMapData(
 
     data.pickupNodes.forEach((pickupNode, index) => {
         const pickupPosition = position(pickupNode);
+        const selection = pickupNode.selectionId
+            ? { kind: 'pickup' as const, id: pickupNode.selectionId }
+            : null;
+        const selectionKey = deliveryMapSelectionKey(selection);
+        const selected = Boolean(selectionKey && selectedKey === selectionKey);
         positions.push(pickupPosition);
-        markers.push(
-            new maps.Marker({
-                map,
-                position: pickupPosition,
-                title: `Lokacija preuzimanja ${index + 1}`,
-                label: {
-                    text: 'P',
-                    color: '#ffffff',
-                    fontSize: '11px',
-                    fontWeight: '700',
-                },
-                icon: markerIcon(maps, '#d97706', 10),
-            }),
-        );
+        if (selectionKey) {
+            selectionPositions.set(selectionKey, pickupPosition);
+        }
+        const marker = new maps.Marker({
+            map,
+            position: pickupPosition,
+            title: `Lokacija preuzimanja ${index + 1}`,
+            label: {
+                text: 'P',
+                color: '#ffffff',
+                fontSize: '11px',
+                fontWeight: '700',
+            },
+            icon: markerIcon(
+                maps,
+                selected ? '#92400e' : '#d97706',
+                selected ? 13 : 10,
+            ),
+            zIndex: selected ? 900 : undefined,
+        });
+        if (selection) {
+            marker.addListener('click', () => onSelectedNodeChange(selection));
+        }
+        markers.push(marker);
     });
 
     for (const stop of data.stops) {
         const stopPosition = position(stop);
+        const selection = stop.selectionId
+            ? { kind: 'delivery' as const, id: stop.selectionId }
+            : null;
+        const selectionKey = deliveryMapSelectionKey(selection);
+        const selected = Boolean(selectionKey && selectedKey === selectionKey);
         positions.push(stopPosition);
-        markers.push(
-            new maps.Marker({
-                map,
-                position: stopPosition,
-                title: `Dostavna stanica ${stop.sequence}`,
-                label: {
-                    text: String(stop.sequence),
-                    color: '#ffffff',
-                    fontSize: '11px',
-                    fontWeight: '700',
-                },
-                icon: markerIcon(maps, '#0f766e', 10),
-            }),
-        );
+        if (selectionKey) {
+            selectionPositions.set(selectionKey, stopPosition);
+        }
+        const marker = new maps.Marker({
+            map,
+            position: stopPosition,
+            title: `Dostavna stanica ${stop.sequence}`,
+            label: {
+                text: String(stop.sequence),
+                color: '#ffffff',
+                fontSize: '11px',
+                fontWeight: '700',
+            },
+            icon: markerIcon(
+                maps,
+                selected ? '#115e59' : '#0f766e',
+                selected ? 13 : 10,
+            ),
+            zIndex: selected ? 900 : undefined,
+        });
+        if (selection) {
+            marker.addListener('click', () => onSelectedNodeChange(selection));
+        }
+        markers.push(marker);
     }
 
     const routePositions = data.encodedPolyline
@@ -190,7 +232,11 @@ function drawMapData(
               })
             : null;
 
-    return { layers: { markers, polyline }, positions };
+    return {
+        layers: { markers, polyline },
+        positions,
+        selectionPositions,
+    };
 }
 
 function fitMap(
@@ -215,22 +261,32 @@ export function DeliveryInteractiveMap({
     mapUrl,
     version,
     title,
+    selectedNode = null,
+    onSelectedNodeChange,
 }: {
     apiKey: string;
     mapUrl: string;
     version: string | null;
     title: string;
+    selectedNode?: DeliveryMapSelection | null;
+    onSelectedNodeChange?: (selection: DeliveryMapSelection) => void;
 }) {
     const containerRef = useRef<HTMLElement>(null);
     const mapRef = useRef<google.maps.Map>(null);
     const mapsRef = useRef<GoogleMapsClient>(null);
     const layersRef = useRef<MapLayers>({ markers: [], polyline: null });
     const positionsRef = useRef<DeliveryMapPosition[]>([]);
+    const dataRef = useRef<DeliveryMapData>(null);
+    const selectedNodeRef = useRef<DeliveryMapSelection | null>(selectedNode);
+    const onSelectedNodeChangeRef = useRef(onSelectedNodeChange);
     const fittedMapUrlRef = useRef<string>(null);
     const [state, setState] = useState<MapState>(
         apiKey ? 'loading' : 'fallback',
     );
     const staticMapUrl = versionedMapUrl(mapUrl, version);
+    const selectedNodeKey = deliveryMapSelectionKey(selectedNode);
+    selectedNodeRef.current = selectedNode;
+    onSelectedNodeChangeRef.current = onSelectedNodeChange;
 
     useEffect(() => {
         if (!apiKey) return;
@@ -275,12 +331,29 @@ export function DeliveryInteractiveMap({
                 }
 
                 clearLayers(layersRef.current);
-                const rendered = drawMapData(map, maps, data);
+                const rendered = drawMapData(
+                    map,
+                    maps,
+                    data,
+                    selectedNodeRef.current,
+                    (selection) => onSelectedNodeChangeRef.current?.(selection),
+                );
                 layersRef.current = rendered.layers;
                 positionsRef.current = rendered.positions;
-                if (
-                    fittedMapUrlRef.current !== mapUrl &&
-                    rendered.positions.length > 0
+                dataRef.current = data;
+                const currentSelectedNodeKey = deliveryMapSelectionKey(
+                    selectedNodeRef.current,
+                );
+                const selectedPosition = currentSelectedNodeKey
+                    ? rendered.selectionPositions.get(currentSelectedNodeKey)
+                    : null;
+                if (selectedPosition) {
+                    map.setCenter(selectedPosition);
+                    map.setZoom(15);
+                } else if (
+                    rendered.positions.length > 0 &&
+                    (currentSelectedNodeKey ||
+                        fittedMapUrlRef.current !== mapUrl)
                 ) {
                     fitMap(map, maps, rendered.positions);
                     fittedMapUrlRef.current = mapUrl;
@@ -308,6 +381,32 @@ export function DeliveryInteractiveMap({
             );
         };
     }, [apiKey, mapUrl, version]);
+
+    useEffect(() => {
+        const map = mapRef.current;
+        const maps = mapsRef.current;
+        const data = dataRef.current;
+        if (!map || !maps || !data) return;
+        clearLayers(layersRef.current);
+        const rendered = drawMapData(
+            map,
+            maps,
+            data,
+            selectedNodeRef.current,
+            (selection) => onSelectedNodeChangeRef.current?.(selection),
+        );
+        layersRef.current = rendered.layers;
+        positionsRef.current = rendered.positions;
+        const selectedPosition = selectedNodeKey
+            ? rendered.selectionPositions.get(selectedNodeKey)
+            : null;
+        if (selectedPosition) {
+            map.setCenter(selectedPosition);
+            map.setZoom(15);
+        } else if (rendered.positions.length > 0) {
+            fitMap(map, maps, rendered.positions);
+        }
+    }, [selectedNodeKey]);
 
     useEffect(
         () => () => {

--- a/apps/delivery/components/DeliveryMap.tsx
+++ b/apps/delivery/components/DeliveryMap.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { DeliveryMapSelection } from '../lib/deliveryMapData';
 import { DeliveryInteractiveMap } from './DeliveryInteractiveMap';
 
 const browserApiKey =
@@ -9,10 +10,14 @@ export function DeliveryMap({
     mapUrl,
     version,
     title,
+    selectedNode,
+    onSelectedNodeChange,
 }: {
     mapUrl: string;
     version: string | null;
     title: string;
+    selectedNode?: DeliveryMapSelection | null;
+    onSelectedNodeChange?: (selection: DeliveryMapSelection) => void;
 }) {
     return (
         <DeliveryInteractiveMap
@@ -20,6 +25,8 @@ export function DeliveryMap({
             mapUrl={mapUrl}
             version={version}
             title={title}
+            selectedNode={selectedNode}
+            onSelectedNodeChange={onSelectedNodeChange}
         />
     );
 }

--- a/apps/delivery/components/DriverDashboard.tsx
+++ b/apps/delivery/components/DriverDashboard.tsx
@@ -20,7 +20,6 @@ import type { DriverTrackingState } from '../hooks/useDriverTracking';
 import {
     deliveryActionAcknowledgementBlocksRoute,
     deliveryActionCompletionMessage,
-    deliveryActionLocallyCompletesStop,
     deliveryActionPermanentFailureMessage,
     deliveryRouteStepsWithLocalActions,
 } from '../lib/deliveryActionPresentation';
@@ -49,6 +48,10 @@ import {
     formatDistance,
     formatTravelDuration,
 } from '../lib/deliveryFormatting';
+import {
+    type DeliveryMapSelection,
+    deliveryMapSelectionKey,
+} from '../lib/deliveryMapData';
 import { resolveRemainingPickupManifest } from '../lib/deliveryPickupCommand';
 import { scanPickupManifest } from '../lib/deliveryPickupScan';
 import {
@@ -56,6 +59,10 @@ import {
     deliveryRouteSelectionCandidatesFromBatches,
     inspectDeliveryRouteSelection,
 } from '../lib/deliveryRouteSelection';
+import {
+    deliveryRouteStepIdentity,
+    deliveryRouteTimelineItems,
+} from '../lib/deliveryRouteTimelinePresentation';
 import { groupByDeliveryStop } from '../lib/deliveryStopGrouping';
 import { deliveryTrackingMapVersion } from '../lib/deliveryTrackingPresentation';
 import { isDriverCommandResult } from '../lib/driverCommandResult';
@@ -67,13 +74,11 @@ import type {
 import { DeliveryAppHeader } from './DeliveryAppHeader';
 import { DeliveryBatchCard } from './DeliveryBatchCard';
 import { DeliveryMap } from './DeliveryMap';
-import {
-    DeliveryPickupCard,
-    type PickupManifestSyncSummary,
-} from './DeliveryPickupCard';
-import { DeliveryStopCard } from './DeliveryStopCard';
+import type { PickupManifestSyncSummary } from './DeliveryPickupCard';
 import { DriverCurrentStopCommandCenter } from './DriverCurrentStopCommandCenter';
 import { DriverRouteContinuity } from './DriverRouteContinuity';
+import { DriverRouteProgressTimeline } from './DriverRouteProgressTimeline';
+import { DriverRouteStepDetails } from './DriverRouteStepDetails';
 import { DriverTrackingStatus } from './DriverTrackingStatus';
 import { HarvestTraceScanner } from './HarvestTraceScanner';
 
@@ -590,6 +595,9 @@ export function DriverDashboard({
     onReconcileDeliverySync: () => unknown | Promise<unknown>;
 }) {
     const run = dashboard.activeRun;
+    const [selectedRouteStepId, setSelectedRouteStepId] = useState<
+        string | null
+    >(null);
     const displayedRouteSteps = run
         ? deliveryRouteStepsWithLocalActions(run.routeSteps, deliveryQueue)
         : [];
@@ -607,6 +615,60 @@ export function DriverDashboard({
                     deliveryActionAcknowledgementBlocksRoute(entry),
             ),
     );
+    const syncingRouteStepIds = new Set(
+        run
+            ? displayedRouteSteps.flatMap((step) => {
+                  const serverStep = run.routeSteps.find(
+                      (candidate) =>
+                          deliveryRouteStepIdentity(candidate) ===
+                          deliveryRouteStepIdentity(step),
+                  );
+                  return step.actionState === 'completed' &&
+                      serverStep?.actionState !== 'completed'
+                      ? [deliveryRouteStepIdentity(step)]
+                      : [];
+              })
+            : [],
+    );
+    const displayedTimelineItems = deliveryRouteTimelineItems(
+        displayedRouteSteps,
+        syncingRouteStepIds,
+    ).map((item) => {
+        if (item.state !== 'syncing') return item;
+        const stepIndex = displayedRouteSteps.findIndex(
+            (step) => deliveryRouteStepIdentity(step) === item.id,
+        );
+        const step = displayedRouteSteps[stepIndex];
+        const entry =
+            step?.kind === 'delivery' && step.stop.id
+                ? deliveryActionPendingEntryForStop(deliveryQueue, step.stop.id)
+                : undefined;
+        return {
+            ...item,
+            statusMessage: deliveryActionCompletionMessage(
+                entry,
+                !deliveryRouteSyncBlocked &&
+                    displayedRouteSteps.some(
+                        (candidate, candidateIndex) =>
+                            candidateIndex > stepIndex &&
+                            candidate.actionState === 'current',
+                    ),
+            ),
+        };
+    });
+    const selectedTimelineItem =
+        displayedTimelineItems.find(
+            (item) => item.id === selectedRouteStepId,
+        ) ?? null;
+    const selectMapNode = (selection: DeliveryMapSelection) => {
+        const selectionKey = deliveryMapSelectionKey(selection);
+        const item = displayedTimelineItems.find(
+            (candidate) =>
+                deliveryMapSelectionKey(candidate.mapSelection ?? null) ===
+                selectionKey,
+        );
+        setSelectedRouteStepId(item?.id ?? null);
+    };
     const currentPickup =
         currentRouteStep?.kind === 'pickup'
             ? queuedPickup(currentRouteStep.pickup, pickupQueue?.entries ?? [])
@@ -1042,6 +1104,10 @@ export function DriverDashboard({
                                     run.estimatesUpdatedAt,
                                 )}
                                 title="Karta aktivne dostavne rute"
+                                selectedNode={
+                                    selectedTimelineItem?.mapSelection ?? null
+                                }
+                                onSelectedNodeChange={selectMapNode}
                             />
                             <Card>
                                 <CardContent
@@ -1147,85 +1213,38 @@ export function DriverDashboard({
                                     Tijek rute
                                 </Typography>
                             </div>
-                            <div className="grid gap-3 lg:grid-cols-2">
-                                {displayedRouteSteps.map((step, stepIndex) => {
+                            <DriverRouteProgressTimeline
+                                items={displayedTimelineItems}
+                                selectedId={selectedRouteStepId}
+                                onSelectionChange={(item) =>
+                                    setSelectedRouteStepId(item?.id ?? null)
+                                }
+                                renderDetails={(item) => {
+                                    const stepIndex =
+                                        displayedRouteSteps.findIndex(
+                                            (candidate) =>
+                                                deliveryRouteStepIdentity(
+                                                    candidate,
+                                                ) === item.id,
+                                        );
+                                    const step = displayedRouteSteps[stepIndex];
+                                    if (!step) return null;
                                     if (step.kind === 'pickup') {
                                         const pickup = queuedPickup(
                                             step.pickup,
                                             pickupQueue?.entries ?? [],
                                         );
                                         return (
-                                            <DeliveryPickupCard
-                                                key={`pickup:${pickup.id}`}
-                                                pickup={pickup}
-                                                actionState={step.actionState}
-                                                pendingAction={pendingAction}
-                                                sync={pickupSyncSummary(
-                                                    pickup.id,
-                                                    pickupQueue,
-                                                )}
-                                                onScan={(scanValue) =>
-                                                    scanPickupManifest(
-                                                        pickup,
-                                                        scanValue,
-                                                        onPickupScan,
-                                                    )
-                                                }
-                                                onSetItemState={(
-                                                    pickupNodeId,
-                                                    manifestId,
-                                                    stopId,
-                                                    outcome,
-                                                ) =>
-                                                    onPickupItemState(
-                                                        pickupNodeId,
-                                                        manifestId,
-                                                        stopId,
-                                                        outcome,
-                                                    )
-                                                }
-                                                onResolveRemaining={(
-                                                    pickupNodeId,
-                                                    manifest,
-                                                ) =>
-                                                    resolveRemainingPickupManifest(
-                                                        pickupNodeId,
-                                                        manifest,
-                                                        onPickupItemState,
-                                                    )
-                                                }
-                                                onConfirmManifest={
-                                                    onConfirmPickupManifest
-                                                }
-                                                onRetrySync={onRetryPickupSync}
-                                                onDiscardSync={
-                                                    onDiscardPickupSync
-                                                }
-                                                showCurrentCommand={
-                                                    step.actionState !==
-                                                    'current'
-                                                }
+                                            <DriverRouteStepDetails
+                                                step={{
+                                                    ...step,
+                                                    pickup,
+                                                }}
                                             />
                                         );
                                     }
-                                    const stop = {
-                                        ...step.stop,
-                                        actionState: step.actionState,
-                                        lockedReason: step.lockedReason,
-                                        isCurrent:
-                                            step.actionState === 'current',
-                                    };
-                                    const deliverySyncEntry = stop.id
-                                        ? deliveryActionPendingEntryForStop(
-                                              deliveryQueue,
-                                              stop.id,
-                                          )
-                                        : undefined;
                                     return (
-                                        <div
-                                            key={`delivery:${stop.id ?? stop.requestId}`}
-                                            className="space-y-2"
-                                        >
+                                        <div className="space-y-2">
                                             {step.retryLaneRank !== null ? (
                                                 <Chip color="warning" size="sm">
                                                     Ponovni pokušaj #
@@ -1235,110 +1254,13 @@ export function DriverDashboard({
                                                         : null}
                                                 </Chip>
                                             ) : null}
-                                            {deliveryActionLocallyCompletesStop(
-                                                deliverySyncEntry,
-                                            ) ? (
-                                                <Alert color="info">
-                                                    {deliveryActionCompletionMessage(
-                                                        deliverySyncEntry,
-                                                        !deliveryRouteSyncBlocked &&
-                                                            displayedRouteSteps.some(
-                                                                (
-                                                                    candidate,
-                                                                    candidateIndex,
-                                                                ) =>
-                                                                    candidateIndex >
-                                                                        stepIndex &&
-                                                                    candidate.actionState ===
-                                                                        'current',
-                                                            ),
-                                                    )}
-                                                </Alert>
-                                            ) : null}
-                                            <DeliveryStopCard
-                                                stop={stop}
-                                                mode="driver"
-                                                routeRevision={
-                                                    run.routeRevision
-                                                }
-                                                pendingAction={pendingStopAction(
-                                                    pendingAction,
-                                                    stop.id,
-                                                )}
-                                                onRetry={() =>
-                                                    stop.id &&
-                                                    onRetry(
-                                                        run.id,
-                                                        stop.id,
-                                                        run.routeRevision,
-                                                    )
-                                                }
-                                                onArrive={() =>
-                                                    stop.id &&
-                                                    onArrive(
-                                                        run.id,
-                                                        stop.id,
-                                                        run.routeRevision,
-                                                    )
-                                                }
-                                                onDeliver={(notes) =>
-                                                    stop.id &&
-                                                    onDeliver(
-                                                        run.id,
-                                                        stop.id,
-                                                        run.routeRevision,
-                                                        notes,
-                                                    )
-                                                }
-                                                onException={(mutation) =>
-                                                    stop.id
-                                                        ? onException(
-                                                              run.id,
-                                                              stop.id,
-                                                              mutation,
-                                                          )
-                                                        : Promise.resolve({
-                                                              status: 'review-required',
-                                                              message:
-                                                                  'Stanica više nije dostupna. Osvježi rutu i provjeri odabir.',
-                                                          })
-                                                }
-                                                syncEntry={deliverySyncEntry}
-                                                verifiedTracePaths={
-                                                    stop.id
-                                                        ? deliveryActionVerifiedTracePaths(
-                                                              deliveryQueue,
-                                                              stop.id,
-                                                          )
-                                                        : []
-                                                }
-                                                onVerificationScan={(
-                                                    tracePath,
-                                                ) =>
-                                                    stop.id &&
-                                                    onVerificationScan(
-                                                        stop.id,
-                                                        tracePath,
-                                                    )
-                                                }
-                                                onRetrySync={
-                                                    onRetryDeliverySync
-                                                }
-                                                onDiscardSync={
-                                                    onDiscardDeliverySync
-                                                }
-                                                routeSyncBlocked={
-                                                    deliveryRouteSyncBlocked
-                                                }
-                                                showDriverCommand={
-                                                    step.actionState !==
-                                                    'current'
-                                                }
+                                            <DriverRouteStepDetails
+                                                step={step}
                                             />
                                         </div>
                                     );
-                                })}
-                            </div>
+                                }}
+                            />
                         </section>
                     </>
                 ) : (

--- a/apps/delivery/components/DriverRouteProgressTimeline.tsx
+++ b/apps/delivery/components/DriverRouteProgressTimeline.tsx
@@ -1,0 +1,328 @@
+'use client';
+
+import { Chip } from '@gredice/ui/Chip';
+import {
+    Check,
+    ExpandDown,
+    Hourglass,
+    Lock,
+    MapPin,
+    Navigate,
+    Reset,
+    Timer,
+    Truck,
+    Warning,
+} from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import {
+    type KeyboardEvent,
+    type ReactNode,
+    useEffect,
+    useId,
+    useRef,
+    useState,
+} from 'react';
+import {
+    formatDeliveryTime,
+    formatTravelDuration,
+} from '../lib/deliveryFormatting';
+import type {
+    DriverRouteTimelineItem,
+    DriverRouteTimelineState,
+} from '../lib/deliveryRouteTimelinePresentation';
+
+function stateLabel(state: DriverRouteTimelineState) {
+    switch (state) {
+        case 'completed':
+            return 'Dovršeno';
+        case 'syncing':
+            return 'Dovršeno · čeka sinkronizaciju';
+        case 'current':
+            return 'Trenutačna stanica';
+        case 'next':
+            return 'Sljedeća stanica';
+        case 'upcoming':
+            return 'Nadolazeća stanica';
+        case 'retry':
+            return 'Ponovni pokušaj';
+        case 'exception':
+            return 'Iznimka';
+        case 'locked':
+            return 'Čeka redoslijed';
+    }
+}
+
+function stateColor(state: DriverRouteTimelineState) {
+    switch (state) {
+        case 'completed':
+            return 'success' as const;
+        case 'syncing':
+            return 'info' as const;
+        case 'current':
+        case 'next':
+            return 'info' as const;
+        case 'retry':
+            return 'warning' as const;
+        case 'exception':
+            return 'error' as const;
+        case 'upcoming':
+        case 'locked':
+            return 'neutral' as const;
+    }
+}
+
+function stateBorder(state: DriverRouteTimelineState) {
+    switch (state) {
+        case 'completed':
+            return 'border-l-emerald-600';
+        case 'syncing':
+            return 'border-l-sky-600 bg-sky-50/40 dark:bg-sky-950/20';
+        case 'current':
+            return 'border-l-primary bg-primary/5';
+        case 'next':
+            return 'border-l-sky-600';
+        case 'retry':
+            return 'border-l-amber-600';
+        case 'exception':
+            return 'border-l-destructive';
+        case 'locked':
+            return 'border-l-muted-foreground/40 bg-muted/30';
+        case 'upcoming':
+            return 'border-l-border';
+    }
+}
+
+function StateIcon({ state }: { state: DriverRouteTimelineState }) {
+    const className = 'size-4';
+    switch (state) {
+        case 'completed':
+            return <Check aria-hidden className={className} />;
+        case 'syncing':
+            return <Hourglass aria-hidden className={className} />;
+        case 'current':
+            return <MapPin aria-hidden className={className} />;
+        case 'next':
+            return <Navigate aria-hidden className={className} />;
+        case 'retry':
+            return <Reset aria-hidden className={className} />;
+        case 'exception':
+            return <Warning aria-hidden className={className} />;
+        case 'locked':
+            return <Lock aria-hidden className={className} />;
+        case 'upcoming':
+            return <Timer aria-hidden className={className} />;
+    }
+}
+
+function countLabel(count: number) {
+    return `${count} ${count === 1 ? 'urod' : 'uroda'}`;
+}
+
+function focusTimelineTrigger(
+    itemIds: readonly string[],
+    triggerRefs: Map<string, HTMLButtonElement>,
+    currentId: string,
+    key: KeyboardEvent<HTMLButtonElement>['key'],
+) {
+    const currentIndex = itemIds.indexOf(currentId);
+    if (currentIndex < 0) return false;
+    let nextIndex: number | null = null;
+    if (key === 'ArrowDown') {
+        nextIndex = (currentIndex + 1) % itemIds.length;
+    } else if (key === 'ArrowUp') {
+        nextIndex = (currentIndex - 1 + itemIds.length) % itemIds.length;
+    } else if (key === 'Home') {
+        nextIndex = 0;
+    } else if (key === 'End') {
+        nextIndex = itemIds.length - 1;
+    }
+    const nextId = nextIndex === null ? null : itemIds[nextIndex];
+    if (!nextId) return false;
+    triggerRefs.get(nextId)?.focus();
+    return true;
+}
+
+export function DriverRouteProgressTimeline({
+    items,
+    renderDetails,
+    onSelectionChange,
+    selectedId,
+    label = 'Tijek dostavne rute',
+}: {
+    items: readonly DriverRouteTimelineItem[];
+    renderDetails: (item: DriverRouteTimelineItem) => ReactNode;
+    onSelectionChange?: (item: DriverRouteTimelineItem | null) => void;
+    selectedId?: string | null;
+    label?: string;
+}) {
+    const [internalExpandedId, setInternalExpandedId] = useState<string | null>(
+        null,
+    );
+    const expandedId =
+        selectedId === undefined ? internalExpandedId : selectedId;
+    const timelineId = useId();
+    const triggerRefs = useRef(new Map<string, HTMLButtonElement>());
+    const itemIds = items.map((item) => item.id);
+
+    useEffect(() => {
+        if (expandedId && !items.some((item) => item.id === expandedId)) {
+            setInternalExpandedId(null);
+            onSelectionChange?.(null);
+        }
+    }, [expandedId, items, onSelectionChange]);
+
+    return (
+        <ol aria-label={label} className="space-y-2">
+            {items.map((item) => {
+                const expanded = expandedId === item.id;
+                const triggerId = `${timelineId}-${item.id}-trigger`;
+                const panelId = `${timelineId}-${item.id}-details`;
+                return (
+                    <li
+                        key={item.id}
+                        data-route-state={item.state}
+                        className={`overflow-hidden rounded-lg border border-l-4 bg-card shadow-sm ${stateBorder(item.state)}`}
+                    >
+                        <button
+                            ref={(element) => {
+                                if (element) {
+                                    triggerRefs.current.set(item.id, element);
+                                } else {
+                                    triggerRefs.current.delete(item.id);
+                                }
+                            }}
+                            id={triggerId}
+                            type="button"
+                            aria-controls={panelId}
+                            aria-expanded={expanded}
+                            aria-current={
+                                item.state === 'current' ? 'step' : undefined
+                            }
+                            className="flex min-h-16 w-full items-start gap-3 px-3 py-3 text-left outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                            onClick={() => {
+                                const nextExpandedId = expanded
+                                    ? null
+                                    : item.id;
+                                setInternalExpandedId(nextExpandedId);
+                                onSelectionChange?.(
+                                    nextExpandedId ? item : null,
+                                );
+                            }}
+                            onKeyDown={(event) => {
+                                if (
+                                    focusTimelineTrigger(
+                                        itemIds,
+                                        triggerRefs.current,
+                                        item.id,
+                                        event.key,
+                                    )
+                                ) {
+                                    event.preventDefault();
+                                }
+                            }}
+                        >
+                            <span className="sr-only">
+                                Stanica {item.sequence}.{' '}
+                            </span>
+                            <span
+                                aria-hidden
+                                className="flex size-9 shrink-0 items-center justify-center rounded-full border bg-background text-sm font-semibold tabular-nums"
+                            >
+                                {item.sequence}
+                            </span>
+                            <span className="min-w-0 flex-1 space-y-1.5">
+                                <span className="flex flex-wrap items-center gap-1.5">
+                                    <Chip
+                                        color={stateColor(item.state)}
+                                        size="sm"
+                                        startDecorator={
+                                            <StateIcon state={item.state} />
+                                        }
+                                    >
+                                        {stateLabel(item.state)}
+                                    </Chip>
+                                    <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                                        {item.kind === 'pickup' ? (
+                                            <MapPin
+                                                aria-hidden
+                                                className="size-3.5"
+                                            />
+                                        ) : (
+                                            <Truck
+                                                aria-hidden
+                                                className="size-3.5"
+                                            />
+                                        )}
+                                        {item.kind === 'pickup'
+                                            ? 'Preuzimanje'
+                                            : 'Dostava'}
+                                    </span>
+                                </span>
+                                <span className="block truncate font-semibold">
+                                    {item.title}
+                                </span>
+                                <span className="block truncate text-sm text-muted-foreground">
+                                    {item.destination}
+                                </span>
+                                <span className="sr-only">
+                                    {`${countLabel(item.deliveryCount)}${
+                                        item.estimatedArrivalAt
+                                            ? `, procijenjeni dolazak ${formatDeliveryTime(item.estimatedArrivalAt)}`
+                                            : ''
+                                    }${
+                                        item.estimatedTravelSeconds !== null
+                                            ? `, ${formatTravelDuration(item.estimatedTravelSeconds)} vožnje`
+                                            : ''
+                                    }`}
+                                </span>
+                                <span
+                                    aria-hidden
+                                    className="block truncate text-xs text-muted-foreground"
+                                >
+                                    {countLabel(item.deliveryCount)}
+                                    {item.estimatedArrivalAt ? (
+                                        <>
+                                            <span aria-hidden> · </span>ETA{' '}
+                                            {formatDeliveryTime(
+                                                item.estimatedArrivalAt,
+                                            )}
+                                        </>
+                                    ) : null}
+                                    {item.estimatedTravelSeconds !== null ? (
+                                        <>
+                                            <span aria-hidden> · </span>
+                                            {formatTravelDuration(
+                                                item.estimatedTravelSeconds,
+                                            )}
+                                        </>
+                                    ) : null}
+                                </span>
+                                {item.statusMessage ? (
+                                    <span className="block text-xs text-sky-800 dark:text-sky-200">
+                                        {item.statusMessage}
+                                    </span>
+                                ) : null}
+                            </span>
+                            <ExpandDown
+                                aria-hidden
+                                className={`mt-2 size-5 shrink-0 transition-transform motion-reduce:transition-none ${expanded ? 'rotate-180' : ''}`}
+                            />
+                        </button>
+                        {expanded ? (
+                            <section
+                                id={panelId}
+                                aria-labelledby={triggerId}
+                                className="border-t bg-background p-3"
+                            >
+                                <Typography level="body3" className="sr-only">
+                                    Detalji stanice {item.sequence}
+                                </Typography>
+                                {renderDetails(item)}
+                            </section>
+                        ) : null}
+                    </li>
+                );
+            })}
+        </ol>
+    );
+}

--- a/apps/delivery/components/DriverRouteStepDetails.tsx
+++ b/apps/delivery/components/DriverRouteStepDetails.tsx
@@ -1,0 +1,286 @@
+import { Chip } from '@gredice/ui/Chip';
+import { ExternalLink, Leaf, MapPin, User, Warning } from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import type { DeliveryRouteStepSummary } from '../lib/deliveryDashboardTypes';
+import {
+    deliveryExceptionOutcomeLabel,
+    deliveryExceptionReasonLabel,
+} from '../lib/deliveryExceptionPresentation';
+import {
+    formatDeliveryDateTime,
+    formatDeliveryTime,
+} from '../lib/deliveryFormatting';
+
+function harvestLabel({
+    plantName,
+    raisedBedName,
+    fieldName,
+}: {
+    plantName: string;
+    raisedBedName: string | null;
+    fieldName: string | null;
+}) {
+    return [plantName, raisedBedName, fieldName].filter(Boolean).join(' · ');
+}
+
+function pickupItemStateLabel(
+    state: Extract<
+        DeliveryRouteStepSummary,
+        { kind: 'pickup' }
+    >['pickup']['manifests'][number]['items'][number]['state'],
+) {
+    switch (state) {
+        case 'ready':
+            return 'Spremno';
+        case 'scanned':
+            return 'Skenirano';
+        case 'missing-label':
+            return 'Preuzeto bez etikete';
+        case 'not-ready':
+            return 'Nije preuzeto';
+    }
+}
+
+function TraceLink({ tracePath }: { tracePath: string }) {
+    return (
+        <a
+            href={`https://www.gredice.com${tracePath}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex min-h-11 items-center gap-1.5 rounded-md px-2 text-sm font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+            Trag uroda
+            <ExternalLink aria-hidden className="size-4" />
+        </a>
+    );
+}
+
+function PickupDetails({
+    step,
+}: {
+    step: Extract<DeliveryRouteStepSummary, { kind: 'pickup' }>;
+}) {
+    const pickup = step.pickup;
+    return (
+        <div className="space-y-3">
+            <div className="flex flex-wrap gap-2">
+                <Chip size="sm">Očekivano {pickup.expectedCount}</Chip>
+                <Chip color="success" size="sm">
+                    Skenirano {pickup.scannedCount}
+                </Chip>
+                {pickup.missingLabelCount > 0 ? (
+                    <Chip color="warning" size="sm">
+                        Bez etikete {pickup.missingLabelCount}
+                    </Chip>
+                ) : null}
+                {pickup.notReadyCount > 0 ? (
+                    <Chip color="error" size="sm">
+                        Nije preuzeto {pickup.notReadyCount}
+                    </Chip>
+                ) : null}
+                <Chip color="neutral" size="sm">
+                    Preostalo {pickup.remainingCount}
+                </Chip>
+            </div>
+            {pickup.manifests.length > 0 ? (
+                <div className="space-y-3">
+                    {pickup.manifests.map((manifest) => (
+                        <section
+                            key={manifest.id}
+                            aria-label={`Termin preuzimanja ${formatDeliveryTime(manifest.startAt)}–${formatDeliveryTime(manifest.endAt)}`}
+                            className="rounded-md border bg-muted/20 p-3"
+                        >
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                                <Typography level="body2" semiBold>
+                                    Termin{' '}
+                                    {formatDeliveryTime(manifest.startAt)}–
+                                    {formatDeliveryTime(manifest.endAt)}
+                                </Typography>
+                                <Chip
+                                    color={
+                                        manifest.state === 'confirmed'
+                                            ? 'success'
+                                            : 'neutral'
+                                    }
+                                    size="sm"
+                                >
+                                    {manifest.state === 'confirmed'
+                                        ? 'Potvrđeno'
+                                        : 'Čeka potvrdu'}
+                                </Chip>
+                            </div>
+                            <ul className="mt-3 space-y-2">
+                                {manifest.items.map((item) => (
+                                    <li
+                                        key={item.id}
+                                        className="rounded-md bg-background p-3"
+                                    >
+                                        <div className="flex flex-wrap items-start justify-between gap-2">
+                                            <Typography level="body3" semiBold>
+                                                {harvestLabel(item.harvest)}
+                                            </Typography>
+                                            <Chip
+                                                color={
+                                                    item.state === 'scanned'
+                                                        ? 'success'
+                                                        : item.state ===
+                                                            'not-ready'
+                                                          ? 'error'
+                                                          : item.state ===
+                                                              'missing-label'
+                                                            ? 'warning'
+                                                            : 'neutral'
+                                                }
+                                                size="sm"
+                                            >
+                                                {pickupItemStateLabel(
+                                                    item.state,
+                                                )}
+                                            </Chip>
+                                        </div>
+                                        {item.tracePath ? (
+                                            <TraceLink
+                                                tracePath={item.tracePath}
+                                            />
+                                        ) : null}
+                                    </li>
+                                ))}
+                            </ul>
+                        </section>
+                    ))}
+                </div>
+            ) : (
+                <Typography level="body3" className="text-muted-foreground">
+                    Detalji manifesta nisu dostupni u ovoj kopiji rute.
+                </Typography>
+            )}
+        </div>
+    );
+}
+
+function DeliveryDetails({
+    step,
+}: {
+    step: Extract<DeliveryRouteStepSummary, { kind: 'delivery' }>;
+}) {
+    const stop = step.stop;
+    return (
+        <div className="space-y-3">
+            {stop.addressLabel ? (
+                <div className="flex items-start gap-2 rounded-md bg-muted/40 p-3">
+                    <MapPin
+                        aria-hidden
+                        className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+                    />
+                    <div>
+                        <Typography level="body3" semiBold>
+                            Uputa za adresu
+                        </Typography>
+                        <Typography level="body3">
+                            {stop.addressLabel}
+                        </Typography>
+                    </div>
+                </div>
+            ) : null}
+            <ul className="space-y-3">
+                {stop.deliveries.map((delivery) => (
+                    <li
+                        key={delivery.requestId}
+                        className="rounded-md border bg-muted/20 p-3"
+                    >
+                        <div className="flex items-start gap-2">
+                            <User
+                                aria-hidden
+                                className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+                            />
+                            <div className="min-w-0">
+                                <Typography level="body2" semiBold>
+                                    {delivery.contactName}
+                                </Typography>
+                                {delivery.phone ? (
+                                    <Typography
+                                        level="body3"
+                                        className="text-muted-foreground"
+                                    >
+                                        Telefon: {delivery.phone}
+                                    </Typography>
+                                ) : null}
+                            </div>
+                        </div>
+                        <div className="mt-3 flex items-start gap-2">
+                            <Leaf
+                                aria-hidden
+                                className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+                            />
+                            <Typography level="body3">
+                                {harvestLabel(delivery.harvest)}
+                            </Typography>
+                        </div>
+                        {delivery.exception ? (
+                            <div className="mt-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-amber-950 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
+                                <div className="flex items-start gap-2">
+                                    <Warning
+                                        aria-hidden
+                                        className="mt-0.5 size-4 shrink-0"
+                                    />
+                                    <div>
+                                        <Typography level="body3" semiBold>
+                                            {deliveryExceptionOutcomeLabel(
+                                                delivery.exception.outcome,
+                                            )}
+                                        </Typography>
+                                        <Typography level="body3">
+                                            {deliveryExceptionReasonLabel(
+                                                delivery.exception.reason,
+                                            )}
+                                        </Typography>
+                                        {delivery.exception.note ? (
+                                            <Typography level="body3">
+                                                {delivery.exception.note}
+                                            </Typography>
+                                        ) : null}
+                                        <Typography
+                                            level="body3"
+                                            className="text-current/70"
+                                        >
+                                            {formatDeliveryDateTime(
+                                                delivery.exception.occurredAt,
+                                            )}
+                                        </Typography>
+                                    </div>
+                                </div>
+                            </div>
+                        ) : null}
+                        {delivery.requestNotes ? (
+                            <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+                                <strong>Napomena korisnika:</strong>{' '}
+                                {delivery.requestNotes}
+                            </div>
+                        ) : null}
+                        {delivery.deliveryNotes ? (
+                            <div className="mt-3 rounded-md bg-muted p-3 text-sm">
+                                <strong>Napomena dostave:</strong>{' '}
+                                {delivery.deliveryNotes}
+                            </div>
+                        ) : null}
+                        {delivery.harvest.tracePath ? (
+                            <TraceLink tracePath={delivery.harvest.tracePath} />
+                        ) : null}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+export function DriverRouteStepDetails({
+    step,
+}: {
+    step: DeliveryRouteStepSummary;
+}) {
+    return step.kind === 'pickup' ? (
+        <PickupDetails step={step} />
+    ) : (
+        <DeliveryDetails step={step} />
+    );
+}

--- a/apps/delivery/components/OfflineRoutePanel.tsx
+++ b/apps/delivery/components/OfflineRoutePanel.tsx
@@ -2,9 +2,8 @@
 
 import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
-import { Card, CardContent } from '@gredice/ui/Card';
 import { Chip } from '@gredice/ui/Chip';
-import { MapPin, Navigate, Warning } from '@gredice/ui/icons';
+import { Navigate, Warning } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
 import type { ReactNode } from 'react';
 import {
@@ -30,8 +29,11 @@ import {
     formatDeliveryDateTime,
     formatDeliveryTime,
     formatDistance,
-    formatTravelDuration,
 } from '../lib/deliveryFormatting';
+import type {
+    DriverRouteTimelineItem,
+    DriverRouteTimelineState,
+} from '../lib/deliveryRouteTimelinePresentation';
 import type {
     OfflineRouteDeliveryStep,
     OfflineRoutePickupStep,
@@ -40,10 +42,7 @@ import type {
 } from '../lib/offlineRouteCache';
 import { DriverCurrentStopCommandCenter } from './DriverCurrentStopCommandCenter';
 import { DeliveryActionSyncStatus } from './DriverDashboard';
-
-function stepTitle(step: OfflineRouteStep) {
-    return step.kind === 'pickup' ? step.name : step.statusLabel;
-}
+import { DriverRouteProgressTimeline } from './DriverRouteProgressTimeline';
 
 function stepItems(step: OfflineRouteStep) {
     return step.kind === 'pickup'
@@ -75,9 +74,68 @@ function stepItems(step: OfflineRouteStep) {
               ]
                   .filter(Boolean)
                   .join(' · '),
-              detail: item.contactName,
+              detail: [item.contactName, item.phone]
+                  .filter(Boolean)
+                  .join(' · '),
               note: item.requestNotes,
           }));
+}
+
+function offlineStepIdentity(step: OfflineRouteStep) {
+    return `${step.kind}:${step.id ?? step.itinerarySequence}`;
+}
+
+function offlineTimelineState(
+    step: OfflineRouteStep,
+    index: number,
+    activeStepIndex: number,
+): DriverRouteTimelineState {
+    if (
+        step.kind === 'delivery' &&
+        (step.stopState === 'failed' ||
+            step.stopState === 'cancelled' ||
+            step.items.some(
+                (item) =>
+                    item.exception?.outcome === 'failed' ||
+                    item.exception?.outcome === 'cancelled',
+            ))
+    ) {
+        return 'exception';
+    }
+    if (
+        step.kind === 'delivery' &&
+        (step.stopState === 'deferred' || step.retryLaneRank !== null)
+    ) {
+        return 'retry';
+    }
+    if (index < activeStepIndex) return 'syncing';
+    if (index === activeStepIndex) return 'current';
+    if (index === activeStepIndex + 1) return 'next';
+    if (step.actionState === 'locked') return 'locked';
+    return 'upcoming';
+}
+
+function offlineTimelineItems(
+    steps: readonly OfflineRouteStep[],
+    activeStepIndex: number,
+): DriverRouteTimelineItem[] {
+    return steps.map((step, index) => ({
+        id: offlineStepIdentity(step),
+        sequence: step.itinerarySequence,
+        kind: step.kind,
+        state: offlineTimelineState(step, index, activeStepIndex),
+        title:
+            step.kind === 'pickup'
+                ? step.name
+                : step.items.length === 1
+                  ? (step.items[0]?.contactName ?? step.statusLabel)
+                  : `${step.items.length} primatelja`,
+        destination: step.address,
+        deliveryCount:
+            step.kind === 'pickup' ? step.expectedCount : step.items.length,
+        estimatedArrivalAt: step.estimatedArrivalAt,
+        estimatedTravelSeconds: step.estimatedTravelSeconds,
+    }));
 }
 
 function hasDeliveryStopId(
@@ -243,6 +301,20 @@ export function OfflineRoutePanel({
         currentStep && hasDeliveryStopId(currentStep)
             ? offlineDeliveryStop(currentStep, snapshot.scope.runId)
             : null;
+    const timelineItems = offlineTimelineItems(
+        snapshot.steps,
+        activeStepIndex,
+    ).map((item) =>
+        item.state === 'syncing'
+            ? {
+                  ...item,
+                  statusMessage: deliveryActionCompletionMessage(
+                      firstEntry,
+                      !routeBarrier,
+                  ),
+              }
+            : item,
+    );
     return (
         <main className="min-h-[100dvh] bg-muted/30 p-4">
             <div className="mx-auto max-w-3xl space-y-4">
@@ -327,194 +399,149 @@ export function OfflineRoutePanel({
                         dok se veza ne vrati i plan ne osvježi.
                     </Alert>
                 ) : null}
-                {snapshot.steps.map((step, index) => {
-                    const actionState =
-                        index < activeStepIndex
-                            ? 'completed'
-                            : index === activeStepIndex
-                              ? 'current'
-                              : step.actionState;
-                    return (
-                        <Card
-                            key={`${step.kind}:${step.id}`}
-                            className={
-                                index === activeStepIndex
-                                    ? 'border-primary'
-                                    : undefined
-                            }
-                        >
-                            <CardContent noHeader className="space-y-3 p-4">
-                                <div className="flex items-start justify-between gap-3">
-                                    <div>
+                <section
+                    aria-labelledby="offline-route-timeline-heading"
+                    className="space-y-3"
+                >
+                    <Typography
+                        id="offline-route-timeline-heading"
+                        level="h3"
+                        semiBold
+                    >
+                        Tijek rute
+                    </Typography>
+                    <DriverRouteProgressTimeline
+                        items={timelineItems}
+                        label="Izvanmrežni tijek dostavne rute"
+                        renderDetails={(item) => {
+                            const index = snapshot.steps.findIndex(
+                                (candidate) =>
+                                    offlineStepIdentity(candidate) === item.id,
+                            );
+                            const step = snapshot.steps[index];
+                            if (!step) return null;
+                            const actionState =
+                                index < activeStepIndex
+                                    ? 'completed'
+                                    : index === activeStepIndex
+                                      ? 'current'
+                                      : step.actionState;
+                            return (
+                                <div className="space-y-3">
+                                    <div className="flex flex-wrap gap-2">
+                                        {step.kind === 'delivery' &&
+                                        step.slotStartAt ? (
+                                            <Chip size="sm">
+                                                Termin{' '}
+                                                {formatDeliveryTime(
+                                                    step.slotStartAt,
+                                                )}
+                                                {step.slotEndAt
+                                                    ? `–${formatDeliveryTime(step.slotEndAt)}`
+                                                    : ''}
+                                            </Chip>
+                                        ) : null}
+                                        {step.estimatedDistanceMeters !==
+                                        null ? (
+                                            <Chip size="sm">
+                                                {formatDistance(
+                                                    step.estimatedDistanceMeters,
+                                                )}
+                                            </Chip>
+                                        ) : null}
+                                    </div>
+                                    {index ===
+                                    activeStepIndex ? null : routeBarrier ||
+                                      actionState === 'locked' ||
+                                      index < activeStepIndex ||
+                                      (index > activeStepIndex &&
+                                          !deliveryQueued) ? (
+                                        <Button
+                                            disabled
+                                            variant="outlined"
+                                            aria-label={
+                                                index < activeStepIndex
+                                                    ? 'Navigacija do prethodne stanice nije potrebna'
+                                                    : index === activeStepIndex
+                                                      ? 'Navigacija do trenutačne stanice čeka novi plan'
+                                                      : routeBarrier
+                                                        ? 'Navigacija do sljedeće stanice čeka novi plan'
+                                                        : 'Navigacija do sljedeće stanice čeka završetak trenutačne dostave'
+                                            }
+                                            startDecorator={
+                                                <Navigate className="size-4" />
+                                            }
+                                        >
+                                            {index < activeStepIndex
+                                                ? 'Prethodna dostava je spremljena'
+                                                : index === activeStepIndex
+                                                  ? 'Navigacija čeka novi plan'
+                                                  : routeBarrier
+                                                    ? 'Navigacija čeka novi plan'
+                                                    : 'Navigacija čeka završetak dostave'}
+                                        </Button>
+                                    ) : (
+                                        <Button
+                                            href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(step.address)}`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            variant="outlined"
+                                            aria-label={
+                                                index === activeStepIndex
+                                                    ? 'Navigacija do trenutačne stanice'
+                                                    : 'Navigacija do sljedeće stanice'
+                                            }
+                                            startDecorator={
+                                                <Navigate className="size-4" />
+                                            }
+                                        >
+                                            Navigacija
+                                        </Button>
+                                    )}
+                                    {step.kind === 'delivery' &&
+                                    actionState === 'locked' &&
+                                    step.lockedReason ? (
                                         <Typography
                                             level="body3"
                                             className="text-muted-foreground"
                                         >
-                                            {index < activeStepIndex
-                                                ? firstEntry?.state === 'synced'
-                                                    ? 'Dovršeni korak čeka osvježenu rutu'
-                                                    : 'Dovršeni korak čeka potvrdu'
-                                                : index === activeStepIndex
-                                                  ? 'Trenutačni korak'
-                                                  : 'Sljedeći korak'}
+                                            {step.lockedReason}
                                         </Typography>
-                                        <Typography level="h3" semiBold>
-                                            {stepTitle(step)}
-                                        </Typography>
-                                    </div>
-                                    <Chip
-                                        color={
-                                            index === activeStepIndex
-                                                ? 'info'
-                                                : 'neutral'
-                                        }
-                                        size="sm"
-                                    >
-                                        #{step.itinerarySequence}
-                                    </Chip>
-                                </div>
-                                {index < activeStepIndex ? (
-                                    <Alert color="info">
-                                        {deliveryActionCompletionMessage(
-                                            firstEntry,
-                                            !routeBarrier,
-                                        )}
-                                    </Alert>
-                                ) : null}
-                                {index !== activeStepIndex ? (
-                                    <>
-                                        <Typography className="flex items-start gap-2">
-                                            <MapPin className="mt-0.5 size-4 shrink-0" />
-                                            {step.address}
-                                        </Typography>
-                                        <div className="flex flex-wrap gap-2">
-                                            {step.kind === 'delivery' &&
-                                            step.slotStartAt ? (
-                                                <Chip size="sm">
-                                                    Termin{' '}
-                                                    {formatDeliveryTime(
-                                                        step.slotStartAt,
-                                                    )}
-                                                    {step.slotEndAt
-                                                        ? `–${formatDeliveryTime(step.slotEndAt)}`
-                                                        : ''}
-                                                </Chip>
-                                            ) : null}
-                                            {step.estimatedArrivalAt ? (
-                                                <Chip size="sm">
-                                                    Dolazak{' '}
-                                                    {formatDeliveryDateTime(
-                                                        step.estimatedArrivalAt,
-                                                    )}
-                                                </Chip>
-                                            ) : null}
-                                            {step.estimatedTravelSeconds !==
-                                            null ? (
-                                                <Chip size="sm">
-                                                    {formatTravelDuration(
-                                                        step.estimatedTravelSeconds,
-                                                    )}
-                                                </Chip>
-                                            ) : null}
-                                            {step.estimatedDistanceMeters !==
-                                            null ? (
-                                                <Chip size="sm">
-                                                    {formatDistance(
-                                                        step.estimatedDistanceMeters,
-                                                    )}
-                                                </Chip>
-                                            ) : null}
-                                        </div>
-                                    </>
-                                ) : null}
-                                {index ===
-                                activeStepIndex ? null : routeBarrier ||
-                                  actionState === 'locked' ||
-                                  index < activeStepIndex ||
-                                  (index > activeStepIndex &&
-                                      !deliveryQueued) ? (
-                                    <Button
-                                        disabled
-                                        variant="outlined"
-                                        aria-label={
-                                            index < activeStepIndex
-                                                ? 'Navigacija do prethodne stanice nije potrebna'
-                                                : index === activeStepIndex
-                                                  ? 'Navigacija do trenutačne stanice čeka novi plan'
-                                                  : routeBarrier
-                                                    ? 'Navigacija do sljedeće stanice čeka novi plan'
-                                                    : 'Navigacija do sljedeće stanice čeka završetak trenutačne dostave'
-                                        }
-                                        startDecorator={
-                                            <Navigate className="size-4" />
-                                        }
-                                    >
-                                        {index < activeStepIndex
-                                            ? 'Prethodna dostava je spremljena'
-                                            : index === activeStepIndex
-                                              ? 'Navigacija čeka novi plan'
-                                              : routeBarrier
-                                                ? 'Navigacija čeka novi plan'
-                                                : 'Navigacija čeka završetak dostave'}
-                                    </Button>
-                                ) : (
-                                    <Button
-                                        href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(step.address)}`}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        variant="outlined"
-                                        aria-label={
-                                            index === activeStepIndex
-                                                ? 'Navigacija do trenutačne stanice'
-                                                : 'Navigacija do sljedeće stanice'
-                                        }
-                                        startDecorator={
-                                            <Navigate className="size-4" />
-                                        }
-                                    >
-                                        Navigacija
-                                    </Button>
-                                )}
-                                {step.kind === 'delivery' &&
-                                actionState === 'locked' &&
-                                step.lockedReason ? (
-                                    <Typography
-                                        level="body3"
-                                        className="text-muted-foreground"
-                                    >
-                                        {step.lockedReason}
-                                    </Typography>
-                                ) : null}
-                                <ul className="space-y-2">
-                                    {stepItems(step).map((item) => (
-                                        <li
-                                            key={item.id}
-                                            className="rounded-md bg-muted px-3 py-2"
-                                        >
-                                            <Typography level="body3" semiBold>
-                                                {item.label}
-                                            </Typography>
-                                            <Typography
-                                                level="body3"
-                                                className="text-muted-foreground"
+                                    ) : null}
+                                    <ul className="space-y-2">
+                                        {stepItems(step).map((item) => (
+                                            <li
+                                                key={item.id}
+                                                className="rounded-md bg-muted px-3 py-2"
                                             >
-                                                {item.detail}
-                                            </Typography>
-                                            {item.note ? (
                                                 <Typography
                                                     level="body3"
-                                                    className="mt-1 text-amber-800 dark:text-amber-200"
+                                                    semiBold
                                                 >
-                                                    Napomena: {item.note}
+                                                    {item.label}
                                                 </Typography>
-                                            ) : null}
-                                        </li>
-                                    ))}
-                                </ul>
-                            </CardContent>
-                        </Card>
-                    );
-                })}
+                                                <Typography
+                                                    level="body3"
+                                                    className="text-muted-foreground"
+                                                >
+                                                    {item.detail}
+                                                </Typography>
+                                                {item.note ? (
+                                                    <Typography
+                                                        level="body3"
+                                                        className="mt-1 text-amber-800 dark:text-amber-200"
+                                                    >
+                                                        Napomena: {item.note}
+                                                    </Typography>
+                                                ) : null}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            );
+                        }}
+                    />
+                </section>
                 <Typography level="body3" className="text-muted-foreground">
                     Kopija vrijedi najviše 24 sata i briše se završetkom rute,
                     promjenom korisnika ili odjavom.

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -44,6 +44,7 @@ import {
     customerDeliveryRecoverySummary,
     driverDeliveryExceptionSummary,
 } from './deliveryExceptionPresentation';
+import { deliveryMapStopGroupSelectionId } from './deliveryMapData';
 import {
     configuredDeliveryHqAddress,
     DeliveryRoutePlanningError,
@@ -765,6 +766,10 @@ async function activeRunSummary(
             itinerarySequence: Number.isFinite(itinerarySequence)
                 ? itinerarySequence
                 : executionStep.itinerarySequence,
+            mapNodeId:
+                deliveryMapStopGroupSelectionId(
+                    group.items.map(({ stop: groupStop }) => groupStop.id),
+                ) ?? undefined,
             retryLaneRank: executionStep.retryLaneRank ?? null,
             retryAttempt: executionStep.retryAttempt ?? 0,
             actionState,

--- a/apps/delivery/lib/deliveryDashboardTypes.ts
+++ b/apps/delivery/lib/deliveryDashboardTypes.ts
@@ -168,6 +168,7 @@ export type DeliveryRouteStepSummary =
     | {
           kind: 'delivery';
           itinerarySequence: number;
+          mapNodeId?: string;
           retryLaneRank: number | null;
           retryAttempt: number;
           actionState: 'locked' | 'upcoming' | 'current' | 'completed';

--- a/apps/delivery/lib/deliveryMapData.node.spec.ts
+++ b/apps/delivery/lib/deliveryMapData.node.spec.ts
@@ -3,12 +3,23 @@ import test from 'node:test';
 import {
     buildDeliveryMapData,
     decodeDeliveryMapPolyline,
+    deliveryMapSelectionKey,
+    deliveryMapStopGroupSelectionId,
     parseDeliveryMapData,
 } from './deliveryMapData';
 
 const driverLocation = { latitude: 45.801, longitude: 15.981 };
-const pickupNodes = [{ latitude: 45.79, longitude: 15.97 }];
-const stops = [{ latitude: 45.81, longitude: 16.01, sequence: 2 }];
+const pickupNodes = [
+    { latitude: 45.79, longitude: 15.97, selectionId: 'pickup-node-1' },
+];
+const stops = [
+    {
+        latitude: 45.81,
+        longitude: 16.01,
+        sequence: 2,
+        selectionId: '20',
+    },
+];
 
 test('keeps the complete route data in the driver map projection', () => {
     assert.deepEqual(
@@ -40,7 +51,7 @@ test('removes pickup checkpoints and the complete route from customer map data',
         {
             driverLocation,
             pickupNodes: [],
-            stops,
+            stops: stops.map((stop) => ({ ...stop, selectionId: null })),
             encodedPolyline: null,
         },
     );
@@ -69,7 +80,14 @@ test('validates map data received by the interactive client', () => {
         parseDeliveryMapData({
             driverLocation,
             pickupNodes,
-            stops: [{ latitude: 45.81, longitude: 16.01, sequence: 0 }],
+            stops: [
+                {
+                    latitude: 45.81,
+                    longitude: 16.01,
+                    sequence: 0,
+                    selectionId: 'invalid-stop',
+                },
+            ],
             encodedPolyline: null,
         }),
         null,
@@ -83,4 +101,24 @@ test('decodes Google encoded route polylines and rejects truncated input', () =>
         { lat: 43.252, lng: -126.453 },
     ]);
     assert.deepEqual(decodeDeliveryMapPolyline('_p~i'), []);
+});
+
+test('uses stable pickup and delivery keys for map timeline selection', () => {
+    assert.equal(deliveryMapSelectionKey(null), null);
+    assert.equal(
+        deliveryMapSelectionKey({ kind: 'pickup', id: 'pickup-node-1' }),
+        'pickup:pickup-node-1',
+    );
+    assert.equal(
+        deliveryMapSelectionKey({ kind: 'delivery', id: '40' }),
+        'delivery:40',
+    );
+    assert.equal(deliveryMapStopGroupSelectionId([41, 40, 41]), '40');
+    assert.equal(
+        deliveryMapStopGroupSelectionId(
+            Array.from({ length: 10_000 }, (_, index) => index + 1),
+        ),
+        '1',
+    );
+    assert.equal(deliveryMapStopGroupSelectionId([]), null);
 });

--- a/apps/delivery/lib/deliveryMapData.ts
+++ b/apps/delivery/lib/deliveryMapData.ts
@@ -3,13 +3,17 @@ export type DeliveryMapCoordinate = {
     longitude: number;
 };
 
-export type DeliveryMapStop = DeliveryMapCoordinate & {
+export type DeliveryMapNode = DeliveryMapCoordinate & {
+    selectionId: string | null;
+};
+
+export type DeliveryMapStop = DeliveryMapNode & {
     sequence: number;
 };
 
 export type DeliveryMapData = {
     driverLocation: DeliveryMapCoordinate | null;
-    pickupNodes: DeliveryMapCoordinate[];
+    pickupNodes: DeliveryMapNode[];
     stops: DeliveryMapStop[];
     encodedPolyline: string | null;
 };
@@ -18,6 +22,24 @@ export type DeliveryMapPosition = {
     lat: number;
     lng: number;
 };
+
+export type DeliveryMapSelection =
+    | { kind: 'pickup'; id: string }
+    | { kind: 'delivery'; id: string };
+
+export function deliveryMapSelectionKey(
+    selection: DeliveryMapSelection | null,
+) {
+    if (!selection) return null;
+    return `${selection.kind}:${selection.id}`;
+}
+
+export function deliveryMapStopGroupSelectionId(stopIds: readonly number[]) {
+    const uniqueStopIds = [...new Set(stopIds)]
+        .filter((stopId) => Number.isInteger(stopId) && stopId > 0)
+        .sort((first, second) => first - second);
+    return uniqueStopIds[0]?.toString() ?? null;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null;
@@ -41,9 +63,24 @@ function parseCoordinate(value: unknown): DeliveryMapCoordinate | null {
     return { latitude, longitude };
 }
 
-function parseStop(value: unknown): DeliveryMapStop | null {
+function parseNode(value: unknown): DeliveryMapNode | null {
     const coordinate = parseCoordinate(value);
     if (!coordinate || !isRecord(value)) return null;
+    const { selectionId } = value;
+    if (
+        selectionId !== null &&
+        (typeof selectionId !== 'string' ||
+            selectionId.length === 0 ||
+            selectionId.length > 512)
+    ) {
+        return null;
+    }
+    return { ...coordinate, selectionId };
+}
+
+function parseStop(value: unknown): DeliveryMapStop | null {
+    const node = parseNode(value);
+    if (!node || !isRecord(value)) return null;
     const { sequence } = value;
     if (
         typeof sequence !== 'number' ||
@@ -52,7 +89,7 @@ function parseStop(value: unknown): DeliveryMapStop | null {
     ) {
         return null;
     }
-    return { ...coordinate, sequence };
+    return { ...node, sequence };
 }
 
 function parseArray<T>(
@@ -75,7 +112,7 @@ export function parseDeliveryMapData(value: unknown): DeliveryMapData | null {
         value.driverLocation === null
             ? null
             : parseCoordinate(value.driverLocation);
-    const pickupNodes = parseArray(value.pickupNodes, parseCoordinate);
+    const pickupNodes = parseArray(value.pickupNodes, parseNode);
     const stops = parseArray(value.stops, parseStop);
     const encodedPolyline = value.encodedPolyline;
     if (
@@ -97,7 +134,7 @@ export function buildDeliveryMapData({
     customerView,
 }: {
     driverLocation: DeliveryMapCoordinate | null;
-    pickupNodes: DeliveryMapCoordinate[];
+    pickupNodes: DeliveryMapNode[];
     stops: DeliveryMapStop[];
     encodedPolyline?: string | null;
     customerView: boolean;
@@ -105,7 +142,9 @@ export function buildDeliveryMapData({
     return {
         driverLocation,
         pickupNodes: customerView ? [] : pickupNodes,
-        stops,
+        stops: customerView
+            ? stops.map((stop) => ({ ...stop, selectionId: null }))
+            : stops,
         encodedPolyline: customerView ? null : (encodedPolyline ?? null),
     };
 }

--- a/apps/delivery/lib/deliveryRouteTimelinePresentation.node.spec.ts
+++ b/apps/delivery/lib/deliveryRouteTimelinePresentation.node.spec.ts
@@ -1,0 +1,223 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type {
+    DeliveryRouteStepSummary,
+    DeliveryStopDeliverySummary,
+    DeliveryStopSummary,
+} from './deliveryDashboardTypes';
+import {
+    deliveryRouteStepIdentity,
+    deliveryRouteTimelineItems,
+} from './deliveryRouteTimelinePresentation';
+
+function deliveryItem(index: number): DeliveryStopDeliverySummary {
+    return {
+        stopId: index,
+        stopState: 'pending',
+        requestId: `request-${index}`,
+        requestState: 'in_delivery',
+        contactName: `Primatelj ${index}`,
+        phone: '+385 91 555 0101',
+        addressLabel: null,
+        requestNotes: null,
+        deliveryNotes: null,
+        harvest: {
+            plantName: `Urod ${index}`,
+            operationName: 'Berba',
+            raisedBedName: `Gredica ${index}`,
+            fieldName: null,
+            tracePath: `/trag/${index}`,
+        },
+        exception: null,
+    };
+}
+
+function deliveryStep({
+    id,
+    actionState,
+    stopState = 'pending',
+    retryLaneRank = null,
+    deliveryCount = 1,
+}: {
+    id: number | null;
+    actionState: Extract<
+        DeliveryRouteStepSummary,
+        { kind: 'delivery' }
+    >['actionState'];
+    stopState?: string;
+    retryLaneRank?: number | null;
+    deliveryCount?: number;
+}): Extract<DeliveryRouteStepSummary, { kind: 'delivery' }> {
+    const numericId = id ?? 99;
+    const deliveries = Array.from({ length: deliveryCount }, (_, index) =>
+        deliveryItem(numericId * 10 + index),
+    );
+    const stop: DeliveryStopSummary = {
+        id,
+        requestId: `request-stop-${numericId}`,
+        sequence: numericId,
+        stopState,
+        requestState: 'in_delivery',
+        statusLabel: stopState === 'delivered' ? 'Dostavljeno' : 'U dostavi',
+        isCurrent: actionState === 'current',
+        contactName: `Primatelj ${numericId}`,
+        phone: '+385 91 555 0101',
+        address: `Adresa ${numericId}, Zagreb`,
+        addressLabel: `Ulaz ${numericId}`,
+        requestNotes: null,
+        deliveryNotes: null,
+        slotStartAt: null,
+        slotEndAt: null,
+        estimatedArrivalAt: '2026-07-15T10:00:00.000Z',
+        estimatedTravelSeconds: 600,
+        estimatedDistanceMeters: 2_000,
+        reroutePending: false,
+        arrivedAt: null,
+        deliveredAt:
+            stopState === 'delivered' ? '2026-07-15T09:45:00.000Z' : null,
+        harvest: deliveries[0]?.harvest ?? deliveryItem(1).harvest,
+        recovery: null,
+        tracking: null,
+        runId: 'run-timeline',
+        deliveryCount,
+        deliveries,
+        actionState,
+        lockedReason: actionState === 'locked' ? 'Prethodna stanica' : null,
+    };
+    return {
+        kind: 'delivery',
+        itinerarySequence: numericId,
+        mapNodeId: id === null ? undefined : String(deliveries[0]?.stopId),
+        retryLaneRank,
+        retryAttempt: retryLaneRank === null ? 0 : 1,
+        actionState,
+        lockedReason: stop.lockedReason ?? null,
+        stop,
+    };
+}
+
+function pickupStep(
+    id: string,
+    itinerarySequence: number,
+): Extract<DeliveryRouteStepSummary, { kind: 'pickup' }> {
+    return {
+        kind: 'pickup',
+        itinerarySequence,
+        actionState: 'completed',
+        pickup: {
+            id,
+            pickupLocationId: itinerarySequence,
+            sequence: itinerarySequence,
+            itinerarySequence,
+            name: `Preuzimanje ${itinerarySequence}`,
+            address: `Lokacija ${itinerarySequence}, Zagreb`,
+            estimatedArrivalAt: null,
+            estimatedTravelSeconds: null,
+            estimatedDistanceMeters: null,
+            serviceDurationSeconds: null,
+            state: 'confirmed',
+            isCurrent: false,
+            expectedCount: 2,
+            scannedCount: 2,
+            missingLabelCount: 0,
+            notReadyCount: 0,
+            remainingCount: 0,
+            manifests: [],
+        },
+    };
+}
+
+test('derives completed, current, next, and locked route states with bulk counts', () => {
+    const steps: DeliveryRouteStepSummary[] = [
+        deliveryStep({
+            id: 1,
+            actionState: 'completed',
+            stopState: 'delivered',
+        }),
+        deliveryStep({ id: 2, actionState: 'current', deliveryCount: 3 }),
+        deliveryStep({ id: 3, actionState: 'upcoming' }),
+        deliveryStep({ id: 4, actionState: 'locked' }),
+    ];
+
+    const items = deliveryRouteTimelineItems(steps);
+    assert.deepEqual(
+        items.map((item) => item.state),
+        ['completed', 'current', 'next', 'locked'],
+    );
+    assert.equal(items[1]?.deliveryCount, 3);
+    assert.equal(items[1]?.title, 'Ulaz 2');
+    assert.deepEqual(items[1]?.mapSelection, {
+        kind: 'delivery',
+        id: '20',
+    });
+});
+
+test('keeps retry and terminal exception states ahead of route progress state', () => {
+    const items = deliveryRouteTimelineItems([
+        deliveryStep({
+            id: 5,
+            actionState: 'completed',
+            stopState: 'failed',
+        }),
+        deliveryStep({
+            id: 6,
+            actionState: 'current',
+            stopState: 'deferred',
+            retryLaneRank: 1,
+        }),
+    ]);
+
+    assert.deepEqual(
+        items.map((item) => item.state),
+        ['exception', 'retry'],
+    );
+});
+
+test('labels locally completed steps as syncing without masking exceptions', () => {
+    const completed = deliveryStep({ id: 7, actionState: 'completed' });
+    const exception = deliveryStep({
+        id: 8,
+        actionState: 'completed',
+        stopState: 'cancelled',
+    });
+    const syncingIds = new Set([
+        deliveryRouteStepIdentity(completed),
+        deliveryRouteStepIdentity(exception),
+    ]);
+
+    const items = deliveryRouteTimelineItems(
+        [completed, exception],
+        syncingIds,
+    );
+    assert.deepEqual(
+        items.map((item) => item.state),
+        ['syncing', 'exception'],
+    );
+});
+
+test('uses a stable request fallback when a delivery has no persisted stop id', () => {
+    const step = deliveryStep({ id: null, actionState: 'current' });
+    assert.equal(deliveryRouteStepIdentity(step), 'delivery:request-stop-99');
+    const withoutMapSequence = {
+        ...step,
+        stop: { ...step.stop, sequence: null },
+    };
+    assert.equal(
+        deliveryRouteTimelineItems([withoutMapSequence])[0]?.mapSelection,
+        null,
+    );
+});
+
+test('maps pickup checkpoints to their stable persisted identities', () => {
+    const items = deliveryRouteTimelineItems([
+        pickupStep('pickup-a', 1),
+        pickupStep('pickup-b', 2),
+    ]);
+    assert.deepEqual(
+        items.map((item) => item.mapSelection),
+        [
+            { kind: 'pickup', id: 'pickup-a' },
+            { kind: 'pickup', id: 'pickup-b' },
+        ],
+    );
+});

--- a/apps/delivery/lib/deliveryRouteTimelinePresentation.ts
+++ b/apps/delivery/lib/deliveryRouteTimelinePresentation.ts
@@ -1,0 +1,119 @@
+import type { DeliveryRouteStepSummary } from './deliveryDashboardTypes';
+import type { DeliveryMapSelection } from './deliveryMapData';
+
+export type DriverRouteTimelineState =
+    | 'completed'
+    | 'syncing'
+    | 'current'
+    | 'next'
+    | 'upcoming'
+    | 'retry'
+    | 'exception'
+    | 'locked';
+
+export type DriverRouteTimelineItem = {
+    id: string;
+    sequence: number;
+    kind: 'pickup' | 'delivery';
+    state: DriverRouteTimelineState;
+    title: string;
+    destination: string;
+    deliveryCount: number;
+    estimatedArrivalAt: string | null;
+    estimatedTravelSeconds: number | null;
+    mapSelection?: DeliveryMapSelection | null;
+    statusMessage?: string | null;
+};
+
+export function deliveryRouteStepIdentity(step: DeliveryRouteStepSummary) {
+    return step.kind === 'pickup'
+        ? `pickup:${step.pickup.id}`
+        : `delivery:${step.stop.id ?? step.stop.requestId}`;
+}
+
+function deliveryRouteTimelineState(
+    step: DeliveryRouteStepSummary,
+    stepIndex: number,
+    nextStepIndex: number,
+    syncingStepIds: ReadonlySet<string>,
+): DriverRouteTimelineState {
+    if (
+        step.kind === 'delivery' &&
+        (step.stop.stopState === 'failed' ||
+            step.stop.stopState === 'cancelled')
+    ) {
+        return 'exception';
+    }
+    if (
+        step.kind === 'delivery' &&
+        (step.retryLaneRank !== null || step.stop.stopState === 'deferred')
+    ) {
+        return 'retry';
+    }
+    if (syncingStepIds.has(deliveryRouteStepIdentity(step))) return 'syncing';
+    if (step.actionState === 'completed') return 'completed';
+    if (step.actionState === 'current') return 'current';
+    if (stepIndex === nextStepIndex) return 'next';
+    if (step.actionState === 'locked') return 'locked';
+    return 'upcoming';
+}
+
+export function deliveryRouteTimelineItems(
+    steps: readonly DeliveryRouteStepSummary[],
+    syncingStepIds: ReadonlySet<string> = new Set(),
+): DriverRouteTimelineItem[] {
+    const currentStepIndex = steps.findIndex(
+        (step) => step.actionState === 'current',
+    );
+    const nextStepIndex = steps.findIndex(
+        (step, index) =>
+            index > currentStepIndex && step.actionState !== 'completed',
+    );
+    return steps.map((step, stepIndex) => {
+        if (step.kind === 'pickup') {
+            const mapSelection = {
+                kind: 'pickup' as const,
+                id: step.pickup.id,
+            };
+            return {
+                id: deliveryRouteStepIdentity(step),
+                sequence: step.itinerarySequence,
+                kind: step.kind,
+                state: deliveryRouteTimelineState(
+                    step,
+                    stepIndex,
+                    nextStepIndex,
+                    syncingStepIds,
+                ),
+                title: step.pickup.name,
+                destination: step.pickup.address,
+                deliveryCount: step.pickup.expectedCount,
+                estimatedArrivalAt: step.pickup.estimatedArrivalAt,
+                estimatedTravelSeconds: step.pickup.estimatedTravelSeconds,
+                mapSelection,
+            };
+        }
+        return {
+            id: deliveryRouteStepIdentity(step),
+            sequence: step.itinerarySequence,
+            kind: step.kind,
+            state: deliveryRouteTimelineState(
+                step,
+                stepIndex,
+                nextStepIndex,
+                syncingStepIds,
+            ),
+            title: step.stop.addressLabel ?? step.stop.contactName,
+            destination: step.stop.address,
+            deliveryCount: step.stop.deliveryCount,
+            estimatedArrivalAt: step.stop.estimatedArrivalAt,
+            estimatedTravelSeconds: step.stop.estimatedTravelSeconds,
+            mapSelection: !step.mapNodeId
+                ? null
+                : {
+                      kind: 'delivery' as const,
+                      id: step.mapNodeId,
+                  },
+        };
+    });
+}

--- a/apps/delivery/tests/DeliveryInteractiveMapSelectionStory.tsx
+++ b/apps/delivery/tests/DeliveryInteractiveMapSelectionStory.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState } from 'react';
+import { DeliveryInteractiveMap } from '../components/DeliveryInteractiveMap';
+import type { DeliveryMapSelection } from '../lib/deliveryMapData';
+import { deliveryMapSelectionKey } from '../lib/deliveryMapData';
+
+export function DeliveryInteractiveMapSelectionStory() {
+    const [selectedNode, setSelectedNode] =
+        useState<DeliveryMapSelection | null>(null);
+    return (
+        <div>
+            <DeliveryInteractiveMap
+                apiKey="browser-test-key"
+                mapUrl="/api/map/run-interactive"
+                version="2026-07-15T14:00:00.000Z"
+                title="Interaktivna karta dostave"
+                selectedNode={selectedNode}
+                onSelectedNodeChange={setSelectedNode}
+            />
+            <output data-testid="map-selection">
+                {deliveryMapSelectionKey(selectedNode) ?? 'none'}
+            </output>
+            <button
+                type="button"
+                onClick={() =>
+                    setSelectedNode({
+                        kind: 'delivery',
+                        id: 'completed-stop-without-marker',
+                    })
+                }
+            >
+                Odaberi dovršenu stanicu bez markera
+            </button>
+        </div>
+    );
+}

--- a/apps/delivery/tests/DriverRouteProgressTimelineStory.tsx
+++ b/apps/delivery/tests/DriverRouteProgressTimelineStory.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState } from 'react';
+import { DriverRouteProgressTimeline } from '../components/DriverRouteProgressTimeline';
+import type { DriverRouteTimelineItem } from '../lib/deliveryRouteTimelinePresentation';
+
+const states: DriverRouteTimelineItem['state'][] = [
+    'completed',
+    'syncing',
+    'current',
+    'next',
+    'retry',
+    'exception',
+    'locked',
+    'completed',
+];
+
+const items: DriverRouteTimelineItem[] = Array.from(
+    { length: 27 },
+    (_, index) => ({
+        id: `stop-${index + 1}`,
+        sequence: index + 1,
+        kind: index === 0 ? 'pickup' : 'delivery',
+        state: states[index] ?? 'upcoming',
+        title:
+            index === 20
+                ? 'Skupna dostava s vrlo dugim nazivom primatelja koji mora ostati u retku'
+                : index === 0
+                  ? 'Glavno sjedište Gredice'
+                  : `Primatelj ${index + 1}`,
+        destination: `Dostavna adresa ${index + 1}, Zagreb`,
+        deliveryCount: index % 3 === 0 ? 3 : 1,
+        estimatedArrivalAt: `2026-07-15T${String(8 + Math.floor(index / 4)).padStart(2, '0')}:${String((index % 4) * 15).padStart(2, '0')}:00.000Z`,
+        estimatedTravelSeconds: 300 + index * 30,
+    }),
+);
+
+export function DriverRouteProgressTimelineStory() {
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+    return (
+        <div className="min-h-screen bg-background p-2">
+            <section
+                data-testid="current-command"
+                aria-label="Trenutačna komanda"
+                className="sticky top-0 z-10 rounded-lg border bg-background p-3 shadow-sm"
+            >
+                Trenutačna stanica i primarna akcija
+            </section>
+            <button
+                type="button"
+                className="mt-2"
+                onClick={() => setSelectedId('stop-5')}
+            >
+                Odaberi stanicu 5 na karti
+            </button>
+            <output data-testid="timeline-selection">
+                {selectedId ?? 'none'}
+            </output>
+            <div className="mt-3">
+                <DriverRouteProgressTimeline
+                    items={items}
+                    selectedId={selectedId}
+                    onSelectionChange={(item) =>
+                        setSelectedId(item?.id ?? null)
+                    }
+                    renderDetails={(item) => (
+                        <div data-testid="route-details">
+                            Detalji za {item.id}: primatelj, telefon, urod i
+                            napomena.
+                        </div>
+                    )}
+                />
+            </div>
+        </div>
+    );
+}

--- a/apps/delivery/tests/delivery-interactive-map.spec.tsx
+++ b/apps/delivery/tests/delivery-interactive-map.spec.tsx
@@ -1,6 +1,13 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import { DeliveryInteractiveMap } from '../components/DeliveryInteractiveMap';
+import { DeliveryInteractiveMapSelectionStory } from './DeliveryInteractiveMapSelectionStory';
 import '../app/globals.css';
+
+declare global {
+    interface Window {
+        __deliveryMarkerClicks?: Record<string, () => void>;
+    }
+}
 
 const googleMapsStub = `
 class TestMap {
@@ -12,13 +19,25 @@ class TestMap {
     const count = Number(this.element.dataset.fitBoundsCalls || '0') + 1;
     this.element.dataset.fitBoundsCalls = String(count);
   }
-  setCenter() {}
-  setZoom() {}
+  setCenter() {
+    const count = Number(this.element.dataset.setCenterCalls || '0') + 1;
+    this.element.dataset.setCenterCalls = String(count);
+  }
+  setZoom(value) { this.element.dataset.zoom = String(value); }
 }
 class TestMarker {
-  constructor({ map }) {
+  constructor({ map, icon, title }) {
+    this.title = title;
     const count = Number(map.element.dataset.markerCount || '0') + 1;
     map.element.dataset.markerCount = String(count);
+    if (icon && icon.scale === 13) {
+      map.element.dataset.selectedMarkerTitle = title;
+    }
+  }
+  addListener(name, handler) {
+    if (name !== 'click') return;
+    window.__deliveryMarkerClicks = window.__deliveryMarkerClicks || {};
+    window.__deliveryMarkerClicks[this.title] = handler;
   }
   setMap() {}
 }
@@ -61,8 +80,21 @@ test('loads authorized map data into a live interactive map', async ({
             contentType: 'application/json',
             body: JSON.stringify({
                 driverLocation: { latitude: 45.801, longitude: 15.981 },
-                pickupNodes: [{ latitude: 45.79, longitude: 15.97 }],
-                stops: [{ latitude: 45.81, longitude: 16.01, sequence: 1 }],
+                pickupNodes: [
+                    {
+                        latitude: 45.79,
+                        longitude: 15.97,
+                        selectionId: 'pickup-node-1',
+                    },
+                ],
+                stops: [
+                    {
+                        latitude: 45.81,
+                        longitude: 16.01,
+                        sequence: 2,
+                        selectionId: '20',
+                    },
+                ],
                 encodedPolyline: '_p~iF~ps|U_ulLnnqC_mqNvxq`@',
             }),
         });
@@ -86,5 +118,80 @@ test('loads authorized map data into a live interactive map', async ({
     await expect(map).toHaveAttribute('data-fit-bounds-calls', '1');
 
     await page.getByRole('button', { name: 'Centriraj kartu' }).click();
+    await expect(map).toHaveAttribute('data-fit-bounds-calls', '2');
+});
+
+test('synchronizes marker selection and highlights the selected route node', async ({
+    mount,
+    page,
+}) => {
+    await page.route('https://maps.googleapis.com/maps/api/js?**', (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: googleMapsStub,
+        }),
+    );
+    await page.route('**/api/map/run-interactive?**', (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                driverLocation: null,
+                pickupNodes: [
+                    {
+                        latitude: 45.79,
+                        longitude: 15.97,
+                        selectionId: 'pickup-node-1',
+                    },
+                ],
+                stops: [
+                    {
+                        latitude: 45.81,
+                        longitude: 16.01,
+                        sequence: 2,
+                        selectionId: '20',
+                    },
+                ],
+                encodedPolyline: null,
+            }),
+        }),
+    );
+
+    await mount(<DeliveryInteractiveMapSelectionStory />);
+    const map = page.getByRole('region', {
+        name: 'Interaktivna karta dostave',
+    });
+    await expect(map).toHaveAttribute('data-google-map-ready', 'true');
+
+    await page.evaluate(() =>
+        window.__deliveryMarkerClicks?.['Dostavna stanica 2']?.(),
+    );
+    await expect(page.getByTestId('map-selection')).toHaveText('delivery:20');
+    await expect(map).toHaveAttribute(
+        'data-selected-marker-title',
+        'Dostavna stanica 2',
+    );
+    await expect(map).toHaveAttribute('data-zoom', '15');
+
+    await page.evaluate(() =>
+        window.__deliveryMarkerClicks?.['Lokacija preuzimanja 1']?.(),
+    );
+    await expect(page.getByTestId('map-selection')).toHaveText(
+        'pickup:pickup-node-1',
+    );
+    await expect(map).toHaveAttribute(
+        'data-selected-marker-title',
+        'Lokacija preuzimanja 1',
+    );
+
+    await page
+        .getByRole('button', {
+            name: 'Odaberi dovršenu stanicu bez markera',
+        })
+        .click();
+    await expect(page.getByTestId('map-selection')).toHaveText(
+        'delivery:completed-stop-without-marker',
+    );
     await expect(map).toHaveAttribute('data-fit-bounds-calls', '2');
 });

--- a/apps/delivery/tests/delivery-offline-actions.spec.tsx
+++ b/apps/delivery/tests/delivery-offline-actions.spec.tsx
@@ -160,8 +160,13 @@ test('restored offline route keeps pending actions visible and supports ordered 
     page,
 }) => {
     await mount(<OfflineRouteArrivalStory />);
+    const nextRouteRow = page
+        .getByRole('list', { name: 'Izvanmrežni tijek dostavne rute' })
+        .getByRole('listitem')
+        .nth(1);
+    await nextRouteRow.getByRole('button').click();
     await expect(
-        page.getByRole('button', {
+        nextRouteRow.getByRole('button', {
             name: 'Navigacija do sljedeće stanice čeka završetak trenutačne dostave',
         }),
     ).toBeDisabled();
@@ -223,7 +228,13 @@ test('server-required reroute blocks stale cached continuation until reconciliat
             'Poslužitelj je potvrdio radnju, ali novi plan rute još nije sigurno učitan.',
         ),
     ).toBeVisible();
-    await expect(page.getByText('Trenutačni korak')).toBeVisible();
+    await expect(
+        page
+            .getByRole('list', {
+                name: 'Izvanmrežni tijek dostavne rute',
+            })
+            .getByText('Trenutačna stanica', { exact: true }),
+    ).toBeVisible();
     await expect(
         page.getByRole('button', {
             name: 'Navigacija do trenutačne stanice čeka novi plan',
@@ -279,8 +290,13 @@ test('restored exception remains a route barrier and memory fallback is truthful
             /Radnje su spremljene samo dok je ova stranica otvorena/,
         ),
     ).toBeVisible();
+    const nextRouteRow = page
+        .getByRole('list', { name: 'Izvanmrežni tijek dostavne rute' })
+        .getByRole('listitem')
+        .nth(1);
+    await nextRouteRow.getByRole('button').click();
     await expect(
-        page.getByRole('button', {
+        nextRouteRow.getByRole('button', {
             name: 'Navigacija do sljedeće stanice čeka novi plan',
         }),
     ).toBeDisabled();

--- a/apps/delivery/tests/driver-current-stop.spec.tsx
+++ b/apps/delivery/tests/driver-current-stop.spec.tsx
@@ -281,9 +281,46 @@ test('uses section-level current-command headings in live and offline route view
     await expect(
         page.getByRole('heading', {
             level: 3,
-            name: 'Sljedeća dostava',
+            name: 'Tijek rute',
         }),
     ).toBeVisible();
+});
+
+test('reveals read-only recipient and harvest details from the compact route timeline', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverDashboardServerAdvanceStory />);
+    const currentSummary = page.getByRole('region', {
+        name: 'Sažetak trenutačne stanice',
+    });
+    const beforeDocumentTop = await currentSummary.evaluate(
+        (element) =>
+            (element.parentElement?.getBoundingClientRect().top ?? 0) +
+            window.scrollY,
+    );
+    const timeline = page.getByRole('list', {
+        name: 'Tijek dostavne rute',
+    });
+    const nextRow = timeline.getByRole('listitem').nth(1);
+
+    await nextRow.getByRole('button').click();
+    await expect(
+        nextRow.getByText('Telefon: +385 91 555 0101').first(),
+    ).toBeVisible();
+    await expect(
+        nextRow.getByText('Rajčica za predaju · Gredica D'),
+    ).toBeVisible();
+    await expect(nextRow.getByRole('button')).toHaveCount(1);
+
+    const afterDocumentTop = await currentSummary.evaluate(
+        (element) =>
+            (element.parentElement?.getBoundingClientRect().top ?? 0) +
+            window.scrollY,
+    );
+    expect(Math.abs(afterDocumentTop - beforeDocumentTop)).toBeLessThanOrEqual(
+        1,
+    );
 });
 
 test('arrived stop exposes advisory scanning and delivers with its local note', async ({

--- a/apps/delivery/tests/driver-route-progress-timeline.spec.tsx
+++ b/apps/delivery/tests/driver-route-progress-timeline.spec.tsx
@@ -1,0 +1,141 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { DriverRouteProgressTimelineStory } from './DriverRouteProgressTimelineStory';
+import '../app/globals.css';
+
+test('keeps the maximum 27-node route compact and horizontally contained', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 640 });
+    await mount(<DriverRouteProgressTimelineStory />);
+
+    const timeline = page.getByRole('list', {
+        name: 'Tijek dostavne rute',
+    });
+    const rows = timeline.getByRole('listitem');
+    await expect(rows).toHaveCount(27);
+    await expect(page.getByTestId('route-details')).toHaveCount(0);
+
+    const firstRow = await rows.first().boundingBox();
+    expect(firstRow).not.toBeNull();
+    expect(firstRow?.height ?? Number.MAX_VALUE).toBeLessThanOrEqual(160);
+    expect(
+        await timeline.evaluate(
+            (element) => element.scrollWidth <= element.clientWidth,
+        ),
+    ).toBe(true);
+});
+
+test('distinguishes route states with text and semantic current-step state', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverRouteProgressTimelineStory />);
+
+    const timeline = page.getByRole('list', {
+        name: 'Tijek dostavne rute',
+    });
+    await expect(timeline.getByText('Dovršeno', { exact: true })).toHaveCount(
+        2,
+    );
+    await expect(
+        timeline.getByText('Trenutačna stanica', { exact: true }),
+    ).toBeVisible();
+    await expect(
+        timeline.getByText('Dovršeno · čeka sinkronizaciju', { exact: true }),
+    ).toBeVisible();
+    await expect(
+        timeline.getByText('Sljedeća stanica', { exact: true }),
+    ).toBeVisible();
+    await expect(
+        timeline.getByText('Ponovni pokušaj', { exact: true }),
+    ).toBeVisible();
+    await expect(timeline.getByText('Iznimka', { exact: true })).toBeVisible();
+    await expect(
+        timeline.getByText('Čeka redoslijed', { exact: true }),
+    ).toBeVisible();
+    await expect(
+        timeline.locator('li[data-route-state="current"] button'),
+    ).toHaveAttribute('aria-current', 'step');
+    await expect(timeline.getByRole('button').nth(4)).toHaveAccessibleName(
+        /Stanica 5/,
+    );
+});
+
+test('expands only one stop while leaving the current command in place', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mount(<DriverRouteProgressTimelineStory />);
+
+    const timeline = page.getByRole('list', {
+        name: 'Tijek dostavne rute',
+    });
+    const triggers = timeline.getByRole('button');
+    const command = page.getByTestId('current-command');
+    const before = await command.boundingBox();
+
+    await triggers.nth(2).click();
+    await expect(triggers.nth(2)).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.getByTestId('route-details')).toHaveText(
+        /Detalji za stop-3/,
+    );
+
+    await triggers.nth(3).click();
+    await expect(triggers.nth(2)).toHaveAttribute('aria-expanded', 'false');
+    await expect(triggers.nth(3)).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.getByTestId('route-details')).toHaveCount(1);
+    await expect(page.getByTestId('route-details')).toHaveText(
+        /Detalji za stop-4/,
+    );
+
+    const after = await command.boundingBox();
+    expect(before).not.toBeNull();
+    expect(after).not.toBeNull();
+    expect(Math.abs((after?.y ?? 0) - (before?.y ?? 0))).toBeLessThanOrEqual(1);
+
+    await triggers.nth(3).click();
+    await expect(page.getByTestId('route-details')).toHaveCount(0);
+});
+
+test('supports arrow, Home, and End keyboard navigation between stops', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverRouteProgressTimelineStory />);
+
+    const triggers = page
+        .getByRole('list', { name: 'Tijek dostavne rute' })
+        .getByRole('button');
+    await triggers.nth(1).focus();
+    await page.keyboard.press('ArrowDown');
+    await expect(triggers.nth(2)).toBeFocused();
+    await page.keyboard.press('End');
+    await expect(triggers.nth(26)).toBeFocused();
+    await page.keyboard.press('Home');
+    await expect(triggers.first()).toBeFocused();
+    await page.keyboard.press('ArrowUp');
+    await expect(triggers.nth(26)).toBeFocused();
+});
+
+test('keeps controlled map selection synchronized with the expanded timeline row', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverRouteProgressTimelineStory />);
+    const timeline = page.getByRole('list', {
+        name: 'Tijek dostavne rute',
+    });
+    const fifthTrigger = timeline.getByRole('button').nth(4);
+
+    await page
+        .getByRole('button', { name: 'Odaberi stanicu 5 na karti' })
+        .click();
+    await expect(page.getByTestId('timeline-selection')).toHaveText('stop-5');
+    await expect(fifthTrigger).toHaveAttribute('aria-expanded', 'true');
+
+    await fifthTrigger.click();
+    await expect(page.getByTestId('timeline-selection')).toHaveText('none');
+    await expect(fifthTrigger).toHaveAttribute('aria-expanded', 'false');
+});


### PR DESCRIPTION
## Summary

- replace full live and offline route cards with a compact, single-expansion progress timeline
- keep current, next, retry, exception, completed, and syncing states distinct with ETA and bulk counts
- synchronize timeline expansion with stable pickup and delivery map markers while keeping customer map data private

## Validation

- `corepack pnpm --filter delivery lint`
- `corepack pnpm --filter delivery typecheck`
- `corepack pnpm --filter delivery test:unit` (245 passed)
- `corepack pnpm --filter delivery test:component` (87 passed)
- `corepack pnpm --filter delivery build`
- `git diff --check`

Closes #4133