### PR TITLE
feat(delivery): add customer ETA ranges and route progress

### DIFF
--- a/apps/delivery/components/CustomerDashboard.tsx
+++ b/apps/delivery/components/CustomerDashboard.tsx
@@ -6,14 +6,19 @@ import type {
     CustomerDeliveryRequestSummary,
 } from '../lib/deliveryDashboardTypes';
 import { CustomerDeliveryCard } from './CustomerDeliveryCard';
-import { CustomerDeliveryTracking } from './CustomerDeliveryTracking';
+import {
+    CustomerDeliveryTracking,
+    type CustomerDeliveryTrackingRequestTiming,
+} from './CustomerDeliveryTracking';
 import { CustomerPickupCard } from './CustomerPickupCard';
 import { DeliveryAppHeader } from './DeliveryAppHeader';
 
 export function CustomerDashboard({
     dashboard,
+    requestTiming,
 }: {
     dashboard: CustomerDeliveryDashboard;
+    requestTiming: CustomerDeliveryTrackingRequestTiming | null;
 }) {
     const hasDelivery = dashboard.deliveries.some(
         (request) => request.mode === 'delivery',
@@ -73,6 +78,7 @@ export function CustomerDashboard({
                     <CustomerDeliveryTracking
                         mapPath={trackedDelivery.mapPath}
                         tracking={trackedDelivery.tracking}
+                        requestTiming={requestTiming}
                     />
                 ) : null}
 

--- a/apps/delivery/components/CustomerDeliveryCard.tsx
+++ b/apps/delivery/components/CustomerDeliveryCard.tsx
@@ -1,23 +1,14 @@
-import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
 import { Chip } from '@gredice/ui/Chip';
-import {
-    Calendar,
-    ExternalLink,
-    Leaf,
-    Timer,
-    Truck,
-    Warning,
-} from '@gredice/ui/icons';
+import { Calendar, ExternalLink, Leaf, Timer, Truck } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
 import type { CustomerDeliveryRequestSummary } from '../lib/deliveryDashboardTypes';
 import {
     formatDeliveryDateTime,
-    formatDeliveryTime,
-    formatDistance,
-    formatTravelDuration,
+    formatDeliveryDateTimeRange,
 } from '../lib/deliveryFormatting';
+import { CustomerDeliveryPromise } from './CustomerDeliveryPromise';
 import { DeliveryCustomerReceipt } from './DeliveryCustomerReceipt';
 import { DeliveryCustomerRecovery } from './DeliveryCustomerRecovery';
 
@@ -48,16 +39,13 @@ export function CustomerDeliveryCard({
 }: {
     delivery: CustomerDeliveryRequestSummary;
 }) {
-    const showRouteEstimates =
-        Boolean(
-            delivery.estimatedArrivalAt || delivery.estimatedTravelSeconds,
-        ) &&
+    const showDeliveryPromise =
+        delivery.status !== 'fulfilled' &&
+        !delivery.receipt &&
         (!delivery.recovery || delivery.recovery.kind === 'retry-planned');
-    const estimatedOutsideWindow = Boolean(
-        delivery.estimatedArrivalAt &&
-            delivery.slotEndAt &&
-            new Date(delivery.estimatedArrivalAt) >
-                new Date(delivery.slotEndAt),
+    const promisedWindow = formatDeliveryDateTimeRange(
+        delivery.slotStartAt,
+        delivery.slotEndAt,
     );
     const harvestDescription = [
         delivery.harvest.plantName,
@@ -102,68 +90,30 @@ export function CustomerDeliveryCard({
                     </div>
                 </div>
 
-                {delivery.slotStartAt && delivery.slotEndAt ? (
-                    <div className="flex items-start gap-2 text-sm">
-                        <Calendar className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                <div className="flex items-start gap-2 text-sm">
+                    <Calendar className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                    {promisedWindow ? (
                         <span>
                             Termin:{' '}
-                            <time dateTime={delivery.slotStartAt}>
-                                {formatDeliveryDateTime(delivery.slotStartAt)}
+                            <time dateTime={promisedWindow.startAt}>
+                                {promisedWindow.startLabel}
                             </time>{' '}
                             –{' '}
-                            <time dateTime={delivery.slotEndAt}>
-                                {formatDeliveryTime(delivery.slotEndAt)}
+                            <time dateTime={promisedWindow.endAt}>
+                                {promisedWindow.endLabel}
                             </time>
                         </span>
-                    </div>
-                ) : null}
+                    ) : (
+                        <span>Termin još nije dostupan.</span>
+                    )}
+                </div>
 
-                {showRouteEstimates ? (
-                    <div className="grid grid-cols-3 gap-2 rounded-lg bg-muted/70 p-3 text-center">
-                        <div>
-                            <Typography
-                                level="body3"
-                                className="text-muted-foreground"
-                            >
-                                Dolazak
-                            </Typography>
-                            <Typography level="body2" semiBold>
-                                {formatDeliveryTime(
-                                    delivery.estimatedArrivalAt,
-                                )}
-                            </Typography>
-                        </div>
-                        <div className="border-x">
-                            <Typography
-                                level="body3"
-                                className="text-muted-foreground"
-                            >
-                                Vožnja
-                            </Typography>
-                            <Typography level="body2" semiBold>
-                                {formatTravelDuration(
-                                    delivery.estimatedTravelSeconds,
-                                )}
-                            </Typography>
-                        </div>
-                        <div>
-                            <Typography
-                                level="body3"
-                                className="text-muted-foreground"
-                            >
-                                Udaljenost
-                            </Typography>
-                            <Typography level="body2" semiBold>
-                                {formatDistance(
-                                    delivery.estimatedDistanceMeters,
-                                )}
-                            </Typography>
-                        </div>
-                    </div>
-                ) : delivery.reroutePending ? (
-                    <Alert color="info">
-                        Procjena dolaska ažurira se nakon promjene rute.
-                    </Alert>
+                {showDeliveryPromise ? (
+                    <CustomerDeliveryPromise
+                        eta={delivery.eta}
+                        progress={delivery.progress}
+                        promisedWindowStartAt={delivery.slotStartAt}
+                    />
                 ) : null}
 
                 {delivery.recovery ? (
@@ -182,19 +132,6 @@ export function CustomerDeliveryCard({
                 {delivery.requestNotes ? (
                     <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
                         <strong>Napomena:</strong> {delivery.requestNotes}
-                    </div>
-                ) : null}
-
-                {showRouteEstimates &&
-                estimatedOutsideWindow &&
-                delivery.status !== 'fulfilled' ? (
-                    <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
-                        <Warning className="mt-0.5 size-4 shrink-0" />
-                        <span>
-                            Trenutačna procjena dolaska je nakon završetka
-                            termina. Prikaz će se ažurirati kada vozač nastavi
-                            rutu.
-                        </span>
                     </div>
                 ) : null}
 

--- a/apps/delivery/components/CustomerDeliveryPromise.tsx
+++ b/apps/delivery/components/CustomerDeliveryPromise.tsx
@@ -1,0 +1,216 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Chip } from '@gredice/ui/Chip';
+import { Hourglass, Tally3, Timer, Warning } from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import { croatianCountLabel } from '../lib/croatianCount';
+import type {
+    CustomerDeliveryEtaSummary,
+    CustomerDeliveryProgressSummary,
+} from '../lib/deliveryDashboardTypes';
+import {
+    formatDeliveryDateTime,
+    formatDeliveryDateTimeRange,
+    formatDeliveryDurationRange,
+} from '../lib/deliveryFormatting';
+
+function etaSourceLabel(eta: CustomerDeliveryEtaSummary) {
+    if (eta.confidence === 'high' && eta.freshness === 'fresh') {
+        return 'Ažurna procjena prema prometu';
+    }
+    switch (eta.source) {
+        case 'route-plan':
+            return 'Okvirna procjena rute';
+        case 'promised-window':
+            return 'Prema odabranom terminu';
+        case 'traffic-route':
+            return eta.freshness === 'stale'
+                ? 'Posljednja procjena rute'
+                : 'Okvirna procjena prema prometu';
+    }
+}
+
+function progressMessage(progress: CustomerDeliveryProgressSummary) {
+    switch (progress.phase) {
+        case 'scheduled':
+            return 'Ruta za ovu dostavu još nije započela.';
+        case 'next':
+            return 'Tvoja dostava je sljedeća.';
+        case 'arrived':
+            return 'Vozač je stigao na lokaciju dostave.';
+        case 'on-route':
+            return progress.stopsAhead === null
+                ? 'Dostava je na ruti.'
+                : `${croatianCountLabel(
+                      progress.stopsAhead,
+                      'zaustavljanje',
+                      'zaustavljanja',
+                      'zaustavljanja',
+                  )} prije tvoje dostave.`;
+        case 'unavailable':
+            return 'Napredak rute trenutačno nije dostupan.';
+    }
+}
+
+function deliveryPromiseAnnouncement(
+    eta: CustomerDeliveryEtaSummary,
+    progress: CustomerDeliveryProgressSummary,
+    range: ReturnType<typeof formatDeliveryDateTimeRange>,
+) {
+    const expiredPromise = progress.delayed && !range;
+    return [
+        range
+            ? eta.source === 'promised-window'
+                ? `Procijenjeni dolazak od ${range.startLabel} do ${range.endLabel}.`
+                : `Procijenjeni dolazak do ${formatDeliveryDateTime(range.endAt)}.`
+            : expiredPromise
+              ? 'Odabrani termin je prošao, a nova procjena dolaska trenutačno nije dostupna.'
+              : 'Procjena dolaska trenutačno nije dostupna.',
+        range ? etaSourceLabel(eta) : null,
+        eta.freshness === 'stale'
+            ? 'Procjena rute nije ažurna; prikazujemo odabrani termin.'
+            : null,
+        progressMessage(progress),
+        progress.delayed && range
+            ? 'Procjena dolaska je nakon završetka odabranog termina.'
+            : null,
+    ]
+        .filter(Boolean)
+        .join(' ');
+}
+
+export function CustomerDeliveryPromise({
+    eta,
+    progress,
+    promisedWindowStartAt,
+}: {
+    eta: CustomerDeliveryEtaSummary;
+    progress: CustomerDeliveryProgressSummary;
+    promisedWindowStartAt: string | null;
+}) {
+    const range = formatDeliveryDateTimeRange(
+        eta.rangeStartAt,
+        eta.rangeEndAt,
+        promisedWindowStartAt,
+    );
+    const hasRange = range !== null;
+    const remaining = formatDeliveryDurationRange(
+        eta.remainingMinSeconds,
+        eta.remainingMaxSeconds,
+    );
+
+    return (
+        <div data-testid="customer-delivery-promise" className="space-y-3">
+            <span
+                className="sr-only"
+                role="status"
+                aria-atomic="true"
+                aria-live="polite"
+            >
+                {deliveryPromiseAnnouncement(eta, progress, range)}
+            </span>
+            {hasRange ? (
+                <div className="rounded-lg bg-muted/70 p-3">
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                        <div>
+                            <Typography
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                Procijenjeni dolazak
+                            </Typography>
+                            <Typography level="body1" semiBold>
+                                <time dateTime={range.startAt}>
+                                    {range.startLabel}
+                                </time>{' '}
+                                –{' '}
+                                <time dateTime={range.endAt}>
+                                    {range.endLabel}
+                                </time>
+                            </Typography>
+                        </div>
+                        <Chip
+                            color={
+                                eta.confidence === 'high'
+                                    ? 'success'
+                                    : 'neutral'
+                            }
+                            size="sm"
+                        >
+                            {etaSourceLabel(eta)}
+                        </Chip>
+                    </div>
+                    {remaining ? (
+                        <Typography
+                            level="body3"
+                            className="mt-2 flex items-center gap-1.5 text-muted-foreground"
+                        >
+                            <Timer className="size-4" />{' '}
+                            {remaining === 'uskoro'
+                                ? 'Dolazak se očekuje uskoro.'
+                                : `Preostalo: ${remaining}`}
+                        </Typography>
+                    ) : null}
+                    {eta.freshness === 'stale' ? (
+                        <Typography
+                            level="body3"
+                            className="mt-2 text-amber-800 dark:text-amber-200"
+                        >
+                            Procjena rute nije ažurna; prikazujemo odabrani
+                            termin.
+                        </Typography>
+                    ) : null}
+                    {eta.calculatedAt ? (
+                        <Typography
+                            level="body3"
+                            className="mt-1 text-muted-foreground"
+                        >
+                            {eta.freshness === 'stale'
+                                ? 'Zadnja procjena rute:'
+                                : 'Procjena izračunata:'}{' '}
+                            <time dateTime={eta.calculatedAt}>
+                                {formatDeliveryDateTime(eta.calculatedAt)}
+                            </time>
+                        </Typography>
+                    ) : null}
+                </div>
+            ) : (
+                <Alert
+                    aria-label={
+                        progress.delayed
+                            ? 'Istek odabranog termina'
+                            : 'Dostupnost procjene dolaska'
+                    }
+                    color={progress.delayed ? 'warning' : 'info'}
+                    role="group"
+                    startDecorator={
+                        progress.delayed ? (
+                            <Warning className="size-5" />
+                        ) : (
+                            <Hourglass className="size-5" />
+                        )
+                    }
+                >
+                    {progress.delayed
+                        ? 'Odabrani termin je prošao, a nova procjena dolaska trenutačno nije dostupna.'
+                        : 'Procjena dolaska trenutačno nije dostupna. Odabrani termin ostaje prikazan iznad.'}
+                </Alert>
+            )}
+
+            <div className="flex items-start gap-2 text-sm">
+                <Tally3 className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                <span>{progressMessage(progress)}</span>
+            </div>
+
+            {progress.delayed && hasRange ? (
+                <Alert
+                    aria-label="Kašnjenje procjene dolaska"
+                    color="warning"
+                    role="group"
+                    startDecorator={<Warning className="size-5" />}
+                >
+                    Procjena dolaska je nakon završetka odabranog termina.
+                </Alert>
+            ) : null}
+        </div>
+    );
+}

--- a/apps/delivery/components/CustomerDeliveryTracking.tsx
+++ b/apps/delivery/components/CustomerDeliveryTracking.tsx
@@ -1,9 +1,19 @@
+import {
+    deliveryRunExactLocationTtlMs,
+    deliveryRunTrackingLiveThresholdMs,
+} from '@gredice/storage/deliveryTrackingPolicy';
 import { Alert } from '@gredice/ui/Alert';
 import { MyLocation, Timer, Warning } from '@gredice/ui/icons';
+import { useEffect, useState } from 'react';
 import type { CustomerDeliveryTrackingSummary } from '../lib/deliveryDashboardTypes';
 import { formatDeliveryDateTime } from '../lib/deliveryFormatting';
 import { deliveryTrackingMapVersion } from '../lib/deliveryTrackingPresentation';
 import { DeliveryMap } from './DeliveryMap';
+
+export type CustomerDeliveryTrackingRequestTiming = {
+    monotonicMs: number;
+    wallMs: number;
+};
 
 function trackingMessage(tracking: CustomerDeliveryTrackingSummary) {
     const lastUpdate = tracking.lastAcceptedAt
@@ -27,18 +37,156 @@ function trackingMessage(tracking: CustomerDeliveryTrackingSummary) {
     }
 }
 
+function exactLocationRemainingMs(
+    tracking: CustomerDeliveryTrackingSummary,
+    requestTiming: CustomerDeliveryTrackingRequestTiming | null,
+) {
+    if (
+        !tracking.mapAvailable ||
+        !tracking.lastAcceptedAt ||
+        tracking.exactLocationExpiresInMs === null ||
+        !Number.isFinite(tracking.exactLocationExpiresInMs) ||
+        tracking.exactLocationExpiresInMs < 0 ||
+        !requestTiming ||
+        !Number.isFinite(requestTiming.monotonicMs) ||
+        !Number.isFinite(requestTiming.wallMs)
+    ) {
+        return null;
+    }
+    const monotonicElapsed = performance.now() - requestTiming.monotonicMs;
+    const wallElapsed = Date.now() - requestTiming.wallMs;
+    const elapsed = Math.max(0, monotonicElapsed, wallElapsed);
+    return tracking.exactLocationExpiresInMs - elapsed;
+}
+
+type ClientTrackingPhase = 'delayed' | 'offline';
+
+const delayedRemainingThresholdMs =
+    deliveryRunExactLocationTtlMs - deliveryRunTrackingLiveThresholdMs;
+
+function clientTrackingPhase(
+    tracking: CustomerDeliveryTrackingSummary,
+    remainingMs: number | null,
+): ClientTrackingPhase | null {
+    if (!tracking.mapAvailable) return null;
+    if (remainingMs === null || remainingMs <= 0) return 'offline';
+    if (
+        tracking.status === 'live' &&
+        remainingMs <= delayedRemainingThresholdMs
+    ) {
+        return 'delayed';
+    }
+    return null;
+}
+
+function useExactLocationAging(
+    tracking: CustomerDeliveryTrackingSummary,
+    requestTiming: CustomerDeliveryTrackingRequestTiming | null,
+) {
+    const [agedTracking, setAgedTracking] = useState<{
+        acceptedAt: string;
+        phase: ClientTrackingPhase;
+    } | null>(() => {
+        const phase = clientTrackingPhase(
+            tracking,
+            exactLocationRemainingMs(tracking, requestTiming),
+        );
+        return phase && tracking.lastAcceptedAt
+            ? { acceptedAt: tracking.lastAcceptedAt, phase }
+            : null;
+    });
+    const remainingMs = exactLocationRemainingMs(tracking, requestTiming);
+    const calculatedPhase = clientTrackingPhase(tracking, remainingMs);
+    const phase =
+        calculatedPhase ??
+        (tracking.lastAcceptedAt !== null &&
+        agedTracking?.acceptedAt === tracking.lastAcceptedAt
+            ? agedTracking.phase
+            : null);
+
+    useEffect(() => {
+        if (!tracking.mapAvailable) {
+            setAgedTracking(null);
+            return;
+        }
+        let timeoutId: number | null = null;
+        const updateAging = () => {
+            if (timeoutId !== null) window.clearTimeout(timeoutId);
+            const remaining = exactLocationRemainingMs(tracking, requestTiming);
+            const nextPhase = clientTrackingPhase(tracking, remaining);
+            if (nextPhase) {
+                setAgedTracking((current) =>
+                    current?.acceptedAt === tracking.lastAcceptedAt &&
+                    current.phase === nextPhase
+                        ? current
+                        : tracking.lastAcceptedAt
+                          ? {
+                                acceptedAt: tracking.lastAcceptedAt,
+                                phase: nextPhase,
+                            }
+                          : null,
+                );
+                if (nextPhase === 'delayed' && remaining !== null) {
+                    timeoutId = window.setTimeout(
+                        updateAging,
+                        Math.max(1, remaining),
+                    );
+                }
+                return;
+            }
+            setAgedTracking(null);
+            if (remaining === null) return;
+            const untilNextPhase =
+                tracking.status === 'live'
+                    ? remaining - delayedRemainingThresholdMs
+                    : remaining;
+            timeoutId = window.setTimeout(
+                updateAging,
+                Math.max(1, untilNextPhase),
+            );
+        };
+        updateAging();
+        window.addEventListener('focus', updateAging);
+        window.addEventListener('pageshow', updateAging);
+        document.addEventListener('visibilitychange', updateAging);
+        return () => {
+            if (timeoutId !== null) window.clearTimeout(timeoutId);
+            window.removeEventListener('focus', updateAging);
+            window.removeEventListener('pageshow', updateAging);
+            document.removeEventListener('visibilitychange', updateAging);
+        };
+    }, [tracking, requestTiming]);
+
+    return phase;
+}
+
 export function CustomerDeliveryTracking({
     mapPath,
     tracking,
+    requestTiming,
 }: {
     mapPath: string;
     tracking: CustomerDeliveryTrackingSummary;
+    requestTiming: CustomerDeliveryTrackingRequestTiming | null;
 }) {
+    const clientPhase = useExactLocationAging(tracking, requestTiming);
+    const visibleTracking: CustomerDeliveryTrackingSummary =
+        clientPhase === 'offline'
+            ? {
+                  ...tracking,
+                  status: 'offline',
+                  mapAvailable: false,
+                  exactLocationExpiresInMs: null,
+              }
+            : clientPhase === 'delayed'
+              ? { ...tracking, status: 'delayed' }
+              : tracking;
     const showMap =
-        tracking.mapAvailable &&
-        (tracking.status === 'live' || tracking.status === 'delayed');
-    const delayed = tracking.status === 'delayed';
-    const offline = tracking.status === 'offline';
+        visibleTracking.mapAvailable &&
+        (visibleTracking.status === 'live' ||
+            visibleTracking.status === 'delayed');
+    const delayed = visibleTracking.status === 'delayed';
+    const offline = visibleTracking.status === 'offline';
 
     return (
         <section className="space-y-3">
@@ -56,14 +204,14 @@ export function CustomerDeliveryTracking({
                     )
                 }
             >
-                {trackingMessage(tracking)}
+                {trackingMessage(visibleTracking)}
             </Alert>
             {showMap ? (
                 <DeliveryMap
                     mapUrl={mapPath}
-                    version={deliveryTrackingMapVersion(tracking)}
+                    version={deliveryTrackingMapVersion(visibleTracking)}
                     title={
-                        tracking.status === 'live'
+                        visibleTracking.status === 'live'
                             ? 'Trenutna lokacija vozača i moja dostava'
                             : 'Posljednja potvrđena lokacija vozača i moja dostava'
                     }

--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -20,6 +20,10 @@ import {
 import { useDriverTracking } from '../hooks/useDriverTracking';
 import { useOfflineRouteCache } from '../hooks/useOfflineRouteCache';
 import { usePickupManifestSync } from '../hooks/usePickupManifestSync';
+import {
+    isCustomerDeliveryEtaSummary,
+    isCustomerDeliveryTrackingSummary,
+} from '../lib/customerDeliveryValidation';
 import { deliveryRouteStepsWithLocalActions } from '../lib/deliveryActionPresentation';
 import {
     clearOtherDeliveryActionQueueScopes,
@@ -101,6 +105,10 @@ async function clearOtherStoredDriverRuns(userId: string, activeRunId: string) {
 
 async function readDashboard({ signal }: { signal: AbortSignal }) {
     assertDeliveryOfflineWritesAllowed();
+    const requestTiming = {
+        monotonicMs: performance.now(),
+        wallMs: Date.now(),
+    };
     const response = await fetch('/api/dashboard', {
         cache: 'no-store',
         signal,
@@ -115,7 +123,7 @@ async function readDashboard({ signal }: { signal: AbortSignal }) {
             'Poslužitelj je vratio neispravne podatke o dostavama.',
         );
     }
-    return data;
+    return { dashboard: data, requestTiming };
 }
 
 function isDeliveryDashboard(value: unknown): value is DeliveryDashboardData {
@@ -159,10 +167,6 @@ function isNullableString(value: unknown) {
     return value === null || typeof value === 'string';
 }
 
-function isNullableNumber(value: unknown) {
-    return value === null || typeof value === 'number';
-}
-
 function isCustomerHarvest(value: unknown) {
     return (
         isRecord(value) &&
@@ -174,16 +178,19 @@ function isCustomerHarvest(value: unknown) {
     );
 }
 
-function isCustomerTracking(value: unknown) {
+function isCustomerProgress(value: unknown) {
     return (
-        value === null ||
-        (isRecord(value) &&
-            (value.status === 'live' ||
-                value.status === 'delayed' ||
-                value.status === 'offline' ||
-                value.status === 'unavailable') &&
-            isNullableString(value.lastAcceptedAt) &&
-            typeof value.mapAvailable === 'boolean')
+        isRecord(value) &&
+        (value.phase === 'scheduled' ||
+            value.phase === 'on-route' ||
+            value.phase === 'next' ||
+            value.phase === 'arrived' ||
+            value.phase === 'unavailable') &&
+        (value.stopsAhead === null ||
+            (typeof value.stopsAhead === 'number' &&
+                Number.isInteger(value.stopsAhead) &&
+                value.stopsAhead >= 0)) &&
+        typeof value.delayed === 'boolean'
     );
 }
 
@@ -212,12 +219,10 @@ function isCustomerDashboardRequest(value: unknown) {
     }
     return (
         value.mode === 'delivery' &&
-        isNullableString(value.estimatedArrivalAt) &&
-        isNullableNumber(value.estimatedTravelSeconds) &&
-        isNullableNumber(value.estimatedDistanceMeters) &&
-        typeof value.reroutePending === 'boolean' &&
+        isCustomerDeliveryEtaSummary(value.eta) &&
+        isCustomerProgress(value.progress) &&
         isNullableString(value.deliveredAt) &&
-        isCustomerTracking(value.tracking) &&
+        isCustomerDeliveryTrackingSummary(value.tracking) &&
         isNullableString(value.mapPath) &&
         (value.receipt === null || isRecord(value.receipt)) &&
         (value.recovery === null || isRecord(value.recovery))
@@ -708,7 +713,7 @@ export function DeliveryDashboard({
         refetchInterval: 10_000,
     });
     const refetchDashboard = query.refetch;
-    const dashboardData = query.data;
+    const dashboardData = query.data?.dashboard;
     const driverDashboard: DriverDeliveryDashboard | null =
         dashboardData?.kind === 'driver' ? dashboardData : null;
     const authenticatedDriverUserId =
@@ -783,11 +788,11 @@ export function DeliveryDashboard({
         },
     });
     const driverWithoutActiveRun =
-        query.data?.kind === 'driver' && !query.data.activeRun
-            ? query.data.user.id
+        dashboardData?.kind === 'driver' && !dashboardData.activeRun
+            ? dashboardData.user.id
             : null;
     const currentDriverUserId =
-        query.data?.kind === 'driver' ? query.data.user.id : null;
+        dashboardData?.kind === 'driver' ? dashboardData.user.id : null;
     const currentDriverRunId = driverDashboard?.activeRun?.id ?? null;
     const previousDriverUserIdRef = useRef<string | null>(null);
     const previousDriverRunScopeRef = useRef<{
@@ -879,11 +884,11 @@ export function DeliveryDashboard({
     }, [authenticatedUserId, queryClient, refetchDashboard]);
 
     useEffect(() => {
-        if (!completedRunId || query.data?.kind !== 'driver') return;
-        if (query.data.activeRun?.id !== completedRunId) {
+        if (!completedRunId || dashboardData?.kind !== 'driver') return;
+        if (dashboardData.activeRun?.id !== completedRunId) {
             setCompletedRunId(null);
         }
-    }, [completedRunId, query.data]);
+    }, [completedRunId, dashboardData]);
 
     useEffect(() => {
         if (authenticatedDriverUserId) return;
@@ -1022,14 +1027,15 @@ export function DeliveryDashboard({
         expectation?: DeliveryServerStateExpectation,
     ) => {
         const refreshed = await query.refetch();
-        if (!refreshed.isSuccess || refreshed.data?.kind !== 'driver') {
+        const refreshedDashboard = refreshed.data?.dashboard;
+        if (!refreshed.isSuccess || refreshedDashboard?.kind !== 'driver') {
             return false;
         }
         if (!expectation) {
             setActionConfirmation(null);
             return true;
         }
-        const refreshedRun = refreshed.data.activeRun;
+        const refreshedRun = refreshedDashboard.activeRun;
         if (!refreshedRun || refreshedRun.id !== expectation.runId) {
             setActionConfirmation(null);
             return true;
@@ -1208,7 +1214,7 @@ export function DeliveryDashboard({
         );
     }
 
-    if (!query.data) {
+    if (!dashboardData) {
         if (offlineRoute && authenticatedDriverUserId) {
             return (
                 <OfflineRouteRecovery
@@ -1245,7 +1251,7 @@ export function DeliveryDashboard({
         );
     }
 
-    const dashboard = query.data;
+    const dashboard = dashboardData;
     return (
         <>
             {!networkOnline || query.isError ? (
@@ -1312,7 +1318,10 @@ export function DeliveryDashboard({
                     onServerStateChanged={refreshDriverServerState}
                 />
             ) : (
-                <CustomerDashboard dashboard={dashboard} />
+                <CustomerDashboard
+                    dashboard={dashboard}
+                    requestTiming={query.data?.requestTiming ?? null}
+                />
             )}
             {!networkOnline || query.isError ? (
                 <div aria-hidden="true" className="h-32 sm:h-24" />

--- a/apps/delivery/lib/customerDeliveryPresentation.node.spec.ts
+++ b/apps/delivery/lib/customerDeliveryPresentation.node.spec.ts
@@ -45,8 +45,9 @@ test('projects a delivery to the exact customer-safe DTO', () => {
         recovery: null,
         tracking: {
             status: 'live',
-            lastAcceptedAt: '2026-07-16T10:15:00.000Z',
+            lastAcceptedAt: '2026-07-16T09:58:30.000Z',
             mapAvailable: true,
+            exactLocationExpiresInMs: 30_000,
         },
         runId: 'safe-map-run',
         deliveryCount: 2,
@@ -70,7 +71,18 @@ test('projects a delivery to the exact customer-safe DTO', () => {
         lockedReason: privateSentinel,
     };
 
-    const projected = customerDeliveryRequestSummary(source);
+    const projectionContext = {
+        now: '2026-07-16T10:00:00.000Z',
+        runState: 'active',
+        stopsAhead: 0,
+        estimatesCalculatedAt: '2026-07-16T09:59:00.000Z',
+        estimateSource: 'legacy',
+        routePlanVersion: 1,
+        hasTrafficRouteArtifact: true,
+        trackingStatus: 'live',
+        trackingLastAcceptedAt: '2026-07-16T09:58:30.000Z',
+    } as const;
+    const projected = customerDeliveryRequestSummary(source, projectionContext);
 
     assert.deepEqual(projected, {
         mode: 'delivery',
@@ -80,18 +92,30 @@ test('projects a delivery to the exact customer-safe DTO', () => {
         requestNotes: 'Pozvoni na portafon.',
         slotStartAt: '2026-07-16T10:00:00.000Z',
         slotEndAt: '2026-07-16T12:00:00.000Z',
-        estimatedArrivalAt: '2026-07-16T10:30:00.000Z',
-        estimatedTravelSeconds: 900,
-        estimatedDistanceMeters: 5_000,
-        reroutePending: false,
+        eta: {
+            source: 'traffic-route',
+            calculatedAt: '2026-07-16T09:59:00.000Z',
+            freshness: 'fresh',
+            confidence: 'high',
+            rangeStartAt: '2026-07-16T10:25:00.000Z',
+            rangeEndAt: '2026-07-16T10:40:00.000Z',
+            remainingMinSeconds: 1_500,
+            remainingMaxSeconds: 2_400,
+        },
+        progress: {
+            phase: 'next',
+            stopsAhead: 0,
+            delayed: false,
+        },
         deliveredAt: null,
         harvest,
         receipt: null,
         recovery: null,
         tracking: {
             status: 'live',
-            lastAcceptedAt: '2026-07-16T10:15:00.000Z',
+            lastAcceptedAt: '2026-07-16T09:58:30.000Z',
             mapAvailable: true,
+            exactLocationExpiresInMs: 30_000,
         },
         mapPath: '/api/map/safe-map-run',
     });
@@ -114,9 +138,22 @@ test('projects a delivery to the exact customer-safe DTO', () => {
         'accuracy',
         'heading',
         'speed',
+        'estimatedArrivalAt',
+        'estimatedTravelSeconds',
+        'estimatedDistanceMeters',
+        'reroutePending',
     ]) {
         assert.equal(privateKey in projected, false, privateKey);
     }
+
+    const laterStop = customerDeliveryRequestSummary(
+        { ...source, tracking: null },
+        { ...projectionContext, stopsAhead: 2 },
+    );
+    assert.equal(laterStop.eta.source, 'traffic-route');
+    assert.equal(laterStop.progress.stopsAhead, 2);
+    assert.equal(laterStop.tracking, null);
+    assert.equal(laterStop.mapPath, null);
 });
 
 test('projects pickup status, public location, and instructions without delivery fields', () => {
@@ -170,6 +207,8 @@ test('projects pickup status, public location, and instructions without delivery
         'recovery',
         'receipt',
         'deliveredAt',
+        'eta',
+        'progress',
     ]) {
         assert.equal(deliveryKey in projected, false, deliveryKey);
     }
@@ -208,7 +247,17 @@ test('does not expose a historical run path when delivery tracking is unavailabl
         deliveries: [],
     };
 
-    const projected = customerDeliveryRequestSummary(source);
+    const projected = customerDeliveryRequestSummary(source, {
+        now: '2026-07-16T12:30:00.000Z',
+        runState: 'completed',
+        stopsAhead: null,
+        estimatesCalculatedAt: null,
+        estimateSource: null,
+        routePlanVersion: 1,
+        hasTrafficRouteArtifact: false,
+        trackingStatus: null,
+        trackingLastAcceptedAt: null,
+    });
 
     assert.equal(projected.mapPath, null);
     assert.equal(JSON.stringify(projected).includes(historicalRun), false);

--- a/apps/delivery/lib/customerDeliveryPresentation.ts
+++ b/apps/delivery/lib/customerDeliveryPresentation.ts
@@ -1,3 +1,7 @@
+import {
+    type CustomerDeliveryTrackerInput,
+    customerDeliveryTracker,
+} from './customerDeliveryTracker';
 import type {
     CustomerDeliveryRequestSummary,
     CustomerPickupRequestSummary,
@@ -6,6 +10,7 @@ import type {
 
 type CustomerDeliveryProjectionSource = Pick<
     DeliveryStopSummary,
+    | 'stopState'
     | 'requestId'
     | 'requestState'
     | 'statusLabel'
@@ -13,8 +18,6 @@ type CustomerDeliveryProjectionSource = Pick<
     | 'slotStartAt'
     | 'slotEndAt'
     | 'estimatedArrivalAt'
-    | 'estimatedTravelSeconds'
-    | 'estimatedDistanceMeters'
     | 'reroutePending'
     | 'deliveredAt'
     | 'harvest'
@@ -24,10 +27,32 @@ type CustomerDeliveryProjectionSource = Pick<
     | 'runId'
 >;
 
+export type CustomerDeliveryProjectionContext = Pick<
+    CustomerDeliveryTrackerInput,
+    | 'now'
+    | 'runState'
+    | 'stopsAhead'
+    | 'estimatesCalculatedAt'
+    | 'estimateSource'
+    | 'routePlanVersion'
+    | 'hasTrafficRouteArtifact'
+    | 'trackingStatus'
+    | 'trackingLastAcceptedAt'
+>;
+
 export function customerDeliveryRequestSummary(
     source: CustomerDeliveryProjectionSource,
+    context: CustomerDeliveryProjectionContext,
 ): CustomerDeliveryRequestSummary {
     const tracking = source.tracking;
+    const { eta, progress } = customerDeliveryTracker({
+        ...context,
+        stopState: source.stopState,
+        promisedWindowStartAt: source.slotStartAt,
+        promisedWindowEndAt: source.slotEndAt,
+        estimatedArrivalAt: source.estimatedArrivalAt,
+        reroutePending: source.reroutePending,
+    });
     return {
         mode: 'delivery',
         requestId: source.requestId,
@@ -36,10 +61,8 @@ export function customerDeliveryRequestSummary(
         requestNotes: source.requestNotes,
         slotStartAt: source.slotStartAt,
         slotEndAt: source.slotEndAt,
-        estimatedArrivalAt: source.estimatedArrivalAt,
-        estimatedTravelSeconds: source.estimatedTravelSeconds,
-        estimatedDistanceMeters: source.estimatedDistanceMeters,
-        reroutePending: source.reroutePending,
+        eta,
+        progress,
         deliveredAt: source.deliveredAt,
         harvest: source.harvest,
         receipt: source.receipt ?? null,

--- a/apps/delivery/lib/customerDeliveryTracker.node.spec.ts
+++ b/apps/delivery/lib/customerDeliveryTracker.node.spec.ts
@@ -1,0 +1,378 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { deliveryRunExactLocationTtlMs } from '@gredice/storage';
+import {
+    type CustomerDeliveryTrackerInput,
+    customerDeliveryTracker,
+} from './customerDeliveryTracker';
+
+const now = '2026-07-16T10:00:00.000Z';
+
+function input(
+    overrides: Partial<CustomerDeliveryTrackerInput> = {},
+): CustomerDeliveryTrackerInput {
+    return {
+        now,
+        runState: 'active',
+        stopState: 'pending',
+        stopsAhead: 0,
+        promisedWindowStartAt: '2026-07-16T10:00:00.000Z',
+        promisedWindowEndAt: '2026-07-16T12:00:00.000Z',
+        estimatedArrivalAt: '2026-07-16T10:30:00.000Z',
+        estimatesCalculatedAt: '2026-07-16T09:59:00.000Z',
+        estimateSource: 'legacy',
+        routePlanVersion: 1,
+        hasTrafficRouteArtifact: true,
+        reroutePending: false,
+        trackingStatus: 'live',
+        trackingLastAcceptedAt: '2026-07-16T09:58:30.000Z',
+        ...overrides,
+    };
+}
+
+test('presents a persisted Google route artifact as high-confidence traffic progress', () => {
+    assert.deepEqual(customerDeliveryTracker(input()), {
+        eta: {
+            source: 'traffic-route',
+            calculatedAt: '2026-07-16T09:59:00.000Z',
+            freshness: 'fresh',
+            confidence: 'high',
+            rangeStartAt: '2026-07-16T10:25:00.000Z',
+            rangeEndAt: '2026-07-16T10:40:00.000Z',
+            remainingMinSeconds: 1_500,
+            remainingMaxSeconds: 2_400,
+        },
+        progress: { phase: 'next', stopsAhead: 0, delayed: false },
+    });
+});
+
+test('keeps a fresh Google refresh when a newer accepted beacon advances tracking', () => {
+    const result = customerDeliveryTracker(
+        input({ trackingLastAcceptedAt: '2026-07-16T09:59:30.000Z' }),
+    );
+    assert.equal(result.eta.source, 'traffic-route');
+    assert.equal(result.eta.confidence, 'high');
+});
+
+test('qualifies a pickup-aware Google estimate as an approximate route plan even with live GPS', () => {
+    const result = customerDeliveryTracker(
+        input({
+            estimateSource: 'google',
+            routePlanVersion: 2,
+            trackingStatus: 'live',
+        }),
+    );
+    assert.deepEqual(result.eta, {
+        source: 'route-plan',
+        calculatedAt: '2026-07-16T09:59:00.000Z',
+        freshness: 'fresh',
+        confidence: 'approximate',
+        rangeStartAt: '2026-07-16T10:25:00.000Z',
+        rangeEndAt: '2026-07-16T10:40:00.000Z',
+        remainingMinSeconds: 1_500,
+        remainingMaxSeconds: 2_400,
+    });
+    assert.deepEqual(result.progress, {
+        phase: 'next',
+        stopsAhead: 0,
+        delayed: false,
+    });
+});
+
+test('falls back to the promised window for local, legacy, rerouting, and malformed routes', () => {
+    const cases: readonly [
+        label: string,
+        overrides: Partial<CustomerDeliveryTrackerInput>,
+    ][] = [
+        ['local', { estimateSource: 'local', routePlanVersion: 2 }],
+        [
+            'legacy initial plan',
+            {
+                hasTrafficRouteArtifact: false,
+                trackingLastAcceptedAt: null,
+            },
+        ],
+        ['rerouting', { reroutePending: true }],
+        ['unknown source', { estimateSource: 'private-provider' }],
+        ['invalid route version', { routePlanVersion: 0 }],
+        [
+            'legacy route without Google artifact',
+            { hasTrafficRouteArtifact: false },
+        ],
+        ['unproven v1 route', { trackingLastAcceptedAt: null }],
+        [
+            'future calculation',
+            { estimatesCalculatedAt: '2026-07-16T10:01:00.000Z' },
+        ],
+        ['malformed arrival', { estimatedArrivalAt: 'not-a-date' }],
+    ];
+    for (const [label, overrides] of cases) {
+        const result = customerDeliveryTracker(input(overrides));
+        assert.deepEqual(
+            result.eta,
+            {
+                source: 'promised-window',
+                calculatedAt: null,
+                freshness: 'fallback',
+                confidence: 'approximate',
+                rangeStartAt: '2026-07-16T10:00:00.000Z',
+                rangeEndAt: '2026-07-16T12:00:00.000Z',
+                remainingMinSeconds: 0,
+                remainingMaxSeconds: 7_200,
+            },
+            label,
+        );
+    }
+});
+
+test('uses the shared two-minute horizon and labels an expired Google ETA stale', () => {
+    const exactlyStale = new Date(
+        Date.parse(now) - deliveryRunExactLocationTtlMs,
+    ).toISOString();
+    const result = customerDeliveryTracker(
+        input({
+            estimatesCalculatedAt: exactlyStale,
+            trackingLastAcceptedAt: '2026-07-16T09:57:30.000Z',
+        }),
+    );
+    assert.deepEqual(result.eta, {
+        source: 'promised-window',
+        calculatedAt: exactlyStale,
+        freshness: 'stale',
+        confidence: 'approximate',
+        rangeStartAt: '2026-07-16T10:00:00.000Z',
+        rangeEndAt: '2026-07-16T12:00:00.000Z',
+        remainingMinSeconds: 0,
+        remainingMaxSeconds: 7_200,
+    });
+});
+
+test('keeps persisted v1 Google provenance stale when tracking is offline', () => {
+    const result = customerDeliveryTracker(
+        input({
+            now: '2026-07-16T10:02:00.000Z',
+            estimatesCalculatedAt: '2026-07-16T10:00:00.000Z',
+            trackingLastAcceptedAt: '2026-07-16T09:59:30.000Z',
+            trackingStatus: 'offline',
+        }),
+    );
+    assert.equal(result.eta.source, 'promised-window');
+    assert.equal(result.eta.freshness, 'stale');
+    assert.equal(result.eta.calculatedAt, '2026-07-16T10:00:00.000Z');
+});
+
+test('does not clamp a genuinely late fresh traffic ETA to the promise', () => {
+    const result = customerDeliveryTracker(
+        input({ estimatedArrivalAt: '2026-07-16T12:20:00.000Z' }),
+    );
+    assert.equal(result.eta.source, 'traffic-route');
+    assert.equal(result.eta.rangeStartAt, '2026-07-16T12:15:00.000Z');
+    assert.equal(result.eta.rangeEndAt, '2026-07-16T12:30:00.000Z');
+    assert.equal(result.eta.remainingMinSeconds, 8_100);
+    assert.equal(result.eta.remainingMaxSeconds, 9_000);
+    assert.equal(result.progress.delayed, true);
+});
+
+test('does not present an expired promise window as a current arrival estimate', () => {
+    const result = customerDeliveryTracker(
+        input({
+            now: '2026-07-16T12:05:00.000Z',
+            estimateSource: 'local',
+            routePlanVersion: 2,
+        }),
+    );
+    assert.deepEqual(result.eta, {
+        source: 'promised-window',
+        calculatedAt: null,
+        freshness: 'unavailable',
+        confidence: 'none',
+        rangeStartAt: null,
+        rangeEndAt: null,
+        remainingMinSeconds: null,
+        remainingMaxSeconds: null,
+    });
+    assert.equal(result.progress.delayed, true);
+});
+
+test('marks a fresh route range delayed once the promised window has passed', () => {
+    const result = customerDeliveryTracker(
+        input({
+            now: '2026-07-16T12:00:30.000Z',
+            estimateSource: 'google',
+            routePlanVersion: 2,
+            estimatedArrivalAt: '2026-07-16T12:00:00.000Z',
+            estimatesCalculatedAt: '2026-07-16T12:00:15.000Z',
+            trackingLastAcceptedAt: '2026-07-16T12:00:20.000Z',
+        }),
+    );
+    assert.equal(result.eta.source, 'route-plan');
+    assert.equal(result.eta.rangeStartAt, '2026-07-16T12:00:30.000Z');
+    assert.equal(result.progress.delayed, true);
+});
+
+test('lower-bounds the route range at now without collapsing it', () => {
+    const result = customerDeliveryTracker(
+        input({ estimatedArrivalAt: '2026-07-16T10:02:00.000Z' }),
+    );
+    assert.equal(result.eta.rangeStartAt, now);
+    assert.equal(result.eta.rangeEndAt, '2026-07-16T10:12:00.000Z');
+    assert.equal(result.eta.remainingMinSeconds, 0);
+    assert.equal(result.eta.remainingMaxSeconds, 720);
+});
+
+test('reports unavailable ETA for missing, reversed, or malformed promised windows', () => {
+    const cases: readonly Partial<CustomerDeliveryTrackerInput>[] = [
+        { estimateSource: 'local', promisedWindowStartAt: null },
+        {
+            estimateSource: 'legacy',
+            promisedWindowEndAt: null,
+            trackingLastAcceptedAt: null,
+        },
+        {
+            estimateSource: 'local',
+            promisedWindowStartAt: '2026-07-16T12:00:00.000Z',
+            promisedWindowEndAt: '2026-07-16T10:00:00.000Z',
+        },
+        {
+            estimateSource: 'local',
+            promisedWindowStartAt: '2026-07-16T10:00:00.000Z',
+            promisedWindowEndAt: '2026-07-16T10:00:00.000Z',
+        },
+        {
+            estimateSource: 'local',
+            promisedWindowEndAt: '16. srpnja u podne',
+        },
+    ];
+    for (const overrides of cases) {
+        assert.deepEqual(customerDeliveryTracker(input(overrides)).eta, {
+            source: 'promised-window',
+            calculatedAt: null,
+            freshness: 'unavailable',
+            confidence: 'none',
+            rangeStartAt: null,
+            rangeEndAt: null,
+            remainingMinSeconds: null,
+            remainingMaxSeconds: null,
+        });
+    }
+});
+
+test('derives scheduled, on-route, next, arrived, and unavailable phases', () => {
+    const phases: readonly [
+        label: string,
+        overrides: Partial<CustomerDeliveryTrackerInput>,
+        expected: {
+            phase:
+                | 'scheduled'
+                | 'on-route'
+                | 'next'
+                | 'arrived'
+                | 'unavailable';
+            stopsAhead: number | null;
+        },
+    ][] = [
+        [
+            'scheduled',
+            { runState: null, stopState: null, stopsAhead: null },
+            { phase: 'scheduled', stopsAhead: null },
+        ],
+        ['on route', { stopsAhead: 1 }, { phase: 'on-route', stopsAhead: 1 }],
+        ['next', { stopsAhead: 0 }, { phase: 'next', stopsAhead: 0 }],
+        [
+            'arrived',
+            { stopState: 'arrived', stopsAhead: 0 },
+            { phase: 'arrived', stopsAhead: 0 },
+        ],
+        [
+            'route unavailable',
+            { runState: 'cancelled', stopState: 'cancelled' },
+            { phase: 'unavailable', stopsAhead: null },
+        ],
+        [
+            'missing itinerary',
+            { stopsAhead: null },
+            { phase: 'unavailable', stopsAhead: null },
+        ],
+        [
+            'invalid checkpoint count',
+            { stopsAhead: -1 },
+            { phase: 'unavailable', stopsAhead: null },
+        ],
+    ];
+    for (const [label, overrides, expected] of phases) {
+        const progress = customerDeliveryTracker(input(overrides)).progress;
+        assert.deepEqual(
+            { phase: progress.phase, stopsAhead: progress.stopsAhead },
+            expected,
+            label,
+        );
+    }
+});
+
+test('uses the server-provided physical pickup and retry checkpoint count', () => {
+    const result = customerDeliveryTracker(
+        input({ stopState: 'deferred', stopsAhead: 2 }),
+    );
+    assert.deepEqual(result.progress, {
+        phase: 'on-route',
+        stopsAhead: 2,
+        delayed: false,
+    });
+});
+
+test('keeps the pre-grouped bulk count instead of counting its orders', () => {
+    const result = customerDeliveryTracker(input({ stopsAhead: 1 }));
+    assert.equal(result.progress.stopsAhead, 1);
+});
+
+test('serializes only the derived privacy-safe contract', () => {
+    const privateSentinel = 'PRIVATE CUSTOMER OR DRIVER DATA 4136';
+    const privateInput: CustomerDeliveryTrackerInput & {
+        runId: string;
+        address: string;
+        customerName: string;
+        routeLegDurationSeconds: number;
+        driverLocation: { latitude: number; longitude: number };
+    } = {
+        ...input({ stopsAhead: 1 }),
+        runId: privateSentinel,
+        address: privateSentinel,
+        customerName: privateSentinel,
+        routeLegDurationSeconds: 123_456,
+        driverLocation: { latitude: 45.812, longitude: 15.977 },
+    };
+
+    const result = customerDeliveryTracker(privateInput);
+    const serialized = JSON.stringify(result);
+    assert.equal(serialized.includes(privateSentinel), false);
+    for (const privateKey of [
+        'id',
+        'address',
+        'customerName',
+        'runId',
+        'driverLocation',
+        'routeLegDurationSeconds',
+        'latitude',
+        'longitude',
+        'stops',
+        'deliveryCount',
+    ]) {
+        assert.equal(serialized.includes(`"${privateKey}"`), false, privateKey);
+    }
+    assert.deepEqual(Object.keys(result).sort(), ['eta', 'progress']);
+    assert.deepEqual(Object.keys(result.eta).sort(), [
+        'calculatedAt',
+        'confidence',
+        'freshness',
+        'rangeEndAt',
+        'rangeStartAt',
+        'remainingMaxSeconds',
+        'remainingMinSeconds',
+        'source',
+    ]);
+    assert.deepEqual(Object.keys(result.progress).sort(), [
+        'delayed',
+        'phase',
+        'stopsAhead',
+    ]);
+});

--- a/apps/delivery/lib/customerDeliveryTracker.ts
+++ b/apps/delivery/lib/customerDeliveryTracker.ts
@@ -1,0 +1,282 @@
+import {
+    DeliveryRunEstimateSources,
+    DeliveryRunStates,
+    DeliveryRunStopStates,
+    deliveryRunExactLocationTtlMs,
+} from '@gredice/storage';
+import type {
+    CustomerDeliveryEtaSummary,
+    CustomerDeliveryProgressSummary,
+    DeliveryTrackingStatus,
+} from './deliveryDashboardTypes';
+
+export type CustomerDeliveryTrackerPresentation = {
+    eta: CustomerDeliveryEtaSummary;
+    progress: CustomerDeliveryProgressSummary;
+};
+
+export type CustomerDeliveryTrackerInput = {
+    now: string;
+    runState: string | null;
+    stopState: string | null;
+    stopsAhead: number | null;
+    promisedWindowStartAt: string | null;
+    promisedWindowEndAt: string | null;
+    estimatedArrivalAt: string | null;
+    estimatesCalculatedAt: string | null;
+    estimateSource: string | null;
+    routePlanVersion: number | null;
+    hasTrafficRouteArtifact: boolean;
+    reroutePending: boolean;
+    trackingStatus: DeliveryTrackingStatus | null;
+    trackingLastAcceptedAt: string | null;
+};
+
+type ParsedTimestamp = {
+    iso: string;
+    time: number;
+};
+
+type ParsedWindow = {
+    start: ParsedTimestamp;
+    end: ParsedTimestamp;
+};
+
+// A route service returns a point estimate, but customers need an honest range.
+// Keep the policy deterministic and asymmetric because traffic is more likely to
+// add time than remove it. The lower bound never promises time that has passed.
+const routeEtaEarlyBandMs = 5 * 60 * 1_000;
+const routeEtaLateBandMs = 10 * 60 * 1_000;
+const minimumCurrentEtaBandMs = 5 * 60 * 1_000;
+
+function parsedTimestamp(value: string | null): ParsedTimestamp | null {
+    if (!value) return null;
+    const time = Date.parse(value);
+    if (!Number.isFinite(time)) return null;
+    const iso = new Date(time).toISOString();
+    if (iso !== value) return null;
+    return { iso, time };
+}
+
+function parsedWindow(
+    startAt: string | null,
+    endAt: string | null,
+): ParsedWindow | null {
+    const start = parsedTimestamp(startAt);
+    const end = parsedTimestamp(endAt);
+    if (!start || !end || start.time >= end.time) return null;
+    return { start, end };
+}
+
+function remainingSeconds(targetTime: number, nowTime: number) {
+    return Math.max(0, Math.ceil((targetTime - nowTime) / 1_000));
+}
+
+function unavailableEta(): CustomerDeliveryEtaSummary {
+    return {
+        source: 'promised-window',
+        calculatedAt: null,
+        freshness: 'unavailable',
+        confidence: 'none',
+        rangeStartAt: null,
+        rangeEndAt: null,
+        remainingMinSeconds: null,
+        remainingMaxSeconds: null,
+    };
+}
+
+function promisedWindowEta({
+    window,
+    nowTime,
+    freshness,
+    calculatedAt = null,
+}: {
+    window: ParsedWindow | null;
+    nowTime: number;
+    freshness: Extract<
+        CustomerDeliveryEtaSummary['freshness'],
+        'stale' | 'fallback'
+    >;
+    calculatedAt?: string | null;
+}): CustomerDeliveryEtaSummary {
+    if (!window) return unavailableEta();
+    if (nowTime > window.end.time) return unavailableEta();
+    return {
+        source: 'promised-window',
+        calculatedAt,
+        freshness,
+        confidence: 'approximate',
+        rangeStartAt: window.start.iso,
+        rangeEndAt: window.end.iso,
+        remainingMinSeconds: remainingSeconds(window.start.time, nowTime),
+        remainingMaxSeconds: remainingSeconds(window.end.time, nowTime),
+    };
+}
+
+function etaPresentation({
+    input,
+    now,
+    window,
+}: {
+    input: CustomerDeliveryTrackerInput;
+    now: ParsedTimestamp;
+    window: ParsedWindow | null;
+}): CustomerDeliveryEtaSummary {
+    const arrival = parsedTimestamp(input.estimatedArrivalAt);
+    const calculated = parsedTimestamp(input.estimatesCalculatedAt);
+    const trackingAccepted = parsedTimestamp(input.trackingLastAcceptedAt);
+    const plannedGoogleRouteProvenance =
+        input.estimateSource === DeliveryRunEstimateSources.GOOGLE &&
+        Number.isInteger(input.routePlanVersion) &&
+        (input.routePlanVersion ?? 0) >= 2;
+    // A post-cutover Google GPS refresh persists a marked route artifact while
+    // the local estimator explicitly clears it. The marker keeps old and
+    // initial legacy polylines conservative without changing the DB schema.
+    const persistedTrafficRouteProvenance =
+        input.estimateSource === DeliveryRunEstimateSources.LEGACY &&
+        input.routePlanVersion === 1 &&
+        input.hasTrafficRouteArtifact &&
+        trackingAccepted !== null;
+    const currentTrafficProvenance =
+        persistedTrafficRouteProvenance &&
+        (input.trackingStatus === 'live' || input.trackingStatus === 'delayed');
+    const calculatedAgeMs = calculated
+        ? now.time - calculated.time
+        : Number.NaN;
+    const estimateIsFresh =
+        Number.isFinite(calculatedAgeMs) &&
+        calculatedAgeMs >= 0 &&
+        calculatedAgeMs < deliveryRunExactLocationTtlMs;
+    const routeEstimateIsUsable =
+        input.runState === DeliveryRunStates.ACTIVE &&
+        !input.reroutePending &&
+        (plannedGoogleRouteProvenance || currentTrafficProvenance) &&
+        estimateIsFresh &&
+        arrival !== null &&
+        calculated !== null;
+
+    if (routeEstimateIsUsable) {
+        const source = currentTrafficProvenance
+            ? 'traffic-route'
+            : 'route-plan';
+        const confidence = source === 'traffic-route' ? 'high' : 'approximate';
+        const rangeStartTime = Math.max(
+            now.time,
+            arrival.time - routeEtaEarlyBandMs,
+        );
+        const rangeEndTime = Math.max(
+            rangeStartTime + minimumCurrentEtaBandMs,
+            arrival.time + routeEtaLateBandMs,
+        );
+        return {
+            source,
+            calculatedAt: calculated.iso,
+            freshness: 'fresh',
+            confidence,
+            rangeStartAt: new Date(rangeStartTime).toISOString(),
+            rangeEndAt: new Date(rangeEndTime).toISOString(),
+            remainingMinSeconds: remainingSeconds(rangeStartTime, now.time),
+            remainingMaxSeconds: remainingSeconds(rangeEndTime, now.time),
+        };
+    }
+
+    const staleGoogleEstimate =
+        input.runState === DeliveryRunStates.ACTIVE &&
+        !input.reroutePending &&
+        (plannedGoogleRouteProvenance || persistedTrafficRouteProvenance) &&
+        arrival !== null &&
+        calculated !== null &&
+        Number.isFinite(calculatedAgeMs) &&
+        calculatedAgeMs >= deliveryRunExactLocationTtlMs;
+
+    return promisedWindowEta({
+        window,
+        nowTime: now.time,
+        freshness: staleGoogleEstimate ? 'stale' : 'fallback',
+        calculatedAt: staleGoogleEstimate ? calculated?.iso : null,
+    });
+}
+
+function activeProgress({
+    stopState,
+    stopsAhead,
+}: Pick<CustomerDeliveryTrackerInput, 'stopState' | 'stopsAhead'>): Pick<
+    CustomerDeliveryProgressSummary,
+    'phase' | 'stopsAhead'
+> {
+    if (stopState === DeliveryRunStopStates.ARRIVED) {
+        return { phase: 'arrived', stopsAhead: 0 };
+    }
+    if (
+        (stopState !== DeliveryRunStopStates.PENDING &&
+            stopState !== DeliveryRunStopStates.DEFERRED) ||
+        !Number.isSafeInteger(stopsAhead) ||
+        (stopsAhead ?? -1) < 0
+    ) {
+        return { phase: 'unavailable', stopsAhead: null };
+    }
+    return {
+        phase: stopsAhead === 0 ? 'next' : 'on-route',
+        stopsAhead,
+    };
+}
+
+function progressPresentation({
+    input,
+    eta,
+    now,
+    window,
+}: {
+    input: CustomerDeliveryTrackerInput;
+    eta: CustomerDeliveryEtaSummary;
+    now: ParsedTimestamp;
+    window: ParsedWindow | null;
+}): CustomerDeliveryProgressSummary {
+    const estimatedArrival = parsedTimestamp(input.estimatedArrivalAt);
+    const freshRouteIsLate = Boolean(
+        eta.source !== 'promised-window' &&
+            estimatedArrival &&
+            window &&
+            estimatedArrival.time > window.end.time,
+    );
+    const promisedWindowHasPassed = Boolean(
+        window && now.time > window.end.time,
+    );
+    const delayed = freshRouteIsLate || promisedWindowHasPassed;
+
+    if (input.runState === null) {
+        return { phase: 'scheduled', stopsAhead: null, delayed };
+    }
+    if (input.runState !== DeliveryRunStates.ACTIVE) {
+        return { phase: 'unavailable', stopsAhead: null, delayed: false };
+    }
+    return {
+        ...activeProgress(input),
+        delayed,
+    };
+}
+
+export function customerDeliveryTracker(
+    input: CustomerDeliveryTrackerInput,
+): CustomerDeliveryTrackerPresentation {
+    const now = parsedTimestamp(input.now);
+    if (!now) {
+        return {
+            eta: unavailableEta(),
+            progress: {
+                phase: 'unavailable',
+                stopsAhead: null,
+                delayed: false,
+            },
+        };
+    }
+    const window = parsedWindow(
+        input.promisedWindowStartAt,
+        input.promisedWindowEndAt,
+    );
+    const eta = etaPresentation({ input, now, window });
+    return {
+        eta,
+        progress: progressPresentation({ input, eta, now, window }),
+    };
+}

--- a/apps/delivery/lib/customerDeliveryValidation.node.spec.ts
+++ b/apps/delivery/lib/customerDeliveryValidation.node.spec.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    isCustomerDeliveryEtaSummary,
+    isCustomerDeliveryTrackingSummary,
+} from './customerDeliveryValidation';
+
+const validTrafficEta = {
+    source: 'traffic-route',
+    calculatedAt: '2026-07-16T09:59:00.000Z',
+    freshness: 'fresh',
+    confidence: 'high',
+    rangeStartAt: '2026-07-16T10:25:00.000Z',
+    rangeEndAt: '2026-07-16T10:40:00.000Z',
+    remainingMinSeconds: 1_500,
+    remainingMaxSeconds: 2_400,
+};
+
+test('accepts constructible customer ETA payload states', () => {
+    assert.equal(isCustomerDeliveryEtaSummary(validTrafficEta), true);
+    assert.equal(
+        isCustomerDeliveryEtaSummary({
+            ...validTrafficEta,
+            source: 'route-plan',
+            confidence: 'approximate',
+        }),
+        true,
+    );
+    assert.equal(
+        isCustomerDeliveryEtaSummary({
+            ...validTrafficEta,
+            source: 'promised-window',
+            calculatedAt: null,
+            freshness: 'fallback',
+            confidence: 'approximate',
+        }),
+        true,
+    );
+    assert.equal(
+        isCustomerDeliveryEtaSummary({
+            ...validTrafficEta,
+            source: 'promised-window',
+            calculatedAt: null,
+            freshness: 'unavailable',
+            confidence: 'none',
+            rangeStartAt: null,
+            rangeEndAt: null,
+            remainingMinSeconds: null,
+            remainingMaxSeconds: null,
+        }),
+        true,
+    );
+});
+
+test('rejects malformed or internally inconsistent ETA payloads before rendering', () => {
+    const invalidPayloads = [
+        { ...validTrafficEta, rangeStartAt: 'not-a-date' },
+        {
+            ...validTrafficEta,
+            rangeStartAt: validTrafficEta.rangeEndAt,
+            rangeEndAt: validTrafficEta.rangeStartAt,
+        },
+        {
+            ...validTrafficEta,
+            rangeEndAt: validTrafficEta.rangeStartAt,
+        },
+        { ...validTrafficEta, remainingMinSeconds: Number.NaN },
+        { ...validTrafficEta, remainingMaxSeconds: Number.POSITIVE_INFINITY },
+        { ...validTrafficEta, remainingMinSeconds: -1 },
+        {
+            ...validTrafficEta,
+            remainingMinSeconds: 2_500,
+            remainingMaxSeconds: 2_400,
+        },
+        { ...validTrafficEta, rangeEndAt: null },
+        { ...validTrafficEta, confidence: 'approximate' },
+        {
+            ...validTrafficEta,
+            source: 'promised-window',
+            freshness: 'fresh',
+        },
+        {
+            ...validTrafficEta,
+            source: 'promised-window',
+            freshness: 'unavailable',
+            confidence: 'none',
+        },
+    ];
+    for (const payload of invalidPayloads) {
+        assert.equal(isCustomerDeliveryEtaSummary(payload), false);
+    }
+});
+
+test('accepts only canonical and bounded customer tracking payloads', () => {
+    const liveTracking = {
+        status: 'live',
+        lastAcceptedAt: '2026-07-16T09:59:00.000Z',
+        mapAvailable: true,
+        exactLocationExpiresInMs: 60_000,
+    };
+    assert.equal(isCustomerDeliveryTrackingSummary(liveTracking), true);
+    assert.equal(
+        isCustomerDeliveryTrackingSummary({
+            ...liveTracking,
+            status: 'offline',
+            mapAvailable: false,
+            exactLocationExpiresInMs: null,
+        }),
+        true,
+    );
+    assert.equal(
+        isCustomerDeliveryTrackingSummary({
+            status: 'unavailable',
+            lastAcceptedAt: null,
+            mapAvailable: false,
+            exactLocationExpiresInMs: null,
+        }),
+        true,
+    );
+    assert.equal(isCustomerDeliveryTrackingSummary(null), true);
+
+    for (const payload of [
+        { ...liveTracking, lastAcceptedAt: 'not-a-date' },
+        { ...liveTracking, lastAcceptedAt: '2026-07-16T09:59:00Z' },
+        { ...liveTracking, exactLocationExpiresInMs: Number.NaN },
+        { ...liveTracking, exactLocationExpiresInMs: -1 },
+        { ...liveTracking, exactLocationExpiresInMs: 120_001 },
+        { ...liveTracking, exactLocationExpiresInMs: null },
+        { ...liveTracking, status: 'offline' },
+        {
+            ...liveTracking,
+            lastAcceptedAt: null,
+            mapAvailable: false,
+            exactLocationExpiresInMs: null,
+        },
+        {
+            ...liveTracking,
+            status: 'delayed',
+            lastAcceptedAt: null,
+            mapAvailable: false,
+            exactLocationExpiresInMs: null,
+        },
+        {
+            ...liveTracking,
+            status: 'offline',
+            lastAcceptedAt: null,
+            mapAvailable: false,
+            exactLocationExpiresInMs: null,
+        },
+        {
+            ...liveTracking,
+            status: 'unavailable',
+            lastAcceptedAt: '2026-07-16T09:59:00.000Z',
+            mapAvailable: false,
+            exactLocationExpiresInMs: null,
+        },
+    ]) {
+        assert.equal(isCustomerDeliveryTrackingSummary(payload), false);
+    }
+});

--- a/apps/delivery/lib/customerDeliveryValidation.ts
+++ b/apps/delivery/lib/customerDeliveryValidation.ts
@@ -1,0 +1,149 @@
+import { deliveryRunExactLocationTtlMs } from '@gredice/storage/deliveryTrackingPolicy';
+import type {
+    CustomerDeliveryEtaSummary,
+    CustomerDeliveryTrackingSummary,
+} from './deliveryDashboardTypes';
+
+function canonicalIsoTimestamp(value: unknown): value is string {
+    if (typeof value !== 'string') return false;
+    const time = Date.parse(value);
+    return Number.isFinite(time) && new Date(time).toISOString() === value;
+}
+
+function nullableCanonicalIsoTimestamp(value: unknown): value is string | null {
+    return value === null || canonicalIsoTimestamp(value);
+}
+
+export function isCustomerDeliveryTrackingSummary(
+    value: unknown,
+): value is CustomerDeliveryTrackingSummary | null {
+    if (value === null) return true;
+    if (
+        typeof value !== 'object' ||
+        !('status' in value) ||
+        (value.status !== 'live' &&
+            value.status !== 'delayed' &&
+            value.status !== 'offline' &&
+            value.status !== 'unavailable') ||
+        !('lastAcceptedAt' in value) ||
+        !nullableCanonicalIsoTimestamp(value.lastAcceptedAt) ||
+        !('mapAvailable' in value) ||
+        typeof value.mapAvailable !== 'boolean' ||
+        !('exactLocationExpiresInMs' in value)
+    ) {
+        return false;
+    }
+    const expiresInMs = value.exactLocationExpiresInMs;
+    const hasAcceptedLocation = value.lastAcceptedAt !== null;
+    if (value.status === 'unavailable') {
+        return (
+            !hasAcceptedLocation && !value.mapAvailable && expiresInMs === null
+        );
+    }
+    if (!hasAcceptedLocation) return false;
+    if (value.mapAvailable) {
+        return (
+            (value.status === 'live' || value.status === 'delayed') &&
+            typeof expiresInMs === 'number' &&
+            Number.isSafeInteger(expiresInMs) &&
+            expiresInMs >= 0 &&
+            expiresInMs <= deliveryRunExactLocationTtlMs
+        );
+    }
+    return expiresInMs === null;
+}
+
+function nullableNonnegativeFiniteNumber(
+    value: unknown,
+): value is number | null {
+    return (
+        value === null ||
+        (typeof value === 'number' && Number.isFinite(value) && value >= 0)
+    );
+}
+
+export function isCustomerDeliveryEtaSummary(
+    value: unknown,
+): value is CustomerDeliveryEtaSummary {
+    if (
+        typeof value !== 'object' ||
+        value === null ||
+        !('source' in value) ||
+        !('calculatedAt' in value) ||
+        !nullableCanonicalIsoTimestamp(value.calculatedAt) ||
+        !('freshness' in value) ||
+        !('confidence' in value) ||
+        !('rangeStartAt' in value) ||
+        !nullableCanonicalIsoTimestamp(value.rangeStartAt) ||
+        !('rangeEndAt' in value) ||
+        !nullableCanonicalIsoTimestamp(value.rangeEndAt) ||
+        !('remainingMinSeconds' in value) ||
+        !nullableNonnegativeFiniteNumber(value.remainingMinSeconds) ||
+        !('remainingMaxSeconds' in value) ||
+        !nullableNonnegativeFiniteNumber(value.remainingMaxSeconds)
+    ) {
+        return false;
+    }
+
+    const hasRange = value.rangeStartAt !== null && value.rangeEndAt !== null;
+    const hasRemaining =
+        value.remainingMinSeconds !== null &&
+        value.remainingMaxSeconds !== null;
+    if (hasRange !== hasRemaining) {
+        return false;
+    }
+    if (hasRange) {
+        const rangeStartAt = value.rangeStartAt;
+        const rangeEndAt = value.rangeEndAt;
+        const remainingMinSeconds = value.remainingMinSeconds;
+        const remainingMaxSeconds = value.remainingMaxSeconds;
+        if (
+            rangeStartAt === null ||
+            rangeEndAt === null ||
+            remainingMinSeconds === null ||
+            remainingMaxSeconds === null ||
+            Date.parse(rangeStartAt) >= Date.parse(rangeEndAt) ||
+            remainingMinSeconds > remainingMaxSeconds
+        ) {
+            return false;
+        }
+    }
+
+    if (value.source === 'traffic-route') {
+        return (
+            value.freshness === 'fresh' &&
+            value.confidence === 'high' &&
+            value.calculatedAt !== null &&
+            hasRange
+        );
+    }
+    if (value.source === 'route-plan') {
+        return (
+            value.freshness === 'fresh' &&
+            value.confidence === 'approximate' &&
+            value.calculatedAt !== null &&
+            hasRange
+        );
+    }
+    if (value.source !== 'promised-window') return false;
+    if (value.freshness === 'fallback') {
+        return (
+            value.confidence === 'approximate' &&
+            value.calculatedAt === null &&
+            hasRange
+        );
+    }
+    if (value.freshness === 'stale') {
+        return (
+            value.confidence === 'approximate' &&
+            value.calculatedAt !== null &&
+            hasRange
+        );
+    }
+    return (
+        value.freshness === 'unavailable' &&
+        value.confidence === 'none' &&
+        value.calculatedAt === null &&
+        !hasRange
+    );
+}

--- a/apps/delivery/lib/deliveryDashboard.node.spec.ts
+++ b/apps/delivery/lib/deliveryDashboard.node.spec.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
     accountCanTrackCurrentDeliveryGroup,
     customerDeliveryReceiptSummary,
+    customerDeliveryStopsAhead,
     deliveryDashboardKindForRole,
     deliveryMutationRouteState,
     deliveryRecipientCount,
@@ -242,6 +243,94 @@ test('current route tracking keeps the server-confirmed physical stop ids', () =
         ],
         [21],
     );
+});
+
+test('customer progress counts unfinished physical checkpoints without splitting bulk stops', () => {
+    const progress = [
+        {
+            kind: 'pickup' as const,
+            pickupNodeId: 'completed-pickup',
+            itinerarySequence: 1,
+            manifestIds: ['manifest-completed'],
+            state: 'completed' as const,
+        },
+        {
+            kind: 'pickup' as const,
+            pickupNodeId: 'current-pickup',
+            itinerarySequence: 2,
+            manifestIds: ['manifest-current'],
+            state: 'current' as const,
+        },
+        {
+            kind: 'delivery' as const,
+            itinerarySequence: 3,
+            stopKey: 'PRIVATE BULK STOP',
+            stopIds: [21, 22],
+            actionableStopIds: [21, 22],
+            pickupConfirmed: true,
+            state: 'upcoming' as const,
+        },
+        {
+            kind: 'delivery' as const,
+            itinerarySequence: 4,
+            stopKey: 'PRIVATE LATER STOP',
+            stopIds: [31],
+            actionableStopIds: [31],
+            pickupConfirmed: true,
+            state: 'upcoming' as const,
+        },
+    ];
+
+    assert.equal(customerDeliveryStopsAhead({ progress, stopId: 21 }), 1);
+    assert.equal(customerDeliveryStopsAhead({ progress, stopId: 22 }), 1);
+    assert.equal(customerDeliveryStopsAhead({ progress, stopId: 31 }), 2);
+});
+
+test('customer progress treats the current stop as next and counts retry checkpoints once', () => {
+    const progress = [
+        {
+            kind: 'delivery' as const,
+            itinerarySequence: 4,
+            stopKey: 'current',
+            stopIds: [41],
+            actionableStopIds: [41],
+            pickupConfirmed: true,
+            state: 'current' as const,
+        },
+        {
+            kind: 'delivery' as const,
+            itinerarySequence: 5,
+            stopKey: 'retry-bulk',
+            stopIds: [51, 52],
+            actionableStopIds: [51, 52],
+            pickupConfirmed: true,
+            retryLaneRank: 1,
+            retryAttempt: 1,
+            state: 'upcoming' as const,
+        },
+    ];
+
+    assert.equal(customerDeliveryStopsAhead({ progress, stopId: 41 }), 0);
+    assert.equal(customerDeliveryStopsAhead({ progress, stopId: 51 }), 1);
+    assert.equal(customerDeliveryStopsAhead({ progress, stopId: 52 }), 1);
+});
+
+test('customer progress is unavailable for completed, unknown, or missing stops', () => {
+    const progress = [
+        {
+            kind: 'delivery' as const,
+            itinerarySequence: 1,
+            stopKey: 'completed',
+            stopIds: [61],
+            actionableStopIds: [],
+            pickupConfirmed: true,
+            state: 'completed' as const,
+        },
+    ];
+
+    assert.equal(customerDeliveryStopsAhead({ progress, stopId: 61 }), null);
+    assert.equal(customerDeliveryStopsAhead({ progress, stopId: 99 }), null);
+    assert.equal(customerDeliveryStopsAhead({ progress, stopId: null }), null);
 });
 
 test('pickup manifest advertises only persisted trace provenance', () => {

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -17,6 +17,7 @@ import {
     getDeliveryRunExecutionProgress,
     getDeliveryRunStopsForRequestIds,
     getUser,
+    hasLegacyGoogleRouteArtifact,
     isDeliveryRunStopActionable,
     isDeliveryRunStopTerminal,
     type RecordDeliveryRunStopExceptionsInput,
@@ -1052,9 +1053,14 @@ async function customerDashboard({
     );
     const activeRuns = await Promise.all(activeRunIds.map(getDeliveryRun));
     const currentStopIdsByRunId = new Map<string, Set<number> | null>();
+    const executionProgressByRunId = new Map<
+        string,
+        DeliveryRunExecutionStep[]
+    >();
     for (const run of activeRuns) {
         if (!run) continue;
         const progress = await getDeliveryRunExecutionProgress(run.id);
+        executionProgressByRunId.set(run.id, progress);
         const current = progress.find((step) => step.state === 'current');
         if (current?.kind !== 'delivery' || !current.pickupConfirmed) {
             currentStopIdsByRunId.set(run.id, null);
@@ -1108,19 +1114,41 @@ async function customerDashboard({
                 ? (currentStopIdsByRunId.get(row.run.id)?.has(row.stop.id) ??
                   false)
                 : false;
-            return customerDeliveryRequestSummary(
-                deliveryStopSummary({
-                    items: [{ request, stop: row?.stop }],
-                    run: row?.run,
+            const summary = deliveryStopSummary({
+                items: [{ request, stop: row?.stop }],
+                run: row?.run,
+                isCurrent,
+                audience: 'customer',
+                now: projectedAt,
+                includeTracking:
+                    row?.run.state === DeliveryRunStates.ACTIVE &&
+                    isDeliveryRunStopActionable(row.stop.state) &&
                     isCurrent,
-                    audience: 'customer',
-                    now: projectedAt,
-                    includeTracking:
-                        row?.run.state === DeliveryRunStates.ACTIVE &&
-                        isDeliveryRunStopActionable(row.stop.state) &&
-                        isCurrent,
-                }),
-            );
+            });
+            const runTracking = row
+                ? customerDeliveryTrackingSummary(row.run, projectedAt)
+                : null;
+            return customerDeliveryRequestSummary(summary, {
+                now: projectedAt.toISOString(),
+                runState: row?.run.state ?? null,
+                stopsAhead:
+                    row?.run.state === DeliveryRunStates.ACTIVE
+                        ? customerDeliveryStopsAhead({
+                              progress:
+                                  executionProgressByRunId.get(row.run.id) ??
+                                  [],
+                              stopId: row.stop.id,
+                          })
+                        : null,
+                estimatesCalculatedAt: iso(row?.run.estimatesUpdatedAt),
+                estimateSource: row?.run.estimateSource ?? null,
+                routePlanVersion: row?.run.routePlanVersion ?? null,
+                hasTrafficRouteArtifact: hasLegacyGoogleRouteArtifact(
+                    row?.run.encodedPolyline,
+                ),
+                trackingStatus: runTracking?.status ?? null,
+                trackingLastAcceptedAt: runTracking?.lastAcceptedAt ?? null,
+            });
         })
         .sort((first, second) => {
             const firstTime = first.slotStartAt ?? '';
@@ -1179,6 +1207,26 @@ export function deliveryTrackingStopIds({
     return routePlanVersion < 2
         ? expandLegacyCurrentDeliveryStopIds({ currentStopIds, groups })
         : new Set(currentStopIds);
+}
+
+export function customerDeliveryStopsAhead({
+    progress,
+    stopId,
+}: {
+    progress: readonly DeliveryRunExecutionStep[];
+    stopId: number | null | undefined;
+}) {
+    if (typeof stopId !== 'number') return null;
+
+    const targetIndex = progress.findIndex(
+        (step) => step.kind === 'delivery' && step.stopIds.includes(stopId),
+    );
+    const target = progress[targetIndex];
+    if (!target || target.state === 'completed') return null;
+
+    return progress
+        .slice(0, targetIndex)
+        .filter((step) => step.state !== 'completed').length;
 }
 
 export function deliveryDashboardKindForRole(role: string) {

--- a/apps/delivery/lib/deliveryDashboardTypes.ts
+++ b/apps/delivery/lib/deliveryDashboardTypes.ts
@@ -26,7 +26,27 @@ export type DriverDeliveryTrackingLocation = {
     acceptedAt: string;
 };
 
-export type CustomerDeliveryTrackingSummary = DeliveryTrackingFreshnessSummary;
+export type CustomerDeliveryTrackingSummary =
+    DeliveryTrackingFreshnessSummary & {
+        exactLocationExpiresInMs: number | null;
+    };
+
+export type CustomerDeliveryEtaSummary = {
+    source: 'traffic-route' | 'route-plan' | 'promised-window';
+    calculatedAt: string | null;
+    freshness: 'fresh' | 'stale' | 'fallback' | 'unavailable';
+    confidence: 'high' | 'approximate' | 'none';
+    rangeStartAt: string | null;
+    rangeEndAt: string | null;
+    remainingMinSeconds: number | null;
+    remainingMaxSeconds: number | null;
+};
+
+export type CustomerDeliveryProgressSummary = {
+    phase: 'scheduled' | 'on-route' | 'next' | 'arrived' | 'unavailable';
+    stopsAhead: number | null;
+    delayed: boolean;
+};
 
 export type DeliveryHarvestSummary = {
     plantName: string;
@@ -80,10 +100,8 @@ export type CustomerDeliveryRequestSummary = {
     requestNotes: string | null;
     slotStartAt: string | null;
     slotEndAt: string | null;
-    estimatedArrivalAt: string | null;
-    estimatedTravelSeconds: number | null;
-    estimatedDistanceMeters: number | null;
-    reroutePending: boolean;
+    eta: CustomerDeliveryEtaSummary;
+    progress: CustomerDeliveryProgressSummary;
     deliveredAt: string | null;
     harvest: DeliveryHarvestSummary;
     receipt: CustomerDeliveryReceiptSummary | null;

--- a/apps/delivery/lib/deliveryFormatting.node.spec.ts
+++ b/apps/delivery/lib/deliveryFormatting.node.spec.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    deliveryPromiseWindow,
+    formatDeliveryDateTimeRange,
+    formatDeliveryDurationRange,
+} from './deliveryFormatting';
+
+test('accepts only complete, ordered ISO delivery promise windows', () => {
+    assert.deepEqual(
+        deliveryPromiseWindow(
+            '2026-07-16T08:00:00.000Z',
+            '2026-07-16T10:00:00.000Z',
+        ),
+        {
+            startAt: '2026-07-16T08:00:00.000Z',
+            endAt: '2026-07-16T10:00:00.000Z',
+        },
+    );
+    assert.equal(deliveryPromiseWindow(null, null), null);
+    assert.equal(
+        deliveryPromiseWindow('not-a-date', '2026-07-16T10:00:00.000Z'),
+        null,
+    );
+    assert.equal(
+        deliveryPromiseWindow(
+            '2026-07-16T10:00:00.000Z',
+            '2026-07-16T08:00:00.000Z',
+        ),
+        null,
+    );
+    assert.equal(
+        deliveryPromiseWindow(
+            '2026-07-16T10:00:00.000Z',
+            '2026-07-16T10:00:00.000Z',
+        ),
+        null,
+    );
+});
+
+test('includes dates whenever a customer time range crosses a local day', () => {
+    const overnightPromise = formatDeliveryDateTimeRange(
+        '2026-07-16T21:00:00.000Z',
+        '2026-07-16T23:00:00.000Z',
+    );
+    assert.ok(overnightPromise);
+    assert.match(overnightPromise.startLabel, /16\. srp.*23:00/);
+    assert.match(overnightPromise.endLabel, /17\. srp.*01:00/);
+
+    const nextDayEta = formatDeliveryDateTimeRange(
+        '2026-07-17T08:00:00.000Z',
+        '2026-07-17T08:15:00.000Z',
+        '2026-07-16T08:00:00.000Z',
+    );
+    assert.ok(nextDayEta);
+    assert.match(nextDayEta.startLabel, /17\. srp.*10:00/);
+    assert.equal(nextDayEta.endLabel, '10:15');
+});
+
+test('formats customer remaining-time ranges without implying false precision', () => {
+    assert.equal(formatDeliveryDurationRange(null, 600), null);
+    assert.equal(formatDeliveryDurationRange(0, 0), 'uskoro');
+    assert.equal(formatDeliveryDurationRange(0, 300), 'do 5 min');
+    assert.equal(formatDeliveryDurationRange(300, 600), '5 min – 10 min');
+    assert.equal(formatDeliveryDurationRange(5_400, 5_400), 'oko 1 h 30 min');
+});

--- a/apps/delivery/lib/deliveryFormatting.ts
+++ b/apps/delivery/lib/deliveryFormatting.ts
@@ -16,6 +16,58 @@ export function formatDeliveryTime(value: string | null) {
     }).format(new Date(value));
 }
 
+function deliveryTimestamp(value: string | null) {
+    if (!value) return null;
+    const time = Date.parse(value);
+    if (!Number.isFinite(time) || new Date(time).toISOString() !== value) {
+        return null;
+    }
+    return { value, time };
+}
+
+export function deliveryPromiseWindow(
+    startAt: string | null,
+    endAt: string | null,
+) {
+    const start = deliveryTimestamp(startAt);
+    const end = deliveryTimestamp(endAt);
+    if (!start || !end || start.time >= end.time) return null;
+    return { startAt: start.value, endAt: end.value };
+}
+
+function deliveryDay(value: string) {
+    return new Intl.DateTimeFormat('en-CA', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        timeZone: 'Europe/Zagreb',
+    }).format(new Date(value));
+}
+
+export function formatDeliveryDateTimeRange(
+    startAt: string | null,
+    endAt: string | null,
+    referenceAt: string | null = null,
+) {
+    const range = deliveryPromiseWindow(startAt, endAt);
+    if (!range) return null;
+    const reference = deliveryTimestamp(referenceAt);
+    const startIncludesDate =
+        !reference ||
+        deliveryDay(range.startAt) !== deliveryDay(reference.value);
+    const endIncludesDate =
+        deliveryDay(range.startAt) !== deliveryDay(range.endAt);
+    return {
+        ...range,
+        startLabel: startIncludesDate
+            ? formatDeliveryDateTime(range.startAt)
+            : formatDeliveryTime(range.startAt),
+        endLabel: endIncludesDate
+            ? formatDeliveryDateTime(range.endAt)
+            : formatDeliveryTime(range.endAt),
+    };
+}
+
 export function formatTravelDuration(value: number | null) {
     if (value === null) return '—';
     const minutes = Math.max(1, Math.round(value / 60));
@@ -23,6 +75,26 @@ export function formatTravelDuration(value: number | null) {
     const hours = Math.floor(minutes / 60);
     const rest = minutes % 60;
     return rest ? `${hours} h ${rest} min` : `${hours} h`;
+}
+
+export function formatDeliveryDurationRange(
+    minimumSeconds: number | null,
+    maximumSeconds: number | null,
+) {
+    if (minimumSeconds === null || maximumSeconds === null) return null;
+    const minimum = Math.max(0, Math.round(minimumSeconds / 60));
+    const maximum = Math.max(minimum, Math.round(maximumSeconds / 60));
+    const formatMinutes = (minutes: number) => {
+        if (minutes < 60) return `${minutes} min`;
+        const hours = Math.floor(minutes / 60);
+        const rest = minutes % 60;
+        return rest ? `${hours} h ${rest} min` : `${hours} h`;
+    };
+
+    if (maximum === 0) return 'uskoro';
+    if (minimum === 0) return `do ${formatMinutes(maximum)}`;
+    if (minimum === maximum) return `oko ${formatMinutes(maximum)}`;
+    return `${formatMinutes(minimum)} – ${formatMinutes(maximum)}`;
 }
 
 export function formatDistance(value: number | null) {

--- a/apps/delivery/lib/deliveryMapRoute.node.spec.ts
+++ b/apps/delivery/lib/deliveryMapRoute.node.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { persistLegacyGoogleRoutePolyline } from '@gredice/storage/deliveryTrackingPolicy';
 import { createDeliveryMapRouteHandlers } from './deliveryMapRoute';
 
 const runId = 'delivery-run-map-1';
@@ -143,7 +144,9 @@ function deliveryRun(options: TestRunOptions = {}): TestDeliveryMapRun {
                 longitude: null,
             },
         ],
-        encodedPolyline: 'private-complete-route',
+        encodedPolyline: persistLegacyGoogleRoutePolyline(
+            'private-complete-route',
+        ),
         groups: deliveryGroups(),
     };
 }
@@ -193,6 +196,7 @@ function createHarness(input: HarnessInput) {
         getCustomerTrackingContext: 0,
         resolveGroups: 0,
         buildStaticMapUrl: 0,
+        staticMapEncodedPolylines: [] as Array<string | null>,
     };
     const handlers = createDeliveryMapRouteHandlers<
         TestDeliveryMapRun,
@@ -225,8 +229,9 @@ function createHarness(input: HarnessInput) {
             return run.driverLocation;
         },
         isStopTerminal: (state) => terminalStates.has(state),
-        buildStaticMapUrl: () => {
+        buildStaticMapUrl: (mapData) => {
             calls.buildStaticMapUrl += 1;
+            calls.staticMapEncodedPolylines.push(mapData.encodedPolyline);
             return null;
         },
         unavailableMapSvg: () => '<svg>Map unavailable</svg>',
@@ -389,6 +394,38 @@ test('assigned drivers and admins receive the complete driver map projection', a
             assert.equal(calls.resolveGroups, 1);
         });
     }
+});
+
+test('assigned driver maps preserve unmarked legacy route geometry', async () => {
+    const run = deliveryRun();
+    run.encodedPolyline = 'old-unmarked-route';
+    const { handlers } = createHarness({
+        role: 'driver',
+        userId: 'assigned-driver',
+        accountId: 'operator-account',
+        run,
+    });
+
+    const response = await handlers.GET(request(), context());
+
+    assert.equal(response.status, 200);
+    assert.equal((await response.json()).encodedPolyline, 'old-unmarked-route');
+});
+
+test('assigned driver static maps receive raw route geometry', async () => {
+    const { handlers, calls } = createHarness({
+        role: 'driver',
+        userId: 'assigned-driver',
+        accountId: 'operator-account',
+    });
+
+    const response = await handlers.GET(request('image'), context());
+
+    assert.equal(response.status, 200);
+    assert.equal(calls.buildStaticMapUrl, 1);
+    assert.deepEqual(calls.staticMapEncodedPolylines, [
+        'private-complete-route',
+    ]);
 });
 
 test('unassigned drivers and admins remain constrained to the customer-safe projection', async (t) => {

--- a/apps/delivery/lib/deliveryMapRoute.ts
+++ b/apps/delivery/lib/deliveryMapRoute.ts
@@ -1,3 +1,4 @@
+import { deliveryRunRoutePolyline } from '@gredice/storage/deliveryTrackingPolicy';
 import {
     buildDeliveryMapData,
     customerCurrentDeliveryMapStops,
@@ -204,7 +205,7 @@ export function createDeliveryMapRouteHandlers<
                       )
                     : [],
                 stops,
-                encodedPolyline: run.encodedPolyline,
+                encodedPolyline: deliveryRunRoutePolyline(run.encodedPolyline),
                 customerView,
             });
             if (new URL(request.url).searchParams.get('format') === 'json') {

--- a/apps/delivery/lib/deliveryTracking.node.spec.ts
+++ b/apps/delivery/lib/deliveryTracking.node.spec.ts
@@ -147,8 +147,10 @@ test('exact driver telemetry disappears after TTL while customer freshness stays
         status: 'offline',
         lastAcceptedAt: acceptedAt.toISOString(),
         mapAvailable: false,
+        exactLocationExpiresInMs: null,
     });
     assert.deepEqual(Object.keys(customer).sort(), [
+        'exactLocationExpiresInMs',
         'lastAcceptedAt',
         'mapAvailable',
         'status',
@@ -160,9 +162,15 @@ test('exact driver telemetry disappears after TTL while customer freshness stays
 });
 
 test('customer map remains available only while exact telemetry is within TTL', () => {
+    const fresh = customerDeliveryTrackingSummary(snapshot(), acceptedAt);
+    assert.equal(fresh.mapAvailable, true);
+    assert.equal(fresh.exactLocationExpiresInMs, deliveryRunExactLocationTtlMs);
     assert.equal(
-        customerDeliveryTrackingSummary(snapshot(), acceptedAt).mapAvailable,
-        true,
+        customerDeliveryTrackingSummary(
+            snapshot(),
+            new Date(acceptedAt.getTime() + 60_000),
+        ).exactLocationExpiresInMs,
+        deliveryRunExactLocationTtlMs - 60_000,
     );
     assert.equal(
         customerDeliveryTrackingSummary(

--- a/apps/delivery/lib/deliveryTracking.ts
+++ b/apps/delivery/lib/deliveryTracking.ts
@@ -103,15 +103,21 @@ export function customerDeliveryTrackingSummary(
     now = new Date(),
 ): CustomerDeliveryTrackingSummary {
     const status = deliveryTrackingStatus(snapshot, now);
+    const ageMs = acceptedLocationAgeMs(snapshot, now);
+    const mapAvailable =
+        driverDeliveryTrackingLocation(snapshot, now) !== null &&
+        (status === 'live' || status === 'delayed');
     return {
         status,
         lastAcceptedAt:
             snapshot.state === DeliveryRunStates.ACTIVE
                 ? (snapshot.currentLocationReceivedAt?.toISOString() ?? null)
                 : null,
-        mapAvailable:
-            driverDeliveryTrackingLocation(snapshot, now) !== null &&
-            (status === 'live' || status === 'delayed'),
+        mapAvailable,
+        exactLocationExpiresInMs:
+            mapAvailable && ageMs !== null
+                ? Math.max(0, deliveryRunExactLocationTtlMs - ageMs)
+                : null,
     };
 }
 

--- a/apps/delivery/tests/CustomerDashboardModesStory.tsx
+++ b/apps/delivery/tests/CustomerDashboardModesStory.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { CustomerDashboard } from '../components/CustomerDashboard';
 import type {
     CustomerDeliveryDashboard,
@@ -14,10 +15,21 @@ const delivery: CustomerDeliveryRequestSummary = {
     requestNotes: 'Pozvoni na portafon.',
     slotStartAt: '2026-07-16T08:00:00.000Z',
     slotEndAt: '2026-07-16T10:00:00.000Z',
-    estimatedArrivalAt: '2026-07-16T09:00:00.000Z',
-    estimatedTravelSeconds: 900,
-    estimatedDistanceMeters: 5_000,
-    reroutePending: false,
+    eta: {
+        source: 'traffic-route',
+        calculatedAt: '2026-07-16T08:45:00.000Z',
+        freshness: 'fresh',
+        confidence: 'high',
+        rangeStartAt: '2026-07-16T08:55:00.000Z',
+        rangeEndAt: '2026-07-16T09:05:00.000Z',
+        remainingMinSeconds: 600,
+        remainingMaxSeconds: 1_200,
+    },
+    progress: {
+        phase: 'next',
+        stopsAhead: 0,
+        delayed: false,
+    },
     deliveredAt: null,
     harvest: {
         plantName: 'Rajčica za dostavu',
@@ -32,6 +44,7 @@ const delivery: CustomerDeliveryRequestSummary = {
         status: 'live',
         lastAcceptedAt: '2026-07-16T08:45:00.000Z',
         mapAvailable: true,
+        exactLocationExpiresInMs: 110_000,
     },
     mapPath: '/api/map/customer-mixed-run-4135',
 };
@@ -99,9 +112,26 @@ function dashboard({
     };
 }
 
-export function MixedCustomerDashboardStory() {
+function CustomerDashboardFromRequest({
+    dashboard,
+}: {
+    dashboard: CustomerDeliveryDashboard;
+}) {
+    const [requestTiming] = useState(() => ({
+        monotonicMs: performance.now(),
+        wallMs: Date.now(),
+    }));
     return (
         <CustomerDashboard
+            dashboard={dashboard}
+            requestTiming={requestTiming}
+        />
+    );
+}
+
+export function MixedCustomerDashboardStory() {
+    return (
+        <CustomerDashboardFromRequest
             dashboard={dashboard({
                 role: 'user',
                 deliveries: [delivery, readyPickup],
@@ -112,7 +142,7 @@ export function MixedCustomerDashboardStory() {
 
 export function PickupFarmerDashboardStory() {
     return (
-        <CustomerDashboard
+        <CustomerDashboardFromRequest
             dashboard={dashboard({
                 role: 'farmer',
                 deliveries: [readyPickup, fulfilledPickup],
@@ -123,7 +153,7 @@ export function PickupFarmerDashboardStory() {
 
 export function DeliveryUserDashboardStory() {
     return (
-        <CustomerDashboard
+        <CustomerDashboardFromRequest
             dashboard={dashboard({
                 role: 'user',
                 deliveries: [delivery],
@@ -134,7 +164,7 @@ export function DeliveryUserDashboardStory() {
 
 export function EmptyCustomerDashboardStory() {
     return (
-        <CustomerDashboard
+        <CustomerDashboardFromRequest
             dashboard={dashboard({ role: 'user', deliveries: [] })}
         />
     );

--- a/apps/delivery/tests/CustomerDeliveryEtaStory.tsx
+++ b/apps/delivery/tests/CustomerDeliveryEtaStory.tsx
@@ -1,0 +1,288 @@
+import { CustomerDeliveryCard } from '../components/CustomerDeliveryCard';
+import type { CustomerDeliveryRequestSummary } from '../lib/deliveryDashboardTypes';
+
+const baseDelivery: CustomerDeliveryRequestSummary = {
+    mode: 'delivery',
+    requestId: 'customer-eta-4136',
+    status: 'ready',
+    statusLabel: 'U dostavi',
+    requestNotes: 'Pozvoni na portafon.',
+    slotStartAt: '2026-07-16T08:00:00.000Z',
+    slotEndAt: '2026-07-16T10:00:00.000Z',
+    eta: {
+        source: 'traffic-route',
+        calculatedAt: '2026-07-16T08:45:00.000Z',
+        freshness: 'fresh',
+        confidence: 'high',
+        rangeStartAt: '2026-07-16T08:55:00.000Z',
+        rangeEndAt: '2026-07-16T09:05:00.000Z',
+        remainingMinSeconds: 600,
+        remainingMaxSeconds: 1_200,
+    },
+    progress: {
+        phase: 'next',
+        stopsAhead: 0,
+        delayed: false,
+    },
+    deliveredAt: null,
+    harvest: {
+        plantName: 'Rajčica ETA 4136',
+        operationName: 'Berba',
+        raisedBedName: 'Gredica 4',
+        fieldName: 'Polje 2',
+        tracePath: '/trag/customer-eta-4136',
+    },
+    receipt: null,
+    recovery: null,
+    tracking: null,
+    mapPath: null,
+};
+
+export function FreshCustomerEtaStory() {
+    return <CustomerDeliveryCard delivery={baseDelivery} />;
+}
+
+export function FallbackCustomerEtaStory() {
+    return (
+        <CustomerDeliveryCard
+            delivery={{
+                ...baseDelivery,
+                requestId: 'customer-fallback-4136',
+                eta: {
+                    source: 'promised-window',
+                    calculatedAt: null,
+                    freshness: 'fallback',
+                    confidence: 'approximate',
+                    rangeStartAt: baseDelivery.slotStartAt,
+                    rangeEndAt: baseDelivery.slotEndAt,
+                    remainingMinSeconds: 3_600,
+                    remainingMaxSeconds: 10_800,
+                },
+                progress: {
+                    phase: 'on-route',
+                    stopsAhead: 3,
+                    delayed: false,
+                },
+            }}
+        />
+    );
+}
+
+export function StaleCustomerEtaStory() {
+    return (
+        <CustomerDeliveryCard
+            delivery={{
+                ...baseDelivery,
+                requestId: 'customer-stale-4136',
+                eta: {
+                    source: 'promised-window',
+                    calculatedAt: '2026-07-16T09:57:00.000Z',
+                    freshness: 'stale',
+                    confidence: 'approximate',
+                    rangeStartAt: baseDelivery.slotStartAt,
+                    rangeEndAt: baseDelivery.slotEndAt,
+                    remainingMinSeconds: 0,
+                    remainingMaxSeconds: 1_800,
+                },
+                progress: {
+                    phase: 'on-route',
+                    stopsAhead: 2,
+                    delayed: false,
+                },
+            }}
+        />
+    );
+}
+
+export function DelayedCustomerEtaStory() {
+    return (
+        <CustomerDeliveryCard
+            delivery={{
+                ...baseDelivery,
+                requestId: 'customer-delayed-4136',
+                eta: {
+                    source: 'traffic-route',
+                    calculatedAt: '2026-07-16T09:55:00.000Z',
+                    freshness: 'fresh',
+                    confidence: 'high',
+                    rangeStartAt: '2026-07-16T10:10:00.000Z',
+                    rangeEndAt: '2026-07-16T10:25:00.000Z',
+                    remainingMinSeconds: 900,
+                    remainingMaxSeconds: 1_800,
+                },
+                progress: {
+                    phase: 'on-route',
+                    stopsAhead: 1,
+                    delayed: true,
+                },
+            }}
+        />
+    );
+}
+
+export function UnavailableCustomerEtaStory() {
+    return (
+        <CustomerDeliveryCard
+            delivery={{
+                ...baseDelivery,
+                requestId: 'customer-unavailable-4136',
+                slotStartAt: null,
+                slotEndAt: null,
+                eta: {
+                    source: 'promised-window',
+                    calculatedAt: null,
+                    freshness: 'unavailable',
+                    confidence: 'none',
+                    rangeStartAt: null,
+                    rangeEndAt: null,
+                    remainingMinSeconds: null,
+                    remainingMaxSeconds: null,
+                },
+                progress: {
+                    phase: 'unavailable',
+                    stopsAhead: null,
+                    delayed: false,
+                },
+            }}
+        />
+    );
+}
+
+export function ExpiredCustomerEtaStory() {
+    return (
+        <CustomerDeliveryCard
+            delivery={{
+                ...baseDelivery,
+                requestId: 'customer-expired-4136',
+                eta: {
+                    source: 'promised-window',
+                    calculatedAt: null,
+                    freshness: 'unavailable',
+                    confidence: 'none',
+                    rangeStartAt: null,
+                    rangeEndAt: null,
+                    remainingMinSeconds: null,
+                    remainingMaxSeconds: null,
+                },
+                progress: {
+                    phase: 'on-route',
+                    stopsAhead: 1,
+                    delayed: true,
+                },
+            }}
+        />
+    );
+}
+
+export function CrossMidnightCustomerEtaStory() {
+    return (
+        <CustomerDeliveryCard
+            delivery={{
+                ...baseDelivery,
+                requestId: 'customer-cross-midnight-4136',
+                slotStartAt: '2026-07-16T21:00:00.000Z',
+                slotEndAt: '2026-07-16T23:00:00.000Z',
+                eta: {
+                    source: 'traffic-route',
+                    calculatedAt: '2026-07-17T21:50:00.000Z',
+                    freshness: 'fresh',
+                    confidence: 'high',
+                    rangeStartAt: '2026-07-17T21:55:00.000Z',
+                    rangeEndAt: '2026-07-17T22:10:00.000Z',
+                    remainingMinSeconds: 300,
+                    remainingMaxSeconds: 1_200,
+                },
+                progress: {
+                    phase: 'on-route',
+                    stopsAhead: 1,
+                    delayed: true,
+                },
+            }}
+        />
+    );
+}
+
+export function InvalidCustomerWindowStory({
+    reversed = false,
+}: {
+    reversed?: boolean;
+}) {
+    return (
+        <CustomerDeliveryCard
+            delivery={{
+                ...baseDelivery,
+                requestId: 'customer-invalid-window-4136',
+                slotStartAt: reversed
+                    ? '2026-07-16T10:00:00.000Z'
+                    : 'not-a-date',
+                slotEndAt: '2026-07-16T08:00:00.000Z',
+                eta: {
+                    source: 'promised-window',
+                    calculatedAt: null,
+                    freshness: 'unavailable',
+                    confidence: 'none',
+                    rangeStartAt: null,
+                    rangeEndAt: null,
+                    remainingMinSeconds: null,
+                    remainingMaxSeconds: null,
+                },
+                progress: {
+                    phase: 'unavailable',
+                    stopsAhead: null,
+                    delayed: false,
+                },
+            }}
+        />
+    );
+}
+
+export function UpdatingCustomerEtaStory({
+    delayed = false,
+    remainingMinSeconds = 3_600,
+    remainingMaxSeconds = 10_800,
+}: {
+    delayed?: boolean;
+    remainingMinSeconds?: number;
+    remainingMaxSeconds?: number;
+}) {
+    return (
+        <CustomerDeliveryCard
+            delivery={{
+                ...baseDelivery,
+                requestId: 'customer-updating-4136',
+                eta: delayed
+                    ? {
+                          source: 'traffic-route',
+                          calculatedAt: '2026-07-16T09:55:00.000Z',
+                          freshness: 'fresh',
+                          confidence: 'high',
+                          rangeStartAt: '2026-07-16T10:10:00.000Z',
+                          rangeEndAt: '2026-07-16T10:25:00.000Z',
+                          remainingMinSeconds: 900,
+                          remainingMaxSeconds: 1_800,
+                      }
+                    : {
+                          source: 'promised-window',
+                          calculatedAt: null,
+                          freshness: 'fallback',
+                          confidence: 'approximate',
+                          rangeStartAt: baseDelivery.slotStartAt,
+                          rangeEndAt: baseDelivery.slotEndAt,
+                          remainingMinSeconds,
+                          remainingMaxSeconds,
+                      },
+                progress: delayed
+                    ? {
+                          phase: 'on-route',
+                          stopsAhead: 1,
+                          delayed: true,
+                      }
+                    : {
+                          phase: 'on-route',
+                          stopsAhead: 3,
+                          delayed: false,
+                      },
+            }}
+        />
+    );
+}

--- a/apps/delivery/tests/CustomerDeliveryReceiptStory.tsx
+++ b/apps/delivery/tests/CustomerDeliveryReceiptStory.tsx
@@ -42,10 +42,21 @@ function customerDelivery({
         requestNotes: null,
         slotStartAt: '2026-07-16T08:00:00.000Z',
         slotEndAt: '2026-07-16T10:00:00.000Z',
-        estimatedArrivalAt: null,
-        estimatedTravelSeconds: null,
-        estimatedDistanceMeters: null,
-        reroutePending: false,
+        eta: {
+            source: 'promised-window',
+            calculatedAt: null,
+            freshness: 'unavailable',
+            confidence: 'none',
+            rangeStartAt: null,
+            rangeEndAt: null,
+            remainingMinSeconds: null,
+            remainingMaxSeconds: null,
+        },
+        progress: {
+            phase: 'unavailable',
+            stopsAhead: null,
+            delayed: false,
+        },
         deliveredAt: '2026-07-16T09:30:00.000Z',
         harvest,
         receipt: {
@@ -69,15 +80,28 @@ const activeDelivery: CustomerDeliveryRequestSummary = {
     requestId: 'customer-owned-request-journey-4144',
     status: 'ready',
     statusLabel: 'Vozač stiže',
-    estimatedArrivalAt: '2026-07-16T09:30:00.000Z',
-    estimatedTravelSeconds: 600,
-    estimatedDistanceMeters: 3_200,
+    eta: {
+        source: 'traffic-route',
+        calculatedAt: '2026-07-16T09:20:00.000Z',
+        freshness: 'fresh',
+        confidence: 'high',
+        rangeStartAt: '2026-07-16T09:25:00.000Z',
+        rangeEndAt: '2026-07-16T09:35:00.000Z',
+        remainingMinSeconds: 300,
+        remainingMaxSeconds: 900,
+    },
+    progress: {
+        phase: 'next',
+        stopsAhead: 0,
+        delayed: false,
+    },
     deliveredAt: null,
     receipt: null,
     tracking: {
         status: 'live',
         lastAcceptedAt: '2026-07-16T09:20:00.000Z',
         mapAvailable: false,
+        exactLocationExpiresInMs: null,
     },
     mapPath: '/api/map/customer-run-journey-4144',
 };
@@ -148,6 +172,10 @@ export function CustomerDeliveryReceiptStatesStory() {
 
 export function CustomerDeliveryReceiptJourneyStory() {
     const [delivered, setDelivered] = useState(false);
+    const [requestTiming] = useState(() => ({
+        monotonicMs: performance.now(),
+        wallMs: Date.now(),
+    }));
     return (
         <div>
             <div className="p-4">
@@ -159,6 +187,7 @@ export function CustomerDeliveryReceiptJourneyStory() {
                 dashboard={dashboard([
                     delivered ? deliveredJourneyDelivery : activeDelivery,
                 ])}
+                requestTiming={requestTiming}
             />
         </div>
     );

--- a/apps/delivery/tests/CustomerDeliveryTrackingStory.tsx
+++ b/apps/delivery/tests/CustomerDeliveryTrackingStory.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useState } from 'react';
+import { CustomerDeliveryTracking } from '../components/CustomerDeliveryTracking';
+
+export function CustomerDeliveryTrackingFromRequest({
+    requestAgeMs = 0,
+    ...props
+}: Omit<Parameters<typeof CustomerDeliveryTracking>[0], 'requestTiming'> & {
+    requestAgeMs?: number;
+}) {
+    const [requestTiming] = useState(() => ({
+        monotonicMs: performance.now() - requestAgeMs,
+        wallMs: Date.now() - requestAgeMs,
+    }));
+    return (
+        <CustomerDeliveryTracking {...props} requestTiming={requestTiming} />
+    );
+}

--- a/apps/delivery/tests/delivery-customer-eta.spec.tsx
+++ b/apps/delivery/tests/delivery-customer-eta.spec.tsx
@@ -1,0 +1,221 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import {
+    CrossMidnightCustomerEtaStory,
+    DelayedCustomerEtaStory,
+    ExpiredCustomerEtaStory,
+    FallbackCustomerEtaStory,
+    FreshCustomerEtaStory,
+    InvalidCustomerWindowStory,
+    StaleCustomerEtaStory,
+    UnavailableCustomerEtaStory,
+    UpdatingCustomerEtaStory,
+} from './CustomerDeliveryEtaStory';
+import '../app/globals.css';
+
+test('shows the full promise and a text-qualified fresh ETA range', async ({
+    mount,
+    page,
+}) => {
+    await mount(<FreshCustomerEtaStory />);
+    const card = page.getByTestId('customer-delivery-card');
+
+    await expect(card.locator('time')).toHaveCount(5);
+    await expect(card.locator('time').first()).toHaveAttribute(
+        'datetime',
+        '2026-07-16T08:00:00.000Z',
+    );
+    await expect(card.locator('time').nth(1)).toHaveAttribute(
+        'datetime',
+        '2026-07-16T10:00:00.000Z',
+    );
+    await expect(
+        card.getByText('Ažurna procjena prema prometu', { exact: true }),
+    ).toBeVisible();
+    await expect(
+        card.getByText('Tvoja dostava je sljedeća.', { exact: true }),
+    ).toBeVisible();
+    expect(await card.innerText()).not.toMatch(/Vožnja|Udaljenost/);
+    await expect(
+        card.getByText('Preostalo: 10 min – 20 min', { exact: true }),
+    ).toBeVisible();
+});
+
+test('uses the promised window as an explicit approximate fallback', async ({
+    mount,
+    page,
+}) => {
+    await mount(<FallbackCustomerEtaStory />);
+
+    await expect(
+        page.getByText('Prema odabranom terminu', { exact: true }),
+    ).toBeVisible();
+    await expect(
+        page.getByText('3 zaustavljanja prije tvoje dostave.', {
+            exact: true,
+        }),
+    ).toBeVisible();
+});
+
+test('labels a stale estimate without exposing another route stop', async ({
+    mount,
+    page,
+}) => {
+    await mount(<StaleCustomerEtaStory />);
+
+    await expect(
+        page.getByText(
+            'Procjena rute nije ažurna; prikazujemo odabrani termin.',
+            { exact: true },
+        ),
+    ).toBeVisible();
+    await expect(page.getByText(/Zadnja procjena rute:/)).toBeVisible();
+    await expect(
+        page.getByText('2 zaustavljanja prije tvoje dostave.', {
+            exact: true,
+        }),
+    ).toBeVisible();
+    expect(await page.locator('body').innerText()).not.toMatch(
+        /adresa|kupac|pickup|stopId|PRIVATE/i,
+    );
+});
+
+test('announces a late ETA politely and keeps the genuine late range', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DelayedCustomerEtaStory />);
+
+    await expect(page.getByRole('alert')).toHaveCount(0);
+    await expect(page.getByRole('status')).toHaveCount(1);
+    await expect(
+        page.getByText(
+            'Procjena dolaska je nakon završetka odabranog termina.',
+            { exact: true },
+        ),
+    ).toBeVisible();
+    const etaTimes = page
+        .getByTestId('customer-delivery-promise')
+        .locator('time');
+    await expect(etaTimes.first()).toHaveAttribute(
+        'datetime',
+        '2026-07-16T10:10:00.000Z',
+    );
+    await expect(etaTimes.nth(1)).toHaveAttribute(
+        'datetime',
+        '2026-07-16T10:25:00.000Z',
+    );
+});
+
+test('does not present an expired fallback window as an imminent ETA', async ({
+    mount,
+    page,
+}) => {
+    await mount(<ExpiredCustomerEtaStory />);
+
+    await expect(
+        page.getByText(
+            'Odabrani termin je prošao, a nova procjena dolaska trenutačno nije dostupna.',
+            { exact: true },
+        ),
+    ).toBeVisible();
+    await expect(page.getByText(/Procijenjeni dolazak/)).toHaveCount(0);
+    await expect(page.getByText(/uskoro/)).toHaveCount(0);
+});
+
+test('includes dates for cross-midnight promises and next-day ETA ranges', async ({
+    mount,
+    page,
+}) => {
+    await mount(<CrossMidnightCustomerEtaStory />);
+    const times = page.getByTestId('customer-delivery-card').locator('time');
+
+    await expect(times.nth(0)).toContainText(/16\. srp.*23:00/);
+    await expect(times.nth(1)).toContainText(/17\. srp.*01:00/);
+    await expect(times.nth(2)).toContainText(/17\. srp.*23:55/);
+    await expect(times.nth(3)).toContainText(/18\. srp.*00:10/);
+});
+
+test('keeps missing legacy data explicit instead of hiding the promise row', async ({
+    mount,
+    page,
+}) => {
+    await mount(<UnavailableCustomerEtaStory />);
+
+    await expect(
+        page.getByText('Termin još nije dostupan.', { exact: true }),
+    ).toBeVisible();
+    await expect(
+        page
+            .getByRole('group', { name: 'Dostupnost procjene dolaska' })
+            .getByText(/Procjena dolaska trenutačno nije dostupna/),
+    ).toBeVisible();
+    await expect(
+        page.getByText('Napredak rute trenutačno nije dostupan.', {
+            exact: true,
+        }),
+    ).toBeVisible();
+});
+
+test('fails closed for malformed and reversed legacy promise windows', async ({
+    mount,
+    page,
+}) => {
+    const component = await mount(<InvalidCustomerWindowStory />);
+
+    await expect(
+        page.getByText('Termin još nije dostupan.', { exact: true }),
+    ).toBeVisible();
+    await component.update(<InvalidCustomerWindowStory reversed />);
+    await expect(
+        page.getByText('Termin još nije dostupan.', { exact: true }),
+    ).toBeVisible();
+});
+
+test('keeps a stable polite announcement for meaningful ETA and progress updates', async ({
+    mount,
+}) => {
+    const component = await mount(<UpdatingCustomerEtaStory />);
+    const announcement = component.getByRole('status');
+
+    await expect(announcement).toContainText(
+        '3 zaustavljanja prije tvoje dostave.',
+    );
+    const initialAnnouncement = await announcement.textContent();
+    await component.update(
+        <UpdatingCustomerEtaStory
+            remainingMinSeconds={300}
+            remainingMaxSeconds={900}
+        />,
+    );
+    await expect(
+        component.getByText('Preostalo: 5 min – 15 min', { exact: true }),
+    ).toBeVisible();
+    await expect(announcement).toHaveText(initialAnnouncement ?? '');
+    await component.update(<UpdatingCustomerEtaStory delayed />);
+    await expect(announcement).toContainText(
+        'Procjena dolaska je nakon završetka odabranog termina.',
+    );
+    await expect(announcement).toHaveAttribute('aria-atomic', 'true');
+    await expect(component.getByRole('alert')).toHaveCount(0);
+});
+
+test.describe('customer ETA on a narrow touch screen', () => {
+    test.use({
+        viewport: { width: 360, height: 800 },
+        hasTouch: true,
+        isMobile: true,
+    });
+
+    test('contains the promise without horizontal overflow', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<FallbackCustomerEtaStory />);
+        const card = page.getByTestId('customer-delivery-card');
+        expect(
+            await card.evaluate(
+                (element) => element.scrollWidth <= element.clientWidth,
+            ),
+        ).toBe(true);
+    });
+});

--- a/apps/delivery/tests/delivery-customer-modes.spec.tsx
+++ b/apps/delivery/tests/delivery-customer-modes.spec.tsx
@@ -11,6 +11,9 @@ test('keeps delivery tracking while presenting pickup location and instructions 
     mount,
     page,
 }) => {
+    await page.clock.install({
+        time: new Date('2026-07-16T08:45:10.000Z'),
+    });
     await mount(<MixedCustomerDashboardStory />);
 
     await expect(
@@ -35,11 +38,18 @@ test('keeps delivery tracking while presenting pickup location and instructions 
         delivery.getByRole('heading', { name: 'Rajčica za dostavu' }),
     ).toBeVisible();
     await expect(delivery.getByText('Dostava', { exact: true })).toBeVisible();
-    await expect(delivery.getByText('Dolazak', { exact: true })).toBeVisible();
-    await expect(delivery.getByText('Vožnja', { exact: true })).toBeVisible();
     await expect(
-        delivery.getByText('Udaljenost', { exact: true }),
+        delivery.getByText('Procijenjeni dolazak', { exact: true }),
     ).toBeVisible();
+    await expect(
+        delivery.getByText('Ažurna procjena prema prometu', { exact: true }),
+    ).toBeVisible();
+    await expect(
+        delivery.getByText('Tvoja dostava je sljedeća.', { exact: true }),
+    ).toBeVisible();
+    await expect(delivery.locator('time')).toHaveCount(5);
+    const deliveryText = await delivery.innerText();
+    expect(deliveryText).not.toMatch(/Vožnja|Udaljenost/);
 
     const map = page.getByRole('img', {
         name: 'Trenutna lokacija vozača i moja dostava',
@@ -144,6 +154,9 @@ test('keeps the user delivery-only heading and tracking experience', async ({
     mount,
     page,
 }) => {
+    await page.clock.install({
+        time: new Date('2026-07-16T08:45:10.000Z'),
+    });
     await mount(<DeliveryUserDashboardStory />);
 
     await expect(

--- a/apps/delivery/tests/delivery-tracking.spec.tsx
+++ b/apps/delivery/tests/delivery-tracking.spec.tsx
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/experimental-ct-react';
-import { CustomerDeliveryTracking } from '../components/CustomerDeliveryTracking';
+import { CustomerDeliveryTrackingFromRequest } from './CustomerDeliveryTrackingStory';
 import '../app/globals.css';
 
 const lastAcceptedAt = '2026-07-15T10:00:00.000Z';
@@ -8,13 +8,17 @@ test('customer sees a live server-acknowledged location and map', async ({
     mount,
     page,
 }) => {
+    await page.clock.install({
+        time: new Date('2026-07-15T10:00:10.000Z'),
+    });
     await mount(
-        <CustomerDeliveryTracking
+        <CustomerDeliveryTrackingFromRequest
             mapPath="/api/map/run-live"
             tracking={{
                 status: 'live',
                 lastAcceptedAt,
                 mapAvailable: true,
+                exactLocationExpiresInMs: 110_000,
             }}
         />,
     );
@@ -29,17 +33,50 @@ test('customer sees a live server-acknowledged location and map', async ({
     ).toBeVisible();
 });
 
+test('ages a live location to delayed when dashboard polling stalls', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({
+        time: new Date('2026-07-15T10:00:29.000Z'),
+    });
+    await mount(
+        <CustomerDeliveryTrackingFromRequest
+            mapPath="/api/map/run-aging"
+            tracking={{
+                status: 'live',
+                lastAcceptedAt,
+                mapAvailable: true,
+                exactLocationExpiresInMs: 91_000,
+            }}
+        />,
+    );
+
+    await expect(page.getByText(/Lokacija vozača je uživo/)).toBeVisible();
+    await page.clock.fastForward(1_001);
+    await expect(page.getByText(/Lokacija vozača kasni/)).toBeVisible();
+    await expect(
+        page.getByRole('img', {
+            name: 'Posljednja potvrđena lokacija vozača i moja dostava',
+        }),
+    ).toBeVisible();
+});
+
 test('customer sees delayed copy while the last exact location remains available', async ({
     mount,
     page,
 }) => {
+    await page.clock.install({
+        time: new Date('2026-07-15T10:01:00.000Z'),
+    });
     await mount(
-        <CustomerDeliveryTracking
+        <CustomerDeliveryTrackingFromRequest
             mapPath="/api/map/run-delayed"
             tracking={{
                 status: 'delayed',
                 lastAcceptedAt,
                 mapAvailable: true,
+                exactLocationExpiresInMs: 60_000,
             }}
         />,
     );
@@ -52,17 +89,96 @@ test('customer sees delayed copy while the last exact location remains available
     ).toBeVisible();
 });
 
+test('removes exact map data at the TTL without waiting for a dashboard poll', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({
+        time: new Date('2026-07-15T10:01:59.000Z'),
+    });
+    await mount(
+        <CustomerDeliveryTrackingFromRequest
+            mapPath="/api/map/run-expiring"
+            tracking={{
+                status: 'delayed',
+                lastAcceptedAt,
+                mapAvailable: true,
+                exactLocationExpiresInMs: 1_000,
+            }}
+        />,
+    );
+
+    await expect(page.getByRole('img')).toBeVisible();
+    await page.clock.fastForward(1_001);
+    await expect(page.getByRole('img')).toHaveCount(0);
+    await expect(
+        page.getByText(/Praćenje je trenutačno izvan mreže/),
+    ).toBeVisible();
+});
+
+test('subtracts request and render transit from the server TTL remainder', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({
+        time: new Date('2026-07-15T10:01:59.000Z'),
+    });
+    await mount(
+        <CustomerDeliveryTrackingFromRequest
+            requestAgeMs={900}
+            mapPath="/api/map/run-transit-delay"
+            tracking={{
+                status: 'delayed',
+                lastAcceptedAt,
+                mapAvailable: true,
+                exactLocationExpiresInMs: 1_000,
+            }}
+        />,
+    );
+
+    await expect(page.getByRole('img')).toBeVisible();
+    await page.clock.fastForward(101);
+    await expect(page.getByRole('img')).toHaveCount(0);
+});
+
+test('uses the server TTL remainder instead of the customer device clock', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({
+        time: new Date('2099-01-01T00:00:00.000Z'),
+    });
+    await mount(
+        <CustomerDeliveryTrackingFromRequest
+            mapPath="/api/map/run-clock-skew"
+            tracking={{
+                status: 'delayed',
+                lastAcceptedAt,
+                mapAvailable: true,
+                exactLocationExpiresInMs: 1_000,
+            }}
+        />,
+    );
+
+    await expect(page.getByRole('img')).toBeVisible();
+    await page.clock.setSystemTime(new Date('1999-01-01T00:00:00.000Z'));
+    await expect(page.getByRole('img')).toBeVisible();
+    await page.clock.fastForward(1_000);
+    await expect(page.getByRole('img')).toHaveCount(0);
+});
+
 test('customer sees offline state without a stale exact-location map', async ({
     mount,
     page,
 }) => {
     await mount(
-        <CustomerDeliveryTracking
+        <CustomerDeliveryTrackingFromRequest
             mapPath="/api/map/run-offline"
             tracking={{
                 status: 'offline',
                 lastAcceptedAt,
                 mapAvailable: false,
+                exactLocationExpiresInMs: null,
             }}
         />,
     );
@@ -78,12 +194,13 @@ test('customer sees unavailable state before the first accepted location', async
     page,
 }) => {
     await mount(
-        <CustomerDeliveryTracking
+        <CustomerDeliveryTrackingFromRequest
             mapPath="/api/map/run-unavailable"
             tracking={{
                 status: 'unavailable',
                 lastAcceptedAt: null,
                 mapAvailable: false,
+                exactLocationExpiresInMs: null,
             }}
         />,
     );

--- a/docs/delivery-customer-tracking.md
+++ b/docs/delivery-customer-tracking.md
@@ -1,0 +1,110 @@
+# Customer delivery promise and tracking
+
+The delivery customer dashboard answers three separate questions with separate,
+data-minimized fields:
+
+1. What time window did Gredice promise?
+2. What is the current ETA and how trustworthy is it?
+3. How far through the physical route is this delivery?
+
+The UI must not present an incoming route leg as the remaining time to a
+customer. Driver-only distance and leg-duration fields stay outside the
+customer DTO.
+
+## Promised window
+
+Every delivery card renders the complete `slotStartAt`–`slotEndAt` window. A
+malformed legacy record renders an explicit unavailable message rather than
+hiding the row.
+
+## ETA contract
+
+Customer delivery responses expose an `eta` object:
+
+- `source`: `traffic-route`, `route-plan`, or `promised-window`;
+- `calculatedAt`: server calculation time when a route estimate is used;
+- `freshness`: `fresh`, `stale`, `fallback`, or `unavailable`;
+- `confidence`: `high`, `approximate`, or `none`;
+- absolute range boundaries and remaining minimum/maximum seconds.
+
+A fresh traffic-aware Google estimate on a legacy route is presented as a
+deterministic display range from five minutes before to ten minutes after the
+point estimate. The lower boundary never precedes the current server projection
+time, and the range always retains at least five minutes. This is a display
+policy, not a statistical confidence interval.
+
+The traffic-aware state is derived only from constructible persisted evidence.
+For a legacy-format run, a GPS refresh or reroute through Google Routes must
+have left a marked, reversible encoded-polyline artifact, tracking must have an
+accepted location and must still be live or delayed, and the estimate
+calculation must still be fresh. Initial and unmarked legacy polylines are never
+treated as traffic provenance. The local estimator never creates the marker
+and explicitly clears any older Google artifact when its fallback is persisted.
+A legacy route without the marked artifact therefore falls back to the promised
+window. Pickup-aware Google plans use the separate approximate route-plan state.
+
+Pickup-aware route plans are not recalculated after every GPS update. Their
+fresh Google estimate is therefore labeled as an approximate `route-plan`, even
+while GPS is live. Local, legacy, stale, rerouting, unknown, and malformed
+estimates fall back conservatively to the complete promised window. A genuinely
+late fresh ETA is never clamped back into that window.
+
+Once the promised window has passed, it remains visible as the original promise
+but is no longer reused as a current ETA. The customer instead sees that the
+term has passed and that a new estimate is unavailable. Cross-day promised and
+ETA ranges include enough date context to avoid presenting next-day times as if
+they were on the same day. Stale route timestamps are labeled as the last route
+calculation, not as the calculation time of the substituted promised window.
+
+The shared exact-location TTL is also the route-estimate freshness horizon:
+two minutes from the server calculation timestamp. Future timestamps fail
+closed. Consuming a short-lived prepared route preserves the preparation's
+original calculation time instead of resetting freshness at activation.
+
+## Privacy-safe progress
+
+The `progress` object exposes only a phase, a nonnegative `stopsAhead` count,
+and a delayed flag. The count comes from authoritative unfinished execution
+checkpoints before the customer checkpoint:
+
+- one same-address/time-slot bulk group counts once;
+- pickup and retry checkpoints count as generic stops;
+- completed checkpoints do not count;
+- no stop ID, checkpoint kind, address, customer identity, route polyline, or
+  coordinate is exposed.
+
+The server uses only the presence of the marked persisted route artifact as
+internal provenance evidence. The polyline and marker are not included in the
+customer DTO.
+
+Only a server-confirmed current physical customer group can receive the exact
+map proxy. Later customers receive the safe count and ETA without another
+customer's location.
+
+## Tracking freshness
+
+Tracking remains orthogonal to ETA and progress:
+
+- `live`: accepted by the server within 30 seconds;
+- `delayed`: older than 30 seconds but still within the two-minute exact-data
+  TTL;
+- `offline`: past the TTL, with the exact map suppressed;
+- `unavailable`: no accepted active-run location.
+
+Customer responses include only status, last accepted time, map availability,
+and the server-calculated milliseconds remaining before exact-location expiry.
+Raw latitude, longitude, accuracy, heading, and speed remain behind the
+authorized current-stop map proxy.
+
+The customer client independently unmounts an already-rendered exact map after
+the server-calculated TTL remainder. It subtracts request, response, and render
+elapsed time using a monotonic request timer, with a nonnegative wall-time delta
+only as a conservative sleep fallback. Absolute customer device time is never
+compared with a server timestamp, and a delayed response cannot extend exact
+location visibility. The same elapsed-time calculation changes a cached `live`
+snapshot to `delayed` at the 30-second boundary even when dashboard polling
+stalls. Malformed tracking or ETA timestamps, impossible tracking states,
+numeric ranges, or illegal source/freshness/confidence combinations fail the
+runtime response guard before rendering.
+
+Dashboard and map responses use `Cache-Control: private, no-store`.

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -8,6 +8,7 @@
     "exports": {
         ".": "./src/index.ts",
         "./cmsPageContent": "./src/cmsPageContent.ts",
+        "./deliveryTrackingPolicy": "./src/deliveryTrackingPolicy.ts",
         "./entityCompleteness": "./src/helpers/entityCompleteness.ts",
         "./entityPageSections": "./src/helpers/entityPageSections.ts",
         "./cmsPageSections": "./src/cmsPageSections.ts"

--- a/packages/storage/src/deliveryTrackingPolicy.ts
+++ b/packages/storage/src/deliveryTrackingPolicy.ts
@@ -1,0 +1,35 @@
+export const deliveryRunTrackingLiveThresholdMs = 30 * 1000;
+export const deliveryRunExactLocationTtlMs = 2 * 60 * 1000;
+
+// `:` cannot occur in a Google encoded polyline (encoded values start at ASCII
+// 63), so this prefix is an unambiguous, reversible marker inside the existing
+// nullable column. Unmarked legacy values predate provider-safe persistence.
+const legacyGoogleRouteArtifactPrefix = 'gredice-google-v1:';
+
+export function persistLegacyGoogleRoutePolyline(
+    encodedPolyline: string | null | undefined,
+) {
+    return encodedPolyline
+        ? `${legacyGoogleRouteArtifactPrefix}${encodedPolyline}`
+        : null;
+}
+
+export function hasLegacyGoogleRouteArtifact(
+    encodedPolyline: string | null | undefined,
+) {
+    return Boolean(
+        encodedPolyline?.startsWith(legacyGoogleRouteArtifactPrefix) &&
+            encodedPolyline.length > legacyGoogleRouteArtifactPrefix.length,
+    );
+}
+
+export function deliveryRunRoutePolyline(
+    encodedPolyline: string | null | undefined,
+) {
+    if (!encodedPolyline) return null;
+    if (!encodedPolyline.startsWith(legacyGoogleRouteArtifactPrefix)) {
+        return encodedPolyline;
+    }
+    const route = encodedPolyline.slice(legacyGoogleRouteArtifactPrefix.length);
+    return route || null;
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -10,6 +10,7 @@ export * from './cache/grediceCached';
 export * from './cache/redisCache';
 export * from './cache/scheduleCache';
 export * from './cmsPageContent';
+export * from './deliveryTrackingPolicy';
 export * from './helpers/communityEditableFields';
 export * from './helpers/deliveryEmail';
 export * from './helpers/entityCompleteness';

--- a/packages/storage/src/repositories/deliveryRunsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRunsRepo.ts
@@ -20,6 +20,10 @@ import {
 } from 'drizzle-orm';
 import 'server-only';
 import {
+    deliveryRunExactLocationTtlMs,
+    persistLegacyGoogleRoutePolyline,
+} from '../deliveryTrackingPolicy';
+import {
     accountUsers,
     DeliveryRequestStates,
     type DeliveryRunCompletionBypass,
@@ -325,9 +329,6 @@ export class DeliveryRunExecutionError extends Error {
         super(message);
     }
 }
-
-export const deliveryRunTrackingLiveThresholdMs = 30 * 1000;
-export const deliveryRunExactLocationTtlMs = 2 * 60 * 1000;
 
 export type DeliveryRunExecutionStep =
     | {
@@ -1653,6 +1654,7 @@ function parsePreparationToken(preparationToken: string) {
 async function insertPreparedDeliveryRun(
     plan: DeliveryRunPreparationPlanPayload,
     preparationId: string,
+    estimatesCalculatedAt: Date,
     db: TransactionClient,
 ) {
     const runId = randomUUID();
@@ -1669,7 +1671,7 @@ async function insertPreparedDeliveryRun(
             plan.formatVersion === 1
                 ? DeliveryRunEstimateSources.LEGACY
                 : plan.createRunInput.estimateSource,
-        estimatesUpdatedAt: new Date(),
+        estimatesUpdatedAt: estimatesCalculatedAt,
     });
 
     const pickupNodeIdsByLocationId = new Map<number, string>();
@@ -1912,7 +1914,12 @@ export async function consumeDeliveryRunPreparation({
         await ensurePreparationCanCreateRun(plan, tx);
         await validatePreparationSnapshot(plan, tx);
         await validatePreparedBulkMembership(plan, tx);
-        return await insertPreparedDeliveryRun(plan, preparationId, tx);
+        return await insertPreparedDeliveryRun(
+            plan,
+            preparationId,
+            preparation.createdAt,
+            tx,
+        );
     });
 
     const run = await getDeliveryRun(runId);
@@ -4951,7 +4958,15 @@ export async function applyDeliveryRunReroute(
         const [updatedRun] = await tx
             .update(deliveryRuns)
             .set({
-                encodedPolyline: input.encodedPolyline ?? null,
+                encodedPolyline:
+                    run.routePlanVersion < 2
+                        ? input.estimateSource ===
+                          DeliveryRunEstimateSources.GOOGLE
+                            ? persistLegacyGoogleRoutePolyline(
+                                  input.encodedPolyline,
+                              )
+                            : null
+                        : (input.encodedPolyline ?? null),
                 totalDistanceMeters: input.totalDistanceMeters,
                 totalDurationSeconds: input.totalDurationSeconds,
                 estimateSource:
@@ -5346,7 +5361,8 @@ export async function updateDeliveryRunEstimates({
         const [updatedRun] = await tx
             .update(deliveryRuns)
             .set({
-                encodedPolyline,
+                encodedPolyline:
+                    persistLegacyGoogleRoutePolyline(encodedPolyline),
                 totalDistanceMeters,
                 totalDurationSeconds,
                 estimatesUpdatedAt: new Date(),
@@ -5356,6 +5372,7 @@ export async function updateDeliveryRunEstimates({
                     eq(deliveryRuns.id, runId),
                     eq(deliveryRuns.driverUserId, driverUserId),
                     eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+                    eq(deliveryRuns.routePlanVersion, 1),
                     eq(deliveryRuns.routeRevision, expectedRouteRevision),
                     eq(
                         deliveryRuns.currentLocationRecordedAt,

--- a/packages/storage/tests/deliveryRunsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRunsRepo.node.spec.ts
@@ -51,6 +51,7 @@ import {
     deliveryRunPickupOperations,
     deliveryRunPreparations,
     deliveryRunRerouteLeaseMs,
+    deliveryRunRoutePolyline,
     deliveryRunStopOperationOccurredAtIsAcceptable,
     deliveryRunStopOperations,
     deliveryRunStops,
@@ -70,6 +71,7 @@ import {
     getDeliveryRunHandoffManifest,
     getDeliveryRunStopsForRequestIds,
     harvestTraceLinks,
+    hasLegacyGoogleRouteArtifact,
     knownEvents,
     knownEventTypes,
     markDeliveryRunStopArrived,
@@ -1374,12 +1376,103 @@ test('a slower estimate calculation cannot overwrite the route for a newer accep
 
     assert.equal(await updateDeliveryRunEstimates(slowerOlderEstimate), false);
     const persisted = await getDeliveryRun(run.id);
-    assert.equal(persisted?.encodedPolyline, 'newer-route');
+    assert.equal(
+        hasLegacyGoogleRouteArtifact(persisted?.encodedPolyline),
+        true,
+    );
+    assert.equal(
+        deliveryRunRoutePolyline(persisted?.encodedPolyline),
+        'newer-route',
+    );
+    assert.equal(persisted?.estimateSource, 'legacy');
     assert.equal(persisted?.totalDistanceMeters, 3_000);
     assert.equal(persisted?.totalDurationSeconds, 600);
     assert.equal(persisted?.stops[0]?.estimatedTravelSeconds, 600);
     assert.equal(persisted?.stops[0]?.estimatedDistanceMeters, 3_000);
     assert.deepEqual(persisted?.stops[0]?.estimatedArrivalAt, newerArrivalAt);
+
+    const localRecordedAt = new Date('2026-07-13T08:10:20.000Z');
+    const localAcknowledgement = await updateDeliveryRunLocation({
+        runId: run.id,
+        driverUserId,
+        latitude: 45.83,
+        longitude: 15.99,
+        recordedAt: localRecordedAt,
+    });
+    assert.equal(
+        await updateDeliveryRunEstimates({
+            runId: run.id,
+            driverUserId,
+            expectedRouteRevision: run.routeRevision,
+            expectedLocationRecordedAt: localRecordedAt,
+            expectedLocationReceivedAt: localAcknowledgement.acceptedAt,
+            totalDistanceMeters: 2_500,
+            totalDurationSeconds: 500,
+            estimates: [
+                {
+                    deliveryRequestId: requestId,
+                    estimatedArrivalAt: new Date('2026-07-13T08:18:40.000Z'),
+                    estimatedTravelSeconds: 500,
+                    estimatedDistanceMeters: 2_500,
+                },
+            ],
+        }),
+        true,
+    );
+    const localPersisted = await getDeliveryRun(run.id);
+    assert.equal(localPersisted?.encodedPolyline, null);
+    assert.equal(localPersisted?.estimateSource, 'legacy');
+});
+
+test('legacy GPS estimate updates cannot mark a pickup-aware route', async () => {
+    const prepared = await createPreparedRunFixture();
+    const driverUserId = prepared.fixture.driverUserIds[0];
+    const requestId = prepared.fixture.requestIds[0];
+    assert.ok(driverUserId);
+    assert.ok(requestId);
+    const saved = await saveDeliveryRunPreparation(prepared);
+    const run = await consumeDeliveryRunPreparation({
+        preparationToken: saved.preparationToken,
+        driverUserId,
+        deliveryRequestIds: prepared.fixture.requestIds,
+    });
+    const recordedAt = new Date('2026-07-13T08:10:00.000Z');
+    const acknowledgement = await updateDeliveryRunLocation({
+        runId: run.id,
+        driverUserId,
+        latitude: 45.81,
+        longitude: 15.97,
+        recordedAt,
+    });
+
+    assert.equal(
+        await updateDeliveryRunEstimates({
+            runId: run.id,
+            driverUserId,
+            expectedRouteRevision: run.routeRevision,
+            expectedLocationRecordedAt: recordedAt,
+            expectedLocationReceivedAt: acknowledgement.acceptedAt,
+            encodedPolyline: 'must-not-mark-v2',
+            totalDistanceMeters: 1,
+            totalDurationSeconds: 1,
+            estimates: [
+                {
+                    deliveryRequestId: requestId,
+                    estimatedArrivalAt: new Date('2026-07-13T08:10:01.000Z'),
+                    estimatedTravelSeconds: 1,
+                    estimatedDistanceMeters: 1,
+                },
+            ],
+        }),
+        false,
+    );
+    const persisted = await getDeliveryRun(run.id);
+    assert.equal(persisted?.routePlanVersion, 2);
+    assert.equal(persisted?.estimateSource, DeliveryRunEstimateSources.LOCAL);
+    assert.equal(
+        deliveryRunRoutePolyline(persisted?.encodedPolyline),
+        deliveryRunRoutePolyline(run.encodedPolyline),
+    );
 });
 
 test('an estimate calculation cannot overwrite a route whose revision advanced at arrival', async () => {
@@ -2634,6 +2727,31 @@ test('persisted v3 itinerary tampering is rejected before run creation', async (
     );
 });
 
+test('prepared run preserves the route calculation time near token expiry', async () => {
+    const prepared = await createPreparedRunFixture();
+    const driverUserId = prepared.fixture.driverUserIds[0];
+    assert.ok(driverUserId);
+    const saved = await saveDeliveryRunPreparation(prepared);
+    const now = new Date();
+    const calculatedAt = new Date(now.getTime() - 110_000);
+    await storage()
+        .update(deliveryRunPreparations)
+        .set({
+            createdAt: calculatedAt,
+            expiresAt: new Date(now.getTime() + 10_000),
+        })
+        .where(eq(deliveryRunPreparations.id, saved.preparationId));
+
+    const run = await consumeDeliveryRunPreparation({
+        preparationToken: saved.preparationToken,
+        driverUserId,
+        deliveryRequestIds: prepared.fixture.requestIds,
+    });
+
+    assert.deepEqual(run.estimatesUpdatedAt, calculatedAt);
+    assert.ok(run.startedAt.getTime() - calculatedAt.getTime() >= 100_000);
+});
+
 test('existing v1 preparation tokens remain consumable as legacy routes', async () => {
     const prepared = await createPreparedRunFixture();
     const driverUserId = prepared.fixture.driverUserIds[0];
@@ -2647,12 +2765,19 @@ test('existing v1 preparation tokens remain consumable as legacy routes', async 
     if (preparation?.plan.formatVersion !== 3) {
         assert.fail('Expected a v3 delivery run preparation');
     }
+    const legacyPlan = asLegacyPreparationPlan(
+        asV2PreparationPlan(preparation.plan),
+    );
     await storage()
         .update(deliveryRunPreparations)
         .set({
-            plan: asLegacyPreparationPlan(
-                asV2PreparationPlan(preparation.plan),
-            ),
+            plan: {
+                ...legacyPlan,
+                createRunInput: {
+                    ...legacyPlan.createRunInput,
+                    encodedPolyline: 'initial-legacy-google-route',
+                },
+            },
         })
         .where(eq(deliveryRunPreparations.id, saved.preparationId));
 
@@ -2663,6 +2788,11 @@ test('existing v1 preparation tokens remain consumable as legacy routes', async 
     });
     assert.equal(run.routePlanVersion, 1);
     assert.equal(run.estimateSource, 'legacy');
+    assert.equal(hasLegacyGoogleRouteArtifact(run.encodedPolyline), false);
+    assert.equal(
+        deliveryRunRoutePolyline(run.encodedPolyline),
+        'initial-legacy-google-route',
+    );
     assert.ok(
         run.pickupNodes.every(
             (node) =>
@@ -4917,6 +5047,7 @@ test('legacy reroute keeps completed bulk sequences and legacy estimate provenan
         expectedRouteRevision: deferred.result.routeRevision,
         rerouteClaimedAt: claimedAt,
         estimateSource: DeliveryRunEstimateSources.GOOGLE,
+        encodedPolyline: 'rerouted-google-route',
         totalDistanceMeters: 2_000,
         totalDurationSeconds: 900,
         pickupEstimates: [],
@@ -4941,6 +5072,11 @@ test('legacy reroute keeps completed bulk sequences and legacy estimate provenan
     const rerouted = await getDeliveryRun(run.id);
     assert.equal(rerouted?.routePlanVersion, 1);
     assert.equal(rerouted?.estimateSource, DeliveryRunEstimateSources.LEGACY);
+    assert.equal(hasLegacyGoogleRouteArtifact(rerouted?.encodedPolyline), true);
+    assert.equal(
+        deliveryRunRoutePolyline(rerouted?.encodedPolyline),
+        'rerouted-google-route',
+    );
     assert.equal(
         rerouted?.stops.find((stop) => stop.id === currentStop.id)?.sequence,
         3,

--- a/packages/storage/tests/deliveryTrackingPolicy.node.spec.ts
+++ b/packages/storage/tests/deliveryTrackingPolicy.node.spec.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    deliveryRunRoutePolyline,
+    hasLegacyGoogleRouteArtifact,
+    persistLegacyGoogleRoutePolyline,
+} from '@gredice/storage';
+
+test('marks future legacy Google artifacts without trusting old raw polylines', () => {
+    const persisted = persistLegacyGoogleRoutePolyline('google-route');
+
+    assert.equal(hasLegacyGoogleRouteArtifact(persisted), true);
+    assert.equal(deliveryRunRoutePolyline(persisted), 'google-route');
+    assert.equal(hasLegacyGoogleRouteArtifact('old-raw-route'), false);
+    assert.equal(deliveryRunRoutePolyline('old-raw-route'), 'old-raw-route');
+});
+
+test('fails closed for empty legacy route artifacts', () => {
+    assert.equal(persistLegacyGoogleRoutePolyline(undefined), null);
+    assert.equal(persistLegacyGoogleRoutePolyline(null), null);
+    assert.equal(persistLegacyGoogleRoutePolyline(''), null);
+    assert.equal(hasLegacyGoogleRouteArtifact(null), false);
+    assert.equal(deliveryRunRoutePolyline(null), null);
+    const emptyMarked = persistLegacyGoogleRoutePolyline('route')?.replace(
+        'route',
+        '',
+    );
+    assert.equal(hasLegacyGoogleRouteArtifact(emptyMarked), false);
+    assert.equal(deliveryRunRoutePolyline(emptyMarked), null);
+});


### PR DESCRIPTION
## Summary

- replace customer-facing route-leg values with the complete promised window, confidence-qualified ETA ranges, and privacy-safe physical stops-ahead progress
- age customer tracking from live to delayed and then offline using server TTL remainder while subtracting request/render time without trusting the device clock
- preserve truthful ETA provenance for legacy runs with a reversible, no-schema Google route marker and keep original prepared-plan calculation time
- strictly validate customer ETA/tracking payloads, keep exact map access current-stop-only, and document the contract

## Safety and privacy

- same-address/time-slot bulk deliveries count as one physical stop
- customer payloads expose no other stop ID, address, identity, coordinate, or route polyline
- old/unmarked v1 polylines fail closed to promised-window fallback
- exact location is suppressed at the shared two-minute TTL, including stalled polling and delayed responses

## Validation

- `pnpm --filter delivery test:unit` — 349/349 passed
- `pnpm --filter delivery test:component` — 123/123 passed
- `pnpm --filter @gredice/storage test` — 547/547 passed
- `pnpm --filter delivery typecheck` — passed
- `pnpm --filter delivery build` — passed
- `pnpm --filter api build` — passed
- scoped Delivery and Storage Biome checks — passed
- `git diff --check` — passed
- independent final correctness/privacy/accessibility review — clean

The repo-wide `pnpm typecheck` still has the existing unrelated `apps/garden/tests/garden-tab.spec.tsx` import error for `Page` from `@playwright/experimental-ct-react`; the unchanged failure is also present on `origin/main`.

Closes #4136
