### PR TITLE
fix(deps): reduce Renovate pnpm memory use

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,8 +31,12 @@
     ],
     "minimumReleaseAge": "5 days",
     "prHourlyLimit": 6,
+    "env": {
+        "PNPM_MAX_WORKERS": "1",
+        "PNPM_WORKERS": "1"
+    },
     "toolSettings": {
-        "nodeMaxMemory": 2048
+        "nodeMaxMemory": 1536
     },
     "platformAutomerge": true,
     "platformCommit": "enabled"


### PR DESCRIPTION
## Summary

- lower Renovate's Node heap from 2 GiB to 1.5 GiB for the 3 GiB Mend Community runner
- restrict pnpm lockfile generation to one worker

## Context

The manual scan after #4207 still exhausted the hosted runner's 3 GiB limit while executing `pnpm install --lockfile-only --recursive --ignore-scripts --ignore-pnpmfile`.

## Validation

- `renovate-config-validator --strict --no-global renovate.json` using Mend's hosted pnpm env allowlist
- `git diff --check`
- JSON parse