### PR TITLE
feat(delivery): separate customer delivery and pickup views

### DIFF
--- a/apps/api/app/api/[...route]/deliveryRoutes.ts
+++ b/apps/api/app/api/[...route]/deliveryRoutes.ts
@@ -314,7 +314,12 @@ const app = new Hono<{ Variables: AuthVariables }>()
         async (context) => {
             const { accountId } = context.get('authContext');
             const requests = await getDeliveryRequestsWithEvents(accountId);
-            return context.json(requests.map(customerDeliveryRequest));
+            return context.json(
+                requests.flatMap((request) => {
+                    const customerRequest = customerDeliveryRequest(request);
+                    return customerRequest ? [customerRequest] : [];
+                }),
+            );
         },
     )
     // POST /requests - create delivery request

--- a/apps/api/lib/delivery/customerDeliveryRequest.node.spec.ts
+++ b/apps/api/lib/delivery/customerDeliveryRequest.node.spec.ts
@@ -2,26 +2,251 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { customerDeliveryRequest } from './customerDeliveryRequest';
 
-test('customer delivery request excludes driver-only notes and preserves the safe receipt', () => {
-    const privateNote = 'PRIVATE DRIVER NOTE';
+const createdAt = new Date('2026-07-16T08:00:00.000Z');
+const startsAt = new Date('2026-07-16T10:00:00.000Z');
+const endsAt = new Date('2026-07-16T12:00:00.000Z');
+const fulfilledAt = new Date('2026-07-16T10:30:00.000Z');
+
+test('customer delivery request returns an explicit delivery allowlist', () => {
+    const privateSentinels = [
+        'PRIVATE ACCOUNT 4135',
+        'PRIVATE DRIVER NOTE 4135',
+        'PRIVATE ROUTE 4135',
+        'PRIVATE PHONE 4135',
+        'PRIVATE TRACE TOKEN 4135',
+        'PRIVATE OPERATION ATTRIBUTE 4135',
+        'PRIVATE RAISED BED ACCOUNT 4135',
+    ];
     const request = customerDeliveryRequest({
-        id: 'customer-request-4144',
-        accountId: 'customer-account-4144',
-        deliveryNotes: privateNote,
+        id: 'delivery-request-4135',
+        operationId: 4135,
+        mode: 'delivery',
+        state: 'fulfilled',
+        createdAt,
+        accountId: privateSentinels[0],
+        deliveryNotes: privateSentinels[1],
+        routeRevision: privateSentinels[2],
+        slot: {
+            id: 10,
+            startAt: startsAt,
+            endAt: endsAt,
+            status: 'scheduled',
+            closesAt: privateSentinels[2],
+        },
+        address: {
+            id: 20,
+            label: 'Dom',
+            street1: 'Vrtna 1',
+            street2: null,
+            city: 'Zagreb',
+            postalCode: '10000',
+            countryCode: 'HR',
+            phone: privateSentinels[3],
+            contactName: 'PRIVATE CONTACT 4135',
+        },
+        location: {
+            id: 30,
+            name: 'PRIVATE PICKUP LOCATION 4135',
+            street1: 'HQ 1',
+            city: 'Zagreb',
+            postalCode: '10000',
+            countryCode: 'HR',
+        },
+        operation: { privateValue: 'PRIVATE OPERATION 4135' },
+        operationData: {
+            information: {
+                label: 'Berba',
+                name: 'harvest',
+                description: privateSentinels[5],
+            },
+            image: {
+                cover: {
+                    url: 'https://example.com/operation.webp',
+                    privateValue: privateSentinels[5],
+                },
+            },
+            attributes: { privateValue: privateSentinels[5] },
+        },
+        plantSort: {
+            information: {
+                name: 'Cherry rajčica',
+                description: 'PRIVATE PLANT DESCRIPTION 4135',
+            },
+            image: {
+                cover: {
+                    url: 'https://example.com/plant.webp',
+                    privateValue: 'PRIVATE PLANT IMAGE 4135',
+                },
+            },
+        },
+        raisedBed: {
+            name: 'Gredica 1',
+            physicalId: 'A-1',
+            accountId: privateSentinels[6],
+        },
+        raisedBedField: {
+            positionIndex: 2,
+            plantCycles: ['PRIVATE PLANT CYCLE 4135'],
+        },
+        requestNotes: 'Pozvoniti na ulaz.',
+        cancelReason: 'Promjena plana',
+        trace: {
+            publicPath: '/trag/javna-putanja',
+            id: 99,
+            publicToken: privateSentinels[4],
+        },
         customerHandoffReceipt: {
-            fulfilledAt: new Date('2026-07-16T10:30:00.000Z'),
-            verification: 'verified' as const,
+            fulfilledAt,
+            verification: 'verified',
+            privateRunId: privateSentinels[2],
         },
     });
 
     assert.deepEqual(request, {
-        id: 'customer-request-4144',
-        accountId: 'customer-account-4144',
+        id: 'delivery-request-4135',
+        operationId: 4135,
+        state: 'fulfilled',
+        createdAt,
+        slot: { id: 10, startAt: startsAt, endAt: endsAt },
+        operationData: {
+            information: { label: 'Berba', name: 'harvest' },
+            image: {
+                cover: { url: 'https://example.com/operation.webp' },
+            },
+        },
+        plantSort: {
+            information: { name: 'Cherry rajčica' },
+            image: { cover: { url: 'https://example.com/plant.webp' } },
+        },
+        raisedBed: { name: 'Gredica 1', physicalId: 'A-1' },
+        raisedBedField: { positionIndex: 2 },
+        trace: { publicPath: '/trag/javna-putanja' },
+        requestNotes: 'Pozvoniti na ulaz.',
+        cancelReason: 'Promjena plana',
+        mode: 'delivery',
+        address: {
+            id: 20,
+            label: 'Dom',
+            street1: 'Vrtna 1',
+            street2: null,
+            city: 'Zagreb',
+            postalCode: '10000',
+            countryCode: 'HR',
+        },
         customerHandoffReceipt: {
-            fulfilledAt: new Date('2026-07-16T10:30:00.000Z'),
+            fulfilledAt,
             verification: 'verified',
         },
     });
-    assert.equal(JSON.stringify(request).includes(privateNote), false);
-    assert.equal('deliveryNotes' in request, false);
+    const serialized = JSON.stringify(request);
+    for (const sentinel of privateSentinels) {
+        assert.equal(serialized.includes(sentinel), false, sentinel);
+    }
+    assert.equal('location' in request, false);
+});
+
+test('customer pickup request exposes only its public pickup destination', () => {
+    const request = customerDeliveryRequest({
+        id: 'pickup-request-4135',
+        operationId: 4136,
+        mode: 'pickup',
+        state: 'ready',
+        createdAt,
+        slot: { id: 11, startAt: startsAt, endAt: endsAt },
+        location: {
+            id: 31,
+            name: 'Gredice HQ',
+            street1: 'Sjedište 1',
+            street2: 'Ulaz iz dvorišta',
+            city: 'Zagreb',
+            postalCode: '10000',
+            countryCode: 'HR',
+            isActive: true,
+            createdAt: 'PRIVATE LOCATION TIMESTAMP 4135',
+        },
+        address: {
+            id: 21,
+            label: 'PRIVATE DELIVERY ADDRESS 4135',
+            street1: 'Privatna 1',
+            city: 'Zagreb',
+            postalCode: '10000',
+            countryCode: 'HR',
+        },
+        operationData: null,
+        plantSort: null,
+        raisedBed: null,
+        raisedBedField: null,
+        trace: null,
+        deliveryNotes: 'PRIVATE PICKUP NOTE 4135',
+        customerHandoffReceipt: {
+            fulfilledAt,
+            verification: 'verified',
+        },
+    });
+
+    assert.deepEqual(request, {
+        id: 'pickup-request-4135',
+        operationId: 4136,
+        state: 'ready',
+        createdAt,
+        slot: { id: 11, startAt: startsAt, endAt: endsAt },
+        operationData: null,
+        plantSort: null,
+        raisedBed: null,
+        raisedBedField: null,
+        trace: null,
+        mode: 'pickup',
+        location: {
+            id: 31,
+            name: 'Gredice HQ',
+            street1: 'Sjedište 1',
+            street2: 'Ulaz iz dvorišta',
+            city: 'Zagreb',
+            postalCode: '10000',
+            countryCode: 'HR',
+        },
+    });
+    const serialized = JSON.stringify(request);
+    assert.equal(serialized.includes('PRIVATE'), false);
+    assert.equal('address' in request, false);
+    assert.equal('customerHandoffReceipt' in request, false);
+});
+
+test('customer delivery receipt is omitted before fulfillment', () => {
+    const request = customerDeliveryRequest({
+        id: 'ready-delivery-request-4135',
+        operationId: 4137,
+        mode: 'delivery',
+        state: 'ready',
+        createdAt,
+        customerHandoffReceipt: {
+            fulfilledAt,
+            verification: 'verified',
+        },
+    });
+
+    assert.ok(request);
+    assert.equal('customerHandoffReceipt' in request, false);
+});
+
+test('customer delivery request rejects missing and unknown modes', () => {
+    assert.equal(
+        customerDeliveryRequest({
+            id: 'missing-mode-4135',
+            operationId: 4138,
+            state: 'pending',
+            createdAt,
+        }),
+        null,
+    );
+    assert.equal(
+        customerDeliveryRequest({
+            id: 'unknown-mode-4135',
+            operationId: 4139,
+            mode: 'courier',
+            state: 'pending',
+            createdAt,
+        }),
+        null,
+    );
 });

--- a/apps/api/lib/delivery/customerDeliveryRequest.ts
+++ b/apps/api/lib/delivery/customerDeliveryRequest.ts
@@ -1,11 +1,242 @@
+type CustomerImageSource = {
+    cover?: {
+        url?: string | null;
+    } | null;
+} | null;
+
+type CustomerDeliveryRequestSource = {
+    id: string;
+    operationId: number;
+    mode?: unknown;
+    state: string;
+    createdAt: Date;
+    slot?: {
+        id: number;
+        startAt: Date;
+        endAt: Date;
+    } | null;
+    address?: {
+        id: number;
+        label: string;
+        street1: string;
+        street2?: string | null;
+        city: string;
+        postalCode: string;
+        countryCode: string;
+    } | null;
+    location?: {
+        id: number;
+        name: string;
+        street1: string;
+        street2?: string | null;
+        city: string;
+        postalCode: string;
+        countryCode: string;
+    } | null;
+    operationData?: {
+        information?: {
+            label?: string | null;
+            name?: string | null;
+        } | null;
+        image?: CustomerImageSource;
+    } | null;
+    plantSort?: {
+        information?: {
+            name?: string | null;
+        } | null;
+        image?: CustomerImageSource;
+    } | null;
+    raisedBed?: {
+        name: string;
+        physicalId?: string | null;
+    } | null;
+    raisedBedField?: {
+        positionIndex: number;
+    } | null;
+    requestNotes?: string;
+    cancelReason?: string;
+    trace?: {
+        publicPath: string;
+    } | null;
+    customerHandoffReceipt?: {
+        fulfilledAt: Date;
+        verification: 'verified' | 'no-label' | 'skipped' | 'not-recorded';
+    };
+};
+
+function customerImage(image: CustomerImageSource | undefined) {
+    const url = image?.cover?.url;
+    return typeof url === 'string' && url.length > 0
+        ? { cover: { url } }
+        : null;
+}
+
+function customerOperationData(
+    operationData: CustomerDeliveryRequestSource['operationData'],
+) {
+    if (!operationData) return null;
+
+    return {
+        information: {
+            label: operationData.information?.label ?? null,
+            name: operationData.information?.name ?? null,
+        },
+        image: customerImage(operationData.image),
+    };
+}
+
+function customerPlantSort(
+    plantSort: CustomerDeliveryRequestSource['plantSort'],
+) {
+    if (!plantSort) return null;
+
+    return {
+        information: {
+            name: plantSort.information?.name ?? null,
+        },
+        image: customerImage(plantSort.image),
+    };
+}
+
+function customerSlot(slot: CustomerDeliveryRequestSource['slot']) {
+    if (!slot) return null;
+
+    return {
+        id: slot.id,
+        startAt: slot.startAt,
+        endAt: slot.endAt,
+    };
+}
+
+function customerAddress(address: CustomerDeliveryRequestSource['address']) {
+    if (!address) return null;
+
+    return {
+        id: address.id,
+        label: address.label,
+        street1: address.street1,
+        street2: address.street2 ?? null,
+        city: address.city,
+        postalCode: address.postalCode,
+        countryCode: address.countryCode,
+    };
+}
+
+function customerPickupLocation(
+    location: CustomerDeliveryRequestSource['location'],
+) {
+    if (!location) return null;
+
+    return {
+        id: location.id,
+        name: location.name,
+        street1: location.street1,
+        street2: location.street2 ?? null,
+        city: location.city,
+        postalCode: location.postalCode,
+        countryCode: location.countryCode,
+    };
+}
+
+type CustomerDeliveryRequest = {
+    id: string;
+    operationId: number;
+    state: string;
+    createdAt: Date;
+    slot: ReturnType<typeof customerSlot>;
+    operationData: ReturnType<typeof customerOperationData>;
+    plantSort: ReturnType<typeof customerPlantSort>;
+    raisedBed: {
+        name: string;
+        physicalId: string | null;
+    } | null;
+    raisedBedField: {
+        positionIndex: number;
+    } | null;
+    trace: {
+        publicPath: string;
+    } | null;
+    requestNotes?: string;
+    cancelReason?: string;
+} & (
+    | {
+          mode: 'delivery';
+          address: ReturnType<typeof customerAddress>;
+          location?: null;
+          customerHandoffReceipt?: {
+              fulfilledAt: Date;
+              verification:
+                  | 'verified'
+                  | 'no-label'
+                  | 'skipped'
+                  | 'not-recorded';
+          };
+      }
+    | {
+          mode: 'pickup';
+          location: ReturnType<typeof customerPickupLocation>;
+          address?: null;
+          customerHandoffReceipt?: never;
+      }
+);
+
 /**
- * Removes driver-only fulfillment notes before an account-owned request leaves
- * the customer API boundary. Customer-safe handoff data is already reduced to
- * a bounded receipt by the storage projection.
+ * Projects the storage aggregate to the fields used by account-owned customer
+ * clients. The mode branches prevent delivery-only data from crossing into a
+ * pickup response (and vice versa), while unknown legacy modes fail closed.
  */
 export function customerDeliveryRequest<
-    TRequest extends { deliveryNotes?: unknown },
->(request: TRequest) {
-    const { deliveryNotes: _driverOnlyNotes, ...customerRequest } = request;
-    return customerRequest;
+    const TRequest extends CustomerDeliveryRequestSource,
+>(request: TRequest): CustomerDeliveryRequest | null {
+    if (request.mode !== 'delivery' && request.mode !== 'pickup') {
+        return null;
+    }
+
+    const common = {
+        id: request.id,
+        operationId: request.operationId,
+        state: request.state,
+        createdAt: request.createdAt,
+        slot: customerSlot(request.slot),
+        operationData: customerOperationData(request.operationData),
+        plantSort: customerPlantSort(request.plantSort),
+        raisedBed: request.raisedBed
+            ? {
+                  name: request.raisedBed.name,
+                  physicalId: request.raisedBed.physicalId ?? null,
+              }
+            : null,
+        raisedBedField: request.raisedBedField
+            ? { positionIndex: request.raisedBedField.positionIndex }
+            : null,
+        trace: request.trace ? { publicPath: request.trace.publicPath } : null,
+        ...(typeof request.requestNotes === 'string'
+            ? { requestNotes: request.requestNotes }
+            : {}),
+        ...(typeof request.cancelReason === 'string'
+            ? { cancelReason: request.cancelReason }
+            : {}),
+    };
+
+    if (request.mode === 'pickup') {
+        return {
+            ...common,
+            mode: 'pickup',
+            location: customerPickupLocation(request.location),
+        };
+    }
+
+    return {
+        ...common,
+        mode: 'delivery',
+        address: customerAddress(request.address),
+        ...(request.state === 'fulfilled' && request.customerHandoffReceipt
+            ? {
+                  customerHandoffReceipt: {
+                      fulfilledAt: request.customerHandoffReceipt.fulfilledAt,
+                      verification: request.customerHandoffReceipt.verification,
+                  },
+              }
+            : {}),
+    };
 }

--- a/apps/delivery/app/api/dashboard/route.ts
+++ b/apps/delivery/app/api/dashboard/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
                     userId,
                     role: user.role,
                 }),
-                { headers: { 'Cache-Control': 'no-store' } },
+                { headers: { 'Cache-Control': 'private, no-store' } },
             ),
     );
 }

