### PR TITLE
feat(delivery): make handoff verification resilient

### DIFF
--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -12,6 +12,7 @@ import {
     type DeliveryServerStateExpectation,
     useDeliveryActionSync,
 } from '../hooks/useDeliveryActionSync';
+import { useDeliveryHandoffSync } from '../hooks/useDeliveryHandoffSync';
 import {
     type DriverRouteWakeLockState,
     useDriverRouteWakeLock,
@@ -19,14 +20,21 @@ import {
 import { useDriverTracking } from '../hooks/useDriverTracking';
 import { useOfflineRouteCache } from '../hooks/useOfflineRouteCache';
 import { usePickupManifestSync } from '../hooks/usePickupManifestSync';
+import { deliveryRouteStepsWithLocalActions } from '../lib/deliveryActionPresentation';
 import {
     clearOtherDeliveryActionQueueScopes,
     createBrowserDeliveryActionQueuePersistence,
+    isDeliveryHandoffCommand,
 } from '../lib/deliveryActionQueue';
+import {
+    currentDeliveryRouteStep,
+    deliveryCurrentStopCommandDeliveries,
+} from '../lib/deliveryCurrentStopPresentation';
 import type {
     DeliveryDashboard as DeliveryDashboardData,
     DriverDeliveryDashboard,
 } from '../lib/deliveryDashboardTypes';
+import { createWebStorageDeliveryHandoffManifestCachePersistence } from '../lib/deliveryHandoffManifestCache';
 import { performDeliveryLogout } from '../lib/deliveryLogout';
 import {
     assertDeliveryOfflineWritesAllowed,
@@ -81,6 +89,9 @@ async function clearOtherStoredDriverRuns(userId: string, activeRunId: string) {
             createBrowserDeliveryActionQueuePersistence(),
             { userId, activeRunId },
         );
+        await createWebStorageDeliveryHandoffManifestCachePersistence(
+            window.localStorage,
+        ).clearOtherRuns?.({ userId, activeRunId });
         return true;
     } catch {
         // A completion marker is retained when supporting cleanup is uncertain.
@@ -373,9 +384,45 @@ function ActiveDriverDashboardWithPickupSync({
         runId: activeRunId,
         refreshServerState: onServerStateChanged,
     });
+    const displayedRouteSteps = dashboard.activeRun
+        ? deliveryRouteStepsWithLocalActions(
+              dashboard.activeRun.routeSteps,
+              deliverySync.snapshot,
+          )
+        : [];
+    const currentRouteStep = currentDeliveryRouteStep(displayedRouteSteps);
+    const handoffSelection =
+        currentRouteStep?.kind === 'delivery' &&
+        currentRouteStep.stop.id !== null
+            ? {
+                  target: {
+                      targetStopId: currentRouteStep.stop.id,
+                      retryAttempt: currentRouteStep.retryAttempt,
+                  },
+                  deliveries: deliveryCurrentStopCommandDeliveries(
+                      currentRouteStep.stop,
+                  ),
+              }
+            : null;
+    const deliveryHandoffSync = useDeliveryHandoffSync({
+        userId: dashboard.user.id,
+        runId: activeRunId,
+        target: handoffSelection?.target ?? null,
+        deliveries: handoffSelection?.deliveries ?? [],
+        actionSync: deliverySync,
+    });
+    const deliveryHandoff = handoffSelection
+        ? {
+              view: deliveryHandoffSync.handoff,
+              feedback: deliveryHandoffSync.feedback,
+              scan: deliveryHandoffSync.scan,
+              markItem: deliveryHandoffSync.markItem,
+              markRemainingReviewed: deliveryHandoffSync.markRemainingReviewed,
+          }
+        : null;
     const serverAcknowledgementCount = deliverySync.snapshot.entries.filter(
         (entry) =>
-            entry.command.kind !== 'verification-scan' &&
+            !isDeliveryHandoffCommand(entry.command) &&
             entry.acknowledgement?.kind === 'server',
     ).length;
     const minimumAcknowledgedRouteRevision = Math.max(
@@ -473,6 +520,7 @@ function ActiveDriverDashboardWithPickupSync({
             }}
             pickupQueue={pickupSync.snapshot}
             deliveryQueue={deliverySync.snapshot}
+            deliveryHandoff={deliveryHandoff}
             onPickupScan={(pickupNodeId, scanValue) =>
                 report(pickupSync.enqueueScan(pickupNodeId, scanValue))
             }
@@ -495,9 +543,25 @@ function ActiveDriverDashboardWithPickupSync({
             onDiscardPickupSync={(operationId) =>
                 report(pickupSync.discardEntry(operationId))
             }
-            onVerificationScan={(stopId, tracePath) =>
-                report(deliverySync.enqueueVerificationScan(stopId, tracePath))
-            }
+            onVerificationScan={(stopId, tracePath) => {
+                if (
+                    !handoffSelection ||
+                    handoffSelection.target.targetStopId !== stopId
+                ) {
+                    return Promise.resolve({
+                        status: 'failed' as const,
+                        message:
+                            'Aktivni posjet stanici promijenio se. Osvježi prikaz prije nove provjere.',
+                    });
+                }
+                return report(
+                    deliverySync.enqueueVerificationScan(
+                        stopId,
+                        tracePath,
+                        handoffSelection.target.retryAttempt,
+                    ),
+                );
+            }}
             onRetryDeliverySync={(operationId) =>
                 report(deliverySync.retry(operationId))
             }

--- a/apps/delivery/components/DeliveryHandoffCompletionDialog.tsx
+++ b/apps/delivery/components/DeliveryHandoffCompletionDialog.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Chip } from '@gredice/ui/Chip';
+import { Info, Warning } from '@gredice/ui/icons';
+import { Modal } from '@gredice/ui/Modal';
+import { Typography } from '@gredice/ui/Typography';
+import { useState } from 'react';
+import type { DeliveryStopDeliverySummary } from '../lib/deliveryDashboardTypes';
+import { isDriverCommandResult } from '../lib/driverCommandResult';
+import type {
+    DeliveryHandoffCompletionConfirmation,
+    DeliveryHandoffManifestItemView,
+    DeliveryHandoffManifestView,
+    DeliveryHandoffSummary,
+} from './DeliveryHarvestVerification';
+
+function matchingDelivery(
+    deliveries: DeliveryStopDeliverySummary[],
+    item: DeliveryHandoffManifestItemView,
+) {
+    return (
+        deliveries.find(
+            (delivery) => delivery.requestId === item.deliveryRequestId,
+        ) ?? deliveries.find((delivery) => delivery.stopId === item.stopId)
+    );
+}
+
+function itemStateLabel(state: DeliveryHandoffManifestItemView['state']) {
+    switch (state) {
+        case 'scanned':
+            return 'Provjereno';
+        case 'unverified':
+            return 'Nije provjereno';
+        case 'no-label':
+            return 'Bez etikete';
+        case 'missing':
+            return 'Nedostaje';
+        case 'skipped':
+            return 'Preskočeno';
+    }
+}
+
+function itemStateColor(
+    state: DeliveryHandoffManifestItemView['state'],
+): 'success' | 'error' | 'warning' | 'neutral' {
+    switch (state) {
+        case 'scanned':
+            return 'success';
+        case 'missing':
+            return 'error';
+        case 'no-label':
+        case 'skipped':
+            return 'warning';
+        case 'unverified':
+            return 'neutral';
+    }
+}
+
+export function DeliveryHandoffCompletionDialog({
+    confirmation,
+    deliveries,
+    handoffSyncState,
+    items,
+    summary,
+}: {
+    confirmation: DeliveryHandoffCompletionConfirmation;
+    deliveries: DeliveryStopDeliverySummary[];
+    handoffSyncState: DeliveryHandoffManifestView['syncState'];
+    items: DeliveryHandoffManifestItemView[];
+    summary: DeliveryHandoffSummary;
+}) {
+    const [error, setError] = useState<string | null>(null);
+    const [submitting, setSubmitting] = useState(false);
+    const busy = submitting || Boolean(confirmation.pending);
+    const summaryLoading = handoffSyncState === 'loading';
+
+    function changeOpen(open: boolean) {
+        if (!open) setError(null);
+        confirmation.onOpenChange(open);
+    }
+
+    async function confirmDelivery() {
+        setSubmitting(true);
+        setError(null);
+        try {
+            const result = await confirmation.onConfirm();
+            if (isDriverCommandResult(result) && result.status === 'failed') {
+                setError(result.message);
+                return;
+            }
+            confirmation.onOpenChange(false);
+        } catch {
+            setError(
+                'Potvrdu dostave nije moguće sigurno spremiti. Pokušaj ponovno.',
+            );
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <Modal
+            open={confirmation.open}
+            onOpenChange={changeOpen}
+            title="Potvrdi dostavu"
+            description="Pregledaj zabilježene ishode provjere uroda prije potvrde skupne dostave."
+            dismissible={!busy}
+            className="md:max-w-xl"
+        >
+            <form
+                className="space-y-4"
+                onSubmit={(event) => {
+                    event.preventDefault();
+                    void confirmDelivery();
+                }}
+            >
+                <div className="pr-8">
+                    <Typography level="h3" semiBold>
+                        Sažetak predaje
+                    </Typography>
+                    <Typography
+                        level="body3"
+                        className="mt-1 text-muted-foreground"
+                    >
+                        {summaryLoading
+                            ? 'Sažetak provjere još se učitava.'
+                            : `${summary.expectedCount} ${
+                                  summary.expectedCount === 1
+                                      ? 'urod na ovoj stanici'
+                                      : 'uroda na ovoj stanici'
+                              }`}
+                    </Typography>
+                </div>
+
+                {summaryLoading ? (
+                    <Alert
+                        color="info"
+                        startDecorator={<Info className="size-5" />}
+                    >
+                        Spremljeni ishodi provjere još se učitavaju. Dostavu i
+                        dalje možeš potvrditi bez čekanja.
+                    </Alert>
+                ) : (
+                    <>
+                        <fieldset
+                            className="flex flex-wrap gap-2"
+                            aria-label="Sažetak za potvrdu dostave"
+                        >
+                            <Chip color="success" size="sm">
+                                {summary.scannedCount} provjereno
+                            </Chip>
+                            <Chip color="neutral" size="sm">
+                                {summary.unverifiedCount} bez provjere
+                            </Chip>
+                            <Chip color="warning" size="sm">
+                                {summary.noLabelCount} bez etikete
+                            </Chip>
+                            <Chip color="error" size="sm">
+                                {summary.missingCount} nedostaje
+                            </Chip>
+                            <Chip color="warning" size="sm">
+                                {summary.skippedCount} preskočeno
+                            </Chip>
+                        </fieldset>
+
+                        <ul
+                            className="max-h-52 space-y-2 overflow-y-auto"
+                            aria-label="Ishodi uroda za potvrdu dostave"
+                        >
+                            {items.map((item) => {
+                                const delivery = matchingDelivery(
+                                    deliveries,
+                                    item,
+                                );
+                                return (
+                                    <li
+                                        key={item.stopId}
+                                        className="flex items-center justify-between gap-3 rounded-md bg-muted/70 px-3 py-2"
+                                    >
+                                        <span className="min-w-0 truncate text-sm">
+                                            {delivery?.harvest.plantName ??
+                                                'Urod na ovoj stanici'}
+                                            {delivery
+                                                ? ` · ${delivery.contactName}`
+                                                : ''}
+                                        </span>
+                                        <Chip
+                                            color={itemStateColor(item.state)}
+                                            size="sm"
+                                        >
+                                            {itemStateLabel(item.state)}
+                                        </Chip>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    </>
+                )}
+
+                <Alert
+                    color="info"
+                    startDecorator={<Info className="size-5" />}
+                >
+                    QR provjera je pomoćna i ne blokira dostavu. Dostavu možeš
+                    potvrditi s neprovjerenim, preskočenim ili nepotvrđenim
+                    promjenama.
+                </Alert>
+
+                {!summaryLoading && summary.unverifiedCount > 0 ? (
+                    <Alert
+                        color="warning"
+                        startDecorator={<Warning className="size-5" />}
+                    >
+                        {summary.unverifiedCount}{' '}
+                        {summary.unverifiedCount === 1
+                            ? 'urod ostaje bez zabilježene provjere.'
+                            : 'uroda ostaju bez zabilježene provjere.'}
+                    </Alert>
+                ) : null}
+
+                {summary.pendingCount > 0 || handoffSyncState === 'failed' ? (
+                    <Alert
+                        color="warning"
+                        startDecorator={<Warning className="size-5" />}
+                    >
+                        {handoffSyncState === 'failed'
+                            ? 'Sinkronizacija nekih provjera nije uspjela. Dostavu i dalje možeš potvrditi.'
+                            : `${summary.pendingCount} ${summary.pendingCount === 1 ? 'promjena čeka' : 'promjene čekaju'} potvrdu poslužitelja. Dostavu i dalje možeš potvrditi.`}
+                    </Alert>
+                ) : null}
+
+                {error ? (
+                    <Alert
+                        color="danger"
+                        role="alert"
+                        aria-live="assertive"
+                        startDecorator={<Warning className="size-5" />}
+                    >
+                        {error}
+                    </Alert>
+                ) : null}
+
+                <div className="flex flex-col-reverse gap-2 border-t pt-4 sm:flex-row sm:justify-end">
+                    <Button
+                        type="button"
+                        variant="plain"
+                        disabled={busy}
+                        onClick={() => changeOpen(false)}
+                    >
+                        Natrag
+                    </Button>
+                    <Button
+                        type="submit"
+                        color="success"
+                        loading={busy}
+                        disabled={busy || Boolean(confirmation.disabled)}
+                    >
+                        Potvrdi dostavu i nastavi
+                    </Button>
+                </div>
+            </form>
+        </Modal>
+    );
+}

--- a/apps/delivery/components/DeliveryHandoffVerificationItem.tsx
+++ b/apps/delivery/components/DeliveryHandoffVerificationItem.tsx
@@ -1,0 +1,275 @@
+'use client';
+
+import type { DeliveryRunHandoffSkipReason } from '@gredice/storage';
+import { Button } from '@gredice/ui/Button';
+import { Chip } from '@gredice/ui/Chip';
+import { Typography } from '@gredice/ui/Typography';
+import { useState } from 'react';
+import type { DeliveryStopDeliverySummary } from '../lib/deliveryDashboardTypes';
+import type {
+    DeliveryHandoffManifestItemView,
+    DeliveryHandoffMarkItemInput,
+} from './DeliveryHarvestVerification';
+
+const skipReasonOptions: Array<{
+    value: DeliveryRunHandoffSkipReason;
+    label: string;
+}> = [
+    { value: 'label-unreadable', label: 'Etiketa nije čitljiva' },
+    { value: 'scanner-unavailable', label: 'Skener nije dostupan' },
+    { value: 'manual-verification', label: 'Ručno provjereno' },
+    { value: 'other-operational', label: 'Drugi operativni razlog' },
+];
+
+function itemStateLabel(state: DeliveryHandoffManifestItemView['state']) {
+    switch (state) {
+        case 'scanned':
+            return 'Provjereno';
+        case 'unverified':
+            return 'Nije provjereno';
+        case 'no-label':
+            return 'Bez etikete';
+        case 'missing':
+            return 'Nedostaje';
+        case 'skipped':
+            return 'Preskočeno';
+    }
+}
+
+function itemStateColor(
+    state: DeliveryHandoffManifestItemView['state'],
+): 'success' | 'error' | 'warning' | 'neutral' {
+    switch (state) {
+        case 'scanned':
+            return 'success';
+        case 'missing':
+            return 'error';
+        case 'no-label':
+        case 'skipped':
+            return 'warning';
+        case 'unverified':
+            return 'neutral';
+    }
+}
+
+function skipReasonLabel(reason: DeliveryRunHandoffSkipReason | null) {
+    return skipReasonOptions.find((option) => option.value === reason)?.label;
+}
+
+function itemSyncLabel(
+    syncState: DeliveryHandoffManifestItemView['syncState'],
+) {
+    switch (syncState) {
+        case 'queued':
+            return 'Čeka slanje';
+        case 'sending':
+            return 'Šalje se';
+        case 'failed':
+            return 'Slanje nije uspjelo';
+        case 'persisted':
+        case undefined:
+            return null;
+    }
+}
+
+export function DeliveryHandoffVerificationItem({
+    compact,
+    delivery,
+    disabled,
+    item,
+    pendingAction,
+    onMarkItem,
+    onRunAction,
+}: {
+    compact: boolean;
+    delivery: DeliveryStopDeliverySummary | undefined;
+    disabled: boolean;
+    item: DeliveryHandoffManifestItemView;
+    pendingAction: string | null;
+    onMarkItem?: (
+        input: DeliveryHandoffMarkItemInput,
+    ) => unknown | Promise<unknown>;
+    onRunAction: (
+        key: string,
+        action: () => unknown | Promise<unknown>,
+    ) => Promise<boolean>;
+}) {
+    const [editingOutcome, setEditingOutcome] = useState(false);
+    const [skipReason, setSkipReason] = useState<DeliveryRunHandoffSkipReason>(
+        item.reason ?? 'label-unreadable',
+    );
+    const identityLabel = delivery
+        ? `${delivery.harvest.plantName} · ${delivery.contactName}`
+        : 'Urod na ovoj stanici';
+    const syncLabel = itemSyncLabel(item.syncState);
+    const canCorrect =
+        item.state === 'scanned' ||
+        item.state === 'no-label' ||
+        item.state === 'missing' ||
+        item.state === 'skipped';
+    const showEditor = item.state === 'unverified' || editingOutcome;
+    const actionsDisabled = disabled || Boolean(pendingAction);
+
+    function updateSkipReason(value: string) {
+        const reason = skipReasonOptions.find(
+            (option) => option.value === value,
+        )?.value;
+        if (reason) setSkipReason(reason);
+    }
+
+    async function mark(key: string, input: DeliveryHandoffMarkItemInput) {
+        if (!onMarkItem) return;
+        const saved = await onRunAction(key, () => onMarkItem(input));
+        if (saved) setEditingOutcome(false);
+    }
+
+    return (
+        <li
+            className={`space-y-2 rounded-md bg-muted/70 ${compact ? 'px-2 py-2' : 'px-3 py-2'}`}
+        >
+            <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                    <Typography level="body3" semiBold className="truncate">
+                        {delivery?.harvest.plantName ?? 'Urod na ovoj stanici'}
+                    </Typography>
+                    <Typography
+                        level="body3"
+                        className="truncate text-muted-foreground"
+                    >
+                        {delivery?.contactName ??
+                            'Podaci o primatelju nisu dostupni'}
+                    </Typography>
+                </div>
+                <div className="flex shrink-0 flex-col items-end gap-1">
+                    <Chip color={itemStateColor(item.state)} size="sm">
+                        {itemStateLabel(item.state)}
+                    </Chip>
+                    {syncLabel ? (
+                        <Chip
+                            color={
+                                item.syncState === 'failed' ? 'warning' : 'info'
+                            }
+                            size="sm"
+                            variant="outlined"
+                        >
+                            {syncLabel}
+                        </Chip>
+                    ) : null}
+                </div>
+            </div>
+
+            {item.state === 'skipped' && item.reason ? (
+                <Typography level="body3" className="text-muted-foreground">
+                    Razlog: {skipReasonLabel(item.reason)}
+                </Typography>
+            ) : null}
+
+            {canCorrect && onMarkItem && !showEditor ? (
+                <Button
+                    type="button"
+                    size="xs"
+                    variant="plain"
+                    disabled={actionsDisabled}
+                    aria-label={`Promijeni ishod: ${identityLabel}`}
+                    onClick={() => setEditingOutcome(true)}
+                >
+                    Promijeni ishod
+                </Button>
+            ) : null}
+
+            {showEditor && onMarkItem ? (
+                <div className="space-y-2 border-t pt-2">
+                    <div className="flex flex-wrap gap-2">
+                        <Button
+                            type="button"
+                            size="xs"
+                            variant="outlined"
+                            color="warning"
+                            loading={
+                                pendingAction === `no-label:${item.stopId}`
+                            }
+                            disabled={actionsDisabled}
+                            aria-label={`Označi bez etikete: ${identityLabel}`}
+                            onClick={() =>
+                                void mark(`no-label:${item.stopId}`, {
+                                    itemStopId: item.stopId,
+                                    outcome: 'no-label',
+                                })
+                            }
+                        >
+                            Bez etikete
+                        </Button>
+                        <Button
+                            type="button"
+                            size="xs"
+                            variant="outlined"
+                            color="danger"
+                            loading={pendingAction === `missing:${item.stopId}`}
+                            disabled={actionsDisabled}
+                            aria-label={`Označi da nedostaje: ${identityLabel}`}
+                            onClick={() =>
+                                void mark(`missing:${item.stopId}`, {
+                                    itemStopId: item.stopId,
+                                    outcome: 'missing',
+                                })
+                            }
+                        >
+                            Nedostaje
+                        </Button>
+                    </div>
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+                        <label className="min-w-0 flex-1 text-xs font-medium">
+                            Razlog preskakanja
+                            <select
+                                className="mt-1 h-9 w-full rounded-md border bg-background px-2 text-sm outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+                                value={skipReason}
+                                disabled={actionsDisabled}
+                                aria-label={`Razlog preskakanja za ${identityLabel}`}
+                                onChange={(event) =>
+                                    updateSkipReason(event.target.value)
+                                }
+                            >
+                                {skipReasonOptions.map((option) => (
+                                    <option
+                                        key={option.value}
+                                        value={option.value}
+                                    >
+                                        {option.label}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="outlined"
+                            loading={pendingAction === `skipped:${item.stopId}`}
+                            disabled={actionsDisabled}
+                            aria-label={`Preskoči provjeru: ${identityLabel}`}
+                            onClick={() =>
+                                void mark(`skipped:${item.stopId}`, {
+                                    itemStopId: item.stopId,
+                                    outcome: 'skipped',
+                                    reason: skipReason,
+                                })
+                            }
+                        >
+                            Preskoči
+                        </Button>
+                    </div>
+                    {canCorrect ? (
+                        <Button
+                            type="button"
+                            size="xs"
+                            variant="plain"
+                            disabled={actionsDisabled}
+                            onClick={() => setEditingOutcome(false)}
+                        >
+                            Odustani od promjene
+                        </Button>
+                    ) : null}
+                </div>
+            ) : null}
+        </li>
+    );
+}

--- a/apps/delivery/components/DeliveryHarvestVerification.tsx
+++ b/apps/delivery/components/DeliveryHarvestVerification.tsx
@@ -1,91 +1,315 @@
 'use client';
 
+import type {
+    DeliveryRunHandoffItemSnapshot,
+    DeliveryRunHandoffItemState,
+    DeliveryRunHandoffManifest,
+    DeliveryRunHandoffSkipReason,
+} from '@gredice/storage';
 import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
 import { Chip } from '@gredice/ui/Chip';
-import { Check, Info } from '@gredice/ui/icons';
+import { Check, Info, Warning } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
-import { useId, useRef, useState } from 'react';
+import { useId, useState } from 'react';
 import type { DeliveryStopDeliverySummary } from '../lib/deliveryDashboardTypes';
 import { isDriverCommandResult } from '../lib/driverCommandResult';
 import {
+    type HarvestTraceVerificationResult,
     normalizeHarvestTraceScanValue,
     verifyDeliveryStopHarvestTrace,
 } from '../lib/harvestTraceScan';
+import { DeliveryHandoffCompletionDialog } from './DeliveryHandoffCompletionDialog';
+import { DeliveryHandoffVerificationItem } from './DeliveryHandoffVerificationItem';
 import {
     type HarvestTraceScanFailureResult,
     HarvestTraceScanner,
 } from './HarvestTraceScanner';
 
+export type { DeliveryRunHandoffItemState, DeliveryRunHandoffSkipReason };
+
+export type DeliveryHandoffItemSyncState =
+    | 'persisted'
+    | 'queued'
+    | 'sending'
+    | 'failed';
+
+export type DeliveryHandoffManifestItemView = DeliveryRunHandoffItemSnapshot & {
+    syncState?: DeliveryHandoffItemSyncState;
+};
+
+export type DeliveryHandoffManifestView = Omit<
+    DeliveryRunHandoffManifest,
+    'items'
+> & {
+    items: DeliveryHandoffManifestItemView[];
+    syncState: 'loading' | 'ready' | 'offline' | 'syncing' | 'failed';
+    pendingCount: number;
+    error: string | null;
+};
+
+export type DeliveryHandoffMarkItemInput = {
+    itemStopId: number;
+    outcome: 'no-label' | 'missing' | 'skipped';
+    reason?: DeliveryRunHandoffSkipReason;
+};
+
+export type DeliveryHandoffFeedbackView = {
+    operationId: string;
+    kind:
+        | 'stale'
+        | 'invalid'
+        | 'wrong-stop'
+        | 'item-not-found'
+        | 'sync-failed'
+        | 'conflict';
+    message: string;
+};
+
+export type DeliveryHandoffCompletionConfirmation = {
+    open: boolean;
+    pending?: boolean;
+    disabled?: boolean;
+    onOpenChange: (open: boolean) => void;
+    onConfirm: () => unknown | Promise<unknown>;
+};
+
+export type DeliveryHandoffSummary = {
+    expectedCount: number;
+    scannedCount: number;
+    unverifiedCount: number;
+    noLabelCount: number;
+    missingCount: number;
+    skippedCount: number;
+    pendingCount: number;
+};
+
+export type DeliveryHarvestVerificationProps = {
+    deliveries: DeliveryStopDeliverySummary[];
+    disabled: boolean;
+    compact?: boolean;
+    /**
+     * `undefined` temporarily selects the legacy controlled trace-path adapter.
+     * `null` means the retry-scoped manifest is still being loaded.
+     */
+    handoff?: DeliveryHandoffManifestView | null;
+    feedback?: readonly DeliveryHandoffFeedbackView[];
+    onScan?: (
+        value: string,
+    ) =>
+        | HarvestTraceVerificationResult
+        | HarvestTraceScanFailureResult
+        | Promise<
+              HarvestTraceVerificationResult | HarvestTraceScanFailureResult
+          >;
+    onMarkItem?: (
+        input: DeliveryHandoffMarkItemInput,
+    ) => unknown | Promise<unknown>;
+    onMarkRemainingReviewed?: () => unknown | Promise<unknown>;
+    completionConfirmation?: DeliveryHandoffCompletionConfirmation;
+    /** @deprecated Use the retry-scoped `handoff` model. */
+    verifiedTracePaths?: string[];
+    /** @deprecated Use `onScan`. */
+    onVerifiedTrace?: (tracePath: string) => unknown | Promise<unknown>;
+};
+
+function handoffItemCount(
+    items: DeliveryHandoffManifestItemView[],
+    state: DeliveryRunHandoffItemState,
+) {
+    return items.filter((item) => item.state === state).length;
+}
+
+function handoffSummaryFromItems(
+    items: DeliveryHandoffManifestItemView[],
+    pendingCount: number,
+): DeliveryHandoffSummary {
+    return {
+        expectedCount: items.length,
+        scannedCount: handoffItemCount(items, 'scanned'),
+        unverifiedCount: handoffItemCount(items, 'unverified'),
+        noLabelCount: handoffItemCount(items, 'no-label'),
+        missingCount: handoffItemCount(items, 'missing'),
+        skippedCount: handoffItemCount(items, 'skipped'),
+        pendingCount,
+    };
+}
+
+export function deliveryHandoffSummary(
+    handoff: DeliveryHandoffManifestView | null,
+): DeliveryHandoffSummary {
+    return handoffSummaryFromItems(
+        handoff?.items ?? [],
+        handoff?.pendingCount ?? 0,
+    );
+}
+
+function matchingDelivery(
+    deliveries: DeliveryStopDeliverySummary[],
+    item: DeliveryHandoffManifestItemView,
+) {
+    return (
+        deliveries.find(
+            (delivery) => delivery.requestId === item.deliveryRequestId,
+        ) ?? deliveries.find((delivery) => delivery.stopId === item.stopId)
+    );
+}
+
+function normalizedItemTracePath(
+    deliveries: DeliveryStopDeliverySummary[],
+    item: DeliveryHandoffManifestItemView,
+) {
+    const tracePath = matchingDelivery(deliveries, item)?.harvest.tracePath;
+    return tracePath ? normalizeHarvestTraceScanValue(tracePath) : null;
+}
+
+function legacyHandoffItems(
+    deliveries: DeliveryStopDeliverySummary[],
+    verifiedTracePaths: string[],
+): DeliveryHandoffManifestItemView[] {
+    const verifiedTracePathSet = new Set(
+        verifiedTracePaths.flatMap((tracePath) => {
+            const normalized = normalizeHarvestTraceScanValue(tracePath);
+            return normalized ? [normalized] : [];
+        }),
+    );
+    return deliveries.flatMap((delivery) => {
+        if (delivery.stopId === null) return [];
+        const tracePath = delivery.harvest.tracePath
+            ? normalizeHarvestTraceScanValue(delivery.harvest.tracePath)
+            : null;
+        const qrAvailable = Boolean(tracePath);
+        const state: DeliveryRunHandoffItemState = !qrAvailable
+            ? 'no-label'
+            : tracePath && verifiedTracePathSet.has(tracePath)
+              ? 'scanned'
+              : 'unverified';
+        return [
+            {
+                stopId: delivery.stopId,
+                deliveryRequestId: delivery.requestId,
+                retryAttempt: 0,
+                traceLinkId: null,
+                qrAvailable,
+                state,
+                reason: null,
+                verifiedAt: null,
+                syncState: 'persisted',
+            },
+        ];
+    });
+}
+
 export function DeliveryHarvestVerification({
     deliveries,
     disabled,
     compact = false,
-    verifiedTracePaths: persistedVerifiedTracePaths = [],
+    handoff,
+    feedback = [],
+    onScan,
+    onMarkItem,
+    onMarkRemainingReviewed,
+    completionConfirmation,
+    verifiedTracePaths = [],
     onVerifiedTrace,
-}: {
-    deliveries: DeliveryStopDeliverySummary[];
-    disabled: boolean;
-    compact?: boolean;
-    verifiedTracePaths?: string[];
-    onVerifiedTrace?: (tracePath: string) => unknown | Promise<unknown>;
-}) {
+}: DeliveryHarvestVerificationProps) {
     const headingId = useId();
-    const [localVerifiedTracePaths, setLocalVerifiedTracePaths] = useState<
-        string[]
-    >([]);
-    const verifiedTracePathsRef = useRef<string[]>([]);
-    const verifiedTracePaths = Array.from(
-        new Set([...persistedVerifiedTracePaths, ...localVerifiedTracePaths]),
-    );
-    verifiedTracePathsRef.current = verifiedTracePaths;
-    const tracePathByRequestId = new Map(
-        deliveries.flatMap((delivery) => {
-            const tracePath = delivery.harvest.tracePath
-                ? normalizeHarvestTraceScanValue(delivery.harvest.tracePath)
-                : null;
-            return tracePath ? [[delivery.requestId, tracePath]] : [];
+    const controlledHandoff = handoff !== undefined;
+    const items = controlledHandoff
+        ? (handoff?.items ?? [])
+        : legacyHandoffItems(deliveries, verifiedTracePaths);
+    const summary = controlledHandoff
+        ? deliveryHandoffSummary(handoff ?? null)
+        : handoffSummaryFromItems(
+              items.filter((item) => item.qrAvailable),
+              0,
+          );
+    const availableTracePaths = new Set(
+        items.flatMap((item) => {
+            if (!item.qrAvailable) return [];
+            const tracePath = normalizedItemTracePath(deliveries, item);
+            return tracePath ? [tracePath] : [];
         }),
     );
-    const expectedTracePaths = new Set(tracePathByRequestId.values());
-    const verifiedTracePathSet = new Set(
-        verifiedTracePaths.filter((tracePath) =>
-            expectedTracePaths.has(tracePath),
-        ),
+    const completedTracePaths = new Set(
+        items.flatMap((item) => {
+            if (!item.qrAvailable || item.state !== 'scanned') return [];
+            const tracePath = normalizedItemTracePath(deliveries, item);
+            return tracePath ? [tracePath] : [];
+        }),
     );
-    const expectedTraceCount = expectedTracePaths.size;
-    const verifiedTraceCount = verifiedTracePathSet.size;
-    const allExpectedTracesVerified =
-        expectedTraceCount > 0 && verifiedTraceCount === expectedTraceCount;
+    const availableTraceCount = availableTracePaths.size;
+    const completedTraceCount = completedTracePaths.size;
+    const fullyScanned =
+        summary.expectedCount > 0 &&
+        summary.scannedCount === summary.expectedCount;
+    const fullyReviewed =
+        summary.expectedCount > 0 && summary.unverifiedCount === 0;
+    const [pendingAction, setPendingAction] = useState<string | null>(null);
+    const [actionError, setActionError] = useState<string | null>(null);
 
-    const verifyTrace = async (
+    async function verifyTrace(
         value: string,
-    ): Promise<
-        | ReturnType<typeof verifyDeliveryStopHarvestTrace>
-        | HarvestTraceScanFailureResult
-    > => {
-        const result = verifyDeliveryStopHarvestTrace({
-            deliveries,
-            verifiedTracePaths: verifiedTracePathsRef.current,
-            scanValue: value,
-        });
-
-        if (result.status === 'verified') {
-            const persistenceResult = await onVerifiedTrace?.(result.tracePath);
-            if (
-                isDriverCommandResult(persistenceResult) &&
-                persistenceResult.status === 'failed'
-            ) {
+    ): Promise<HarvestTraceVerificationResult | HarvestTraceScanFailureResult> {
+        if (controlledHandoff) {
+            if (!onScan) {
                 return {
                     status: 'scan-failed',
-                    message: persistenceResult.message,
+                    message:
+                        'Provjeru trenutačno nije moguće sigurno spremiti.',
                 };
             }
-            verifiedTracePathsRef.current = result.nextVerifiedTracePaths;
-            setLocalVerifiedTracePaths(result.nextVerifiedTracePaths);
+            return await onScan(value);
         }
 
+        const result = verifyDeliveryStopHarvestTrace({
+            deliveries,
+            verifiedTracePaths,
+            scanValue: value,
+        });
+        if (result.status !== 'verified') return result;
+
+        const persistenceResult = await onVerifiedTrace?.(result.tracePath);
+        if (
+            isDriverCommandResult(persistenceResult) &&
+            persistenceResult.status === 'failed'
+        ) {
+            return {
+                status: 'scan-failed',
+                message: persistenceResult.message,
+            };
+        }
         return result;
-    };
+    }
+
+    async function runItemAction(
+        key: string,
+        action: () => unknown | Promise<unknown>,
+    ) {
+        setPendingAction(key);
+        setActionError(null);
+        try {
+            const result = await action();
+            if (isDriverCommandResult(result) && result.status === 'failed') {
+                setActionError(result.message);
+                return false;
+            }
+            return true;
+        } catch {
+            setActionError(
+                'Promjenu nije moguće sigurno spremiti. Pokušaj ponovno ili potvrdi dostavu bez QR provjere.',
+            );
+            return false;
+        } finally {
+            setPendingAction(null);
+        }
+    }
+
+    const verificationLoading =
+        controlledHandoff &&
+        (handoff === null || handoff.syncState === 'loading');
+    const verificationDisabled =
+        disabled || verificationLoading || (controlledHandoff && !onScan);
 
     return (
         <section
@@ -107,85 +331,203 @@ export function DeliveryHarvestVerification({
                 </Typography>
             </div>
 
-            <Alert
-                color={allExpectedTracesVerified ? 'success' : 'info'}
-                startDecorator={
-                    allExpectedTracesVerified ? (
-                        <Check className="size-5" />
-                    ) : (
-                        <Info className="size-5" />
-                    )
-                }
-            >
-                {expectedTraceCount === 0
-                    ? 'Za ovu stanicu nema dostupnih QR kodova. Nastavi ručnom provjerom.'
-                    : allExpectedTracesVerified
-                      ? 'Svi urodi s dostupnim QR kodom provjereni su za ovu stanicu.'
-                      : `Provjereno ${verifiedTraceCount} od ${expectedTraceCount}. Skeniraj preostale etikete ako su dostupne.`}
-            </Alert>
+            {verificationLoading ? (
+                <Alert
+                    color="info"
+                    startDecorator={<Info className="size-5" />}
+                >
+                    Učitavanje popisa uroda za ovu predaju…
+                </Alert>
+            ) : (
+                <Alert
+                    color={fullyScanned ? 'success' : 'info'}
+                    startDecorator={
+                        fullyScanned ? (
+                            <Check className="size-5" />
+                        ) : (
+                            <Info className="size-5" />
+                        )
+                    }
+                >
+                    {!controlledHandoff && summary.expectedCount === 0
+                        ? 'Za ovu stanicu nema dostupnih QR kodova. Nastavi ručnom provjerom.'
+                        : !controlledHandoff && fullyScanned
+                          ? 'Svi urodi s dostupnim QR kodom provjereni su za ovu stanicu.'
+                          : !controlledHandoff
+                            ? `Provjereno ${summary.scannedCount} od ${availableTraceCount}. Skeniraj preostale etikete ako su dostupne.`
+                            : summary.expectedCount === 0
+                              ? 'Za ovu predaju nema uroda u manifestu.'
+                              : fullyScanned
+                                ? 'Svi urodi provjereni su QR kodom za ovu predaju.'
+                                : fullyReviewed
+                                  ? 'Svi urodi imaju zabilježen ishod provjere.'
+                                  : `Provjereno ${summary.scannedCount} od ${summary.expectedCount}. Preostalo ${summary.unverifiedCount} bez zabilježene provjere.`}
+                </Alert>
+            )}
 
-            {expectedTraceCount > 0 ? (
+            {controlledHandoff && handoff && !verificationLoading ? (
+                <fieldset
+                    className="flex flex-wrap gap-2"
+                    aria-label="Sažetak provjere predaje"
+                >
+                    <Chip color="neutral" size="sm">
+                        {summary.expectedCount} ukupno
+                    </Chip>
+                    <Chip color="success" size="sm">
+                        {summary.scannedCount} provjereno
+                    </Chip>
+                    <Chip color="warning" size="sm">
+                        {summary.noLabelCount} bez etikete
+                    </Chip>
+                    <Chip color="error" size="sm">
+                        {summary.missingCount} nedostaje
+                    </Chip>
+                    <Chip color="warning" size="sm">
+                        {summary.skippedCount} preskočeno
+                    </Chip>
+                    {summary.pendingCount > 0 ? (
+                        <Chip color="info" size="sm">
+                            {summary.pendingCount} čeka potvrdu
+                        </Chip>
+                    ) : null}
+                </fieldset>
+            ) : null}
+
+            {handoff?.syncState === 'offline' ? (
+                <Alert
+                    color="warning"
+                    startDecorator={<Warning className="size-5" />}
+                >
+                    Nema internetske veze. Zabilježene promjene ostaju vidljive
+                    i čekaju slanje nakon povratka veze.
+                </Alert>
+            ) : handoff?.syncState === 'failed' ? (
+                <Alert
+                    color="warning"
+                    startDecorator={<Warning className="size-5" />}
+                >
+                    {handoff.error ??
+                        'Neke provjere još nisu potvrđene na poslužitelju.'}{' '}
+                    To ne blokira potvrdu dostave.
+                </Alert>
+            ) : handoff?.syncState === 'syncing' || summary.pendingCount > 0 ? (
+                <Alert
+                    color="info"
+                    startDecorator={<Info className="size-5" />}
+                >
+                    {summary.pendingCount > 0
+                        ? `${summary.pendingCount} ${summary.pendingCount === 1 ? 'promjena čeka' : 'promjene čekaju'} potvrdu poslužitelja.`
+                        : 'Provjere se usklađuju s poslužiteljem.'}
+                </Alert>
+            ) : null}
+
+            {controlledHandoff && feedback.length > 0 ? (
+                <Alert
+                    color="warning"
+                    role="status"
+                    aria-live="polite"
+                    aria-label="Povratne informacije provjere predaje"
+                    startDecorator={<Warning className="size-5" />}
+                >
+                    <ul className="space-y-1">
+                        {feedback.slice(-3).map((item) => (
+                            <li key={item.operationId}>{item.message}</li>
+                        ))}
+                    </ul>
+                </Alert>
+            ) : null}
+
+            {availableTraceCount > 0 ? (
                 <HarvestTraceScanner
                     variant="verification"
-                    availableTraceCount={expectedTraceCount}
-                    completedTraceCount={verifiedTraceCount}
-                    disabled={disabled}
+                    availableTraceCount={availableTraceCount}
+                    completedTraceCount={completedTraceCount}
+                    disabled={verificationDisabled}
                     onScan={verifyTrace}
                 />
             ) : null}
 
-            <ul
-                className={compact ? 'sr-only' : 'space-y-2'}
-                aria-label="Urodi na ovoj stanici"
-            >
-                {deliveries.map((delivery) => {
-                    const tracePath = tracePathByRequestId.get(
-                        delivery.requestId,
-                    );
-                    const verified = Boolean(
-                        tracePath && verifiedTracePathSet.has(tracePath),
-                    );
+            {!verificationLoading ? (
+                <ul
+                    className={
+                        compact && !controlledHandoff ? 'sr-only' : 'space-y-2'
+                    }
+                    aria-label="Urodi na ovoj stanici"
+                >
+                    {items.map((item) => (
+                        <DeliveryHandoffVerificationItem
+                            key={item.stopId}
+                            compact={compact}
+                            delivery={matchingDelivery(deliveries, item)}
+                            disabled={disabled}
+                            item={item}
+                            pendingAction={pendingAction}
+                            onMarkItem={
+                                controlledHandoff ? onMarkItem : undefined
+                            }
+                            onRunAction={runItemAction}
+                        />
+                    ))}
+                </ul>
+            ) : null}
 
-                    return (
-                        <li
-                            key={delivery.requestId}
-                            className="flex items-center justify-between gap-3 rounded-md bg-muted/70 px-3 py-2"
-                        >
-                            <div className="min-w-0">
-                                <Typography
-                                    level="body3"
-                                    semiBold
-                                    className="truncate"
-                                >
-                                    {delivery.harvest.plantName}
-                                </Typography>
-                                <Typography
-                                    level="body3"
-                                    className="truncate text-muted-foreground"
-                                >
-                                    {delivery.contactName}
-                                </Typography>
-                            </div>
-                            <Chip
-                                color={verified ? 'success' : 'neutral'}
-                                size="sm"
-                            >
-                                {verified
-                                    ? 'Provjereno'
-                                    : tracePath
-                                      ? 'Nije skenirano'
-                                      : 'Bez QR koda'}
-                            </Chip>
-                        </li>
-                    );
-                })}
-            </ul>
+            {controlledHandoff &&
+            !verificationLoading &&
+            summary.unverifiedCount > 0 &&
+            onMarkRemainingReviewed ? (
+                <div className="space-y-1 rounded-md border border-dashed p-3">
+                    <Button
+                        type="button"
+                        size="sm"
+                        variant="outlined"
+                        loading={pendingAction === 'manual-review'}
+                        disabled={disabled || Boolean(pendingAction)}
+                        onClick={() =>
+                            void runItemAction(
+                                'manual-review',
+                                onMarkRemainingReviewed,
+                            )
+                        }
+                    >
+                        Označi preostalo kao ručno provjereno
+                    </Button>
+                    <Typography level="body3" className="text-muted-foreground">
+                        Zabilježit će se ručna provjera svih preostalih uroda.
+                        Dostavu možeš potvrditi i bez toga.
+                    </Typography>
+                </div>
+            ) : null}
+
+            {actionError ? (
+                <Alert
+                    color="warning"
+                    role="alert"
+                    aria-live="assertive"
+                    startDecorator={<Warning className="size-5" />}
+                >
+                    {actionError}
+                </Alert>
+            ) : null}
 
             <Typography level="body3" className="text-muted-foreground">
                 {compact
                     ? 'Provjera nije obavezna i ne blokira potvrdu dostave.'
                     : 'Ova provjera nije obavezna. Dostavu možeš potvrditi i ako etiketa nedostaje ili skeniranje nije moguće.'}
             </Typography>
+
+            {completionConfirmation ? (
+                <DeliveryHandoffCompletionDialog
+                    confirmation={completionConfirmation}
+                    deliveries={deliveries}
+                    handoffSyncState={
+                        controlledHandoff
+                            ? (handoff?.syncState ?? 'loading')
+                            : 'ready'
+                    }
+                    items={items}
+                    summary={summary}
+                />
+            ) : null}
         </section>
     );
 }

--- a/apps/delivery/components/DriverCurrentStopCommandCenter.tsx
+++ b/apps/delivery/components/DriverCurrentStopCommandCenter.tsx
@@ -15,7 +15,14 @@ import {
     Warning,
 } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
-import { type CSSProperties, useEffect, useId, useRef, useState } from 'react';
+import {
+    type ComponentProps,
+    type CSSProperties,
+    useEffect,
+    useId,
+    useRef,
+    useState,
+} from 'react';
 import {
     deliveryActionLocallyCompletesStop,
     deliveryActionPermanentFailureMessage,
@@ -45,9 +52,26 @@ import {
 import type { PickupManifestScanResult } from '../lib/deliveryPickupScan';
 import { isDriverCommandResult } from '../lib/driverCommandResult';
 import { DeliveryExceptionSheet } from './DeliveryExceptionSheet';
-import { DeliveryHarvestVerification } from './DeliveryHarvestVerification';
+import {
+    type DeliveryHandoffFeedbackView,
+    type DeliveryHandoffManifestView,
+    type DeliveryHandoffMarkItemInput,
+    DeliveryHarvestVerification,
+} from './DeliveryHarvestVerification';
 import type { PickupManifestSyncSummary } from './DeliveryPickupCard';
 import { HarvestTraceScanner } from './HarvestTraceScanner';
+
+export type DeliveryHandoffCommandController = {
+    view: DeliveryHandoffManifestView | null;
+    feedback: readonly DeliveryHandoffFeedbackView[];
+    scan: NonNullable<
+        ComponentProps<typeof DeliveryHarvestVerification>['onScan']
+    >;
+    markItem: (
+        input: DeliveryHandoffMarkItemInput,
+    ) => unknown | Promise<unknown>;
+    markRemainingReviewed: () => unknown | Promise<unknown>;
+};
 
 type DeliveryCommandCenterProps = {
     kind: 'delivery';
@@ -55,6 +79,7 @@ type DeliveryCommandCenterProps = {
     routeRevision: number;
     pendingAction?: 'retry' | 'arrive' | 'deliver' | 'exception' | null;
     syncEntry?: DeliveryActionQueueEntry | null;
+    handoff?: DeliveryHandoffCommandController;
     verifiedTracePaths?: string[];
     routeSyncBlocked?: boolean;
     checkpointPending?: boolean;
@@ -188,6 +213,7 @@ function DeliveryCurrentStopCommandCenter({
     routeRevision,
     pendingAction = null,
     syncEntry,
+    handoff,
     verifiedTracePaths = [],
     routeSyncBlocked = false,
     checkpointPending = false,
@@ -211,6 +237,8 @@ function DeliveryCurrentStopCommandCenter({
         'retry' | 'arrive' | 'deliver' | null
     >(null);
     const [localError, setLocalError] = useState<string | null>(null);
+    const [deliveryConfirmationOpen, setDeliveryConfirmationOpen] =
+        useState(false);
     const [syncRecoveryPending, setSyncRecoveryPending] = useState(false);
     const stickyHeadingHeight = useElementHeight(headingRef, 96);
     const stickyActionHeight = useElementHeight(actionRef, 48);
@@ -283,8 +311,11 @@ function DeliveryCurrentStopCommandCenter({
             if (isDriverCommandResult(result) && result.status === 'failed') {
                 setLocalError(result.message);
             }
+            return result;
         } catch (error) {
-            setLocalError(commandErrorMessage(error));
+            const message = commandErrorMessage(error);
+            setLocalError(message);
+            return { status: 'failed' as const, message };
         } finally {
             setLocalPendingAction(null);
         }
@@ -620,9 +651,11 @@ function DeliveryCurrentStopCommandCenter({
                                         : undefined
                                 }
                                 onClick={() =>
-                                    void runCommand('deliver', () =>
-                                        onDeliver?.(notes || undefined),
-                                    )
+                                    !handoff
+                                        ? void runCommand('deliver', () =>
+                                              onDeliver?.(notes || undefined),
+                                          )
+                                        : setDeliveryConfirmationOpen(true)
                                 }
                                 startDecorator={<Approved className="size-4" />}
                             >
@@ -736,6 +769,37 @@ function DeliveryCurrentStopCommandCenter({
                             disabled={
                                 Boolean(effectivePendingAction) ||
                                 routeCommandBlocked
+                            }
+                            handoff={handoff?.view}
+                            feedback={handoff?.feedback}
+                            onScan={handoff?.scan}
+                            onMarkItem={handoff?.markItem}
+                            onMarkRemainingReviewed={
+                                handoff?.markRemainingReviewed
+                            }
+                            completionConfirmation={
+                                !handoff
+                                    ? undefined
+                                    : {
+                                          open: deliveryConfirmationOpen,
+                                          pending:
+                                              effectivePendingAction ===
+                                              'deliver',
+                                          disabled:
+                                              routeCommandBlocked ||
+                                              deliveryQueued ||
+                                              actionableDeliveries.length ===
+                                                  0 ||
+                                              !onDeliver,
+                                          onOpenChange:
+                                              setDeliveryConfirmationOpen,
+                                          onConfirm: () =>
+                                              runCommand('deliver', () =>
+                                                  onDeliver?.(
+                                                      notes || undefined,
+                                                  ),
+                                              ),
+                                      }
                             }
                             verifiedTracePaths={verifiedTracePaths}
                             onVerifiedTrace={onVerificationScan}

--- a/apps/delivery/components/DriverDashboard.tsx
+++ b/apps/delivery/components/DriverDashboard.tsx
@@ -28,6 +28,7 @@ import {
     type DeliveryActionQueueSnapshot,
     deliveryActionPendingEntryForStop,
     deliveryActionVerifiedTracePaths,
+    isDeliveryHandoffCommand,
 } from '../lib/deliveryActionQueue';
 import {
     currentDeliveryRouteStep,
@@ -75,7 +76,10 @@ import { DeliveryAppHeader } from './DeliveryAppHeader';
 import { DeliveryBatchCard } from './DeliveryBatchCard';
 import { DeliveryMap } from './DeliveryMap';
 import type { PickupManifestSyncSummary } from './DeliveryPickupCard';
-import { DriverCurrentStopCommandCenter } from './DriverCurrentStopCommandCenter';
+import {
+    type DeliveryHandoffCommandController,
+    DriverCurrentStopCommandCenter,
+} from './DriverCurrentStopCommandCenter';
 import { DriverRouteContinuity } from './DriverRouteContinuity';
 import { DriverRouteProgressTimeline } from './DriverRouteProgressTimeline';
 import { DriverRouteStepDetails } from './DriverRouteStepDetails';
@@ -349,7 +353,7 @@ export function DeliveryActionSyncStatus({
     const pendingEntries =
         snapshot?.entries.filter(
             (entry) =>
-                entry.command.kind !== 'verification-scan' &&
+                !isDeliveryHandoffCommand(entry.command) &&
                 entry.state !== 'synced',
         ) ?? [];
     const blockingEntry: DeliveryActionQueueEntry | undefined =
@@ -531,6 +535,7 @@ export function DriverDashboard({
     onException,
     pickupQueue,
     deliveryQueue,
+    deliveryHandoff,
     onPickupScan,
     onPickupItemState,
     onConfirmPickupManifest,
@@ -570,6 +575,7 @@ export function DriverDashboard({
     ) => Promise<DeliveryExceptionSubmitResult>;
     pickupQueue: PickupManifestQueueSnapshot | null;
     deliveryQueue: DeliveryActionQueueSnapshot | null;
+    deliveryHandoff?: DeliveryHandoffCommandController | null;
     onPickupScan: (
         pickupNodeId: string,
         scanValue: string,
@@ -609,10 +615,11 @@ export function DriverDashboard({
         run?.reroutePending ||
             deliveryQueue?.entries.some(
                 (entry) =>
-                    entry.state === 'failed' ||
-                    entry.state === 'conflicted' ||
-                    entry.state === 'reconciling' ||
-                    deliveryActionAcknowledgementBlocksRoute(entry),
+                    !isDeliveryHandoffCommand(entry.command) &&
+                    (entry.state === 'failed' ||
+                        entry.state === 'conflicted' ||
+                        entry.state === 'reconciling' ||
+                        deliveryActionAcknowledgementBlocksRoute(entry)),
             ),
     );
     const syncingRouteStepIds = new Set(
@@ -710,7 +717,7 @@ export function DriverDashboard({
     const currentCommandIdentity = currentRouteStepIdentity
         ? currentPickup
             ? `${currentRouteStepIdentity}:manifest:${currentPickupManifestId ?? 'complete'}`
-            : `${currentRouteStepIdentity}:requests:${currentDeliveryCommandRequestIdentity ?? 'none'}`
+            : `${currentRouteStepIdentity}:attempt:${currentRouteStep?.kind === 'delivery' ? currentRouteStep.retryAttempt : 0}:requests:${currentDeliveryCommandRequestIdentity ?? 'none'}`
         : null;
     const focusCurrentCommand = useCurrentCommandTransitionFocus(
         currentCommandIdentity,
@@ -990,7 +997,7 @@ export function DriverDashboard({
                             />
                         ) : currentDeliveryStop ? (
                             <DriverCurrentStopCommandCenter
-                                key={`${run.id}:delivery:${currentDeliveryStop.id}:requests:${currentDeliveryCommandRequestIdentity}`}
+                                key={`${run.id}:delivery:${currentDeliveryStop.id}:attempt:${currentRouteStep?.kind === 'delivery' ? currentRouteStep.retryAttempt : 0}:requests:${currentDeliveryCommandRequestIdentity}`}
                                 kind="delivery"
                                 stop={currentDeliveryStop}
                                 routeRevision={run.routeRevision}
@@ -1000,11 +1007,16 @@ export function DriverDashboard({
                                     currentDeliveryStop.id,
                                 )}
                                 syncEntry={currentDeliverySyncEntry}
+                                handoff={deliveryHandoff ?? undefined}
                                 verifiedTracePaths={
                                     currentDeliveryStopId
                                         ? deliveryActionVerifiedTracePaths(
                                               deliveryQueue,
                                               currentDeliveryStopId,
+                                              currentRouteStep?.kind ===
+                                                  'delivery'
+                                                  ? currentRouteStep.retryAttempt
+                                                  : 0,
                                           )
                                         : []
                                 }

--- a/apps/delivery/components/OfflineRoutePanel.tsx
+++ b/apps/delivery/components/OfflineRoutePanel.tsx
@@ -15,6 +15,7 @@ import {
     type DeliveryActionQueueSnapshot,
     deliveryActionPendingEntryForStop,
     deliveryActionVerifiedTracePaths,
+    isDeliveryHandoffCommand,
 } from '../lib/deliveryActionQueue';
 import type {
     DeliveryPickupStepSummary,
@@ -40,7 +41,10 @@ import type {
     OfflineRouteSnapshot,
     OfflineRouteStep,
 } from '../lib/offlineRouteCache';
-import { DriverCurrentStopCommandCenter } from './DriverCurrentStopCommandCenter';
+import {
+    type DeliveryHandoffCommandController,
+    DriverCurrentStopCommandCenter,
+} from './DriverCurrentStopCommandCenter';
 import { DeliveryActionSyncStatus } from './DriverDashboard';
 import { DriverRouteProgressTimeline } from './DriverRouteProgressTimeline';
 
@@ -144,7 +148,7 @@ function hasDeliveryStopId(
     return step.kind === 'delivery' && step.id !== null;
 }
 
-function offlineDeliveryItems(
+export function offlineDeliveryItems(
     step: OfflineRouteDeliveryStep,
 ): DeliveryStopDeliverySummary[] {
     return step.items.map((item) => ({
@@ -163,6 +167,37 @@ function offlineDeliveryItems(
         },
         exception: null,
     }));
+}
+
+export function offlineRouteActiveStepIndex(
+    snapshot: OfflineRouteSnapshot,
+    actionQueue: DeliveryActionQueueSnapshot,
+) {
+    const firstStep = snapshot.steps[0];
+    const firstStopId = firstStep?.kind === 'delivery' ? firstStep.id : null;
+    const firstEntry = firstStopId
+        ? deliveryActionPendingEntryForStop(actionQueue, firstStopId)
+        : undefined;
+    return deliveryActionLocallyCompletesStop(firstEntry) &&
+        snapshot.steps.length > 1
+        ? 1
+        : 0;
+}
+
+export function offlineDeliveryHandoffSelection(
+    snapshot: OfflineRouteSnapshot,
+    actionQueue: DeliveryActionQueueSnapshot,
+) {
+    const step =
+        snapshot.steps[offlineRouteActiveStepIndex(snapshot, actionQueue)];
+    if (!step || !hasDeliveryStopId(step)) return null;
+    return {
+        target: {
+            targetStopId: step.id,
+            retryAttempt: step.retryAttempt,
+        },
+        deliveries: offlineDeliveryItems(step),
+    };
 }
 
 function offlineDeliveryStop(
@@ -237,6 +272,7 @@ function offlinePickup(
 export function OfflineRoutePanel({
     snapshot,
     actionQueue,
+    deliveryHandoff,
     routeContinuity,
     onArrive,
     onDeliver,
@@ -248,6 +284,7 @@ export function OfflineRoutePanel({
 }: {
     snapshot: OfflineRouteSnapshot;
     actionQueue: DeliveryActionQueueSnapshot;
+    deliveryHandoff?: DeliveryHandoffCommandController | null;
     routeContinuity?: ReactNode;
     onArrive: (
         stopId: number,
@@ -275,11 +312,7 @@ export function OfflineRoutePanel({
     const firstEntry = firstStopId
         ? deliveryActionPendingEntryForStop(actionQueue, firstStopId)
         : undefined;
-    const activeStepIndex =
-        deliveryActionLocallyCompletesStop(firstEntry) &&
-        snapshot.steps.length > 1
-            ? 1
-            : 0;
+    const activeStepIndex = offlineRouteActiveStepIndex(snapshot, actionQueue);
     const currentStep = snapshot.steps[activeStepIndex];
     const currentStopId =
         currentStep?.kind === 'delivery' ? currentStep.id : null;
@@ -291,12 +324,13 @@ export function OfflineRoutePanel({
         snapshot.source.reroutePending ||
         actionQueue.entries.some(
             (entry) =>
-                (entry.command.kind === 'exception' &&
+                !isDeliveryHandoffCommand(entry.command) &&
+                ((entry.command.kind === 'exception' &&
                     entry.state !== 'synced') ||
-                entry.state === 'failed' ||
-                deliveryActionAcknowledgementBlocksRoute(entry),
-        ) ||
-        actionQueue.conflictedCount > 0;
+                    entry.state === 'failed' ||
+                    entry.state === 'conflicted' ||
+                    deliveryActionAcknowledgementBlocksRoute(entry)),
+        );
     const currentDeliveryStop =
         currentStep && hasDeliveryStopId(currentStep)
             ? offlineDeliveryStop(currentStep, snapshot.scope.runId)
@@ -320,16 +354,18 @@ export function OfflineRoutePanel({
             <div className="mx-auto max-w-3xl space-y-4">
                 {currentDeliveryStop && currentStep?.kind === 'delivery' ? (
                     <DriverCurrentStopCommandCenter
-                        key={`${snapshot.scope.runId}:delivery:${currentDeliveryStop.id}`}
+                        key={`${snapshot.scope.runId}:delivery:${currentDeliveryStop.id}:attempt:${currentStep.retryAttempt}`}
                         kind="delivery"
                         offline
                         focusOnMount={activeStepIndex > 0}
                         stop={currentDeliveryStop}
                         routeRevision={snapshot.source.routeRevision}
                         syncEntry={currentEntry}
+                        handoff={deliveryHandoff ?? undefined}
                         verifiedTracePaths={deliveryActionVerifiedTracePaths(
                             actionQueue,
                             currentDeliveryStop.id,
+                            currentStep.retryAttempt,
                         )}
                         routeSyncBlocked={routeBarrier}
                         onArrive={() =>

--- a/apps/delivery/components/OfflineRouteRecovery.tsx
+++ b/apps/delivery/components/OfflineRouteRecovery.tsx
@@ -4,12 +4,16 @@ import {
     type DeliveryServerStateExpectation,
     useDeliveryActionSync,
 } from '../hooks/useDeliveryActionSync';
+import { useDeliveryHandoffSync } from '../hooks/useDeliveryHandoffSync';
 import type { DriverRouteWakeLockState } from '../hooks/useDriverRouteWakeLock';
 import type { DriverCommandResult } from '../lib/driverCommandResult';
 import type { OfflineRouteSnapshot } from '../lib/offlineRouteCache';
 import { DeliveryAppHeader } from './DeliveryAppHeader';
 import { DriverRouteContinuity } from './DriverRouteContinuity';
-import { OfflineRoutePanel } from './OfflineRoutePanel';
+import {
+    OfflineRoutePanel,
+    offlineDeliveryHandoffSelection,
+} from './OfflineRoutePanel';
 
 export function OfflineRouteRecovery({
     snapshot,
@@ -31,6 +35,26 @@ export function OfflineRouteRecovery({
         runId: snapshot.scope.runId,
         refreshServerState,
     });
+    const handoffSelection = offlineDeliveryHandoffSelection(
+        snapshot,
+        sync.snapshot,
+    );
+    const deliveryHandoffSync = useDeliveryHandoffSync({
+        userId: authenticatedUserId,
+        runId: snapshot.scope.runId,
+        target: handoffSelection?.target ?? null,
+        deliveries: handoffSelection?.deliveries ?? [],
+        actionSync: sync,
+    });
+    const deliveryHandoff = handoffSelection
+        ? {
+              view: deliveryHandoffSync.handoff,
+              feedback: deliveryHandoffSync.feedback,
+              scan: deliveryHandoffSync.scan,
+              markItem: deliveryHandoffSync.markItem,
+              markRemainingReviewed: deliveryHandoffSync.markRemainingReviewed,
+          }
+        : null;
 
     const report = async (
         action: Promise<unknown>,
@@ -64,6 +88,7 @@ export function OfflineRouteRecovery({
             <OfflineRoutePanel
                 snapshot={snapshot}
                 actionQueue={sync.snapshot}
+                deliveryHandoff={deliveryHandoff}
                 routeContinuity={
                     <DriverRouteContinuity
                         state={routeWakeLock}
@@ -89,9 +114,25 @@ export function OfflineRouteRecovery({
                             : { status: 'retryable', message };
                     }
                 }}
-                onVerificationScan={(stopId, tracePath) =>
-                    report(sync.enqueueVerificationScan(stopId, tracePath))
-                }
+                onVerificationScan={(stopId, tracePath) => {
+                    if (
+                        !handoffSelection ||
+                        handoffSelection.target.targetStopId !== stopId
+                    ) {
+                        return Promise.resolve({
+                            status: 'failed' as const,
+                            message:
+                                'Aktivni posjet stanici promijenio se. Osvježi prikaz prije nove provjere.',
+                        });
+                    }
+                    return report(
+                        sync.enqueueVerificationScan(
+                            stopId,
+                            tracePath,
+                            handoffSelection.target.retryAttempt,
+                        ),
+                    );
+                }}
                 onRetry={(operationId) => report(sync.retry(operationId))}
                 onRecoverConflict={(operationId) =>
                     report(

--- a/apps/delivery/hooks/useDeliveryActionSync.ts
+++ b/apps/delivery/hooks/useDeliveryActionSync.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import type { DeliveryRunHandoffSkipReason } from '@gredice/storage';
 import {
     useCallback,
     useEffect,
@@ -19,14 +20,16 @@ import {
     createDeliveryArriveCommand,
     createDeliveryCompleteCommand,
     createDeliveryExceptionCommand,
+    createDeliveryVerificationMarkCommand,
     createDeliveryVerificationScanCommand,
     DeliveryActionBarrierError,
     type DeliveryActionCommand,
     DeliveryActionQueue,
     type DeliveryActionQueueCoordinator,
     type DeliveryActionQueueSnapshot,
-    type DeliveryServerActionCommand,
+    type DeliveryRouteActionCommand,
     deliveryActionQueueCanReplay,
+    isDeliveryHandoffCommand,
 } from '../lib/deliveryActionQueue';
 import { sendDeliveryAction } from '../lib/deliveryActionTransport';
 import type { DeliveryExceptionMutation } from '../lib/deliveryExceptionPresentation';
@@ -182,7 +185,7 @@ export function useDeliveryActionSync({
             const next = await queue.replay();
             announceChange();
             const changedServerEntries = next.entries.filter((entry) => {
-                if (entry.command.kind === 'verification-scan') return false;
+                if (isDeliveryHandoffCommand(entry.command)) return false;
                 const previous = before.entries.find(
                     (candidate) =>
                         candidate.command.operationId ===
@@ -215,7 +218,7 @@ export function useDeliveryActionSync({
             if (changedServerEntries.length === 0) return next;
             const acknowledgedEntries = next.entries.filter(
                 (entry) =>
-                    entry.command.kind !== 'verification-scan' &&
+                    !isDeliveryHandoffCommand(entry.command) &&
                     entry.acknowledgement?.kind === 'server',
             );
             const highestRevision = Math.max(
@@ -267,7 +270,7 @@ export function useDeliveryActionSync({
             .getSnapshot()
             .entries.filter(
                 (entry) =>
-                    entry.command.kind !== 'verification-scan' &&
+                    !isDeliveryHandoffCommand(entry.command) &&
                     entry.acknowledgement?.kind === 'server' &&
                     !entry.acknowledgement.runCompleted,
             );
@@ -312,7 +315,7 @@ export function useDeliveryActionSync({
             }
             const hasServerAcknowledgement = restored.entries.some(
                 (entry) =>
-                    entry.command.kind !== 'verification-scan' &&
+                    !isDeliveryHandoffCommand(entry.command) &&
                     entry.acknowledgement?.kind === 'server',
             );
             if (hasServerAcknowledgement) {
@@ -377,7 +380,7 @@ export function useDeliveryActionSync({
         async (command: DeliveryActionCommand) => {
             const entry = await queue.enqueue(command);
             announceChange();
-            if (navigator.onLine && command.kind !== 'verification-scan') {
+            if (navigator.onLine) {
                 void replay().catch(() => undefined);
             }
             return entry;
@@ -390,7 +393,7 @@ export function useDeliveryActionSync({
             serverRouteRevision: number,
             createCommand: (
                 expectedRouteRevision: number,
-            ) => DeliveryServerActionCommand,
+            ) => DeliveryRouteActionCommand,
         ) => {
             const entry = await queue.enqueueRouteAction(
                 serverRouteRevision,
@@ -465,15 +468,59 @@ export function useDeliveryActionSync({
                         exceptions: mutation.exceptions,
                     }),
             ),
-        enqueueVerificationScan: (stopId: number, tracePath: string) =>
+        enqueueVerificationScan: (
+            stopId: number,
+            tracePath: string,
+            expectedRetryAttempt: number,
+        ) =>
             enqueue(
                 createDeliveryVerificationScanCommand({
                     operationId: operationId('verification'),
                     runId,
                     stopId,
+                    expectedRetryAttempt,
                     tracePath,
                 }),
             ),
+        enqueueVerificationMark: ({
+            stopId,
+            expectedRetryAttempt,
+            itemStopId,
+            outcome,
+            reason,
+        }: {
+            stopId: number;
+            expectedRetryAttempt: number;
+            itemStopId: number;
+            outcome: 'no-label' | 'missing' | 'skipped';
+            reason?: DeliveryRunHandoffSkipReason;
+        }) =>
+            enqueue(
+                createDeliveryVerificationMarkCommand({
+                    operationId: operationId('verification'),
+                    runId,
+                    stopId,
+                    expectedRetryAttempt,
+                    itemStopId,
+                    outcome,
+                    reason,
+                }),
+            ),
+        completeHandoffReconciliation: async (
+            stopId: number,
+            expectedRetryAttempt: number,
+            operationIds: readonly string[],
+        ) => {
+            const removed = await queue.completeHandoffReconciliation({
+                stopId,
+                expectedRetryAttempt,
+                operationIds,
+            });
+            if (removed > 0) announceChange();
+            return removed;
+        },
+        getSnapshot: queue.getSnapshot,
+        syncNow: replay,
         retry,
         recoverConflict,
         reconcilePendingServerState,

--- a/apps/delivery/hooks/useDeliveryHandoffSync.ts
+++ b/apps/delivery/hooks/useDeliveryHandoffSync.ts
@@ -1,0 +1,277 @@
+'use client';
+
+import type { DeliveryRunHandoffSkipReason } from '@gredice/storage';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useSyncExternalStore,
+} from 'react';
+import type { DeliveryActionQueueSnapshot } from '../lib/deliveryActionQueue';
+import type { DeliveryStopDeliverySummary } from '../lib/deliveryDashboardTypes';
+import {
+    type DeliveryHandoffManifestFetchResult,
+    fetchDeliveryHandoffManifest,
+} from '../lib/deliveryHandoffManifest';
+import {
+    createMemoryDeliveryHandoffManifestCachePersistence,
+    createWebStorageDeliveryHandoffManifestCachePersistence,
+} from '../lib/deliveryHandoffManifestCache';
+import {
+    type DeliveryHandoffActionSyncAdapter,
+    type DeliveryHandoffFeedback,
+    type DeliveryHandoffManifestView,
+    DeliveryHandoffSyncController,
+    type DeliveryHandoffSyncStatus,
+    type DeliveryHandoffTarget,
+    deliveryHandoffDeliveriesFingerprint,
+    type HarvestTraceScanFailureResult,
+} from '../lib/deliveryHandoffSyncController';
+import type { DriverCommandResult } from '../lib/driverCommandResult';
+import type { HarvestTraceVerificationResult } from '../lib/harvestTraceScan';
+
+export type UseDeliveryHandoffSyncResult = {
+    handoff: DeliveryHandoffManifestView | null;
+    status: DeliveryHandoffSyncStatus;
+    error: string | null;
+    feedback: readonly DeliveryHandoffFeedback[];
+    scan: (
+        value: string,
+    ) => Promise<
+        HarvestTraceVerificationResult | HarvestTraceScanFailureResult
+    >;
+    markItem: (input: {
+        itemStopId: number;
+        outcome: 'no-label' | 'missing' | 'skipped';
+        reason?: DeliveryRunHandoffSkipReason;
+    }) => Promise<DriverCommandResult>;
+    markRemainingReviewed: () => Promise<DriverCommandResult>;
+    refresh: () => Promise<boolean>;
+};
+
+type DeliveryHandoffActionSync = DeliveryHandoffActionSyncAdapter & {
+    snapshot: DeliveryActionQueueSnapshot;
+};
+
+function browserHandoffManifestCache() {
+    if (typeof window === 'undefined') {
+        return createMemoryDeliveryHandoffManifestCachePersistence();
+    }
+    try {
+        return createWebStorageDeliveryHandoffManifestCachePersistence(
+            window.localStorage,
+        );
+    } catch {
+        return {
+            ...createMemoryDeliveryHandoffManifestCachePersistence(),
+            durableCleanupRequired: true,
+        };
+    }
+}
+
+function browserIsOnline() {
+    return typeof navigator === 'undefined' || navigator.onLine;
+}
+
+export function useDeliveryHandoffSync({
+    userId,
+    runId,
+    target,
+    deliveries,
+    actionSync,
+}: {
+    userId: string;
+    runId: string;
+    target: DeliveryHandoffTarget | null;
+    deliveries: readonly DeliveryStopDeliverySummary[];
+    actionSync: DeliveryHandoffActionSync;
+}): UseDeliveryHandoffSyncResult {
+    const actionSyncScopesRef = useRef(
+        new Map<string, { current: DeliveryHandoffActionSync }>(),
+    );
+    const actionSyncScopeKey = JSON.stringify([userId, runId]);
+    const existingActionSyncRef =
+        actionSyncScopesRef.current.get(actionSyncScopeKey);
+    const actionSyncRef = existingActionSyncRef ?? { current: actionSync };
+    if (!existingActionSyncRef) {
+        actionSyncScopesRef.current.set(actionSyncScopeKey, actionSyncRef);
+    }
+    actionSyncRef.current = actionSync;
+
+    const actions = useMemo<DeliveryHandoffActionSyncAdapter>(
+        () => ({
+            getSnapshot: () => actionSyncRef.current.getSnapshot(),
+            syncNow: async () => await actionSyncRef.current.syncNow(),
+            enqueueVerificationScan: async (
+                targetStopId,
+                tracePath,
+                expectedRetryAttempt,
+            ) =>
+                await actionSyncRef.current.enqueueVerificationScan(
+                    targetStopId,
+                    tracePath,
+                    expectedRetryAttempt,
+                ),
+            enqueueVerificationMark: async (input) =>
+                await actionSyncRef.current.enqueueVerificationMark(input),
+            completeHandoffReconciliation: async (
+                targetStopId,
+                expectedRetryAttempt,
+                operationIds,
+            ) =>
+                await actionSyncRef.current.completeHandoffReconciliation(
+                    targetStopId,
+                    expectedRetryAttempt,
+                    operationIds,
+                ),
+        }),
+        [actionSyncRef],
+    );
+    const cache = useMemo(browserHandoffManifestCache, []);
+    const controller = useMemo(
+        () =>
+            new DeliveryHandoffSyncController({
+                userId,
+                runId,
+                cache,
+                actions,
+                fetchManifest: async (
+                    input,
+                ): Promise<DeliveryHandoffManifestFetchResult> =>
+                    await fetchDeliveryHandoffManifest(input),
+                isOnline: browserIsOnline,
+            }),
+        [actions, cache, runId, userId],
+    );
+    const state = useSyncExternalStore(
+        controller.subscribe,
+        controller.getSnapshot,
+        controller.getServerSnapshot,
+    );
+    const deliveriesFingerprint =
+        deliveryHandoffDeliveriesFingerprint(deliveries);
+    const deliveryContextRef = useRef({
+        fingerprint: deliveriesFingerprint,
+        deliveries,
+    });
+    deliveryContextRef.current = {
+        fingerprint: deliveriesFingerprint,
+        deliveries,
+    };
+    const targetStopId = target?.targetStopId ?? null;
+    const retryAttempt = target?.retryAttempt ?? null;
+    const requestedTargetIsActive = useCallback(
+        () =>
+            targetStopId !== null &&
+            retryAttempt !== null &&
+            controller.matchesTarget({ targetStopId, retryAttempt }),
+        [controller, retryAttempt, targetStopId],
+    );
+
+    useEffect(() => {
+        const deliveryContext = deliveryContextRef.current;
+        if (deliveryContext.fingerprint !== deliveriesFingerprint) return;
+        void controller.setContext({
+            target:
+                targetStopId === null || retryAttempt === null
+                    ? null
+                    : { targetStopId, retryAttempt },
+            deliveries: deliveryContext.deliveries,
+            queueSnapshot: actions.getSnapshot(),
+        });
+    }, [
+        actions,
+        controller,
+        deliveriesFingerprint,
+        retryAttempt,
+        targetStopId,
+    ]);
+
+    useEffect(() => {
+        controller.updateQueueSnapshot(actionSync.snapshot);
+    }, [actionSync.snapshot, controller]);
+
+    useEffect(() => {
+        const handleConnectionChange = () => controller.connectionChanged();
+        window.addEventListener('online', handleConnectionChange);
+        window.addEventListener('offline', handleConnectionChange);
+        return () => {
+            window.removeEventListener('online', handleConnectionChange);
+            window.removeEventListener('offline', handleConnectionChange);
+        };
+    }, [controller]);
+
+    useEffect(() => () => controller.dispose(), [controller]);
+
+    const scan = useCallback<UseDeliveryHandoffSyncResult['scan']>(
+        async (value: string) =>
+            requestedTargetIsActive()
+                ? await controller.scan(value)
+                : {
+                      status: 'scan-failed',
+                      message:
+                          'Trenutačna stanica predaje još nije spremna za provjeru.',
+                  },
+        [controller, requestedTargetIsActive],
+    );
+    const markItem = useCallback<UseDeliveryHandoffSyncResult['markItem']>(
+        async (input: {
+            itemStopId: number;
+            outcome: 'no-label' | 'missing' | 'skipped';
+            reason?: DeliveryRunHandoffSkipReason;
+        }) =>
+            requestedTargetIsActive()
+                ? await controller.markItem(input)
+                : {
+                      status: 'failed',
+                      message:
+                          'Trenutačna stanica predaje još nije spremna za provjeru.',
+                  },
+        [controller, requestedTargetIsActive],
+    );
+    const markRemainingReviewed = useCallback<
+        UseDeliveryHandoffSyncResult['markRemainingReviewed']
+    >(
+        async () =>
+            requestedTargetIsActive()
+                ? await controller.markRemainingReviewed()
+                : {
+                      status: 'failed',
+                      message:
+                          'Trenutačna stanica predaje još nije spremna za provjeru.',
+                  },
+        [controller, requestedTargetIsActive],
+    );
+    const refresh = useCallback(
+        async () =>
+            requestedTargetIsActive() ? await controller.refresh() : false,
+        [controller, requestedTargetIsActive],
+    );
+
+    const stateMatchesRequestedTarget =
+        targetStopId !== null &&
+        retryAttempt !== null &&
+        state.handoff?.runId === runId &&
+        state.handoff.targetStopId === targetStopId &&
+        state.handoff.retryAttempt === retryAttempt;
+    const visibleStatus =
+        targetStopId === null || retryAttempt === null
+            ? 'idle'
+            : stateMatchesRequestedTarget
+              ? state.status
+              : browserIsOnline()
+                ? 'loading'
+                : 'offline';
+
+    return {
+        handoff: stateMatchesRequestedTarget ? state.handoff : null,
+        status: visibleStatus,
+        error: stateMatchesRequestedTarget ? state.error : null,
+        feedback: stateMatchesRequestedTarget ? state.feedback : [],
+        scan,
+        markItem,
+        markRemainingReviewed,
+        refresh,
+    };
+}

--- a/apps/delivery/lib/deliveryActionCompletion.ts
+++ b/apps/delivery/lib/deliveryActionCompletion.ts
@@ -1,4 +1,5 @@
 import type { DeliveryActionQueueSnapshot } from './deliveryActionQueue';
+import { isDeliveryHandoffCommand } from './deliveryActionQueue';
 
 const channelMessageVersion = 1;
 
@@ -37,7 +38,7 @@ export function deliveryRunCompletionFromSnapshot(
 ): DeliveryRunCompletion | null {
     const completed = snapshot.entries.find(
         (entry) =>
-            entry.command.kind !== 'verification-scan' &&
+            !isDeliveryHandoffCommand(entry.command) &&
             entry.acknowledgement?.kind === 'server' &&
             entry.acknowledgement.runCompleted,
     );

--- a/apps/delivery/lib/deliveryActionQueue.node.spec.ts
+++ b/apps/delivery/lib/deliveryActionQueue.node.spec.ts
@@ -10,6 +10,7 @@ import {
     createDeliveryArriveCommand,
     createDeliveryCompleteCommand,
     createDeliveryExceptionCommand,
+    createDeliveryVerificationMarkCommand,
     createDeliveryVerificationScanCommand,
     createMemoryDeliveryActionQueuePersistence,
     DeliveryActionBarrierError,
@@ -21,6 +22,7 @@ import {
     deliveryActionPendingEntryForStop,
     deliveryActionQueueCanReplay,
     deliveryActionVerifiedTracePaths,
+    isDeliveryHandoffCommand,
     nextDeliveryActionRouteRevision,
 } from './deliveryActionQueue';
 
@@ -206,6 +208,9 @@ test('a server-required reroute stops replay before dependent route work', async
     const actions = queue({
         transport: async (command) => {
             transported.push(command.operationId);
+            if (isDeliveryHandoffCommand(command)) {
+                throw new Error('Expected a route command');
+            }
             return {
                 status: 'applied',
                 routeRevision: command.expectedRouteRevision + 1,
@@ -302,9 +307,9 @@ test('computes a new command revision after restoring durable predecessors atomi
     const secondCommand = commands[1];
     if (
         !firstCommand ||
-        firstCommand.kind === 'verification-scan' ||
+        isDeliveryHandoffCommand(firstCommand) ||
         !secondCommand ||
-        secondCommand.kind === 'verification-scan'
+        isDeliveryHandoffCommand(secondCommand)
     ) {
         throw new Error('Expected two route-changing commands');
     }
@@ -417,13 +422,26 @@ test('rapid repeated route taps reuse the durable pending operation', async () =
     assert.equal(actionQueue.getSnapshot().entries.length, 1);
 });
 
-test('advisory verification scans persist locally, deduplicate, and never call transport', async () => {
+test('server-backed handoff scans deduplicate and replay before later route actions', async () => {
     const persistence = createMemoryDeliveryActionQueuePersistence();
-    let transportCalls = 0;
+    const transported: string[] = [];
     const actionQueue = queue({
         persistence,
-        transport: async () => {
-            transportCalls += 1;
+        transport: async (command) => {
+            transported.push(command.operationId);
+            if (command.kind === 'verification-scan') {
+                return {
+                    status: 'handoff-acknowledged',
+                    replayed: false,
+                    retryAttempt: 0,
+                    result: {
+                        kind: 'scan',
+                        outcome: 'applied',
+                        affectedStopIds: [101],
+                        itemState: 'scanned',
+                    },
+                };
+            }
             return {
                 status: 'applied',
                 routeRevision: 5,
@@ -433,9 +451,10 @@ test('advisory verification scans persist locally, deduplicate, and never call t
         },
     });
     const scan = createDeliveryVerificationScanCommand({
-        operationId: 'scan-1',
+        operationId: 'scan-0001',
         runId: scope.runId,
         stopId: 101,
+        expectedRetryAttempt: 0,
         tracePath: '/trag/plant-trace-token-0001',
         now,
     });
@@ -444,17 +463,288 @@ test('advisory verification scans persist locally, deduplicate, and never call t
     await actionQueue.enqueue(arrive());
     await actionQueue.replay();
 
-    assert.equal(transportCalls, 1);
+    assert.deepEqual(transported, ['scan-0001', 'arrive-1']);
     assert.deepEqual(
-        deliveryActionVerifiedTracePaths(actionQueue.getSnapshot(), 101),
+        deliveryActionVerifiedTracePaths(actionQueue.getSnapshot(), 101, 0),
         ['/trag/plant-trace-token-0001'],
     );
     const restored = queue({ persistence });
     await restored.restore();
     assert.deepEqual(
-        deliveryActionVerifiedTracePaths(restored.getSnapshot(), 101),
+        deliveryActionVerifiedTracePaths(restored.getSnapshot(), 101, 0),
         ['/trag/plant-trace-token-0001'],
     );
+    assert.equal(
+        await restored.completeHandoffReconciliation({
+            stopId: 101,
+            expectedRetryAttempt: 0,
+            operationIds: ['scan-0001'],
+        }),
+        1,
+    );
+    assert.equal(
+        restored
+            .getSnapshot()
+            .entries.some(
+                (entry) => entry.command.kind === 'verification-scan',
+            ),
+        false,
+    );
+});
+
+test('advisory handoff failures remain visible without blocking later route replay', async () => {
+    const transported: string[] = [];
+    const actionQueue = queue({
+        transport: async (command) => {
+            transported.push(command.operationId);
+            if (command.kind === 'verification-scan') {
+                return { status: 'retryable-failure', code: 'offline' };
+            }
+            if (command.kind === 'verification-mark') {
+                return {
+                    status: 'permanent-failure',
+                    code: 'handoff-operation-conflict',
+                };
+            }
+            return {
+                status: 'applied',
+                routeRevision: 5,
+                reroutePending: false,
+                runCompleted: false,
+            };
+        },
+    });
+    await actionQueue.enqueue(
+        createDeliveryVerificationScanCommand({
+            operationId: 'scan-failure-0001',
+            runId: scope.runId,
+            stopId: 101,
+            expectedRetryAttempt: 0,
+            tracePath: '/trag/plant-trace-token-0002',
+            now,
+        }),
+    );
+    await actionQueue.enqueue(
+        createDeliveryVerificationMarkCommand({
+            operationId: 'mark-failure-0001',
+            runId: scope.runId,
+            stopId: 101,
+            expectedRetryAttempt: 0,
+            itemStopId: 102,
+            outcome: 'missing',
+            now,
+        }),
+    );
+    await actionQueue.enqueue(arrive());
+
+    const replayed = await actionQueue.replay();
+
+    assert.deepEqual(transported, [
+        'scan-failure-0001',
+        'mark-failure-0001',
+        'arrive-1',
+    ]);
+    assert.deepEqual(
+        replayed.entries.map((entry) => [
+            entry.command.operationId,
+            entry.state,
+            entry.errorCode,
+        ]),
+        [
+            ['scan-failure-0001', 'failed', 'offline'],
+            ['mark-failure-0001', 'conflicted', 'handoff-operation-conflict'],
+            ['arrive-1', 'synced', undefined],
+        ],
+    );
+    assert.equal(
+        deliveryActionPendingEntryForStop(replayed, 101)?.command.operationId,
+        'arrive-1',
+    );
+});
+
+test('rapid mark duplicates collapse while later semantic corrections stay ordered', async () => {
+    const actionQueue = queue();
+    const first = await actionQueue.enqueue(
+        createDeliveryVerificationMarkCommand({
+            operationId: 'mark-no-label-0001',
+            runId: scope.runId,
+            stopId: 101,
+            expectedRetryAttempt: 2,
+            itemStopId: 102,
+            outcome: 'no-label',
+            now,
+        }),
+    );
+    const duplicate = await actionQueue.enqueue(
+        createDeliveryVerificationMarkCommand({
+            operationId: 'mark-no-label-0002',
+            runId: scope.runId,
+            stopId: 101,
+            expectedRetryAttempt: 2,
+            itemStopId: 102,
+            outcome: 'no-label',
+            now,
+        }),
+    );
+    const correction = await actionQueue.enqueue(
+        createDeliveryVerificationMarkCommand({
+            operationId: 'mark-missing-0001',
+            runId: scope.runId,
+            stopId: 101,
+            expectedRetryAttempt: 2,
+            itemStopId: 102,
+            outcome: 'missing',
+            now,
+        }),
+    );
+    const reversion = await actionQueue.enqueue(
+        createDeliveryVerificationMarkCommand({
+            operationId: 'mark-no-label-0003',
+            runId: scope.runId,
+            stopId: 101,
+            expectedRetryAttempt: 2,
+            itemStopId: 102,
+            outcome: 'no-label',
+            now,
+        }),
+    );
+
+    assert.equal(duplicate.command.operationId, first.command.operationId);
+    assert.notEqual(correction.command.operationId, first.command.operationId);
+    assert.notEqual(reversion.command.operationId, first.command.operationId);
+    assert.deepEqual(
+        actionQueue
+            .getSnapshot()
+            .entries.map((entry) => entry.command.operationId),
+        ['mark-no-label-0001', 'mark-missing-0001', 'mark-no-label-0003'],
+    );
+    assert.deepEqual(
+        actionQueue
+            .getSnapshot()
+            .entries.map((entry) => entry.command.occurredAt),
+        [
+            '2026-07-15T12:00:00.000Z',
+            '2026-07-15T12:00:00.001Z',
+            '2026-07-15T12:00:00.002Z',
+        ],
+    );
+});
+
+test('arbitrary QR payloads are rejected before durable handoff enqueue', async () => {
+    const persistence = createMemoryDeliveryActionQueuePersistence();
+    const actionQueue = queue({ persistence });
+
+    assert.throws(
+        () =>
+            createDeliveryVerificationScanCommand({
+                operationId: 'private-scan-0001',
+                runId: scope.runId,
+                stopId: 101,
+                expectedRetryAttempt: 0,
+                tracePath: 'WIFI:T:WPA;S:private-network;P:secret-password;;',
+                now,
+            }),
+        TypeError,
+    );
+
+    assert.equal((await actionQueue.restore()).entries.length, 0);
+    const restored = queue({ persistence });
+    assert.equal((await restored.restore()).entries.length, 0);
+});
+
+test('restore drops legacy local-only scans without losing route actions', async () => {
+    let savedEntries: readonly unknown[] = [];
+    const persistence: DeliveryActionQueuePersistence = {
+        durability: 'memory',
+        async load() {
+            return {
+                version: 1,
+                entries: [
+                    {
+                        sequence: 0,
+                        command: arrive(),
+                        state: 'queued',
+                        attemptCount: 0,
+                        createdAt: now().toISOString(),
+                        updatedAt: now().toISOString(),
+                    },
+                    {
+                        sequence: 1,
+                        command: {
+                            kind: 'verification-scan',
+                            operationId: 'legacy-scan-0001',
+                            runId: scope.runId,
+                            stopId: 101,
+                            occurredAt: now().toISOString(),
+                            tracePath: '/trag/legacy-plant-trace-0001',
+                        },
+                        state: 'synced',
+                        attemptCount: 0,
+                        createdAt: now().toISOString(),
+                        updatedAt: now().toISOString(),
+                        acknowledgement: {
+                            kind: 'device',
+                            replayed: false,
+                        },
+                    },
+                    {
+                        sequence: 2,
+                        command: createDeliveryVerificationMarkCommand({
+                            operationId: 'tampered-mark-0001',
+                            runId: scope.runId,
+                            stopId: 101,
+                            expectedRetryAttempt: 0,
+                            itemStopId: 102,
+                            outcome: 'missing',
+                            now,
+                        }),
+                        state: 'synced',
+                        attemptCount: 1,
+                        createdAt: now().toISOString(),
+                        updatedAt: now().toISOString(),
+                        acknowledgement: {
+                            kind: 'handoff',
+                            replayed: false,
+                            retryAttempt: 0,
+                            result: {
+                                kind: 'mark-item',
+                                outcome: 'applied',
+                                affectedStopIds: [999],
+                                itemState: 'scanned',
+                            },
+                        },
+                    },
+                    {
+                        sequence: 3,
+                        command: createDeliveryVerificationScanCommand({
+                            operationId: 'unacked-scan-0001',
+                            runId: scope.runId,
+                            stopId: 101,
+                            expectedRetryAttempt: 0,
+                            tracePath: '/trag/unacked-trace-token-0001',
+                            now,
+                        }),
+                        state: 'synced',
+                        attemptCount: 1,
+                        createdAt: now().toISOString(),
+                        updatedAt: now().toISOString(),
+                    },
+                ],
+            };
+        },
+        async save(_scope, entries) {
+            savedEntries = entries;
+        },
+        async clear() {},
+    };
+
+    const restored = await queue({ persistence }).restore();
+
+    assert.deepEqual(
+        restored.entries.map((entry) => entry.command.operationId),
+        ['arrive-1'],
+    );
+    assert.equal(savedEntries.length, 1);
 });
 
 test('rejects operation ID reuse with a changed payload and expires old device data', async () => {
@@ -669,6 +959,7 @@ test('shared state and replay locks preserve concurrent cross-tab actions', asyn
                 operationId: 'cross-tab-scan',
                 runId: scope.runId,
                 stopId: 101,
+                expectedRetryAttempt: 0,
                 tracePath: '/trag/cross-tab-trace-0001',
                 now,
             }),

--- a/apps/delivery/lib/deliveryActionQueue.ts
+++ b/apps/delivery/lib/deliveryActionQueue.ts
@@ -1,4 +1,8 @@
 import type {
+    DeliveryRunHandoffItemState,
+    DeliveryRunHandoffSkipReason,
+} from '@gredice/storage';
+import type {
     DeliveryExceptionOutcome,
     DeliveryExceptionReason,
 } from './deliveryDashboardTypes';
@@ -37,25 +41,42 @@ export type DeliveryExceptionCommand = DeliveryRouteCommandBase & {
     }>;
 };
 
-export type DeliveryVerificationScanCommand = {
-    kind: 'verification-scan';
+type DeliveryHandoffCommandBase = {
     operationId: string;
     runId: string;
     stopId: number;
+    expectedRetryAttempt: number;
     occurredAt: string;
+};
+
+export type DeliveryVerificationScanCommand = DeliveryHandoffCommandBase & {
+    kind: 'verification-scan';
     tracePath: string;
 };
+
+export type DeliveryVerificationMarkCommand = DeliveryHandoffCommandBase & {
+    kind: 'verification-mark';
+    itemStopId: number;
+    outcome: 'no-label' | 'missing' | 'skipped';
+    reason?: DeliveryRunHandoffSkipReason;
+};
+
+export type DeliveryHandoffCommand =
+    | DeliveryVerificationScanCommand
+    | DeliveryVerificationMarkCommand;
 
 export type DeliveryActionCommand =
     | DeliveryArriveCommand
     | DeliveryCompleteCommand
     | DeliveryExceptionCommand
-    | DeliveryVerificationScanCommand;
+    | DeliveryHandoffCommand;
 
-export type DeliveryServerActionCommand = Exclude<
+export type DeliveryRouteActionCommand = Exclude<
     DeliveryActionCommand,
-    DeliveryVerificationScanCommand
+    DeliveryHandoffCommand
 >;
+
+export type DeliveryServerActionCommand = DeliveryActionCommand;
 
 export type DeliveryActionCommandState =
     | 'queued'
@@ -65,13 +86,43 @@ export type DeliveryActionCommandState =
     | 'failed'
     | 'conflicted';
 
-export type DeliveryActionAcknowledgement = {
-    kind: 'server' | 'device';
+export type DeliveryRouteActionAcknowledgement = {
+    kind: 'server';
     replayed: boolean;
     routeRevision?: number;
     reroutePending?: boolean;
     runCompleted?: boolean;
 };
+
+export type DeliveryHandoffOperationOutcome =
+    | 'applied'
+    | 'already-applied'
+    | 'stale'
+    | 'invalid'
+    | 'wrong-stop'
+    | 'item-not-found';
+
+export type DeliveryHandoffOperationResult = {
+    kind: 'scan' | 'mark-item';
+    outcome: DeliveryHandoffOperationOutcome;
+    affectedStopIds: number[];
+    itemState?: DeliveryRunHandoffItemState;
+    reason?: DeliveryRunHandoffSkipReason;
+};
+
+export type DeliveryHandoffActionAcknowledgement = {
+    kind: 'handoff';
+    replayed: boolean;
+    retryAttempt: number;
+    result: DeliveryHandoffOperationResult;
+    routeRevision?: undefined;
+    reroutePending?: undefined;
+    runCompleted?: undefined;
+};
+
+export type DeliveryActionAcknowledgement =
+    | DeliveryRouteActionAcknowledgement
+    | DeliveryHandoffActionAcknowledgement;
 
 export type DeliveryActionQueueEntry = {
     sequence: number;
@@ -112,6 +163,12 @@ export type DeliveryActionTransportResult =
           routeRevision: number;
           reroutePending: boolean;
           runCompleted: boolean;
+      }
+    | {
+          status: 'handoff-acknowledged';
+          replayed: boolean;
+          retryAttempt: number;
+          result: DeliveryHandoffOperationResult;
       }
     | { status: 'retryable-failure'; code?: string }
     | { status: 'permanent-failure'; code?: string };
@@ -161,6 +218,15 @@ type DeliveryRouteCommandInput = {
     now?: () => Date;
 };
 
+type DeliveryHandoffCommandInput = {
+    operationId: string;
+    runId: string;
+    stopId: number;
+    expectedRetryAttempt: number;
+    occurredAt?: string;
+    now?: () => Date;
+};
+
 const persistenceVersion = 1;
 export const deliveryActionQueueTtlMs = 24 * 60 * 60 * 1_000;
 const maximumPersistedEntries = 200;
@@ -184,12 +250,36 @@ function validStopId(value: unknown): value is number {
     return typeof value === 'number' && Number.isInteger(value) && value > 0;
 }
 
+function validHandoffStopId(value: unknown): value is number {
+    return (
+        validStopId(value) &&
+        Number.isSafeInteger(value) &&
+        value <= 2_147_483_647
+    );
+}
+
 function validRevision(value: unknown): value is number {
     return typeof value === 'number' && Number.isInteger(value) && value >= 0;
 }
 
+function validRetryAttempt(value: unknown): value is number {
+    return (
+        typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+    );
+}
+
 function validDate(value: unknown): value is string {
     return typeof value === 'string' && Number.isFinite(Date.parse(value));
+}
+
+function validHandoffDate(value: unknown): value is string {
+    return (
+        typeof value === 'string' &&
+        /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?(?:Z|[+-](\d{2}):(\d{2}))$/.test(
+            value,
+        ) &&
+        Number.isFinite(Date.parse(value))
+    );
 }
 
 function validErrorCode(value: unknown): value is string {
@@ -224,10 +314,51 @@ function validOutcome(value: unknown): value is DeliveryExceptionOutcome {
     return value === 'deferred' || value === 'failed' || value === 'cancelled';
 }
 
+function validHandoffOperationId(value: unknown): value is string {
+    return typeof value === 'string' && /^[A-Za-z0-9_-]{8,128}$/.test(value);
+}
+
 function validTracePath(value: unknown): value is string {
     return (
         typeof value === 'string' &&
+        value.length <= 2_048 &&
         normalizeHarvestTraceScanValue(value) === value
+    );
+}
+
+function validHandoffState(
+    value: unknown,
+): value is DeliveryRunHandoffItemState {
+    return (
+        value === 'unverified' ||
+        value === 'scanned' ||
+        value === 'no-label' ||
+        value === 'missing' ||
+        value === 'skipped'
+    );
+}
+
+function validHandoffSkipReason(
+    value: unknown,
+): value is DeliveryRunHandoffSkipReason {
+    return (
+        value === 'scanner-unavailable' ||
+        value === 'label-unreadable' ||
+        value === 'manual-verification' ||
+        value === 'other-operational'
+    );
+}
+
+function validHandoffOutcome(
+    value: unknown,
+): value is DeliveryHandoffOperationOutcome {
+    return (
+        value === 'applied' ||
+        value === 'already-applied' ||
+        value === 'stale' ||
+        value === 'invalid' ||
+        value === 'wrong-stop' ||
+        value === 'item-not-found'
     );
 }
 
@@ -239,6 +370,37 @@ function validException(value: unknown) {
         validReason(value.reason) &&
         validNote(value.note)
     );
+}
+
+export function isDeliveryHandoffCommand(
+    value: unknown,
+): value is DeliveryHandoffCommand {
+    if (
+        !isRecord(value) ||
+        (value.kind !== 'verification-scan' &&
+            value.kind !== 'verification-mark') ||
+        !validHandoffOperationId(value.operationId) ||
+        !validIdentifier(value.runId) ||
+        !validHandoffStopId(value.stopId) ||
+        !validRetryAttempt(value.expectedRetryAttempt) ||
+        !validHandoffDate(value.occurredAt)
+    ) {
+        return false;
+    }
+    if (value.kind === 'verification-scan') {
+        return validTracePath(value.tracePath);
+    }
+    if (
+        !validHandoffStopId(value.itemStopId) ||
+        (value.outcome !== 'no-label' &&
+            value.outcome !== 'missing' &&
+            value.outcome !== 'skipped')
+    ) {
+        return false;
+    }
+    return value.outcome === 'skipped'
+        ? validHandoffSkipReason(value.reason)
+        : value.reason === undefined;
 }
 
 function isDeliveryActionCommand(
@@ -253,9 +415,7 @@ function isDeliveryActionCommand(
     ) {
         return false;
     }
-    if (value.kind === 'verification-scan') {
-        return validTracePath(value.tracePath);
-    }
+    if (isDeliveryHandoffCommand(value)) return true;
     if (!validRevision(value.expectedRouteRevision)) return false;
     if (value.kind === 'arrive') return true;
     if (value.kind === 'deliver') return validNote(value.notes);
@@ -268,17 +428,74 @@ function isDeliveryActionCommand(
     );
 }
 
-function isAcknowledgement(
+function isHandoffOperationResult(
     value: unknown,
-): value is DeliveryActionAcknowledgement {
+): value is DeliveryHandoffOperationResult {
+    return (
+        isRecord(value) &&
+        (value.kind === 'scan' || value.kind === 'mark-item') &&
+        validHandoffOutcome(value.outcome) &&
+        Array.isArray(value.affectedStopIds) &&
+        value.affectedStopIds.every(validStopId) &&
+        new Set(value.affectedStopIds).size === value.affectedStopIds.length &&
+        (value.itemState === undefined || validHandoffState(value.itemState)) &&
+        (value.reason === undefined || validHandoffSkipReason(value.reason))
+    );
+}
+
+function handoffAcknowledgementMatchesCommand(
+    command: DeliveryHandoffCommand,
+    acknowledgement: DeliveryHandoffActionAcknowledgement,
+) {
+    const result = acknowledgement.result;
     if (
-        !isRecord(value) ||
-        !(value.kind === 'server' || value.kind === 'device') ||
-        typeof value.replayed !== 'boolean'
+        acknowledgement.retryAttempt !== command.expectedRetryAttempt ||
+        result.kind !==
+            (command.kind === 'verification-scan' ? 'scan' : 'mark-item')
     ) {
         return false;
     }
+    const emptyOutcome =
+        result.outcome === 'invalid' ||
+        result.outcome === 'wrong-stop' ||
+        result.outcome === 'item-not-found';
+    if (emptyOutcome) {
+        return (
+            result.affectedStopIds.length === 0 &&
+            result.itemState === undefined &&
+            result.reason === undefined &&
+            (result.outcome === 'wrong-stop' ||
+                (command.kind === 'verification-scan' &&
+                    result.outcome === 'invalid') ||
+                (command.kind === 'verification-mark' &&
+                    result.outcome === 'item-not-found'))
+        );
+    }
+    if (result.affectedStopIds.length === 0) return false;
+    if (command.kind === 'verification-scan') {
+        return result.itemState === 'scanned' && result.reason === undefined;
+    }
     return (
+        result.affectedStopIds.length === 1 &&
+        result.affectedStopIds[0] === command.itemStopId &&
+        result.itemState === command.outcome &&
+        result.reason ===
+            (command.outcome === 'skipped' ? command.reason : undefined)
+    );
+}
+
+function isAcknowledgement(
+    value: unknown,
+): value is DeliveryActionAcknowledgement {
+    if (!isRecord(value) || typeof value.replayed !== 'boolean') return false;
+    if (value.kind === 'handoff') {
+        return (
+            validRetryAttempt(value.retryAttempt) &&
+            isHandoffOperationResult(value.result)
+        );
+    }
+    return (
+        value.kind === 'server' &&
         (value.routeRevision === undefined ||
             validRevision(value.routeRevision)) &&
         (value.reroutePending === undefined ||
@@ -289,26 +506,47 @@ function isAcknowledgement(
 }
 
 function isEntry(value: unknown): value is DeliveryActionQueueEntry {
+    if (
+        !(
+            isRecord(value) &&
+            typeof value.sequence === 'number' &&
+            Number.isInteger(value.sequence) &&
+            value.sequence >= 0 &&
+            isDeliveryActionCommand(value.command) &&
+            (value.state === 'queued' ||
+                value.state === 'sending' ||
+                value.state === 'reconciling' ||
+                value.state === 'synced' ||
+                value.state === 'failed' ||
+                value.state === 'conflicted') &&
+            typeof value.attemptCount === 'number' &&
+            Number.isInteger(value.attemptCount) &&
+            value.attemptCount >= 0 &&
+            validDate(value.createdAt) &&
+            validDate(value.updatedAt) &&
+            (value.acknowledgement === undefined ||
+                isAcknowledgement(value.acknowledgement)) &&
+            (value.errorCode === undefined || validErrorCode(value.errorCode))
+        )
+    ) {
+        return false;
+    }
+    if (value.acknowledgement?.kind === 'handoff') {
+        return (
+            isDeliveryHandoffCommand(value.command) &&
+            value.state === 'synced' &&
+            handoffAcknowledgementMatchesCommand(
+                value.command,
+                value.acknowledgement,
+            )
+        );
+    }
+    if (isDeliveryHandoffCommand(value.command)) {
+        return value.state !== 'synced' && value.acknowledgement === undefined;
+    }
     return (
-        isRecord(value) &&
-        typeof value.sequence === 'number' &&
-        Number.isInteger(value.sequence) &&
-        value.sequence >= 0 &&
-        isDeliveryActionCommand(value.command) &&
-        (value.state === 'queued' ||
-            value.state === 'sending' ||
-            value.state === 'reconciling' ||
-            value.state === 'synced' ||
-            value.state === 'failed' ||
-            value.state === 'conflicted') &&
-        typeof value.attemptCount === 'number' &&
-        Number.isInteger(value.attemptCount) &&
-        value.attemptCount >= 0 &&
-        validDate(value.createdAt) &&
-        validDate(value.updatedAt) &&
-        (value.acknowledgement === undefined ||
-            isAcknowledgement(value.acknowledgement)) &&
-        (value.errorCode === undefined || validErrorCode(value.errorCode))
+        value.acknowledgement?.kind !== 'server' ||
+        !isDeliveryHandoffCommand(value.command)
     );
 }
 
@@ -323,6 +561,53 @@ function cloneEntry(entry: DeliveryActionQueueEntry) {
 
 function fingerprint(command: DeliveryActionCommand) {
     return JSON.stringify(command);
+}
+
+function handoffSemanticFingerprint(command: DeliveryHandoffCommand) {
+    return JSON.stringify(
+        command.kind === 'verification-scan'
+            ? {
+                  kind: command.kind,
+                  operationId: command.operationId,
+                  runId: command.runId,
+                  stopId: command.stopId,
+                  expectedRetryAttempt: command.expectedRetryAttempt,
+                  tracePath: command.tracePath,
+              }
+            : {
+                  kind: command.kind,
+                  operationId: command.operationId,
+                  runId: command.runId,
+                  stopId: command.stopId,
+                  expectedRetryAttempt: command.expectedRetryAttempt,
+                  itemStopId: command.itemStopId,
+                  outcome: command.outcome,
+                  reason: command.reason,
+              },
+    );
+}
+
+function monotonicHandoffCommand(
+    command: DeliveryHandoffCommand,
+    entries: readonly DeliveryActionQueueEntry[],
+): DeliveryHandoffCommand {
+    const previousOccurredAt = Math.max(
+        -1,
+        ...entries.flatMap((entry) =>
+            isDeliveryHandoffCommand(entry.command) &&
+            entry.command.runId === command.runId &&
+            entry.command.stopId === command.stopId &&
+            entry.command.expectedRetryAttempt === command.expectedRetryAttempt
+                ? [Date.parse(entry.command.occurredAt)]
+                : [],
+        ),
+    );
+    const occurredAt = Date.parse(command.occurredAt);
+    if (occurredAt > previousOccurredAt) return command;
+    return {
+        ...command,
+        occurredAt: new Date(previousOccurredAt + 1).toISOString(),
+    };
 }
 
 function resolvedOccurredAt(value: string | undefined, now: () => Date) {
@@ -389,18 +674,51 @@ export function createDeliveryVerificationScanCommand({
     operationId,
     runId,
     stopId,
+    expectedRetryAttempt,
     tracePath,
     occurredAt,
     now = () => new Date(),
-}: Omit<DeliveryRouteCommandInput, 'expectedRouteRevision'> & {
+}: DeliveryHandoffCommandInput & {
     tracePath: string;
 }): DeliveryVerificationScanCommand {
+    const trimmedTracePath = tracePath.trim();
+    const normalizedTracePath =
+        normalizeHarvestTraceScanValue(trimmedTracePath);
     return validatedCommand({
         kind: 'verification-scan',
         operationId,
         runId,
         stopId,
-        tracePath,
+        expectedRetryAttempt,
+        tracePath: normalizedTracePath ?? '',
+        occurredAt: resolvedOccurredAt(occurredAt, now),
+    });
+}
+
+export function createDeliveryVerificationMarkCommand({
+    operationId,
+    runId,
+    stopId,
+    expectedRetryAttempt,
+    itemStopId,
+    outcome,
+    reason,
+    occurredAt,
+    now = () => new Date(),
+}: DeliveryHandoffCommandInput & {
+    itemStopId: number;
+    outcome: DeliveryVerificationMarkCommand['outcome'];
+    reason?: DeliveryRunHandoffSkipReason;
+}): DeliveryVerificationMarkCommand {
+    return validatedCommand({
+        kind: 'verification-mark',
+        operationId,
+        runId,
+        stopId,
+        expectedRetryAttempt,
+        itemStopId,
+        outcome,
+        ...(reason ? { reason } : {}),
         occurredAt: resolvedOccurredAt(occurredAt, now),
     });
 }
@@ -508,7 +826,7 @@ export function deliveryActionPendingEntryForStop(
     const entries =
         snapshot?.entries.filter(
             (entry) =>
-                entry.command.kind !== 'verification-scan' &&
+                !isDeliveryHandoffCommand(entry.command) &&
                 entry.command.stopId === stopId &&
                 (entry.state !== 'synced' ||
                     entry.acknowledgement?.kind === 'server'),
@@ -534,10 +852,19 @@ export function deliveryActionQueueCanReplay(
     snapshot: DeliveryActionQueueSnapshot,
 ) {
     return (
-        snapshot.queuedCount > 0 &&
-        snapshot.failedCount === 0 &&
-        snapshot.conflictedCount === 0 &&
-        snapshot.reconcilingCount === 0 &&
+        snapshot.entries.some(
+            (entry) =>
+                entry.state === 'queued' ||
+                (isDeliveryHandoffCommand(entry.command) &&
+                    entry.state === 'failed'),
+        ) &&
+        !snapshot.entries.some(
+            (entry) =>
+                !isDeliveryHandoffCommand(entry.command) &&
+                (entry.state === 'failed' ||
+                    entry.state === 'conflicted' ||
+                    entry.state === 'reconciling'),
+        ) &&
         !snapshot.entries.some(deliveryActionAcknowledgementBlocksRoute)
     );
 }
@@ -545,12 +872,17 @@ export function deliveryActionQueueCanReplay(
 export function deliveryActionVerifiedTracePaths(
     snapshot: DeliveryActionQueueSnapshot | null,
     stopId: number,
+    expectedRetryAttempt: number,
 ) {
     return (
         snapshot?.entries.flatMap((entry) =>
             entry.command.kind === 'verification-scan' &&
             entry.command.stopId === stopId &&
-            entry.state === 'synced'
+            entry.command.expectedRetryAttempt === expectedRetryAttempt &&
+            entry.state !== 'conflicted' &&
+            (entry.acknowledgement?.kind !== 'handoff' ||
+                entry.acknowledgement.result.outcome === 'applied' ||
+                entry.acknowledgement.result.outcome === 'already-applied')
                 ? [entry.command.tracePath]
                 : [],
         ) ?? []
@@ -564,7 +896,7 @@ export function nextDeliveryActionRouteRevision(
     let revision = serverRouteRevision;
     for (const entry of snapshot?.entries ?? []) {
         if (
-            entry.command.kind === 'verification-scan' ||
+            isDeliveryHandoffCommand(entry.command) ||
             entry.state === 'conflicted'
         ) {
             continue;
@@ -907,7 +1239,7 @@ export class DeliveryActionQueue {
         serverRouteRevision: number,
         createCommand: (
             expectedRouteRevision: number,
-        ) => DeliveryServerActionCommand,
+        ) => DeliveryRouteActionCommand,
     ) {
         if (!validRevision(serverRouteRevision)) {
             throw new TypeError('Server route revision is invalid');
@@ -930,34 +1262,63 @@ export class DeliveryActionQueue {
         });
     }
 
-    private async enqueueLoaded(command: DeliveryActionCommand) {
+    private async enqueueLoaded(inputCommand: DeliveryActionCommand) {
         const exact = this.entries.find(
-            (entry) => entry.command.operationId === command.operationId,
+            (entry) => entry.command.operationId === inputCommand.operationId,
         );
         if (exact) {
-            if (fingerprint(exact.command) !== fingerprint(command)) {
+            const queueNormalizedReplay =
+                isDeliveryHandoffCommand(exact.command) &&
+                isDeliveryHandoffCommand(inputCommand) &&
+                handoffSemanticFingerprint(exact.command) ===
+                    handoffSemanticFingerprint(inputCommand) &&
+                Date.parse(inputCommand.occurredAt) <=
+                    Date.parse(exact.command.occurredAt);
+            if (
+                fingerprint(exact.command) !== fingerprint(inputCommand) &&
+                !queueNormalizedReplay
+            ) {
                 throw new DeliveryActionOperationConflictError(
-                    command.operationId,
+                    inputCommand.operationId,
                 );
             }
             return cloneEntry(exact);
         }
-        if (command.kind === 'verification-scan') {
-            const existingScan = this.entries.find(
-                (entry) =>
-                    entry.command.kind === 'verification-scan' &&
-                    entry.command.stopId === command.stopId &&
-                    entry.command.tracePath === command.tracePath,
-            );
-            if (existingScan) return cloneEntry(existingScan);
+        const command = isDeliveryHandoffCommand(inputCommand)
+            ? monotonicHandoffCommand(inputCommand, this.entries)
+            : inputCommand;
+        if (isDeliveryHandoffCommand(command)) {
+            const latestHandoff = this.entries
+                .filter(
+                    (entry) =>
+                        isDeliveryHandoffCommand(entry.command) &&
+                        entry.command.stopId === command.stopId &&
+                        entry.command.expectedRetryAttempt ===
+                            command.expectedRetryAttempt,
+                )
+                .at(-1);
+            const latestCommand = latestHandoff?.command;
+            const semanticDuplicate =
+                (command.kind === 'verification-scan' &&
+                    latestCommand?.kind === 'verification-scan' &&
+                    latestCommand.tracePath === command.tracePath) ||
+                (command.kind === 'verification-mark' &&
+                    latestCommand?.kind === 'verification-mark' &&
+                    latestCommand.itemStopId === command.itemStopId &&
+                    latestCommand.outcome === command.outcome &&
+                    latestCommand.reason === command.reason);
+            if (latestHandoff && semanticDuplicate) {
+                return cloneEntry(latestHandoff);
+            }
         } else {
             if (
                 this.entries.some(
                     (entry) =>
-                        entry.state === 'failed' ||
-                        entry.state === 'conflicted' ||
-                        entry.state === 'reconciling' ||
-                        deliveryActionAcknowledgementBlocksRoute(entry),
+                        !isDeliveryHandoffCommand(entry.command) &&
+                        (entry.state === 'failed' ||
+                            entry.state === 'conflicted' ||
+                            entry.state === 'reconciling' ||
+                            deliveryActionAcknowledgementBlocksRoute(entry)),
                 )
             ) {
                 throw new DeliveryActionBarrierError();
@@ -975,28 +1336,23 @@ export class DeliveryActionQueue {
                 }
             }
             if (
-                this.entries.some((entry) => entry.command.kind === 'exception')
+                this.entries.some(
+                    (entry) =>
+                        !isDeliveryHandoffCommand(entry.command) &&
+                        entry.command.kind === 'exception',
+                )
             ) {
                 throw new DeliveryActionBarrierError();
             }
         }
         const timestamp = this.now().toISOString();
-        const localOnly = command.kind === 'verification-scan';
         const entry: DeliveryActionQueueEntry = {
             sequence: this.nextSequence,
             command: cloneValue(command),
-            state: localOnly ? 'synced' : 'queued',
+            state: 'queued',
             attemptCount: 0,
             createdAt: timestamp,
             updatedAt: timestamp,
-            ...(localOnly
-                ? {
-                      acknowledgement: {
-                          kind: 'device' as const,
-                          replayed: false,
-                      },
-                  }
-                : {}),
         };
         this.nextSequence += 1;
         this.entries.push(entry);
@@ -1046,7 +1402,7 @@ export class DeliveryActionQueue {
             );
             if (
                 !entry ||
-                entry.command.kind === 'verification-scan' ||
+                isDeliveryHandoffCommand(entry.command) ||
                 entry.acknowledgement?.kind !== 'server'
             ) {
                 return false;
@@ -1059,6 +1415,44 @@ export class DeliveryActionQueue {
         });
     }
 
+    async completeHandoffReconciliation({
+        stopId,
+        expectedRetryAttempt,
+        operationIds,
+    }: {
+        stopId: number;
+        expectedRetryAttempt: number;
+        operationIds: readonly string[];
+    }) {
+        if (
+            !validHandoffStopId(stopId) ||
+            !validRetryAttempt(expectedRetryAttempt) ||
+            operationIds.some(
+                (operationId) => !validHandoffOperationId(operationId),
+            ) ||
+            new Set(operationIds).size !== operationIds.length
+        ) {
+            throw new TypeError('Delivery handoff reconciliation is invalid');
+        }
+        const reconciledOperationIds = new Set(operationIds);
+        return await this.runExclusive(async () => {
+            await this.load();
+            const before = this.entries.length;
+            this.entries = this.entries.filter(
+                (entry) =>
+                    !isDeliveryHandoffCommand(entry.command) ||
+                    entry.command.stopId !== stopId ||
+                    entry.command.expectedRetryAttempt !==
+                        expectedRetryAttempt ||
+                    entry.state !== 'synced' ||
+                    !reconciledOperationIds.has(entry.command.operationId),
+            );
+            if (this.entries.length === before) return 0;
+            await this.persist();
+            return before - this.entries.length;
+        });
+    }
+
     async discardConflictAndDependents(operationId: string) {
         return await this.runExclusive(async () => {
             await this.load();
@@ -1066,9 +1460,16 @@ export class DeliveryActionQueue {
                 (entry) => entry.command.operationId === operationId,
             );
             if (conflicted?.state !== 'conflicted') return false;
+            if (isDeliveryHandoffCommand(conflicted.command)) {
+                this.entries = this.entries.filter(
+                    (entry) => entry.command.operationId !== operationId,
+                );
+                await this.persist();
+                return true;
+            }
             this.entries = this.entries.filter(
                 (entry) =>
-                    entry.command.kind === 'verification-scan' ||
+                    isDeliveryHandoffCommand(entry.command) ||
                     entry.sequence < conflicted.sequence,
             );
             await this.persist();
@@ -1134,6 +1535,7 @@ export class DeliveryActionQueue {
     }
 
     private async replayEntries(generation: number) {
+        const attemptedHandoffOperationIds = new Set<string>();
         while (generation === this.generation) {
             const command = await this.runExclusive(async () => {
                 await this.load();
@@ -1142,18 +1544,32 @@ export class DeliveryActionQueue {
                 ) {
                     return null;
                 }
-                const entry = this.entries.find(
-                    (candidate) =>
-                        candidate.command.kind !== 'verification-scan' &&
-                        candidate.state !== 'synced',
-                );
+                const entry = this.entries.find((candidate) => {
+                    if (candidate.state === 'synced') return false;
+                    if (!isDeliveryHandoffCommand(candidate.command)) {
+                        return true;
+                    }
+                    if (
+                        candidate.state === 'conflicted' ||
+                        candidate.state === 'reconciling'
+                    ) {
+                        return false;
+                    }
+                    return !attemptedHandoffOperationIds.has(
+                        candidate.command.operationId,
+                    );
+                });
+                if (!entry) return null;
                 if (
-                    !entry ||
-                    entry.state === 'failed' ||
-                    entry.state === 'conflicted' ||
-                    entry.state === 'reconciling'
+                    !isDeliveryHandoffCommand(entry.command) &&
+                    (entry.state === 'failed' ||
+                        entry.state === 'conflicted' ||
+                        entry.state === 'reconciling')
                 ) {
                     return null;
+                }
+                if (isDeliveryHandoffCommand(entry.command)) {
+                    attemptedHandoffOperationIds.add(entry.command.operationId);
                 }
                 entry.state = 'sending';
                 entry.attemptCount += 1;
@@ -1161,10 +1577,7 @@ export class DeliveryActionQueue {
                 delete entry.errorCode;
                 delete entry.acknowledgement;
                 await this.persist();
-                return cloneValue(entry.command) as Exclude<
-                    DeliveryActionCommand,
-                    DeliveryVerificationScanCommand
-                >;
+                return cloneValue(entry.command);
             });
             if (!command) break;
             let result: DeliveryActionTransportResult;
@@ -1184,32 +1597,60 @@ export class DeliveryActionQueue {
                 );
                 if (!entry || entry.state === 'synced') return false;
                 entry.updatedAt = this.now().toISOString();
+                const handoffCommand = isDeliveryHandoffCommand(command);
                 if (
+                    result.status === 'handoff-acknowledged' &&
+                    handoffCommand
+                ) {
+                    entry.state = 'synced';
+                    entry.acknowledgement = {
+                        kind: 'handoff',
+                        replayed: result.replayed,
+                        retryAttempt: result.retryAttempt,
+                        result: cloneValue(result.result),
+                    };
+                    delete entry.errorCode;
+                } else if (
                     result.status === 'applied' ||
                     result.status === 'exact-duplicate'
                 ) {
-                    entry.state =
-                        command.kind === 'exception' ? 'reconciling' : 'synced';
-                    entry.acknowledgement = {
-                        kind: 'server',
-                        replayed: result.status === 'exact-duplicate',
-                        routeRevision: result.routeRevision,
-                        reroutePending: result.reroutePending,
-                        runCompleted: result.runCompleted,
-                    };
-                    delete entry.errorCode;
+                    if (handoffCommand) {
+                        entry.state = 'failed';
+                        entry.errorCode = 'invalid-acknowledgement';
+                    } else {
+                        entry.state =
+                            command.kind === 'exception'
+                                ? 'reconciling'
+                                : 'synced';
+                        entry.acknowledgement = {
+                            kind: 'server',
+                            replayed: result.status === 'exact-duplicate',
+                            routeRevision: result.routeRevision,
+                            reroutePending: result.reroutePending,
+                            runCompleted: result.runCompleted,
+                        };
+                        delete entry.errorCode;
+                    }
                 } else if (result.status === 'retryable-failure') {
                     entry.state = 'failed';
                     entry.errorCode = validErrorCode(result.code)
                         ? result.code
-                        : 'delivery-action-sync-failed';
-                } else {
+                        : handoffCommand
+                          ? 'handoff-sync-failed'
+                          : 'delivery-action-sync-failed';
+                } else if (result.status === 'permanent-failure') {
                     entry.state = 'conflicted';
                     entry.errorCode = validErrorCode(result.code)
                         ? result.code
-                        : 'delivery-action-conflict';
+                        : handoffCommand
+                          ? 'handoff-sync-conflict'
+                          : 'delivery-action-conflict';
+                } else {
+                    entry.state = 'failed';
+                    entry.errorCode = 'invalid-acknowledgement';
                 }
                 await this.persist();
+                if (handoffCommand) return false;
                 return (
                     entry.state === 'failed' ||
                     entry.state === 'conflicted' ||

--- a/apps/delivery/lib/deliveryActionTransport.node.spec.ts
+++ b/apps/delivery/lib/deliveryActionTransport.node.spec.ts
@@ -3,10 +3,13 @@ import test from 'node:test';
 import {
     createDeliveryArriveCommand,
     createDeliveryExceptionCommand,
+    createDeliveryVerificationMarkCommand,
+    createDeliveryVerificationScanCommand,
 } from './deliveryActionQueue';
 import {
     deliveryActionAcknowledgement,
     deliveryActionHttpFailure,
+    deliveryHandoffAcknowledgement,
 } from './deliveryActionTransport';
 
 const arrive = createDeliveryArriveCommand({
@@ -144,4 +147,155 @@ test('classifies transport failures without turning infrastructure errors into c
             code: 'route-revision-conflict',
         },
     );
+});
+
+test('strictly accepts persisted scan outcomes and bulk affected stop IDs', () => {
+    const scan = createDeliveryVerificationScanCommand({
+        operationId: 'verification-scan-0001',
+        runId: 'run-1',
+        stopId: 22,
+        expectedRetryAttempt: 2,
+        tracePath: 'https://dostava.gredice.com/trag/plant-trace-token-0001',
+        occurredAt: '2026-07-15T12:00:00.000Z',
+    });
+    assert.deepEqual(
+        deliveryHandoffAcknowledgement(
+            {
+                results: [
+                    {
+                        clientOperationId: 'verification-scan-0001',
+                        retryAttempt: 2,
+                        replayed: false,
+                        result: {
+                            kind: 'scan',
+                            outcome: 'applied',
+                            affectedStopIds: [22, 23],
+                            itemState: 'scanned',
+                        },
+                    },
+                ],
+            },
+            scan,
+        ),
+        {
+            status: 'handoff-acknowledged',
+            replayed: false,
+            retryAttempt: 2,
+            result: {
+                kind: 'scan',
+                outcome: 'applied',
+                affectedStopIds: [22, 23],
+                itemState: 'scanned',
+            },
+        },
+    );
+    assert.deepEqual(
+        deliveryHandoffAcknowledgement(
+            {
+                results: [
+                    {
+                        clientOperationId: 'verification-scan-0001',
+                        retryAttempt: 2,
+                        replayed: true,
+                        result: {
+                            kind: 'scan',
+                            outcome: 'wrong-stop',
+                            affectedStopIds: [],
+                        },
+                    },
+                ],
+            },
+            scan,
+        ),
+        {
+            status: 'handoff-acknowledged',
+            replayed: true,
+            retryAttempt: 2,
+            result: {
+                kind: 'scan',
+                outcome: 'wrong-stop',
+                affectedStopIds: [],
+            },
+        },
+    );
+});
+
+test('strictly parses mark receipts and rejects mismatched or extended success payloads', () => {
+    const mark = createDeliveryVerificationMarkCommand({
+        operationId: 'verification-mark-0001',
+        runId: 'run-1',
+        stopId: 22,
+        expectedRetryAttempt: 1,
+        itemStopId: 23,
+        outcome: 'skipped',
+        reason: 'label-unreadable',
+        occurredAt: '2026-07-15T12:00:00.000Z',
+    });
+    const receipt = {
+        results: [
+            {
+                clientOperationId: 'verification-mark-0001',
+                retryAttempt: 1,
+                replayed: false,
+                result: {
+                    kind: 'mark-item',
+                    outcome: 'already-applied',
+                    affectedStopIds: [23],
+                    itemState: 'skipped',
+                    reason: 'label-unreadable',
+                },
+            },
+        ],
+    };
+    assert.deepEqual(deliveryHandoffAcknowledgement(receipt, mark), {
+        status: 'handoff-acknowledged',
+        replayed: false,
+        retryAttempt: 1,
+        result: {
+            kind: 'mark-item',
+            outcome: 'already-applied',
+            affectedStopIds: [23],
+            itemState: 'skipped',
+            reason: 'label-unreadable',
+        },
+    });
+    for (const invalid of [
+        { ...receipt, extra: true },
+        {
+            results: [
+                {
+                    ...receipt.results[0],
+                    retryAttempt: 0,
+                },
+            ],
+        },
+        {
+            results: [
+                {
+                    ...receipt.results[0],
+                    result: {
+                        ...receipt.results[0]?.result,
+                        reason: 'manual-verification',
+                    },
+                },
+            ],
+        },
+        {
+            results: [
+                {
+                    ...receipt.results[0],
+                    result: {
+                        ...receipt.results[0]?.result,
+                        affectedStopIds: [99],
+                    },
+                },
+            ],
+        },
+        { results: [...receipt.results, ...receipt.results] },
+    ]) {
+        assert.deepEqual(deliveryHandoffAcknowledgement(invalid, mark), {
+            status: 'retryable-failure',
+            code: 'invalid-acknowledgement',
+        });
+    }
 });

--- a/apps/delivery/lib/deliveryActionTransport.ts
+++ b/apps/delivery/lib/deliveryActionTransport.ts
@@ -1,17 +1,20 @@
 import type {
-    DeliveryActionCommand,
     DeliveryActionTransportResult,
-    DeliveryVerificationScanCommand,
+    DeliveryHandoffCommand,
+    DeliveryHandoffOperationResult,
+    DeliveryRouteActionCommand,
+    DeliveryServerActionCommand,
 } from './deliveryActionQueue';
+import { isDeliveryHandoffCommand } from './deliveryActionQueue';
 import { assertDeliveryOfflineWritesAllowed } from './deliveryOfflineEvents';
 
-type ServerDeliveryActionCommand = Exclude<
-    DeliveryActionCommand,
-    DeliveryVerificationScanCommand
->;
-
 function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null;
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: string[]) {
+    const allowedKeys = new Set(allowed);
+    return Object.keys(value).every((key) => allowedKeys.has(key));
 }
 
 function validRevision(value: unknown): value is number {
@@ -19,7 +22,37 @@ function validRevision(value: unknown): value is number {
 }
 
 function validStopId(value: unknown): value is number {
-    return typeof value === 'number' && Number.isInteger(value) && value > 0;
+    return (
+        typeof value === 'number' &&
+        Number.isSafeInteger(value) &&
+        value > 0 &&
+        value <= 2_147_483_647
+    );
+}
+
+function validRetryAttempt(value: unknown): value is number {
+    return (
+        typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+    );
+}
+
+function validHandoffItemState(value: unknown) {
+    return (
+        value === 'unverified' ||
+        value === 'scanned' ||
+        value === 'no-label' ||
+        value === 'missing' ||
+        value === 'skipped'
+    );
+}
+
+function validHandoffSkipReason(value: unknown) {
+    return (
+        value === 'scanner-unavailable' ||
+        value === 'label-unreadable' ||
+        value === 'manual-verification' ||
+        value === 'other-operational'
+    );
 }
 
 function responseCode(value: unknown) {
@@ -45,7 +78,7 @@ export function deliveryActionHttpFailure(
 
 export function deliveryActionAcknowledgement(
     value: unknown,
-    command: ServerDeliveryActionCommand,
+    command: DeliveryRouteActionCommand,
 ): DeliveryActionTransportResult {
     if (
         !isRecord(value) ||
@@ -113,15 +146,170 @@ export function deliveryActionAcknowledgement(
     };
 }
 
-function endpoint(command: ServerDeliveryActionCommand) {
+function handoffResult(
+    value: unknown,
+    command: DeliveryHandoffCommand,
+): DeliveryHandoffOperationResult | null {
+    if (
+        !isRecord(value) ||
+        !hasOnlyKeys(value, [
+            'kind',
+            'outcome',
+            'affectedStopIds',
+            'itemState',
+            'reason',
+        ]) ||
+        !Array.isArray(value.affectedStopIds) ||
+        !value.affectedStopIds.every(validStopId) ||
+        new Set(value.affectedStopIds).size !== value.affectedStopIds.length
+    ) {
+        return null;
+    }
+    const expectedKind =
+        command.kind === 'verification-scan' ? 'scan' : 'mark-item';
+    if (value.kind !== expectedKind) return null;
+    const outcome = value.outcome;
+    if (
+        outcome !== 'applied' &&
+        outcome !== 'already-applied' &&
+        outcome !== 'stale' &&
+        outcome !== 'invalid' &&
+        outcome !== 'wrong-stop' &&
+        outcome !== 'item-not-found'
+    ) {
+        return null;
+    }
+    const emptyOutcome =
+        outcome === 'invalid' ||
+        outcome === 'wrong-stop' ||
+        outcome === 'item-not-found';
+    if (emptyOutcome) {
+        const outcomeMatchesKind =
+            outcome === 'wrong-stop' ||
+            (command.kind === 'verification-scan' && outcome === 'invalid') ||
+            (command.kind === 'verification-mark' &&
+                outcome === 'item-not-found');
+        return outcomeMatchesKind &&
+            value.affectedStopIds.length === 0 &&
+            value.itemState === undefined &&
+            value.reason === undefined
+            ? { kind: expectedKind, outcome, affectedStopIds: [] }
+            : null;
+    }
+    if (value.affectedStopIds.length === 0) return null;
+    if (
+        command.kind === 'verification-mark' &&
+        (value.affectedStopIds.length !== 1 ||
+            value.affectedStopIds[0] !== command.itemStopId)
+    ) {
+        return null;
+    }
+    const expectedItemState =
+        command.kind === 'verification-scan' ? 'scanned' : command.outcome;
+    if (
+        value.itemState !== expectedItemState ||
+        !validHandoffItemState(value.itemState)
+    ) {
+        return null;
+    }
+    const expectedReason =
+        command.kind === 'verification-mark' && command.outcome === 'skipped'
+            ? command.reason
+            : undefined;
+    if (
+        value.reason !== expectedReason ||
+        (value.reason !== undefined && !validHandoffSkipReason(value.reason))
+    ) {
+        return null;
+    }
+    return {
+        kind: expectedKind,
+        outcome,
+        affectedStopIds: [...value.affectedStopIds],
+        itemState: value.itemState,
+        ...(value.reason ? { reason: value.reason } : {}),
+    };
+}
+
+export function deliveryHandoffAcknowledgement(
+    value: unknown,
+    command: DeliveryHandoffCommand,
+): DeliveryActionTransportResult {
+    if (
+        !isRecord(value) ||
+        !hasOnlyKeys(value, ['results']) ||
+        !Array.isArray(value.results) ||
+        value.results.length !== 1
+    ) {
+        return {
+            status: 'retryable-failure',
+            code: 'invalid-acknowledgement',
+        };
+    }
+    const receipt = value.results[0];
+    if (
+        !isRecord(receipt) ||
+        !hasOnlyKeys(receipt, [
+            'clientOperationId',
+            'retryAttempt',
+            'replayed',
+            'result',
+        ]) ||
+        receipt.clientOperationId !== command.operationId ||
+        !validRetryAttempt(receipt.retryAttempt) ||
+        receipt.retryAttempt !== command.expectedRetryAttempt ||
+        typeof receipt.replayed !== 'boolean'
+    ) {
+        return {
+            status: 'retryable-failure',
+            code: 'invalid-acknowledgement',
+        };
+    }
+    const result = handoffResult(receipt.result, command);
+    if (!result) {
+        return {
+            status: 'retryable-failure',
+            code: 'invalid-acknowledgement',
+        };
+    }
+    return {
+        status: 'handoff-acknowledged',
+        replayed: receipt.replayed,
+        retryAttempt: receipt.retryAttempt,
+        result,
+    };
+}
+
+function endpoint(command: DeliveryServerActionCommand) {
     const runId = encodeURIComponent(command.runId);
+    if (isDeliveryHandoffCommand(command)) {
+        return `/api/driver/runs/${runId}/stops/${command.stopId}/handoff/mutations`;
+    }
     if (command.kind === 'exception') {
         return `/api/driver/runs/${runId}/exceptions`;
     }
     return `/api/driver/runs/${runId}/stops/${command.stopId}/${command.kind}`;
 }
 
-function requestBody(command: ServerDeliveryActionCommand) {
+function requestBody(command: DeliveryServerActionCommand) {
+    if (isDeliveryHandoffCommand(command)) {
+        const mutation = {
+            clientOperationId: command.operationId,
+            occurredAt: command.occurredAt,
+            ...(command.kind === 'verification-scan'
+                ? { kind: 'scan', tracePath: command.tracePath }
+                : {
+                      kind: 'mark-item',
+                      stopId: command.itemStopId,
+                      outcome: command.outcome,
+                      ...(command.reason ? { reason: command.reason } : {}),
+                  }),
+        };
+        return {
+            expectedRetryAttempt: command.expectedRetryAttempt,
+            mutations: [mutation],
+        };
+    }
     const common = {
         clientOperationId: command.operationId,
         occurredAt: command.occurredAt,
@@ -140,7 +328,7 @@ function requestBody(command: ServerDeliveryActionCommand) {
 }
 
 export async function sendDeliveryAction(
-    command: ServerDeliveryActionCommand,
+    command: DeliveryServerActionCommand,
 ): Promise<DeliveryActionTransportResult> {
     assertDeliveryOfflineWritesAllowed();
     let response: Response;
@@ -155,7 +343,8 @@ export async function sendDeliveryAction(
     }
     const value: unknown = await response.json().catch(() => null);
     assertDeliveryOfflineWritesAllowed();
-    return response.ok
-        ? deliveryActionAcknowledgement(value, command)
-        : deliveryActionHttpFailure(response.status, value);
+    if (!response.ok) return deliveryActionHttpFailure(response.status, value);
+    return isDeliveryHandoffCommand(command)
+        ? deliveryHandoffAcknowledgement(value, command)
+        : deliveryActionAcknowledgement(value, command);
 }

--- a/apps/delivery/lib/deliveryHandoffManifest.node.spec.ts
+++ b/apps/delivery/lib/deliveryHandoffManifest.node.spec.ts
@@ -1,0 +1,280 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    createDeliveryVerificationMarkCommand,
+    createDeliveryVerificationScanCommand,
+    createMemoryDeliveryActionQueuePersistence,
+    DeliveryActionQueue,
+} from './deliveryActionQueue';
+import {
+    type DeliveryHandoffManifest,
+    fetchDeliveryHandoffManifest,
+    parseDeliveryHandoffManifest,
+    projectDeliveryHandoffManifest,
+} from './deliveryHandoffManifest';
+
+const now = () => new Date('2026-07-16T08:00:00.000Z');
+
+function manifest(): DeliveryHandoffManifest {
+    return {
+        runId: 'run-1',
+        targetStopId: 101,
+        version: 1,
+        retryAttempt: 2,
+        items: [
+            {
+                stopId: 101,
+                deliveryRequestId: 'request-101',
+                retryAttempt: 2,
+                traceLinkId: 501,
+                qrAvailable: true,
+                state: 'unverified',
+                reason: null,
+                verifiedAt: null,
+            },
+            {
+                stopId: 102,
+                deliveryRequestId: 'request-102',
+                retryAttempt: 2,
+                traceLinkId: null,
+                qrAvailable: false,
+                state: 'no-label',
+                reason: null,
+                verifiedAt: null,
+            },
+        ],
+        expectedCount: 2,
+        scannedCount: 0,
+        unverifiedCount: 1,
+        noLabelCount: 1,
+        missingCount: 0,
+        skippedCount: 0,
+    };
+}
+
+test('runtime parser accepts only a self-consistent v1 handoff manifest', () => {
+    const value = manifest();
+    assert.deepEqual(parseDeliveryHandoffManifest(value), value);
+    for (const invalid of [
+        { ...value, expectedCount: 3 },
+        { ...value, targetStopId: 999 },
+        { ...value, extra: true },
+        {
+            ...value,
+            items: [{ ...value.items[0], retryAttempt: 1 }, value.items[1]],
+        },
+        {
+            ...value,
+            items: [
+                { ...value.items[0], state: 'skipped', reason: null },
+                value.items[1],
+            ],
+            unverifiedCount: 0,
+            skippedCount: 1,
+        },
+    ]) {
+        assert.equal(parseDeliveryHandoffManifest(invalid), null);
+    }
+});
+
+test('manifest GET parsing classifies malformed success and HTTP failures safely', async () => {
+    let requestedUrl = '';
+    const loaded = await fetchDeliveryHandoffManifest({
+        runId: 'run/with space',
+        targetStopId: 101,
+        fetcher: async (input) => {
+            requestedUrl = String(input);
+            return Response.json({ ...manifest(), runId: 'run/with space' });
+        },
+    });
+    assert.equal(
+        requestedUrl,
+        '/api/driver/runs/run%2Fwith%20space/stops/101/handoff/mutations',
+    );
+    assert.equal(loaded.status, 'loaded');
+
+    assert.deepEqual(
+        await fetchDeliveryHandoffManifest({
+            runId: 'run-1',
+            targetStopId: 101,
+            fetcher: async () => Response.json({ ...manifest(), extra: true }),
+        }),
+        { status: 'retryable-failure', code: 'invalid-manifest' },
+    );
+    assert.deepEqual(
+        await fetchDeliveryHandoffManifest({
+            runId: 'run-requested',
+            targetStopId: 101,
+            fetcher: async () => Response.json(manifest()),
+        }),
+        {
+            status: 'retryable-failure',
+            code: 'manifest-identity-mismatch',
+        },
+    );
+    assert.deepEqual(
+        await fetchDeliveryHandoffManifest({
+            runId: 'run-1',
+            targetStopId: 101,
+            fetcher: async () =>
+                Response.json(
+                    { code: 'route-revision-conflict' },
+                    { status: 409 },
+                ),
+        }),
+        {
+            status: 'permanent-failure',
+            code: 'route-revision-conflict',
+        },
+    );
+});
+
+test('optimistic projection overlays queued item evidence by stable stop identity', async () => {
+    const actionQueue = new DeliveryActionQueue({
+        scope: { userId: 'driver-1', runId: 'run-1' },
+        persistence: createMemoryDeliveryActionQueuePersistence(),
+        transport: async (command) =>
+            command.kind === 'verification-scan'
+                ? {
+                      status: 'handoff-acknowledged',
+                      replayed: false,
+                      retryAttempt: 2,
+                      result: {
+                          kind: 'scan',
+                          outcome: 'invalid',
+                          affectedStopIds: [],
+                      },
+                  }
+                : {
+                      status: 'handoff-acknowledged',
+                      replayed: false,
+                      retryAttempt: 2,
+                      result: {
+                          kind: 'mark-item',
+                          outcome: 'applied',
+                          affectedStopIds: [102],
+                          itemState: 'missing',
+                      },
+                  },
+        now,
+    });
+    await actionQueue.enqueue(
+        createDeliveryVerificationScanCommand({
+            operationId: 'projection-scan-0001',
+            runId: 'run-1',
+            stopId: 101,
+            expectedRetryAttempt: 2,
+            tracePath: '/trag/projection-trace-0001',
+            now,
+        }),
+    );
+    await actionQueue.enqueue(
+        createDeliveryVerificationMarkCommand({
+            operationId: 'projection-mark-0001',
+            runId: 'run-1',
+            stopId: 101,
+            expectedRetryAttempt: 2,
+            itemStopId: 102,
+            outcome: 'missing',
+            now,
+        }),
+    );
+    const queued = projectDeliveryHandoffManifest({
+        manifest: manifest(),
+        snapshot: actionQueue.getSnapshot(),
+        traceItems: [
+            {
+                stopId: 101,
+                tracePath: '/trag/projection-trace-0001',
+            },
+        ],
+    });
+    assert.deepEqual(
+        queued.manifest.items.map((item) => [item.stopId, item.state]),
+        [
+            [101, 'scanned'],
+            [102, 'missing'],
+        ],
+    );
+    assert.deepEqual(queued.pendingOperationIds, [
+        'projection-scan-0001',
+        'projection-mark-0001',
+    ]);
+    assert.equal(queued.manifest.scannedCount, 1);
+    assert.equal(queued.manifest.missingCount, 1);
+
+    await actionQueue.replay();
+    const acknowledged = projectDeliveryHandoffManifest({
+        manifest: manifest(),
+        snapshot: actionQueue.getSnapshot(),
+        traceItems: [
+            {
+                stopId: 101,
+                tracePath: '/trag/projection-trace-0001',
+            },
+        ],
+    });
+    assert.deepEqual(
+        acknowledged.manifest.items.map((item) => [item.stopId, item.state]),
+        [
+            [101, 'unverified'],
+            [102, 'missing'],
+        ],
+    );
+    assert.deepEqual(acknowledged.acknowledgedOutcomes, [
+        { operationId: 'projection-scan-0001', outcome: 'invalid' },
+        { operationId: 'projection-mark-0001', outcome: 'applied' },
+    ]);
+});
+
+test('optimistic projection mirrors server last-occurrence-wins timestamp guards', async () => {
+    const actionQueue = new DeliveryActionQueue({
+        scope: { userId: 'driver-1', runId: 'run-1' },
+        persistence: createMemoryDeliveryActionQueuePersistence(),
+        transport: async () => ({
+            status: 'retryable-failure',
+            code: 'offline',
+        }),
+        now,
+    });
+    await actionQueue.enqueue(
+        createDeliveryVerificationMarkCommand({
+            operationId: 'stale-projection-mark-0001',
+            runId: 'run-1',
+            stopId: 101,
+            expectedRetryAttempt: 2,
+            itemStopId: 101,
+            outcome: 'missing',
+            occurredAt: '2026-07-16T08:00:00.010Z',
+        }),
+    );
+    const base = manifest();
+    const newerManifest: DeliveryHandoffManifest = {
+        ...base,
+        items: base.items.map((item) =>
+            item.stopId === 101
+                ? {
+                      ...item,
+                      state: 'scanned',
+                      verifiedAt: '2026-07-16T08:00:00.010Z',
+                  }
+                : item,
+        ),
+        scannedCount: 1,
+        unverifiedCount: 0,
+    };
+
+    const projected = projectDeliveryHandoffManifest({
+        manifest: newerManifest,
+        snapshot: actionQueue.getSnapshot(),
+    });
+
+    assert.equal(projected.manifest.items[0]?.state, 'scanned');
+    assert.equal(
+        projected.manifest.items[0]?.verifiedAt,
+        '2026-07-16T08:00:00.010Z',
+    );
+    assert.deepEqual(projected.pendingOperationIds, [
+        'stale-projection-mark-0001',
+    ]);
+});

--- a/apps/delivery/lib/deliveryHandoffManifest.ts
+++ b/apps/delivery/lib/deliveryHandoffManifest.ts
@@ -1,0 +1,436 @@
+import type {
+    DeliveryRunHandoffItemSnapshot,
+    DeliveryRunHandoffItemState,
+    DeliveryRunHandoffManifest,
+    DeliveryRunHandoffSkipReason,
+} from '@gredice/storage';
+import {
+    type DeliveryActionQueueEntry,
+    type DeliveryActionQueueSnapshot,
+    type DeliveryHandoffOperationOutcome,
+    isDeliveryHandoffCommand,
+} from './deliveryActionQueue';
+import { normalizeHarvestTraceScanValue } from './harvestTraceScan';
+
+export type DeliveryHandoffManifest = DeliveryRunHandoffManifest;
+
+export type DeliveryHandoffManifestScope = {
+    userId: string;
+    runId: string;
+    targetStopId: number;
+    expectedRetryAttempt: number;
+};
+
+export type DeliveryHandoffTraceItem = {
+    stopId: number;
+    tracePath: string | null;
+};
+
+export type DeliveryHandoffManifestProjection = {
+    manifest: DeliveryHandoffManifest;
+    pendingOperationIds: string[];
+    failedOperationIds: string[];
+    conflictedOperationIds: string[];
+    acknowledgedOutcomes: Array<{
+        operationId: string;
+        outcome: DeliveryHandoffOperationOutcome;
+    }>;
+};
+
+export type DeliveryHandoffManifestFetchResult =
+    | { status: 'loaded'; manifest: DeliveryHandoffManifest }
+    | { status: 'retryable-failure'; code?: string }
+    | { status: 'permanent-failure'; code?: string };
+
+const manifestKeys = [
+    'runId',
+    'targetStopId',
+    'version',
+    'retryAttempt',
+    'items',
+    'expectedCount',
+    'scannedCount',
+    'unverifiedCount',
+    'noLabelCount',
+    'missingCount',
+    'skippedCount',
+];
+const itemKeys = [
+    'stopId',
+    'deliveryRequestId',
+    'retryAttempt',
+    'traceLinkId',
+    'qrAvailable',
+    'state',
+    'reason',
+    'verifiedAt',
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: string[]) {
+    const allowedKeys = new Set(allowed);
+    return Object.keys(value).every((key) => allowedKeys.has(key));
+}
+
+function validIdentifier(value: unknown): value is string {
+    return (
+        typeof value === 'string' &&
+        value.trim() === value &&
+        value.length > 0 &&
+        value.length <= 256
+    );
+}
+
+function validStopId(value: unknown): value is number {
+    return (
+        typeof value === 'number' &&
+        Number.isSafeInteger(value) &&
+        value > 0 &&
+        value <= 2_147_483_647
+    );
+}
+
+function validCount(value: unknown): value is number {
+    return (
+        typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+    );
+}
+
+function validItemState(value: unknown): value is DeliveryRunHandoffItemState {
+    return (
+        value === 'unverified' ||
+        value === 'scanned' ||
+        value === 'no-label' ||
+        value === 'missing' ||
+        value === 'skipped'
+    );
+}
+
+function validSkipReason(
+    value: unknown,
+): value is DeliveryRunHandoffSkipReason {
+    return (
+        value === 'scanner-unavailable' ||
+        value === 'label-unreadable' ||
+        value === 'manual-verification' ||
+        value === 'other-operational'
+    );
+}
+
+function validVerifiedAt(value: unknown): value is string | null {
+    return (
+        value === null ||
+        (typeof value === 'string' &&
+            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value) &&
+            Number.isFinite(Date.parse(value)))
+    );
+}
+
+function parseManifestItem(
+    value: unknown,
+): DeliveryRunHandoffItemSnapshot | null {
+    if (
+        !isRecord(value) ||
+        !hasOnlyKeys(value, itemKeys) ||
+        !validStopId(value.stopId) ||
+        !validIdentifier(value.deliveryRequestId) ||
+        !validCount(value.retryAttempt) ||
+        !(
+            value.traceLinkId === null ||
+            (typeof value.traceLinkId === 'number' &&
+                Number.isSafeInteger(value.traceLinkId) &&
+                value.traceLinkId > 0)
+        ) ||
+        typeof value.qrAvailable !== 'boolean' ||
+        (value.qrAvailable && value.traceLinkId === null) ||
+        !validItemState(value.state) ||
+        !validVerifiedAt(value.verifiedAt)
+    ) {
+        return null;
+    }
+    let reason: DeliveryRunHandoffSkipReason | null = null;
+    if (value.state === 'skipped') {
+        if (!validSkipReason(value.reason)) return null;
+        reason = value.reason;
+    } else if (value.reason !== null) {
+        return null;
+    }
+    return {
+        stopId: value.stopId,
+        deliveryRequestId: value.deliveryRequestId,
+        retryAttempt: value.retryAttempt,
+        traceLinkId: value.traceLinkId,
+        qrAvailable: value.qrAvailable,
+        state: value.state,
+        reason,
+        verifiedAt: value.verifiedAt,
+    };
+}
+
+export function parseDeliveryHandoffManifest(
+    value: unknown,
+): DeliveryHandoffManifest | null {
+    if (
+        !isRecord(value) ||
+        !hasOnlyKeys(value, manifestKeys) ||
+        !validIdentifier(value.runId) ||
+        !validStopId(value.targetStopId) ||
+        value.version !== 1 ||
+        !validCount(value.retryAttempt) ||
+        !Array.isArray(value.items) ||
+        !validCount(value.expectedCount) ||
+        !validCount(value.scannedCount) ||
+        !validCount(value.unverifiedCount) ||
+        !validCount(value.noLabelCount) ||
+        !validCount(value.missingCount) ||
+        !validCount(value.skippedCount)
+    ) {
+        return null;
+    }
+    const items: DeliveryRunHandoffItemSnapshot[] = [];
+    const stopIds = new Set<number>();
+    for (const candidate of value.items) {
+        const item = parseManifestItem(candidate);
+        if (
+            !item ||
+            item.retryAttempt !== value.retryAttempt ||
+            stopIds.has(item.stopId)
+        ) {
+            return null;
+        }
+        stopIds.add(item.stopId);
+        items.push(item);
+    }
+    const count = (state: DeliveryRunHandoffItemState) =>
+        items.filter((item) => item.state === state).length;
+    if (
+        value.expectedCount !== items.length ||
+        (items.length > 0 && !stopIds.has(value.targetStopId)) ||
+        value.scannedCount !== count('scanned') ||
+        value.unverifiedCount !== count('unverified') ||
+        value.noLabelCount !== count('no-label') ||
+        value.missingCount !== count('missing') ||
+        value.skippedCount !== count('skipped')
+    ) {
+        return null;
+    }
+    return {
+        runId: value.runId,
+        targetStopId: value.targetStopId,
+        version: 1,
+        retryAttempt: value.retryAttempt,
+        items,
+        expectedCount: value.expectedCount,
+        scannedCount: value.scannedCount,
+        unverifiedCount: value.unverifiedCount,
+        noLabelCount: value.noLabelCount,
+        missingCount: value.missingCount,
+        skippedCount: value.skippedCount,
+    };
+}
+
+function responseCode(value: unknown) {
+    if (
+        isRecord(value) &&
+        typeof value.code === 'string' &&
+        /^[a-z0-9-]{1,128}$/.test(value.code)
+    ) {
+        return value.code;
+    }
+    return undefined;
+}
+
+export async function fetchDeliveryHandoffManifest({
+    runId,
+    targetStopId,
+    signal,
+    fetcher = fetch,
+}: {
+    runId: string;
+    targetStopId: number;
+    signal?: AbortSignal;
+    fetcher?: typeof fetch;
+}): Promise<DeliveryHandoffManifestFetchResult> {
+    let response: Response;
+    try {
+        response = await fetcher(
+            `/api/driver/runs/${encodeURIComponent(runId)}/stops/${targetStopId}/handoff/mutations`,
+            { method: 'GET', signal },
+        );
+    } catch {
+        return { status: 'retryable-failure', code: 'offline' };
+    }
+    const value: unknown = await response.json().catch(() => null);
+    if (!response.ok) {
+        const code = responseCode(value);
+        return response.status === 408 ||
+            response.status === 425 ||
+            response.status === 429 ||
+            response.status >= 500
+            ? { status: 'retryable-failure', code }
+            : { status: 'permanent-failure', code };
+    }
+    const manifest = parseDeliveryHandoffManifest(value);
+    if (
+        manifest &&
+        (manifest.runId !== runId || manifest.targetStopId !== targetStopId)
+    ) {
+        return {
+            status: 'retryable-failure',
+            code: 'manifest-identity-mismatch',
+        };
+    }
+    return manifest
+        ? { status: 'loaded', manifest }
+        : { status: 'retryable-failure', code: 'invalid-manifest' };
+}
+
+export function deliveryHandoffQueueEntries(
+    snapshot: DeliveryActionQueueSnapshot | null,
+    manifest: DeliveryHandoffManifest,
+) {
+    return (
+        snapshot?.entries.filter(
+            (entry) =>
+                isDeliveryHandoffCommand(entry.command) &&
+                entry.command.runId === manifest.runId &&
+                entry.command.stopId === manifest.targetStopId &&
+                entry.command.expectedRetryAttempt === manifest.retryAttempt,
+        ) ?? []
+    );
+}
+
+function resolvedScanStopIds(
+    entry: DeliveryActionQueueEntry,
+    traceItems: readonly DeliveryHandoffTraceItem[],
+) {
+    if (entry.command.kind !== 'verification-scan') return [];
+    const normalized = normalizeHarvestTraceScanValue(entry.command.tracePath);
+    if (!normalized) return [];
+    return traceItems.flatMap((item) =>
+        item.tracePath &&
+        normalizeHarvestTraceScanValue(item.tracePath) === normalized
+            ? [item.stopId]
+            : [],
+    );
+}
+
+function projectedItemState(
+    entry: DeliveryActionQueueEntry,
+    traceItems: readonly DeliveryHandoffTraceItem[],
+): {
+    stopIds: number[];
+    state: DeliveryRunHandoffItemState;
+    reason: DeliveryRunHandoffSkipReason | null;
+} | null {
+    if (!isDeliveryHandoffCommand(entry.command)) return null;
+    if (entry.state === 'conflicted') return null;
+    if (entry.acknowledgement?.kind === 'handoff') {
+        if (
+            entry.acknowledgement.result.outcome !== 'applied' &&
+            entry.acknowledgement.result.outcome !== 'already-applied'
+        ) {
+            return null;
+        }
+        const itemState = entry.acknowledgement.result.itemState;
+        if (!itemState) return null;
+        return {
+            stopIds: entry.acknowledgement.result.affectedStopIds,
+            state: itemState,
+            reason: entry.acknowledgement.result.reason ?? null,
+        };
+    }
+    if (entry.command.kind === 'verification-mark') {
+        return {
+            stopIds: [entry.command.itemStopId],
+            state: entry.command.outcome,
+            reason: entry.command.reason ?? null,
+        };
+    }
+    return {
+        stopIds: resolvedScanStopIds(entry, traceItems),
+        state: 'scanned',
+        reason: null,
+    };
+}
+
+function withRecomputedCounts(
+    manifest: DeliveryHandoffManifest,
+    items: DeliveryRunHandoffItemSnapshot[],
+): DeliveryHandoffManifest {
+    const count = (state: DeliveryRunHandoffItemState) =>
+        items.filter((item) => item.state === state).length;
+    return {
+        ...manifest,
+        items,
+        expectedCount: items.length,
+        scannedCount: count('scanned'),
+        unverifiedCount: count('unverified'),
+        noLabelCount: count('no-label'),
+        missingCount: count('missing'),
+        skippedCount: count('skipped'),
+    };
+}
+
+export function projectDeliveryHandoffManifest({
+    manifest,
+    snapshot,
+    traceItems = [],
+}: {
+    manifest: DeliveryHandoffManifest;
+    snapshot: DeliveryActionQueueSnapshot | null;
+    traceItems?: readonly DeliveryHandoffTraceItem[];
+}): DeliveryHandoffManifestProjection {
+    const entries = deliveryHandoffQueueEntries(snapshot, manifest).sort(
+        (first, second) => first.sequence - second.sequence,
+    );
+    let items = manifest.items.map((item) => ({ ...item }));
+    for (const entry of entries) {
+        const projected = projectedItemState(entry, traceItems);
+        if (!projected || projected.stopIds.length === 0) continue;
+        const affectedIds = new Set(projected.stopIds);
+        items = items.map((item) => {
+            if (!affectedIds.has(item.stopId)) return item;
+            if (
+                item.verifiedAt &&
+                Date.parse(item.verifiedAt) >=
+                    Date.parse(entry.command.occurredAt)
+            ) {
+                return item;
+            }
+            return {
+                ...item,
+                state: projected.state,
+                reason: projected.reason,
+                verifiedAt: entry.command.occurredAt,
+            };
+        });
+    }
+    return {
+        manifest: withRecomputedCounts(manifest, items),
+        pendingOperationIds: entries.flatMap((entry) =>
+            entry.state === 'queued' || entry.state === 'sending'
+                ? [entry.command.operationId]
+                : [],
+        ),
+        failedOperationIds: entries.flatMap((entry) =>
+            entry.state === 'failed' ? [entry.command.operationId] : [],
+        ),
+        conflictedOperationIds: entries.flatMap((entry) =>
+            entry.state === 'conflicted' ? [entry.command.operationId] : [],
+        ),
+        acknowledgedOutcomes: entries.flatMap((entry) =>
+            entry.acknowledgement?.kind === 'handoff'
+                ? [
+                      {
+                          operationId: entry.command.operationId,
+                          outcome: entry.acknowledgement.result.outcome,
+                      },
+                  ]
+                : [],
+        ),
+    };
+}

--- a/apps/delivery/lib/deliveryHandoffManifestCache.node.spec.ts
+++ b/apps/delivery/lib/deliveryHandoffManifestCache.node.spec.ts
@@ -1,0 +1,212 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { DeliveryHandoffManifest } from './deliveryHandoffManifest';
+import {
+    createDeliveryHandoffManifestCacheRecord,
+    createMemoryDeliveryHandoffManifestCachePersistence,
+    createWebStorageDeliveryHandoffManifestCachePersistence,
+    type DeliveryHandoffManifestWebStorage,
+    deliveryHandoffManifestCacheTtlMs,
+} from './deliveryHandoffManifestCache';
+
+class MemoryWebStorage implements DeliveryHandoffManifestWebStorage {
+    readonly values = new Map<string, string>();
+    failReads = false;
+    failRemoval = false;
+
+    get length() {
+        return this.values.size;
+    }
+
+    key(index: number) {
+        return Array.from(this.values.keys())[index] ?? null;
+    }
+
+    getItem(key: string) {
+        if (this.failReads) throw new Error('storage unavailable');
+        return this.values.get(key) ?? null;
+    }
+
+    setItem(key: string, value: string) {
+        this.values.set(key, value);
+    }
+
+    removeItem(key: string) {
+        if (this.failRemoval) throw new Error('storage unavailable');
+        this.values.delete(key);
+    }
+}
+
+function manifest({
+    runId = 'run-1',
+    targetStopId = 101,
+    retryAttempt = 0,
+}: {
+    runId?: string;
+    targetStopId?: number;
+    retryAttempt?: number;
+} = {}): DeliveryHandoffManifest {
+    return {
+        runId,
+        targetStopId,
+        version: 1,
+        retryAttempt,
+        items: [
+            {
+                stopId: targetStopId,
+                deliveryRequestId: `request-${targetStopId}`,
+                retryAttempt,
+                traceLinkId: 500 + targetStopId,
+                qrAvailable: true,
+                state: 'unverified',
+                reason: null,
+                verifiedAt: null,
+            },
+        ],
+        expectedCount: 1,
+        scannedCount: 0,
+        unverifiedCount: 1,
+        noLabelCount: 0,
+        missingCount: 0,
+        skippedCount: 0,
+    };
+}
+
+const now = new Date('2026-07-16T08:00:00.000Z');
+
+test('cache identity includes user, run, physical target, and retry attempt', async () => {
+    const persistence = createMemoryDeliveryHandoffManifestCachePersistence();
+    const records = [
+        createDeliveryHandoffManifestCacheRecord({
+            userId: 'driver-1',
+            manifest: manifest(),
+            now,
+        }),
+        createDeliveryHandoffManifestCacheRecord({
+            userId: 'driver-1',
+            manifest: manifest({ retryAttempt: 1 }),
+            now,
+        }),
+        createDeliveryHandoffManifestCacheRecord({
+            userId: 'driver-1',
+            manifest: manifest({ targetStopId: 102 }),
+            now,
+        }),
+        createDeliveryHandoffManifestCacheRecord({
+            userId: 'driver-2',
+            manifest: manifest(),
+            now,
+        }),
+        createDeliveryHandoffManifestCacheRecord({
+            userId: 'driver-1',
+            manifest: manifest({ retryAttempt: 10 }),
+            now,
+        }),
+    ];
+    for (const record of records) await persistence.save(record);
+    const [first, second, third, fourth, tenthAttempt] = records;
+    if (!first || !second || !third || !fourth || !tenthAttempt) {
+        throw new Error('Expected five isolated cache records');
+    }
+
+    for (const record of records) {
+        assert.deepEqual(await persistence.load(record.scope, now), record);
+    }
+    await persistence.clear({
+        userId: 'driver-1',
+        runId: 'run-1',
+        targetStopId: 101,
+        expectedRetryAttempt: 1,
+    });
+    assert.ok(await persistence.load(first.scope, now));
+    assert.equal(await persistence.load(second.scope, now), null);
+    assert.ok(await persistence.load(tenthAttempt.scope, now));
+    assert.ok(await persistence.load(third.scope, now));
+    assert.ok(await persistence.load(fourth.scope, now));
+
+    await persistence.clear({ userId: 'driver-1', runId: 'run-1' });
+    assert.equal(await persistence.load(first.scope, now), null);
+    assert.equal(await persistence.load(second.scope, now), null);
+    assert.equal(await persistence.load(tenthAttempt.scope, now), null);
+    assert.equal(await persistence.load(third.scope, now), null);
+    assert.ok(await persistence.load(fourth.scope, now));
+});
+
+test('cache expires records and never persists queued raw trace values', async () => {
+    const storage = new MemoryWebStorage();
+    const persistence =
+        createWebStorageDeliveryHandoffManifestCachePersistence(storage);
+    const record = createDeliveryHandoffManifestCacheRecord({
+        userId: 'driver-1',
+        manifest: manifest(),
+        now,
+    });
+    await persistence.save(record);
+
+    assert.equal(
+        Array.from(storage.values.values()).some((value) =>
+            value.includes('/trag/'),
+        ),
+        false,
+    );
+    assert.deepEqual(await persistence.load(record.scope, now), record);
+    assert.equal(
+        await persistence.load(
+            record.scope,
+            new Date(now.getTime() + deliveryHandoffManifestCacheTtlMs),
+        ),
+        null,
+    );
+    assert.equal(storage.length, 0);
+});
+
+test('a durable load mirrors the manifest before storage degradation', async () => {
+    const storage = new MemoryWebStorage();
+    const writer =
+        createWebStorageDeliveryHandoffManifestCachePersistence(storage);
+    const record = createDeliveryHandoffManifestCacheRecord({
+        userId: 'driver-1',
+        manifest: manifest(),
+        now,
+    });
+    await writer.save(record);
+    const reader =
+        createWebStorageDeliveryHandoffManifestCachePersistence(storage);
+    assert.deepEqual(await reader.load(record.scope, now), record);
+
+    storage.failReads = true;
+    assert.deepEqual(await reader.load(record.scope, now), record);
+    assert.equal(reader.durability, 'memory');
+});
+
+test('cache cleanup prunes other runs and fails closed when durable removal is unconfirmed', async () => {
+    const storage = new MemoryWebStorage();
+    const persistence =
+        createWebStorageDeliveryHandoffManifestCachePersistence(storage);
+    const active = createDeliveryHandoffManifestCacheRecord({
+        userId: 'driver-1',
+        manifest: manifest(),
+        now,
+    });
+    const stale = createDeliveryHandoffManifestCacheRecord({
+        userId: 'driver-1',
+        manifest: manifest({ runId: 'run-old' }),
+        now,
+    });
+    await persistence.save(active);
+    await persistence.save(stale);
+
+    await persistence.clearOtherRuns?.({
+        userId: 'driver-1',
+        activeRunId: 'run-1',
+    });
+    assert.ok(await persistence.load(active.scope, now));
+    assert.equal(await persistence.load(stale.scope, now), null);
+
+    storage.failRemoval = true;
+    await assert.rejects(
+        persistence.clear({ userId: 'driver-1', runId: 'run-1' }),
+        /cleanup could not be confirmed/,
+    );
+    assert.equal(persistence.durability, 'memory');
+});

--- a/apps/delivery/lib/deliveryHandoffManifestCache.ts
+++ b/apps/delivery/lib/deliveryHandoffManifestCache.ts
@@ -1,0 +1,419 @@
+import {
+    type DeliveryHandoffManifest,
+    type DeliveryHandoffManifestScope,
+    parseDeliveryHandoffManifest,
+} from './deliveryHandoffManifest';
+import { assertDeliveryOfflineWritesAllowed } from './deliveryOfflineEvents';
+
+export const deliveryHandoffManifestCacheTtlMs = 24 * 60 * 60 * 1_000;
+
+export type DeliveryHandoffManifestCacheRecord = {
+    version: 1;
+    scope: DeliveryHandoffManifestScope;
+    manifest: DeliveryHandoffManifest;
+    cachedAt: string;
+    expiresAt: string;
+};
+
+export type DeliveryHandoffManifestCacheDurability = 'durable' | 'memory';
+
+export type DeliveryHandoffManifestCacheClearScope = {
+    userId: string;
+    runId?: string;
+    targetStopId?: number;
+    expectedRetryAttempt?: number;
+};
+
+export type DeliveryHandoffManifestCachePersistence = {
+    readonly durability: DeliveryHandoffManifestCacheDurability;
+    readonly durableCleanupRequired?: boolean;
+    load: (
+        scope: DeliveryHandoffManifestScope,
+        now?: Date,
+    ) => Promise<DeliveryHandoffManifestCacheRecord | null>;
+    save: (record: DeliveryHandoffManifestCacheRecord) => Promise<void>;
+    clear: (scope: DeliveryHandoffManifestCacheClearScope) => Promise<void>;
+    clearOtherRuns?: (scope: {
+        userId: string;
+        activeRunId: string;
+    }) => Promise<void>;
+};
+
+export type DeliveryHandoffManifestWebStorage = {
+    readonly length: number;
+    key: (index: number) => string | null;
+    getItem: (key: string) => string | null;
+    setItem: (key: string, value: string) => void;
+    removeItem: (key: string) => void;
+};
+
+const storagePrefix = 'gredice:delivery:handoff-manifest:v1:';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: string[]) {
+    const allowedKeys = new Set(allowed);
+    return Object.keys(value).every((key) => allowedKeys.has(key));
+}
+
+function validIdentifier(value: unknown): value is string {
+    return (
+        typeof value === 'string' &&
+        value.trim() === value &&
+        value.length > 0 &&
+        value.length <= 256
+    );
+}
+
+function validStopId(value: unknown): value is number {
+    return (
+        typeof value === 'number' &&
+        Number.isSafeInteger(value) &&
+        value > 0 &&
+        value <= 2_147_483_647
+    );
+}
+
+function validRetryAttempt(value: unknown): value is number {
+    return (
+        typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+    );
+}
+
+function validDate(value: unknown): value is string {
+    return (
+        typeof value === 'string' &&
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value) &&
+        Number.isFinite(Date.parse(value))
+    );
+}
+
+function validScope(value: unknown): value is DeliveryHandoffManifestScope {
+    return (
+        isRecord(value) &&
+        hasOnlyKeys(value, [
+            'userId',
+            'runId',
+            'targetStopId',
+            'expectedRetryAttempt',
+        ]) &&
+        validIdentifier(value.userId) &&
+        validIdentifier(value.runId) &&
+        validStopId(value.targetStopId) &&
+        validRetryAttempt(value.expectedRetryAttempt)
+    );
+}
+
+function cacheKey(scope: DeliveryHandoffManifestScope) {
+    return `${storagePrefix}${encodeURIComponent(scope.userId)}:${encodeURIComponent(scope.runId)}:${scope.targetStopId}:${scope.expectedRetryAttempt}`;
+}
+
+function clearPrefix(scope: DeliveryHandoffManifestCacheClearScope) {
+    if (!validIdentifier(scope.userId)) {
+        throw new TypeError('Delivery handoff manifest cache scope is invalid');
+    }
+    let prefix = `${storagePrefix}${encodeURIComponent(scope.userId)}:`;
+    if (scope.runId === undefined) {
+        if (
+            scope.targetStopId !== undefined ||
+            scope.expectedRetryAttempt !== undefined
+        ) {
+            throw new TypeError(
+                'Delivery handoff manifest cache scope is invalid',
+            );
+        }
+        return prefix;
+    }
+    if (!validIdentifier(scope.runId)) {
+        throw new TypeError('Delivery handoff manifest cache scope is invalid');
+    }
+    prefix += `${encodeURIComponent(scope.runId)}:`;
+    if (scope.targetStopId === undefined) {
+        if (scope.expectedRetryAttempt !== undefined) {
+            throw new TypeError(
+                'Delivery handoff manifest cache scope is invalid',
+            );
+        }
+        return prefix;
+    }
+    if (!validStopId(scope.targetStopId)) {
+        throw new TypeError('Delivery handoff manifest cache scope is invalid');
+    }
+    prefix += `${scope.targetStopId}:`;
+    if (scope.expectedRetryAttempt === undefined) return prefix;
+    if (!validRetryAttempt(scope.expectedRetryAttempt)) {
+        throw new TypeError('Delivery handoff manifest cache scope is invalid');
+    }
+    return `${prefix}${scope.expectedRetryAttempt}`;
+}
+
+function cacheKeyMatchesClearScope(
+    key: string,
+    scope: DeliveryHandoffManifestCacheClearScope,
+) {
+    const candidate = clearPrefix(scope);
+    return scope.runId !== undefined &&
+        scope.targetStopId !== undefined &&
+        scope.expectedRetryAttempt !== undefined
+        ? key === candidate
+        : key.startsWith(candidate);
+}
+
+function parseCacheRecord(
+    value: unknown,
+    expectedScope?: DeliveryHandoffManifestScope,
+): DeliveryHandoffManifestCacheRecord | null {
+    if (
+        !isRecord(value) ||
+        !hasOnlyKeys(value, [
+            'version',
+            'scope',
+            'manifest',
+            'cachedAt',
+            'expiresAt',
+        ]) ||
+        value.version !== 1 ||
+        !validScope(value.scope) ||
+        !validDate(value.cachedAt) ||
+        !validDate(value.expiresAt)
+    ) {
+        return null;
+    }
+    const manifest = parseDeliveryHandoffManifest(value.manifest);
+    if (
+        !manifest ||
+        manifest.runId !== value.scope.runId ||
+        manifest.targetStopId !== value.scope.targetStopId ||
+        manifest.retryAttempt !== value.scope.expectedRetryAttempt ||
+        Date.parse(value.expiresAt) <= Date.parse(value.cachedAt) ||
+        (expectedScope &&
+            (expectedScope.userId !== value.scope.userId ||
+                expectedScope.runId !== value.scope.runId ||
+                expectedScope.targetStopId !== value.scope.targetStopId ||
+                expectedScope.expectedRetryAttempt !==
+                    value.scope.expectedRetryAttempt))
+    ) {
+        return null;
+    }
+    return {
+        version: 1,
+        scope: { ...value.scope },
+        manifest,
+        cachedAt: value.cachedAt,
+        expiresAt: value.expiresAt,
+    };
+}
+
+export function createDeliveryHandoffManifestCacheRecord({
+    userId,
+    manifest,
+    now = new Date(),
+}: {
+    userId: string;
+    manifest: DeliveryHandoffManifest;
+    now?: Date;
+}): DeliveryHandoffManifestCacheRecord {
+    const parsedManifest = parseDeliveryHandoffManifest(manifest);
+    if (
+        !validIdentifier(userId) ||
+        !parsedManifest ||
+        !Number.isFinite(now.getTime())
+    ) {
+        throw new TypeError(
+            'Delivery handoff manifest cache record is invalid',
+        );
+    }
+    const cachedAt = now.toISOString();
+    return {
+        version: 1,
+        scope: {
+            userId,
+            runId: parsedManifest.runId,
+            targetStopId: parsedManifest.targetStopId,
+            expectedRetryAttempt: parsedManifest.retryAttempt,
+        },
+        manifest: parsedManifest,
+        cachedAt,
+        expiresAt: new Date(
+            now.getTime() + deliveryHandoffManifestCacheTtlMs,
+        ).toISOString(),
+    };
+}
+
+function serializedRecord(record: DeliveryHandoffManifestCacheRecord) {
+    const parsed = parseCacheRecord(record);
+    if (!parsed) {
+        throw new TypeError(
+            'Delivery handoff manifest cache record is invalid',
+        );
+    }
+    return JSON.stringify(parsed);
+}
+
+function parsedSerializedRecord(
+    value: string | null,
+    expectedScope: DeliveryHandoffManifestScope,
+) {
+    if (!value) return null;
+    try {
+        return parseCacheRecord(JSON.parse(value), expectedScope);
+    } catch {
+        return null;
+    }
+}
+
+function validAt(record: DeliveryHandoffManifestCacheRecord | null, now: Date) {
+    return record &&
+        Number.isFinite(now.getTime()) &&
+        Date.parse(record.cachedAt) <= now.getTime() + 5 * 60 * 1_000 &&
+        Date.parse(record.expiresAt) > now.getTime()
+        ? record
+        : null;
+}
+
+export function createMemoryDeliveryHandoffManifestCachePersistence(): DeliveryHandoffManifestCachePersistence {
+    const values = new Map<string, string>();
+    return {
+        durability: 'memory',
+        durableCleanupRequired: false,
+        async load(scope, now = new Date()) {
+            const key = cacheKey(scope);
+            const record = validAt(
+                parsedSerializedRecord(values.get(key) ?? null, scope),
+                now,
+            );
+            if (!record) values.delete(key);
+            return record;
+        },
+        async save(record) {
+            assertDeliveryOfflineWritesAllowed();
+            values.set(cacheKey(record.scope), serializedRecord(record));
+        },
+        async clear(scope) {
+            for (const key of values.keys()) {
+                if (cacheKeyMatchesClearScope(key, scope)) values.delete(key);
+            }
+        },
+        async clearOtherRuns({ userId, activeRunId }) {
+            const userPrefix = clearPrefix({ userId });
+            const activePrefix = clearPrefix({ userId, runId: activeRunId });
+            for (const key of values.keys()) {
+                if (
+                    key.startsWith(userPrefix) &&
+                    !key.startsWith(activePrefix)
+                ) {
+                    values.delete(key);
+                }
+            }
+        },
+    };
+}
+
+export function createWebStorageDeliveryHandoffManifestCachePersistence(
+    storage: DeliveryHandoffManifestWebStorage,
+): DeliveryHandoffManifestCachePersistence {
+    const fallbackValues = new Map<string, string>();
+    let durable = true;
+
+    function storageKeys() {
+        return Array.from({ length: storage.length }, (_, index) =>
+            storage.key(index),
+        );
+    }
+
+    return {
+        get durability() {
+            return durable ? 'durable' : 'memory';
+        },
+        durableCleanupRequired: true,
+        async load(scope, now = new Date()) {
+            const key = cacheKey(scope);
+            if (durable) {
+                try {
+                    const serialized = storage.getItem(key);
+                    if (serialized === null) fallbackValues.delete(key);
+                    else fallbackValues.set(key, serialized);
+                    const record = validAt(
+                        parsedSerializedRecord(serialized, scope),
+                        now,
+                    );
+                    if (!record && serialized !== null) {
+                        storage.removeItem(key);
+                        fallbackValues.delete(key);
+                    }
+                    return record;
+                } catch {
+                    durable = false;
+                }
+            }
+            const record = validAt(
+                parsedSerializedRecord(fallbackValues.get(key) ?? null, scope),
+                now,
+            );
+            if (!record) fallbackValues.delete(key);
+            return record;
+        },
+        async save(record) {
+            assertDeliveryOfflineWritesAllowed();
+            const value = serializedRecord(record);
+            const key = cacheKey(record.scope);
+            fallbackValues.set(key, value);
+            if (!durable) return;
+            try {
+                storage.setItem(key, value);
+            } catch {
+                durable = false;
+            }
+        },
+        async clear(scope) {
+            try {
+                for (const key of storageKeys()) {
+                    if (key && cacheKeyMatchesClearScope(key, scope)) {
+                        storage.removeItem(key);
+                    }
+                }
+                for (const key of fallbackValues.keys()) {
+                    if (cacheKeyMatchesClearScope(key, scope)) {
+                        fallbackValues.delete(key);
+                    }
+                }
+                durable = true;
+            } catch {
+                durable = false;
+                throw new Error(
+                    'Durable delivery handoff manifest cleanup could not be confirmed',
+                );
+            }
+        },
+        async clearOtherRuns({ userId, activeRunId }) {
+            const userPrefix = clearPrefix({ userId });
+            const activePrefix = clearPrefix({ userId, runId: activeRunId });
+            try {
+                for (const key of storageKeys()) {
+                    if (
+                        key?.startsWith(userPrefix) &&
+                        !key.startsWith(activePrefix)
+                    ) {
+                        storage.removeItem(key);
+                    }
+                }
+                for (const key of fallbackValues.keys()) {
+                    if (
+                        key.startsWith(userPrefix) &&
+                        !key.startsWith(activePrefix)
+                    ) {
+                        fallbackValues.delete(key);
+                    }
+                }
+                durable = true;
+            } catch {
+                durable = false;
+                throw new Error(
+                    'Durable delivery handoff manifest cleanup could not be confirmed',
+                );
+            }
+        },
+    };
+}

--- a/apps/delivery/lib/deliveryHandoffSyncController.node.spec.ts
+++ b/apps/delivery/lib/deliveryHandoffSyncController.node.spec.ts
@@ -1,0 +1,807 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    createDeliveryVerificationMarkCommand,
+    createDeliveryVerificationScanCommand,
+    createMemoryDeliveryActionQueuePersistence,
+    DeliveryActionQueue,
+    type DeliveryActionQueueSnapshot,
+    type DeliveryActionTransport,
+    isDeliveryHandoffCommand,
+} from './deliveryActionQueue';
+import type { DeliveryStopDeliverySummary } from './deliveryDashboardTypes';
+import type { DeliveryHandoffManifest } from './deliveryHandoffManifest';
+import {
+    createDeliveryHandoffManifestCacheRecord,
+    type DeliveryHandoffManifestCachePersistence,
+    type DeliveryHandoffManifestCacheRecord,
+} from './deliveryHandoffManifestCache';
+import {
+    type DeliveryHandoffActionSyncAdapter,
+    DeliveryHandoffSyncController,
+    deliveryHandoffDeliveriesFingerprint,
+} from './deliveryHandoffSyncController';
+
+const userId = 'driver-controller-1';
+const runId = 'run-controller-1';
+const nowValue = new Date('2026-07-16T08:00:00.000Z');
+const now = () => new Date(nowValue);
+
+type ManifestItemState = DeliveryHandoffManifest['items'][number]['state'];
+
+function delivery(
+    stopId: number,
+    tracePath = `/trag/controller-trace-token-${stopId}`,
+): DeliveryStopDeliverySummary {
+    return {
+        stopId,
+        stopState: 'arrived',
+        requestId: `request-${stopId}`,
+        requestState: 'in_delivery',
+        contactName: `Kontakt ${stopId}`,
+        phone: null,
+        addressLabel: null,
+        requestNotes: null,
+        deliveryNotes: null,
+        harvest: {
+            plantName: `Biljka ${stopId}`,
+            operationName: null,
+            raisedBedName: null,
+            fieldName: null,
+            tracePath,
+        },
+        exception: null,
+    };
+}
+
+function manifest({
+    retryAttempt = 0,
+    targetStopId = 101,
+    itemStates = [
+        { stopId: 101, state: 'unverified' },
+        { stopId: 102, state: 'unverified' },
+    ],
+}: {
+    retryAttempt?: number;
+    targetStopId?: number;
+    itemStates?: Array<{ stopId: number; state: ManifestItemState }>;
+} = {}): DeliveryHandoffManifest {
+    const items = itemStates.map(({ stopId, state }) => ({
+        stopId,
+        deliveryRequestId: `request-${stopId}`,
+        retryAttempt,
+        traceLinkId: 1_000 + stopId,
+        qrAvailable: true,
+        state,
+        reason: state === 'skipped' ? ('manual-verification' as const) : null,
+        verifiedAt: state === 'unverified' ? null : '2026-07-16T08:01:00.000Z',
+    }));
+    const count = (state: ManifestItemState) =>
+        items.filter((item) => item.state === state).length;
+    return {
+        runId,
+        targetStopId,
+        version: 1,
+        retryAttempt,
+        items,
+        expectedCount: items.length,
+        scannedCount: count('scanned'),
+        unverifiedCount: count('unverified'),
+        noLabelCount: count('no-label'),
+        missingCount: count('missing'),
+        skippedCount: count('skipped'),
+    };
+}
+
+function cacheKey(record: DeliveryHandoffManifestCacheRecord) {
+    const { scope } = record;
+    return `${scope.userId}:${scope.runId}:${scope.targetStopId}:${scope.expectedRetryAttempt}`;
+}
+
+function cacheHarness({
+    manifests = [],
+    events = [],
+}: {
+    manifests?: DeliveryHandoffManifest[];
+    events?: string[];
+} = {}) {
+    const records = new Map<string, DeliveryHandoffManifestCacheRecord>();
+    for (const value of manifests) {
+        const record = createDeliveryHandoffManifestCacheRecord({
+            userId,
+            manifest: value,
+            now: nowValue,
+        });
+        records.set(cacheKey(record), record);
+    }
+    const cache: DeliveryHandoffManifestCachePersistence = {
+        durability: 'memory',
+        async load(scope) {
+            events.push(
+                `load:${scope.targetStopId}:${scope.expectedRetryAttempt}`,
+            );
+            return (
+                records.get(
+                    `${scope.userId}:${scope.runId}:${scope.targetStopId}:${scope.expectedRetryAttempt}`,
+                ) ?? null
+            );
+        },
+        async save(record) {
+            events.push(
+                `save:${record.scope.targetStopId}:${record.scope.expectedRetryAttempt}`,
+            );
+            records.set(cacheKey(record), record);
+        },
+        async clear() {},
+        async clearOtherRuns(scope) {
+            events.push(`prune:${scope.activeRunId}`);
+        },
+    };
+    return { cache, records };
+}
+
+function defaultTransport(): DeliveryActionTransport {
+    return async (command) =>
+        isDeliveryHandoffCommand(command)
+            ? { status: 'retryable-failure', code: 'offline' }
+            : {
+                  status: 'applied',
+                  routeRevision: command.expectedRouteRevision + 1,
+                  reroutePending: false,
+                  runCompleted: false,
+              };
+}
+
+function actionHarness({
+    events = [],
+    transport = defaultTransport(),
+    syncNow,
+}: {
+    events?: string[];
+    transport?: DeliveryActionTransport;
+    syncNow?: (
+        queue: DeliveryActionQueue,
+    ) => Promise<DeliveryActionQueueSnapshot>;
+} = {}) {
+    const queue = new DeliveryActionQueue({
+        scope: { userId, runId },
+        persistence: createMemoryDeliveryActionQueuePersistence(),
+        transport,
+        now,
+    });
+    let operationIndex = 0;
+    const operationId = () => {
+        operationIndex += 1;
+        return `controller-operation-${operationIndex.toString().padStart(4, '0')}`;
+    };
+    const actions: DeliveryHandoffActionSyncAdapter = {
+        getSnapshot: queue.getSnapshot,
+        syncNow: async () =>
+            syncNow ? await syncNow(queue) : await queue.replay(),
+        enqueueVerificationScan: async (
+            targetStopId,
+            tracePath,
+            expectedRetryAttempt,
+        ) =>
+            await queue.enqueue(
+                createDeliveryVerificationScanCommand({
+                    operationId: operationId(),
+                    runId,
+                    stopId: targetStopId,
+                    expectedRetryAttempt,
+                    tracePath,
+                    now,
+                }),
+            ),
+        enqueueVerificationMark: async (input) =>
+            await queue.enqueue(
+                createDeliveryVerificationMarkCommand({
+                    operationId: operationId(),
+                    runId,
+                    stopId: input.stopId,
+                    expectedRetryAttempt: input.expectedRetryAttempt,
+                    itemStopId: input.itemStopId,
+                    outcome: input.outcome,
+                    reason: input.reason,
+                    now,
+                }),
+            ),
+        completeHandoffReconciliation: async (
+            targetStopId,
+            expectedRetryAttempt,
+            operationIds,
+        ) => {
+            events.push(
+                `reconcile:${targetStopId}:${expectedRetryAttempt}:${operationIds.join(',')}`,
+            );
+            return await queue.completeHandoffReconciliation({
+                stopId: targetStopId,
+                expectedRetryAttempt,
+                operationIds,
+            });
+        },
+    };
+    return { actions, queue };
+}
+
+function deferred<Value>() {
+    let resolve: (value: Value) => void = () => undefined;
+    const promise = new Promise<Value>((resolvePromise) => {
+        resolve = resolvePromise;
+    });
+    return { promise, resolve };
+}
+
+test('delivery fingerprints are order-independent but preserve handoff identity', () => {
+    const first = [
+        delivery(
+            101,
+            'https://www.gredice.com/trag/controller-trace-token-101',
+        ),
+        delivery(102),
+    ];
+    const equivalent = [
+        delivery(102),
+        delivery(101, '/trag/controller-trace-token-101'),
+    ];
+    const fingerprint = deliveryHandoffDeliveriesFingerprint(first);
+
+    assert.equal(deliveryHandoffDeliveriesFingerprint(equivalent), fingerprint);
+    assert.notEqual(
+        deliveryHandoffDeliveriesFingerprint([
+            { ...equivalent[0], requestId: 'different-request' },
+            equivalent[1],
+        ]),
+        fingerprint,
+    );
+    assert.notEqual(
+        deliveryHandoffDeliveriesFingerprint([delivery(103), equivalent[1]]),
+        fingerprint,
+    );
+    assert.notEqual(
+        deliveryHandoffDeliveriesFingerprint([
+            equivalent[0],
+            delivery(101, '/trag/different-controller-trace-token'),
+        ]),
+        fingerprint,
+    );
+});
+
+test('emits a matching cached manifest before the authoritative refresh', async () => {
+    const cached = manifest({
+        itemStates: [
+            { stopId: 101, state: 'no-label' },
+            { stopId: 102, state: 'unverified' },
+        ],
+    });
+    const authoritative = manifest({
+        itemStates: [
+            { stopId: 101, state: 'scanned' },
+            { stopId: 102, state: 'unverified' },
+        ],
+    });
+    const events: string[] = [];
+    const { cache } = cacheHarness({ manifests: [cached], events });
+    const { actions } = actionHarness({ events });
+    const controller = new DeliveryHandoffSyncController({
+        userId,
+        runId,
+        cache,
+        actions,
+        fetchManifest: async () => ({
+            status: 'loaded',
+            manifest: authoritative,
+        }),
+        isOnline: () => true,
+        now,
+    });
+    const emittedStates: ManifestItemState[] = [];
+    controller.subscribe(() => {
+        const itemState = controller.getSnapshot().handoff?.items[0]?.state;
+        if (itemState) emittedStates.push(itemState);
+    });
+
+    await controller.setContext({
+        target: { targetStopId: 101, retryAttempt: 0 },
+        deliveries: [delivery(101), delivery(102)],
+        queueSnapshot: actions.getSnapshot(),
+    });
+
+    const cachedIndex = emittedStates.indexOf('no-label');
+    const authoritativeIndex = emittedStates.indexOf('scanned');
+    assert.notEqual(cachedIndex, -1);
+    assert.ok(authoritativeIndex > cachedIndex);
+    assert.equal(controller.getSnapshot().status, 'ready');
+    assert.deepEqual(events.slice(0, 2), [`prune:${runId}`, 'load:101:0']);
+});
+
+test('projects offline scan and mark work immediately and deduplicates a repeated scan', async () => {
+    const { cache } = cacheHarness();
+    const { actions, queue } = actionHarness();
+    const controller = new DeliveryHandoffSyncController({
+        userId,
+        runId,
+        cache,
+        actions,
+        fetchManifest: async () => ({
+            status: 'retryable-failure',
+            code: 'offline',
+        }),
+        isOnline: () => false,
+        now,
+    });
+    await controller.setContext({
+        target: { targetStopId: 101, retryAttempt: 0 },
+        deliveries: [delivery(101), delivery(102)],
+        queueSnapshot: actions.getSnapshot(),
+    });
+
+    const first = await controller.scan(
+        'https://www.gredice.com/trag/controller-trace-token-101',
+    );
+    const duplicate = await controller.scan('/trag/controller-trace-token-101');
+
+    assert.equal(first.status, 'verified');
+    assert.equal(duplicate.status, 'already-verified');
+    assert.equal(queue.getSnapshot().entries.length, 1);
+    assert.equal(controller.getSnapshot().handoff?.pendingCount, 1);
+    assert.equal(controller.getSnapshot().handoff?.items[0]?.state, 'scanned');
+    assert.equal(
+        controller.getSnapshot().handoff?.items[0]?.syncState,
+        'queued',
+    );
+
+    assert.deepEqual(
+        await controller.markItem({
+            itemStopId: 102,
+            outcome: 'missing',
+        }),
+        { status: 'saved' },
+    );
+    assert.equal(controller.getSnapshot().status, 'offline');
+    assert.equal(controller.getSnapshot().handoff?.pendingCount, 2);
+    assert.equal(controller.getSnapshot().handoff?.items[1]?.state, 'missing');
+    assert.equal(
+        controller.getSnapshot().handoff?.items[1]?.syncState,
+        'queued',
+    );
+});
+
+test('persists the authoritative manifest before purging acknowledged raw handoff commands', async () => {
+    const events: string[] = [];
+    const transport: DeliveryActionTransport = async (command) => {
+        if (command.kind !== 'verification-scan') {
+            throw new Error('Expected a handoff scan');
+        }
+        return {
+            status: 'handoff-acknowledged',
+            replayed: false,
+            retryAttempt: 0,
+            result: {
+                kind: 'scan',
+                outcome: 'applied',
+                affectedStopIds: [101],
+                itemState: 'scanned',
+            },
+        };
+    };
+    const { actions, queue } = actionHarness({ events, transport });
+    await queue.enqueue(
+        createDeliveryVerificationScanCommand({
+            operationId: 'seeded-controller-scan-0001',
+            runId,
+            stopId: 101,
+            expectedRetryAttempt: 0,
+            tracePath: '/trag/controller-trace-token-101',
+            now,
+        }),
+    );
+    const { cache } = cacheHarness({ events });
+    const controller = new DeliveryHandoffSyncController({
+        userId,
+        runId,
+        cache,
+        actions,
+        fetchManifest: async () => ({
+            status: 'loaded',
+            manifest: manifest({
+                itemStates: [{ stopId: 101, state: 'scanned' }],
+            }),
+        }),
+        isOnline: () => true,
+        now,
+    });
+
+    await controller.setContext({
+        target: { targetStopId: 101, retryAttempt: 0 },
+        deliveries: [delivery(101)],
+        queueSnapshot: actions.getSnapshot(),
+    });
+
+    assert.deepEqual(
+        events.filter(
+            (event) =>
+                event.startsWith('save:') || event.startsWith('reconcile:'),
+        ),
+        ['save:101:0', 'reconcile:101:0:seeded-controller-scan-0001'],
+    );
+    assert.equal(queue.getSnapshot().entries.length, 0);
+    assert.equal(controller.getSnapshot().handoff?.items[0]?.state, 'scanned');
+});
+
+test('keeps acknowledged raw evidence when browser cache durability is unavailable', async () => {
+    const events: string[] = [];
+    const transport: DeliveryActionTransport = async (command) => {
+        if (command.kind !== 'verification-scan') {
+            throw new Error('Expected a handoff scan');
+        }
+        return {
+            status: 'handoff-acknowledged',
+            replayed: false,
+            retryAttempt: 0,
+            result: {
+                kind: 'scan',
+                outcome: 'applied',
+                affectedStopIds: [101],
+                itemState: 'scanned',
+            },
+        };
+    };
+    const { actions, queue } = actionHarness({ events, transport });
+    await queue.enqueue(
+        createDeliveryVerificationScanCommand({
+            operationId: 'non-durable-controller-scan-0001',
+            runId,
+            stopId: 101,
+            expectedRetryAttempt: 0,
+            tracePath: '/trag/controller-trace-token-101',
+            now,
+        }),
+    );
+    const baseCache = cacheHarness({ events }).cache;
+    const cache: DeliveryHandoffManifestCachePersistence = {
+        ...baseCache,
+        durableCleanupRequired: true,
+    };
+    const controller = new DeliveryHandoffSyncController({
+        userId,
+        runId,
+        cache,
+        actions,
+        fetchManifest: async () => ({
+            status: 'loaded',
+            manifest: manifest({
+                itemStates: [{ stopId: 101, state: 'scanned' }],
+            }),
+        }),
+        isOnline: () => true,
+        now,
+    });
+
+    await controller.setContext({
+        target: { targetStopId: 101, retryAttempt: 0 },
+        deliveries: [delivery(101)],
+        queueSnapshot: actions.getSnapshot(),
+    });
+
+    assert.equal(queue.getSnapshot().entries[0]?.state, 'synced');
+    assert.equal(controller.getSnapshot().status, 'failed');
+    assert.equal(
+        events.some((event) => event.startsWith('reconcile:')),
+        false,
+    );
+});
+
+test('refreshes again before purging an acknowledgement that races with the authoritative GET', async () => {
+    const events: string[] = [];
+    const transport: DeliveryActionTransport = async (command) => {
+        if (command.kind !== 'verification-scan') {
+            throw new Error('Expected a handoff scan');
+        }
+        return {
+            status: 'handoff-acknowledged',
+            replayed: false,
+            retryAttempt: 0,
+            result: {
+                kind: 'scan',
+                outcome: 'applied',
+                affectedStopIds: [101],
+                itemState: 'scanned',
+            },
+        };
+    };
+    const { actions, queue } = actionHarness({
+        events,
+        transport,
+        syncNow: async (currentQueue) => currentQueue.getSnapshot(),
+    });
+    await queue.enqueue(
+        createDeliveryVerificationScanCommand({
+            operationId: 'racing-controller-scan-0001',
+            runId,
+            stopId: 101,
+            expectedRetryAttempt: 0,
+            tracePath: '/trag/controller-trace-token-101',
+            now,
+        }),
+    );
+    const getStarted = deferred<void>();
+    const getResult = deferred<{
+        status: 'loaded';
+        manifest: DeliveryHandoffManifest;
+    }>();
+    const racedAcknowledgementPurged = deferred<void>();
+    const { cache, records } = cacheHarness({ events });
+    let fetchCount = 0;
+    const controller = new DeliveryHandoffSyncController({
+        userId,
+        runId,
+        cache,
+        actions: {
+            ...actions,
+            completeHandoffReconciliation: async (
+                targetStopId,
+                expectedRetryAttempt,
+                operationIds,
+            ) => {
+                const removed = await actions.completeHandoffReconciliation(
+                    targetStopId,
+                    expectedRetryAttempt,
+                    operationIds,
+                );
+                if (operationIds.includes('racing-controller-scan-0001')) {
+                    racedAcknowledgementPurged.resolve();
+                }
+                return removed;
+            },
+        },
+        fetchManifest: async () => {
+            fetchCount += 1;
+            if (fetchCount === 1) {
+                getStarted.resolve();
+                return await getResult.promise;
+            }
+            return {
+                status: 'loaded',
+                manifest: manifest({
+                    itemStates: [{ stopId: 101, state: 'scanned' }],
+                }),
+            };
+        },
+        isOnline: () => true,
+        now,
+    });
+
+    const activation = controller.setContext({
+        target: { targetStopId: 101, retryAttempt: 0 },
+        deliveries: [delivery(101)],
+        queueSnapshot: actions.getSnapshot(),
+    });
+    await getStarted.promise;
+    await queue.replay();
+    assert.equal(queue.getSnapshot().entries[0]?.state, 'synced');
+    getResult.resolve({
+        status: 'loaded',
+        manifest: manifest({
+            itemStates: [{ stopId: 101, state: 'unverified' }],
+        }),
+    });
+    await activation;
+    await racedAcknowledgementPurged.promise;
+
+    assert.equal(fetchCount, 2);
+    assert.equal(queue.getSnapshot().entries.length, 0);
+    assert.equal(
+        records.get(`${userId}:${runId}:101:0`)?.manifest.items[0]?.state,
+        'scanned',
+    );
+    assert.deepEqual(
+        events.filter(
+            (event) =>
+                event.startsWith('save:') || event.startsWith('reconcile:'),
+        ),
+        [
+            'save:101:0',
+            'reconcile:101:0:',
+            'save:101:0',
+            'reconcile:101:0:racing-controller-scan-0001',
+        ],
+    );
+});
+
+test('a retry switch ignores stale async data without clearing queued work', async () => {
+    const firstFetch = deferred<{
+        status: 'loaded';
+        manifest: DeliveryHandoffManifest;
+    }>();
+    const firstFetchStarted = deferred<void>();
+    const events: string[] = [];
+    const { cache } = cacheHarness({ events });
+    const { actions, queue } = actionHarness({ events });
+    await queue.enqueue(
+        createDeliveryVerificationScanCommand({
+            operationId: 'retry-switch-scan-0001',
+            runId,
+            stopId: 101,
+            expectedRetryAttempt: 0,
+            tracePath: '/trag/controller-trace-token-101',
+            now,
+        }),
+    );
+    let fetchCount = 0;
+    const controller = new DeliveryHandoffSyncController({
+        userId,
+        runId,
+        cache,
+        actions,
+        fetchManifest: async () => {
+            fetchCount += 1;
+            if (fetchCount === 1) {
+                firstFetchStarted.resolve();
+                return await firstFetch.promise;
+            }
+            return {
+                status: 'loaded',
+                manifest: manifest({
+                    retryAttempt: 1,
+                    itemStates: [{ stopId: 101, state: 'missing' }],
+                }),
+            };
+        },
+        isOnline: () => true,
+        now,
+    });
+
+    const firstContext = controller.setContext({
+        target: { targetStopId: 101, retryAttempt: 0 },
+        deliveries: [delivery(101)],
+        queueSnapshot: actions.getSnapshot(),
+    });
+    await firstFetchStarted.promise;
+    await controller.setContext({
+        target: { targetStopId: 101, retryAttempt: 1 },
+        deliveries: [delivery(101)],
+        queueSnapshot: actions.getSnapshot(),
+    });
+    firstFetch.resolve({
+        status: 'loaded',
+        manifest: manifest({
+            retryAttempt: 0,
+            itemStates: [{ stopId: 101, state: 'scanned' }],
+        }),
+    });
+    await firstContext;
+
+    assert.equal(controller.getSnapshot().handoff?.retryAttempt, 1);
+    assert.equal(controller.getSnapshot().handoff?.items[0]?.state, 'missing');
+    assert.deepEqual(
+        events.filter((event) => event.startsWith('load:')),
+        ['load:101:0', 'load:101:1'],
+    );
+    assert.deepEqual(
+        events.filter((event) => event.startsWith('save:')),
+        ['save:101:1'],
+    );
+    assert.equal(queue.getSnapshot().entries.length, 1);
+});
+
+test('a failed reconnect preserves queued optimistic verification work', async () => {
+    let online = false;
+    const { cache } = cacheHarness();
+    const { actions } = actionHarness({
+        syncNow: async () => {
+            throw new Error('network unavailable');
+        },
+    });
+    const controller = new DeliveryHandoffSyncController({
+        userId,
+        runId,
+        cache,
+        actions,
+        fetchManifest: async () => ({
+            status: 'retryable-failure',
+            code: 'offline',
+        }),
+        isOnline: () => online,
+        now,
+    });
+    await controller.setContext({
+        target: { targetStopId: 101, retryAttempt: 0 },
+        deliveries: [delivery(101)],
+        queueSnapshot: actions.getSnapshot(),
+    });
+    await controller.scan('/trag/controller-trace-token-101');
+
+    online = true;
+    controller.connectionChanged();
+    assert.equal(await controller.refresh(), false);
+
+    assert.equal(controller.getSnapshot().status, 'failed');
+    assert.equal(controller.getSnapshot().handoff?.pendingCount, 1);
+    assert.equal(controller.getSnapshot().handoff?.items[0]?.state, 'scanned');
+    assert.equal(
+        controller.getSnapshot().handoff?.items[0]?.syncState,
+        'queued',
+    );
+});
+
+test('manual review preserves manifest order without an arbitrary batch cap', async () => {
+    const orderedDeliveries = [delivery(103), delivery(101), delivery(102)];
+    const { cache } = cacheHarness();
+    const { actions, queue } = actionHarness();
+    const controller = new DeliveryHandoffSyncController({
+        userId,
+        runId,
+        cache,
+        actions,
+        fetchManifest: async () => ({
+            status: 'retryable-failure',
+            code: 'offline',
+        }),
+        isOnline: () => false,
+        now,
+    });
+    await controller.setContext({
+        target: { targetStopId: 101, retryAttempt: 0 },
+        deliveries: orderedDeliveries,
+        queueSnapshot: actions.getSnapshot(),
+    });
+
+    assert.deepEqual(await controller.markRemainingReviewed(), {
+        status: 'saved',
+    });
+    assert.deepEqual(
+        queue
+            .getSnapshot()
+            .entries.map((entry) =>
+                entry.command.kind === 'verification-mark'
+                    ? [
+                          entry.command.itemStopId,
+                          entry.command.outcome,
+                          entry.command.reason,
+                      ]
+                    : [],
+            ),
+        [
+            [103, 'skipped', 'manual-verification'],
+            [101, 'skipped', 'manual-verification'],
+            [102, 'skipped', 'manual-verification'],
+        ],
+    );
+
+    const largeHarness = actionHarness();
+    const largeController = new DeliveryHandoffSyncController({
+        userId,
+        runId,
+        cache: cacheHarness().cache,
+        actions: largeHarness.actions,
+        fetchManifest: async () => ({
+            status: 'retryable-failure',
+            code: 'offline',
+        }),
+        isOnline: () => false,
+        now,
+    });
+    const largeDeliveries = Array.from({ length: 101 }, (_, index) =>
+        delivery(index + 1),
+    );
+    await largeController.setContext({
+        target: { targetStopId: 1, retryAttempt: 0 },
+        deliveries: largeDeliveries,
+        queueSnapshot: largeHarness.actions.getSnapshot(),
+    });
+
+    assert.deepEqual(await largeController.markRemainingReviewed(), {
+        status: 'saved',
+    });
+    assert.deepEqual(
+        largeHarness.queue
+            .getSnapshot()
+            .entries.map((entry) =>
+                entry.command.kind === 'verification-mark'
+                    ? entry.command.itemStopId
+                    : null,
+            ),
+        Array.from({ length: 101 }, (_, index) => index + 1),
+    );
+});

--- a/apps/delivery/lib/deliveryHandoffSyncController.ts
+++ b/apps/delivery/lib/deliveryHandoffSyncController.ts
@@ -1,0 +1,878 @@
+import type {
+    DeliveryRunHandoffItemSnapshot,
+    DeliveryRunHandoffManifest,
+    DeliveryRunHandoffSkipReason,
+} from '@gredice/storage';
+import {
+    type DeliveryActionQueueEntry,
+    type DeliveryActionQueueSnapshot,
+    isDeliveryHandoffCommand,
+} from './deliveryActionQueue';
+import type { DeliveryStopDeliverySummary } from './deliveryDashboardTypes';
+import {
+    type DeliveryHandoffManifest,
+    type DeliveryHandoffManifestFetchResult,
+    type DeliveryHandoffTraceItem,
+    deliveryHandoffQueueEntries,
+    projectDeliveryHandoffManifest,
+} from './deliveryHandoffManifest';
+import {
+    createDeliveryHandoffManifestCacheRecord,
+    type DeliveryHandoffManifestCachePersistence,
+} from './deliveryHandoffManifestCache';
+import type { DriverCommandResult } from './driverCommandResult';
+import {
+    type HarvestTraceVerificationResult,
+    normalizeHarvestTraceScanValue,
+    verifyDeliveryStopHarvestTrace,
+} from './harvestTraceScan';
+
+export type DeliveryHandoffTarget = {
+    targetStopId: number;
+    retryAttempt: number;
+};
+
+export type DeliveryHandoffItemSyncState =
+    | 'persisted'
+    | 'queued'
+    | 'sending'
+    | 'failed';
+
+export type DeliveryHandoffSyncStatus =
+    | 'idle'
+    | 'loading'
+    | 'ready'
+    | 'offline'
+    | 'syncing'
+    | 'failed';
+
+export type DeliveryHandoffManifestItemView = DeliveryRunHandoffItemSnapshot & {
+    syncState?: DeliveryHandoffItemSyncState;
+};
+
+export type DeliveryHandoffManifestView = Omit<
+    DeliveryRunHandoffManifest,
+    'items'
+> & {
+    items: DeliveryHandoffManifestItemView[];
+    syncState: Exclude<DeliveryHandoffSyncStatus, 'idle'>;
+    pendingCount: number;
+    error: string | null;
+};
+
+export type DeliveryHandoffFeedback = {
+    operationId: string;
+    kind:
+        | 'stale'
+        | 'invalid'
+        | 'wrong-stop'
+        | 'item-not-found'
+        | 'sync-failed'
+        | 'conflict';
+    message: string;
+};
+
+export type DeliveryHandoffMarkInput = {
+    itemStopId: number;
+    outcome: 'no-label' | 'missing' | 'skipped';
+    reason?: DeliveryRunHandoffSkipReason;
+};
+
+export type HarvestTraceScanFailureResult = {
+    status: 'scan-failed';
+    message: string;
+};
+
+export type DeliveryHandoffScanResult =
+    | HarvestTraceVerificationResult
+    | HarvestTraceScanFailureResult;
+
+export type DeliveryHandoffActionSyncAdapter = {
+    getSnapshot: () => DeliveryActionQueueSnapshot;
+    syncNow: () => Promise<DeliveryActionQueueSnapshot>;
+    enqueueVerificationScan: (
+        targetStopId: number,
+        tracePath: string,
+        expectedRetryAttempt: number,
+    ) => Promise<DeliveryActionQueueEntry>;
+    enqueueVerificationMark: (input: {
+        stopId: number;
+        expectedRetryAttempt: number;
+        itemStopId: number;
+        outcome: 'no-label' | 'missing' | 'skipped';
+        reason?: DeliveryRunHandoffSkipReason;
+    }) => Promise<DeliveryActionQueueEntry>;
+    completeHandoffReconciliation: (
+        targetStopId: number,
+        expectedRetryAttempt: number,
+        operationIds: readonly string[],
+    ) => Promise<number>;
+};
+
+export type DeliveryHandoffControllerState = {
+    handoff: DeliveryHandoffManifestView | null;
+    status: DeliveryHandoffSyncStatus;
+    error: string | null;
+    feedback: readonly DeliveryHandoffFeedback[];
+};
+
+type DeliveryHandoffControllerOptions = {
+    userId: string;
+    runId: string;
+    cache: DeliveryHandoffManifestCachePersistence;
+    actions: DeliveryHandoffActionSyncAdapter;
+    fetchManifest: (input: {
+        runId: string;
+        targetStopId: number;
+    }) => Promise<DeliveryHandoffManifestFetchResult>;
+    isOnline: () => boolean;
+    now?: () => Date;
+};
+
+const idleState: DeliveryHandoffControllerState = {
+    handoff: null,
+    status: 'idle',
+    error: null,
+    feedback: [],
+};
+
+function sameTarget(
+    first: DeliveryHandoffTarget | null,
+    second: DeliveryHandoffTarget | null,
+) {
+    return (
+        first?.targetStopId === second?.targetStopId &&
+        first?.retryAttempt === second?.retryAttempt
+    );
+}
+
+function traceItems(
+    deliveries: readonly DeliveryStopDeliverySummary[],
+): DeliveryHandoffTraceItem[] {
+    return deliveries.flatMap((delivery) =>
+        delivery.stopId === null
+            ? []
+            : [
+                  {
+                      stopId: delivery.stopId,
+                      tracePath: delivery.harvest.tracePath,
+                  },
+              ],
+    );
+}
+
+export function deliveryHandoffDeliveriesFingerprint(
+    deliveries: readonly DeliveryStopDeliverySummary[],
+) {
+    const items = deliveries
+        .map((delivery) => [
+            delivery.stopId,
+            delivery.requestId,
+            delivery.harvest.tracePath
+                ? normalizeHarvestTraceScanValue(delivery.harvest.tracePath)
+                : null,
+        ])
+        .sort((first, second) => {
+            const firstValue = JSON.stringify(first);
+            const secondValue = JSON.stringify(second);
+            if (firstValue === secondValue) return 0;
+            return firstValue < secondValue ? -1 : 1;
+        });
+    return JSON.stringify(items);
+}
+
+export function createSyntheticDeliveryHandoffManifest({
+    runId,
+    target,
+    deliveries,
+}: {
+    runId: string;
+    target: DeliveryHandoffTarget;
+    deliveries: readonly DeliveryStopDeliverySummary[];
+}): DeliveryHandoffManifest {
+    const itemsByStopId = new Map<number, DeliveryRunHandoffItemSnapshot>();
+    for (const delivery of deliveries) {
+        if (delivery.stopId === null || itemsByStopId.has(delivery.stopId)) {
+            continue;
+        }
+        const qrAvailable = Boolean(
+            delivery.harvest.tracePath &&
+                normalizeHarvestTraceScanValue(delivery.harvest.tracePath),
+        );
+        itemsByStopId.set(delivery.stopId, {
+            stopId: delivery.stopId,
+            deliveryRequestId: delivery.requestId,
+            retryAttempt: target.retryAttempt,
+            traceLinkId: null,
+            qrAvailable,
+            state: qrAvailable ? 'unverified' : 'no-label',
+            reason: null,
+            verifiedAt: null,
+        });
+    }
+    const items = Array.from(itemsByStopId.values());
+    return {
+        runId,
+        targetStopId: target.targetStopId,
+        version: 1,
+        retryAttempt: target.retryAttempt,
+        items,
+        expectedCount: items.length,
+        scannedCount: 0,
+        unverifiedCount: items.filter((item) => item.state === 'unverified')
+            .length,
+        noLabelCount: items.filter((item) => item.state === 'no-label').length,
+        missingCount: 0,
+        skippedCount: 0,
+    };
+}
+
+function affectedItemStopIds(
+    entry: DeliveryActionQueueEntry,
+    currentTraceItems: readonly DeliveryHandoffTraceItem[],
+) {
+    if (!isDeliveryHandoffCommand(entry.command)) return [];
+    if (entry.acknowledgement?.kind === 'handoff') {
+        return entry.acknowledgement.result.affectedStopIds;
+    }
+    if (entry.command.kind === 'verification-mark') {
+        return [entry.command.itemStopId];
+    }
+    const normalized = normalizeHarvestTraceScanValue(entry.command.tracePath);
+    return normalized
+        ? currentTraceItems.flatMap((item) =>
+              item.tracePath &&
+              normalizeHarvestTraceScanValue(item.tracePath) === normalized
+                  ? [item.stopId]
+                  : [],
+          )
+        : [];
+}
+
+function itemSyncState(
+    itemStopId: number,
+    entries: readonly DeliveryActionQueueEntry[],
+    currentTraceItems: readonly DeliveryHandoffTraceItem[],
+): DeliveryHandoffItemSyncState {
+    const latest = entries
+        .filter((entry) =>
+            affectedItemStopIds(entry, currentTraceItems).includes(itemStopId),
+        )
+        .at(-1);
+    switch (latest?.state) {
+        case 'queued':
+            return 'queued';
+        case 'sending':
+            return 'sending';
+        case 'failed':
+        case 'conflicted':
+            return 'failed';
+        default:
+            return 'persisted';
+    }
+}
+
+function feedbackMessage(
+    entry: DeliveryActionQueueEntry,
+): DeliveryHandoffFeedback | null {
+    if (!isDeliveryHandoffCommand(entry.command)) return null;
+    if (entry.state === 'failed') {
+        return {
+            operationId: entry.command.operationId,
+            kind: 'sync-failed',
+            message:
+                'Provjera je spremljena na uređaju i ponovno će se poslati nakon povratka veze.',
+        };
+    }
+    if (entry.state === 'conflicted') {
+        return {
+            operationId: entry.command.operationId,
+            kind: 'conflict',
+            message:
+                'Provjeru nije moguće primijeniti na trenutačni posjet. Dostava i dalje nije blokirana.',
+        };
+    }
+    if (entry.acknowledgement?.kind !== 'handoff') return null;
+    switch (entry.acknowledgement.result.outcome) {
+        case 'stale':
+            return {
+                operationId: entry.command.operationId,
+                kind: 'stale',
+                message:
+                    'Noviji zapis provjere već postoji pa ova promjena nije prepisala stanje.',
+            };
+        case 'invalid':
+            return {
+                operationId: entry.command.operationId,
+                kind: 'invalid',
+                message: 'QR kod nije povezan s poznatim tragom uroda.',
+            };
+        case 'wrong-stop':
+            return {
+                operationId: entry.command.operationId,
+                kind: 'wrong-stop',
+                message: 'QR kod pripada drugoj stanici na ruti.',
+            };
+        case 'item-not-found':
+            return {
+                operationId: entry.command.operationId,
+                kind: 'item-not-found',
+                message:
+                    'Urod više nije u trenutačnom manifestu. Osvježi popis i nastavi dostavu.',
+            };
+        case 'applied':
+        case 'already-applied':
+            return null;
+    }
+}
+
+function feedbackForEntries(entries: readonly DeliveryActionQueueEntry[]) {
+    return entries.flatMap((entry) => {
+        const feedback = feedbackMessage(entry);
+        return feedback ? [feedback] : [];
+    });
+}
+
+function acknowledgementFeedbackForEntries(
+    entries: readonly DeliveryActionQueueEntry[],
+) {
+    return feedbackForEntries(
+        entries.filter((entry) => entry.acknowledgement?.kind === 'handoff'),
+    );
+}
+
+function mergeFeedback(
+    first: readonly DeliveryHandoffFeedback[],
+    second: readonly DeliveryHandoffFeedback[],
+) {
+    const byOperationId = new Map<string, DeliveryHandoffFeedback>();
+    for (const item of [...first, ...second]) {
+        byOperationId.set(item.operationId, item);
+    }
+    return Array.from(byOperationId.values());
+}
+
+function verifiedTracePaths(
+    handoff: DeliveryHandoffManifestView | null,
+    deliveries: readonly DeliveryStopDeliverySummary[],
+) {
+    const scannedStopIds = new Set(
+        handoff?.items.flatMap((item) =>
+            item.state === 'scanned' ? [item.stopId] : [],
+        ) ?? [],
+    );
+    return deliveries.flatMap((delivery) =>
+        delivery.stopId !== null &&
+        scannedStopIds.has(delivery.stopId) &&
+        delivery.harvest.tracePath
+            ? [delivery.harvest.tracePath]
+            : [],
+    );
+}
+
+function actionFailureMessage() {
+    return 'Promjenu nije moguće sigurno spremiti. Pokušaj ponovno ili potvrdi dostavu bez QR provjere.';
+}
+
+export class DeliveryHandoffSyncController {
+    private target: DeliveryHandoffTarget | null = null;
+    private deliveries: readonly DeliveryStopDeliverySummary[] = [];
+    private deliveriesFingerprint = '';
+    private queueSnapshot: DeliveryActionQueueSnapshot;
+    private manifest: DeliveryHandoffManifest | null = null;
+    private state = idleState;
+    private readonly listeners = new Set<() => void>();
+    private generation = 0;
+    private loading = false;
+    private refreshing = false;
+    private error: string | null = null;
+    private refreshTask: {
+        generation: number;
+        promise: Promise<boolean>;
+    } | null = null;
+    private refreshRequested = false;
+    private lastAcknowledgementSignature = '';
+    private retainedFeedback: readonly DeliveryHandoffFeedback[] = [];
+    private pruneTask: Promise<void> | null = null;
+    private readonly now: () => Date;
+
+    constructor(private readonly options: DeliveryHandoffControllerOptions) {
+        this.queueSnapshot = options.actions.getSnapshot();
+        this.now = options.now ?? (() => new Date());
+    }
+
+    getSnapshot = () => this.state;
+    getServerSnapshot = () => idleState;
+
+    subscribe = (listener: () => void) => {
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    };
+
+    matchesTarget(target: DeliveryHandoffTarget) {
+        return sameTarget(this.target, target);
+    }
+
+    dispose() {
+        this.generation += 1;
+        this.refreshRequested = false;
+        this.listeners.clear();
+    }
+
+    async setContext({
+        target,
+        deliveries,
+        queueSnapshot,
+    }: {
+        target: DeliveryHandoffTarget | null;
+        deliveries: readonly DeliveryStopDeliverySummary[];
+        queueSnapshot: DeliveryActionQueueSnapshot;
+    }) {
+        const changed = !sameTarget(this.target, target);
+        const nextDeliveriesFingerprint =
+            deliveryHandoffDeliveriesFingerprint(deliveries);
+        const deliveriesChanged =
+            this.deliveriesFingerprint !== nextDeliveriesFingerprint;
+        this.target = target ? { ...target } : null;
+        this.deliveries = deliveries;
+        this.deliveriesFingerprint = nextDeliveriesFingerprint;
+        this.queueSnapshot = queueSnapshot;
+        if (!changed) {
+            this.publish();
+            if (deliveriesChanged && target && this.options.isOnline()) {
+                await this.refresh();
+            } else {
+                this.refreshAfterNewAcknowledgement();
+            }
+            return;
+        }
+
+        this.generation += 1;
+        const generation = this.generation;
+        this.loading = Boolean(target);
+        this.refreshing = false;
+        this.error = null;
+        this.refreshRequested = false;
+        this.lastAcknowledgementSignature = '';
+        this.retainedFeedback = [];
+        if (!target) {
+            this.manifest = null;
+            this.state = idleState;
+            this.publishListeners();
+            return;
+        }
+        this.manifest = createSyntheticDeliveryHandoffManifest({
+            runId: this.options.runId,
+            target,
+            deliveries,
+        });
+        this.publish();
+        await this.activateTarget(generation, target);
+    }
+
+    private async activateTarget(
+        generation: number,
+        target: DeliveryHandoffTarget,
+    ) {
+        this.pruneTask ??=
+            this.options.cache.clearOtherRuns?.({
+                userId: this.options.userId,
+                activeRunId: this.options.runId,
+            }) ?? Promise.resolve();
+        await this.pruneTask.catch(() => undefined);
+        let cached = null;
+        try {
+            cached = await this.options.cache.load({
+                userId: this.options.userId,
+                runId: this.options.runId,
+                targetStopId: target.targetStopId,
+                expectedRetryAttempt: target.retryAttempt,
+            });
+        } catch {
+            this.error =
+                'Spremljeni manifest nije moguće pročitati. Pokušat ćemo ga ponovno preuzeti.';
+        }
+        if (!this.isCurrent(generation, target)) return;
+        if (cached) {
+            this.manifest = cached.manifest;
+            this.loading = false;
+            this.publish();
+        }
+        if (!this.options.isOnline()) {
+            this.loading = false;
+            this.publish();
+            return;
+        }
+        await this.refresh();
+    }
+
+    updateQueueSnapshot(queueSnapshot: DeliveryActionQueueSnapshot) {
+        this.queueSnapshot = queueSnapshot;
+        this.publish();
+        this.refreshAfterNewAcknowledgement();
+    }
+
+    private isCurrent(generation: number, target: DeliveryHandoffTarget) {
+        return (
+            generation === this.generation && sameTarget(this.target, target)
+        );
+    }
+
+    async refresh() {
+        const target = this.target;
+        if (!target || !this.options.isOnline()) {
+            this.loading = false;
+            this.publish();
+            return false;
+        }
+        if (this.refreshTask?.generation === this.generation) {
+            this.refreshRequested = true;
+            return await this.refreshTask.promise;
+        }
+        const generation = this.generation;
+        const promise = this.refreshCurrent(generation, { ...target }).finally(
+            () => {
+                if (this.refreshTask?.promise === promise) {
+                    const repeat =
+                        this.refreshRequested &&
+                        this.isCurrent(generation, target) &&
+                        this.options.isOnline();
+                    this.refreshTask = null;
+                    this.refreshRequested = false;
+                    if (repeat) void this.refresh();
+                }
+            },
+        );
+        this.refreshTask = { generation, promise };
+        return await promise;
+    }
+
+    private async refreshCurrent(
+        generation: number,
+        target: DeliveryHandoffTarget,
+    ) {
+        this.refreshing = true;
+        this.error = null;
+        this.publish();
+        try {
+            this.queueSnapshot = await this.options.actions.syncNow();
+        } catch {
+            this.queueSnapshot = this.options.actions.getSnapshot();
+        }
+        if (!this.isCurrent(generation, target)) return false;
+        this.publish();
+        const reconciliationEntries = deliveryHandoffQueueEntries(
+            this.queueSnapshot,
+            this.manifest ??
+                createSyntheticDeliveryHandoffManifest({
+                    runId: this.options.runId,
+                    target,
+                    deliveries: this.deliveries,
+                }),
+        ).filter(
+            (entry) =>
+                entry.state === 'synced' &&
+                entry.acknowledgement?.kind === 'handoff',
+        );
+        const reconciliationOperationIds = reconciliationEntries.map(
+            (entry) => entry.command.operationId,
+        );
+        const reconciliationFeedback = acknowledgementFeedbackForEntries(
+            reconciliationEntries,
+        );
+        let result: DeliveryHandoffManifestFetchResult;
+        try {
+            result = await this.options.fetchManifest({
+                runId: this.options.runId,
+                targetStopId: target.targetStopId,
+            });
+        } catch {
+            result = { status: 'retryable-failure', code: 'offline' };
+        }
+        if (!this.isCurrent(generation, target)) return false;
+        if (result.status !== 'loaded') {
+            this.loading = false;
+            this.refreshing = false;
+            this.error =
+                result.code === 'offline'
+                    ? 'Nema internetske veze. Provjere ostaju spremljene na uređaju.'
+                    : 'Manifest predaje trenutačno nije moguće osvježiti. Dostava nije blokirana.';
+            this.publish();
+            return false;
+        }
+        if (
+            result.manifest.runId !== this.options.runId ||
+            result.manifest.targetStopId !== target.targetStopId ||
+            result.manifest.retryAttempt !== target.retryAttempt
+        ) {
+            this.loading = false;
+            this.refreshing = false;
+            this.error =
+                'Posjet stanici promijenio se. Osvježi rutu prije nove provjere.';
+            this.publish();
+            return false;
+        }
+
+        this.manifest = result.manifest;
+        try {
+            await this.options.cache.save(
+                createDeliveryHandoffManifestCacheRecord({
+                    userId: this.options.userId,
+                    manifest: result.manifest,
+                    now: this.now(),
+                }),
+            );
+            if (
+                this.options.cache.durableCleanupRequired &&
+                this.options.cache.durability !== 'durable'
+            ) {
+                throw new Error(
+                    'Durable delivery handoff persistence could not be confirmed',
+                );
+            }
+        } catch {
+            this.loading = false;
+            this.refreshing = false;
+            this.error =
+                'Manifest je učitan, ali ga nije moguće sigurno spremiti na uređaj. Provjera ostaje neblokirajuća.';
+            this.publish();
+            return false;
+        }
+        if (!this.isCurrent(generation, target)) return false;
+        this.loading = false;
+        this.retainedFeedback = mergeFeedback(
+            this.retainedFeedback,
+            reconciliationFeedback,
+        );
+        this.publish();
+        try {
+            await this.options.actions.completeHandoffReconciliation(
+                target.targetStopId,
+                target.retryAttempt,
+                reconciliationOperationIds,
+            );
+        } catch {
+            this.error =
+                'Provjere su potvrđene, ali lokalni QR podaci još nisu očišćeni.';
+        }
+        if (!this.isCurrent(generation, target)) return false;
+        this.queueSnapshot = this.options.actions.getSnapshot();
+        const reconciledOperationIdSet = new Set(reconciliationOperationIds);
+        const acknowledgementRacedManifestFetch = deliveryHandoffQueueEntries(
+            this.queueSnapshot,
+            result.manifest,
+        ).some(
+            (entry) =>
+                entry.state === 'synced' &&
+                entry.acknowledgement?.kind === 'handoff' &&
+                !reconciledOperationIdSet.has(entry.command.operationId),
+        );
+        if (acknowledgementRacedManifestFetch) {
+            this.refreshRequested = true;
+        }
+        this.refreshing = false;
+        this.lastAcknowledgementSignature = '';
+        this.publish();
+        return this.error === null;
+    }
+
+    connectionChanged() {
+        if (!this.options.isOnline()) {
+            this.refreshing = false;
+            this.publish();
+            return;
+        }
+        void this.refresh();
+    }
+
+    async scan(value: string): Promise<DeliveryHandoffScanResult> {
+        const target = this.target;
+        if (!target) {
+            return {
+                status: 'scan-failed',
+                message: 'Trenutačna stanica predaje nije dostupna.',
+            };
+        }
+        const generation = this.generation;
+        const result = verifyDeliveryStopHarvestTrace({
+            deliveries: [...this.deliveries],
+            verifiedTracePaths: verifiedTracePaths(
+                this.state.handoff,
+                this.deliveries,
+            ),
+            scanValue: value,
+        });
+        if (
+            result.status === 'verification-invalid' ||
+            result.status === 'already-verified'
+        ) {
+            return result;
+        }
+        try {
+            await this.options.actions.enqueueVerificationScan(
+                target.targetStopId,
+                result.tracePath,
+                target.retryAttempt,
+            );
+            if (!this.isCurrent(generation, target)) {
+                return {
+                    status: 'scan-failed',
+                    message:
+                        'Stanica se promijenila tijekom spremanja provjere. Provjeri trenutačnu dostavu.',
+                };
+            }
+            this.queueSnapshot = this.options.actions.getSnapshot();
+            this.publish();
+        } catch {
+            if (result.status !== 'verified') return result;
+            return { status: 'scan-failed', message: actionFailureMessage() };
+        }
+        return result;
+    }
+
+    async markItem(
+        input: DeliveryHandoffMarkInput,
+    ): Promise<DriverCommandResult> {
+        const target = this.target;
+        if (
+            !target ||
+            !this.state.handoff?.items.some(
+                (item) => item.stopId === input.itemStopId,
+            )
+        ) {
+            return {
+                status: 'failed',
+                message: 'Urod više nije u trenutačnom manifestu.',
+            };
+        }
+        const generation = this.generation;
+        try {
+            await this.options.actions.enqueueVerificationMark({
+                stopId: target.targetStopId,
+                expectedRetryAttempt: target.retryAttempt,
+                itemStopId: input.itemStopId,
+                outcome: input.outcome,
+                reason: input.reason,
+            });
+            if (!this.isCurrent(generation, target)) {
+                return {
+                    status: 'failed',
+                    message:
+                        'Stanica se promijenila tijekom spremanja provjere.',
+                };
+            }
+            this.queueSnapshot = this.options.actions.getSnapshot();
+            this.publish();
+            return { status: 'saved' };
+        } catch {
+            return { status: 'failed', message: actionFailureMessage() };
+        }
+    }
+
+    async markRemainingReviewed(): Promise<DriverCommandResult> {
+        const unresolved =
+            this.state.handoff?.items.filter(
+                (item) => item.state === 'unverified',
+            ) ?? [];
+        for (const item of unresolved) {
+            const result = await this.markItem({
+                itemStopId: item.stopId,
+                outcome: 'skipped',
+                reason: 'manual-verification',
+            });
+            if (result.status === 'failed') return result;
+        }
+        return { status: 'saved' };
+    }
+
+    private refreshAfterNewAcknowledgement() {
+        if (!this.target || !this.options.isOnline()) return;
+        const signature = deliveryHandoffQueueEntries(
+            this.queueSnapshot,
+            this.manifest ??
+                createSyntheticDeliveryHandoffManifest({
+                    runId: this.options.runId,
+                    target: this.target,
+                    deliveries: this.deliveries,
+                }),
+        )
+            .flatMap((entry) =>
+                entry.acknowledgement?.kind === 'handoff'
+                    ? [
+                          `${entry.command.operationId}:${entry.acknowledgement.result.outcome}`,
+                      ]
+                    : [],
+            )
+            .join('|');
+        if (!signature || signature === this.lastAcknowledgementSignature) {
+            return;
+        }
+        this.lastAcknowledgementSignature = signature;
+        void this.refresh();
+    }
+
+    private publish() {
+        if (!this.target || !this.manifest) {
+            this.state = idleState;
+            this.publishListeners();
+            return;
+        }
+        const currentTraceItems = traceItems(this.deliveries);
+        const projection = projectDeliveryHandoffManifest({
+            manifest: this.manifest,
+            snapshot: this.queueSnapshot,
+            traceItems: currentTraceItems,
+        });
+        const entries = deliveryHandoffQueueEntries(
+            this.queueSnapshot,
+            this.manifest,
+        );
+        const feedback = mergeFeedback(
+            this.retainedFeedback,
+            feedbackForEntries(entries),
+        );
+        const failed =
+            projection.failedOperationIds.length > 0 ||
+            projection.conflictedOperationIds.length > 0;
+        const status: Exclude<DeliveryHandoffSyncStatus, 'idle'> = this.loading
+            ? this.options.isOnline()
+                ? 'loading'
+                : 'offline'
+            : !this.options.isOnline()
+              ? 'offline'
+              : this.error || failed
+                ? 'failed'
+                : this.refreshing || projection.pendingOperationIds.length > 0
+                  ? 'syncing'
+                  : 'ready';
+        const error =
+            this.error ??
+            (failed
+                ? 'Neke provjere još nisu potvrđene. Dostava nije blokirana.'
+                : null);
+        this.state = {
+            status,
+            error,
+            feedback,
+            handoff: {
+                ...projection.manifest,
+                items: projection.manifest.items.map((item) => ({
+                    ...item,
+                    syncState: itemSyncState(
+                        item.stopId,
+                        entries,
+                        currentTraceItems,
+                    ),
+                })),
+                syncState: status,
+                pendingCount: projection.pendingOperationIds.length,
+                error,
+            },
+        };
+        this.publishListeners();
+    }
+
+    private publishListeners() {
+        for (const listener of this.listeners) listener();
+    }
+}

--- a/apps/delivery/lib/deliveryRunStoredState.node.spec.ts
+++ b/apps/delivery/lib/deliveryRunStoredState.node.spec.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { createMemoryDeliveryActionQueuePersistence } from './deliveryActionQueue';
+import type { DeliveryHandoffManifest } from './deliveryHandoffManifest';
+import {
+    createDeliveryHandoffManifestCacheRecord,
+    createMemoryDeliveryHandoffManifestCachePersistence,
+} from './deliveryHandoffManifestCache';
 import {
     clearDeliveryRunSupportingStores,
     clearDeliveryUserStoredState,
@@ -69,39 +74,108 @@ function offlineSnapshot(): OfflineRouteSnapshot {
     };
 }
 
+function handoffManifest(runId = scope.runId): DeliveryHandoffManifest {
+    return {
+        runId,
+        targetStopId: 101,
+        version: 1,
+        retryAttempt: 0,
+        items: [
+            {
+                stopId: 101,
+                deliveryRequestId: 'request-cleanup',
+                retryAttempt: 0,
+                traceLinkId: 501,
+                qrAvailable: true,
+                state: 'unverified',
+                reason: null,
+                verifiedAt: null,
+            },
+        ],
+        expectedCount: 1,
+        scannedCount: 0,
+        unverifiedCount: 1,
+        noLabelCount: 0,
+        missingCount: 0,
+        skippedCount: 0,
+    };
+}
+
 test('completion cleanup removes exact pickup and route stores but preserves another run', async () => {
     const pickupManifest = createMemoryPickupManifestQueuePersistence();
     const offlineRoute = createMemoryOfflineRouteCachePersistence();
+    const handoffManifestCache =
+        createMemoryDeliveryHandoffManifestCachePersistence();
     const otherScope = { userId: scope.userId, runId: 'run-other' };
     await pickupManifest.save(scope, []);
     await pickupManifest.save(otherScope, []);
     await offlineRoute.save(offlineSnapshot());
+    const currentHandoff = createDeliveryHandoffManifestCacheRecord({
+        userId: scope.userId,
+        manifest: handoffManifest(),
+        now: new Date(now),
+    });
+    const otherHandoff = createDeliveryHandoffManifestCacheRecord({
+        userId: scope.userId,
+        manifest: handoffManifest(otherScope.runId),
+        now: new Date(now),
+    });
+    await handoffManifestCache.save(currentHandoff);
+    await handoffManifestCache.save(otherHandoff);
 
     await clearDeliveryRunSupportingStores(
-        { pickupManifest, offlineRoute },
+        {
+            pickupManifest,
+            offlineRoute,
+            handoffManifest: handoffManifestCache,
+        },
         scope,
     );
 
     assert.equal(await pickupManifest.load(scope), undefined);
     assert.notEqual(await pickupManifest.load(otherScope), undefined);
     assert.equal(await offlineRoute.load(scope), null);
+    assert.equal(
+        await handoffManifestCache.load(currentHandoff.scope, new Date(now)),
+        null,
+    );
+    assert.ok(
+        await handoffManifestCache.load(otherHandoff.scope, new Date(now)),
+    );
 });
 
 test('user cleanup removes pickup, route, and action data together', async () => {
     const pickupManifest = createMemoryPickupManifestQueuePersistence();
     const offlineRoute = createMemoryOfflineRouteCachePersistence();
+    const handoffManifestCache =
+        createMemoryDeliveryHandoffManifestCachePersistence();
     const deliveryActions = createMemoryDeliveryActionQueuePersistence();
     await pickupManifest.save(scope, []);
     await offlineRoute.save(offlineSnapshot());
     await deliveryActions.save(scope, []);
+    const handoff = createDeliveryHandoffManifestCacheRecord({
+        userId: scope.userId,
+        manifest: handoffManifest(),
+        now: new Date(now),
+    });
+    await handoffManifestCache.save(handoff);
 
     await clearDeliveryUserStoredState(
-        { pickupManifest, offlineRoute, deliveryActions },
+        {
+            pickupManifest,
+            offlineRoute,
+            handoffManifest: handoffManifestCache,
+            deliveryActions,
+        },
         { userId: scope.userId },
     );
 
     assert.equal(await pickupManifest.load(scope), undefined);
     assert.equal(await offlineRoute.load(scope), null);
+    assert.equal(
+        await handoffManifestCache.load(handoff.scope, new Date(now)),
+        null,
+    );
     assert.equal(await deliveryActions.load(scope), undefined);
 });
 
@@ -115,6 +189,7 @@ test('user cleanup retains the action marker until every supporting store is cle
                 throw new Error('route cleanup failed');
             },
         },
+        handoffManifest: createMemoryDeliveryHandoffManifestCachePersistence(),
         deliveryActions: {
             ...createMemoryDeliveryActionQueuePersistence(),
             async clear() {
@@ -146,6 +221,7 @@ test('completion marker must remain when a formerly durable store cannot confirm
             },
         },
         offlineRoute: createMemoryOfflineRouteCachePersistence(),
+        handoffManifest: createMemoryDeliveryHandoffManifestCachePersistence(),
     };
 
     await assert.rejects(
@@ -166,6 +242,7 @@ test('completion marker must remain when a degraded store may still have an olde
             async clear() {},
         },
         offlineRoute: createMemoryOfflineRouteCachePersistence(),
+        handoffManifest: createMemoryDeliveryHandoffManifestCachePersistence(),
     };
 
     await assert.rejects(

--- a/apps/delivery/lib/deliveryRunStoredState.ts
+++ b/apps/delivery/lib/deliveryRunStoredState.ts
@@ -3,6 +3,10 @@ import {
     type DeliveryActionQueuePersistence,
 } from './deliveryActionQueue';
 import {
+    createWebStorageDeliveryHandoffManifestCachePersistence,
+    type DeliveryHandoffManifestCachePersistence,
+} from './deliveryHandoffManifestCache';
+import {
     createBrowserOfflineRouteCachePersistence,
     type OfflineRouteCachePersistence,
 } from './offlineRouteCache';
@@ -14,6 +18,7 @@ import {
 export type DeliveryRunSupportingStores = {
     pickupManifest: PickupManifestQueuePersistence;
     offlineRoute: OfflineRouteCachePersistence;
+    handoffManifest: DeliveryHandoffManifestCachePersistence;
 };
 
 export type DeliveryUserStoredState = DeliveryRunSupportingStores & {
@@ -26,6 +31,10 @@ export function createBrowserDeliveryRunSupportingStores(): DeliveryRunSupportin
             window.localStorage,
         ),
         offlineRoute: createBrowserOfflineRouteCachePersistence(),
+        handoffManifest:
+            createWebStorageDeliveryHandoffManifestCachePersistence(
+                window.localStorage,
+            ),
     };
 }
 
@@ -63,6 +72,9 @@ export async function clearDeliveryRunSupportingStores(
         clearStoreDurably(stores.offlineRoute, async () =>
             stores.offlineRoute.clear(scope),
         ),
+        clearStoreDurably(stores.handoffManifest, async () =>
+            stores.handoffManifest.clear(scope),
+        ),
     ]);
     if (results.some((result) => result.status === 'rejected')) {
         throw new Error('Durable delivery cleanup could not be confirmed');
@@ -79,6 +91,9 @@ export async function clearDeliveryUserStoredState(
         ),
         clearStoreDurably(stores.offlineRoute, async () =>
             stores.offlineRoute.clear(scope),
+        ),
+        clearStoreDurably(stores.handoffManifest, async () =>
+            stores.handoffManifest.clear(scope),
         ),
     ]);
     if (supportingResults.some((result) => result.status === 'rejected')) {

--- a/apps/delivery/tests/DeliveryHandoffVerificationStory.tsx
+++ b/apps/delivery/tests/DeliveryHandoffVerificationStory.tsx
@@ -1,0 +1,306 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { useState } from 'react';
+import {
+    type DeliveryHandoffManifestItemView,
+    type DeliveryHandoffManifestView,
+    type DeliveryHandoffMarkItemInput,
+    DeliveryHarvestVerification,
+} from '../components/DeliveryHarvestVerification';
+import type { DeliveryStopDeliverySummary } from '../lib/deliveryDashboardTypes';
+import { normalizeHarvestTraceScanValue } from '../lib/harvestTraceScan';
+import { bulkExceptionStop } from './deliveryRecoveryFixtures';
+
+const [tomatoDelivery, basilDelivery, lettuceDelivery] =
+    bulkExceptionStop.deliveries;
+if (!tomatoDelivery || !basilDelivery || !lettuceDelivery) {
+    throw new Error('The handoff story requires three bulk deliveries.');
+}
+
+const pepperDelivery: DeliveryStopDeliverySummary = {
+    ...lettuceDelivery,
+    stopId: 104,
+    requestId: 'request-pepper',
+    contactName: 'Davor Dostavić',
+    harvest: {
+        ...lettuceDelivery.harvest,
+        plantName: 'Paprika babura',
+        raisedBedName: 'Gredica D',
+        tracePath: '/trag/pepper-trace-00004',
+    },
+};
+
+const deliveries = [
+    tomatoDelivery,
+    basilDelivery,
+    lettuceDelivery,
+    pepperDelivery,
+];
+
+function initialItems(): DeliveryHandoffManifestItemView[] {
+    return deliveries.flatMap((delivery, index) =>
+        delivery.stopId === null
+            ? []
+            : [
+                  {
+                      stopId: delivery.stopId,
+                      deliveryRequestId: delivery.requestId,
+                      retryAttempt: 0,
+                      traceLinkId: index + 1,
+                      qrAvailable: true,
+                      state: 'unverified',
+                      reason: null,
+                      verifiedAt: null,
+                      syncState: 'persisted',
+                  },
+              ],
+    );
+}
+
+function countItems(
+    items: DeliveryHandoffManifestItemView[],
+    state: DeliveryHandoffManifestItemView['state'],
+) {
+    return items.filter((item) => item.state === state).length;
+}
+
+function manifestView(
+    items: DeliveryHandoffManifestItemView[],
+    syncState: DeliveryHandoffManifestView['syncState'],
+): DeliveryHandoffManifestView {
+    return {
+        runId: 'run-handoff-component',
+        targetStopId: 101,
+        retryAttempt: 0,
+        version: 1,
+        items,
+        expectedCount: items.length,
+        scannedCount: countItems(items, 'scanned'),
+        unverifiedCount: countItems(items, 'unverified'),
+        noLabelCount: countItems(items, 'no-label'),
+        missingCount: countItems(items, 'missing'),
+        skippedCount: countItems(items, 'skipped'),
+        syncState,
+        pendingCount: items.filter(
+            (item) =>
+                item.syncState !== undefined && item.syncState !== 'persisted',
+        ).length,
+        error:
+            syncState === 'failed'
+                ? 'Sinkronizacija provjere nije uspjela.'
+                : null,
+    };
+}
+
+function deliveriesForTracePath(
+    storyDeliveries: DeliveryStopDeliverySummary[],
+    tracePath: string,
+) {
+    return storyDeliveries.filter((delivery) => {
+        const deliveryTracePath = delivery.harvest.tracePath;
+        return (
+            deliveryTracePath !== null &&
+            normalizeHarvestTraceScanValue(deliveryTracePath) === tracePath
+        );
+    });
+}
+
+export function DeliveryHandoffVerificationStory({
+    handoffUnavailable = false,
+    serverFeedback = false,
+    sharedTrace = false,
+    syncState = 'ready',
+}: {
+    handoffUnavailable?: boolean;
+    serverFeedback?: boolean;
+    sharedTrace?: boolean;
+    syncState?: DeliveryHandoffManifestView['syncState'];
+}) {
+    const [items, setItems] = useState(initialItems);
+    const [verificationKey, setVerificationKey] = useState(0);
+    const [completionOpen, setCompletionOpen] = useState(false);
+    const [events, setEvents] = useState<string[]>([]);
+    const [completionResult, setCompletionResult] = useState('none');
+    const handoff = manifestView(items, syncState);
+    const storyDeliveries = sharedTrace
+        ? deliveries.map((delivery) =>
+              delivery.requestId === basilDelivery.requestId
+                  ? {
+                        ...delivery,
+                        harvest: {
+                            ...delivery.harvest,
+                            tracePath: tomatoDelivery.harvest.tracePath,
+                        },
+                    }
+                  : delivery,
+          )
+        : deliveries;
+
+    function recordEvent(event: string) {
+        setEvents((current) => [...current, event]);
+    }
+
+    async function scan(value: string) {
+        const tracePath = normalizeHarvestTraceScanValue(value);
+        if (!tracePath) {
+            recordEvent('invalid');
+            return { status: 'verification-invalid' as const };
+        }
+        const matchedDeliveries = deliveriesForTracePath(
+            storyDeliveries,
+            tracePath,
+        ).filter(
+            (
+                delivery,
+            ): delivery is DeliveryStopDeliverySummary & {
+                stopId: number;
+            } => delivery.stopId !== null,
+        );
+        const delivery = matchedDeliveries[0];
+        if (!delivery) {
+            recordEvent('wrong-stop');
+            return { status: 'not-at-stop' as const, tracePath };
+        }
+        const matchedStopIds = new Set(
+            matchedDeliveries.map((candidate) => candidate.stopId),
+        );
+        if (
+            matchedDeliveries.every((candidate) =>
+                items.some(
+                    (item) =>
+                        item.stopId === candidate.stopId &&
+                        item.state === 'scanned',
+                ),
+            )
+        ) {
+            recordEvent('duplicate');
+            return {
+                status: 'already-verified' as const,
+                tracePath,
+                plantName: delivery.harvest.plantName,
+                contactName: delivery.contactName,
+            };
+        }
+
+        setItems((current) =>
+            current.map((candidate) =>
+                matchedStopIds.has(candidate.stopId)
+                    ? {
+                          ...candidate,
+                          state: 'scanned',
+                          reason: null,
+                          verifiedAt: '2026-07-16T08:00:00.000Z',
+                          syncState: 'queued',
+                      }
+                    : candidate,
+            ),
+        );
+        recordEvent(
+            `scanned:${matchedDeliveries
+                .map((candidate) => candidate.stopId)
+                .join(',')}`,
+        );
+        return {
+            status: 'verified' as const,
+            tracePath,
+            plantName: delivery.harvest.plantName,
+            contactName: delivery.contactName,
+            nextVerifiedTracePaths: [tracePath],
+        };
+    }
+
+    async function markItem({
+        itemStopId,
+        outcome,
+        reason,
+    }: DeliveryHandoffMarkItemInput) {
+        setItems((current) =>
+            current.map((item) =>
+                item.stopId === itemStopId
+                    ? {
+                          ...item,
+                          state: outcome,
+                          reason:
+                              outcome === 'skipped' ? (reason ?? null) : null,
+                          verifiedAt: '2026-07-16T08:05:00.000Z',
+                          syncState: 'queued',
+                      }
+                    : item,
+            ),
+        );
+        recordEvent(
+            `mark:${itemStopId}:${outcome}${reason ? `:${reason}` : ''}`,
+        );
+    }
+
+    async function markRemainingReviewed() {
+        const remainingStopIds = items.flatMap((item) =>
+            item.state === 'unverified' ? [item.stopId] : [],
+        );
+        setItems((current) =>
+            current.map((item) =>
+                item.state === 'unverified'
+                    ? {
+                          ...item,
+                          state: 'skipped',
+                          reason: 'manual-verification',
+                          verifiedAt: '2026-07-16T08:10:00.000Z',
+                          syncState: 'queued',
+                      }
+                    : item,
+            ),
+        );
+        recordEvent(`manual:${remainingStopIds.join(',')}`);
+    }
+
+    return (
+        <main className="mx-auto max-w-2xl space-y-4 p-4">
+            <output data-testid="handoff-events">{events.join('|')}</output>
+            <output data-testid="completion-result">{completionResult}</output>
+            <div className="flex flex-wrap gap-2">
+                <Button
+                    type="button"
+                    size="sm"
+                    variant="outlined"
+                    onClick={() => setVerificationKey((current) => current + 1)}
+                >
+                    Simuliraj osvježavanje prikaza
+                </Button>
+                <Button
+                    type="button"
+                    color="success"
+                    onClick={() => setCompletionOpen(true)}
+                >
+                    Dostavi 4 uroda · dalje
+                </Button>
+            </div>
+            <DeliveryHarvestVerification
+                key={verificationKey}
+                deliveries={storyDeliveries}
+                disabled={false}
+                handoff={handoffUnavailable ? null : handoff}
+                feedback={
+                    serverFeedback
+                        ? [
+                              {
+                                  operationId: 'server-feedback-1',
+                                  kind: 'wrong-stop',
+                                  message:
+                                      'QR kod pripada drugoj stanici na ruti.',
+                              },
+                          ]
+                        : []
+                }
+                onScan={scan}
+                onMarkItem={markItem}
+                onMarkRemainingReviewed={markRemainingReviewed}
+                completionConfirmation={{
+                    open: completionOpen,
+                    onOpenChange: setCompletionOpen,
+                    onConfirm: () => setCompletionResult('delivered'),
+                }}
+            />
+        </main>
+    );
+}

--- a/apps/delivery/tests/DriverCurrentStopCommandCenterStory.tsx
+++ b/apps/delivery/tests/DriverCurrentStopCommandCenterStory.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { DriverCurrentStopCommandCenter } from '../components/DriverCurrentStopCommandCenter';
+import type { DeliveryHandoffManifestView } from '../components/DeliveryHarvestVerification';
+import {
+    type DeliveryHandoffCommandController,
+    DriverCurrentStopCommandCenter,
+} from '../components/DriverCurrentStopCommandCenter';
 import { HarvestTraceScanner } from '../components/HarvestTraceScanner';
 import type { DeliveryActionQueueEntry } from '../lib/deliveryActionQueue';
 import type {
@@ -76,6 +80,58 @@ const arrivedStop: DeliveryStopSummary = {
     })),
 };
 
+function handoffController(): DeliveryHandoffCommandController {
+    const items = arrivedStop.deliveries.flatMap((delivery, index) =>
+        delivery.stopId === null || delivery.stopState !== 'arrived'
+            ? []
+            : [
+                  {
+                      stopId: delivery.stopId,
+                      deliveryRequestId: delivery.requestId,
+                      retryAttempt: 0,
+                      traceLinkId: delivery.harvest.tracePath
+                          ? index + 1
+                          : null,
+                      qrAvailable: Boolean(delivery.harvest.tracePath),
+                      state:
+                          index === 0
+                              ? ('scanned' as const)
+                              : index === 1
+                                ? ('unverified' as const)
+                                : ('no-label' as const),
+                      reason: null,
+                      verifiedAt:
+                          index === 0 ? '2026-07-15T08:32:00.000Z' : null,
+                      syncState: 'persisted' as const,
+                  },
+              ],
+    );
+    const view: DeliveryHandoffManifestView = {
+        runId: 'run-component-4127',
+        targetStopId: arrivedStop.id ?? 41,
+        version: 1,
+        retryAttempt: 0,
+        items,
+        expectedCount: items.length,
+        scannedCount: items.filter((item) => item.state === 'scanned').length,
+        unverifiedCount: items.filter((item) => item.state === 'unverified')
+            .length,
+        noLabelCount: items.filter((item) => item.state === 'no-label').length,
+        missingCount: 0,
+        skippedCount: 0,
+        syncState: 'ready',
+        pendingCount: 0,
+        error: null,
+    };
+    return {
+        view,
+        feedback: [],
+        scan: () => ({ status: 'verification-invalid' }),
+        markItem: () => undefined,
+        markRemainingReviewed: () => undefined,
+    };
+}
+
 function actionEntry(
     kind: 'arrive' | 'deliver',
     state: DeliveryActionQueueEntry['state'],
@@ -107,12 +163,14 @@ export function DriverCurrentDeliveryCommandStory({
     syncKind = 'arrive',
     throwOnArrive = false,
     late = false,
+    withHandoff = false,
 }: {
     arrived?: boolean;
     syncState?: DeliveryActionQueueEntry['state'];
     syncKind?: 'arrive' | 'deliver';
     throwOnArrive?: boolean;
     late?: boolean;
+    withHandoff?: boolean;
 }) {
     const [result, setResult] = useState('none');
     const selectedStop = arrived ? arrivedStop : currentStop;
@@ -133,6 +191,7 @@ export function DriverCurrentDeliveryCommandStory({
                     kind="delivery"
                     stop={stop}
                     routeRevision={12}
+                    handoff={withHandoff ? handoffController() : undefined}
                     syncEntry={
                         syncState ? actionEntry(syncKind, syncState) : undefined
                     }

--- a/apps/delivery/tests/delivery-handoff-verification.spec.tsx
+++ b/apps/delivery/tests/delivery-handoff-verification.spec.tsx
@@ -1,0 +1,208 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { DeliveryHandoffVerificationStory } from './DeliveryHandoffVerificationStory';
+import '../app/globals.css';
+
+test('keeps controlled handoff progress across scanner close and component refresh while reporting safe failures', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryHandoffVerificationStory />);
+
+    await page.getByRole('button', { name: 'Provjeri QR kodove' }).click();
+    const manualInput = page.getByLabel('Ručni unos');
+    await manualInput.fill('https://www.gredice.com/trag/tomato-trace-0001');
+    await page.getByRole('button', { name: 'Dodaj kod' }).click();
+    await expect(
+        page.getByText('Rajčica Roma · Ana Anić potvrđen je za ovu dostavu.'),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Završi provjeru' }).click();
+    await expect(page.getByLabel('Sažetak provjere predaje')).toContainText(
+        '1 provjereno',
+    );
+    const scannedTomato = page.getByRole('listitem').filter({
+        hasText: 'Rajčica Roma',
+    });
+    await expect(scannedTomato).toContainText('Provjereno');
+    await scannedTomato
+        .getByRole('button', { name: /Promijeni ishod/ })
+        .click();
+    await expect(
+        scannedTomato.getByRole('button', { name: /Označi da nedostaje/ }),
+    ).toBeVisible();
+    await scannedTomato
+        .getByRole('button', { name: 'Odustani od promjene' })
+        .click();
+
+    await page
+        .getByRole('button', { name: 'Simuliraj osvježavanje prikaza' })
+        .click();
+    await expect(page.getByLabel('Sažetak provjere predaje')).toContainText(
+        '1 provjereno',
+    );
+
+    await page.getByRole('button', { name: 'Provjeri QR kodove' }).click();
+    await manualInput.fill('tomato-trace-0001');
+    await page.getByRole('button', { name: 'Dodaj kod' }).click();
+    await expect(
+        page.getByText(
+            'Rajčica Roma · Ana Anić već je provjeren na ovoj stanici.',
+        ),
+    ).toBeVisible();
+
+    await manualInput.fill('nije-kod');
+    await page.getByRole('button', { name: 'Dodaj kod' }).click();
+    await expect(
+        page.getByText('Kod nije valjana Gredice poveznica traga uroda.'),
+    ).toBeVisible();
+
+    await manualInput.fill('/trag/wrong-stop-trace-0001');
+    await page.getByRole('button', { name: 'Dodaj kod' }).click();
+    await expect(
+        page.getByText(
+            'Ovaj QR kod nije na popisu uroda za trenutačnu stanicu.',
+        ),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('log', { name: 'Posljednja očitanja' }),
+    ).toBeVisible();
+    await expect(page.getByTestId('handoff-events')).toContainText(
+        'scanned:101|duplicate|invalid|wrong-stop',
+    );
+    await expect(page.getByLabel('Sažetak provjere predaje')).toContainText(
+        '1 provjereno',
+    );
+});
+
+test('records nonblocking outcomes and keeps bulk completion enabled with unresolved and pending verification', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryHandoffVerificationStory syncState="failed" />);
+
+    const tomato = page.getByRole('listitem').filter({
+        hasText: 'Rajčica Roma',
+    });
+    await tomato.getByRole('button', { name: /Označi bez etikete/ }).click();
+    await expect(
+        tomato.getByRole('button', { name: /Promijeni ishod/ }),
+    ).toBeVisible();
+    await tomato.getByRole('button', { name: /Promijeni ishod/ }).click();
+    await tomato.getByRole('button', { name: /Označi da nedostaje/ }).click();
+
+    const basil = page.getByRole('listitem').filter({
+        hasText: 'Bosiljak Genovese',
+    });
+    await basil.getByRole('button', { name: /Označi bez etikete/ }).click();
+
+    const lettuce = page.getByRole('listitem').filter({
+        hasText: 'Salata puterica',
+    });
+    await lettuce
+        .getByLabel(/Razlog preskakanja/)
+        .selectOption('scanner-unavailable');
+    await lettuce.getByRole('button', { name: /Preskoči provjeru/ }).click();
+
+    await page.getByRole('button', { name: 'Dostavi 4 uroda · dalje' }).click();
+    const confirmation = page.getByRole('dialog', {
+        name: 'Potvrdi dostavu',
+    });
+    await expect(confirmation).toContainText('1 bez provjere');
+    await expect(confirmation).toContainText(
+        'Sinkronizacija nekih provjera nije uspjela. Dostavu i dalje možeš potvrditi.',
+    );
+    await expect(
+        confirmation.getByRole('button', {
+            name: 'Potvrdi dostavu i nastavi',
+        }),
+    ).toBeEnabled();
+    await confirmation.getByRole('button', { name: 'Natrag' }).click();
+
+    await page
+        .getByRole('button', {
+            name: 'Označi preostalo kao ručno provjereno',
+        })
+        .click();
+    await expect(page.getByTestId('handoff-events')).toContainText(
+        'mark:101:no-label|mark:101:missing|mark:102:no-label|mark:103:skipped:scanner-unavailable|manual:104',
+    );
+
+    await page.getByRole('button', { name: 'Dostavi 4 uroda · dalje' }).click();
+    await expect(confirmation).toContainText('0 bez provjere');
+    await expect(confirmation).toContainText('2 preskočeno');
+    await expect(
+        confirmation.getByRole('button', {
+            name: 'Potvrdi dostavu i nastavi',
+        }),
+    ).toBeEnabled();
+    await confirmation
+        .getByRole('button', { name: 'Potvrdi dostavu i nastavi' })
+        .click();
+    await expect(page.getByTestId('completion-result')).toHaveText('delivered');
+});
+
+test('counts a shared physical QR once while reporting every grouped harvest outcome', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryHandoffVerificationStory sharedTrace />);
+    await page.getByRole('button', { name: 'Provjeri QR kodove' }).click();
+    const scanner = page.getByRole('dialog', {
+        name: 'Provjera uroda za dostavu',
+    });
+    await expect(scanner).toContainText('3 očekivanih QR kodova');
+
+    await scanner.getByLabel('Ručni unos').fill('tomato-trace-0001');
+    await scanner.getByRole('button', { name: 'Dodaj kod' }).click();
+    await expect(scanner).toContainText('1 provjereno');
+    await scanner.getByRole('button', { name: 'Završi provjeru' }).click();
+
+    await expect(page.getByLabel('Sažetak provjere predaje')).toContainText(
+        '2 provjereno',
+    );
+    await expect(page.getByTestId('handoff-events')).toContainText(
+        'scanned:101,102',
+    );
+});
+
+test('announces nonblocking server feedback after an advisory verification is reconciled', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryHandoffVerificationStory serverFeedback />);
+
+    await expect(
+        page.getByRole('status', {
+            name: 'Povratne informacije provjere predaje',
+        }),
+    ).toContainText('QR kod pripada drugoj stanici na ruti.');
+    await expect(
+        page.getByRole('button', { name: 'Dostavi 4 uroda · dalje' }),
+    ).toBeEnabled();
+});
+
+test('keeps verification controls hidden while persisted progress loads without blocking delivery', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryHandoffVerificationStory handoffUnavailable />);
+
+    await expect(
+        page.getByText('Učitavanje popisa uroda za ovu predaju…'),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('list', { name: 'Urodi na ovoj stanici' }),
+    ).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Dostavi 4 uroda · dalje' }).click();
+    const confirmation = page.getByRole('dialog', {
+        name: 'Potvrdi dostavu',
+    });
+    await expect(confirmation).toContainText(
+        'Spremljeni ishodi provjere još se učitavaju.',
+    );
+    await expect(
+        confirmation.getByRole('button', {
+            name: 'Potvrdi dostavu i nastavi',
+        }),
+    ).toBeEnabled();
+});

--- a/apps/delivery/tests/driver-current-stop.spec.tsx
+++ b/apps/delivery/tests/driver-current-stop.spec.tsx
@@ -166,6 +166,33 @@ test.describe('320px current-stop command center', () => {
         );
     });
 
+    test('opens the persisted handoff summary before completing a delivery without blocking unresolved items', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<DriverCurrentDeliveryCommandStory arrived withHandoff />);
+        await page.getByRole('button', { name: 'Dostavi 3 · dalje' }).click();
+
+        const confirmation = page.getByRole('dialog', {
+            name: 'Potvrdi dostavu',
+        });
+        await expect(confirmation).toContainText('1 provjereno');
+        await expect(confirmation).toContainText('1 bez provjere');
+        await expect(confirmation).toContainText('1 bez etikete');
+        await expect(page.getByTestId('current-stop-result')).toHaveText(
+            'none',
+        );
+
+        const confirm = confirmation.getByRole('button', {
+            name: 'Potvrdi dostavu i nastavi',
+        });
+        await expect(confirm).toBeEnabled();
+        await confirm.click();
+        await expect(page.getByTestId('current-stop-result')).toHaveText(
+            'delivered:',
+        );
+    });
+
     test('keeps failed delivery recovery attached to the sticky delivery action', async ({
         mount,
         page,


### PR DESCRIPTION
## Summary

- persist retry-scoped delivery handoff manifests across refreshes and offline recovery
- replay rapid QR scans and manual outcomes in the ordered delivery action queue without blocking route progress
- show accessible server feedback, correctable per-harvest outcomes, and a persisted bulk completion summary
- retain raw trace evidence until an authoritative manifest is durably cached, including raced acknowledgements

## Validation

- pnpm --filter delivery test:unit (287 passed)
- pnpm --filter delivery test:component (93 passed)
- pnpm --filter delivery lint
- pnpm --filter delivery typecheck
- pnpm --filter delivery build
- git diff --check
- two independent final reviews: no findings

Closes #4143