### PR TITLE
test(delivery): avoid fixed offline cache clock

### DIFF
--- a/apps/delivery/lib/offlineRouteCache.node.spec.ts
+++ b/apps/delivery/lib/offlineRouteCache.node.spec.ts
@@ -17,7 +17,7 @@ import {
     parseOfflineRouteSnapshot,
 } from './offlineRouteCache';
 
-const now = new Date('2026-07-15T12:00:00.000Z');
+const now = new Date();
 
 type DeliveryStep = Extract<DeliveryRouteStepSummary, { kind: 'delivery' }>;
 type PickupStep = Extract<DeliveryRouteStepSummary, { kind: 'pickup' }>;


### PR DESCRIPTION
## Summary

- anchor the offline route-cache test clock at test execution time instead of a fixed July 2026 timestamp
- preserve the existing explicit TTL and expiry-boundary assertions
- leave production cache behavior and the 24-hour TTL unchanged

## Root cause

The fixture timestamp expired after 24 hours, but two pruning tests intentionally exercise a helper that loads with the real current time. Once the calendar crossed the fixture expiry, the helper correctly discarded the snapshots and the tests failed independently of application behavior.

## Validation

- `corepack pnpm --filter delivery exec node --import tsx --test lib/offlineRouteCache.node.spec.ts` — 15/15 passed
- `corepack pnpm --filter delivery test:unit` — 323/323 passed
- `corepack pnpm --filter delivery exec biome check lib/offlineRouteCache.node.spec.ts` — passed
- `git diff --check` — passed

Closes #4217