--- a/apps/delivery/app/api/map/[runId]/route.ts
+++ b/apps/delivery/app/api/map/[runId]/route.ts
@@ -1,148 +1,35 @@
 import { getDeliveryRun, isDeliveryRunStopTerminal } from '@gredice/storage';
 import { withAuth } from '../../../../lib/auth/auth';
 import {
-    accountCanTrackDeliveryRun,
+    customerDeliveryTrackingContext,
+    type DeliveryRun,
+    type ResolvedDeliveryRunStopGroup,
     resolveDeliveryRunStopGroups,
 } from '../../../../lib/deliveryDashboard';
-import {
-    buildDeliveryMapData,
-    deliveryMapStopGroupSelectionId,
-} from '../../../../lib/deliveryMapData';
+import { createDeliveryMapRouteHandlers } from '../../../../lib/deliveryMapRoute';
 import { driverDeliveryTrackingLocation } from '../../../../lib/deliveryTracking';
 import {
     buildGoogleStaticMapUrl,
     unavailableMapSvg,
 } from '../../../../lib/googleStaticMap';
 
-const noStoreHeaders = { 'Cache-Control': 'private, no-store' };
-
-function unavailableMapResponse() {
-    return new Response(unavailableMapSvg(), {
-        status: 200,
-        headers: {
-            'Content-Type': 'image/svg+xml; charset=utf-8',
-            ...noStoreHeaders,
-        },
-    });
-}
+const handlers = createDeliveryMapRouteHandlers<
+    DeliveryRun,
+    ResolvedDeliveryRunStopGroup
+>({
+    withAuth,
+    getRun: getDeliveryRun,
+    getCustomerTrackingContext: customerDeliveryTrackingContext,
+    resolveGroups: resolveDeliveryRunStopGroups,
+    getDriverLocation: driverDeliveryTrackingLocation,
+    isStopTerminal: isDeliveryRunStopTerminal,
+    buildStaticMapUrl: buildGoogleStaticMapUrl,
+    unavailableMapSvg,
+});
 
 export async function GET(
     request: Request,
     { params }: { params: Promise<{ runId: string }> },
 ) {
-    return await withAuth(
-        ['user', 'farmer', 'driver', 'admin'],
-        async ({ accountId, userId, user }) => {
-            const { runId } = await params;
-            const run = await getDeliveryRun(runId);
-            if (!run) {
-                return new Response(null, {
-                    status: 404,
-                    headers: noStoreHeaders,
-                });
-            }
-
-            const driverView =
-                (user.role === 'driver' || user.role === 'admin') &&
-                run.driverUserId === userId;
-            const customerView = !driverView;
-            if (
-                customerView &&
-                !(await accountCanTrackDeliveryRun({ accountId, runId }))
-            ) {
-                return new Response(null, {
-                    status: 403,
-                    headers: noStoreHeaders,
-                });
-            }
-
-            const projectedAt = new Date();
-            const location = driverDeliveryTrackingLocation(run, projectedAt);
-            const groups = await resolveDeliveryRunStopGroups(run);
-            const stops = groups.flatMap((group, index) => {
-                const customerOwnsStop = group.items.some(
-                    ({ request }) => request?.accountId === accountId,
-                );
-                const delivered = group.items.every(({ stop }) =>
-                    isDeliveryRunStopTerminal(stop.state),
-                );
-                const representative = group.items[0]?.stop;
-                if (
-                    !representative ||
-                    (!driverView && !customerOwnsStop) ||
-                    (driverView && delivered)
-                ) {
-                    return [];
-                }
-                return [
-                    {
-                        latitude: representative.latitude,
-                        longitude: representative.longitude,
-                        sequence: index + 1,
-                        selectionId: driverView
-                            ? deliveryMapStopGroupSelectionId(
-                                  group.items.map(({ stop }) => stop.id),
-                              )
-                            : null,
-                    },
-                ];
-            });
-            const mapData = buildDeliveryMapData({
-                driverLocation: location
-                    ? {
-                          latitude: location.latitude,
-                          longitude: location.longitude,
-                      }
-                    : null,
-                pickupNodes: driverView
-                    ? run.pickupNodes.flatMap((pickupNode) =>
-                          pickupNode.latitude !== null &&
-                          pickupNode.longitude !== null
-                              ? [
-                                    {
-                                        latitude: pickupNode.latitude,
-                                        longitude: pickupNode.longitude,
-                                        selectionId: pickupNode.id,
-                                    },
-                                ]
-                              : [],
-                      )
-                    : [],
-                stops,
-                encodedPolyline: run.encodedPolyline,
-                customerView,
-            });
-            if (new URL(request.url).searchParams.get('format') === 'json') {
-                return Response.json(mapData, {
-                    status: 200,
-                    headers: noStoreHeaders,
-                });
-            }
-
-            const url = buildGoogleStaticMapUrl({
-                ...mapData,
-                customerView,
-            });
-            if (!url) return unavailableMapResponse();
-
-            try {
-                const response = await fetch(url, { cache: 'no-store' });
-                if (!response.ok) return unavailableMapResponse();
-                return new Response(await response.arrayBuffer(), {
-                    status: 200,
-                    headers: {
-                        'Content-Type':
-                            response.headers.get('content-type') ?? 'image/png',
-                        ...noStoreHeaders,
-                    },
-                });
-            } catch (error) {
-                console.error('Failed to load delivery map', {
-                    runId,
-                    errorName: error instanceof Error ? error.name : 'Unknown',
-                });
-                return unavailableMapResponse();
-            }
-        },
-    );
+    return await handlers.GET(request, { params });
 }

--- a/apps/delivery/components/CustomerDashboard.tsx
+++ b/apps/delivery/components/CustomerDashboard.tsx
@@ -1,22 +1,55 @@
 import { Card, CardContent } from '@gredice/ui/Card';
 import { ShoppingCart, Truck } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
-import type { CustomerDeliveryDashboard } from '../lib/deliveryDashboardTypes';
+import type {
+    CustomerDeliveryDashboard,
+    CustomerDeliveryRequestSummary,
+} from '../lib/deliveryDashboardTypes';
+import { CustomerDeliveryCard } from './CustomerDeliveryCard';
 import { CustomerDeliveryTracking } from './CustomerDeliveryTracking';
+import { CustomerPickupCard } from './CustomerPickupCard';
 import { DeliveryAppHeader } from './DeliveryAppHeader';
