### PR TITLE
feat(delivery): guard bulk fulfillment

### DIFF
--- a/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/deliver/route.ts
+++ b/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/deliver/route.ts
@@ -50,6 +50,7 @@ export async function POST(
                 runId,
                 stopId,
                 notes: mutation.notes,
+                completionOverride: mutation.completionOverride,
                 expectedRouteRevision: mutation.expectedRouteRevision,
                 clientOperationId: mutation.clientOperationId,
                 occurredAt: mutation.occurredAt,

--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -485,12 +485,19 @@ function ActiveDriverDashboardWithPickupSync({
                 if (runId !== activeRunId) return;
                 await deliverySync.enqueueArrive(stopId, routeRevision);
             }}
-            onDeliver={async (runId, stopId, routeRevision, notes) => {
+            onDeliver={async (
+                runId,
+                stopId,
+                routeRevision,
+                notes,
+                completionOverride,
+            ) => {
                 if (runId !== activeRunId) return;
                 await deliverySync.enqueueDelivery(
                     stopId,
                     routeRevision,
                     notes,
+                    completionOverride,
                 );
             }}
             onException={async (runId, stopId, mutation) => {

--- a/apps/delivery/components/DeliveryExceptionSheet.tsx
+++ b/apps/delivery/components/DeliveryExceptionSheet.tsx
@@ -165,6 +165,7 @@ export function DeliveryExceptionSheet({
             className="md:max-w-2xl"
             trigger={
                 <Button
+                    size="lg"
                     color="warning"
                     variant="outlined"
                     disabled={disabled || actionableDeliveries.length === 0}
@@ -203,6 +204,7 @@ export function DeliveryExceptionSheet({
                                 <Button
                                     type="button"
                                     size="sm"
+                                    className="min-h-11 min-w-11"
                                     variant="plain"
                                     onClick={() => {
                                         invalidatePendingOperation();
@@ -220,6 +222,7 @@ export function DeliveryExceptionSheet({
                                     <Button
                                         type="button"
                                         size="sm"
+                                        className="min-h-11 min-w-11"
                                         variant="plain"
                                         onClick={() => {
                                             invalidatePendingOperation();
@@ -270,6 +273,7 @@ export function DeliveryExceptionSheet({
                                         <Button
                                             href={`tel:${delivery.phone}`}
                                             size="sm"
+                                            className="min-h-11 min-w-11"
                                             variant="plain"
                                             aria-label={`Nazovi kontakt za ${identityLabel}`}
                                             startDecorator={
@@ -476,6 +480,7 @@ export function DeliveryExceptionSheet({
 
                 <div className="flex flex-col-reverse gap-2 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
                     <Button
+                        size="lg"
                         href={deliveryDispatchContactHref({
                             runId,
                             stopId: stop.id,
@@ -488,6 +493,7 @@ export function DeliveryExceptionSheet({
                     <div className="flex flex-col-reverse gap-2 sm:flex-row">
                         <Button
                             type="button"
+                            size="lg"
                             variant="plain"
                             disabled={mutationPending}
                             onClick={() => handleOpenChange(false)}
@@ -496,6 +502,7 @@ export function DeliveryExceptionSheet({
                         </Button>
                         <Button
                             type="submit"
+                            size="lg"
                             color={
                                 effectiveOutcome === 'deferred'
                                     ? 'warning'

--- a/apps/delivery/components/DeliveryHandoffCompletionDialog.tsx
+++ b/apps/delivery/components/DeliveryHandoffCompletionDialog.tsx
@@ -1,12 +1,14 @@
 'use client';
 
+import type { DeliveryRunCompletionOverrideReason } from '@gredice/storage';
 import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { Chip } from '@gredice/ui/Chip';
 import { Info, Warning } from '@gredice/ui/icons';
 import { Modal } from '@gredice/ui/Modal';
 import { Typography } from '@gredice/ui/Typography';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+import { croatianCountLabel } from '../lib/croatianCount';
 import type { DeliveryStopDeliverySummary } from '../lib/deliveryDashboardTypes';
 import { isDriverCommandResult } from '../lib/driverCommandResult';
 import type {
@@ -58,6 +60,58 @@ function itemStateColor(
     }
 }
 
+const overrideReasons = [
+    {
+        value: 'device-unavailable',
+        label: 'Uređaj ili skener nisu dostupni',
+    },
+    {
+        value: 'workflow-recovery',
+        label: 'Oporavak prekinutog tijeka dostave',
+    },
+    {
+        value: 'manual-handoff',
+        label: 'Predaja je provjerena ručno',
+    },
+    {
+        value: 'other-operational',
+        label: 'Drugi operativni razlog',
+    },
+] satisfies Array<{
+    value: DeliveryRunCompletionOverrideReason;
+    label: string;
+}>;
+
+function legacyRecipientCount(deliveries: DeliveryStopDeliverySummary[]) {
+    return new Set(
+        deliveries.map((delivery) => {
+            const name = delivery.contactName.trim().toLocaleLowerCase('hr');
+            const phoneDigits = delivery.phone?.replace(/\D/g, '') ?? '';
+            const phone = phoneDigits.startsWith('385')
+                ? phoneDigits.slice(3)
+                : phoneDigits.startsWith('0')
+                  ? phoneDigits.slice(1)
+                  : phoneDigits;
+            if (name) return `name:${name}`;
+            return phone ? `phone:${phone}` : `request:${delivery.requestId}`;
+        }),
+    ).size;
+}
+
+function completionOverrideReason(
+    value: string,
+): DeliveryRunCompletionOverrideReason | null {
+    switch (value) {
+        case 'device-unavailable':
+        case 'workflow-recovery':
+        case 'manual-handoff':
+        case 'other-operational':
+            return value;
+        default:
+            return null;
+    }
+}
+
 export function DeliveryHandoffCompletionDialog({
     confirmation,
     deliveries,
@@ -73,19 +127,36 @@ export function DeliveryHandoffCompletionDialog({
 }) {
     const [error, setError] = useState<string | null>(null);
     const [submitting, setSubmitting] = useState(false);
+    const [overrideReason, setOverrideReason] =
+        useState<DeliveryRunCompletionOverrideReason | null>(null);
+    const submittingRef = useRef(false);
     const busy = submitting || Boolean(confirmation.pending);
     const summaryLoading = handoffSyncState === 'loading';
+    const overrideRequired = confirmation.overrideBypasses.length > 0;
+    const recipients =
+        confirmation.recipientCount ?? legacyRecipientCount(deliveries);
 
     function changeOpen(open: boolean) {
-        if (!open) setError(null);
+        if (!open) {
+            setError(null);
+            setOverrideReason(null);
+            requestAnimationFrame(() =>
+                confirmation.returnFocusRef?.current?.focus(),
+            );
+        }
         confirmation.onOpenChange(open);
     }
 
     async function confirmDelivery() {
+        if (submittingRef.current || busy) return;
+        if (overrideRequired && !overrideReason) return;
+        submittingRef.current = true;
         setSubmitting(true);
         setError(null);
         try {
-            const result = await confirmation.onConfirm();
+            const result = await confirmation.onConfirm(
+                overrideReason ? { reason: overrideReason } : undefined,
+            );
             if (isDriverCommandResult(result) && result.status === 'failed') {
                 setError(result.message);
                 return;
@@ -96,6 +167,7 @@ export function DeliveryHandoffCompletionDialog({
                 'Potvrdu dostave nije moguće sigurno spremiti. Pokušaj ponovno.',
             );
         } finally {
+            submittingRef.current = false;
             setSubmitting(false);
         }
     }
@@ -105,9 +177,9 @@ export function DeliveryHandoffCompletionDialog({
             open={confirmation.open}
             onOpenChange={changeOpen}
             title="Potvrdi dostavu"
-            description="Pregledaj zabilježene ishode provjere uroda prije potvrde skupne dostave."
+            description="Pregledaj primatelje, urode i zabilježene ishode prije konačne potvrde dostave."
             dismissible={!busy}
-            className="md:max-w-xl"
+            className="motion-reduce:transition-none md:max-w-xl"
         >
             <form
                 className="space-y-4"
@@ -116,54 +188,106 @@ export function DeliveryHandoffCompletionDialog({
                     void confirmDelivery();
                 }}
             >
-                <div className="pr-8">
+                <div
+                    className="pr-8"
+                    role="status"
+                    aria-live="polite"
+                    aria-atomic="true"
+                    aria-busy={summaryLoading || busy}
+                >
                     <Typography level="h3" semiBold>
-                        Sažetak predaje
+                        {overrideRequired
+                            ? 'Dostava zahtijeva operativnu iznimku'
+                            : 'Sažetak skupne predaje'}
                     </Typography>
                     <Typography
                         level="body3"
                         className="mt-1 text-muted-foreground"
                     >
-                        {summaryLoading
-                            ? 'Sažetak provjere još se učitava.'
-                            : `${summary.expectedCount} ${
-                                  summary.expectedCount === 1
-                                      ? 'urod na ovoj stanici'
-                                      : 'uroda na ovoj stanici'
-                              }`}
+                        {croatianCountLabel(
+                            recipients,
+                            'primatelj',
+                            'primatelja',
+                            'primatelja',
+                        )}{' '}
+                        ·{' '}
+                        {croatianCountLabel(
+                            summary.expectedCount,
+                            'očekivani urod',
+                            'očekivana uroda',
+                            'očekivanih uroda',
+                        )}
+                        {' · '}
+                        {confirmation.arrived
+                            ? 'dolazak potvrđen'
+                            : 'dolazak nije potvrđen'}
                     </Typography>
+                    <span className="sr-only">
+                        {summary.scannedCount} provjereno,{' '}
+                        {summary.unverifiedCount} neskenirano,{' '}
+                        {summary.noLabelCount} bez etikete,{' '}
+                        {croatianCountLabel(
+                            summary.exceptionCount,
+                            'iznimka',
+                            'iznimke',
+                            'iznimki',
+                        )}
+                        .
+                    </span>
                 </div>
 
                 {summaryLoading ? (
-                    <Alert
-                        color="info"
-                        startDecorator={<Info className="size-5" />}
-                    >
-                        Spremljeni ishodi provjere još se učitavaju. Dostavu i
-                        dalje možeš potvrditi bez čekanja.
-                    </Alert>
+                    <div className="flex gap-2 rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-950 dark:border-blue-900 dark:bg-blue-950 dark:text-blue-100">
+                        <Info className="size-5 shrink-0" />
+                        <span>
+                            Spremljeni ishodi provjere još se učitavaju. Broj
+                            primatelja i uroda dolazi iz trenutačne stanice.
+                        </span>
+                    </div>
                 ) : (
                     <>
                         <fieldset
                             className="flex flex-wrap gap-2"
                             aria-label="Sažetak za potvrdu dostave"
                         >
+                            <Chip color="neutral" size="sm">
+                                Očekivano: {summary.expectedCount}
+                            </Chip>
                             <Chip color="success" size="sm">
                                 {summary.scannedCount} provjereno
                             </Chip>
                             <Chip color="neutral" size="sm">
-                                {summary.unverifiedCount} bez provjere
+                                {summary.unverifiedCount} neskenirano
                             </Chip>
                             <Chip color="warning" size="sm">
                                 {summary.noLabelCount} bez etikete
                             </Chip>
-                            <Chip color="error" size="sm">
-                                {summary.missingCount} nedostaje
-                            </Chip>
-                            <Chip color="warning" size="sm">
-                                {summary.skippedCount} preskočeno
+                            <Chip
+                                color={
+                                    summary.exceptionCount > 0
+                                        ? 'warning'
+                                        : 'neutral'
+                                }
+                                size="sm"
+                            >
+                                {croatianCountLabel(
+                                    summary.exceptionCount,
+                                    'iznimka',
+                                    'iznimke',
+                                    'iznimki',
+                                )}
                             </Chip>
                         </fieldset>
+
+                        {summary.exceptionCount > 0 ? (
+                            <Typography
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                Iznimke: {summary.missingCount} nedostaje ·{' '}
+                                {summary.skippedCount} preskočeno
+                            </Typography>
+                        ) : null}
 
                         <ul
                             className="max-h-52 space-y-2 overflow-y-auto"
@@ -199,36 +323,88 @@ export function DeliveryHandoffCompletionDialog({
                     </>
                 )}
 
-                <Alert
-                    color="info"
-                    startDecorator={<Info className="size-5" />}
-                >
-                    QR provjera je pomoćna i ne blokira dostavu. Dostavu možeš
-                    potvrditi s neprovjerenim, preskočenim ili nepotvrđenim
-                    promjenama.
-                </Alert>
+                {overrideRequired ? (
+                    <section className="space-y-3 rounded-lg border border-amber-300 bg-amber-50 p-3 text-amber-950 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
+                        <div className="flex gap-2">
+                            <Warning className="size-5 shrink-0" />
+                            <div className="space-y-1 text-sm">
+                                <p className="font-semibold">
+                                    Ova potvrda zaobilazi uobičajenu provjeru.
+                                </p>
+                                <p>
+                                    {confirmation.overrideBypasses.includes(
+                                        'arrival',
+                                    )
+                                        ? 'Dolazak nije zabilježen. '
+                                        : ''}
+                                    {confirmation.overrideBypasses.includes(
+                                        'handoff-review',
+                                    )
+                                        ? 'Manifest nije u potpunosti pregledan ili potvrđen. '
+                                        : ''}
+                                    QR je i dalje neobavezan, ali razlog iznimke
+                                    ostat će u revizijskom zapisu.
+                                </p>
+                            </div>
+                        </div>
+                        <label className="block text-sm font-medium">
+                            Razlog operativne iznimke
+                            <select
+                                className="mt-1 min-h-11 w-full rounded-md border bg-background px-3 py-2 text-base text-foreground outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+                                value={overrideReason ?? ''}
+                                disabled={busy}
+                                required
+                                onChange={(event) =>
+                                    setOverrideReason(
+                                        completionOverrideReason(
+                                            event.target.value,
+                                        ),
+                                    )
+                                }
+                            >
+                                <option value="">Odaberi razlog</option>
+                                {overrideReasons.map((reason) => (
+                                    <option
+                                        key={reason.value}
+                                        value={reason.value}
+                                    >
+                                        {reason.label}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+                    </section>
+                ) : null}
+
+                <div className="flex gap-2 rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-950 dark:border-blue-900 dark:bg-blue-950 dark:text-blue-100">
+                    <Info className="size-5 shrink-0" />
+                    <span>
+                        QR provjera je pomoćna. Dostavu možeš potvrditi i kada
+                        etiketa ili skeniranje nisu dostupni.
+                    </span>
+                </div>
 
                 {!summaryLoading && summary.unverifiedCount > 0 ? (
-                    <Alert
-                        color="warning"
-                        startDecorator={<Warning className="size-5" />}
-                    >
-                        {summary.unverifiedCount}{' '}
-                        {summary.unverifiedCount === 1
-                            ? 'urod ostaje bez zabilježene provjere.'
-                            : 'uroda ostaju bez zabilježene provjere.'}
-                    </Alert>
+                    <div className="flex gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+                        <Warning className="size-5 shrink-0" />
+                        <span>
+                            {summary.unverifiedCount}{' '}
+                            {summary.unverifiedCount === 1
+                                ? 'urod ostaje bez zabilježene provjere.'
+                                : 'uroda ostaju bez zabilježene provjere.'}
+                        </span>
+                    </div>
                 ) : null}
 
                 {summary.pendingCount > 0 || handoffSyncState === 'failed' ? (
-                    <Alert
-                        color="warning"
-                        startDecorator={<Warning className="size-5" />}
-                    >
-                        {handoffSyncState === 'failed'
-                            ? 'Sinkronizacija nekih provjera nije uspjela. Dostavu i dalje možeš potvrditi.'
-                            : `${summary.pendingCount} ${summary.pendingCount === 1 ? 'promjena čeka' : 'promjene čekaju'} potvrdu poslužitelja. Dostavu i dalje možeš potvrditi.`}
-                    </Alert>
+                    <div className="flex gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+                        <Warning className="size-5 shrink-0" />
+                        <span>
+                            {handoffSyncState === 'failed'
+                                ? 'Sinkronizacija nekih provjera nije uspjela. Dostavu i dalje možeš potvrditi.'
+                                : `${summary.pendingCount} ${summary.pendingCount === 1 ? 'promjena čeka' : 'promjene čekaju'} potvrdu poslužitelja. Dostavu i dalje možeš potvrditi.`}
+                        </span>
+                    </div>
                 ) : null}
 
                 {error ? (
@@ -242,10 +418,12 @@ export function DeliveryHandoffCompletionDialog({
                     </Alert>
                 ) : null}
 
-                <div className="flex flex-col-reverse gap-2 border-t pt-4 sm:flex-row sm:justify-end">
+                <div className="sticky bottom-0 -mx-1 flex flex-col-reverse gap-2 border-t bg-background/95 px-1 pb-[max(0.25rem,env(safe-area-inset-bottom))] pt-4 backdrop-blur sm:static sm:mx-0 sm:flex-row sm:justify-end sm:px-0 sm:pb-0">
                     <Button
                         type="button"
+                        size="lg"
                         variant="plain"
+                        className="w-full motion-reduce:transition-none sm:w-auto"
                         disabled={busy}
                         onClick={() => changeOpen(false)}
                     >
@@ -253,11 +431,21 @@ export function DeliveryHandoffCompletionDialog({
                     </Button>
                     <Button
                         type="submit"
+                        size="lg"
                         color="success"
+                        className="w-full motion-reduce:transition-none sm:w-auto"
                         loading={busy}
-                        disabled={busy || Boolean(confirmation.disabled)}
+                        disabled={
+                            busy ||
+                            Boolean(confirmation.disabled) ||
+                            (overrideRequired && !overrideReason)
+                        }
                     >
-                        Potvrdi dostavu i nastavi
+                        {busy
+                            ? 'Spremanje dostave…'
+                            : overrideRequired
+                              ? 'Potvrdi iznimku i dostavu'
+                              : 'Potvrdi dostavu i nastavi'}
                     </Button>
                 </div>
             </form>

--- a/apps/delivery/components/DeliveryHandoffVerificationItem.tsx
+++ b/apps/delivery/components/DeliveryHandoffVerificationItem.tsx
@@ -168,6 +168,7 @@ export function DeliveryHandoffVerificationItem({
                 <Button
                     type="button"
                     size="xs"
+                    className="min-h-11 min-w-11"
                     variant="plain"
                     disabled={actionsDisabled}
                     aria-label={`Promijeni ishod: ${identityLabel}`}
@@ -183,6 +184,7 @@ export function DeliveryHandoffVerificationItem({
                         <Button
                             type="button"
                             size="xs"
+                            className="min-h-11 min-w-11"
                             variant="outlined"
                             color="warning"
                             loading={
@@ -202,6 +204,7 @@ export function DeliveryHandoffVerificationItem({
                         <Button
                             type="button"
                             size="xs"
+                            className="min-h-11 min-w-11"
                             variant="outlined"
                             color="danger"
                             loading={pendingAction === `missing:${item.stopId}`}
@@ -221,7 +224,7 @@ export function DeliveryHandoffVerificationItem({
                         <label className="min-w-0 flex-1 text-xs font-medium">
                             Razlog preskakanja
                             <select
-                                className="mt-1 h-9 w-full rounded-md border bg-background px-2 text-sm outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+                                className="mt-1 h-11 min-w-11 w-full rounded-md border bg-background px-2 text-sm outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
                                 value={skipReason}
                                 disabled={actionsDisabled}
                                 aria-label={`Razlog preskakanja za ${identityLabel}`}
@@ -242,6 +245,7 @@ export function DeliveryHandoffVerificationItem({
                         <Button
                             type="button"
                             size="sm"
+                            className="min-h-11 min-w-11"
                             variant="outlined"
                             loading={pendingAction === `skipped:${item.stopId}`}
                             disabled={actionsDisabled}
@@ -261,6 +265,7 @@ export function DeliveryHandoffVerificationItem({
                         <Button
                             type="button"
                             size="xs"
+                            className="min-h-11 min-w-11"
                             variant="plain"
                             disabled={actionsDisabled}
                             onClick={() => setEditingOutcome(false)}

--- a/apps/delivery/components/DeliveryHarvestVerification.tsx
+++ b/apps/delivery/components/DeliveryHarvestVerification.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import type {
+    DeliveryRunCompletionBypass,
+    DeliveryRunCompletionOverrideReason,
     DeliveryRunHandoffItemSnapshot,
     DeliveryRunHandoffItemState,
     DeliveryRunHandoffManifest,
@@ -11,7 +13,7 @@ import { Button } from '@gredice/ui/Button';
 import { Chip } from '@gredice/ui/Chip';
 import { Check, Info, Warning } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
-import { useId, useState } from 'react';
+import { type RefObject, useId, useState } from 'react';
 import type { DeliveryStopDeliverySummary } from '../lib/deliveryDashboardTypes';
 import { isDriverCommandResult } from '../lib/driverCommandResult';
 import {
@@ -70,8 +72,14 @@ export type DeliveryHandoffCompletionConfirmation = {
     open: boolean;
     pending?: boolean;
     disabled?: boolean;
+    arrived: boolean;
+    overrideBypasses: DeliveryRunCompletionBypass[];
+    recipientCount?: number;
+    returnFocusRef?: RefObject<HTMLButtonElement | null>;
     onOpenChange: (open: boolean) => void;
-    onConfirm: () => unknown | Promise<unknown>;
+    onConfirm: (completionOverride?: {
+        reason: DeliveryRunCompletionOverrideReason;
+    }) => unknown | Promise<unknown>;
 };
 
 export type DeliveryHandoffSummary = {
@@ -81,6 +89,7 @@ export type DeliveryHandoffSummary = {
     noLabelCount: number;
     missingCount: number;
     skippedCount: number;
+    exceptionCount: number;
     pendingCount: number;
 };
 
@@ -131,6 +140,9 @@ function handoffSummaryFromItems(
         noLabelCount: handoffItemCount(items, 'no-label'),
         missingCount: handoffItemCount(items, 'missing'),
         skippedCount: handoffItemCount(items, 'skipped'),
+        exceptionCount:
+            handoffItemCount(items, 'missing') +
+            handoffItemCount(items, 'skipped'),
         pendingCount,
     };
 }
@@ -478,7 +490,7 @@ export function DeliveryHarvestVerification({
                 <div className="space-y-1 rounded-md border border-dashed p-3">
                     <Button
                         type="button"
-                        size="sm"
+                        size="lg"
                         variant="outlined"
                         loading={pendingAction === 'manual-review'}
                         disabled={disabled || Boolean(pendingAction)}

--- a/apps/delivery/components/DriverCurrentStopCommandCenter.tsx
+++ b/apps/delivery/components/DriverCurrentStopCommandCenter.tsx
@@ -304,8 +304,13 @@ function DeliveryCurrentStopCommandCenter({
         checkpointPending ||
         Boolean(pendingCompletion) ||
         offlineConflict;
+    const allActionableDeliveriesArrived =
+        actionableDeliveries.length > 0 &&
+        actionableDeliveries.every(
+            (delivery) => delivery.stopState === 'arrived',
+        );
     const arrived =
-        stop.stopState === 'arrived' || pendingArrival || acknowledgedArrival;
+        allActionableDeliveriesArrived || pendingArrival || acknowledgedArrival;
     const handoffView = handoff?.view ?? null;
     const actionableStopIds = new Set(
         actionableDeliveries.map((delivery) => delivery.stopId),

--- a/apps/delivery/components/DriverCurrentStopCommandCenter.tsx
+++ b/apps/delivery/components/DriverCurrentStopCommandCenter.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import type {
+    DeliveryRunCompletionBypass,
+    DeliveryRunCompletionOverrideReason,
+} from '@gredice/storage';
 import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { Chip } from '@gredice/ui/Chip';
@@ -52,11 +56,13 @@ import {
 import type { PickupManifestScanResult } from '../lib/deliveryPickupScan';
 import { isDriverCommandResult } from '../lib/driverCommandResult';
 import { DeliveryExceptionSheet } from './DeliveryExceptionSheet';
+import { DeliveryHandoffCompletionDialog } from './DeliveryHandoffCompletionDialog';
 import {
     type DeliveryHandoffFeedbackView,
     type DeliveryHandoffManifestView,
     type DeliveryHandoffMarkItemInput,
     DeliveryHarvestVerification,
+    deliveryHandoffSummary,
 } from './DeliveryHarvestVerification';
 import type { PickupManifestSyncSummary } from './DeliveryPickupCard';
 import { HarvestTraceScanner } from './HarvestTraceScanner';
@@ -87,7 +93,10 @@ type DeliveryCommandCenterProps = {
     focusOnMount?: boolean;
     onRetry?: () => unknown | Promise<unknown>;
     onArrive?: () => unknown | Promise<unknown>;
-    onDeliver?: (notes?: string) => unknown | Promise<unknown>;
+    onDeliver?: (
+        notes?: string,
+        completionOverride?: { reason: DeliveryRunCompletionOverrideReason },
+    ) => unknown | Promise<unknown>;
     onException?: (
         mutation: DeliveryExceptionMutation,
     ) => Promise<DeliveryExceptionSubmitResult>;
@@ -232,6 +241,8 @@ function DeliveryCurrentStopCommandCenter({
     const syncStatusId = useId();
     const headingRef = useRef<HTMLElement>(null);
     const actionRef = useRef<HTMLFieldSetElement>(null);
+    const completionTriggerRef = useRef<HTMLButtonElement>(null);
+    const pendingCommandRef = useRef(false);
     const [notes, setNotes] = useState('');
     const [localPendingAction, setLocalPendingAction] = useState<
         'retry' | 'arrive' | 'deliver' | null
@@ -261,16 +272,20 @@ function DeliveryCurrentStopCommandCenter({
         actionableDeliveryExceptionItems(commandDeliveries);
     const commandStop = { ...stop, deliveries: commandDeliveries };
     const primaryCommandDelivery = commandDeliveries[0];
+    const displayedCommandDeliveries =
+        stop.stopState === 'deferred'
+            ? commandDeliveries
+            : actionableDeliveries;
     const recipientNames = Array.from(
         new Set(
-            commandDeliveries
+            displayedCommandDeliveries
                 .map((delivery) => delivery.contactName.trim())
                 .filter(Boolean),
         ),
     );
     const contacts = deliveryCurrentStopContacts(commandStop);
     const criticalNotes = deliveryCurrentStopCriticalNotes(commandStop);
-    const groupedDelivery = commandDeliveries.length > 1;
+    const groupedDelivery = displayedCommandDeliveries.length > 1;
     const acknowledgedArrival =
         syncEntry?.command.kind === 'arrive' && syncEntry.state === 'synced';
     const pendingArrival =
@@ -291,6 +306,67 @@ function DeliveryCurrentStopCommandCenter({
         offlineConflict;
     const arrived =
         stop.stopState === 'arrived' || pendingArrival || acknowledgedArrival;
+    const handoffView = handoff?.view ?? null;
+    const actionableStopIds = new Set(
+        actionableDeliveries.map((delivery) => delivery.stopId),
+    );
+    const completionHandoffItems =
+        handoffView?.items.filter((item) =>
+            actionableStopIds.has(item.stopId),
+        ) ?? [];
+    const completionPendingCount = completionHandoffItems.filter(
+        (item) =>
+            item.syncState !== undefined && item.syncState !== 'persisted',
+    ).length;
+    const knownActionableStopIds = new Set(
+        completionHandoffItems.map((item) => item.stopId),
+    );
+    const missingHandoffItemCount = Math.max(
+        0,
+        actionableStopIds.size - knownActionableStopIds.size,
+    );
+    const persistedCompletionSummary = handoffView
+        ? deliveryHandoffSummary({
+              ...handoffView,
+              items: completionHandoffItems,
+              pendingCount: completionPendingCount,
+          })
+        : null;
+    const completionSummary = persistedCompletionSummary
+        ? {
+              ...persistedCompletionSummary,
+              expectedCount: actionableDeliveries.length,
+              unverifiedCount:
+                  persistedCompletionSummary.unverifiedCount +
+                  missingHandoffItemCount,
+          }
+        : {
+              expectedCount: actionableDeliveries.length,
+              scannedCount: 0,
+              unverifiedCount: actionableDeliveries.length,
+              noLabelCount: 0,
+              missingCount: 0,
+              skippedCount: 0,
+              exceptionCount: 0,
+              pendingCount: 0,
+          };
+    const handoffReviewBypassed = Boolean(
+        handoff !== undefined &&
+            (!handoffView ||
+                handoffView.syncState === 'loading' ||
+                completionHandoffItems.some(
+                    (item) => item.syncState === 'failed',
+                ) ||
+                completionPendingCount > 0 ||
+                completionSummary.unverifiedCount > 0),
+    );
+    const completionOverrideBypasses: DeliveryRunCompletionBypass[] = [];
+    if (!arrived) completionOverrideBypasses.push('arrival');
+    if (handoffReviewBypassed) {
+        completionOverrideBypasses.push('handoff-review');
+    }
+    const completionDialogRequired =
+        groupedDelivery || completionOverrideBypasses.length > 0;
     const deferred = stop.stopState === 'deferred';
     const estimatedOutsideWindow = Boolean(
         stop.estimatedArrivalAt &&
@@ -303,7 +379,8 @@ function DeliveryCurrentStopCommandCenter({
         kind: 'retry' | 'arrive' | 'deliver',
         action: (() => unknown | Promise<unknown>) | undefined,
     ) => {
-        if (!action || localPendingAction) return;
+        if (!action || pendingCommandRef.current || localPendingAction) return;
+        pendingCommandRef.current = true;
         setLocalError(null);
         setLocalPendingAction(kind);
         try {
@@ -317,6 +394,7 @@ function DeliveryCurrentStopCommandCenter({
             setLocalError(message);
             return { status: 'failed' as const, message };
         } finally {
+            pendingCommandRef.current = false;
             setLocalPendingAction(null);
         }
     };
@@ -337,6 +415,16 @@ function DeliveryCurrentStopCommandCenter({
             setSyncRecoveryPending(false);
         }
     };
+    const openCompletionDialog = (trigger: HTMLButtonElement) => {
+        completionTriggerRef.current = trigger;
+        setDeliveryConfirmationOpen(true);
+    };
+    const confirmDelivery = (completionOverride?: {
+        reason: DeliveryRunCompletionOverrideReason;
+    }) =>
+        runCommand('deliver', () =>
+            onDeliver?.(notes || undefined, completionOverride),
+        );
 
     useEffect(() => {
         if (!focusOnMount) return;
@@ -370,7 +458,7 @@ function DeliveryCurrentStopCommandCenter({
                             </Typography>
                             {syncEntry.state === 'failed' ? (
                                 <Button
-                                    size="sm"
+                                    size="lg"
                                     color="warning"
                                     loading={syncRecoveryPending}
                                     disabled={
@@ -393,7 +481,7 @@ function DeliveryCurrentStopCommandCenter({
                             ) : null}
                             {syncEntry.state === 'conflicted' ? (
                                 <Button
-                                    size="sm"
+                                    size="lg"
                                     color="danger"
                                     variant="outlined"
                                     loading={syncRecoveryPending}
@@ -419,7 +507,7 @@ function DeliveryCurrentStopCommandCenter({
                             syncEntry.acknowledgement?.reroutePending ||
                             syncEntry.acknowledgement?.runCompleted ? (
                                 <Button
-                                    size="sm"
+                                    size="lg"
                                     color="warning"
                                     variant="outlined"
                                     loading={syncRecoveryPending}
@@ -451,6 +539,7 @@ function DeliveryCurrentStopCommandCenter({
         <div className="grid min-w-0 grid-cols-2 gap-2 max-[340px]:grid-cols-1">
             {routeSyncBlocked || stop.reroutePending || deferred ? (
                 <Button
+                    size="lg"
                     aria-label={
                         offline
                             ? 'Navigacija do trenutačne stanice čeka novi plan'
@@ -465,6 +554,7 @@ function DeliveryCurrentStopCommandCenter({
                 </Button>
             ) : (
                 <Button
+                    size="lg"
                     aria-label="Navigacija do trenutačne stanice"
                     className="min-w-0"
                     href={navigationUrl}
@@ -479,6 +569,7 @@ function DeliveryCurrentStopCommandCenter({
             {contacts.map((contact) => (
                 <Button
                     key={contact.phone}
+                    size="lg"
                     aria-label={`Nazovi ${contact.label}`}
                     className="min-w-0"
                     href={`tel:${contact.phone}`}
@@ -571,6 +662,7 @@ function DeliveryCurrentStopCommandCenter({
                 >
                     <Button
                         className="w-full"
+                        size="lg"
                         color="warning"
                         loading={effectivePendingAction === 'retry'}
                         disabled={
@@ -614,6 +706,7 @@ function DeliveryCurrentStopCommandCenter({
                         {arrived && (pendingArrival || acknowledgedArrival) ? (
                             <Button
                                 variant="outlined"
+                                size="lg"
                                 disabled
                                 aria-describedby={
                                     syncEntry?.command.kind === 'arrive'
@@ -633,9 +726,10 @@ function DeliveryCurrentStopCommandCenter({
                             <Button
                                 className={
                                     pendingArrival || acknowledgedArrival
-                                        ? 'col-span-2'
-                                        : undefined
+                                        ? 'col-span-2 motion-reduce:transition-none'
+                                        : 'motion-reduce:transition-none'
                                 }
+                                size="lg"
                                 color="success"
                                 loading={effectivePendingAction === 'deliver'}
                                 disabled={
@@ -650,13 +744,15 @@ function DeliveryCurrentStopCommandCenter({
                                         ? syncStatusId
                                         : undefined
                                 }
-                                onClick={() =>
-                                    !handoff
-                                        ? void runCommand('deliver', () =>
-                                              onDeliver?.(notes || undefined),
-                                          )
-                                        : setDeliveryConfirmationOpen(true)
-                                }
+                                onClick={(event) => {
+                                    if (completionDialogRequired) {
+                                        openCompletionDialog(
+                                            event.currentTarget,
+                                        );
+                                        return;
+                                    }
+                                    void confirmDelivery();
+                                }}
                                 startDecorator={<Approved className="size-4" />}
                             >
                                 {syncEntry?.command.kind === 'deliver'
@@ -670,6 +766,8 @@ function DeliveryCurrentStopCommandCenter({
                         ) : (
                             <Button
                                 variant="outlined"
+                                size="lg"
+                                className="motion-reduce:transition-none"
                                 loading={effectivePendingAction === 'arrive'}
                                 disabled={
                                     Boolean(effectivePendingAction) ||
@@ -694,6 +792,28 @@ function DeliveryCurrentStopCommandCenter({
                             </Button>
                         )}
                     </div>
+                    {!arrived && onDeliver ? (
+                        <Button
+                            type="button"
+                            size="lg"
+                            fullWidth
+                            variant="outlined"
+                            color="warning"
+                            className="motion-reduce:transition-none"
+                            loading={effectivePendingAction === 'deliver'}
+                            disabled={
+                                Boolean(effectivePendingAction) ||
+                                routeCommandBlocked ||
+                                deliveryQueued ||
+                                actionableDeliveries.length === 0
+                            }
+                            onClick={(event) =>
+                                openCompletionDialog(event.currentTarget)
+                            }
+                        >
+                            Dostavi bez potvrde dolaska
+                        </Button>
+                    ) : null}
                     {commandStatus}
                 </fieldset>
             )}
@@ -777,30 +897,6 @@ function DeliveryCurrentStopCommandCenter({
                             onMarkRemainingReviewed={
                                 handoff?.markRemainingReviewed
                             }
-                            completionConfirmation={
-                                !handoff
-                                    ? undefined
-                                    : {
-                                          open: deliveryConfirmationOpen,
-                                          pending:
-                                              effectivePendingAction ===
-                                              'deliver',
-                                          disabled:
-                                              routeCommandBlocked ||
-                                              deliveryQueued ||
-                                              actionableDeliveries.length ===
-                                                  0 ||
-                                              !onDeliver,
-                                          onOpenChange:
-                                              setDeliveryConfirmationOpen,
-                                          onConfirm: () =>
-                                              runCommand('deliver', () =>
-                                                  onDeliver?.(
-                                                      notes || undefined,
-                                                  ),
-                                              ),
-                                      }
-                            }
                             verifiedTracePaths={verifiedTracePaths}
                             onVerifiedTrace={onVerificationScan}
                         />
@@ -831,6 +927,31 @@ function DeliveryCurrentStopCommandCenter({
                     </label>
                 </>
             )}
+            <DeliveryHandoffCompletionDialog
+                confirmation={{
+                    open: deliveryConfirmationOpen,
+                    pending: effectivePendingAction === 'deliver',
+                    disabled:
+                        routeCommandBlocked ||
+                        deliveryQueued ||
+                        actionableDeliveries.length === 0 ||
+                        !onDeliver,
+                    arrived,
+                    overrideBypasses: completionOverrideBypasses,
+                    recipientCount: stop.recipientCount,
+                    returnFocusRef: completionTriggerRef,
+                    onOpenChange: setDeliveryConfirmationOpen,
+                    onConfirm: confirmDelivery,
+                }}
+                deliveries={actionableDeliveries}
+                handoffSyncState={
+                    handoff === undefined
+                        ? 'ready'
+                        : (handoffView?.syncState ?? 'loading')
+                }
+                items={completionHandoffItems}
+                summary={completionSummary}
+            />
         </section>
     );
 }
@@ -986,7 +1107,7 @@ function PickupCurrentStopCommandCenter({
                                 <div className="flex flex-wrap gap-2">
                                     {sync.state === 'failed' ? (
                                         <Button
-                                            size="sm"
+                                            size="lg"
                                             variant="outlined"
                                             loading={recoveryPending}
                                             disabled={
@@ -1009,7 +1130,7 @@ function PickupCurrentStopCommandCenter({
                                     ) : null}
                                     {sync.state === 'conflicted' ? (
                                         <Button
-                                            size="sm"
+                                            size="lg"
                                             variant="plain"
                                             loading={recoveryPending}
                                             disabled={
@@ -1131,6 +1252,7 @@ function PickupCurrentStopCommandCenter({
             <div className="grid grid-cols-2 gap-2 max-[340px]:grid-cols-1">
                 {routeSyncBlocked ? (
                     <Button
+                        size="lg"
                         aria-label="Navigacija do trenutačne stanice preuzimanja čeka novi plan"
                         disabled
                         variant="outlined"
@@ -1140,6 +1262,7 @@ function PickupCurrentStopCommandCenter({
                     </Button>
                 ) : (
                     <Button
+                        size="lg"
                         aria-label="Navigacija do trenutačne stanice preuzimanja"
                         href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(pickup.address)}`}
                         target="_blank"
@@ -1160,6 +1283,7 @@ function PickupCurrentStopCommandCenter({
                     />
                 ) : (
                     <Button
+                        size="lg"
                         disabled
                         startDecorator={<Timer className="size-4" />}
                     >
@@ -1225,7 +1349,7 @@ function PickupCurrentStopCommandCenter({
                                     {item.state === 'ready' ? (
                                         <div className="grid gap-2 sm:grid-cols-2">
                                             <Button
-                                                size="sm"
+                                                size="lg"
                                                 variant="outlined"
                                                 loading={
                                                     effectivePendingAction ===
@@ -1251,7 +1375,7 @@ function PickupCurrentStopCommandCenter({
                                                 Preuzeto bez QR etikete
                                             </Button>
                                             <Button
-                                                size="sm"
+                                                size="lg"
                                                 color="warning"
                                                 variant="outlined"
                                                 loading={
@@ -1280,7 +1404,7 @@ function PickupCurrentStopCommandCenter({
                                         </div>
                                     ) : (
                                         <Button
-                                            size="sm"
+                                            size="lg"
                                             variant="outlined"
                                             loading={
                                                 effectivePendingAction ===
@@ -1313,6 +1437,7 @@ function PickupCurrentStopCommandCenter({
 
                     {unresolvedReady.length > 1 ? (
                         <Button
+                            size="lg"
                             variant="outlined"
                             loading={
                                 effectivePendingAction === 'resolve-remaining'
@@ -1340,6 +1465,7 @@ function PickupCurrentStopCommandCenter({
                     ) : null}
 
                     <Button
+                        size="lg"
                         className="w-full"
                         color="success"
                         loading={effectivePendingAction === 'confirm-manifest'}

--- a/apps/delivery/components/DriverDashboard.tsx
+++ b/apps/delivery/components/DriverDashboard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { DeliveryRunCompletionOverrideReason } from '@gredice/storage';
 import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
@@ -567,6 +568,7 @@ export function DriverDashboard({
         stopId: number,
         expectedRouteRevision: number,
         notes?: string,
+        completionOverride?: { reason: DeliveryRunCompletionOverrideReason },
     ) => unknown | Promise<unknown>;
     onException: (
         runId: string,
@@ -1048,12 +1050,13 @@ export function DriverDashboard({
                                 }
                                 onDeliver={
                                     currentDeliveryStopId
-                                        ? (notes) =>
+                                        ? (notes, completionOverride) =>
                                               onDeliver(
                                                   run.id,
                                                   currentDeliveryStopId,
                                                   run.routeRevision,
                                                   notes,
+                                                  completionOverride,
                                               )
                                         : undefined
                                 }

--- a/apps/delivery/components/HarvestTraceScanner.tsx
+++ b/apps/delivery/components/HarvestTraceScanner.tsx
@@ -501,6 +501,7 @@ export function HarvestTraceScanner({
     return (
         <>
             <Button
+                size="lg"
                 variant="outlined"
                 disabled={disabled || availableTraceCount === 0}
                 onClick={openScanner}
@@ -634,6 +635,7 @@ export function HarvestTraceScanner({
                                         .length > 0 ? (
                                         <Button
                                             size="sm"
+                                            className="min-h-11 min-w-11"
                                             variant="outlined"
                                             onClick={() =>
                                                 replacePickupSelection(
@@ -648,6 +650,7 @@ export function HarvestTraceScanner({
                                         .length > 0 ? (
                                         <Button
                                             size="sm"
+                                            className="min-h-11 min-w-11"
                                             variant="plain"
                                             onClick={() =>
                                                 replacePickupSelection(
@@ -708,6 +711,7 @@ export function HarvestTraceScanner({
                         />
                         <Button
                             type="submit"
+                            size="lg"
                             variant="outlined"
                             disabled={!manualValue.trim()}
                             className="sm:mb-5"
@@ -717,6 +721,7 @@ export function HarvestTraceScanner({
                     </form>
 
                     <Button
+                        size="lg"
                         className="w-full"
                         onClick={() => changeScannerOpen(false)}
                     >

--- a/apps/delivery/components/OfflineRoutePanel.tsx
+++ b/apps/delivery/components/OfflineRoutePanel.tsx
@@ -1,11 +1,13 @@
 'use client';
 
+import type { DeliveryRunCompletionOverrideReason } from '@gredice/storage';
 import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { Chip } from '@gredice/ui/Chip';
 import { Navigate, Warning } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
 import type { ReactNode } from 'react';
+import { croatianCountLabel } from '../lib/croatianCount';
 import {
     deliveryActionAcknowledgementBlocksRoute,
     deliveryActionCompletionMessage,
@@ -133,7 +135,12 @@ function offlineTimelineItems(
                 ? step.name
                 : step.items.length === 1
                   ? (step.items[0]?.contactName ?? step.statusLabel)
-                  : `${step.items.length} primatelja`,
+                  : croatianCountLabel(
+                        step.recipientCount ?? step.items.length,
+                        'primatelj',
+                        'primatelja',
+                        'primatelja',
+                    ),
         destination: step.address,
         deliveryCount:
             step.kind === 'pickup' ? step.expectedCount : step.items.length,
@@ -238,6 +245,9 @@ function offlineDeliveryStop(
         tracking: null,
         runId,
         deliveryCount: step.items.length,
+        ...(step.recipientCount !== undefined
+            ? { recipientCount: step.recipientCount }
+            : {}),
         deliveries: offlineDeliveryItems(step),
         actionState: 'current',
         lockedReason: step.lockedReason,
@@ -294,6 +304,7 @@ export function OfflineRoutePanel({
         stopId: number,
         routeRevision: number,
         notes?: string,
+        completionOverride?: { reason: DeliveryRunCompletionOverrideReason },
     ) => unknown | Promise<unknown>;
     onException: (
         stopId: number,
@@ -374,11 +385,12 @@ export function OfflineRoutePanel({
                                 snapshot.source.routeRevision,
                             )
                         }
-                        onDeliver={(notes) =>
+                        onDeliver={(notes, completionOverride) =>
                             onDeliver(
                                 currentDeliveryStop.id,
                                 snapshot.source.routeRevision,
                                 notes,
+                                completionOverride,
                             )
                         }
                         onException={(mutation) =>

--- a/apps/delivery/components/OfflineRouteRecovery.tsx
+++ b/apps/delivery/components/OfflineRouteRecovery.tsx
@@ -98,8 +98,15 @@ export function OfflineRouteRecovery({
                 onArrive={(stopId, routeRevision) =>
                     report(sync.enqueueArrive(stopId, routeRevision))
                 }
-                onDeliver={(stopId, routeRevision, notes) =>
-                    report(sync.enqueueDelivery(stopId, routeRevision, notes))
+                onDeliver={(stopId, routeRevision, notes, completionOverride) =>
+                    report(
+                        sync.enqueueDelivery(
+                            stopId,
+                            routeRevision,
+                            notes,
+                            completionOverride,
+                        ),
+                    )
                 }
                 onException={async (stopId, mutation) => {
                     try {

--- a/apps/delivery/hooks/useDeliveryActionSync.ts
+++ b/apps/delivery/hooks/useDeliveryActionSync.ts
@@ -1,6 +1,9 @@
 'use client';
 
-import type { DeliveryRunHandoffSkipReason } from '@gredice/storage';
+import type {
+    DeliveryRunCompletionOverrideInput,
+    DeliveryRunHandoffSkipReason,
+} from '@gredice/storage';
 import {
     useCallback,
     useEffect,
@@ -442,6 +445,7 @@ export function useDeliveryActionSync({
             stopId: number,
             serverRouteRevision: number,
             notes?: string,
+            completionOverride?: DeliveryRunCompletionOverrideInput,
         ) =>
             enqueueRouteAction(serverRouteRevision, (expectedRouteRevision) =>
                 createDeliveryCompleteCommand({
@@ -450,6 +454,7 @@ export function useDeliveryActionSync({
                     stopId,
                     expectedRouteRevision,
                     notes,
+                    completionOverride,
                 }),
             ),
         enqueueException: (

--- a/apps/delivery/lib/croatianCount.node.spec.ts
+++ b/apps/delivery/lib/croatianCount.node.spec.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { croatianCountLabel } from './croatianCount';
+
+test('selects Croatian singular, paucal, and plural count forms', () => {
+    const label = (count: number) =>
+        croatianCountLabel(count, 'iznimka', 'iznimke', 'iznimki');
+
+    assert.deepEqual([0, 1, 2, 4, 5, 11, 21, 22].map(label), [
+        '0 iznimki',
+        '1 iznimka',
+        '2 iznimke',
+        '4 iznimke',
+        '5 iznimki',
+        '11 iznimki',
+        '21 iznimka',
+        '22 iznimke',
+    ]);
+});

--- a/apps/delivery/lib/croatianCount.ts
+++ b/apps/delivery/lib/croatianCount.ts
@@ -1,0 +1,18 @@
+export function croatianCountLabel(
+    count: number,
+    singular: string,
+    paucal: string,
+    plural: string,
+) {
+    const lastTwoDigits = count % 100;
+    const lastDigit = count % 10;
+    const form =
+        lastDigit === 1 && lastTwoDigits !== 11
+            ? singular
+            : lastDigit >= 2 &&
+                lastDigit <= 4 &&
+                (lastTwoDigits < 12 || lastTwoDigits > 14)
+              ? paucal
+              : plural;
+    return `${count} ${form}`;
+}

--- a/apps/delivery/lib/deliveryActionPresentation.node.spec.ts
+++ b/apps/delivery/lib/deliveryActionPresentation.node.spec.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
     deliveryActionCompletionMessage,
+    deliveryActionPermanentFailureMessage,
     deliveryRouteStepsWithLocalActions,
 } from './deliveryActionPresentation';
 import type {
@@ -15,6 +16,23 @@ import type {
 } from './deliveryDashboardTypes';
 
 const occurredAt = '2026-07-15T12:00:00.000Z';
+
+test('explains how to recover when completion requires an override reason', () => {
+    assert.match(
+        deliveryActionPermanentFailureMessage(
+            'completion-override-required',
+            'stop',
+        ),
+        /Učitaj stanje poslužitelja, zatim odaberi razlog/,
+    );
+    assert.match(
+        deliveryActionPermanentFailureMessage(
+            'completion-override-required',
+            'global',
+        ),
+        /ponovno potvrdi dostavu s razlogom/,
+    );
+});
 
 function stop(id: number, isCurrent: boolean): DeliveryStopSummary {
     return {

--- a/apps/delivery/lib/deliveryActionPresentation.ts
+++ b/apps/delivery/lib/deliveryActionPresentation.ts
@@ -17,6 +17,11 @@ export function deliveryActionPermanentFailureMessage(
     errorCode: string | undefined,
     scope: 'global' | 'stop',
 ) {
+    if (errorCode === 'completion-override-required') {
+        return scope === 'global'
+            ? 'Dostava traži razlog za nastavak bez potvrđenog dolaska ili pregleda uroda. Učitaj trenutačno stanje i ponovno potvrdi dostavu s razlogom.'
+            : 'Učitaj stanje poslužitelja, zatim odaberi razlog za dostavu bez pune provjere i ponovno potvrdi dostavu.';
+    }
     if (changedRouteCodes.has(errorCode ?? '')) {
         return scope === 'global'
             ? 'Ruta na poslužitelju se promijenila. Lokalna radnja i sve ovisne radnje ostaju blokirane.'

--- a/apps/delivery/lib/deliveryActionQueue.node.spec.ts
+++ b/apps/delivery/lib/deliveryActionQueue.node.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { DeliveryRunCompletionOverrideReasons } from '@gredice/storage';
 import {
     deliveryRunCompletedMessage,
     deliveryRunCompletionFromSnapshot,
@@ -117,6 +118,89 @@ test('normalizes immutable route commands and rejects malformed payloads', () =>
                 now,
             }),
         TypeError,
+    );
+
+    const completionOverride = {
+        reason: DeliveryRunCompletionOverrideReasons.DEVICE_UNAVAILABLE,
+    };
+    const overridden = createDeliveryCompleteCommand({
+        operationId: 'deliver-with-override',
+        runId: scope.runId,
+        stopId: 101,
+        expectedRouteRevision: 5,
+        completionOverride,
+        now,
+    });
+    assert.deepEqual(overridden.completionOverride, completionOverride);
+    assert.notEqual(overridden.completionOverride, completionOverride);
+    assert.throws(
+        () =>
+            Reflect.apply(createDeliveryCompleteCommand, undefined, [
+                {
+                    operationId: 'deliver-invalid-override',
+                    runId: scope.runId,
+                    stopId: 101,
+                    expectedRouteRevision: 5,
+                    completionOverride: {
+                        reason: 'unsupported-reason',
+                    },
+                    now,
+                },
+            ]),
+        TypeError,
+    );
+});
+
+test('persists a completion override and its bounded server acknowledgement', async () => {
+    const persistence = createMemoryDeliveryActionQueuePersistence();
+    const command = createDeliveryCompleteCommand({
+        operationId: 'deliver-override-persisted',
+        runId: scope.runId,
+        stopId: 101,
+        expectedRouteRevision: 5,
+        completionOverride: {
+            reason: DeliveryRunCompletionOverrideReasons.WORKFLOW_RECOVERY,
+        },
+        now,
+    });
+    const actionQueue = queue({
+        persistence,
+        transport: async () => ({
+            status: 'applied',
+            routeRevision: 6,
+            reroutePending: false,
+            runCompleted: false,
+            override: {
+                reason: DeliveryRunCompletionOverrideReasons.WORKFLOW_RECOVERY,
+                bypassed: ['arrival', 'handoff-review'],
+            },
+        }),
+    });
+
+    await actionQueue.enqueue(command);
+    await actionQueue.replay();
+    const restored = await queue({ persistence }).restore();
+
+    assert.deepEqual(restored.entries[0]?.command, command);
+    assert.deepEqual(restored.entries[0]?.acknowledgement, {
+        kind: 'server',
+        replayed: false,
+        routeRevision: 6,
+        reroutePending: false,
+        runCompleted: false,
+        override: {
+            reason: DeliveryRunCompletionOverrideReasons.WORKFLOW_RECOVERY,
+            bypassed: ['arrival', 'handoff-review'],
+        },
+    });
+    await assert.rejects(
+        actionQueue.enqueue({
+            ...command,
+            completionOverride: {
+                reason: DeliveryRunCompletionOverrideReasons.MANUAL_HANDOFF,
+            },
+        }),
+        DeliveryActionOperationConflictError,
     );
 });
 

--- a/apps/delivery/lib/deliveryActionQueue.ts
+++ b/apps/delivery/lib/deliveryActionQueue.ts
@@ -1,4 +1,7 @@
 import type {
+    DeliveryRunCompletionOverrideInput,
+    DeliveryRunCompletionOverrideReason,
+    DeliveryRunCompletionOverrideStoredResult,
     DeliveryRunHandoffItemState,
     DeliveryRunHandoffSkipReason,
 } from '@gredice/storage';
@@ -29,6 +32,7 @@ export type DeliveryArriveCommand = DeliveryRouteCommandBase & {
 export type DeliveryCompleteCommand = DeliveryRouteCommandBase & {
     kind: 'deliver';
     notes?: string;
+    completionOverride?: DeliveryRunCompletionOverrideInput;
 };
 
 export type DeliveryExceptionCommand = DeliveryRouteCommandBase & {
@@ -92,6 +96,7 @@ export type DeliveryRouteActionAcknowledgement = {
     routeRevision?: number;
     reroutePending?: boolean;
     runCompleted?: boolean;
+    override?: DeliveryRunCompletionOverrideStoredResult;
 };
 
 export type DeliveryHandoffOperationOutcome =
@@ -157,12 +162,14 @@ export type DeliveryActionTransportResult =
           routeRevision: number;
           reroutePending: boolean;
           runCompleted: boolean;
+          override?: DeliveryRunCompletionOverrideStoredResult;
       }
     | {
           status: 'exact-duplicate';
           routeRevision: number;
           reroutePending: boolean;
           runCompleted: boolean;
+          override?: DeliveryRunCompletionOverrideStoredResult;
       }
     | {
           status: 'handoff-acknowledged';
@@ -298,6 +305,49 @@ function validNote(value: unknown): value is string | undefined {
     );
 }
 
+function validCompletionOverrideReason(
+    value: unknown,
+): value is DeliveryRunCompletionOverrideReason {
+    return (
+        value === 'device-unavailable' ||
+        value === 'workflow-recovery' ||
+        value === 'manual-handoff' ||
+        value === 'other-operational'
+    );
+}
+
+function validCompletionOverride(
+    value: unknown,
+): value is DeliveryRunCompletionOverrideInput | undefined {
+    return (
+        value === undefined ||
+        (isRecord(value) &&
+            Object.keys(value).length === 1 &&
+            validCompletionOverrideReason(value.reason))
+    );
+}
+
+function validCompletionOverrideResult(
+    value: unknown,
+): value is DeliveryRunCompletionOverrideStoredResult | undefined {
+    if (value === undefined) return true;
+    if (
+        !isRecord(value) ||
+        Object.keys(value).some(
+            (key) => key !== 'reason' && key !== 'bypassed',
+        ) ||
+        !validCompletionOverrideReason(value.reason) ||
+        !Array.isArray(value.bypassed) ||
+        value.bypassed.length > 2 ||
+        value.bypassed.some(
+            (bypass) => bypass !== 'arrival' && bypass !== 'handoff-review',
+        )
+    ) {
+        return false;
+    }
+    return new Set(value.bypassed).size === value.bypassed.length;
+}
+
 function validReason(value: unknown): value is DeliveryExceptionReason {
     return (
         value === 'customer-unavailable' ||
@@ -417,8 +467,15 @@ function isDeliveryActionCommand(
     }
     if (isDeliveryHandoffCommand(value)) return true;
     if (!validRevision(value.expectedRouteRevision)) return false;
-    if (value.kind === 'arrive') return true;
-    if (value.kind === 'deliver') return validNote(value.notes);
+    if (value.kind === 'arrive') {
+        return value.completionOverride === undefined;
+    }
+    if (value.kind === 'deliver') {
+        return (
+            validNote(value.notes) &&
+            validCompletionOverride(value.completionOverride)
+        );
+    }
     return (
         value.kind === 'exception' &&
         Array.isArray(value.exceptions) &&
@@ -501,7 +558,8 @@ function isAcknowledgement(
         (value.reroutePending === undefined ||
             typeof value.reroutePending === 'boolean') &&
         (value.runCompleted === undefined ||
-            typeof value.runCompleted === 'boolean')
+            typeof value.runCompleted === 'boolean') &&
+        validCompletionOverrideResult(value.override)
     );
 }
 
@@ -543,6 +601,21 @@ function isEntry(value: unknown): value is DeliveryActionQueueEntry {
     }
     if (isDeliveryHandoffCommand(value.command)) {
         return value.state !== 'synced' && value.acknowledgement === undefined;
+    }
+    if (value.acknowledgement?.kind === 'server') {
+        const commandOverride =
+            value.command.kind === 'deliver'
+                ? value.command.completionOverride
+                : undefined;
+        const acknowledgementOverride = value.acknowledgement.override;
+        if (
+            (commandOverride === undefined) !==
+                (acknowledgementOverride === undefined) ||
+            (commandOverride &&
+                acknowledgementOverride?.reason !== commandOverride.reason)
+        ) {
+            return false;
+        }
     }
     return (
         value.acknowledgement?.kind !== 'server' ||
@@ -641,16 +714,27 @@ export function createDeliveryArriveCommand({
 
 export function createDeliveryCompleteCommand({
     notes,
+    completionOverride,
     occurredAt,
     now = () => new Date(),
     ...input
-}: DeliveryRouteCommandInput & { notes?: string }): DeliveryCompleteCommand {
+}: DeliveryRouteCommandInput & {
+    notes?: string;
+    completionOverride?: DeliveryRunCompletionOverrideInput;
+}): DeliveryCompleteCommand {
     const normalizedNotes = notes?.trim();
     return validatedCommand({
         ...input,
         kind: 'deliver',
         occurredAt: resolvedOccurredAt(occurredAt, now),
         ...(normalizedNotes ? { notes: normalizedNotes } : {}),
+        ...(completionOverride
+            ? {
+                  completionOverride: {
+                      reason: completionOverride.reason,
+                  },
+              }
+            : {}),
     });
 }
 
@@ -1628,6 +1712,9 @@ export class DeliveryActionQueue {
                             routeRevision: result.routeRevision,
                             reroutePending: result.reroutePending,
                             runCompleted: result.runCompleted,
+                            ...(result.override
+                                ? { override: cloneValue(result.override) }
+                                : {}),
                         };
                         delete entry.errorCode;
                     }

--- a/apps/delivery/lib/deliveryActionTransport.node.spec.ts
+++ b/apps/delivery/lib/deliveryActionTransport.node.spec.ts
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { DeliveryRunCompletionOverrideReasons } from '@gredice/storage';
 import {
     createDeliveryArriveCommand,
+    createDeliveryCompleteCommand,
     createDeliveryExceptionCommand,
     createDeliveryVerificationMarkCommand,
     createDeliveryVerificationScanCommand,
@@ -10,6 +12,7 @@ import {
     deliveryActionAcknowledgement,
     deliveryActionHttpFailure,
     deliveryHandoffAcknowledgement,
+    sendDeliveryAction,
 } from './deliveryActionTransport';
 
 const arrive = createDeliveryArriveCommand({
@@ -65,6 +68,154 @@ test('accepts only the exact route-operation receipt contract', () => {
             code: 'invalid-acknowledgement',
         },
     );
+});
+
+test('round-trips and strictly validates completion override receipts', () => {
+    const command = createDeliveryCompleteCommand({
+        operationId: 'delivery-override-1',
+        runId: 'run-1',
+        stopId: 22,
+        expectedRouteRevision: 3,
+        occurredAt: '2026-07-15T12:00:00.000Z',
+        completionOverride: {
+            reason: DeliveryRunCompletionOverrideReasons.DEVICE_UNAVAILABLE,
+        },
+    });
+    const acknowledgement = {
+        clientOperationId: command.operationId,
+        replayed: false,
+        result: {
+            kind: 'deliver',
+            targetStopId: 22,
+            affectedStopIds: [22, 23],
+            routeRevision: 4,
+            reroutePending: false,
+            runCompleted: false,
+            override: {
+                reason: DeliveryRunCompletionOverrideReasons.DEVICE_UNAVAILABLE,
+                bypassed: ['arrival', 'handoff-review'],
+            },
+        },
+    };
+
+    assert.deepEqual(deliveryActionAcknowledgement(acknowledgement, command), {
+        status: 'applied',
+        routeRevision: 4,
+        reroutePending: false,
+        runCompleted: false,
+        override: {
+            reason: DeliveryRunCompletionOverrideReasons.DEVICE_UNAVAILABLE,
+            bypassed: ['arrival', 'handoff-review'],
+        },
+    });
+
+    for (const override of [
+        undefined,
+        {
+            reason: DeliveryRunCompletionOverrideReasons.MANUAL_HANDOFF,
+            bypassed: ['arrival'],
+        },
+        {
+            reason: DeliveryRunCompletionOverrideReasons.DEVICE_UNAVAILABLE,
+            bypassed: ['arrival', 'arrival'],
+        },
+        {
+            reason: DeliveryRunCompletionOverrideReasons.DEVICE_UNAVAILABLE,
+            bypassed: ['arrival', 'handoff-review', 'future-bypass'],
+        },
+    ]) {
+        assert.deepEqual(
+            deliveryActionAcknowledgement(
+                {
+                    ...acknowledgement,
+                    result: { ...acknowledgement.result, override },
+                },
+                command,
+            ),
+            {
+                status: 'retryable-failure',
+                code: 'invalid-acknowledgement',
+            },
+        );
+    }
+
+    assert.deepEqual(
+        deliveryActionAcknowledgement(
+            acknowledgement,
+            createDeliveryCompleteCommand({
+                operationId: 'delivery-override-1',
+                runId: 'run-1',
+                stopId: 22,
+                expectedRouteRevision: 3,
+                occurredAt: '2026-07-15T12:00:00.000Z',
+            }),
+        ),
+        {
+            status: 'retryable-failure',
+            code: 'invalid-acknowledgement',
+        },
+    );
+});
+
+test('posts a completion override as a strict nested delivery payload', async () => {
+    const originalFetch = globalThis.fetch;
+    let body: unknown;
+    globalThis.fetch = async (_input, init) => {
+        body = JSON.parse(String(init?.body));
+        return Response.json({
+            clientOperationId: 'delivery-override-post',
+            replayed: false,
+            result: {
+                kind: 'deliver',
+                targetStopId: 22,
+                affectedStopIds: [22],
+                routeRevision: 4,
+                reroutePending: false,
+                runCompleted: false,
+                override: {
+                    reason: DeliveryRunCompletionOverrideReasons.WORKFLOW_RECOVERY,
+                    bypassed: ['handoff-review'],
+                },
+            },
+        });
+    };
+    try {
+        const result = await sendDeliveryAction(
+            createDeliveryCompleteCommand({
+                operationId: 'delivery-override-post',
+                runId: 'run-1',
+                stopId: 22,
+                expectedRouteRevision: 3,
+                occurredAt: '2026-07-15T12:00:00.000Z',
+                notes: 'Predano ručno',
+                completionOverride: {
+                    reason: DeliveryRunCompletionOverrideReasons.WORKFLOW_RECOVERY,
+                },
+            }),
+        );
+
+        assert.deepEqual(body, {
+            clientOperationId: 'delivery-override-post',
+            occurredAt: '2026-07-15T12:00:00.000Z',
+            expectedRouteRevision: 3,
+            notes: 'Predano ručno',
+            completionOverride: {
+                reason: DeliveryRunCompletionOverrideReasons.WORKFLOW_RECOVERY,
+            },
+        });
+        assert.deepEqual(result, {
+            status: 'applied',
+            routeRevision: 4,
+            reroutePending: false,
+            runCompleted: false,
+            override: {
+                reason: DeliveryRunCompletionOverrideReasons.WORKFLOW_RECOVERY,
+                bypassed: ['handoff-review'],
+            },
+        });
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
 });
 
 test('validates the existing idempotent exception acknowledgement', () => {

--- a/apps/delivery/lib/deliveryActionTransport.ts
+++ b/apps/delivery/lib/deliveryActionTransport.ts
@@ -1,4 +1,9 @@
 import type {
+    DeliveryRunCompletionBypass,
+    DeliveryRunCompletionOverrideReason,
+    DeliveryRunCompletionOverrideStoredResult,
+} from '@gredice/storage';
+import type {
     DeliveryActionTransportResult,
     DeliveryHandoffCommand,
     DeliveryHandoffOperationResult,
@@ -53,6 +58,48 @@ function validHandoffSkipReason(value: unknown) {
         value === 'manual-verification' ||
         value === 'other-operational'
     );
+}
+
+function validCompletionOverrideReason(
+    value: unknown,
+): value is DeliveryRunCompletionOverrideReason {
+    return (
+        value === 'device-unavailable' ||
+        value === 'workflow-recovery' ||
+        value === 'manual-handoff' ||
+        value === 'other-operational'
+    );
+}
+
+function validCompletionBypass(
+    value: unknown,
+): value is DeliveryRunCompletionBypass {
+    return value === 'arrival' || value === 'handoff-review';
+}
+
+function completionOverrideResult(
+    value: unknown,
+    command: DeliveryRouteActionCommand,
+): DeliveryRunCompletionOverrideStoredResult | null | undefined {
+    const expected =
+        command.kind === 'deliver' ? command.completionOverride : undefined;
+    if (!expected) return value === undefined ? undefined : null;
+    if (
+        !isRecord(value) ||
+        !hasOnlyKeys(value, ['reason', 'bypassed']) ||
+        value.reason !== expected.reason ||
+        !validCompletionOverrideReason(value.reason) ||
+        !Array.isArray(value.bypassed) ||
+        value.bypassed.length > 2 ||
+        !value.bypassed.every(validCompletionBypass) ||
+        new Set(value.bypassed).size !== value.bypassed.length
+    ) {
+        return null;
+    }
+    return {
+        reason: value.reason,
+        bypassed: [...value.bypassed],
+    };
 }
 
 function responseCode(value: unknown) {
@@ -122,6 +169,10 @@ export function deliveryActionAcknowledgement(
         };
     }
     const result = value.result;
+    const override =
+        isRecord(result) && 'override' in result
+            ? completionOverrideResult(result.override, command)
+            : completionOverrideResult(undefined, command);
     if (
         !isRecord(result) ||
         result.kind !== command.kind ||
@@ -131,7 +182,8 @@ export function deliveryActionAcknowledgement(
         !result.affectedStopIds.every(validStopId) ||
         !validRevision(result.routeRevision) ||
         typeof result.reroutePending !== 'boolean' ||
-        typeof result.runCompleted !== 'boolean'
+        typeof result.runCompleted !== 'boolean' ||
+        override === null
     ) {
         return {
             status: 'retryable-failure',
@@ -143,6 +195,7 @@ export function deliveryActionAcknowledgement(
         routeRevision: result.routeRevision,
         reroutePending: result.reroutePending,
         runCompleted: result.runCompleted,
+        ...(override ? { override } : {}),
     };
 }
 
@@ -322,6 +375,13 @@ function requestBody(command: DeliveryServerActionCommand) {
         return {
             ...common,
             ...(command.notes ? { notes: command.notes } : {}),
+            ...(command.completionOverride
+                ? {
+                      completionOverride: {
+                          reason: command.completionOverride.reason,
+                      },
+                  }
+                : {}),
         };
     }
     return common;

--- a/apps/delivery/lib/deliveryDashboard.node.spec.ts
+++ b/apps/delivery/lib/deliveryDashboard.node.spec.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
     accountCanTrackCurrentDeliveryGroup,
     deliveryMutationRouteState,
+    deliveryRecipientCount,
     deliveryStatusLabel,
     deliveryTrackingStopIds,
     expandLegacyCurrentDeliveryStopIds,
@@ -15,6 +16,29 @@ import {
 
 const pending = 'pending';
 const delivered = 'delivered';
+
+test('counts actionable recipients by stable server identity', () => {
+    assert.equal(
+        deliveryRecipientCount([
+            {
+                requestId: 'harvest-1',
+                recipientIdentity: 71,
+                actionable: true,
+            },
+            {
+                requestId: 'harvest-2',
+                recipientIdentity: 71,
+                actionable: true,
+            },
+            {
+                requestId: 'terminal-history',
+                recipientIdentity: 99,
+                actionable: false,
+            },
+        ]),
+        1,
+    );
+});
 
 function group(
     items: Array<{

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -3,6 +3,7 @@ import {
     abandonDeliveryRun,
     consumeDeliveryRunPreparation,
     DeliveryRequestStates,
+    type DeliveryRunCompletionOverrideInput,
     DeliveryRunManifestItemStates,
     DeliveryRunManifestStates,
     DeliveryRunStates,
@@ -369,6 +370,24 @@ function deliverySummaryItem(
     };
 }
 
+export function deliveryRecipientCount(
+    items: readonly {
+        requestId: string;
+        recipientIdentity: string | number | null;
+        actionable: boolean;
+    }[],
+) {
+    const actionableItems = items.filter((item) => item.actionable);
+    const countedItems = actionableItems.length > 0 ? actionableItems : items;
+    return new Set(
+        countedItems.map((item) =>
+            item.recipientIdentity === null
+                ? `request:${item.requestId}`
+                : `recipient:${typeof item.recipientIdentity}:${item.recipientIdentity}`,
+        ),
+    ).size;
+}
+
 function deliveryStopSummary({
     items,
     run,
@@ -489,6 +508,17 @@ function deliveryStopSummary({
                 : null,
         runId: run?.id ?? null,
         deliveryCount: items.length,
+        recipientCount: deliveryRecipientCount(
+            items.map(({ request: itemRequest, stop }) => ({
+                requestId: itemRequest.id,
+                recipientIdentity:
+                    stop?.deliveryAddressId ??
+                    itemRequest.address?.id ??
+                    itemRequest.accountId ??
+                    null,
+                actionable: !stop || isDeliveryRunStopActionable(stop.state),
+            })),
+        ),
         deliveries: items.map((item) =>
             deliverySummaryItem(item.request, item.stop, audience),
         ),
@@ -1159,6 +1189,7 @@ export async function deliverDeliveryStop({
     runId,
     stopId,
     notes,
+    completionOverride,
     expectedRouteRevision,
     clientOperationId,
     occurredAt,
@@ -1167,6 +1198,7 @@ export async function deliverDeliveryStop({
     runId: string;
     stopId: number;
     notes?: string;
+    completionOverride?: DeliveryRunCompletionOverrideInput;
     expectedRouteRevision: number;
     clientOperationId: string;
     occurredAt: Date;
@@ -1177,6 +1209,7 @@ export async function deliverDeliveryStop({
         runId,
         targetStopId: stopId,
         deliveryNotes: notes,
+        completionOverride,
         expectedRouteRevision,
         clientOperationId,
         occurredAt,

--- a/apps/delivery/lib/deliveryDashboardTypes.ts
+++ b/apps/delivery/lib/deliveryDashboardTypes.ts
@@ -100,6 +100,8 @@ export type DeliveryStopSummary = {
     tracking: CustomerDeliveryTrackingSummary | null;
     runId: string | null;
     deliveryCount: number;
+    /** Server-derived unique recipient count for the actionable physical stop. */
+    recipientCount?: number;
     deliveries: DeliveryStopDeliverySummary[];
     actionState?: 'locked' | 'upcoming' | 'current' | 'completed';
     lockedReason?: string | null;

--- a/apps/delivery/lib/deliveryMutationRequest.node.spec.ts
+++ b/apps/delivery/lib/deliveryMutationRequest.node.spec.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { DeliveryRunStopOperationKinds } from '@gredice/storage';
+import {
+    DeliveryRunCompletionOverrideReasons,
+    DeliveryRunStopOperationKinds,
+} from '@gredice/storage';
 import {
     DeliveryMutationRequestError,
     expectedRouteRevision,
@@ -82,6 +85,9 @@ test('parses strict arrive and deliver stop operation payloads', () => {
             clientOperationId: ' deliver-1 ',
             occurredAt: '2026-07-15T10:05:00.000Z',
             notes: '  Predano susjedu  ',
+            completionOverride: {
+                reason: DeliveryRunCompletionOverrideReasons.MANUAL_HANDOFF,
+            },
         },
         DeliveryRunStopOperationKinds.DELIVER,
     );
@@ -91,6 +97,9 @@ test('parses strict arrive and deliver stop operation payloads', () => {
         clientOperationId: 'deliver-1',
         occurredAt: new Date('2026-07-15T10:05:00.000Z'),
         notes: 'Predano susjedu',
+        completionOverride: {
+            reason: DeliveryRunCompletionOverrideReasons.MANUAL_HANDOFF,
+        },
     });
 });
 
@@ -108,6 +117,12 @@ test('rejects incomplete or unsupported stop operation payloads', () => {
         { ...valid, occurredAt: 'not-a-date' },
         { ...valid, extra: true },
         { ...valid, notes: 'not allowed' },
+        {
+            ...valid,
+            completionOverride: {
+                reason: DeliveryRunCompletionOverrideReasons.DEVICE_UNAVAILABLE,
+            },
+        },
     ]) {
         assert.throws(
             () =>
@@ -123,6 +138,20 @@ test('rejects incomplete or unsupported stop operation payloads', () => {
         { ...valid, notes: 42 },
         { ...valid, notes: 'x'.repeat(1_001) },
         { ...valid, unexpected: 'field' },
+        { ...valid, completionOverride: null },
+        { ...valid, completionOverride: [] },
+        { ...valid, completionOverride: {} },
+        {
+            ...valid,
+            completionOverride: { reason: 'unsupported-reason' },
+        },
+        {
+            ...valid,
+            completionOverride: {
+                reason: DeliveryRunCompletionOverrideReasons.OTHER_OPERATIONAL,
+                extra: true,
+            },
+        },
     ]) {
         assert.throws(
             () =>

--- a/apps/delivery/lib/deliveryMutationRequest.ts
+++ b/apps/delivery/lib/deliveryMutationRequest.ts
@@ -1,4 +1,6 @@
 import {
+    type DeliveryRunCompletionOverrideInput,
+    DeliveryRunCompletionOverrideReasons,
     type DeliveryRunExceptionOutcome,
     DeliveryRunExceptionOutcomes,
     type DeliveryRunExceptionReason,
@@ -13,6 +15,31 @@ export class DeliveryMutationRequestError extends Error {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null;
+}
+
+function completionOverride(
+    value: unknown,
+): DeliveryRunCompletionOverrideInput {
+    if (
+        !isRecord(value) ||
+        Object.keys(value).length !== 1 ||
+        !('reason' in value)
+    ) {
+        throw new DeliveryMutationRequestError(
+            'Razlog dovršetka bez pune provjere nije valjan.',
+        );
+    }
+    switch (value.reason) {
+        case DeliveryRunCompletionOverrideReasons.DEVICE_UNAVAILABLE:
+        case DeliveryRunCompletionOverrideReasons.WORKFLOW_RECOVERY:
+        case DeliveryRunCompletionOverrideReasons.MANUAL_HANDOFF:
+        case DeliveryRunCompletionOverrideReasons.OTHER_OPERATIONAL:
+            return { reason: value.reason };
+        default:
+            throw new DeliveryMutationRequestError(
+                'Razlog dovršetka bez pune provjere nije valjan.',
+            );
+    }
 }
 
 export function expectedRouteRevision(value: unknown) {
@@ -65,7 +92,9 @@ export function parseDeliveryStopMutation(
         'clientOperationId',
         'expectedRouteRevision',
         'occurredAt',
-        ...(kind === DeliveryRunStopOperationKinds.DELIVER ? ['notes'] : []),
+        ...(kind === DeliveryRunStopOperationKinds.DELIVER
+            ? ['notes', 'completionOverride']
+            : []),
     ]);
     if (Object.keys(value).some((key) => !allowedKeys.has(key))) {
         throw new DeliveryMutationRequestError(
@@ -75,6 +104,14 @@ export function parseDeliveryStopMutation(
     if (kind === DeliveryRunStopOperationKinds.ARRIVE && 'notes' in value) {
         throw new DeliveryMutationRequestError(
             'Napomena nije dopuštena za potvrdu dolaska.',
+        );
+    }
+    if (
+        kind === DeliveryRunStopOperationKinds.ARRIVE &&
+        'completionOverride' in value
+    ) {
+        throw new DeliveryMutationRequestError(
+            'Razlog dovršetka nije dopušten za potvrdu dolaska.',
         );
     }
     let notes: string | undefined;
@@ -89,12 +126,20 @@ export function parseDeliveryStopMutation(
             );
         }
     }
+    const parsedCompletionOverride =
+        kind === DeliveryRunStopOperationKinds.DELIVER &&
+        'completionOverride' in value
+            ? completionOverride(value.completionOverride)
+            : undefined;
     return {
         kind,
         expectedRouteRevision: routeRevision,
         clientOperationId: value.clientOperationId.trim(),
         occurredAt,
         ...(notes ? { notes } : {}),
+        ...(parsedCompletionOverride
+            ? { completionOverride: parsedCompletionOverride }
+            : {}),
     };
 }
 

--- a/apps/delivery/lib/deliveryRunExecutionError.node.spec.ts
+++ b/apps/delivery/lib/deliveryRunExecutionError.node.spec.ts
@@ -24,6 +24,20 @@ test('maps typed stop operation failures to conflict responses', () => {
     }
 });
 
+test('maps a missing completion override to actionable recovery copy', () => {
+    const error = new DeliveryRunExecutionError(
+        DeliveryRunExecutionErrorCodes.COMPLETION_OVERRIDE_REQUIRED,
+        'internal detail',
+    );
+
+    assert.deepEqual(deliveryRunExecutionErrorDetails(error), {
+        code: 'completion-override-required',
+        message:
+            'Za dostavu bez potvrđenog dolaska ili pregleda uroda odaberi razlog i ponovno potvrdi dostavu.',
+    });
+    assert.equal(deliveryRunExecutionErrorStatus(error), 409);
+});
+
 test('maps unknown failures to internal server errors without details', () => {
     const error = new Error('database unavailable');
 

--- a/apps/delivery/lib/deliveryRunExecutionError.ts
+++ b/apps/delivery/lib/deliveryRunExecutionError.ts
@@ -63,6 +63,12 @@ export function deliveryRunExecutionErrorDetails(
                 message:
                     'Stanje dostave promijenilo se. Osvježi rutu prije nastavka.',
             };
+        case 'completion-override-required':
+            return {
+                code: error.code,
+                message:
+                    'Za dostavu bez potvrđenog dolaska ili pregleda uroda odaberi razlog i ponovno potvrdi dostavu.',
+            };
         default:
             return {
                 code: error.code,

--- a/apps/delivery/lib/offlineRouteCache.node.spec.ts
+++ b/apps/delivery/lib/offlineRouteCache.node.spec.ts
@@ -70,6 +70,7 @@ function deliveryStep({
         tracking: null,
         runId: 'run-one',
         deliveryCount: 1,
+        recipientCount: 1,
         deliveries: [
             {
                 stopId: id,
@@ -317,6 +318,7 @@ test('projects only the current and immediate next non-completed route steps', (
     assert.equal(current?.kind, 'delivery');
     if (current?.kind === 'delivery') {
         assert.equal(current.address, 'CURRENT_ESSENTIAL door address');
+        assert.equal(current.recipientCount, 1);
         assert.equal(
             current.items[0]?.contactName,
             'CURRENT_ESSENTIAL contact',
@@ -371,6 +373,32 @@ test('serialized projection is an allowlist and excludes privacy canaries', () =
     }
     assert.match(serialized, /CURRENT_ESSENTIAL/);
     assert.match(serialized, /NEXT_PICKUP/);
+});
+
+test('recipient count remains aggregate-only and legacy caches stay readable', () => {
+    const current = firstStep(jsonRecord(snapshot()));
+    assert.equal(current.recipientCount, 1);
+
+    const legacy = jsonRecord(snapshot());
+    delete firstStep(legacy).recipientCount;
+    assert.ok(
+        parseOfflineRouteSnapshot(legacy, {
+            userId: 'driver-one',
+            runId: 'run-one',
+            now,
+        }),
+    );
+
+    const invalid = jsonRecord(snapshot());
+    firstStep(invalid).recipientCount = 0;
+    assert.equal(
+        parseOfflineRouteSnapshot(invalid, {
+            userId: 'driver-one',
+            runId: 'run-one',
+            now,
+        }),
+        null,
+    );
 });
 
 test('parser validates every cached nullable time as a timestamp', () => {

--- a/apps/delivery/lib/offlineRouteCache.ts
+++ b/apps/delivery/lib/offlineRouteCache.ts
@@ -85,6 +85,7 @@ export type OfflineRouteDeliveryStep = OfflineRouteStepBase & {
     retryLaneRank: number | null;
     retryAttempt: number;
     lockedReason: string | null;
+    recipientCount?: number;
     items: OfflineRouteDeliveryItem[];
 };
 
@@ -191,6 +192,9 @@ function projectDeliveryStep(
         retryLaneRank: step.retryLaneRank,
         retryAttempt: step.retryAttempt,
         lockedReason: step.lockedReason,
+        ...(stop.recipientCount !== undefined
+            ? { recipientCount: stop.recipientCount }
+            : {}),
         items: stop.deliveries.flatMap((delivery) =>
             delivery.stopId === null
                 ? []
@@ -544,6 +548,7 @@ function parseDeliveryStep(value: Record<string, unknown>) {
             'retryLaneRank',
             'retryAttempt',
             'lockedReason',
+            'recipientCount',
             'items',
         ]) ||
         !common ||
@@ -564,6 +569,11 @@ function parseDeliveryStep(value: Record<string, unknown>) {
         ) ||
         !validNonNegativeInteger(value.retryAttempt) ||
         !nullableString(value.lockedReason) ||
+        !(
+            value.recipientCount === undefined ||
+            (validNonNegativeInteger(value.recipientCount) &&
+                value.recipientCount > 0)
+        ) ||
         !Array.isArray(value.items)
     ) {
         return null;
@@ -583,6 +593,9 @@ function parseDeliveryStep(value: Record<string, unknown>) {
         retryLaneRank: value.retryLaneRank,
         retryAttempt: value.retryAttempt,
         lockedReason: value.lockedReason,
+        ...(value.recipientCount !== undefined
+            ? { recipientCount: value.recipientCount }
+            : {}),
         items: items.flatMap((item) => (item ? [item] : [])),
     };
 }

--- a/apps/delivery/tests/DeliveryHandoffVerificationStory.tsx
+++ b/apps/delivery/tests/DeliveryHandoffVerificationStory.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { DeliveryRunCompletionBypass } from '@gredice/storage';
 import { Button } from '@gredice/ui/Button';
 import { useState } from 'react';
 import {
@@ -18,11 +19,17 @@ if (!tomatoDelivery || !basilDelivery || !lettuceDelivery) {
     throw new Error('The handoff story requires three bulk deliveries.');
 }
 
-const pepperDelivery: DeliveryStopDeliverySummary = {
+const lettuceDeliveryWithoutPhone: DeliveryStopDeliverySummary = {
     ...lettuceDelivery,
+    phone: null,
+};
+
+const pepperDelivery: DeliveryStopDeliverySummary = {
+    ...lettuceDeliveryWithoutPhone,
     stopId: 104,
     requestId: 'request-pepper',
-    contactName: 'Davor Dostavić',
+    contactName: `${lettuceDelivery.contactName} – ažurirano`,
+    phone: '+385 (91) 333-3333',
     harvest: {
         ...lettuceDelivery.harvest,
         plantName: 'Paprika babura',
@@ -34,7 +41,7 @@ const pepperDelivery: DeliveryStopDeliverySummary = {
 const deliveries = [
     tomatoDelivery,
     basilDelivery,
-    lettuceDelivery,
+    lettuceDeliveryWithoutPhone,
     pepperDelivery,
 ];
 
@@ -122,7 +129,18 @@ export function DeliveryHandoffVerificationStory({
     const [completionOpen, setCompletionOpen] = useState(false);
     const [events, setEvents] = useState<string[]>([]);
     const [completionResult, setCompletionResult] = useState('none');
+    const [completionCalls, setCompletionCalls] = useState(0);
     const handoff = manifestView(items, syncState);
+    const completionOverrideBypasses: DeliveryRunCompletionBypass[] = [];
+    if (
+        handoffUnavailable ||
+        handoff.unverifiedCount > 0 ||
+        handoff.pendingCount > 0 ||
+        syncState === 'failed' ||
+        syncState === 'loading'
+    ) {
+        completionOverrideBypasses.push('handoff-review');
+    }
     const storyDeliveries = sharedTrace
         ? deliveries.map((delivery) =>
               delivery.requestId === basilDelivery.requestId
@@ -258,6 +276,7 @@ export function DeliveryHandoffVerificationStory({
         <main className="mx-auto max-w-2xl space-y-4 p-4">
             <output data-testid="handoff-events">{events.join('|')}</output>
             <output data-testid="completion-result">{completionResult}</output>
+            <output data-testid="completion-calls">{completionCalls}</output>
             <div className="flex flex-wrap gap-2">
                 <Button
                     type="button"
@@ -297,8 +316,14 @@ export function DeliveryHandoffVerificationStory({
                 onMarkRemainingReviewed={markRemainingReviewed}
                 completionConfirmation={{
                     open: completionOpen,
+                    arrived: true,
+                    overrideBypasses: completionOverrideBypasses,
+                    recipientCount: 3,
                     onOpenChange: setCompletionOpen,
-                    onConfirm: () => setCompletionResult('delivered'),
+                    onConfirm: () => {
+                        setCompletionCalls((current) => current + 1);
+                        setCompletionResult('delivered');
+                    },
                 }}
             />
         </main>

--- a/apps/delivery/tests/DriverCurrentStopCommandCenterStory.tsx
+++ b/apps/delivery/tests/DriverCurrentStopCommandCenterStory.tsx
@@ -28,6 +28,7 @@ const currentStop: DeliveryStopSummary = {
     stopState: 'pending',
     statusLabel: 'U dostavi',
     arrivedAt: null,
+    recipientCount: 3,
     addressLabel: 'Ulaz iz dvorišta',
     requestNotes: null,
     deliveries: [
@@ -80,9 +81,24 @@ const arrivedStop: DeliveryStopSummary = {
     })),
 };
 
+const singleArrivedDelivery = arrivedStop.deliveries[0];
+if (!singleArrivedDelivery) {
+    throw new Error('Current-stop story requires one actionable delivery.');
+}
+
+const singleArrivedStop: DeliveryStopSummary = {
+    ...arrivedStop,
+    requestId: singleArrivedDelivery.requestId,
+    contactName: singleArrivedDelivery.contactName,
+    phone: singleArrivedDelivery.phone,
+    harvest: singleArrivedDelivery.harvest,
+    deliveryCount: 1,
+    deliveries: [singleArrivedDelivery],
+};
+
 function handoffController(): DeliveryHandoffCommandController {
     const items = arrivedStop.deliveries.flatMap((delivery, index) =>
-        delivery.stopId === null || delivery.stopState !== 'arrived'
+        delivery.stopId === null
             ? []
             : [
                   {
@@ -98,7 +114,9 @@ function handoffController(): DeliveryHandoffCommandController {
                               ? ('scanned' as const)
                               : index === 1
                                 ? ('unverified' as const)
-                                : ('no-label' as const),
+                                : index === 2
+                                  ? ('no-label' as const)
+                                  : ('unverified' as const),
                       reason: null,
                       verifiedAt:
                           index === 0 ? '2026-07-15T08:32:00.000Z' : null,
@@ -125,6 +143,48 @@ function handoffController(): DeliveryHandoffCommandController {
     };
     return {
         view,
+        feedback: [],
+        scan: () => ({ status: 'verification-invalid' }),
+        markItem: () => undefined,
+        markRemainingReviewed: () => undefined,
+    };
+}
+
+function singleHandoffController(
+    state: 'scanned' | 'unverified',
+): DeliveryHandoffCommandController {
+    const stopId = singleArrivedDelivery.stopId;
+    if (stopId === null) {
+        throw new Error('Single delivery story requires a persisted stop.');
+    }
+    const item = {
+        stopId,
+        deliveryRequestId: singleArrivedDelivery.requestId,
+        retryAttempt: 0,
+        traceLinkId: 1,
+        qrAvailable: true,
+        state,
+        reason: null,
+        verifiedAt: state === 'scanned' ? '2026-07-15T08:32:00.000Z' : null,
+        syncState: 'persisted' as const,
+    };
+    return {
+        view: {
+            runId: 'run-component-4127',
+            targetStopId: stopId,
+            version: 1,
+            retryAttempt: 0,
+            items: [item],
+            expectedCount: 1,
+            scannedCount: state === 'scanned' ? 1 : 0,
+            unverifiedCount: state === 'unverified' ? 1 : 0,
+            noLabelCount: 0,
+            missingCount: 0,
+            skippedCount: 0,
+            syncState: 'ready',
+            pendingCount: 0,
+            error: null,
+        },
         feedback: [],
         scan: () => ({ status: 'verification-invalid' }),
         markItem: () => undefined,
@@ -203,7 +263,15 @@ export function DriverCurrentDeliveryCommandStory({
                         }
                         setResult('arrived');
                     }}
-                    onDeliver={(notes) => setResult(`delivered:${notes ?? ''}`)}
+                    onDeliver={(notes, completionOverride) =>
+                        setResult(
+                            `delivered:${notes ?? ''}${
+                                completionOverride
+                                    ? `:${completionOverride.reason}`
+                                    : ''
+                            }`,
+                        )
+                    }
                     onException={async () => ({ status: 'saved' })}
                     onVerificationScan={(tracePath) =>
                         setResult(`verified:${tracePath}`)
@@ -215,6 +283,42 @@ export function DriverCurrentDeliveryCommandStory({
                 <div className="h-96" aria-hidden="true" />
             </main>
         </div>
+    );
+}
+
+export function DriverSingleDeliveryCommandStory({
+    pendingDelivery = false,
+    unverified = false,
+}: {
+    pendingDelivery?: boolean;
+    unverified?: boolean;
+}) {
+    const [deliveryCalls, setDeliveryCalls] = useState(0);
+    const [overrideReason, setOverrideReason] = useState('none');
+    return (
+        <main className="min-h-[100dvh] bg-muted/30 p-4">
+            <output data-testid="single-delivery-calls">{deliveryCalls}</output>
+            <output data-testid="single-override-reason">
+                {overrideReason}
+            </output>
+            <DriverCurrentStopCommandCenter
+                kind="delivery"
+                stop={singleArrivedStop}
+                routeRevision={12}
+                handoff={singleHandoffController(
+                    unverified ? 'unverified' : 'scanned',
+                )}
+                onArrive={() => undefined}
+                onDeliver={async (_notes, completionOverride) => {
+                    setDeliveryCalls((current) => current + 1);
+                    setOverrideReason(completionOverride?.reason ?? 'none');
+                    if (pendingDelivery) {
+                        await new Promise<void>(() => undefined);
+                    }
+                }}
+                onException={async () => ({ status: 'saved' })}
+            />
+        </main>
     );
 }
 

--- a/apps/delivery/tests/DriverCurrentStopCommandCenterStory.tsx
+++ b/apps/delivery/tests/DriverCurrentStopCommandCenterStory.tsx
@@ -81,6 +81,19 @@ const arrivedStop: DeliveryStopSummary = {
     })),
 };
 
+const mixedArrivalStop: DeliveryStopSummary = {
+    ...arrivedStop,
+    deliveries: arrivedStop.deliveries.map((delivery, index) => ({
+        ...delivery,
+        stopState:
+            delivery.requestId === 'request-terminal-history'
+                ? 'failed'
+                : index === 1
+                  ? 'pending'
+                  : 'arrived',
+    })),
+};
+
 const singleArrivedDelivery = arrivedStop.deliveries[0];
 if (!singleArrivedDelivery) {
     throw new Error('Current-stop story requires one actionable delivery.');
@@ -96,7 +109,9 @@ const singleArrivedStop: DeliveryStopSummary = {
     deliveries: [singleArrivedDelivery],
 };
 
-function handoffController(): DeliveryHandoffCommandController {
+function handoffController(
+    fullyReviewed = false,
+): DeliveryHandoffCommandController {
     const items = arrivedStop.deliveries.flatMap((delivery, index) =>
         delivery.stopId === null
             ? []
@@ -109,17 +124,20 @@ function handoffController(): DeliveryHandoffCommandController {
                           ? index + 1
                           : null,
                       qrAvailable: Boolean(delivery.harvest.tracePath),
-                      state:
-                          index === 0
-                              ? ('scanned' as const)
-                              : index === 1
-                                ? ('unverified' as const)
-                                : index === 2
-                                  ? ('no-label' as const)
-                                  : ('unverified' as const),
+                      state: fullyReviewed
+                          ? ('scanned' as const)
+                          : index === 0
+                            ? ('scanned' as const)
+                            : index === 1
+                              ? ('unverified' as const)
+                              : index === 2
+                                ? ('no-label' as const)
+                                : ('unverified' as const),
                       reason: null,
                       verifiedAt:
-                          index === 0 ? '2026-07-15T08:32:00.000Z' : null,
+                          fullyReviewed || index === 0
+                              ? '2026-07-15T08:32:00.000Z'
+                              : null,
                       syncState: 'persisted' as const,
                   },
               ],
@@ -219,21 +237,29 @@ function actionEntry(
 
 export function DriverCurrentDeliveryCommandStory({
     arrived = false,
+    mixedArrival = false,
     syncState,
     syncKind = 'arrive',
     throwOnArrive = false,
     late = false,
     withHandoff = false,
+    fullyReviewedHandoff = false,
 }: {
     arrived?: boolean;
+    mixedArrival?: boolean;
     syncState?: DeliveryActionQueueEntry['state'];
     syncKind?: 'arrive' | 'deliver';
     throwOnArrive?: boolean;
     late?: boolean;
     withHandoff?: boolean;
+    fullyReviewedHandoff?: boolean;
 }) {
     const [result, setResult] = useState('none');
-    const selectedStop = arrived ? arrivedStop : currentStop;
+    const selectedStop = mixedArrival
+        ? mixedArrivalStop
+        : arrived
+          ? arrivedStop
+          : currentStop;
     const stop = late
         ? {
               ...selectedStop,
@@ -251,7 +277,11 @@ export function DriverCurrentDeliveryCommandStory({
                     kind="delivery"
                     stop={stop}
                     routeRevision={12}
-                    handoff={withHandoff ? handoffController() : undefined}
+                    handoff={
+                        withHandoff
+                            ? handoffController(fullyReviewedHandoff)
+                            : undefined
+                    }
                     syncEntry={
                         syncState ? actionEntry(syncKind, syncState) : undefined
                     }

--- a/apps/delivery/tests/OfflineRoutePanelStory.tsx
+++ b/apps/delivery/tests/OfflineRoutePanelStory.tsx
@@ -98,6 +98,32 @@ const routeSnapshot: OfflineRouteSnapshot = {
     ],
 };
 
+const bulkRecipientRouteSnapshot: OfflineRouteSnapshot = {
+    ...routeSnapshot,
+    steps: routeSnapshot.steps.map((step, index) => {
+        if (index !== 0 || step.kind !== 'delivery') return step;
+        const [item] = step.items;
+        if (!item) return step;
+        return {
+            ...step,
+            recipientCount: 1,
+            items: [
+                ...step.items,
+                {
+                    ...item,
+                    stopId: 73,
+                    requestId: 'request-73',
+                    harvest: {
+                        ...item.harvest,
+                        plantName: 'Paprika',
+                        tracePath: '/trag/offline-pepper-0001',
+                    },
+                },
+            ],
+        };
+    }),
+};
+
 function queueSnapshot(
     entries: DeliveryActionQueueEntry[],
     durability: DeliveryActionQueueSnapshot['durability'] = 'durable',
@@ -162,6 +188,22 @@ export function OfflineRouteAcknowledgedDeliveryStory() {
             actionQueue={queueSnapshot([
                 routeEntry('deliver', 0, 71, 'synced'),
             ])}
+            onArrive={() => undefined}
+            onDeliver={() => undefined}
+            onException={async () => ({ status: 'saved' })}
+            onVerificationScan={() => undefined}
+            onRetry={() => undefined}
+            onRecoverConflict={() => undefined}
+            onReconcile={() => undefined}
+        />
+    );
+}
+
+export function OfflineRouteBulkRecipientCountStory() {
+    return (
+        <OfflineRoutePanel
+            snapshot={bulkRecipientRouteSnapshot}
+            actionQueue={queueSnapshot([])}
             onArrive={() => undefined}
             onDeliver={() => undefined}
             onException={async () => ({ status: 'saved' })}

--- a/apps/delivery/tests/delivery-handoff-verification.spec.tsx
+++ b/apps/delivery/tests/delivery-handoff-verification.spec.tsx
@@ -106,15 +106,21 @@ test('records nonblocking outcomes and keeps bulk completion enabled with unreso
     const confirmation = page.getByRole('dialog', {
         name: 'Potvrdi dostavu',
     });
-    await expect(confirmation).toContainText('1 bez provjere');
+    await expect(confirmation).toContainText(
+        '3 primatelja · 4 očekivana uroda',
+    );
+    await expect(confirmation).toContainText('1 neskenirano');
+    await expect(confirmation).toContainText('2 iznimke');
     await expect(confirmation).toContainText(
         'Sinkronizacija nekih provjera nije uspjela. Dostavu i dalje možeš potvrditi.',
     );
-    await expect(
-        confirmation.getByRole('button', {
-            name: 'Potvrdi dostavu i nastavi',
-        }),
-    ).toBeEnabled();
+    const overrideReason = confirmation.getByLabel('Razlog operativne iznimke');
+    const confirmOverride = confirmation.getByRole('button', {
+        name: 'Potvrdi iznimku i dostavu',
+    });
+    await expect(confirmOverride).toBeDisabled();
+    await overrideReason.selectOption('manual-handoff');
+    await expect(confirmOverride).toBeEnabled();
     await confirmation.getByRole('button', { name: 'Natrag' }).click();
 
     await page
@@ -127,16 +133,35 @@ test('records nonblocking outcomes and keeps bulk completion enabled with unreso
     );
 
     await page.getByRole('button', { name: 'Dostavi 4 uroda · dalje' }).click();
-    await expect(confirmation).toContainText('0 bez provjere');
+    await expect(confirmation).toContainText('0 neskenirano');
+    await expect(confirmation).toContainText('3 iznimke');
     await expect(confirmation).toContainText('2 preskočeno');
-    await expect(
-        confirmation.getByRole('button', {
-            name: 'Potvrdi dostavu i nastavi',
-        }),
-    ).toBeEnabled();
+    await overrideReason.selectOption('workflow-recovery');
     await confirmation
-        .getByRole('button', { name: 'Potvrdi dostavu i nastavi' })
+        .getByRole('button', { name: 'Potvrdi iznimku i dostavu' })
         .click();
+    await expect(page.getByTestId('completion-result')).toHaveText('delivered');
+});
+
+test('submits one irreversible bulk completion for same-frame repeat submits', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryHandoffVerificationStory />);
+    await page.getByRole('button', { name: 'Dostavi 4 uroda · dalje' }).click();
+    const confirmation = page.getByRole('dialog', {
+        name: 'Potvrdi dostavu',
+    });
+    await confirmation
+        .getByLabel('Razlog operativne iznimke')
+        .selectOption('manual-handoff');
+    await confirmation.locator('form').evaluate((element) => {
+        if (!(element instanceof HTMLFormElement)) return;
+        element.requestSubmit();
+        element.requestSubmit();
+    });
+
+    await expect(page.getByTestId('completion-calls')).toHaveText('1');
     await expect(page.getByTestId('completion-result')).toHaveText('delivered');
 });
 
@@ -202,7 +227,15 @@ test('keeps verification controls hidden while persisted progress loads without 
     );
     await expect(
         confirmation.getByRole('button', {
-            name: 'Potvrdi dostavu i nastavi',
+            name: 'Potvrdi iznimku i dostavu',
+        }),
+    ).toBeDisabled();
+    await confirmation
+        .getByLabel('Razlog operativne iznimke')
+        .selectOption('device-unavailable');
+    await expect(
+        confirmation.getByRole('button', {
+            name: 'Potvrdi iznimku i dostavu',
         }),
     ).toBeEnabled();
 });

--- a/apps/delivery/tests/delivery-offline-actions.spec.tsx
+++ b/apps/delivery/tests/delivery-offline-actions.spec.tsx
@@ -16,6 +16,7 @@ import {
     OfflineRouteAcknowledgedDeliveryStory,
     OfflineRouteArrivalStory,
     OfflineRouteBlockedContinuationStory,
+    OfflineRouteBulkRecipientCountStory,
     OfflineRouteExceptionBarrierStory,
     OfflineRoutePendingRerouteStory,
 } from './OfflineRoutePanelStory';
@@ -216,6 +217,22 @@ test('restored server acknowledgement is not mislabeled as waiting for confirmat
     await expect(
         page.getByRole('link', { name: 'Navigacija do trenutačne stanice' }),
     ).toBeEnabled();
+});
+
+test('offline bulk timeline uses the server recipient count with Croatian singular', async ({
+    mount,
+    page,
+}) => {
+    await mount(<OfflineRouteBulkRecipientCountStory />);
+    const timeline = page.getByRole('list', {
+        name: 'Izvanmrežni tijek dostavne rute',
+    });
+    await expect(
+        timeline.getByText('1 primatelj', { exact: true }),
+    ).toBeVisible();
+    await expect(
+        timeline.getByText('1 primatelja', { exact: true }),
+    ).toHaveCount(0);
 });
 
 test('server-required reroute blocks stale cached continuation until reconciliation', async ({

--- a/apps/delivery/tests/driver-current-stop.spec.tsx
+++ b/apps/delivery/tests/driver-current-stop.spec.tsx
@@ -3,6 +3,7 @@ import {
     DriverCurrentDeferredCommandStory,
     DriverCurrentDeliveryCommandStory,
     DriverCurrentPickupCommandStory,
+    DriverSingleDeliveryCommandStory,
     HarvestTraceScannerSessionStory,
 } from './DriverCurrentStopCommandCenterStory';
 import {
@@ -177,19 +178,28 @@ test.describe('320px current-stop command center', () => {
             name: 'Potvrdi dostavu',
         });
         await expect(confirmation).toContainText('1 provjereno');
-        await expect(confirmation).toContainText('1 bez provjere');
+        await expect(confirmation).toContainText(
+            '3 primatelja · 3 očekivana uroda',
+        );
+        await expect(confirmation).not.toContainText('4 očekivana uroda');
+        await expect(confirmation).toContainText('1 neskenirano');
         await expect(confirmation).toContainText('1 bez etikete');
+        await expect(confirmation).toContainText('0 iznimki');
         await expect(page.getByTestId('current-stop-result')).toHaveText(
             'none',
         );
 
         const confirm = confirmation.getByRole('button', {
-            name: 'Potvrdi dostavu i nastavi',
+            name: 'Potvrdi iznimku i dostavu',
         });
+        await expect(confirm).toBeDisabled();
+        await confirmation
+            .getByLabel('Razlog operativne iznimke')
+            .selectOption('manual-handoff');
         await expect(confirm).toBeEnabled();
         await confirm.click();
         await expect(page.getByTestId('current-stop-result')).toHaveText(
-            'delivered:',
+            'delivered::manual-handoff',
         );
     });
 
@@ -227,6 +237,20 @@ test.describe('320px current-stop command center', () => {
         page,
     }) => {
         const component = await mount(<DriverCurrentPickupCommandStory />);
+        const pickupControls = [
+            page.getByRole('link', {
+                name: 'Navigacija do trenutačne stanice preuzimanja',
+            }),
+            page.getByRole('button', { name: 'Skeniraj urode' }),
+            page.getByRole('button', { name: 'Preuzeto bez QR etikete' }),
+            page.getByRole('button', { name: 'Nije spremno' }),
+        ];
+        for (const control of pickupControls) {
+            const box = await control.boundingBox();
+            expect(box).not.toBeNull();
+            expect(box?.height ?? 0).toBeGreaterThanOrEqual(44);
+            expect(box?.width ?? 0).toBeGreaterThanOrEqual(44);
+        }
         for (const buttonName of [
             'Skeniraj urode',
             'Preuzeto bez QR etikete',
@@ -234,7 +258,6 @@ test.describe('320px current-stop command center', () => {
             const box = await page
                 .getByRole('button', { name: buttonName })
                 .boundingBox();
-            expect(box).not.toBeNull();
             expect((box?.y ?? 568) + (box?.height ?? 0)).toBeLessThanOrEqual(
                 568,
             );
@@ -249,6 +272,8 @@ test.describe('320px current-stop command center', () => {
             })
             .boundingBox();
         expect(confirmBox).not.toBeNull();
+        expect(confirmBox?.height ?? 0).toBeGreaterThanOrEqual(44);
+        expect(confirmBox?.width ?? 0).toBeGreaterThanOrEqual(44);
         expect(
             (confirmBox?.y ?? 568) + (confirmBox?.height ?? 0),
         ).toBeLessThanOrEqual(568);
@@ -266,6 +291,9 @@ test.describe('320px current-stop command center', () => {
         });
         const retry = page.getByRole('button', { name: 'Pokušaj ponovno' });
         await expect(retry).toBeInViewport();
+        const retryBox = await retry.boundingBox();
+        expect(retryBox?.height ?? 0).toBeGreaterThanOrEqual(44);
+        expect(retryBox?.width ?? 0).toBeGreaterThanOrEqual(44);
         await retry.click();
 
         const recoveryError = page.getByRole('alert').filter({
@@ -281,6 +309,111 @@ test.describe('320px current-stop command center', () => {
         expect(errorBox?.y ?? 0).toBeGreaterThanOrEqual(syncBottom);
         expect((errorBox?.y ?? 0) - syncBottom).toBeLessThanOrEqual(12);
     });
+
+    test('uses 44px delivery targets, reduced motion, and returns focus after cancelling an override', async ({
+        mount,
+        page,
+    }) => {
+        await page.emulateMedia({ reducedMotion: 'reduce' });
+        await mount(<DriverCurrentDeliveryCommandStory />);
+        const command = page.getByRole('region', { name: /skupna dostava/ });
+        const trigger = command.getByRole('button', {
+            name: 'Dostavi bez potvrde dolaska',
+        });
+        const controls = [
+            command.getByRole('button', { name: 'Prijavi problem' }),
+            command.getByRole('button', { name: 'Stigao sam' }),
+            trigger,
+            command.getByRole('link', {
+                name: 'Navigacija do trenutačne stanice',
+            }),
+            command.getByRole('link', { name: /^Nazovi / }).first(),
+        ];
+        for (const control of controls) {
+            const box = await control.boundingBox();
+            expect(box).not.toBeNull();
+            expect(box?.height ?? 0).toBeGreaterThanOrEqual(44);
+            expect(box?.width ?? 0).toBeGreaterThanOrEqual(44);
+        }
+
+        await trigger.click();
+        const dialog = page.getByRole('dialog', { name: 'Potvrdi dostavu' });
+        const reason = dialog.getByLabel('Razlog operativne iznimke');
+        const confirm = dialog.getByRole('button', {
+            name: 'Potvrdi iznimku i dostavu',
+        });
+        await expect(dialog).toContainText('dolazak nije potvrđen');
+        await expect(confirm).toBeDisabled();
+        for (const control of [
+            reason,
+            confirm,
+            dialog.getByRole('button', { name: 'Natrag' }),
+        ]) {
+            const box = await control.boundingBox();
+            expect(box).not.toBeNull();
+            expect(box?.height ?? 0).toBeGreaterThanOrEqual(44);
+        }
+        const motion = await dialog.evaluate((element) => {
+            const style = getComputedStyle(element);
+            return {
+                animationName: style.animationName,
+                transitionDuration: style.transitionDuration,
+            };
+        });
+        expect(motion.animationName).toBe('none');
+        expect(motion.transitionDuration).toBe('0s');
+
+        await dialog.getByRole('button', { name: 'Natrag' }).click();
+        await expect(trigger).toBeFocused();
+    });
+});
+
+test('completes a reviewed single delivery directly without a repeated dialog', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverSingleDeliveryCommandStory />);
+    await page.getByRole('button', { name: 'Dostavljeno · dalje' }).click();
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+    await expect(page.getByTestId('single-delivery-calls')).toHaveText('1');
+    await expect(page.getByTestId('single-override-reason')).toHaveText('none');
+});
+
+test('requires an intentional reason for an unreviewed single while keeping QR optional', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverSingleDeliveryCommandStory unverified />);
+    await page.getByRole('button', { name: 'Dostavljeno · dalje' }).click();
+    const dialog = page.getByRole('dialog', { name: 'Potvrdi dostavu' });
+    const confirm = dialog.getByRole('button', {
+        name: 'Potvrdi iznimku i dostavu',
+    });
+    await expect(dialog).toContainText('1 neskenirano');
+    await expect(confirm).toBeDisabled();
+    await dialog
+        .getByLabel('Razlog operativne iznimke')
+        .selectOption('manual-handoff');
+    await confirm.click();
+    await expect(page.getByTestId('single-delivery-calls')).toHaveText('1');
+    await expect(page.getByTestId('single-override-reason')).toHaveText(
+        'manual-handoff',
+    );
+});
+
+test('guards a direct single completion against same-frame repeat taps', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DriverSingleDeliveryCommandStory pendingDelivery />);
+    const deliver = page.getByRole('button', { name: 'Dostavljeno · dalje' });
+    await deliver.evaluate((element) => {
+        if (!(element instanceof HTMLButtonElement)) return;
+        element.click();
+        element.click();
+    });
+    await expect(page.getByTestId('single-delivery-calls')).toHaveText('1');
+    await expect(deliver).toBeDisabled();
 });
 
 test('uses section-level current-command headings in live and offline route views', async ({
@@ -363,6 +496,10 @@ test('arrived stop exposes advisory scanning and delivers with its local note', 
     ).toBeVisible();
     await page.getByLabel('Napomena o predaji').fill('Predano susjedu');
     await page.getByRole('button', { name: /Dostavi 3 · dalje/ }).click();
+    await page
+        .getByRole('dialog', { name: 'Potvrdi dostavu' })
+        .getByRole('button', { name: 'Potvrdi dostavu i nastavi' })
+        .click();
     await expect(page.getByTestId('current-stop-result')).toHaveText(
         'delivered:Predano susjedu',
     );

--- a/apps/delivery/tests/driver-current-stop.spec.tsx
+++ b/apps/delivery/tests/driver-current-stop.spec.tsx
@@ -401,6 +401,38 @@ test('requires an intentional reason for an unreviewed single while keeping QR o
     );
 });
 
+test('requires an arrival override when any actionable bulk sibling has not arrived', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <DriverCurrentDeliveryCommandStory
+            mixedArrival
+            withHandoff
+            fullyReviewedHandoff
+        />,
+    );
+    await page
+        .getByRole('button', { name: 'Dostavi bez potvrde dolaska' })
+        .click();
+    const dialog = page.getByRole('dialog', { name: 'Potvrdi dostavu' });
+    await expect(dialog).toContainText('dolazak nije potvrđen');
+    await expect(dialog).not.toContainText(
+        'Manifest nije u potpunosti pregledan ili potvrđen.',
+    );
+    const confirm = dialog.getByRole('button', {
+        name: 'Potvrdi iznimku i dostavu',
+    });
+    await expect(confirm).toBeDisabled();
+    await dialog
+        .getByLabel('Razlog operativne iznimke')
+        .selectOption('manual-handoff');
+    await confirm.click();
+    await expect(page.getByTestId('current-stop-result')).toHaveText(
+        'delivered::manual-handoff',
+    );
+});
+
 test('guards a direct single completion against same-frame repeat taps', async ({
     mount,
     page,

--- a/docs/delivery-driver-mobile-validation.md
+++ b/docs/delivery-driver-mobile-validation.md
@@ -1,0 +1,58 @@
+# Delivery driver mobile validation
+
+## Purpose
+
+Use this checklist to validate the irreversible current-stop actions on physical
+phones. Responsive browser tests are useful regression evidence, but they do not
+replace one-handed checks on real devices.
+
+## Pass criteria
+
+- Every visible driver action, completion action, override reason control, and
+  handoff outcome control has a touch target of at least 44 by 44 CSS pixels.
+- Adjacent actions keep at least 8 CSS pixels of separation and do not overflow
+  horizontally at 320 CSS pixels.
+- A reviewed single delivery completes with one action and no repeated dialog.
+- A bulk delivery states the unique recipient count, harvest count, and expected,
+  verified, unscanned, no-label, and exception counts before completion.
+- Delivery without a recorded arrival or completed handoff review requires an
+  explicit operational reason; QR scanning itself remains optional.
+- Cancelling the completion dialog returns focus to its opener. Successful
+  completion moves focus to the next current-stop heading.
+- Two rapid taps or submit gestures create exactly one local delivery command.
+- Loading, offline, failed-sync, keyboard-open, and reduced-motion states remain
+  understandable and operable.
+- Ten consecutive routine single deliveries and ten bulk/override attempts
+  produce zero accidental duplicate completions and zero missed touch targets.
+
+## Automated regression evidence
+
+Run from the repository root:
+
+```sh
+pnpm --filter delivery test:unit
+pnpm --filter delivery exec playwright test tests/driver-current-stop.spec.tsx tests/delivery-handoff-verification.spec.tsx --project=chromium
+pnpm --filter delivery typecheck
+pnpm --filter delivery build
+```
+
+The component suite covers the constrained 320 by 568 touch viewport and the
+default desktop viewport, minimum target geometry, focus return, reduced motion,
+single and bulk completion, scan/no-scan states, loading, explicit overrides,
+and same-frame repeat submits. The physical-device matrix supplies the remaining
+large-phone and browser-specific evidence.
+
+## Physical-device matrix
+
+Record observed results against the production delivery app. Do not mark a row
+passed from browser emulation alone.
+
+| Device class | Device / OS / browser | Hand | Routine single x10 | Bulk and override x10 | Offline / keyboard / reduced motion | Result | Tester / date |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Small iPhone | Not run | Left and right | Pending | Pending | Pending | Pending | Unassigned |
+| Current large iPhone | Not run | Left and right | Pending | Pending | Pending | Pending | Unassigned |
+| Small Android | Not run | Left and right | Pending | Pending | Pending | Pending | Unassigned |
+| Current large Android | Not run | Left and right | Pending | Pending | Pending | Pending | Unassigned |
+
+For a failed row, record the exact control, screen state, viewport dimensions,
+and reproduction sequence in the related GitHub issue before retrying.

--- a/docs/delivery-handoff-audit.md
+++ b/docs/delivery-handoff-audit.md
@@ -6,7 +6,9 @@ The delivery handoff check is an advisory record of what the driver observed at
 the customer stop. It helps the driver confirm that every expected harvest left
 the vehicle, while keeping delivery possible when a sticker is missing, a QR
 code cannot be read, or another operational exception occurs. QR verification
-never blocks arrival or fulfillment.
+never blocks arrival or fulfillment. If fulfillment bypasses the recorded
+arrival or leaves a manifest item unreviewed, the driver explicitly selects a
+bounded operational reason; scanning itself is still optional.
 
 The expected manifest comes from the immutable per-harvest trace snapshot on
 `delivery_run_stops`. The server does not trust the device to define which
@@ -43,6 +45,15 @@ The audit has two layers:
    attempt. Results distinguish scanned, already-scanned, no-label, missing,
    skipped, stale, invalid, wrong-stop, and unknown-item attempts without
    exposing data from a mismatched trace.
+3. The final stop-operation receipt records a bounded completion override reason
+   and the server-derived checks it bypassed (`arrival`, `handoff-review`) when
+   delivery proceeds without a recorded arrival or with an unreviewed item. The
+   receipt already binds that choice to the driver, run, stop, operation ID, and
+   audit timestamps; it stores no free-text override details.
+
+The bulk confirmation receives only a server-derived aggregate recipient count;
+the stable address or account identity used to calculate that count is not sent
+to the browser or stored in the offline route cache.
 
 The client supplies a stable operation identifier. Retrying the same operation
 with the same payload returns the original receipt; it does not create another
@@ -81,7 +92,9 @@ idempotency and support. Logs and cron responses contain aggregate counts only.
 4. The UI can rebuild the latest manifest from the server after a refresh. A
    lost device cache therefore does not erase successful or skipped results.
 5. The driver can fulfill the stop with zero, partial, or complete QR coverage.
-   Handoff verification is evidence, not a delivery gate.
+   An unreviewed item requires an explicit completion override reason, not a QR
+   scan. No-label, missing, and skipped outcomes count as reviewed advisory
+   outcomes and do not themselves require a stop-level override.
 6. The final per-stop advisory state and the delivery fulfillment event follow
    the normal delivery and account-history lifecycle. They remain available as
    long as the corresponding operational delivery history remains available.
@@ -115,7 +128,8 @@ Use focused storage and API coverage for:
 - every advisory result and attempt outcome;
 - exact idempotent replay, conflicting reuse, bulk partial results, and retry
   after a lost response;
-- refresh reconstruction from persisted state and fulfillment with zero scans;
+- refresh reconstruction from persisted state and fulfillment with zero scans,
+  including the required bounded override when items remain unreviewed;
 - 90-day boundary behavior, bounded cleanup, and counts-only cron responses;
 - proof that operation receipts and logs contain no raw QR value.
 

--- a/packages/storage/src/repositories/deliveryRunsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRunsRepo.ts
@@ -22,6 +22,10 @@ import 'server-only';
 import {
     accountUsers,
     DeliveryRequestStates,
+    type DeliveryRunCompletionBypass,
+    type DeliveryRunCompletionOverrideInput,
+    type DeliveryRunCompletionOverrideReason,
+    DeliveryRunCompletionOverrideReasons,
     type DeliveryRunEstimateSource,
     DeliveryRunEstimateSources,
     type DeliveryRunExceptionOperationStoredResult,
@@ -298,6 +302,7 @@ export const DeliveryRunExecutionErrorCodes = {
     EXCEPTION_OPERATION_CONFLICT: 'exception-operation-conflict',
     EXCEPTION_INVALID: 'exception-invalid',
     EXCEPTION_TRANSITION_INVALID: 'exception-transition-invalid',
+    COMPLETION_OVERRIDE_REQUIRED: 'completion-override-required',
     STOP_OPERATION_CONFLICT: 'stop-operation-conflict',
     STOP_OPERATION_INVALID: 'stop-operation-invalid',
     STOP_OPERATION_STATE_CONFLICT: 'stop-operation-state-conflict',
@@ -437,6 +442,7 @@ export type RecordDeliveryRunStopOperationInput =
     | (RecordDeliveryRunStopOperationBase & {
           kind: 'deliver';
           deliveryNotes?: string;
+          completionOverride?: DeliveryRunCompletionOverrideInput;
       });
 
 export type RecordDeliveryRunStopOperationResult = {
@@ -5397,7 +5403,13 @@ type NormalizedRecordDeliveryRunStopOperationInput =
     RecordDeliveryRunStopOperationBase & {
         kind: DeliveryRunStopOperationKind;
         deliveryNotes?: string;
+        completionOverride?: DeliveryRunCompletionOverrideInput;
     };
+
+const deliveryRunCompletionOverrideReasons =
+    new Set<DeliveryRunCompletionOverrideReason>(
+        Object.values(DeliveryRunCompletionOverrideReasons),
+    );
 
 function invalidDeliveryRunStopOperation(message: string): never {
     throw new DeliveryRunExecutionError(
@@ -5465,6 +5477,18 @@ function normalizeDeliveryRunStopOperationInput(
             'Delivery notes must not exceed 1000 characters',
         );
     }
+    const completionOverride =
+        input.kind === DeliveryRunStopOperationKinds.DELIVER
+            ? input.completionOverride
+            : undefined;
+    if (
+        completionOverride &&
+        !deliveryRunCompletionOverrideReasons.has(completionOverride.reason)
+    ) {
+        invalidDeliveryRunStopOperation(
+            'Delivery completion override reason is invalid',
+        );
+    }
     return {
         driverUserId: input.driverUserId,
         runId: input.runId,
@@ -5474,6 +5498,13 @@ function normalizeDeliveryRunStopOperationInput(
         occurredAt: input.occurredAt,
         kind: input.kind,
         ...(deliveryNotes ? { deliveryNotes } : {}),
+        ...(completionOverride
+            ? {
+                  completionOverride: {
+                      reason: completionOverride.reason,
+                  },
+              }
+            : {}),
     };
 }
 
@@ -5488,6 +5519,11 @@ function deliveryRunStopOperationPayloadHash(
             expectedRouteRevision: input.expectedRouteRevision,
             occurredAt: input.occurredAt.toISOString(),
             deliveryNotes: input.deliveryNotes ?? null,
+            ...(input.completionOverride
+                ? {
+                      completionOverrideReason: input.completionOverride.reason,
+                  }
+                : {}),
         }),
     );
 }
@@ -6114,6 +6150,30 @@ async function recordDeliveryRunStopOperationInDatabase(
         input.kind === DeliveryRunStopOperationKinds.DELIVER
             ? deliveryRunHandoffSnapshot(stops)
             : undefined;
+    const completionBypasses: DeliveryRunCompletionBypass[] = [];
+    if (input.kind === DeliveryRunStopOperationKinds.DELIVER) {
+        const newlyFulfilledStopIds = new Set(
+            newlyFulfilledStops.map((stop) => stop.id),
+        );
+        if (newlyFulfilledStops.some((stop) => !stop.arrivedAt)) {
+            completionBypasses.push('arrival');
+        }
+        if (
+            handoff?.items.some(
+                (item) =>
+                    newlyFulfilledStopIds.has(item.stopId) &&
+                    item.state === DeliveryRunHandoffItemStates.UNVERIFIED,
+            )
+        ) {
+            completionBypasses.push('handoff-review');
+        }
+        if (completionBypasses.length > 0 && !input.completionOverride) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.COMPLETION_OVERRIDE_REQUIRED,
+                'Delivery completion override is required when arrival or handoff review is missing',
+            );
+        }
+    }
     if (input.kind === DeliveryRunStopOperationKinds.DELIVER) {
         for (const stop of newlyFulfilledStops) {
             try {
@@ -6191,6 +6251,14 @@ async function recordDeliveryRunStopOperationInDatabase(
             !runCompleted && Boolean(runAfterMutation.rerouteRequiredAt),
         runCompleted,
         ...(handoff ? { handoff } : {}),
+        ...(input.completionOverride
+            ? {
+                  override: {
+                      reason: input.completionOverride.reason,
+                      bypassed: completionBypasses,
+                  },
+              }
+            : {}),
     };
     await db.insert(deliveryRunStopOperations).values({
         runId: input.runId,

--- a/packages/storage/src/schema/deliverySchema.ts
+++ b/packages/storage/src/schema/deliverySchema.ts
@@ -318,6 +318,27 @@ export const DeliveryRunStopOperationKinds = {
 export type DeliveryRunStopOperationKind =
     (typeof DeliveryRunStopOperationKinds)[keyof typeof DeliveryRunStopOperationKinds];
 
+export const DeliveryRunCompletionOverrideReasons = {
+    DEVICE_UNAVAILABLE: 'device-unavailable',
+    WORKFLOW_RECOVERY: 'workflow-recovery',
+    MANUAL_HANDOFF: 'manual-handoff',
+    OTHER_OPERATIONAL: 'other-operational',
+} as const;
+
+export type DeliveryRunCompletionOverrideReason =
+    (typeof DeliveryRunCompletionOverrideReasons)[keyof typeof DeliveryRunCompletionOverrideReasons];
+
+export type DeliveryRunCompletionBypass = 'arrival' | 'handoff-review';
+
+export type DeliveryRunCompletionOverrideInput = {
+    reason: DeliveryRunCompletionOverrideReason;
+};
+
+export type DeliveryRunCompletionOverrideStoredResult =
+    DeliveryRunCompletionOverrideInput & {
+        bypassed: DeliveryRunCompletionBypass[];
+    };
+
 export type DeliveryRunStopOperationStoredResult = {
     kind: DeliveryRunStopOperationKind;
     targetStopId: number;
@@ -326,6 +347,7 @@ export type DeliveryRunStopOperationStoredResult = {
     reroutePending: boolean;
     runCompleted: boolean;
     handoff?: DeliveryRunHandoffSnapshot;
+    override?: DeliveryRunCompletionOverrideStoredResult;
 };
 
 // Delivery Runs - one optimized route picked up and driven by a driver/admin.

--- a/packages/storage/tests/deliveryRunsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRunsRepo.node.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
     abandonDeliveryRun,
@@ -20,6 +20,7 @@ import {
     DeliveryRequestStates,
     DeliveryRunAssignmentError,
     DeliveryRunAssignmentErrorCodes,
+    DeliveryRunCompletionOverrideReasons,
     DeliveryRunEstimateSources,
     DeliveryRunExceptionOutcomes,
     DeliveryRunExceptionReasons,
@@ -5081,6 +5082,254 @@ test('a partially cancelled stop is released for explicit admin reactivation', a
     );
 });
 
+test('a legacy no-override delivery receipt keeps its exact replay hash', async () => {
+    const { run, driverUserId } =
+        await startPreparedBulkRunWithConfirmedPickup();
+    const [targetStop] = run.stops;
+    assert.ok(targetStop);
+    const input = {
+        kind: DeliveryRunStopOperationKinds.DELIVER,
+        driverUserId,
+        runId: run.id,
+        targetStopId: targetStop.id,
+        expectedRouteRevision: run.routeRevision,
+        clientOperationId: 'legacy-no-override-delivery',
+        occurredAt: new Date(Date.now() - 1_000),
+        deliveryNotes: 'Legacy receipt replay',
+    } as const;
+    const legacyPayloadHash = createHash('sha256')
+        .update(
+            JSON.stringify({
+                clientOperationId: input.clientOperationId,
+                kind: input.kind,
+                targetStopId: input.targetStopId,
+                expectedRouteRevision: input.expectedRouteRevision,
+                occurredAt: input.occurredAt.toISOString(),
+                deliveryNotes: input.deliveryNotes,
+            }),
+        )
+        .digest('hex');
+    const legacyResult = {
+        kind: DeliveryRunStopOperationKinds.DELIVER,
+        targetStopId: targetStop.id,
+        affectedStopIds: run.stops.map((stop) => stop.id),
+        routeRevision: run.routeRevision + 1,
+        reroutePending: false,
+        runCompleted: true,
+    } as const;
+    await storage().insert(deliveryRunStopOperations).values({
+        runId: run.id,
+        targetStopId: targetStop.id,
+        driverUserId,
+        clientOperationId: input.clientOperationId,
+        kind: input.kind,
+        payloadHash: legacyPayloadHash,
+        result: legacyResult,
+        occurredAt: input.occurredAt,
+        appliedAt: new Date(),
+    });
+
+    const replayed = await recordDeliveryRunStopOperation(input);
+
+    assert.equal(replayed.replayed, true);
+    assert.deepEqual(replayed.result, legacyResult);
+    assert.deepEqual(replayed.newlyFulfilledRequestIds, []);
+});
+
+test('arrived and reviewed bulk completion does not require an override', async () => {
+    const { run, driverUserId } =
+        await startPreparedBulkRunWithConfirmedPickup();
+    const [targetStop] = run.stops;
+    assert.ok(targetStop);
+
+    const arrival = await recordDeliveryRunStopOperation({
+        kind: DeliveryRunStopOperationKinds.ARRIVE,
+        driverUserId,
+        runId: run.id,
+        targetStopId: targetStop.id,
+        expectedRouteRevision: run.routeRevision,
+        clientOperationId: 'reviewed-bulk-arrival',
+        occurredAt: new Date(Date.now() - 2_000),
+    });
+    await applyDeliveryRunHandoffMutations({
+        driverUserId,
+        runId: run.id,
+        targetStopId: targetStop.id,
+        expectedRetryAttempt: 0,
+        mutations: run.stops.map((stop, index) => ({
+            clientOperationId: `reviewed-bulk-handoff-${index}`,
+            occurredAt: new Date(Date.now() - 1_500 + index),
+            kind: DeliveryRunHandoffOperationKinds.MARK_ITEM,
+            stopId: stop.id,
+            outcome: DeliveryRunHandoffItemStates.SKIPPED,
+            reason: DeliveryRunHandoffSkipReasons.MANUAL_VERIFICATION,
+        })),
+    });
+
+    const completion = await recordDeliveryRunStopOperation({
+        kind: DeliveryRunStopOperationKinds.DELIVER,
+        driverUserId,
+        runId: run.id,
+        targetStopId: targetStop.id,
+        expectedRouteRevision: arrival.result.routeRevision,
+        clientOperationId: 'reviewed-bulk-delivery',
+        occurredAt: new Date(Date.now() - 500),
+    });
+
+    assert.equal(completion.replayed, false);
+    assert.equal(completion.result.override, undefined);
+    assert.equal(completion.result.handoff?.unverifiedCount, 0);
+    assert.equal(completion.result.handoff?.skippedCount, run.stops.length);
+    await storage()
+        .delete(deliveryRunHandoffOperations)
+        .where(eq(deliveryRunHandoffOperations.runId, run.id));
+});
+
+test('an explicit completion override persists the server-computed empty bypass list', async () => {
+    const { run, driverUserId } =
+        await startPreparedBulkRunWithConfirmedPickup();
+    const [targetStop] = run.stops;
+    assert.ok(targetStop);
+
+    const arrival = await recordDeliveryRunStopOperation({
+        kind: DeliveryRunStopOperationKinds.ARRIVE,
+        driverUserId,
+        runId: run.id,
+        targetStopId: targetStop.id,
+        expectedRouteRevision: run.routeRevision,
+        clientOperationId: 'concurrent-review-arrival',
+        occurredAt: new Date(Date.now() - 2_000),
+    });
+    await applyDeliveryRunHandoffMutations({
+        driverUserId,
+        runId: run.id,
+        targetStopId: targetStop.id,
+        expectedRetryAttempt: 0,
+        mutations: run.stops.map((stop, index) => ({
+            clientOperationId: `concurrent-review-handoff-${index}`,
+            occurredAt: new Date(Date.now() - 1_500 + index),
+            kind: DeliveryRunHandoffOperationKinds.MARK_ITEM,
+            stopId: stop.id,
+            outcome: DeliveryRunHandoffItemStates.SKIPPED,
+            reason: DeliveryRunHandoffSkipReasons.MANUAL_VERIFICATION,
+        })),
+    });
+
+    const completion = await recordDeliveryRunStopOperation({
+        kind: DeliveryRunStopOperationKinds.DELIVER,
+        driverUserId,
+        runId: run.id,
+        targetStopId: targetStop.id,
+        expectedRouteRevision: arrival.result.routeRevision,
+        clientOperationId: 'concurrent-review-delivery',
+        occurredAt: new Date(Date.now() - 500),
+        completionOverride: {
+            reason: DeliveryRunCompletionOverrideReasons.WORKFLOW_RECOVERY,
+        },
+    });
+
+    assert.deepEqual(completion.result.override, {
+        reason: DeliveryRunCompletionOverrideReasons.WORKFLOW_RECOVERY,
+        bypassed: [],
+    });
+    await storage()
+        .delete(deliveryRunHandoffOperations)
+        .where(eq(deliveryRunHandoffOperations.runId, run.id));
+});
+
+test('missing arrival and handoff review require an auditable completion override', async () => {
+    const { run, driverUserId } =
+        await startPreparedBulkRunWithConfirmedPickup();
+    const [targetStop] = run.stops;
+    assert.ok(targetStop);
+    const occurredAt = new Date(Date.now() - 1_000);
+
+    await assertExecutionError(
+        recordDeliveryRunStopOperation({
+            kind: DeliveryRunStopOperationKinds.DELIVER,
+            driverUserId,
+            runId: run.id,
+            targetStopId: targetStop.id,
+            expectedRouteRevision: run.routeRevision,
+            clientOperationId: 'unguarded-bulk-delivery',
+            occurredAt,
+        }),
+        DeliveryRunExecutionErrorCodes.COMPLETION_OVERRIDE_REQUIRED,
+    );
+    const unchangedRun = await getDeliveryRun(run.id);
+    assert.ok(
+        unchangedRun?.stops.every(
+            (stop) => stop.state === DeliveryRunStopStates.PENDING,
+        ),
+    );
+    assert.equal(
+        (
+            await storage()
+                .select()
+                .from(deliveryRunStopOperations)
+                .where(eq(deliveryRunStopOperations.runId, run.id))
+        ).length,
+        0,
+    );
+    assert.equal(
+        (
+            await storage()
+                .select()
+                .from(events)
+                .where(
+                    and(
+                        eq(
+                            events.type,
+                            knownEventTypes.delivery.requestFulfilled,
+                        ),
+                        inArray(
+                            events.aggregateId,
+                            run.stops.map((stop) => stop.deliveryRequestId),
+                        ),
+                    ),
+                )
+        ).length,
+        0,
+    );
+
+    const overrideInput = {
+        kind: DeliveryRunStopOperationKinds.DELIVER,
+        driverUserId,
+        runId: run.id,
+        targetStopId: targetStop.id,
+        expectedRouteRevision: run.routeRevision,
+        clientOperationId: 'overridden-bulk-delivery',
+        occurredAt,
+        completionOverride: {
+            reason: DeliveryRunCompletionOverrideReasons.MANUAL_HANDOFF,
+        },
+    } as const;
+    const applied = await recordDeliveryRunStopOperation(overrideInput);
+    assert.equal(applied.replayed, false);
+    assert.deepEqual(applied.result.override, {
+        reason: DeliveryRunCompletionOverrideReasons.MANUAL_HANDOFF,
+        bypassed: ['arrival', 'handoff-review'],
+    });
+
+    const replayed = await recordDeliveryRunStopOperation(overrideInput);
+    assert.equal(replayed.replayed, true);
+    assert.deepEqual(replayed.result, applied.result);
+    await assertExecutionError(
+        recordDeliveryRunStopOperation({
+            ...overrideInput,
+            completionOverride: {
+                reason: DeliveryRunCompletionOverrideReasons.DEVICE_UNAVAILABLE,
+            },
+        }),
+        DeliveryRunExecutionErrorCodes.STOP_OPERATION_CONFLICT,
+    );
+    const [receipt] = await storage()
+        .select({ result: deliveryRunStopOperations.result })
+        .from(deliveryRunStopOperations)
+        .where(eq(deliveryRunStopOperations.runId, run.id));
+    assert.deepEqual(receipt?.result.override, applied.result.override);
+});
+
 test('stop operation receipts replay exact bulk arrival and delivery results after completion', async () => {
     const { run, driverUserId } =
         await startPreparedBulkRunWithConfirmedPickup();
@@ -5143,6 +5392,9 @@ test('stop operation receipts replay exact bulk arrival and delivery results aft
         clientOperationId: 'offline-bulk-delivery',
         occurredAt: deliveryOccurredAt,
         deliveryNotes: privateNote,
+        completionOverride: {
+            reason: DeliveryRunCompletionOverrideReasons.WORKFLOW_RECOVERY,
+        },
     } as const;
     const deliveryAttempts = await Promise.all([
         recordDeliveryRunStopOperation(deliveryInput),
@@ -5174,6 +5426,10 @@ test('stop operation receipts replay exact bulk arrival and delivery results aft
         reroutePending: false,
         runCompleted: true,
         handoff: expectedHandoff,
+        override: {
+            reason: DeliveryRunCompletionOverrideReasons.WORKFLOW_RECOVERY,
+            bypassed: ['handoff-review'],
+        },
     });
 
     const completedRun = await getDeliveryRun(run.id);
@@ -5240,6 +5496,15 @@ test('stop operation receipts replay exact bulk arrival and delivery results aft
     assert.deepEqual(arrivalReplay.result, arrival.result);
     assert.deepEqual(deliveryReplay.result, appliedDelivery.result);
     assert.deepEqual(deliveryReplay.newlyFulfilledRequestIds, []);
+    await assertExecutionError(
+        recordDeliveryRunStopOperation({
+            ...deliveryInput,
+            completionOverride: {
+                reason: DeliveryRunCompletionOverrideReasons.DEVICE_UNAVAILABLE,
+            },
+        }),
+        DeliveryRunExecutionErrorCodes.STOP_OPERATION_CONFLICT,
+    );
 
     const fulfillmentEventsAfterReplay = await storage()
         .select({
@@ -5388,6 +5653,9 @@ test('bulk delivery command rolls back fulfillment events, stop state, and recei
             expectedRouteRevision: run.routeRevision,
             clientOperationId: 'rollback-bulk-delivery',
             occurredAt: new Date(),
+            completionOverride: {
+                reason: DeliveryRunCompletionOverrideReasons.WORKFLOW_RECOVERY,
+            },
         }),
         DeliveryRunExecutionErrorCodes.STOP_OPERATION_STATE_CONFLICT,
     );
@@ -5481,6 +5749,9 @@ test('bulk delivery command treats deferred and failed request races as state co
                 expectedRouteRevision: run.routeRevision,
                 clientOperationId: `rollback-bulk-${outcome}`,
                 occurredAt: new Date(),
+                completionOverride: {
+                    reason: DeliveryRunCompletionOverrideReasons.WORKFLOW_RECOVERY,
+                },
             }),
             DeliveryRunExecutionErrorCodes.STOP_OPERATION_STATE_CONFLICT,
         );

--- a/packages/ui/src/Modal/Modal.tsx
+++ b/packages/ui/src/Modal/Modal.tsx
@@ -120,7 +120,7 @@ function DesktopModal({
             <DialogPrimitive.Portal>
                 <DialogPrimitive.Overlay
                     className={cx(
-                        'fixed inset-0 z-50 bg-background/80 backdrop-blur-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+                        'fixed inset-0 z-50 bg-background/80 backdrop-blur-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 motion-reduce:animate-none motion-reduce:transition-none',
                         overlayClassName,
                     )}
                 />
@@ -129,7 +129,7 @@ function DesktopModal({
                         ? {}
                         : { 'aria-describedby': undefined })}
                     className={cx(
-                        'fixed left-1/2 top-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-lg min-w-0 -translate-x-1/2 -translate-y-1/2 gap-4 overflow-x-auto overflow-y-auto overscroll-contain border bg-background p-6 shadow-lg duration-200 [overflow-wrap:anywhere] data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:rounded-lg',
+                        'fixed left-1/2 top-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-lg min-w-0 -translate-x-1/2 -translate-y-1/2 gap-4 overflow-x-auto overflow-y-auto overscroll-contain border bg-background p-6 shadow-lg duration-200 [overflow-wrap:anywhere] data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 motion-reduce:animate-none motion-reduce:transition-none sm:rounded-lg',
                         className,
                     )}
                     onEscapeKeyDown={preventDismiss}
@@ -146,7 +146,7 @@ function DesktopModal({
                     ) : null}
                     {children}
                     {dismissible && !hideClose ? (
-                        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+                        <DialogPrimitive.Close className="absolute right-1 top-1 inline-flex size-11 items-center justify-center rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground motion-reduce:transition-none">
                             <Close aria-hidden className="size-4" />
                             <span className="sr-only">Zatvori</span>
                         </DialogPrimitive.Close>
@@ -187,7 +187,7 @@ function MobileModal({
             <Drawer.Portal>
                 <Drawer.Overlay
                     className={cx(
-                        'fixed inset-0 z-50 bg-black/50',
+                        'fixed inset-0 z-50 bg-black/50 motion-reduce:!animate-none motion-reduce:!transition-none motion-reduce:!duration-0',
                         overlayClassName,
                     )}
                 />
@@ -196,7 +196,7 @@ function MobileModal({
                         ? {}
                         : { 'aria-describedby': undefined })}
                     className={cx(
-                        'fixed inset-x-0 bottom-0 z-50 mt-4 flex max-h-[calc(100dvh-1rem)] w-full max-w-full min-w-0 flex-col overflow-hidden rounded-t-[10px] border bg-background',
+                        'fixed inset-x-0 bottom-0 z-50 mt-4 flex max-h-[calc(100dvh-1rem)] w-full max-w-full min-w-0 flex-col overflow-hidden rounded-t-[10px] border bg-background motion-reduce:!animate-none motion-reduce:!transition-none motion-reduce:!duration-0',
                         className,
                     )}
                     ref={drawerRef}


### PR DESCRIPTION
## Summary

- derive missing-arrival and unreviewed-handoff bypasses on the server, require a bounded operational reason, and persist that reason in the idempotent stop receipt
- keep reviewed single deliveries one-tap while giving grouped deliveries a recipient/harvest summary from an aggregate-only server count; QR remains advisory and optional
- harden current-stop and recovery controls for 44 px touch targets, focus return, reduced motion, safe-area placement, same-frame duplicate taps, and Croatian offline count copy
- document the audit contract and the production physical-device validation matrix

## Validation

- pnpm --filter delivery test:unit (295 passed)
- pnpm --filter delivery test:component (99 passed)
- pnpm --filter delivery typecheck
- pnpm --filter delivery build
- pnpm --dir packages/storage test -- deliveryRunsRepo.node.spec.ts (74 passed)
- pnpm --dir packages/ui typecheck
- Biome checks for delivery, storage, and UI changed surfaces
- git diff --check
- independent storage, acceptance, and UX/accessibility reviews; no actionable findings remain

## Remaining validation

The documented small/large iPhone and Android one-handed production matrix still requires physical devices and tester/date evidence. This PR intentionally references, rather than closes, the issue so that gate remains visible after merge.

Refs #4134