-import { DeliveryStopCard } from './DeliveryStopCard';
 
 export function CustomerDashboard({
     dashboard,
 }: {
     dashboard: CustomerDeliveryDashboard;
 }) {
-    const trackedDelivery = dashboard.deliveries.find(
-        (delivery) =>
-            delivery.runId &&
-            delivery.tracking &&
-            delivery.statusLabel !== 'Dostavljeno',
+    const hasDelivery = dashboard.deliveries.some(
+        (request) => request.mode === 'delivery',
     );
+    const hasPickup = dashboard.deliveries.some(
+        (request) => request.mode === 'pickup',
+    );
+    const trackedDelivery = dashboard.deliveries.find(
+        (request): request is CustomerDeliveryRequestSummary =>
+            request.mode === 'delivery' &&
+            Boolean(request.mapPath) &&
+            Boolean(request.tracking) &&
+            request.status !== 'fulfilled',
+    );
+    const heading = hasDelivery
+        ? hasPickup
+            ? 'Moje dostave i preuzimanja'
+            : 'Moje dostave'
+        : hasPickup
+          ? 'Moja preuzimanja'
+          : 'Moje dostave i preuzimanja';
+    const headerContext = hasDelivery
+        ? hasPickup
+            ? 'mixed'
+            : 'delivery'
+        : hasPickup
+          ? 'pickup'
+          : 'mixed';
+    const description =
+        !hasDelivery && !hasPickup
+            ? 'Statusi uroda i planirani termini dostava i preuzimanja na jednom mjestu.'
+            : hasDelivery
+              ? hasPickup
+                  ? 'Statusi uroda, planirani termini, lokacije preuzimanja i praćenje aktivne dostave na jednom mjestu.'
+                  : 'Statusi uroda, planirani termini i praćenje aktivne dostave na jednom mjestu.'
+              : 'Statusi uroda, lokacije i planirani termini preuzimanja na jednom mjestu.';
 
     return (
         <div className="min-h-[100dvh] bg-background">
@@ -24,34 +57,40 @@ export function CustomerDashboard({
                 userId={dashboard.user.id}
                 displayName={dashboard.user.displayName}
                 role={dashboard.user.role}
+                context={headerContext}
             />
             <main className="mx-auto w-full max-w-5xl space-y-6 px-4 py-5 sm:py-8">
                 <div>
                     <Typography level="h2" semiBold>
-                        Moje dostave
+                        {heading}
                     </Typography>
                     <Typography className="mt-1 text-muted-foreground">
-                        Statusi uroda, planirani termini i praćenje aktivne
-                        dostave na jednom mjestu.
+                        {description}
                     </Typography>
                 </div>
 
-                {trackedDelivery?.runId && trackedDelivery.tracking ? (
+                {trackedDelivery?.mapPath && trackedDelivery.tracking ? (
                     <CustomerDeliveryTracking
-                        runId={trackedDelivery.runId}
+                        mapPath={trackedDelivery.mapPath}
                         tracking={trackedDelivery.tracking}
                     />
                 ) : null}
 
                 {dashboard.deliveries.length > 0 ? (
                     <section className="grid gap-3 lg:grid-cols-2">
-                        {dashboard.deliveries.map((delivery) => (
-                            <DeliveryStopCard
-                                key={delivery.requestId}
-                                stop={delivery}
-                                mode="customer"
-                            />
-                        ))}
+                        {dashboard.deliveries.map((request) =>
+                            request.mode === 'delivery' ? (
+                                <CustomerDeliveryCard
+                                    key={request.requestId}
+                                    delivery={request}
+                                />
+                            ) : (
+                                <CustomerPickupCard
+                                    key={request.requestId}
+                                    pickup={request}
+                                />
+                            ),
+                        )}
                     </section>
                 ) : (
                     <Card>
@@ -64,11 +103,12 @@ export function CustomerDashboard({
                                 <Truck className="absolute -bottom-1 -right-4 size-7 text-primary" />
                             </div>
                             <Typography level="h3" semiBold>
-                                Još nema dostava
+                                Još nema dostava ni preuzimanja
                             </Typography>
                             <Typography className="max-w-md text-muted-foreground">
-                                Kada zatražiš dostavu uroda, ovdje ćeš vidjeti
-                                njezin termin, status i praćenje vozača.
+                                Kada zatražiš dostavu ili preuzimanje uroda,
+                                ovdje ćeš vidjeti termin, status i dostupne
+                                informacije o preuzimanju.
                             </Typography>
                         </CardContent>
                     </Card>

--- a/apps/delivery/components/CustomerDeliveryCard.tsx
+++ b/apps/delivery/components/CustomerDeliveryCard.tsx
@@ -1,0 +1,238 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Card, CardContent } from '@gredice/ui/Card';
+import { Chip } from '@gredice/ui/Chip';
+import {
+    Calendar,
+    ExternalLink,
+    Leaf,
+    Timer,
+    Truck,
+    Warning,
+} from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import type { CustomerDeliveryRequestSummary } from '../lib/deliveryDashboardTypes';
+import {
+    formatDeliveryDateTime,
+    formatDeliveryTime,
+    formatDistance,
+    formatTravelDuration,
+} from '../lib/deliveryFormatting';
+import { DeliveryCustomerReceipt } from './DeliveryCustomerReceipt';
+import { DeliveryCustomerRecovery } from './DeliveryCustomerRecovery';
+
+function statusColor(
+    delivery: CustomerDeliveryRequestSummary,
+): 'success' | 'info' | 'error' | 'warning' | 'neutral' {
+    if (delivery.statusLabel === 'Dostavljeno') return 'success';
+    if (
+        delivery.statusLabel === 'Otkazano' ||
+        delivery.statusLabel === 'Dostava je otkazana' ||
+        delivery.statusLabel === 'Dostava nije uspjela'
+    ) {
+        return 'error';
+    }
+    if (
+        delivery.statusLabel === 'Dostava je odgođena' ||
+        delivery.statusLabel === 'Vozač stiže' ||
+        delivery.statusLabel === 'U dostavi'
+    ) {
+        return 'warning';
+    }
+    if (delivery.statusLabel === 'Vozač je stigao') return 'info';
+    return 'neutral';
+}
+
+export function CustomerDeliveryCard({
+    delivery,
+}: {
+    delivery: CustomerDeliveryRequestSummary;
+}) {
+    const showRouteEstimates =
+        Boolean(
+            delivery.estimatedArrivalAt || delivery.estimatedTravelSeconds,
+        ) &&
+        (!delivery.recovery || delivery.recovery.kind === 'retry-planned');
+    const estimatedOutsideWindow = Boolean(
+        delivery.estimatedArrivalAt &&
+            delivery.slotEndAt &&
+            new Date(delivery.estimatedArrivalAt) >
+                new Date(delivery.slotEndAt),
+    );
+    const harvestDescription = [
+        delivery.harvest.plantName,
+        delivery.harvest.raisedBedName,
+        delivery.harvest.fieldName,
+    ]
+        .filter(Boolean)
+        .join(' · ');
+
+    return (
+        <Card data-testid="customer-delivery-card" className="min-w-0">
+            <CardContent noHeader className="min-w-0 space-y-4 p-4">
+                <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex min-w-0 items-start gap-3">
+                        <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-muted">
+                            <Truck className="size-4" />
+                        </div>
+                        <div className="min-w-0">
+                            <Typography
+                                component="h3"
+                                level="body1"
+                                semiBold
+                                className="break-words"
+                            >
+                                {delivery.harvest.plantName}
+                            </Typography>
+                            <Typography
+                                level="body3"
+                                className="mt-0.5 text-muted-foreground"
+                            >
+                                Dostava uroda
+                            </Typography>
+                        </div>
+                    </div>
+                    <div className="flex shrink-0 flex-wrap gap-2">
+                        <Chip color="neutral" size="sm">
+                            Dostava
+                        </Chip>
+                        <Chip color={statusColor(delivery)} size="sm">
+                            {delivery.statusLabel}
+                        </Chip>
+                    </div>
+                </div>
+
+                {delivery.slotStartAt && delivery.slotEndAt ? (
+                    <div className="flex items-start gap-2 text-sm">
+                        <Calendar className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                        <span>
+                            Termin:{' '}
+                            <time dateTime={delivery.slotStartAt}>
+                                {formatDeliveryDateTime(delivery.slotStartAt)}
+                            </time>{' '}
+                            –{' '}
+                            <time dateTime={delivery.slotEndAt}>
+                                {formatDeliveryTime(delivery.slotEndAt)}
+                            </time>
+                        </span>
+                    </div>
+                ) : null}
+
+                {showRouteEstimates ? (
+                    <div className="grid grid-cols-3 gap-2 rounded-lg bg-muted/70 p-3 text-center">
+                        <div>
+                            <Typography
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                Dolazak
+                            </Typography>
+                            <Typography level="body2" semiBold>
+                                {formatDeliveryTime(
+                                    delivery.estimatedArrivalAt,
+                                )}
+                            </Typography>
+                        </div>
+                        <div className="border-x">
+                            <Typography
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                Vožnja
+                            </Typography>
+                            <Typography level="body2" semiBold>
+                                {formatTravelDuration(
+                                    delivery.estimatedTravelSeconds,
+                                )}
+                            </Typography>
+                        </div>
+                        <div>
+                            <Typography
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                Udaljenost
+                            </Typography>
+                            <Typography level="body2" semiBold>
+                                {formatDistance(
+                                    delivery.estimatedDistanceMeters,
+                                )}
+                            </Typography>
+                        </div>
+                    </div>
+                ) : delivery.reroutePending ? (
+                    <Alert color="info">
+                        Procjena dolaska ažurira se nakon promjene rute.
+                    </Alert>
+                ) : null}
+
+                {delivery.recovery ? (
+                    <DeliveryCustomerRecovery recovery={delivery.recovery} />
+                ) : null}
+
+                {!delivery.receipt ? (
+                    <div className="flex items-start gap-2 text-sm">
+                        <Leaf className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                        <span className="break-words">
+                            {harvestDescription}
+                        </span>
+                    </div>
+                ) : null}
+
+                {delivery.requestNotes ? (
+                    <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+                        <strong>Napomena:</strong> {delivery.requestNotes}
+                    </div>
+                ) : null}
+
+                {showRouteEstimates &&
+                estimatedOutsideWindow &&
+                delivery.status !== 'fulfilled' ? (
+                    <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+                        <Warning className="mt-0.5 size-4 shrink-0" />
+                        <span>
+                            Trenutačna procjena dolaska je nakon završetka
+                            termina. Prikaz će se ažurirati kada vozač nastavi
+                            rutu.
+                        </span>
+                    </div>
+                ) : null}
+
+                {!delivery.receipt && delivery.harvest.tracePath ? (
+                    <div className="flex flex-wrap gap-2">
+                        <Button
+                            aria-label={`Otvori trag uroda: ${delivery.harvest.plantName}`}
+                            href={`https://www.gredice.com${delivery.harvest.tracePath}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            variant="plain"
+                            className="min-h-11"
+                            startDecorator={<ExternalLink className="size-4" />}
+                        >
+                            Trag uroda
+                        </Button>
+                    </div>
+                ) : null}
+
+                {delivery.receipt ? (
+                    <DeliveryCustomerReceipt
+                        receipt={delivery.receipt}
+                        headingLevel="h4"
+                    />
+                ) : null}
+
+                {delivery.deliveredAt && !delivery.receipt ? (
+                    <Typography
+                        level="body3"
+                        className="flex items-center gap-2 text-muted-foreground"
+                    >
+                        <Timer className="size-4" /> Dostavljeno{' '}
+                        <time dateTime={delivery.deliveredAt}>
+                            {formatDeliveryDateTime(delivery.deliveredAt)}
+                        </time>
+                    </Typography>
+                ) : null}
+            </CardContent>
+        </Card>
+    );
+}

--- a/apps/delivery/components/CustomerDeliveryTracking.tsx
+++ b/apps/delivery/components/CustomerDeliveryTracking.tsx
@@ -28,10 +28,10 @@ function trackingMessage(tracking: CustomerDeliveryTrackingSummary) {
 }
 
 export function CustomerDeliveryTracking({
-    runId,
+    mapPath,
     tracking,
 }: {
-    runId: string;
+    mapPath: string;
     tracking: CustomerDeliveryTrackingSummary;
 }) {
     const showMap =
@@ -60,7 +60,7 @@ export function CustomerDeliveryTracking({
             </Alert>
             {showMap ? (
                 <DeliveryMap
-                    mapUrl={`/api/map/${runId}`}
+                    mapUrl={mapPath}
                     version={deliveryTrackingMapVersion(tracking)}
                     title={
                         tracking.status === 'live'

--- a/apps/delivery/components/CustomerPickupCard.tsx
+++ b/apps/delivery/components/CustomerPickupCard.tsx
@@ -1,0 +1,181 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Card, CardContent } from '@gredice/ui/Card';
+import { Chip } from '@gredice/ui/Chip';
+import {
+    Calendar,
+    ExternalLink,
+    Info,
+    Leaf,
+    MapPin,
+    ShoppingCart,
+    Timer,
+} from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import type { CustomerPickupRequestSummary } from '../lib/deliveryDashboardTypes';
+import {
+    formatDeliveryDateTime,
+    formatDeliveryTime,
+} from '../lib/deliveryFormatting';
+
+function statusColor(
+    status: string,
+): 'success' | 'info' | 'error' | 'warning' | 'neutral' {
+    if (status === 'fulfilled' || status === 'ready') return 'success';
+    if (status === 'failed' || status === 'cancelled') return 'error';
+    if (status === 'deferred') return 'warning';
+    if (status === 'confirmed' || status === 'preparing') return 'info';
+    return 'neutral';
+}
+
+export function CustomerPickupCard({
+    pickup,
+}: {
+    pickup: CustomerPickupRequestSummary;
+}) {
+    const harvestDescription = [
+        pickup.harvest.plantName,
+        pickup.harvest.raisedBedName,
+        pickup.harvest.fieldName,
+    ]
+        .filter(Boolean)
+        .join(' · ');
+    const navigationUrl = pickup.location
+        ? `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(pickup.location.address)}`
+        : null;
+
+    return (
+        <Card data-testid="customer-pickup-card" className="min-w-0">
+            <CardContent noHeader className="min-w-0 space-y-4 p-4">
+                <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex min-w-0 items-start gap-3">
+                        <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-muted">
+                            <ShoppingCart className="size-4" />
+                        </div>
+                        <div className="min-w-0">
+                            <Typography
+                                component="h3"
+                                level="body1"
+                                semiBold
+                                className="break-words"
+                            >
+                                {pickup.harvest.plantName}
+                            </Typography>
+                            <Typography
+                                level="body3"
+                                className="mt-0.5 text-muted-foreground"
+                            >
+                                Osobno preuzimanje
+                            </Typography>
+                        </div>
+                    </div>
+                    <div className="flex shrink-0 flex-wrap gap-2">
+                        <Chip color="neutral" size="sm">
+                            Preuzimanje
+                        </Chip>
+                        <Chip color={statusColor(pickup.status)} size="sm">
+                            {pickup.statusLabel}
+                        </Chip>
+                    </div>
+                </div>
+
+                {pickup.slotStartAt && pickup.slotEndAt ? (
+                    <div className="flex items-start gap-2 text-sm">
+                        <Calendar className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                        <span>
+                            Termin:{' '}
+                            <time dateTime={pickup.slotStartAt}>
+                                {formatDeliveryDateTime(pickup.slotStartAt)}
+                            </time>{' '}
+                            –{' '}
+                            <time dateTime={pickup.slotEndAt}>
+                                {formatDeliveryTime(pickup.slotEndAt)}
+                            </time>
+                        </span>
+                    </div>
+                ) : null}
+
+                {pickup.location ? (
+                    <div className="space-y-3 rounded-lg bg-muted/70 p-3">
+                        <div className="flex items-start gap-2 text-sm">
+                            <MapPin className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                            <div className="min-w-0">
+                                <Typography level="body2" semiBold>
+                                    {pickup.location.name}
+                                </Typography>
+                                <Typography
+                                    level="body3"
+                                    className="mt-0.5 break-words text-muted-foreground"
+                                >
+                                    {pickup.location.address}
+                                </Typography>
+                            </div>
+                        </div>
+                        <div className="flex items-start gap-2 text-sm">
+                            <Info className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                            <span>{pickup.location.instructions}</span>
+                        </div>
+                        {navigationUrl ? (
+                            <Button
+                                aria-label={`Otvori lokaciju preuzimanja: ${pickup.location.name}`}
+                                href={navigationUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                size="sm"
+                                variant="outlined"
+                                className="min-h-11 whitespace-normal"
+                                startDecorator={<MapPin className="size-4" />}
+                            >
+                                Otvori lokaciju
+                            </Button>
+                        ) : null}
+                    </div>
+                ) : (
+                    <Alert color="warning">
+                        Lokacija preuzimanja još nije dostupna. Pričekaj potvrdu
+                        prije dolaska.
+                    </Alert>
+                )}
+
+                <div className="flex items-start gap-2 text-sm">
+                    <Leaf className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                    <span className="break-words">{harvestDescription}</span>
+                </div>
+
+                {pickup.requestNotes ? (
+                    <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+                        <strong>Napomena:</strong> {pickup.requestNotes}
+                    </div>
+                ) : null}
+
+                {pickup.harvest.tracePath ? (
+                    <div className="flex flex-wrap gap-2">
+                        <Button
+                            aria-label={`Otvori trag uroda: ${pickup.harvest.plantName}`}
+                            href={`https://www.gredice.com${pickup.harvest.tracePath}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            variant="plain"
+                            className="min-h-11"
+                            startDecorator={<ExternalLink className="size-4" />}
+                        >
+                            Trag uroda
+                        </Button>
+                    </div>
+                ) : null}
+
+                {pickup.pickedUpAt ? (
+                    <Typography
+                        level="body3"
+                        className="flex items-center gap-2 text-muted-foreground"
+                    >
+                        <Timer className="size-4" /> Preuzeto{' '}
+                        <time dateTime={pickup.pickedUpAt}>
+                            {formatDeliveryDateTime(pickup.pickedUpAt)}
+                        </time>
+                    </Typography>
+                ) : null}
+            </CardContent>
+        </Card>
+    );
+}

--- a/apps/delivery/components/DeliveryAppHeader.tsx
+++ b/apps/delivery/components/DeliveryAppHeader.tsx
@@ -1,5 +1,5 @@
 import { Chip } from '@gredice/ui/Chip';
-import { Shield, Truck, User } from '@gredice/ui/icons';
+import { Leaf, Shield, ShoppingCart, Truck, User } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
 import { LogoutButton } from './auth/LogoutButton';
 
@@ -7,22 +7,38 @@ export function DeliveryAppHeader({
     userId,
     displayName,
     role,
+    context = 'delivery',
 }: {
     userId: string;
     displayName: string;
     role: string;
+    context?: 'delivery' | 'pickup' | 'mixed';
 }) {
     const isDriver = role === 'driver' || role === 'admin';
+    const productName =
+        context === 'pickup'
+            ? 'Gredice preuzimanje'
+            : context === 'mixed'
+              ? 'Gredice urodi'
+              : 'Gredice dostava';
+    const productIcon =
+        context === 'pickup' ? (
+            <ShoppingCart className="size-5" />
+        ) : context === 'mixed' ? (
+            <Leaf className="size-5" />
+        ) : (
+            <Truck className="size-5" />
+        );
     return (
         <header className="sticky top-0 z-20 border-b bg-background/95 px-4 pb-3 pt-[calc(env(safe-area-inset-top)+0.75rem)] backdrop-blur">
             <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-3">
                 <div className="flex min-w-0 items-center gap-3">
                     <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground">
-                        <Truck className="size-5" />
+                        {productIcon}
                     </div>
                     <div className="min-w-0">
                         <Typography level="body1" semiBold className="truncate">
-                            Gredice dostava
+                            {productName}
                         </Typography>
                         <Typography
                             level="body3"

--- a/apps/delivery/components/DeliveryCustomerReceipt.tsx
+++ b/apps/delivery/components/DeliveryCustomerReceipt.tsx
@@ -12,8 +12,10 @@ import { formatDeliveryDateTime } from '../lib/deliveryFormatting';
 
 export function DeliveryCustomerReceipt({
     receipt,
+    headingLevel = 'h3',
 }: {
     receipt: CustomerDeliveryReceiptSummary;
+    headingLevel?: 'h3' | 'h4';
 }) {
     const headingId = useId();
     const harvestDescription = [
@@ -35,7 +37,7 @@ export function DeliveryCustomerReceipt({
                 <div className="min-w-0">
                     <Typography
                         id={headingId}
-                        component="h3"
+                        component={headingLevel}
                         level="body2"
                         semiBold
                     >

--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -147,7 +147,81 @@ function isDeliveryDashboard(value: unknown): value is DeliveryDashboardData {
               typeof value.maximumRouteWindowHours === 'number'
         : value.kind === 'customer' &&
               'deliveries' in value &&
-              Array.isArray(value.deliveries);
+              Array.isArray(value.deliveries) &&
+              value.deliveries.every(isCustomerDashboardRequest);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function isNullableString(value: unknown) {
+    return value === null || typeof value === 'string';
+}
+
+function isNullableNumber(value: unknown) {
+    return value === null || typeof value === 'number';
+}
+
+function isCustomerHarvest(value: unknown) {
+    return (
+        isRecord(value) &&
+        typeof value.plantName === 'string' &&
+        isNullableString(value.operationName) &&
+        isNullableString(value.raisedBedName) &&
+        isNullableString(value.fieldName) &&
+        isNullableString(value.tracePath)
+    );
+}
+
+function isCustomerTracking(value: unknown) {
+    return (
+        value === null ||
+        (isRecord(value) &&
+            (value.status === 'live' ||
+                value.status === 'delayed' ||
+                value.status === 'offline' ||
+                value.status === 'unavailable') &&
+            isNullableString(value.lastAcceptedAt) &&
+            typeof value.mapAvailable === 'boolean')
+    );
+}
+
+function isCustomerDashboardRequest(value: unknown) {
+    if (
+        !isRecord(value) ||
+        typeof value.requestId !== 'string' ||
+        typeof value.status !== 'string' ||
+        typeof value.statusLabel !== 'string' ||
+        !isNullableString(value.requestNotes) ||
+        !isNullableString(value.slotStartAt) ||
+        !isNullableString(value.slotEndAt) ||
+        !isCustomerHarvest(value.harvest)
+    ) {
+        return false;
+    }
+    if (value.mode === 'pickup') {
+        return (
+            isNullableString(value.pickedUpAt) &&
+            (value.location === null ||
+                (isRecord(value.location) &&
+                    typeof value.location.name === 'string' &&
+                    typeof value.location.address === 'string' &&
+                    typeof value.location.instructions === 'string'))
+        );
+    }
+    return (
+        value.mode === 'delivery' &&
+        isNullableString(value.estimatedArrivalAt) &&
+        isNullableNumber(value.estimatedTravelSeconds) &&
+        isNullableNumber(value.estimatedDistanceMeters) &&
+        typeof value.reroutePending === 'boolean' &&
+        isNullableString(value.deliveredAt) &&
+        isCustomerTracking(value.tracking) &&
+        isNullableString(value.mapPath) &&
+        (value.receipt === null || isRecord(value.receipt)) &&
+        (value.recovery === null || isRecord(value.recovery))
+    );
 }
 
 function isSafeActiveRun(value: unknown) {

--- a/apps/delivery/lib/customerDeliveryPresentation.node.spec.ts
+++ b/apps/delivery/lib/customerDeliveryPresentation.node.spec.ts
@@ -1,0 +1,244 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    customerDeliveryRequestSummary,
+    customerPickupInstructions,
+    customerPickupRequestSummary,
+    customerPickupStatusLabel,
+} from './customerDeliveryPresentation';
+import type { DeliveryStopSummary } from './deliveryDashboardTypes';
+
+const harvest = {
+    plantName: 'Rajčica',
+    operationName: 'Berba',
+    raisedBedName: 'Gredica 4',
+    fieldName: 'Polje 2',
+    tracePath: '/trag/customer-owned',
+};
+
+test('projects a delivery to the exact customer-safe DTO', () => {
+    const privateSentinel = 'PRIVATE DRIVER DATA 4135';
+    const source: DeliveryStopSummary = {
+        id: 41,
+        requestId: 'request-delivery',
+        sequence: 7,
+        stopState: 'pending',
+        requestState: 'ready',
+        statusLabel: 'Vozač stiže',
+        isCurrent: true,
+        contactName: privateSentinel,
+        phone: privateSentinel,
+        address: privateSentinel,
+        addressLabel: privateSentinel,
+        requestNotes: 'Pozvoni na portafon.',
+        deliveryNotes: privateSentinel,
+        slotStartAt: '2026-07-16T10:00:00.000Z',
+        slotEndAt: '2026-07-16T12:00:00.000Z',
+        estimatedArrivalAt: '2026-07-16T10:30:00.000Z',
+        estimatedTravelSeconds: 900,
+        estimatedDistanceMeters: 5_000,
+        reroutePending: false,
+        arrivedAt: null,
+        deliveredAt: null,
+        harvest,
+        receipt: null,
+        recovery: null,
+        tracking: {
+            status: 'live',
+            lastAcceptedAt: '2026-07-16T10:15:00.000Z',
+            mapAvailable: true,
+        },
+        runId: 'safe-map-run',
+        deliveryCount: 2,
+        recipientCount: 2,
+        deliveries: [
+            {
+                stopId: 99,
+                stopState: 'pending',
+                requestId: privateSentinel,
+                requestState: 'ready',
+                contactName: privateSentinel,
+                phone: privateSentinel,
+                addressLabel: privateSentinel,
+                requestNotes: privateSentinel,
+                deliveryNotes: privateSentinel,
+                harvest,
+                exception: null,
+            },
+        ],
+        actionState: 'current',
+        lockedReason: privateSentinel,
+    };
+
+    const projected = customerDeliveryRequestSummary(source);
+
+    assert.deepEqual(projected, {
+        mode: 'delivery',
+        requestId: 'request-delivery',
+        status: 'ready',
+        statusLabel: 'Vozač stiže',
+        requestNotes: 'Pozvoni na portafon.',
+        slotStartAt: '2026-07-16T10:00:00.000Z',
+        slotEndAt: '2026-07-16T12:00:00.000Z',
+        estimatedArrivalAt: '2026-07-16T10:30:00.000Z',
+        estimatedTravelSeconds: 900,
+        estimatedDistanceMeters: 5_000,
+        reroutePending: false,
+        deliveredAt: null,
+        harvest,
+        receipt: null,
+        recovery: null,
+        tracking: {
+            status: 'live',
+            lastAcceptedAt: '2026-07-16T10:15:00.000Z',
+            mapAvailable: true,
+        },
+        mapPath: '/api/map/safe-map-run',
+    });
+    const serialized = JSON.stringify(projected);
+    assert.equal(serialized.includes(privateSentinel), false);
+    for (const privateKey of [
+        'id',
+        'sequence',
+        'stopState',
+        'contactName',
+        'phone',
+        'address',
+        'deliveryNotes',
+        'runId',
+        'deliveries',
+        'actionState',
+        'lockedReason',
+        'latitude',
+        'longitude',
+        'accuracy',
+        'heading',
+        'speed',
+    ]) {
+        assert.equal(privateKey in projected, false, privateKey);
+    }
+});
+
+test('projects pickup status, public location, and instructions without delivery fields', () => {
+    const privateSentinel = 'PRIVATE PICKUP DATA 4135';
+    const source = {
+        requestId: 'request-pickup',
+        status: 'ready',
+        requestNotes: 'Donijet ću svoju košaru.',
+        slotStartAt: '2026-07-16T14:00:00.000Z',
+        slotEndAt: '2026-07-16T16:00:00.000Z',
+        harvest,
+        location: {
+            name: 'Gredice HQ',
+            address: 'Vrtna 1, 10000 Zagreb, HR',
+            instructions: customerPickupInstructions('ready'),
+        },
+        pickedUpAt: null,
+        runId: privateSentinel,
+        tracking: privateSentinel,
+        deliveryNotes: privateSentinel,
+    };
+
+    const projected = customerPickupRequestSummary(source);
+
+    assert.deepEqual(projected, {
+        mode: 'pickup',
+        requestId: 'request-pickup',
+        status: 'ready',
+        statusLabel: 'Spremno za preuzimanje',
+        requestNotes: 'Donijet ću svoju košaru.',
+        slotStartAt: '2026-07-16T14:00:00.000Z',
+        slotEndAt: '2026-07-16T16:00:00.000Z',
+        harvest,
+        location: {
+            name: 'Gredice HQ',
+            address: 'Vrtna 1, 10000 Zagreb, HR',
+            instructions:
+                'Urod je spreman. Preuzmi ga na ovoj lokaciji tijekom odabranog termina.',
+        },
+        pickedUpAt: null,
+    });
+    const serialized = JSON.stringify(projected);
+    assert.equal(serialized.includes(privateSentinel), false);
+    for (const deliveryKey of [
+        'tracking',
+        'mapPath',
+        'estimatedArrivalAt',
+        'estimatedTravelSeconds',
+        'estimatedDistanceMeters',
+        'reroutePending',
+        'recovery',
+        'receipt',
+        'deliveredAt',
+    ]) {
+        assert.equal(deliveryKey in projected, false, deliveryKey);
+    }
+});
+
+test('does not expose a historical run path when delivery tracking is unavailable', () => {
+    const historicalRun = 'PRIVATE HISTORICAL RUN 4135';
+    const source: DeliveryStopSummary = {
+        id: 41,
+        requestId: 'request-history',
+        sequence: 7,
+        stopState: 'delivered',
+        requestState: 'fulfilled',
+        statusLabel: 'Dostavljeno',
+        isCurrent: false,
+        contactName: 'Kupac',
+        phone: null,
+        address: 'Adresa kupca',
+        addressLabel: null,
+        requestNotes: null,
+        deliveryNotes: null,
+        slotStartAt: '2026-07-16T10:00:00.000Z',
+        slotEndAt: '2026-07-16T12:00:00.000Z',
+        estimatedArrivalAt: null,
+        estimatedTravelSeconds: null,
+        estimatedDistanceMeters: null,
+        reroutePending: false,
+        arrivedAt: '2026-07-16T10:20:00.000Z',
+        deliveredAt: '2026-07-16T10:25:00.000Z',
+        harvest,
+        receipt: null,
+        recovery: null,
+        tracking: null,
+        runId: historicalRun,
+        deliveryCount: 1,
+        deliveries: [],
+    };
+
+    const projected = customerDeliveryRequestSummary(source);
+
+    assert.equal(projected.mapPath, null);
+    assert.equal(JSON.stringify(projected).includes(historicalRun), false);
+});
+
+test('uses pickup-safe copy for every request state', () => {
+    assert.deepEqual(
+        [
+            'pending',
+            'confirmed',
+            'preparing',
+            'ready',
+            'fulfilled',
+            'deferred',
+            'failed',
+            'cancelled',
+        ].map(customerPickupStatusLabel),
+        [
+            'Čeka potvrdu',
+            'Preuzimanje potvrđeno',
+            'Urod se priprema',
+            'Spremno za preuzimanje',
+            'Preuzeto',
+            'Preuzimanje je odgođeno',
+            'Preuzimanje trenutačno nije moguće',
+            'Preuzimanje je otkazano',
+        ],
+    );
+    assert.equal(
+        customerPickupInstructions('confirmed'),
+        'Pričekaj status „Spremno za preuzimanje” prije dolaska.',
+    );
+});

--- a/apps/delivery/lib/customerDeliveryPresentation.ts
+++ b/apps/delivery/lib/customerDeliveryPresentation.ts
@@ -1,0 +1,113 @@
+import type {
+    CustomerDeliveryRequestSummary,
+    CustomerPickupRequestSummary,
+    DeliveryStopSummary,
+} from './deliveryDashboardTypes';
+
+type CustomerDeliveryProjectionSource = Pick<
+    DeliveryStopSummary,
+    | 'requestId'
+    | 'requestState'
+    | 'statusLabel'
+    | 'requestNotes'
+    | 'slotStartAt'
+    | 'slotEndAt'
+    | 'estimatedArrivalAt'
+    | 'estimatedTravelSeconds'
+    | 'estimatedDistanceMeters'
+    | 'reroutePending'
+    | 'deliveredAt'
+    | 'harvest'
+    | 'receipt'
+    | 'recovery'
+    | 'tracking'
+    | 'runId'
+>;
+
+export function customerDeliveryRequestSummary(
+    source: CustomerDeliveryProjectionSource,
+): CustomerDeliveryRequestSummary {
+    const tracking = source.tracking;
+    return {
+        mode: 'delivery',
+        requestId: source.requestId,
+        status: source.requestState,
+        statusLabel: source.statusLabel,
+        requestNotes: source.requestNotes,
+        slotStartAt: source.slotStartAt,
+        slotEndAt: source.slotEndAt,
+        estimatedArrivalAt: source.estimatedArrivalAt,
+        estimatedTravelSeconds: source.estimatedTravelSeconds,
+        estimatedDistanceMeters: source.estimatedDistanceMeters,
+        reroutePending: source.reroutePending,
+        deliveredAt: source.deliveredAt,
+        harvest: source.harvest,
+        receipt: source.receipt ?? null,
+        recovery: source.recovery,
+        tracking,
+        mapPath: tracking && source.runId ? `/api/map/${source.runId}` : null,
+    };
+}
+
+export function customerPickupStatusLabel(status: string) {
+    switch (status) {
+        case 'pending':
+            return 'Čeka potvrdu';
+        case 'confirmed':
+            return 'Preuzimanje potvrđeno';
+        case 'preparing':
+            return 'Urod se priprema';
+        case 'ready':
+            return 'Spremno za preuzimanje';
+        case 'fulfilled':
+            return 'Preuzeto';
+        case 'deferred':
+            return 'Preuzimanje je odgođeno';
+        case 'failed':
+            return 'Preuzimanje trenutačno nije moguće';
+        case 'cancelled':
+            return 'Preuzimanje je otkazano';
+        default:
+            return status;
+    }
+}
+
+export function customerPickupInstructions(status: string) {
+    if (status === 'ready') {
+        return 'Urod je spreman. Preuzmi ga na ovoj lokaciji tijekom odabranog termina.';
+    }
+    if (status === 'fulfilled') {
+        return 'Preuzimanje uroda je evidentirano.';
+    }
+    if (status === 'cancelled') {
+        return 'Ovo preuzimanje više nije aktivno.';
+    }
+    if (status === 'deferred' || status === 'failed') {
+        return 'Pričekaj novu potvrdu prije dolaska na lokaciju preuzimanja.';
+    }
+    return 'Pričekaj status „Spremno za preuzimanje” prije dolaska.';
+}
+
+export function customerPickupRequestSummary({
+    requestId,
+    status,
+    requestNotes,
+    slotStartAt,
+    slotEndAt,
+    harvest,
+    location,
+    pickedUpAt,
+}: Omit<CustomerPickupRequestSummary, 'mode' | 'statusLabel'>) {
+    return {
+        mode: 'pickup',
+        requestId,
+        status,
+        statusLabel: customerPickupStatusLabel(status),
+        requestNotes,
+        slotStartAt,
+        slotEndAt,
+        harvest,
+        location,
+        pickedUpAt,
+    } satisfies CustomerPickupRequestSummary;
+}

--- a/apps/delivery/lib/deliveryDashboard.node.spec.ts
+++ b/apps/delivery/lib/deliveryDashboard.node.spec.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
     accountCanTrackCurrentDeliveryGroup,
     customerDeliveryReceiptSummary,
+    deliveryDashboardKindForRole,
     deliveryMutationRouteState,
     deliveryRecipientCount,
     deliveryStatusLabel,
@@ -446,6 +447,7 @@ test('customer receipt projection allowlists one completed request and harvest',
 
     const receipt = customerDeliveryReceiptSummary({
         audience: 'customer',
+        mode: 'delivery',
         requestState: 'fulfilled',
         requestId: 'customer-request-4144',
         handoffReceipt,
@@ -484,6 +486,7 @@ test('customer receipt projection excludes active and driver-facing requests', (
         customerDeliveryReceiptSummary({
             ...input,
             audience: 'customer',
+            mode: 'delivery',
             requestState: 'ready',
         }),
         null,
@@ -492,6 +495,7 @@ test('customer receipt projection excludes active and driver-facing requests', (
         customerDeliveryReceiptSummary({
             ...input,
             audience: 'driver',
+            mode: 'delivery',
             requestState: 'fulfilled',
         }),
         null,
@@ -499,12 +503,30 @@ test('customer receipt projection excludes active and driver-facing requests', (
     assert.equal(
         customerDeliveryReceiptSummary({
             audience: 'customer',
+            mode: 'delivery',
             requestState: 'fulfilled',
             requestId: input.requestId,
             harvest: input.harvest,
         }),
         null,
     );
+    assert.equal(
+        customerDeliveryReceiptSummary({
+            ...input,
+            audience: 'customer',
+            mode: 'pickup',
+            requestState: 'fulfilled',
+        }),
+        null,
+    );
+});
+
+test('delivery dashboard roles fail closed and preserve customer role boundaries', () => {
+    assert.equal(deliveryDashboardKindForRole('user'), 'customer');
+    assert.equal(deliveryDashboardKindForRole('farmer'), 'customer');
+    assert.equal(deliveryDashboardKindForRole('driver'), 'driver');
+    assert.equal(deliveryDashboardKindForRole('admin'), 'driver');
+    assert.equal(deliveryDashboardKindForRole('unknown'), null);
 });
 
 test('exception receipt replay returns current revision without rerouting a stale receipt', () => {

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -29,6 +29,11 @@ import {
     updateDeliveryRunLocation,
 } from '@gredice/storage';
 import 'server-only';
+import {
+    customerDeliveryRequestSummary,
+    customerPickupInstructions,
+    customerPickupRequestSummary,
+} from './customerDeliveryPresentation';
 import type {
     ActiveDeliveryRunSummary,
     CustomerDeliveryReceiptSummary,
@@ -90,7 +95,6 @@ type DeliveryRunExecutionStep = Awaited<
     ReturnType<typeof getDeliveryRunExecutionProgress>
 >[number];
 
-const driverRoles = new Set(['driver', 'admin']);
 const batchStates: ReadonlySet<string> = new Set([
     DeliveryRequestStates.CONFIRMED,
     DeliveryRequestStates.PREPARING,
@@ -147,12 +151,14 @@ function harvestSummary(request: DeliveryRequest): DeliveryHarvestSummary {
 
 export function customerDeliveryReceiptSummary({
     audience,
+    mode,
     requestState,
     requestId,
     handoffReceipt,
     harvest,
 }: {
     audience: 'driver' | 'customer';
+    mode: 'delivery' | 'pickup';
     requestState: string;
     requestId: string;
     handoffReceipt?: {
@@ -163,6 +169,7 @@ export function customerDeliveryReceiptSummary({
 }): CustomerDeliveryReceiptSummary | null {
     if (
         audience !== 'customer' ||
+        mode !== 'delivery' ||
         requestState !== DeliveryRequestStates.FULFILLED ||
         !handoffReceipt
     ) {
@@ -495,6 +502,7 @@ function deliveryStopSummary({
     });
     const receipt = customerDeliveryReceiptSummary({
         audience,
+        mode: request.mode ?? 'delivery',
         requestState: request.state,
         requestId: request.id,
         handoffReceipt: request.customerHandoffReceipt,
@@ -1026,8 +1034,11 @@ async function customerDashboard({
         throw new Error('Korisnik nije pronađen.');
     }
 
+    const deliveryRequests = requests.filter(
+        (request) => request.mode !== 'pickup',
+    );
     const runRows = await getDeliveryRunStopsForRequestIds(
-        requests.map((request) => request.id),
+        deliveryRequests.map((request) => request.id),
     );
     const rowsByRequestId = new Map(
         runRows.map((row) => [row.stop.deliveryRequestId, row]),
@@ -1062,6 +1073,31 @@ async function customerDashboard({
     const projectedAt = new Date();
     const deliveries = requests
         .map((request) => {
+            if (request.mode === 'pickup') {
+                const location = request.slot?.location ?? request.location;
+                return customerPickupRequestSummary({
+                    requestId: request.id,
+                    status: request.state,
+                    requestNotes: request.requestNotes ?? null,
+                    slotStartAt: iso(request.slot?.startAt),
+                    slotEndAt: iso(request.slot?.endAt),
+                    harvest: harvestSummary(request),
+                    location: location
+                        ? {
+                              name: location.name,
+                              address:
+                                  formatDeliveryDestinationAddress(location),
+                              instructions: customerPickupInstructions(
+                                  request.state,
+                              ),
+                          }
+                        : null,
+                    pickedUpAt:
+                        request.state === DeliveryRequestStates.FULFILLED
+                            ? iso(request.customerHandoffReceipt?.fulfilledAt)
+                            : null,
+                });
+            }
             const historicalRow = rowsByRequestId.get(request.id);
             const row =
                 historicalRow?.stop.releasedAt !== null &&
@@ -1072,17 +1108,19 @@ async function customerDashboard({
                 ? (currentStopIdsByRunId.get(row.run.id)?.has(row.stop.id) ??
                   false)
                 : false;
-            return deliveryStopSummary({
-                items: [{ request, stop: row?.stop }],
-                run: row?.run,
-                isCurrent,
-                audience: 'customer',
-                now: projectedAt,
-                includeTracking:
-                    row?.run.state === DeliveryRunStates.ACTIVE &&
-                    isDeliveryRunStopActionable(row.stop.state) &&
+            return customerDeliveryRequestSummary(
+                deliveryStopSummary({
+                    items: [{ request, stop: row?.stop }],
+                    run: row?.run,
                     isCurrent,
-            });
+                    audience: 'customer',
+                    now: projectedAt,
+                    includeTracking:
+                        row?.run.state === DeliveryRunStates.ACTIVE &&
+                        isDeliveryRunStopActionable(row.stop.state) &&
+                        isCurrent,
+                }),
+            );
         })
         .sort((first, second) => {
             const firstTime = first.slotStartAt ?? '';
@@ -1143,6 +1181,19 @@ export function deliveryTrackingStopIds({
         : new Set(currentStopIds);
 }
 
+export function deliveryDashboardKindForRole(role: string) {
+    switch (role) {
+        case 'driver':
+        case 'admin':
+            return 'driver';
+        case 'user':
+        case 'farmer':
+            return 'customer';
+        default:
+            return null;
+    }
+}
+
 export async function getDeliveryDashboard({
     accountId,
     userId,
@@ -1152,7 +1203,11 @@ export async function getDeliveryDashboard({
     userId: string;
     role: string;
 }) {
-    return driverRoles.has(role)
+    const kind = deliveryDashboardKindForRole(role);
+    if (!kind) {
+        throw new Error('Uloga nema pristup dostavnoj aplikaciji.');
+    }
+    return kind === 'driver'
         ? await driverDashboard({ userId, role })
         : await customerDashboard({ accountId, userId, role });
 }
@@ -1440,9 +1495,18 @@ export async function accountCanTrackDeliveryRun({
     runId: string;
 }) {
     const run = await getDeliveryRun(runId);
-    if (!run || run.state !== DeliveryRunStates.ACTIVE) {
-        return false;
-    }
+    if (!run) return false;
+    return Boolean(await customerDeliveryTrackingContext({ accountId, run }));
+}
+
+export async function customerDeliveryTrackingContext({
+    accountId,
+    run,
+}: {
+    accountId: string;
+    run: DeliveryRun;
+}) {
+    if (run.state !== DeliveryRunStates.ACTIVE) return null;
     const [groups, progress] = await Promise.all([
         resolveDeliveryRunStopGroups(run),
         getDeliveryRunExecutionProgress(run.id),
@@ -1456,12 +1520,21 @@ export async function accountCanTrackDeliveryRun({
                   groups,
               })
             : null;
-    return accountCanTrackCurrentDeliveryGroup({
-        accountId,
-        runState: run.state,
+    if (
+        !currentDeliveryStopIds ||
+        !accountCanTrackCurrentDeliveryGroup({
+            accountId,
+            runState: run.state,
+            groups,
+            currentDeliveryStopIds,
+        })
+    ) {
+        return null;
+    }
+    return {
         groups,
         currentDeliveryStopIds,
-    });
+    };
 }
 
 export function accountCanTrackCurrentDeliveryGroup({

--- a/apps/delivery/lib/deliveryDashboardTypes.ts
+++ b/apps/delivery/lib/deliveryDashboardTypes.ts
@@ -72,6 +72,49 @@ export type CustomerDeliveryRecoverySummary =
     | { kind: 'support' }
     | { kind: 'cancelled' };
 
+export type CustomerDeliveryRequestSummary = {
+    mode: 'delivery';
+    requestId: string;
+    status: string;
+    statusLabel: string;
+    requestNotes: string | null;
+    slotStartAt: string | null;
+    slotEndAt: string | null;
+    estimatedArrivalAt: string | null;
+    estimatedTravelSeconds: number | null;
+    estimatedDistanceMeters: number | null;
+    reroutePending: boolean;
+    deliveredAt: string | null;
+    harvest: DeliveryHarvestSummary;
+    receipt: CustomerDeliveryReceiptSummary | null;
+    recovery: CustomerDeliveryRecoverySummary | null;
+    tracking: CustomerDeliveryTrackingSummary | null;
+    mapPath: string | null;
+};
+
+export type CustomerPickupLocationSummary = {
+    name: string;
+    address: string;
+    instructions: string;
+};
+
+export type CustomerPickupRequestSummary = {
+    mode: 'pickup';
+    requestId: string;
+    status: string;
+    statusLabel: string;
+    requestNotes: string | null;
+    slotStartAt: string | null;
+    slotEndAt: string | null;
+    harvest: DeliveryHarvestSummary;
+    location: CustomerPickupLocationSummary | null;
+    pickedUpAt: string | null;
+};
+
+export type CustomerDeliveryDashboardRequest =
+    | CustomerDeliveryRequestSummary
+    | CustomerPickupRequestSummary;
+
 export type DeliveryStopDeliverySummary = {
     stopId: number | null;
     stopState: string | null;
@@ -258,7 +301,7 @@ export type CustomerDeliveryDashboard = {
         displayName: string;
         role: string;
     };
-    deliveries: DeliveryStopSummary[];
+    deliveries: CustomerDeliveryDashboardRequest[];
     refreshedAt: string;
 };
 

--- a/apps/delivery/lib/deliveryMapData.node.spec.ts
+++ b/apps/delivery/lib/deliveryMapData.node.spec.ts
@@ -2,7 +2,9 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
     buildDeliveryMapData,
+    customerCurrentDeliveryMapStops,
     decodeDeliveryMapPolyline,
+    deliveryMapAudience,
     deliveryMapSelectionKey,
     deliveryMapStopGroupSelectionId,
     parseDeliveryMapData,
@@ -121,4 +123,104 @@ test('uses stable pickup and delivery keys for map timeline selection', () => {
         '1',
     );
     assert.equal(deliveryMapStopGroupSelectionId([]), null);
+});
+
+test('customer map includes only the server-confirmed current physical stop', () => {
+    const currentCoordinates = { latitude: 45.81, longitude: 16.01 };
+    const groups = [
+        {
+            items: [
+                {
+                    stop: {
+                        id: 11,
+                        latitude: 45.7,
+                        longitude: 15.9,
+                    },
+                    request: { accountId: 'account-a' },
+                },
+            ],
+        },
+        {
+            items: [
+                {
+                    stop: { id: 21, ...currentCoordinates },
+                    request: { accountId: 'account-a' },
+                },
+                {
+                    stop: { id: 22, ...currentCoordinates },
+                    request: { accountId: 'account-b' },
+                },
+            ],
+        },
+        {
+            items: [
+                {
+                    stop: {
+                        id: 31,
+                        latitude: 45.9,
+                        longitude: 16.2,
+                    },
+                    request: { accountId: 'account-a' },
+                },
+            ],
+        },
+    ];
+    const input = {
+        groups,
+        currentDeliveryStopIds: new Set([21, 22]),
+    };
+
+    const accountAStops = customerCurrentDeliveryMapStops({
+        accountId: 'account-a',
+        ...input,
+    });
+    assert.deepEqual(accountAStops, [
+        { ...currentCoordinates, sequence: 1, selectionId: null },
+    ]);
+    assert.deepEqual(
+        customerCurrentDeliveryMapStops({
+            accountId: 'account-b',
+            ...input,
+        }),
+        accountAStops,
+    );
+    assert.deepEqual(
+        customerCurrentDeliveryMapStops({
+            accountId: 'account-c',
+            ...input,
+        }),
+        [],
+    );
+    assert.equal(JSON.stringify(accountAStops).includes('45.9'), false);
+});
+
+test('map roles expose driver data only to the assigned driver or admin', () => {
+    for (const role of ['user', 'farmer']) {
+        assert.equal(
+            deliveryMapAudience({
+                role,
+                userId: 'customer',
+                driverUserId: 'assigned-driver',
+            }),
+            'customer',
+        );
+    }
+    for (const role of ['driver', 'admin']) {
+        assert.equal(
+            deliveryMapAudience({
+                role,
+                userId: 'assigned-driver',
+                driverUserId: 'assigned-driver',
+            }),
+            'driver',
+        );
+        assert.equal(
+            deliveryMapAudience({
+                role,
+                userId: 'other-operator',
+                driverUserId: 'assigned-driver',
+            }),
+            'customer',
+        );
+    }
 });

--- a/apps/delivery/lib/deliveryMapData.ts
+++ b/apps/delivery/lib/deliveryMapData.ts
@@ -27,6 +27,67 @@ export type DeliveryMapSelection =
     | { kind: 'pickup'; id: string }
     | { kind: 'delivery'; id: string };
 
+export function deliveryMapAudience({
+    role,
+    userId,
+    driverUserId,
+}: {
+    role: string;
+    userId: string;
+    driverUserId: string | null;
+}) {
+    return (role === 'driver' || role === 'admin') && userId === driverUserId
+        ? 'driver'
+        : 'customer';
+}
+
+export function customerCurrentDeliveryMapStops({
+    accountId,
+    groups,
+    currentDeliveryStopIds,
+}: {
+    accountId: string;
+    groups: ReadonlyArray<{
+        items: ReadonlyArray<{
+            stop: {
+                id: number;
+                latitude: number;
+                longitude: number;
+            };
+            request?: { accountId?: string | null };
+        }>;
+    }>;
+    currentDeliveryStopIds: ReadonlySet<number>;
+}): DeliveryMapStop[] {
+    const currentGroup = groups.find((group) =>
+        group.items.some(({ stop }) => currentDeliveryStopIds.has(stop.id)),
+    );
+    if (
+        !currentGroup?.items.some(
+            ({ stop, request }) =>
+                currentDeliveryStopIds.has(stop.id) &&
+                request?.accountId === accountId,
+        )
+    ) {
+        return [];
+    }
+    const representative = currentGroup.items.find(
+        ({ stop, request }) =>
+            currentDeliveryStopIds.has(stop.id) &&
+            request?.accountId === accountId,
+    )?.stop;
+    return representative
+        ? [
+              {
+                  latitude: representative.latitude,
+                  longitude: representative.longitude,
+                  sequence: 1,
+                  selectionId: null,
+              },
+          ]
+        : [];
+}
+
 export function deliveryMapSelectionKey(
     selection: DeliveryMapSelection | null,
 ) {

--- a/apps/delivery/lib/deliveryMapRoute.node.spec.ts
+++ b/apps/delivery/lib/deliveryMapRoute.node.spec.ts
@@ -1,0 +1,447 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createDeliveryMapRouteHandlers } from './deliveryMapRoute';
+
+const runId = 'delivery-run-map-1';
+const fixedNow = new Date('2026-07-16T10:00:00.000Z');
+const authenticatedRoles = ['user', 'farmer', 'driver', 'admin'];
+const terminalStates = new Set(['delivered', 'failed', 'cancelled']);
+
+type TestDeliveryMapGroup = {
+    label: string;
+    items: Array<{
+        stop: {
+            id: number;
+            state: string;
+            latitude: number;
+            longitude: number;
+        };
+        request: {
+            accountId: string;
+        };
+    }>;
+};
+
+type TestDeliveryMapRun = {
+    id: string;
+    state: string;
+    currentKind: 'delivery' | 'pickup';
+    pickupConfirmed: boolean;
+    currentDeliveryStopIds: Set<number>;
+    driverUserId: string | null;
+    driverLocation: {
+        latitude: number;
+        longitude: number;
+    } | null;
+    pickupNodes: Array<{
+        id: string;
+        latitude: number | null;
+        longitude: number | null;
+    }>;
+    encodedPolyline: string | null;
+    groups: TestDeliveryMapGroup[];
+};
+
+type TestRunOptions = {
+    state?: string;
+    currentKind?: 'delivery' | 'pickup';
+    pickupConfirmed?: boolean;
+    driverUserId?: string | null;
+};
+
+function deliveryGroups(): TestDeliveryMapGroup[] {
+    return [
+        {
+            label: 'previous',
+            items: [
+                {
+                    stop: {
+                        id: 11,
+                        state: 'pending',
+                        latitude: 45.7,
+                        longitude: 15.9,
+                    },
+                    request: { accountId: 'account-previous' },
+                },
+            ],
+        },
+        {
+            label: 'current-bulk',
+            items: [
+                {
+                    stop: {
+                        id: 21,
+                        state: 'pending',
+                        latitude: 45.81,
+                        longitude: 16.01,
+                    },
+                    request: { accountId: 'account-current' },
+                },
+                {
+                    stop: {
+                        id: 22,
+                        state: 'pending',
+                        latitude: 45.82,
+                        longitude: 16.02,
+                    },
+                    request: { accountId: 'account-other-current' },
+                },
+            ],
+        },
+        {
+            label: 'later-same-account',
+            items: [
+                {
+                    stop: {
+                        id: 31,
+                        state: 'pending',
+                        latitude: 45.99,
+                        longitude: 16.29,
+                    },
+                    request: { accountId: 'account-later' },
+                },
+            ],
+        },
+        {
+            label: 'terminal',
+            items: [
+                {
+                    stop: {
+                        id: 41,
+                        state: 'delivered',
+                        latitude: 46.1,
+                        longitude: 16.4,
+                    },
+                    request: { accountId: 'account-delivered' },
+                },
+            ],
+        },
+    ];
+}
+
+function deliveryRun(options: TestRunOptions = {}): TestDeliveryMapRun {
+    return {
+        id: runId,
+        state: options.state ?? 'active',
+        currentKind: options.currentKind ?? 'delivery',
+        pickupConfirmed: options.pickupConfirmed ?? true,
+        currentDeliveryStopIds: new Set([21, 22]),
+        driverUserId:
+            options.driverUserId === undefined
+                ? 'assigned-driver'
+                : options.driverUserId,
+        driverLocation: { latitude: 45.8, longitude: 15.98 },
+        pickupNodes: [
+            {
+                id: 'pickup-hq',
+                latitude: 45.79,
+                longitude: 15.97,
+            },
+            {
+                id: 'pickup-without-coordinates',
+                latitude: null,
+                longitude: null,
+            },
+        ],
+        encodedPolyline: 'private-complete-route',
+        groups: deliveryGroups(),
+    };
+}
+
+function customerTrackingContext({
+    accountId,
+    run,
+}: {
+    accountId: string;
+    run: TestDeliveryMapRun;
+}) {
+    if (
+        run.state !== 'active' ||
+        run.currentKind !== 'delivery' ||
+        !run.pickupConfirmed
+    ) {
+        return null;
+    }
+    const ownsCurrentActionableStop = run.groups.some((group) =>
+        group.items.some(
+            ({ stop, request }) =>
+                run.currentDeliveryStopIds.has(stop.id) &&
+                !terminalStates.has(stop.state) &&
+                request.accountId === accountId,
+        ),
+    );
+    return ownsCurrentActionableStop
+        ? {
+              groups: run.groups,
+              currentDeliveryStopIds: run.currentDeliveryStopIds,
+          }
+        : null;
+}
+
+type HarnessInput = {
+    role: string;
+    userId: string;
+    accountId: string;
+    run?: TestDeliveryMapRun | null;
+    authResponse?: Response;
+};
+
+function createHarness(input: HarnessInput) {
+    const selectedRun = input.run === undefined ? deliveryRun() : input.run;
+    const calls = {
+        getRun: 0,
+        getCustomerTrackingContext: 0,
+        resolveGroups: 0,
+        buildStaticMapUrl: 0,
+    };
+    const handlers = createDeliveryMapRouteHandlers<
+        TestDeliveryMapRun,
+        TestDeliveryMapGroup
+    >({
+        withAuth: async (roles, handler) => {
+            assert.deepEqual(roles, authenticatedRoles);
+            if (input.authResponse) return input.authResponse;
+            return await handler({
+                accountId: input.accountId,
+                userId: input.userId,
+                user: { role: input.role },
+            });
+        },
+        getRun: async (requestedRunId) => {
+            calls.getRun += 1;
+            assert.equal(requestedRunId, runId);
+            return selectedRun;
+        },
+        getCustomerTrackingContext: async (trackingInput) => {
+            calls.getCustomerTrackingContext += 1;
+            return customerTrackingContext(trackingInput);
+        },
+        resolveGroups: async (run) => {
+            calls.resolveGroups += 1;
+            return run.groups;
+        },
+        getDriverLocation: (run, projectedAt) => {
+            assert.equal(projectedAt.toISOString(), fixedNow.toISOString());
+            return run.driverLocation;
+        },
+        isStopTerminal: (state) => terminalStates.has(state),
+        buildStaticMapUrl: () => {
+            calls.buildStaticMapUrl += 1;
+            return null;
+        },
+        unavailableMapSvg: () => '<svg>Map unavailable</svg>',
+        fetchMap: async () => {
+            throw new Error('JSON route must not fetch a static map');
+        },
+        now: () => fixedNow,
+        logger: { error() {} },
+    });
+    return { handlers, calls };
+}
+
+function request(format = 'json') {
+    return new Request(
+        `https://dostava.gredice.com/api/map/${runId}?format=${format}`,
+    );
+}
+
+function context() {
+    return { params: Promise.resolve({ runId }) };
+}
+
+function assertPrivateNoStore(response: Response) {
+    assert.equal(response.headers.get('Cache-Control'), 'private, no-store');
+}
+
+const customerSafeMap = {
+    driverLocation: { latitude: 45.8, longitude: 15.98 },
+    pickupNodes: [],
+    stops: [
+        {
+            latitude: 45.81,
+            longitude: 16.01,
+            sequence: 1,
+            selectionId: null,
+        },
+    ],
+    encodedPolyline: null,
+};
+
+test('exact-current owner user and farmer receive only the customer-safe map projection', async (t) => {
+    for (const role of ['user', 'farmer']) {
+        await t.test(role, async () => {
+            const { handlers, calls } = createHarness({
+                role,
+                userId: `${role}-user`,
+                accountId: 'account-current',
+            });
+
+            const response = await handlers.GET(request(), context());
+            const body = await response.json();
+
+            assert.equal(response.status, 200);
+            assertPrivateNoStore(response);
+            assert.deepEqual(body, customerSafeMap);
+            assert.equal(calls.getCustomerTrackingContext, 1);
+            assert.equal(calls.resolveGroups, 0);
+            assert.equal(calls.buildStaticMapUrl, 0);
+            const serialized = JSON.stringify(body);
+            assert.equal(serialized.includes('private-complete-route'), false);
+            assert.equal(serialized.includes('45.99'), false);
+            assert.equal(serialized.includes('pickup-hq'), false);
+        });
+    }
+});
+
+test('cross-account, non-current, pickup-current, and inactive customer contexts are forbidden', async (t) => {
+    const cases: Array<{
+        name: string;
+        accountId: string;
+        run: TestDeliveryMapRun;
+    }> = [
+        {
+            name: 'cross-account',
+            accountId: 'account-cross',
+            run: deliveryRun(),
+        },
+        {
+            name: 'same account only at a non-current stop',
+            accountId: 'account-later',
+            run: deliveryRun(),
+        },
+        {
+            name: 'pickup checkpoint is current',
+            accountId: 'account-current',
+            run: deliveryRun({ currentKind: 'pickup' }),
+        },
+        {
+            name: 'run is inactive',
+            accountId: 'account-current',
+            run: deliveryRun({ state: 'completed' }),
+        },
+    ];
+
+    for (const testCase of cases) {
+        await t.test(testCase.name, async () => {
+            const { handlers, calls } = createHarness({
+                role: 'user',
+                userId: 'customer-user',
+                accountId: testCase.accountId,
+                run: testCase.run,
+            });
+
+            const response = await handlers.GET(request(), context());
+
+            assert.equal(response.status, 403);
+            assertPrivateNoStore(response);
+            assert.equal(calls.getCustomerTrackingContext, 1);
+            assert.equal(calls.resolveGroups, 0);
+            assert.equal(calls.buildStaticMapUrl, 0);
+        });
+    }
+});
+
+test('assigned drivers and admins receive the complete driver map projection', async (t) => {
+    for (const role of ['driver', 'admin']) {
+        await t.test(role, async () => {
+            const { handlers, calls } = createHarness({
+                role,
+                userId: 'assigned-driver',
+                accountId: 'operator-account',
+            });
+
+            const response = await handlers.GET(request(), context());
+
+            assert.equal(response.status, 200);
+            assertPrivateNoStore(response);
+            assert.deepEqual(await response.json(), {
+                driverLocation: { latitude: 45.8, longitude: 15.98 },
+                pickupNodes: [
+                    {
+                        latitude: 45.79,
+                        longitude: 15.97,
+                        selectionId: 'pickup-hq',
+                    },
+                ],
+                stops: [
+                    {
+                        latitude: 45.7,
+                        longitude: 15.9,
+                        sequence: 1,
+                        selectionId: '11',
+                    },
+                    {
+                        latitude: 45.81,
+                        longitude: 16.01,
+                        sequence: 2,
+                        selectionId: '21',
+                    },
+                    {
+                        latitude: 45.99,
+                        longitude: 16.29,
+                        sequence: 3,
+                        selectionId: '31',
+                    },
+                ],
+                encodedPolyline: 'private-complete-route',
+            });
+            assert.equal(calls.getCustomerTrackingContext, 0);
+            assert.equal(calls.resolveGroups, 1);
+        });
+    }
+});
+
+test('unassigned drivers and admins remain constrained to the customer-safe projection', async (t) => {
+    for (const role of ['driver', 'admin']) {
+        await t.test(role, async () => {
+            const { handlers, calls } = createHarness({
+                role,
+                userId: 'unassigned-operator',
+                accountId: 'account-current',
+            });
+
+            const response = await handlers.GET(request(), context());
+
+            assert.equal(response.status, 200);
+            assertPrivateNoStore(response);
+            assert.deepEqual(await response.json(), customerSafeMap);
+            assert.equal(calls.getCustomerTrackingContext, 1);
+            assert.equal(calls.resolveGroups, 0);
+        });
+    }
+});
+
+test('missing runs return a private 404 before resolving tracking or map data', async () => {
+    const { handlers, calls } = createHarness({
+        role: 'user',
+        userId: 'customer-user',
+        accountId: 'account-current',
+        run: null,
+    });
+
+    const response = await handlers.GET(request(), context());
+
+    assert.equal(response.status, 404);
+    assertPrivateNoStore(response);
+    assert.equal(calls.getRun, 1);
+    assert.equal(calls.getCustomerTrackingContext, 0);
+    assert.equal(calls.resolveGroups, 0);
+    assert.equal(calls.buildStaticMapUrl, 0);
+});
+
+test('authentication failures still request every supported role and remain private no-store', async () => {
+    const { handlers, calls } = createHarness({
+        role: 'user',
+        userId: 'customer-user',
+        accountId: 'account-current',
+        authResponse: Response.json({ error: 'Unauthorized' }, { status: 401 }),
+    });
+
+    const response = await handlers.GET(request(), context());
+
+    assert.equal(response.status, 401);
+    assertPrivateNoStore(response);
+    assert.equal(calls.getRun, 0);
+    assert.equal(calls.getCustomerTrackingContext, 0);
+    assert.equal(calls.resolveGroups, 0);
+});

--- a/apps/delivery/lib/deliveryMapRoute.ts
+++ b/apps/delivery/lib/deliveryMapRoute.ts
@@ -1,0 +1,247 @@
+import {
+    buildDeliveryMapData,
+    customerCurrentDeliveryMapStops,
+    type DeliveryMapCoordinate,
+    type DeliveryMapData,
+    deliveryMapAudience,
+    deliveryMapStopGroupSelectionId,
+} from './deliveryMapData';
+
+const privateNoStoreHeaders = { 'Cache-Control': 'private, no-store' };
+const authenticatedRoles = ['user', 'farmer', 'driver', 'admin'];
+
+type DeliveryMapAuthContext = {
+    accountId: string;
+    userId: string;
+    user: {
+        role: string;
+    };
+};
+
+type DeliveryMapRouteContext = {
+    params: Promise<{ runId: string }>;
+};
+
+export type DeliveryMapRouteRun = {
+    id: string;
+    driverUserId: string | null;
+    pickupNodes: ReadonlyArray<{
+        id: string;
+        latitude: number | null;
+        longitude: number | null;
+    }>;
+    encodedPolyline: string | null;
+};
+
+export type DeliveryMapRouteGroup = {
+    items: ReadonlyArray<{
+        stop: {
+            id: number;
+            state: string;
+            latitude: number;
+            longitude: number;
+        };
+        request?: {
+            accountId?: string | null;
+        };
+    }>;
+};
+
+type CustomerDeliveryMapTrackingContext<TGroup extends DeliveryMapRouteGroup> =
+    {
+        groups: ReadonlyArray<TGroup>;
+        currentDeliveryStopIds: ReadonlySet<number>;
+    };
+
+type DeliveryMapRouteDependencies<
+    TRun extends DeliveryMapRouteRun,
+    TGroup extends DeliveryMapRouteGroup,
+> = {
+    withAuth: (
+        roles: string[],
+        handler: (context: DeliveryMapAuthContext) => Promise<Response>,
+    ) => Promise<Response>;
+    getRun: (runId: string) => Promise<TRun | null | undefined>;
+    getCustomerTrackingContext: (input: {
+        accountId: string;
+        run: TRun;
+    }) => Promise<CustomerDeliveryMapTrackingContext<TGroup> | null>;
+    resolveGroups: (run: TRun) => Promise<ReadonlyArray<TGroup>>;
+    getDriverLocation: (
+        run: TRun,
+        projectedAt: Date,
+    ) => DeliveryMapCoordinate | null;
+    isStopTerminal: (state: string) => boolean;
+    buildStaticMapUrl: (
+        input: DeliveryMapData & { customerView: boolean },
+    ) => string | URL | null;
+    unavailableMapSvg: () => string;
+    fetchMap?: (
+        input: string | URL,
+        init: { cache: 'no-store' },
+    ) => Promise<Response>;
+    now?: () => Date;
+    logger?: Pick<Console, 'error'>;
+};
+
+function addPrivateNoStoreHeader(response: Response) {
+    response.headers.set(
+        'Cache-Control',
+        privateNoStoreHeaders['Cache-Control'],
+    );
+    return response;
+}
+
+function unavailableMapResponse(unavailableMapSvg: () => string) {
+    return new Response(unavailableMapSvg(), {
+        status: 200,
+        headers: {
+            'Content-Type': 'image/svg+xml; charset=utf-8',
+            ...privateNoStoreHeaders,
+        },
+    });
+}
+
+export function createDeliveryMapRouteHandlers<
+    TRun extends DeliveryMapRouteRun,
+    TGroup extends DeliveryMapRouteGroup,
+>({
+    withAuth,
+    getRun,
+    getCustomerTrackingContext,
+    resolveGroups,
+    getDriverLocation,
+    isStopTerminal,
+    buildStaticMapUrl,
+    unavailableMapSvg,
+    fetchMap = fetch,
+    now = () => new Date(),
+    logger = console,
+}: DeliveryMapRouteDependencies<TRun, TGroup>) {
+    async function authorize(
+        handler: (context: DeliveryMapAuthContext) => Promise<Response>,
+    ) {
+        return addPrivateNoStoreHeader(
+            await withAuth(authenticatedRoles, handler),
+        );
+    }
+
+    async function GET(request: Request, { params }: DeliveryMapRouteContext) {
+        return await authorize(async ({ accountId, userId, user }) => {
+            const { runId } = await params;
+            const run = await getRun(runId);
+            if (!run) {
+                return new Response(null, {
+                    status: 404,
+                    headers: privateNoStoreHeaders,
+                });
+            }
+
+            const driverView =
+                deliveryMapAudience({
+                    role: user.role,
+                    userId,
+                    driverUserId: run.driverUserId,
+                }) === 'driver';
+            const customerView = !driverView;
+            const customerTracking = customerView
+                ? await getCustomerTrackingContext({ accountId, run })
+                : null;
+            if (customerView && !customerTracking) {
+                return new Response(null, {
+                    status: 403,
+                    headers: privateNoStoreHeaders,
+                });
+            }
+
+            const projectedAt = now();
+            const location = getDriverLocation(run, projectedAt);
+            const groups =
+                customerTracking?.groups ?? (await resolveGroups(run));
+            const stops = driverView
+                ? groups.flatMap((group, index) => {
+                      const delivered = group.items.every(({ stop }) =>
+                          isStopTerminal(stop.state),
+                      );
+                      const representative = group.items[0]?.stop;
+                      if (!representative || delivered) return [];
+                      return [
+                          {
+                              latitude: representative.latitude,
+                              longitude: representative.longitude,
+                              sequence: index + 1,
+                              selectionId: deliveryMapStopGroupSelectionId(
+                                  group.items.map(({ stop }) => stop.id),
+                              ),
+                          },
+                      ];
+                  })
+                : customerCurrentDeliveryMapStops({
+                      accountId,
+                      groups,
+                      currentDeliveryStopIds:
+                          customerTracking?.currentDeliveryStopIds ?? new Set(),
+                  });
+            const mapData = buildDeliveryMapData({
+                driverLocation: location
+                    ? {
+                          latitude: location.latitude,
+                          longitude: location.longitude,
+                      }
+                    : null,
+                pickupNodes: driverView
+                    ? run.pickupNodes.flatMap((pickupNode) =>
+                          pickupNode.latitude !== null &&
+                          pickupNode.longitude !== null
+                              ? [
+                                    {
+                                        latitude: pickupNode.latitude,
+                                        longitude: pickupNode.longitude,
+                                        selectionId: pickupNode.id,
+                                    },
+                                ]
+                              : [],
+                      )
+                    : [],
+                stops,
+                encodedPolyline: run.encodedPolyline,
+                customerView,
+            });
+            if (new URL(request.url).searchParams.get('format') === 'json') {
+                return Response.json(mapData, {
+                    status: 200,
+                    headers: privateNoStoreHeaders,
+                });
+            }
+
+            const url = buildStaticMapUrl({
+                ...mapData,
+                customerView,
+            });
+            if (!url) return unavailableMapResponse(unavailableMapSvg);
+
+            try {
+                const response = await fetchMap(url, { cache: 'no-store' });
+                if (!response.ok) {
+                    return unavailableMapResponse(unavailableMapSvg);
+                }
+                return new Response(await response.arrayBuffer(), {
+                    status: 200,
+                    headers: {
+                        'Content-Type':
+                            response.headers.get('content-type') ?? 'image/png',
+                        ...privateNoStoreHeaders,
+                    },
+                });
+            } catch (error) {
+                logger.error('Failed to load delivery map', {
+                    runId,
+                    errorName: error instanceof Error ? error.name : 'Unknown',
+                });
+                return unavailableMapResponse(unavailableMapSvg);
+            }
+        });
+    }
+
+    return { GET };
+}

--- a/apps/delivery/tests/CustomerDashboardModesStory.tsx
+++ b/apps/delivery/tests/CustomerDashboardModesStory.tsx
@@ -1,0 +1,141 @@
+import { CustomerDashboard } from '../components/CustomerDashboard';
+import type {
+    CustomerDeliveryDashboard,
+    CustomerDeliveryDashboardRequest,
+    CustomerDeliveryRequestSummary,
+    CustomerPickupRequestSummary,
+} from '../lib/deliveryDashboardTypes';
+
+const delivery: CustomerDeliveryRequestSummary = {
+    mode: 'delivery',
+    requestId: 'customer-delivery-4135',
+    status: 'ready',
+    statusLabel: 'Vozač stiže',
+    requestNotes: 'Pozvoni na portafon.',
+    slotStartAt: '2026-07-16T08:00:00.000Z',
+    slotEndAt: '2026-07-16T10:00:00.000Z',
+    estimatedArrivalAt: '2026-07-16T09:00:00.000Z',
+    estimatedTravelSeconds: 900,
+    estimatedDistanceMeters: 5_000,
+    reroutePending: false,
+    deliveredAt: null,
+    harvest: {
+        plantName: 'Rajčica za dostavu',
+        operationName: 'Berba',
+        raisedBedName: 'Gredica 4',
+        fieldName: 'Polje 2',
+        tracePath: '/trag/customer-delivery-4135',
+    },
+    receipt: null,
+    recovery: null,
+    tracking: {
+        status: 'live',
+        lastAcceptedAt: '2026-07-16T08:45:00.000Z',
+        mapAvailable: true,
+    },
+    mapPath: '/api/map/customer-mixed-run-4135',
+};
+
+const readyPickup: CustomerPickupRequestSummary = {
+    mode: 'pickup',
+    requestId: 'customer-pickup-ready-4135',
+    status: 'ready',
+    statusLabel: 'Spremno za preuzimanje',
+    requestNotes: 'Donijet ću svoju košaru.',
+    slotStartAt: '2026-07-16T12:00:00.000Z',
+    slotEndAt: '2026-07-16T14:00:00.000Z',
+    harvest: {
+        plantName:
+            'Vrlo dugačka sorta salate za provjeru prikaza na uskom zaslonu',
+        operationName: 'Berba',
+        raisedBedName: 'Gredica 8',
+        fieldName: 'Polje 1',
+        tracePath: '/trag/customer-pickup-ready-4135',
+    },
+    location: {
+        name: 'Gredice HQ',
+        address: 'Vrtna 1, 10000 Zagreb, HR',
+        instructions:
+            'Urod je spreman. Preuzmi ga na ovoj lokaciji tijekom odabranog termina.',
+    },
+    pickedUpAt: null,
+};
+
+const fulfilledPickup: CustomerPickupRequestSummary = {
+    ...readyPickup,
+    requestId: 'customer-pickup-fulfilled-4135',
+    status: 'fulfilled',
+    statusLabel: 'Preuzeto',
+    requestNotes: null,
+    harvest: {
+        ...readyPickup.harvest,
+        plantName: 'Mrkva za osobno preuzimanje',
+        tracePath: null,
+    },
+    location: {
+        name: 'Gredice HQ',
+        address: 'Vrtna 1, 10000 Zagreb, HR',
+        instructions: 'Preuzimanje uroda je evidentirano.',
+    },
+    pickedUpAt: '2026-07-16T13:15:00.000Z',
+};
+
+function dashboard({
+    role,
+    deliveries,
+}: {
+    role: 'user' | 'farmer';
+    deliveries: CustomerDeliveryDashboardRequest[];
+}): CustomerDeliveryDashboard {
+    return {
+        kind: 'customer',
+        user: {
+            id: `customer-${role}-4135`,
+            displayName: role === 'farmer' ? 'Farmer Fran' : 'Korisnik Korina',
+            role,
+        },
+        deliveries,
+        refreshedAt: '2026-07-16T09:00:00.000Z',
+    };
+}
+
+export function MixedCustomerDashboardStory() {
+    return (
+        <CustomerDashboard
+            dashboard={dashboard({
+                role: 'user',
+                deliveries: [delivery, readyPickup],
+            })}
+        />
+    );
+}
+
+export function PickupFarmerDashboardStory() {
+    return (
+        <CustomerDashboard
+            dashboard={dashboard({
+                role: 'farmer',
+                deliveries: [readyPickup, fulfilledPickup],
+            })}
+        />
+    );
+}
+
+export function DeliveryUserDashboardStory() {
+    return (
+        <CustomerDashboard
+            dashboard={dashboard({
+                role: 'user',
+                deliveries: [delivery],
+            })}
+        />
+    );
+}
+
+export function EmptyCustomerDashboardStory() {
+    return (
+        <CustomerDashboard
+            dashboard={dashboard({ role: 'user', deliveries: [] })}
+        />
+    );
+}

--- a/apps/delivery/tests/CustomerDeliveryReceiptStory.tsx
+++ b/apps/delivery/tests/CustomerDeliveryReceiptStory.tsx
@@ -3,17 +3,14 @@
 import { Button } from '@gredice/ui/Button';
 import { useState } from 'react';
 import { CustomerDashboard } from '../components/CustomerDashboard';
-import { DeliveryStopCard } from '../components/DeliveryStopCard';
+import { CustomerDeliveryCard } from '../components/CustomerDeliveryCard';
 import type {
     CustomerDeliveryDashboard,
+    CustomerDeliveryRequestSummary,
     CustomerHandoffVerification,
-    DeliveryStopSummary,
 } from '../lib/deliveryDashboardTypes';
 
-const privateDriverNote = 'PRIVATE DRIVER NOTE 4144';
-const foreignBulkRecipient = 'FOREIGN BULK RECIPIENT 4144';
-
-function customerStop({
+function customerDelivery({
     verification,
     index,
     trace = true,
@@ -23,7 +20,7 @@ function customerStop({
     index: number;
     trace?: boolean;
     longName?: boolean;
-}): DeliveryStopSummary {
+}): CustomerDeliveryRequestSummary {
     const requestReference = `customer-owned-request-${index}-4144`;
     const plantName = longName
         ? 'Vrlo dugačka sorta ekološke rajčice za provjeru prijeloma teksta na malom zaslonu'
@@ -38,26 +35,17 @@ function customerStop({
     };
 
     return {
-        id: 700 + index,
+        mode: 'delivery',
         requestId: requestReference,
-        sequence: null,
-        stopState: 'delivered',
-        requestState: 'fulfilled',
+        status: 'fulfilled',
         statusLabel: 'Dostavljeno',
-        isCurrent: false,
-        contactName: 'Kupac',
-        phone: null,
-        address: 'Adresa kupca',
-        addressLabel: null,
         requestNotes: null,
-        deliveryNotes: privateDriverNote,
         slotStartAt: '2026-07-16T08:00:00.000Z',
         slotEndAt: '2026-07-16T10:00:00.000Z',
         estimatedArrivalAt: null,
         estimatedTravelSeconds: null,
         estimatedDistanceMeters: null,
         reroutePending: false,
-        arrivedAt: '2026-07-16T09:25:00.000Z',
         deliveredAt: '2026-07-16T09:30:00.000Z',
         harvest,
         receipt: {
@@ -68,66 +56,22 @@ function customerStop({
         },
         recovery: null,
         tracking: null,
-        runId: null,
-        deliveryCount: 1,
-        recipientCount: 1,
-        deliveries: [
-            {
-                stopId: 700 + index,
-                stopState: 'delivered',
-                requestId: requestReference,
-                requestState: 'fulfilled',
-                contactName: 'Kupac',
-                phone: null,
-                addressLabel: null,
-                requestNotes: null,
-                deliveryNotes: privateDriverNote,
-                harvest,
-                exception: null,
-            },
-            {
-                stopId: 9_999,
-                stopState: 'delivered',
-                requestId: 'foreign-bulk-request-4144',
-                requestState: 'fulfilled',
-                contactName: foreignBulkRecipient,
-                phone: '+385 91 999 9999',
-                addressLabel: 'FOREIGN ADDRESS 4144',
-                requestNotes: 'FOREIGN REQUEST NOTE 4144',
-                deliveryNotes: 'FOREIGN DRIVER NOTE 4144',
-                harvest: {
-                    plantName: 'FOREIGN HARVEST 4144',
-                    operationName: null,
-                    raisedBedName: null,
-                    fieldName: null,
-                    tracePath: '/trag/foreign-trace-4144',
-                },
-                exception: null,
-            },
-        ],
-        actionState: 'completed',
-        lockedReason: null,
+        mapPath: null,
     };
 }
 
-const activeBase = customerStop({ verification: 'not-recorded', index: 9 });
-const activePrimaryDelivery = activeBase.deliveries[0];
-if (!activePrimaryDelivery) {
-    throw new Error('The active customer receipt fixture needs one delivery.');
-}
-
-const activeStop: DeliveryStopSummary = {
+const activeBase = customerDelivery({
+    verification: 'not-recorded',
+    index: 9,
+});
+const activeDelivery: CustomerDeliveryRequestSummary = {
     ...activeBase,
-    id: 709,
     requestId: 'customer-owned-request-journey-4144',
-    stopState: 'pending',
-    requestState: 'ready',
+    status: 'ready',
     statusLabel: 'Vozač stiže',
-    isCurrent: true,
     estimatedArrivalAt: '2026-07-16T09:30:00.000Z',
     estimatedTravelSeconds: 600,
     estimatedDistanceMeters: 3_200,
-    arrivedAt: null,
     deliveredAt: null,
     receipt: null,
     tracking: {
@@ -135,44 +79,27 @@ const activeStop: DeliveryStopSummary = {
         lastAcceptedAt: '2026-07-16T09:20:00.000Z',
         mapAvailable: false,
     },
-    runId: 'customer-run-journey-4144',
-    actionState: 'current',
-    deliveries: [
-        {
-            ...activePrimaryDelivery,
-            requestId: 'customer-owned-request-journey-4144',
-            stopState: 'pending',
-            requestState: 'ready',
-        },
-    ],
+    mapPath: '/api/map/customer-run-journey-4144',
 };
 
-const deliveredJourneyBase = customerStop({
+const deliveredJourneyBase = customerDelivery({
     verification: 'verified',
     index: 9,
 });
 if (!deliveredJourneyBase.receipt) {
     throw new Error('The delivered customer fixture needs a receipt.');
 }
-const deliveredJourneyStop: DeliveryStopSummary = {
+const deliveredJourneyDelivery: CustomerDeliveryRequestSummary = {
     ...deliveredJourneyBase,
     requestId: 'customer-owned-request-journey-4144',
     receipt: {
         ...deliveredJourneyBase.receipt,
         requestReference: 'customer-owned-request-journey-4144',
     },
-    deliveries: deliveredJourneyBase.deliveries.map((delivery, index) =>
-        index === 0
-            ? {
-                  ...delivery,
-                  requestId: 'customer-owned-request-journey-4144',
-              }
-            : delivery,
-    ),
 };
 
 function dashboard(
-    deliveries: DeliveryStopSummary[],
+    deliveries: CustomerDeliveryRequestSummary[],
 ): CustomerDeliveryDashboard {
     return {
         kind: 'customer',
@@ -189,29 +116,31 @@ function dashboard(
 export function CustomerDeliveryReceiptStatesStory() {
     return (
         <div className="max-w-2xl space-y-4 p-4">
-            <DeliveryStopCard
-                stop={customerStop({
+            <CustomerDeliveryCard
+                delivery={customerDelivery({
                     verification: 'verified',
                     index: 1,
                     longName: true,
                 })}
-                mode="customer"
             />
-            <DeliveryStopCard
-                stop={customerStop({ verification: 'no-label', index: 2 })}
-                mode="customer"
+            <CustomerDeliveryCard
+                delivery={customerDelivery({
+                    verification: 'no-label',
+                    index: 2,
+                })}
             />
-            <DeliveryStopCard
-                stop={customerStop({ verification: 'skipped', index: 3 })}
-                mode="customer"
+            <CustomerDeliveryCard
+                delivery={customerDelivery({
+                    verification: 'skipped',
+                    index: 3,
+                })}
             />
-            <DeliveryStopCard
-                stop={customerStop({
+            <CustomerDeliveryCard
+                delivery={customerDelivery({
                     verification: 'not-recorded',
                     index: 4,
                     trace: false,
                 })}
-                mode="customer"
             />
         </div>
     );
@@ -228,7 +157,7 @@ export function CustomerDeliveryReceiptJourneyStory() {
             </div>
             <CustomerDashboard
                 dashboard={dashboard([
-                    delivered ? deliveredJourneyStop : activeStop,
+                    delivered ? deliveredJourneyDelivery : activeDelivery,
                 ])}
             />
         </div>

--- a/apps/delivery/tests/delivery-customer-modes.spec.tsx
+++ b/apps/delivery/tests/delivery-customer-modes.spec.tsx
@@ -1,0 +1,208 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import {
+    DeliveryUserDashboardStory,
+    EmptyCustomerDashboardStory,
+    MixedCustomerDashboardStory,
+    PickupFarmerDashboardStory,
+} from './CustomerDashboardModesStory';
+import '../app/globals.css';
+
+test('keeps delivery tracking while presenting pickup location and instructions separately', async ({
+    mount,
+    page,
+}) => {
+    await mount(<MixedCustomerDashboardStory />);
+
+    await expect(
+        page.getByRole('heading', {
+            level: 2,
+            name: 'Moje dostave i preuzimanja',
+        }),
+    ).toBeVisible();
+    await expect(
+        page.getByText(
+            'Statusi uroda, planirani termini, lokacije preuzimanja i praćenje aktivne dostave na jednom mjestu.',
+            { exact: true },
+        ),
+    ).toBeVisible();
+    await expect(
+        page.getByText('Lokacija vozača je uživo.', { exact: false }),
+    ).toBeVisible();
+
+    const delivery = page.getByTestId('customer-delivery-card');
+    await expect(delivery).toHaveCount(1);
+    await expect(
+        delivery.getByRole('heading', { name: 'Rajčica za dostavu' }),
+    ).toBeVisible();
+    await expect(delivery.getByText('Dostava', { exact: true })).toBeVisible();
+    await expect(delivery.getByText('Dolazak', { exact: true })).toBeVisible();
+    await expect(delivery.getByText('Vožnja', { exact: true })).toBeVisible();
+    await expect(
+        delivery.getByText('Udaljenost', { exact: true }),
+    ).toBeVisible();
+
+    const map = page.getByRole('img', {
+        name: 'Trenutna lokacija vozača i moja dostava',
+    });
+    await expect(map).toBeVisible();
+    const mapSource = await map.getAttribute('src');
+    expect(mapSource).toContain('/api/map/customer-mixed-run-4135');
+
+    const pickup = page.getByTestId('customer-pickup-card');
+    await expect(pickup).toHaveCount(1);
+    await expect(
+        pickup.getByRole('heading', {
+            name: 'Vrlo dugačka sorta salate za provjeru prikaza na uskom zaslonu',
+        }),
+    ).toBeVisible();
+    await expect(
+        pickup.getByText('Preuzimanje', { exact: true }),
+    ).toBeVisible();
+    await expect(
+        pickup.getByText('Spremno za preuzimanje', { exact: true }),
+    ).toBeVisible();
+    await expect(pickup.getByText('Gredice HQ', { exact: true })).toBeVisible();
+    await expect(
+        pickup.getByText('Vrtna 1, 10000 Zagreb, HR', { exact: true }),
+    ).toBeVisible();
+    await expect(
+        pickup.getByText(
+            'Urod je spreman. Preuzmi ga na ovoj lokaciji tijekom odabranog termina.',
+            { exact: true },
+        ),
+    ).toBeVisible();
+    await expect(pickup.locator('time')).toHaveCount(2);
+    await expect(pickup.locator('time').first()).toHaveAttribute(
+        'datetime',
+        '2026-07-16T12:00:00.000Z',
+    );
+    await expect(pickup.locator('time').nth(1)).toHaveAttribute(
+        'datetime',
+        '2026-07-16T14:00:00.000Z',
+    );
+
+    const locationHref = await pickup
+        .getByRole('link', { name: /Otvori lokaciju preuzimanja:/ })
+        .getAttribute('href');
+    if (!locationHref) throw new Error('Pickup location link is missing.');
+    expect(new URL(locationHref).searchParams.get('destination')).toBe(
+        'Vrtna 1, 10000 Zagreb, HR',
+    );
+    const pickupText = await pickup.innerText();
+    expect(pickupText).not.toMatch(
+        /Lokacija vozača|Vožnja|Udaljenost|Potvrda o dostavi/,
+    );
+    await expect(pickup.getByTestId('customer-delivery-receipt')).toHaveCount(
+        0,
+    );
+});
+
+test('shows farmer pickup-only copy without delivery promises or receipts', async ({
+    mount,
+    page,
+}) => {
+    await mount(<PickupFarmerDashboardStory />);
+
+    await expect(page.getByText('Farmer Fran', { exact: true })).toBeVisible();
+    await expect(
+        page.getByText('Gredice preuzimanje', { exact: true }),
+    ).toBeVisible();
+    await expect(
+        page.getByText('Gredice dostava', { exact: true }),
+    ).toHaveCount(0);
+    await expect(
+        page.getByRole('heading', { level: 2, name: 'Moja preuzimanja' }),
+    ).toBeVisible();
+    await expect(
+        page.getByText(
+            'Statusi uroda, lokacije i planirani termini preuzimanja na jednom mjestu.',
+            { exact: true },
+        ),
+    ).toBeVisible();
+    await expect(page.getByTestId('customer-pickup-card')).toHaveCount(2);
+    await expect(page.getByTestId('customer-delivery-card')).toHaveCount(0);
+    await expect(page.getByTestId('customer-delivery-receipt')).toHaveCount(0);
+    await expect(
+        page.getByText('Lokacija vozača je uživo.', { exact: false }),
+    ).toHaveCount(0);
+    expect(await page.locator('body').innerText()).not.toMatch(
+        /Gredice dostava|Dostava uroda|Vozač|Vožnja|Udaljenost|Potvrda o dostavi/,
+    );
+    const fulfilled = page
+        .getByTestId('customer-pickup-card')
+        .filter({ hasText: 'Mrkva za osobno preuzimanje' });
+    await expect(
+        fulfilled.getByText('Preuzeto', { exact: true }),
+    ).toBeVisible();
+    await expect(fulfilled.locator('time').last()).toHaveAttribute(
+        'datetime',
+        '2026-07-16T13:15:00.000Z',
+    );
+});
+
+test('keeps the user delivery-only heading and tracking experience', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryUserDashboardStory />);
+
+    await expect(
+        page.getByRole('heading', { level: 2, name: 'Moje dostave' }),
+    ).toBeVisible();
+    await expect(
+        page.getByText('Korisnik Korina', { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByTestId('customer-delivery-card')).toHaveCount(1);
+    await expect(page.getByTestId('customer-pickup-card')).toHaveCount(0);
+    await expect(
+        page.getByText('Lokacija vozača je uživo.', { exact: false }),
+    ).toBeVisible();
+});
+
+test('uses a mode-neutral empty state', async ({ mount, page }) => {
+    await mount(<EmptyCustomerDashboardStory />);
+
+    await expect(
+        page.getByRole('heading', {
+            level: 2,
+            name: 'Moje dostave i preuzimanja',
+        }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('heading', {
+            level: 3,
+            name: 'Još nema dostava ni preuzimanja',
+        }),
+    ).toBeVisible();
+    await expect(
+        page.getByText(
+            'Kada zatražiš dostavu ili preuzimanje uroda, ovdje ćeš vidjeti termin, status i dostupne informacije o preuzimanju.',
+            { exact: true },
+        ),
+    ).toBeVisible();
+});
+
+test.describe('pickup presentation on a small touch screen', () => {
+    test.use({
+        viewport: { width: 360, height: 800 },
+        hasTouch: true,
+        isMobile: true,
+    });
+
+    test('contains long content and keeps pickup actions touch-sized', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<MixedCustomerDashboardStory />);
+        const pickup = page.getByTestId('customer-pickup-card');
+
+        const fitsViewport = await pickup.evaluate(
+            (element) => element.scrollWidth <= element.clientWidth,
+        );
+        expect(fitsViewport).toBe(true);
+        for (const link of await pickup.getByRole('link').all()) {
+            const box = await link.boundingBox();
+            expect(box?.height).toBeGreaterThanOrEqual(44);
+        }
+    });
+});

--- a/apps/delivery/tests/delivery-customer-receipt.spec.tsx
+++ b/apps/delivery/tests/delivery-customer-receipt.spec.tsx
@@ -12,19 +12,28 @@ test('renders every advisory receipt state with owned harvest data and contextua
     await mount(<CustomerDeliveryReceiptStatesStory />);
 
     const receipts = page.getByTestId('customer-delivery-receipt');
+    await expect(page.getByTestId('customer-delivery-card')).toHaveCount(4);
     await expect(receipts).toHaveCount(4);
     await expect(
         page.getByRole('heading', {
+            level: 4,
             name: /Potvrda o dostavi · Vrlo dugačka sorta/,
         }),
     ).toBeVisible();
     for (const index of [2, 3, 4]) {
         await expect(
             page.getByRole('heading', {
+                level: 4,
                 name: `Potvrda o dostavi · Rajčica kupca ${index}`,
             }),
         ).toBeVisible();
     }
+    await expect(
+        page.getByRole('heading', {
+            level: 3,
+            name: /Vrlo dugačka sorta ekološke rajčice/,
+        }),
+    ).toBeVisible();
     for (const label of [
         'QR etiketa provjerena je pri predaji.',
         'QR etiketa nije bila dostupna pri predaji.',
@@ -80,17 +89,6 @@ test('renders every advisory receipt state with owned harvest data and contextua
     expect(missingUrl.searchParams.get('body')).toContain(
         'customer-owned-trace-1-4144',
     );
-
-    const renderedText = await page.locator('body').innerText();
-    for (const sentinel of [
-        'PRIVATE DRIVER NOTE 4144',
-        'FOREIGN BULK RECIPIENT 4144',
-        'FOREIGN HARVEST 4144',
-        'FOREIGN REQUEST NOTE 4144',
-        'foreign-trace-4144',
-    ]) {
-        expect(renderedText).not.toContain(sentinel);
-    }
 });
 
 test.describe('customer receipt on a small touch screen', () => {

--- a/apps/delivery/tests/delivery-tracking.spec.tsx
+++ b/apps/delivery/tests/delivery-tracking.spec.tsx
@@ -10,7 +10,7 @@ test('customer sees a live server-acknowledged location and map', async ({
 }) => {
     await mount(
         <CustomerDeliveryTracking
-            runId="run-live"
+            mapPath="/api/map/run-live"
             tracking={{
                 status: 'live',
                 lastAcceptedAt,
@@ -35,7 +35,7 @@ test('customer sees delayed copy while the last exact location remains available
 }) => {
     await mount(
         <CustomerDeliveryTracking
-            runId="run-delayed"
+            mapPath="/api/map/run-delayed"
             tracking={{
                 status: 'delayed',
                 lastAcceptedAt,
@@ -58,7 +58,7 @@ test('customer sees offline state without a stale exact-location map', async ({
 }) => {
     await mount(
         <CustomerDeliveryTracking
-            runId="run-offline"
+            mapPath="/api/map/run-offline"
             tracking={{
                 status: 'offline',
                 lastAcceptedAt,
@@ -79,7 +79,7 @@ test('customer sees unavailable state before the first accepted location', async
 }) => {
     await mount(
         <CustomerDeliveryTracking
-            runId="run-unavailable"
+            mapPath="/api/map/run-unavailable"
             tracking={{
                 status: 'unavailable',
                 lastAcceptedAt: null,

--- a/docs/delivery-handoff-audit.md
+++ b/docs/delivery-handoff-audit.md
@@ -108,8 +108,11 @@ operation identifier is safe even if the first response was lost.
 The customer receipt starts from the operation-owner-scoped delivery request,
 not from the driver's physical-stop manifest. A bulk stop can contain requests
 for multiple accounts, but each account receives only its own request, harvest
-description, and public trace path. The customer requests API explicitly omits
-driver fulfillment notes before serialization.
+description, and public trace path. The customer requests API uses an explicit,
+mode-specific allowlist: delivery responses include only the customer's public
+address and bounded receipt, while pickup responses include only the public
+pickup location and never a delivery receipt. Driver notes, contacts, route
+state, account identifiers, and private trace identifiers are not serialized.
 
 The durable fulfillment event carries the validated recorded handoff time so
 an offline completion keeps the time it happened instead of the later sync
@@ -128,6 +131,14 @@ ID, numeric trace-link ID, driver identity, skip reason, raw QR value, address,
 phone number, or arbitrary delivery note. QR copy explicitly describes the
 check as supplemental evidence that does not affect the completed delivery
 status.
+
+The delivery dashboard has a separate discriminated customer contract. Pickup
+requests carry pickup status, location, and readiness instructions without ETA,
+driver-tracking, or delivery-recovery fields. Delivery requests carry only
+customer-facing ETA and tracking freshness. Exact driver coordinates remain
+behind the authenticated map proxy, which returns only the server-confirmed
+current physical destination for the owning account; it does not reveal later
+stops for the same account or their route sequence.
 
 Missing-harvest, damaged-harvest, and general-support actions open a prefilled
 message to `podrska@gredice.com`. The message contains only the owned delivery


### PR DESCRIPTION
## Summary

- split the customer dashboard contract into explicit delivery and pickup variants with allowlisted fields
- present pickup status, location, instructions, navigation, and history without delivery promises or receipts
- constrain customer map output to an owned server-confirmed current physical stop while preserving full assigned-driver and admin views
- fail closed for unsupported roles or request modes and keep customer responses private and non-cacheable
- document the customer-safe response and map authorization boundary

## Validation

- `corepack pnpm --filter delivery test:unit` (323 passed)
- `corepack pnpm --filter delivery typecheck`
- `corepack pnpm --filter delivery build`
- `corepack pnpm --filter api build`
- delivery component suite (108 passed)
- focused Biome checks for API and delivery files
- `git diff --check`

Closes #4135