### PR TITLE
feat(delivery): organize customer delivery history

### DIFF
--- a/apps/delivery/components/CustomerDashboard.tsx
+++ b/apps/delivery/components/CustomerDashboard.tsx
@@ -1,8 +1,15 @@
+import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
-import { ShoppingCart, Truck } from '@gredice/ui/icons';
+import { History, Hourglass, ShoppingCart, Truck } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
+import { useEffect, useId, useRef, useState } from 'react';
+import {
+    customerDeliveryInitialHistoryCount,
+    organizeCustomerDeliverySections,
+} from '../lib/customerDeliverySections';
 import type {
     CustomerDeliveryDashboard,
+    CustomerDeliveryDashboardRequest,
     CustomerDeliveryRequestSummary,
 } from '../lib/deliveryDashboardTypes';
 import { CustomerDeliveryCard } from './CustomerDeliveryCard';
@@ -12,6 +19,37 @@ import {
 } from './CustomerDeliveryTracking';
 import { CustomerPickupCard } from './CustomerPickupCard';
 import { DeliveryAppHeader } from './DeliveryAppHeader';
+
+function CustomerRequestCard({
+    request,
+    emphasized = false,
+}: {
+    request: CustomerDeliveryDashboardRequest;
+    emphasized?: boolean;
+}) {
+    return request.mode === 'delivery' ? (
+        <CustomerDeliveryCard
+            delivery={request}
+            emphasized={emphasized}
+            headingLevel="h4"
+        />
+    ) : (
+        <CustomerPickupCard pickup={request} headingLevel="h4" />
+    );
+}
+
+function CustomerSectionEmpty({ children }: { children: string }) {
+    return (
+        <div
+            data-testid="customer-section-empty"
+            className="rounded-lg border border-dashed bg-background/70 px-4 py-5"
+        >
+            <Typography level="body3" className="text-muted-foreground">
+                {children}
+            </Typography>
+        </div>
+    );
+}
 
 export function CustomerDashboard({
     dashboard,
@@ -26,13 +64,53 @@ export function CustomerDashboard({
     const hasPickup = dashboard.deliveries.some(
         (request) => request.mode === 'pickup',
     );
-    const trackedDelivery = dashboard.deliveries.find(
+    const sections = organizeCustomerDeliverySections(dashboard.deliveries);
+    const hasActiveDelivery = sections.active.length > 0;
+    const trackedDelivery = sections.active.find(
         (request): request is CustomerDeliveryRequestSummary =>
-            request.mode === 'delivery' &&
-            Boolean(request.mapPath) &&
-            Boolean(request.tracking) &&
-            request.status !== 'fulfilled',
+            Boolean(request.mapPath) && Boolean(request.tracking),
     );
+    const [visibleHistoryCount, setVisibleHistoryCount] = useState(
+        customerDeliveryInitialHistoryCount,
+    );
+    const [historyFocusIndex, setHistoryFocusIndex] = useState<number | null>(
+        null,
+    );
+    const [historyAnnouncement, setHistoryAnnouncement] = useState('');
+    const revealedHistoryRef = useRef<HTMLElement>(null);
+    const activeHeadingId = useId();
+    const upcomingHeadingId = useId();
+    const historyHeadingId = useId();
+    const historyListId = useId();
+    const visibleHistory = sections.history.slice(0, visibleHistoryCount);
+    const hiddenHistoryCount = Math.max(
+        sections.history.length - visibleHistory.length,
+        0,
+    );
+    const historyCanCollapse =
+        visibleHistory.length > customerDeliveryInitialHistoryCount;
+    useEffect(() => {
+        if (historyFocusIndex === null) return;
+        revealedHistoryRef.current?.focus();
+    }, [historyFocusIndex]);
+    const revealMoreHistory = () => {
+        const nextCount = Math.min(
+            visibleHistoryCount + customerDeliveryInitialHistoryCount,
+            sections.history.length,
+        );
+        setHistoryFocusIndex(visibleHistory.length);
+        setVisibleHistoryCount(nextCount);
+        setHistoryAnnouncement(
+            `Prikazano ${nextCount} od ${sections.history.length} stavki povijesti.`,
+        );
+    };
+    const collapseHistory = () => {
+        setVisibleHistoryCount(customerDeliveryInitialHistoryCount);
+        setHistoryFocusIndex(null);
+        setHistoryAnnouncement(
+            `Povijest je sažeta. Prikazano ${customerDeliveryInitialHistoryCount} od ${sections.history.length}.`,
+        );
+    };
     const heading = hasDelivery
         ? hasPickup
             ? 'Moje dostave i preuzimanja'
@@ -52,8 +130,12 @@ export function CustomerDashboard({
             ? 'Statusi uroda i planirani termini dostava i preuzimanja na jednom mjestu.'
             : hasDelivery
               ? hasPickup
-                  ? 'Statusi uroda, planirani termini, lokacije preuzimanja i praćenje aktivne dostave na jednom mjestu.'
-                  : 'Statusi uroda, planirani termini i praćenje aktivne dostave na jednom mjestu.'
+                  ? hasActiveDelivery
+                      ? 'Statusi uroda, planirani termini, lokacije preuzimanja i praćenje aktivne dostave na jednom mjestu.'
+                      : 'Statusi uroda, planirani termini, lokacije preuzimanja i povijest na jednom mjestu.'
+                  : hasActiveDelivery
+                    ? 'Statusi uroda, planirani termini i praćenje aktivne dostave na jednom mjestu.'
+                    : 'Statusi uroda, planirani termini i povijest dostava na jednom mjestu.'
               : 'Statusi uroda, lokacije i planirani termini preuzimanja na jednom mjestu.';
 
     return (
@@ -74,30 +156,227 @@ export function CustomerDashboard({
                     </Typography>
                 </div>
 
-                {trackedDelivery?.mapPath && trackedDelivery.tracking ? (
-                    <CustomerDeliveryTracking
-                        mapPath={trackedDelivery.mapPath}
-                        tracking={trackedDelivery.tracking}
-                        requestTiming={requestTiming}
-                    />
-                ) : null}
-
                 {dashboard.deliveries.length > 0 ? (
-                    <section className="grid gap-3 lg:grid-cols-2">
-                        {dashboard.deliveries.map((request) =>
-                            request.mode === 'delivery' ? (
-                                <CustomerDeliveryCard
-                                    key={request.requestId}
-                                    delivery={request}
-                                />
+                    <div className="space-y-6">
+                        {hasDelivery ? (
+                            <section
+                                aria-labelledby={activeHeadingId}
+                                data-testid="customer-active-section"
+                                className="space-y-4 rounded-xl border border-primary/20 bg-primary/5 p-4 sm:p-5"
+                            >
+                                <div className="flex items-start gap-3">
+                                    <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+                                        <Truck className="size-5" />
+                                    </div>
+                                    <div>
+                                        <Typography
+                                            id={activeHeadingId}
+                                            component="h3"
+                                            level="h4"
+                                            semiBold
+                                        >
+                                            Aktivna dostava
+                                        </Typography>
+                                        <Typography
+                                            level="body3"
+                                            className="mt-1 text-muted-foreground"
+                                        >
+                                            Najvažniji status, procjena i
+                                            praćenje trenutačne rute.
+                                        </Typography>
+                                    </div>
+                                </div>
+
+                                {sections.active.length > 0 ? (
+                                    <>
+                                        {trackedDelivery?.mapPath &&
+                                        trackedDelivery.tracking ? (
+                                            <CustomerDeliveryTracking
+                                                mapPath={
+                                                    trackedDelivery.mapPath
+                                                }
+                                                tracking={
+                                                    trackedDelivery.tracking
+                                                }
+                                                requestTiming={requestTiming}
+                                            />
+                                        ) : null}
+                                        <div className="grid gap-3 lg:grid-cols-2">
+                                            {sections.active.map(
+                                                (request, index) => (
+                                                    <div
+                                                        key={request.requestId}
+                                                        className={
+                                                            index === 0
+                                                                ? 'lg:col-span-2'
+                                                                : undefined
+                                                        }
+                                                    >
+                                                        <CustomerRequestCard
+                                                            request={request}
+                                                            emphasized={
+                                                                index === 0
+                                                            }
+                                                        />
+                                                    </div>
+                                                ),
+                                            )}
+                                        </div>
+                                    </>
+                                ) : (
+                                    <CustomerSectionEmpty>
+                                        Trenutačno nema dostave na putu.
+                                    </CustomerSectionEmpty>
+                                )}
+                            </section>
+                        ) : null}
+
+                        <section
+                            aria-labelledby={upcomingHeadingId}
+                            data-testid="customer-upcoming-section"
+                            className="space-y-3"
+                        >
+                            <div className="flex items-center gap-2">
+                                <Hourglass className="size-5 text-muted-foreground" />
+                                <Typography
+                                    id={upcomingHeadingId}
+                                    component="h3"
+                                    level="h4"
+                                    semiBold
+                                >
+                                    Nadolazeće i potrebne radnje
+                                </Typography>
+                            </div>
+                            {sections.upcoming.length > 0 ? (
+                                <div className="grid gap-3 lg:grid-cols-2">
+                                    {sections.upcoming.map((request) => (
+                                        <CustomerRequestCard
+                                            key={request.requestId}
+                                            request={request}
+                                        />
+                                    ))}
+                                </div>
                             ) : (
-                                <CustomerPickupCard
-                                    key={request.requestId}
-                                    pickup={request}
-                                />
-                            ),
-                        )}
-                    </section>
+                                <CustomerSectionEmpty>
+                                    Nema nadolazećih termina ni radnji.
+                                </CustomerSectionEmpty>
+                            )}
+                        </section>
+
+                        <section
+                            aria-labelledby={historyHeadingId}
+                            data-testid="customer-history-section"
+                            className="space-y-3"
+                        >
+                            <div className="flex items-center justify-between gap-3">
+                                <div className="flex items-center gap-2">
+                                    <History className="size-5 text-muted-foreground" />
+                                    <Typography
+                                        id={historyHeadingId}
+                                        component="h3"
+                                        level="h4"
+                                        semiBold
+                                    >
+                                        Povijest
+                                    </Typography>
+                                </div>
+                                {sections.history.length > 0 ? (
+                                    <Typography
+                                        level="body3"
+                                        className="shrink-0 text-muted-foreground"
+                                    >
+                                        {visibleHistory.length} od{' '}
+                                        {sections.history.length}
+                                    </Typography>
+                                ) : null}
+                            </div>
+                            {sections.history.length > 0 ? (
+                                <>
+                                    <div
+                                        id={historyListId}
+                                        className="grid gap-3 lg:grid-cols-2"
+                                    >
+                                        {visibleHistory.map(
+                                            (request, index) => {
+                                                const isFirstRevealed =
+                                                    index === historyFocusIndex;
+                                                return (
+                                                    <article
+                                                        key={request.requestId}
+                                                        ref={
+                                                            isFirstRevealed
+                                                                ? revealedHistoryRef
+                                                                : undefined
+                                                        }
+                                                        aria-label={
+                                                            isFirstRevealed
+                                                                ? `Nova stavka povijesti: ${request.harvest.plantName}`
+                                                                : undefined
+                                                        }
+                                                        tabIndex={
+                                                            isFirstRevealed
+                                                                ? -1
+                                                                : undefined
+                                                        }
+                                                    >
+                                                        <CustomerRequestCard
+                                                            request={request}
+                                                        />
+                                                    </article>
+                                                );
+                                            },
+                                        )}
+                                    </div>
+                                    <div className="flex flex-wrap gap-2">
+                                        {historyCanCollapse &&
+                                        hiddenHistoryCount > 0 ? (
+                                            <Button
+                                                aria-controls={historyListId}
+                                                onClick={revealMoreHistory}
+                                                variant="outlined"
+                                                className="min-h-11"
+                                            >
+                                                {`Prikaži još (${hiddenHistoryCount})`}
+                                            </Button>
+                                        ) : null}
+                                        {sections.history.length >
+                                        customerDeliveryInitialHistoryCount ? (
+                                            <Button
+                                                aria-controls={historyListId}
+                                                onClick={
+                                                    historyCanCollapse
+                                                        ? collapseHistory
+                                                        : revealMoreHistory
+                                                }
+                                                variant={
+                                                    historyCanCollapse
+                                                        ? 'plain'
+                                                        : 'outlined'
+                                                }
+                                                className="min-h-11"
+                                            >
+                                                {historyCanCollapse
+                                                    ? 'Prikaži manje'
+                                                    : `Prikaži još (${hiddenHistoryCount})`}
+                                            </Button>
+                                        ) : null}
+                                    </div>
+                                    <span
+                                        className="sr-only"
+                                        role="status"
+                                        aria-live="polite"
+                                        aria-atomic="true"
+                                    >
+                                        {historyAnnouncement}
+                                    </span>
+                                </>
+                            ) : (
+                                <CustomerSectionEmpty>
+                                    Još nema dovršenih zahtjeva.
+                                </CustomerSectionEmpty>
+                            )}
+                        </section>
+                    </div>
                 ) : (
                     <Card>
                         <CardContent

--- a/apps/delivery/components/CustomerDeliveryCard.tsx
+++ b/apps/delivery/components/CustomerDeliveryCard.tsx
@@ -1,8 +1,19 @@
 import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
 import { Chip } from '@gredice/ui/Chip';
-import { Calendar, ExternalLink, Leaf, Timer, Truck } from '@gredice/ui/icons';
+import {
+    Calendar,
+    ExternalLink,
+    Info,
+    Leaf,
+    Mail,
+    MapPin,
+    Timer,
+    Truck,
+    User,
+} from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
+import { customerDeliveryRequestSupportHref } from '../lib/deliveryCustomerReceipt';
 import type { CustomerDeliveryRequestSummary } from '../lib/deliveryDashboardTypes';
 import {
     formatDeliveryDateTime,
@@ -36,8 +47,12 @@ function statusColor(
 
 export function CustomerDeliveryCard({
     delivery,
+    emphasized = false,
+    headingLevel = 'h3',
 }: {
     delivery: CustomerDeliveryRequestSummary;
+    emphasized?: boolean;
+    headingLevel?: 'h3' | 'h4';
 }) {
     const showDeliveryPromise =
         delivery.status !== 'fulfilled' &&
@@ -54,9 +69,23 @@ export function CustomerDeliveryCard({
     ]
         .filter(Boolean)
         .join(' · ');
+    const supportHref = customerDeliveryRequestSupportHref({
+        kind: 'support',
+        delivery: {
+            requestReference: delivery.requestId,
+            harvest: delivery.harvest,
+        },
+    });
 
     return (
-        <Card data-testid="customer-delivery-card" className="min-w-0">
+        <Card
+            data-testid="customer-delivery-card"
+            className={
+                emphasized
+                    ? 'min-w-0 border-primary/40 shadow-md ring-1 ring-primary/20'
+                    : 'min-w-0'
+            }
+        >
             <CardContent noHeader className="min-w-0 space-y-4 p-4">
                 <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                     <div className="flex min-w-0 items-start gap-3">
@@ -65,7 +94,7 @@ export function CustomerDeliveryCard({
                         </div>
                         <div className="min-w-0">
                             <Typography
-                                component="h3"
+                                component={headingLevel}
                                 level="body1"
                                 semiBold
                                 className="break-words"
@@ -117,8 +146,90 @@ export function CustomerDeliveryCard({
                 ) : null}
 
                 {delivery.recovery ? (
-                    <DeliveryCustomerRecovery recovery={delivery.recovery} />
+                    <DeliveryCustomerRecovery
+                        recovery={delivery.recovery}
+                        requestReference={delivery.requestId}
+                        harvest={delivery.harvest}
+                    />
                 ) : null}
+
+                <div className="space-y-3 rounded-lg bg-muted/70 p-3">
+                    <div className="flex items-start gap-2 text-sm">
+                        <User className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                        <div className="min-w-0">
+                            <Typography
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                Primatelj
+                            </Typography>
+                            <Typography
+                                level="body2"
+                                semiBold
+                                className="break-words"
+                            >
+                                {delivery.destination.recipientName}
+                            </Typography>
+                        </div>
+                    </div>
+                    <div className="flex items-start gap-2 text-sm">
+                        <MapPin className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                        <div className="min-w-0">
+                            <Typography
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                Odredište
+                            </Typography>
+                            {delivery.destination.addressLabel ? (
+                                <Typography
+                                    level="body2"
+                                    semiBold
+                                    className="break-words"
+                                >
+                                    {delivery.destination.addressLabel}
+                                </Typography>
+                            ) : null}
+                            <Typography level="body3" className="break-words">
+                                {delivery.destination.address}
+                            </Typography>
+                        </div>
+                    </div>
+                    {delivery.requestNotes ? (
+                        <div className="flex items-start gap-2 text-sm">
+                            <Info className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                            <div className="min-w-0">
+                                <Typography
+                                    level="body3"
+                                    className="text-muted-foreground"
+                                >
+                                    Upute za dostavu
+                                </Typography>
+                                <Typography
+                                    level="body3"
+                                    className="break-words"
+                                >
+                                    {delivery.requestNotes}
+                                </Typography>
+                            </div>
+                        </div>
+                    ) : (
+                        <div className="flex items-start gap-2 text-sm">
+                            <Info className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                            <div className="min-w-0">
+                                <Typography
+                                    level="body3"
+                                    className="text-muted-foreground"
+                                >
+                                    Upute za dostavu
+                                </Typography>
+                                <Typography level="body3">
+                                    Nema posebnih uputa.
+                                </Typography>
+                            </div>
+                        </div>
+                    )}
+                </div>
 
                 {!delivery.receipt ? (
                     <div className="flex items-start gap-2 text-sm">
@@ -126,12 +237,6 @@ export function CustomerDeliveryCard({
                         <span className="break-words">
                             {harvestDescription}
                         </span>
-                    </div>
-                ) : null}
-
-                {delivery.requestNotes ? (
-                    <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
-                        <strong>Napomena:</strong> {delivery.requestNotes}
                     </div>
                 ) : null}
 
@@ -151,10 +256,23 @@ export function CustomerDeliveryCard({
                     </div>
                 ) : null}
 
+                {!delivery.receipt && !delivery.recovery ? (
+                    <Button
+                        aria-label={`Prijavi problem za dostavu: ${delivery.harvest.plantName}`}
+                        href={supportHref}
+                        size="sm"
+                        variant="outlined"
+                        className="min-h-11 min-w-0 justify-start whitespace-normal"
+                        startDecorator={<Mail className="size-4" />}
+                    >
+                        Prijavi problem
+                    </Button>
+                ) : null}
+
                 {delivery.receipt ? (
                     <DeliveryCustomerReceipt
                         receipt={delivery.receipt}
-                        headingLevel="h4"
+                        headingLevel={headingLevel === 'h4' ? 'h5' : 'h4'}
                     />
                 ) : null}
 

--- a/apps/delivery/components/CustomerPickupCard.tsx
+++ b/apps/delivery/components/CustomerPickupCard.tsx
@@ -7,11 +7,13 @@ import {
     ExternalLink,
     Info,
     Leaf,
+    Mail,
     MapPin,
     ShoppingCart,
     Timer,
 } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
+import { customerPickupSupportHref } from '../lib/deliveryCustomerReceipt';
 import type { CustomerPickupRequestSummary } from '../lib/deliveryDashboardTypes';
 import {
     formatDeliveryDateTime,
@@ -30,8 +32,10 @@ function statusColor(
 
 export function CustomerPickupCard({
     pickup,
+    headingLevel = 'h3',
 }: {
     pickup: CustomerPickupRequestSummary;
+    headingLevel?: 'h3' | 'h4';
 }) {
     const harvestDescription = [
         pickup.harvest.plantName,
@@ -43,6 +47,7 @@ export function CustomerPickupCard({
     const navigationUrl = pickup.location
         ? `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(pickup.location.address)}`
         : null;
+    const supportHref = customerPickupSupportHref(pickup);
 
     return (
         <Card data-testid="customer-pickup-card" className="min-w-0">
@@ -54,7 +59,7 @@ export function CustomerPickupCard({
                         </div>
                         <div className="min-w-0">
                             <Typography
-                                component="h3"
+                                component={headingLevel}
                                 level="body1"
                                 semiBold
                                 className="break-words"
@@ -148,8 +153,8 @@ export function CustomerPickupCard({
                     </div>
                 ) : null}
 
-                {pickup.harvest.tracePath ? (
-                    <div className="flex flex-wrap gap-2">
+                <div className="flex flex-wrap gap-2">
+                    {pickup.harvest.tracePath ? (
                         <Button
                             aria-label={`Otvori trag uroda: ${pickup.harvest.plantName}`}
                             href={`https://www.gredice.com${pickup.harvest.tracePath}`}
@@ -161,8 +166,18 @@ export function CustomerPickupCard({
                         >
                             Trag uroda
                         </Button>
-                    </div>
-                ) : null}
+                    ) : null}
+                    <Button
+                        aria-label={`Kontaktiraj podršku za preuzimanje: ${pickup.harvest.plantName}`}
+                        href={supportHref}
+                        size="sm"
+                        variant="outlined"
+                        className="min-h-11 min-w-0 justify-start whitespace-normal"
+                        startDecorator={<Mail className="size-4" />}
+                    >
+                        Kontaktiraj podršku
+                    </Button>
+                </div>
 
                 {pickup.pickedUpAt ? (
                     <Typography

--- a/apps/delivery/components/DeliveryCustomerReceipt.tsx
+++ b/apps/delivery/components/DeliveryCustomerReceipt.tsx
@@ -15,7 +15,7 @@ export function DeliveryCustomerReceipt({
     headingLevel = 'h3',
 }: {
     receipt: CustomerDeliveryReceiptSummary;
-    headingLevel?: 'h3' | 'h4';
+    headingLevel?: 'h3' | 'h4' | 'h5';
 }) {
     const headingId = useId();
     const harvestDescription = [

--- a/apps/delivery/components/DeliveryCustomerRecovery.tsx
+++ b/apps/delivery/components/DeliveryCustomerRecovery.tsx
@@ -1,30 +1,55 @@
 import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { Info, Mail, MapPin, Reset, Warning } from '@gredice/ui/icons';
-import { PublicPagePaths, publicChromeHref } from '@gredice/ui/PublicChrome';
 import { Typography } from '@gredice/ui/Typography';
-import type { CustomerDeliveryRecoverySummary } from '../lib/deliveryDashboardTypes';
+import { customerDeliveryRequestSupportHref } from '../lib/deliveryCustomerReceipt';
+import type {
+    CustomerDeliveryRecoverySummary,
+    DeliveryHarvestSummary,
+} from '../lib/deliveryDashboardTypes';
 import { formatDeliveryDateTime } from '../lib/deliveryFormatting';
 
 export function DeliveryCustomerRecovery({
     recovery,
+    requestReference,
+    harvest,
 }: {
     recovery: CustomerDeliveryRecoverySummary;
+    requestReference: string;
+    harvest: DeliveryHarvestSummary;
 }) {
-    const supportHref = publicChromeHref(PublicPagePaths.Contact, 'www-origin');
+    const supportHref = customerDeliveryRequestSupportHref({
+        kind: 'support',
+        delivery: { requestReference, harvest },
+    });
     if (recovery.kind === 'retry-planned') {
         return (
             <Alert
                 color="warning"
                 startDecorator={<Reset className="size-5" />}
             >
-                <Typography level="body2" semiBold>
-                    Ponovni pokušaj je planiran
-                </Typography>
-                <Typography level="body3" className="mt-1">
-                    Vozač nastavlja rutu i vratit će se kasnije. Novo vrijeme
-                    dolaska prikazat će se čim ruta bude ažurirana.
-                </Typography>
+                <div className="space-y-3">
+                    <div>
+                        <Typography level="body2" semiBold>
+                            Ponovni pokušaj je planiran
+                        </Typography>
+                        <Typography level="body3" className="mt-1">
+                            Vozač nastavlja rutu i vratit će se kasnije. Novo
+                            vrijeme dolaska prikazat će se čim ruta bude
+                            ažurirana.
+                        </Typography>
+                    </div>
+                    <Button
+                        aria-label={`Prijavi problem za dostavu: ${harvest.plantName}`}
+                        href={supportHref}
+                        size="sm"
+                        className="min-h-11"
+                        variant="outlined"
+                        startDecorator={<Mail className="size-4" />}
+                    >
+                        Prijavi problem
+                    </Button>
+                </div>
             </Alert>
         );
     }
@@ -61,20 +86,22 @@ export function DeliveryCustomerRecovery({
                     </div>
                     <div className="flex flex-wrap gap-2">
                         <Button
+                            aria-label={`Potvrdi preuzimanje za dostavu: ${harvest.plantName}`}
                             href={supportHref}
-                            target="_blank"
-                            rel="noopener noreferrer"
                             size="sm"
+                            className="min-h-11"
                             variant="outlined"
                             startDecorator={<Mail className="size-4" />}
                         >
                             Potvrdi preuzimanje
                         </Button>
                         <Button
+                            aria-label={`Otvori lokaciju HQ za dostavu: ${harvest.plantName}`}
                             href={navigationUrl}
                             target="_blank"
                             rel="noopener noreferrer"
                             size="sm"
+                            className="min-h-11"
                             variant="outlined"
                             startDecorator={<MapPin className="size-4" />}
                         >
@@ -104,10 +131,10 @@ export function DeliveryCustomerRecovery({
                         </Typography>
                     </div>
                     <Button
+                        aria-label={`Kontaktiraj podršku za dostavu: ${harvest.plantName}`}
                         href={supportHref}
-                        target="_blank"
-                        rel="noopener noreferrer"
                         size="sm"
+                        className="min-h-11"
                         variant="outlined"
                         startDecorator={<Mail className="size-4" />}
                     >
@@ -138,10 +165,10 @@ export function DeliveryCustomerRecovery({
                     </Typography>
                 </div>
                 <Button
+                    aria-label={`Kontaktiraj podršku za dostavu: ${harvest.plantName}`}
                     href={supportHref}
-                    target="_blank"
-                    rel="noopener noreferrer"
                     size="sm"
+                    className="min-h-11"
                     variant="outlined"
                     startDecorator={<Mail className="size-4" />}
                 >

--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -198,6 +198,9 @@ function isCustomerDashboardRequest(value: unknown) {
     if (
         !isRecord(value) ||
         typeof value.requestId !== 'string' ||
+        (value.lifecycle !== 'active' &&
+            value.lifecycle !== 'upcoming' &&
+            value.lifecycle !== 'history') ||
         typeof value.status !== 'string' ||
         typeof value.statusLabel !== 'string' ||
         !isNullableString(value.requestNotes) ||
@@ -209,6 +212,7 @@ function isCustomerDashboardRequest(value: unknown) {
     }
     if (value.mode === 'pickup') {
         return (
+            value.lifecycle !== 'active' &&
             isNullableString(value.pickedUpAt) &&
             (value.location === null ||
                 (isRecord(value.location) &&
@@ -222,6 +226,10 @@ function isCustomerDashboardRequest(value: unknown) {
         isCustomerDeliveryEtaSummary(value.eta) &&
         isCustomerProgress(value.progress) &&
         isNullableString(value.deliveredAt) &&
+        isRecord(value.destination) &&
+        typeof value.destination.recipientName === 'string' &&
+        typeof value.destination.address === 'string' &&
+        isNullableString(value.destination.addressLabel) &&
         isCustomerDeliveryTrackingSummary(value.tracking) &&
         isNullableString(value.mapPath) &&
         (value.receipt === null || isRecord(value.receipt)) &&

--- a/apps/delivery/components/DeliveryStopCard.tsx
+++ b/apps/delivery/components/DeliveryStopCard.tsx
@@ -249,7 +249,11 @@ export function DeliveryStopCard({
                 ) : null}
 
                 {!driverMode && stop.recovery ? (
-                    <DeliveryCustomerRecovery recovery={stop.recovery} />
+                    <DeliveryCustomerRecovery
+                        recovery={stop.recovery}
+                        requestReference={stop.requestId}
+                        harvest={stop.harvest}
+                    />
                 ) : null}
 
                 {driverMode && showDriverCommand ? (

--- a/apps/delivery/lib/customerDeliveryPresentation.node.spec.ts
+++ b/apps/delivery/lib/customerDeliveryPresentation.node.spec.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    customerDeliveryLifecycle,
     customerDeliveryRequestSummary,
     customerPickupInstructions,
+    customerPickupLifecycle,
     customerPickupRequestSummary,
     customerPickupStatusLabel,
 } from './customerDeliveryPresentation';
@@ -26,10 +28,10 @@ test('projects a delivery to the exact customer-safe DTO', () => {
         requestState: 'ready',
         statusLabel: 'Vozač stiže',
         isCurrent: true,
-        contactName: privateSentinel,
+        contactName: 'Korina Kupac',
         phone: privateSentinel,
-        address: privateSentinel,
-        addressLabel: privateSentinel,
+        address: 'Ilica 1, 10000 Zagreb, HR',
+        addressLabel: 'Dom',
         requestNotes: 'Pozvoni na portafon.',
         deliveryNotes: privateSentinel,
         slotStartAt: '2026-07-16T10:00:00.000Z',
@@ -86,6 +88,7 @@ test('projects a delivery to the exact customer-safe DTO', () => {
 
     assert.deepEqual(projected, {
         mode: 'delivery',
+        lifecycle: 'active',
         requestId: 'request-delivery',
         status: 'ready',
         statusLabel: 'Vozač stiže',
@@ -109,6 +112,11 @@ test('projects a delivery to the exact customer-safe DTO', () => {
         },
         deliveredAt: null,
         harvest,
+        destination: {
+            recipientName: 'Korina Kupac',
+            address: 'Ilica 1, 10000 Zagreb, HR',
+            addressLabel: 'Dom',
+        },
         receipt: null,
         recovery: null,
         tracking: {
@@ -125,9 +133,7 @@ test('projects a delivery to the exact customer-safe DTO', () => {
         'id',
         'sequence',
         'stopState',
-        'contactName',
         'phone',
-        'address',
         'deliveryNotes',
         'runId',
         'deliveries',
@@ -180,6 +186,7 @@ test('projects pickup status, public location, and instructions without delivery
 
     assert.deepEqual(projected, {
         mode: 'pickup',
+        lifecycle: 'upcoming',
         requestId: 'request-pickup',
         status: 'ready',
         statusLabel: 'Spremno za preuzimanje',
@@ -289,5 +296,51 @@ test('uses pickup-safe copy for every request state', () => {
     assert.equal(
         customerPickupInstructions('confirmed'),
         'Pričekaj status „Spremno za preuzimanje” prije dolaska.',
+    );
+});
+
+test('derives a server-authoritative customer lifecycle when progress fails closed', () => {
+    assert.equal(
+        customerDeliveryLifecycle({
+            requestState: 'ready',
+            runState: 'active',
+            deliveredAt: null,
+            recovery: null,
+        }),
+        'active',
+    );
+    assert.equal(
+        customerDeliveryLifecycle({
+            requestState: 'failed',
+            runState: 'active',
+            deliveredAt: null,
+            recovery: {
+                kind: 'hq-pickup',
+                pickupAddress: 'Gredice HQ',
+                pickupDeadlineAt: '2026-07-19T10:00:00.000Z',
+                pickupWindowHours: 72,
+            },
+        }),
+        'upcoming',
+    );
+    assert.equal(
+        customerDeliveryLifecycle({
+            requestState: 'fulfilled',
+            runState: 'active',
+            deliveredAt: '2026-07-16T10:00:00.000Z',
+            recovery: null,
+        }),
+        'history',
+    );
+    assert.equal(
+        customerPickupLifecycle({ status: 'ready', pickedUpAt: null }),
+        'upcoming',
+    );
+    assert.equal(
+        customerPickupLifecycle({
+            status: 'ready',
+            pickedUpAt: '2026-07-16T10:00:00.000Z',
+        }),
+        'history',
     );
 });

--- a/apps/delivery/lib/customerDeliveryPresentation.ts
+++ b/apps/delivery/lib/customerDeliveryPresentation.ts
@@ -14,6 +14,9 @@ type CustomerDeliveryProjectionSource = Pick<
     | 'requestId'
     | 'requestState'
     | 'statusLabel'
+    | 'contactName'
+    | 'address'
+    | 'addressLabel'
     | 'requestNotes'
     | 'slotStartAt'
     | 'slotEndAt'
@@ -40,6 +43,45 @@ export type CustomerDeliveryProjectionContext = Pick<
     | 'trackingLastAcceptedAt'
 >;
 
+export function customerDeliveryLifecycle({
+    requestState,
+    runState,
+    deliveredAt,
+    recovery,
+}: {
+    requestState: string;
+    runState: string | null;
+    deliveredAt: string | null;
+    recovery: CustomerDeliveryRequestSummary['recovery'];
+}): CustomerDeliveryRequestSummary['lifecycle'] {
+    if (
+        deliveredAt ||
+        requestState === 'fulfilled' ||
+        requestState === 'cancelled'
+    ) {
+        return 'history';
+    }
+    if (requestState === 'failed') {
+        return recovery?.kind === 'hq-pickup' ? 'upcoming' : 'history';
+    }
+    return runState === 'active' ? 'active' : 'upcoming';
+}
+
+export function customerPickupLifecycle({
+    status,
+    pickedUpAt,
+}: Pick<
+    CustomerPickupRequestSummary,
+    'status' | 'pickedUpAt'
+>): CustomerPickupRequestSummary['lifecycle'] {
+    return pickedUpAt ||
+        status === 'fulfilled' ||
+        status === 'failed' ||
+        status === 'cancelled'
+        ? 'history'
+        : 'upcoming';
+}
+
 export function customerDeliveryRequestSummary(
     source: CustomerDeliveryProjectionSource,
     context: CustomerDeliveryProjectionContext,
@@ -55,6 +97,12 @@ export function customerDeliveryRequestSummary(
     });
     return {
         mode: 'delivery',
+        lifecycle: customerDeliveryLifecycle({
+            requestState: source.requestState,
+            runState: context.runState,
+            deliveredAt: source.deliveredAt,
+            recovery: source.recovery,
+        }),
         requestId: source.requestId,
         status: source.requestState,
         statusLabel: source.statusLabel,
@@ -65,6 +113,11 @@ export function customerDeliveryRequestSummary(
         progress,
         deliveredAt: source.deliveredAt,
         harvest: source.harvest,
+        destination: {
+            recipientName: source.contactName,
+            address: source.address,
+            addressLabel: source.addressLabel,
+        },
         receipt: source.receipt ?? null,
         recovery: source.recovery,
         tracking,
@@ -120,9 +173,10 @@ export function customerPickupRequestSummary({
     harvest,
     location,
     pickedUpAt,
-}: Omit<CustomerPickupRequestSummary, 'mode' | 'statusLabel'>) {
+}: Omit<CustomerPickupRequestSummary, 'mode' | 'lifecycle' | 'statusLabel'>) {
     return {
         mode: 'pickup',
+        lifecycle: customerPickupLifecycle({ status, pickedUpAt }),
         requestId,
         status,
         statusLabel: customerPickupStatusLabel(status),

--- a/apps/delivery/lib/customerDeliverySections.node.spec.ts
+++ b/apps/delivery/lib/customerDeliverySections.node.spec.ts
@@ -1,0 +1,367 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    customerDeliveryInitialHistoryCount,
+    organizeCustomerDeliverySections,
+} from './customerDeliverySections';
+import type {
+    CustomerDeliveryDashboardRequest,
+    CustomerDeliveryProgressSummary,
+    CustomerDeliveryRequestSummary,
+    CustomerPickupRequestSummary,
+} from './deliveryDashboardTypes';
+
+const harvest = {
+    plantName: 'Rajčica',
+    operationName: 'Berba',
+    raisedBedName: 'Gredica 4',
+    fieldName: 'Polje 2',
+    tracePath: '/trag/customer-owned',
+};
+
+function delivery({
+    requestId,
+    status = 'confirmed',
+    lifecycle = 'upcoming',
+    phase = 'scheduled',
+    stopsAhead = null,
+    slotStartAt = '2026-07-16T10:00:00.000Z',
+    slotEndAt = '2026-07-16T12:00:00.000Z',
+    deliveredAt = null,
+    recovery = null,
+}: {
+    requestId: string;
+    status?: string;
+    lifecycle?: CustomerDeliveryRequestSummary['lifecycle'];
+    phase?: CustomerDeliveryProgressSummary['phase'];
+    stopsAhead?: number | null;
+    slotStartAt?: string | null;
+    slotEndAt?: string | null;
+    deliveredAt?: string | null;
+    recovery?: CustomerDeliveryRequestSummary['recovery'];
+}): CustomerDeliveryRequestSummary {
+    return {
+        mode: 'delivery',
+        requestId,
+        status,
+        lifecycle,
+        statusLabel: status,
+        requestNotes: null,
+        slotStartAt,
+        slotEndAt,
+        eta: {
+            source: 'promised-window',
+            calculatedAt: null,
+            freshness: 'fallback',
+            confidence: 'approximate',
+            rangeStartAt: slotStartAt,
+            rangeEndAt: slotEndAt,
+            remainingMinSeconds: null,
+            remainingMaxSeconds: null,
+        },
+        progress: { phase, stopsAhead, delayed: false },
+        deliveredAt,
+        harvest,
+        destination: {
+            recipientName: 'Kupac',
+            address: 'Vrtna 1, 10000 Zagreb, HR',
+            addressLabel: 'Dom',
+        },
+        receipt: null,
+        recovery,
+        tracking: null,
+        mapPath: null,
+    };
+}
+
+function pickup({
+    requestId,
+    status = 'confirmed',
+    lifecycle = 'upcoming',
+    slotStartAt = '2026-07-16T10:00:00.000Z',
+    slotEndAt = '2026-07-16T12:00:00.000Z',
+    pickedUpAt = null,
+}: {
+    requestId: string;
+    status?: string;
+    lifecycle?: CustomerPickupRequestSummary['lifecycle'];
+    slotStartAt?: string | null;
+    slotEndAt?: string | null;
+    pickedUpAt?: string | null;
+}): CustomerPickupRequestSummary {
+    return {
+        mode: 'pickup',
+        requestId,
+        status,
+        lifecycle,
+        statusLabel: status,
+        requestNotes: null,
+        slotStartAt,
+        slotEndAt,
+        harvest,
+        location: null,
+        pickedUpAt,
+    };
+}
+
+function requestIds(requests: readonly CustomerDeliveryDashboardRequest[]) {
+    return requests.map(({ requestId }) => requestId);
+}
+
+test('organizes mixed delivery and pickup requests by lifecycle and time', () => {
+    const requests = [
+        delivery({
+            requestId: 'upcoming-delivery-later',
+            slotStartAt: '2026-07-16T14:00:00.000Z',
+        }),
+        pickup({
+            requestId: 'history-pickup',
+            status: 'fulfilled',
+            lifecycle: 'history',
+            pickedUpAt: '2026-07-16T11:30:00.000Z',
+        }),
+        delivery({
+            requestId: 'active-delivery',
+            status: 'ready',
+            lifecycle: 'active',
+            phase: 'next',
+            stopsAhead: 0,
+        }),
+        pickup({
+            requestId: 'upcoming-pickup-first',
+            status: 'ready',
+            slotStartAt: '2026-07-16T09:00:00.000Z',
+        }),
+        delivery({
+            requestId: 'history-delivery',
+            status: 'fulfilled',
+            lifecycle: 'history',
+            deliveredAt: '2026-07-16T10:30:00.000Z',
+        }),
+        delivery({
+            requestId: 'history-failed',
+            status: 'failed',
+            lifecycle: 'history',
+            phase: 'arrived',
+            slotStartAt: '2026-07-16T08:00:00.000Z',
+            recovery: { kind: 'support' },
+        }),
+    ];
+
+    const sections = organizeCustomerDeliverySections(requests);
+
+    assert.deepEqual(requestIds(sections.active), ['active-delivery']);
+    assert.deepEqual(requestIds(sections.upcoming), [
+        'upcoming-pickup-first',
+        'upcoming-delivery-later',
+    ]);
+    assert.deepEqual(requestIds(sections.history), [
+        'history-failed',
+        'history-pickup',
+        'history-delivery',
+    ]);
+    assert.equal(customerDeliveryInitialHistoryCount, 6);
+});
+
+test('uses the server lifecycle without inferring sections from request status', () => {
+    const sections = organizeCustomerDeliverySections([
+        delivery({
+            requestId: 'fulfilled-but-upcoming',
+            status: 'fulfilled',
+            lifecycle: 'upcoming',
+        }),
+        delivery({
+            requestId: 'ready-but-history',
+            status: 'ready',
+            lifecycle: 'history',
+        }),
+        delivery({
+            requestId: 'failed-but-active',
+            status: 'failed',
+            lifecycle: 'active',
+            phase: 'unavailable',
+        }),
+    ]);
+
+    assert.deepEqual(requestIds(sections.active), ['failed-but-active']);
+    assert.deepEqual(requestIds(sections.upcoming), ['fulfilled-but-upcoming']);
+    assert.deepEqual(requestIds(sections.history), ['ready-but-history']);
+});
+
+test('keeps multiple active bulk requests and orders active phases and progress', () => {
+    const requests = [
+        delivery({
+            requestId: 'bulk-second',
+            status: 'ready',
+            lifecycle: 'active',
+            phase: 'on-route',
+            stopsAhead: 2,
+        }),
+        delivery({
+            requestId: 'on-route-unknown',
+            status: 'ready',
+            lifecycle: 'active',
+            phase: 'on-route',
+            stopsAhead: null,
+        }),
+        delivery({
+            requestId: 'next',
+            status: 'ready',
+            lifecycle: 'active',
+            phase: 'next',
+            stopsAhead: 0,
+        }),
+        delivery({
+            requestId: 'bulk-first',
+            status: 'ready',
+            lifecycle: 'active',
+            phase: 'on-route',
+            stopsAhead: 2,
+        }),
+        delivery({
+            requestId: 'arrived',
+            status: 'ready',
+            lifecycle: 'active',
+            phase: 'arrived',
+            stopsAhead: 0,
+        }),
+        delivery({
+            requestId: 'on-route-first',
+            status: 'ready',
+            lifecycle: 'active',
+            phase: 'on-route',
+            stopsAhead: 1,
+        }),
+        delivery({
+            requestId: 'active-unavailable',
+            status: 'ready',
+            lifecycle: 'active',
+            phase: 'unavailable',
+            stopsAhead: null,
+        }),
+    ];
+
+    const sections = organizeCustomerDeliverySections(requests);
+
+    assert.deepEqual(requestIds(sections.active), [
+        'arrived',
+        'next',
+        'on-route-first',
+        'bulk-second',
+        'bulk-first',
+        'on-route-unknown',
+        'active-unavailable',
+    ]);
+    assert.equal(sections.active.length, requests.length);
+});
+
+test('fails malformed and null dates to the end without changing stable ties', () => {
+    const requests = [
+        pickup({
+            requestId: 'upcoming-invalid-first',
+            slotStartAt: 'not-a-date',
+            slotEndAt: null,
+        }),
+        delivery({
+            requestId: 'history-invalid-first',
+            status: 'cancelled',
+            lifecycle: 'history',
+            deliveredAt: '2026-02-31T10:00:00.000Z',
+            slotStartAt: null,
+            slotEndAt: null,
+        }),
+        delivery({
+            requestId: 'upcoming-later',
+            slotStartAt: '2026-07-16T12:00:00.000Z',
+        }),
+        pickup({
+            requestId: 'history-slot-fallback',
+            status: 'failed',
+            lifecycle: 'history',
+            pickedUpAt: 'invalid',
+            slotStartAt: '2026-07-16T13:00:00.000Z',
+        }),
+        pickup({
+            requestId: 'upcoming-null-second',
+            slotStartAt: null,
+            slotEndAt: null,
+        }),
+        delivery({
+            requestId: 'history-completed',
+            status: 'fulfilled',
+            lifecycle: 'history',
+            deliveredAt: '2026-07-16T14:00:00.000Z',
+        }),
+        delivery({
+            requestId: 'upcoming-earlier',
+            slotStartAt: '2026-07-16T09:00:00.000Z',
+        }),
+        pickup({
+            requestId: 'history-null-second',
+            status: 'fulfilled',
+            lifecycle: 'history',
+            pickedUpAt: null,
+            slotStartAt: null,
+            slotEndAt: null,
+        }),
+    ];
+    const originalOrder = requestIds(requests);
+
+    const sections = organizeCustomerDeliverySections(requests);
+
+    assert.deepEqual(requestIds(sections.upcoming), [
+        'upcoming-earlier',
+        'upcoming-later',
+        'upcoming-invalid-first',
+        'upcoming-null-second',
+    ]);
+    assert.deepEqual(requestIds(sections.history), [
+        'history-completed',
+        'history-slot-fallback',
+        'history-invalid-first',
+        'history-null-second',
+    ]);
+    assert.deepEqual(requestIds(requests), originalOrder);
+});
+
+test('preserves input order when every section sort key ties', () => {
+    const requests = [
+        delivery({
+            requestId: 'active-a',
+            status: 'ready',
+            lifecycle: 'active',
+            phase: 'on-route',
+            stopsAhead: 3,
+        }),
+        delivery({
+            requestId: 'active-b',
+            status: 'ready',
+            lifecycle: 'active',
+            phase: 'on-route',
+            stopsAhead: 3,
+        }),
+        pickup({ requestId: 'upcoming-a' }),
+        delivery({ requestId: 'upcoming-b' }),
+        delivery({
+            requestId: 'history-a',
+            status: 'fulfilled',
+            lifecycle: 'history',
+            deliveredAt: '2026-07-16T11:00:00.000Z',
+        }),
+        pickup({
+            requestId: 'history-b',
+            status: 'fulfilled',
+            lifecycle: 'history',
+            pickedUpAt: '2026-07-16T11:00:00.000Z',
+        }),
+    ];
+
+    const sections = organizeCustomerDeliverySections(requests);
+
+    assert.deepEqual(requestIds(sections.active), ['active-a', 'active-b']);
+    assert.deepEqual(requestIds(sections.upcoming), [
+        'upcoming-a',
+        'upcoming-b',
+    ]);
+    assert.deepEqual(requestIds(sections.history), ['history-a', 'history-b']);
+});

--- a/apps/delivery/lib/customerDeliverySections.ts
+++ b/apps/delivery/lib/customerDeliverySections.ts
@@ -1,0 +1,159 @@
+import type {
+    CustomerDeliveryDashboardRequest,
+    CustomerDeliveryProgressSummary,
+    CustomerDeliveryRequestSummary,
+} from './deliveryDashboardTypes';
+
+export const customerDeliveryInitialHistoryCount = 6;
+
+export type CustomerDeliverySections = {
+    active: CustomerDeliveryRequestSummary[];
+    upcoming: CustomerDeliveryDashboardRequest[];
+    history: CustomerDeliveryDashboardRequest[];
+};
+
+type IndexedRequest<TRequest extends CustomerDeliveryDashboardRequest> = {
+    index: number;
+    request: TRequest;
+};
+
+const activePhaseRanks: Record<
+    CustomerDeliveryProgressSummary['phase'],
+    number
+> = {
+    arrived: 0,
+    next: 1,
+    'on-route': 2,
+    scheduled: 3,
+    unavailable: 4,
+};
+
+function activePhaseRank(request: CustomerDeliveryDashboardRequest) {
+    return request.mode === 'delivery'
+        ? activePhaseRanks[request.progress.phase]
+        : Number.MAX_SAFE_INTEGER;
+}
+
+function canonicalTimestamp(value: string | null) {
+    if (!value) return null;
+    const timestamp = Date.parse(value);
+    if (!Number.isFinite(timestamp)) return null;
+    return new Date(timestamp).toISOString() === value ? timestamp : null;
+}
+
+function requestSlotTimestamp(request: CustomerDeliveryDashboardRequest) {
+    return (
+        canonicalTimestamp(request.slotStartAt) ??
+        canonicalTimestamp(request.slotEndAt)
+    );
+}
+
+function requestCompletionTimestamp(request: CustomerDeliveryDashboardRequest) {
+    const completedAt =
+        request.mode === 'delivery' ? request.deliveredAt : request.pickedUpAt;
+    return canonicalTimestamp(completedAt) ?? requestSlotTimestamp(request);
+}
+
+function compareNullableNumbers(
+    first: number | null,
+    second: number | null,
+    direction: 'ascending' | 'descending',
+) {
+    if (first === null) return second === null ? 0 : 1;
+    if (second === null) return -1;
+    if (first === second) return 0;
+    if (direction === 'ascending') return first < second ? -1 : 1;
+    return first > second ? -1 : 1;
+}
+
+function stableSort<TRequest extends CustomerDeliveryDashboardRequest>(
+    requests: IndexedRequest<TRequest>[],
+    compare: (first: TRequest, second: TRequest) => number,
+) {
+    return requests
+        .sort(
+            (first, second) =>
+                compare(first.request, second.request) ||
+                first.index - second.index,
+        )
+        .map(({ request }) => request);
+}
+
+function activeStopsAhead(request: CustomerDeliveryDashboardRequest) {
+    if (request.mode !== 'delivery') return null;
+    const { stopsAhead } = request.progress;
+    return Number.isSafeInteger(stopsAhead) && (stopsAhead ?? -1) >= 0
+        ? stopsAhead
+        : null;
+}
+
+function compareActiveRequests(
+    first: CustomerDeliveryRequestSummary,
+    second: CustomerDeliveryRequestSummary,
+) {
+    const phaseDifference = activePhaseRank(first) - activePhaseRank(second);
+    if (phaseDifference !== 0) return phaseDifference;
+
+    const stopsDifference = compareNullableNumbers(
+        activeStopsAhead(first),
+        activeStopsAhead(second),
+        'ascending',
+    );
+    if (stopsDifference !== 0) return stopsDifference;
+
+    return compareNullableNumbers(
+        requestSlotTimestamp(first),
+        requestSlotTimestamp(second),
+        'ascending',
+    );
+}
+
+function historyRecoveryRank(request: CustomerDeliveryDashboardRequest) {
+    return request.mode === 'delivery' && request.recovery !== null ? 0 : 1;
+}
+
+export function organizeCustomerDeliverySections(
+    requests: readonly CustomerDeliveryDashboardRequest[],
+): CustomerDeliverySections {
+    const active: IndexedRequest<CustomerDeliveryRequestSummary>[] = [];
+    const upcoming: IndexedRequest<CustomerDeliveryDashboardRequest>[] = [];
+    const history: IndexedRequest<CustomerDeliveryDashboardRequest>[] = [];
+
+    requests.forEach((request, index) => {
+        const indexed = { index, request };
+        switch (request.lifecycle) {
+            case 'active':
+                if (request.mode === 'delivery') {
+                    active.push({ index, request });
+                }
+                break;
+            case 'upcoming':
+                upcoming.push(indexed);
+                break;
+            case 'history':
+                history.push(indexed);
+                break;
+        }
+    });
+
+    return {
+        active: stableSort(active, compareActiveRequests),
+        upcoming: stableSort(upcoming, (first, second) =>
+            compareNullableNumbers(
+                requestSlotTimestamp(first),
+                requestSlotTimestamp(second),
+                'ascending',
+            ),
+        ),
+        history: stableSort(history, (first, second) => {
+            const recoveryDifference =
+                historyRecoveryRank(first) - historyRecoveryRank(second);
+            if (recoveryDifference !== 0) return recoveryDifference;
+            return compareNullableNumbers(
+                requestCompletionTimestamp(first),
+                requestCompletionTimestamp(second),
+                'descending',
+            );
+        }),
+    };
+}

--- a/apps/delivery/lib/deliveryCustomerReceipt.node.spec.ts
+++ b/apps/delivery/lib/deliveryCustomerReceipt.node.spec.ts
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    customerDeliveryRequestSupportHref,
     customerDeliverySupportHref,
     customerHandoffAdvisory,
     customerHandoffVerificationLabel,
+    customerPickupSupportHref,
 } from './deliveryCustomerReceipt';
 import type { CustomerDeliveryReceiptSummary } from './deliveryDashboardTypes';
 
@@ -88,4 +90,35 @@ test('customer support action handles a receipt without a public trace', () => {
         new URL(href).searchParams.get('body') ?? '',
         /Trag uroda nije dostupan/,
     );
+});
+
+test('active and recovery support actions identify the exact request without destination data', () => {
+    const href = customerDeliveryRequestSupportHref({
+        kind: 'support',
+        delivery: {
+            requestReference: 'active-customer-request-4137',
+            harvest: receipt.harvest,
+        },
+    });
+    const body = new URL(href).searchParams.get('body') ?? '';
+
+    assert.match(body, /active-customer-request-4137/);
+    assert.match(body, /Rajčica & bosiljak/);
+    assert.doesNotMatch(body, /Ilica|Primatelj|PRIVATE DRIVER/);
+});
+
+test('pickup support action uses pickup-safe copy and its exact request reference', () => {
+    const href = customerPickupSupportHref({
+        requestId: 'pickup-customer-request-4137',
+        harvest: receipt.harvest,
+    });
+    const url = new URL(href);
+    const subject = url.searchParams.get('subject') ?? '';
+    const body = url.searchParams.get('body') ?? '';
+
+    assert.match(subject, /Pitanje o preuzimanju/);
+    assert.doesNotMatch(subject, /dostava/i);
+    assert.match(body, /Vrsta zahtjeva: Preuzimanje/);
+    assert.match(body, /Referenca preuzimanja: pickup-customer-request-4137/);
+    assert.doesNotMatch(body, /Vozač|PRIVATE DRIVER/);
 });

--- a/apps/delivery/lib/deliveryCustomerReceipt.ts
+++ b/apps/delivery/lib/deliveryCustomerReceipt.ts
@@ -1,9 +1,15 @@
 import type {
     CustomerDeliveryReceiptSummary,
     CustomerHandoffVerification,
+    CustomerPickupRequestSummary,
 } from './deliveryDashboardTypes';
 
 export type CustomerDeliverySupportKind = 'missing' | 'damaged' | 'support';
+
+export type CustomerDeliverySupportReference = Pick<
+    CustomerDeliveryReceiptSummary,
+    'requestReference' | 'harvest'
+>;
 
 export const customerHandoffAdvisory =
     'QR skeniranje služi samo kao dodatna evidencija i ne utječe na status dovršene dostave.';
@@ -40,6 +46,69 @@ function customerTraceReference(
         : 'Trag uroda nije dostupan';
 }
 
+function customerRequestSupportHref({
+    kind,
+    mode,
+    requestReference,
+    harvest,
+}: {
+    kind: CustomerDeliverySupportKind;
+    mode: 'delivery' | 'pickup';
+    requestReference: string;
+    harvest: CustomerDeliverySupportReference['harvest'];
+}) {
+    const label =
+        mode === 'pickup' && kind === 'support'
+            ? 'Pitanje o preuzimanju'
+            : supportLabels[kind];
+    const modeLabel = mode === 'delivery' ? 'Dostava' : 'Preuzimanje';
+    const subjectMode = mode === 'delivery' ? 'dostava' : 'preuzimanje';
+    const referenceLabel =
+        mode === 'delivery' ? 'Referenca dostave' : 'Referenca preuzimanja';
+    const query = new URLSearchParams({
+        subject: `${label} · ${subjectMode} ${safeSubjectReference(requestReference)}`,
+        body: [
+            'Pozdrav,',
+            '',
+            `Vrsta zahtjeva: ${modeLabel}`,
+            `Vrsta prijave: ${label}`,
+            `${referenceLabel}: ${requestReference}`,
+            `Urod: ${harvest.plantName}`,
+            `Trag uroda: ${customerTraceReference(harvest.tracePath)}`,
+            '',
+            'Opis:',
+        ].join('\n'),
+    });
+
+    return `mailto:podrska@gredice.com?${query.toString()}`;
+}
+
+export function customerDeliveryRequestSupportHref({
+    kind,
+    delivery,
+}: {
+    kind: CustomerDeliverySupportKind;
+    delivery: CustomerDeliverySupportReference;
+}) {
+    return customerRequestSupportHref({
+        kind,
+        mode: 'delivery',
+        requestReference: delivery.requestReference,
+        harvest: delivery.harvest,
+    });
+}
+
+export function customerPickupSupportHref(
+    pickup: Pick<CustomerPickupRequestSummary, 'requestId' | 'harvest'>,
+) {
+    return customerRequestSupportHref({
+        kind: 'support',
+        mode: 'pickup',
+        requestReference: pickup.requestId,
+        harvest: pickup.harvest,
+    });
+}
+
 export function customerDeliverySupportHref({
     kind,
     receipt,
@@ -47,20 +116,8 @@ export function customerDeliverySupportHref({
     kind: CustomerDeliverySupportKind;
     receipt: CustomerDeliveryReceiptSummary;
 }) {
-    const label = supportLabels[kind];
-    const query = new URLSearchParams({
-        subject: `${label} · dostava ${safeSubjectReference(receipt.requestReference)}`,
-        body: [
-            'Pozdrav,',
-            '',
-            `Vrsta prijave: ${label}`,
-            `Referenca dostave: ${receipt.requestReference}`,
-            `Urod: ${receipt.harvest.plantName}`,
-            `Trag uroda: ${customerTraceReference(receipt.harvest.tracePath)}`,
-            '',
-            'Opis:',
-        ].join('\n'),
+    return customerDeliveryRequestSupportHref({
+        kind,
+        delivery: receipt,
     });
-
-    return `mailto:podrska@gredice.com?${query.toString()}`;
 }

--- a/apps/delivery/lib/deliveryDashboardTypes.ts
+++ b/apps/delivery/lib/deliveryDashboardTypes.ts
@@ -92,8 +92,17 @@ export type CustomerDeliveryRecoverySummary =
     | { kind: 'support' }
     | { kind: 'cancelled' };
 
+export type CustomerDeliveryDestinationSummary = {
+    recipientName: string;
+    address: string;
+    addressLabel: string | null;
+};
+
+export type CustomerDeliveryLifecycle = 'active' | 'upcoming' | 'history';
+
 export type CustomerDeliveryRequestSummary = {
     mode: 'delivery';
+    lifecycle: CustomerDeliveryLifecycle;
     requestId: string;
     status: string;
     statusLabel: string;
@@ -104,6 +113,7 @@ export type CustomerDeliveryRequestSummary = {
     progress: CustomerDeliveryProgressSummary;
     deliveredAt: string | null;
     harvest: DeliveryHarvestSummary;
+    destination: CustomerDeliveryDestinationSummary;
     receipt: CustomerDeliveryReceiptSummary | null;
     recovery: CustomerDeliveryRecoverySummary | null;
     tracking: CustomerDeliveryTrackingSummary | null;
@@ -118,6 +128,7 @@ export type CustomerPickupLocationSummary = {
 
 export type CustomerPickupRequestSummary = {
     mode: 'pickup';
+    lifecycle: Exclude<CustomerDeliveryLifecycle, 'active'>;
     requestId: string;
     status: string;
     statusLabel: string;

--- a/apps/delivery/tests/CustomerDashboardModesStory.tsx
+++ b/apps/delivery/tests/CustomerDashboardModesStory.tsx
@@ -9,6 +9,7 @@ import type {
 
 const delivery: CustomerDeliveryRequestSummary = {
     mode: 'delivery',
+    lifecycle: 'active',
     requestId: 'customer-delivery-4135',
     status: 'ready',
     statusLabel: 'Vozač stiže',
@@ -38,6 +39,11 @@ const delivery: CustomerDeliveryRequestSummary = {
         fieldName: 'Polje 2',
         tracePath: '/trag/customer-delivery-4135',
     },
+    destination: {
+        recipientName: 'Korisnik Korina',
+        address: 'Ilica 1, 10000 Zagreb, HR',
+        addressLabel: 'Dom',
+    },
     receipt: null,
     recovery: null,
     tracking: {
@@ -51,6 +57,7 @@ const delivery: CustomerDeliveryRequestSummary = {
 
 const readyPickup: CustomerPickupRequestSummary = {
     mode: 'pickup',
+    lifecycle: 'upcoming',
     requestId: 'customer-pickup-ready-4135',
     status: 'ready',
     statusLabel: 'Spremno za preuzimanje',
@@ -76,6 +83,7 @@ const readyPickup: CustomerPickupRequestSummary = {
 
 const fulfilledPickup: CustomerPickupRequestSummary = {
     ...readyPickup,
+    lifecycle: 'history',
     requestId: 'customer-pickup-fulfilled-4135',
     status: 'fulfilled',
     statusLabel: 'Preuzeto',

--- a/apps/delivery/tests/CustomerDeliveryEtaStory.tsx
+++ b/apps/delivery/tests/CustomerDeliveryEtaStory.tsx
@@ -3,6 +3,7 @@ import type { CustomerDeliveryRequestSummary } from '../lib/deliveryDashboardTyp
 
 const baseDelivery: CustomerDeliveryRequestSummary = {
     mode: 'delivery',
+    lifecycle: 'active',
     requestId: 'customer-eta-4136',
     status: 'ready',
     statusLabel: 'U dostavi',
@@ -31,6 +32,11 @@ const baseDelivery: CustomerDeliveryRequestSummary = {
         raisedBedName: 'Gredica 4',
         fieldName: 'Polje 2',
         tracePath: '/trag/customer-eta-4136',
+    },
+    destination: {
+        recipientName: 'Korisnik Korina',
+        address: 'Ilica 1, 10000 Zagreb, HR',
+        addressLabel: 'Dom',
     },
     receipt: null,
     recovery: null,

--- a/apps/delivery/tests/CustomerDeliveryHistoryStory.tsx
+++ b/apps/delivery/tests/CustomerDeliveryHistoryStory.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+import { useState } from 'react';
+import { CustomerDashboard } from '../components/CustomerDashboard';
+import type {
+    CustomerDeliveryDashboard,
+    CustomerDeliveryDashboardRequest,
+    CustomerDeliveryRequestSummary,
+    CustomerPickupRequestSummary,
+} from '../lib/deliveryDashboardTypes';
+
+const harvestBase = {
+    operationName: 'Berba',
+    raisedBedName: 'Gredica 4',
+    fieldName: 'Polje 2',
+};
+
+function delivery({
+    requestId,
+    plantName,
+    lifecycle,
+    status = lifecycle === 'history' ? 'fulfilled' : 'ready',
+    slotStartAt,
+    deliveredAt = null,
+    phase = lifecycle === 'active' ? 'next' : 'scheduled',
+    stopsAhead = lifecycle === 'active' ? 0 : null,
+    requestNotes = null,
+    recovery = null,
+    map = false,
+}: {
+    requestId: string;
+    plantName: string;
+    lifecycle: CustomerDeliveryRequestSummary['lifecycle'];
+    status?: string;
+    slotStartAt: string;
+    deliveredAt?: string | null;
+    phase?: CustomerDeliveryRequestSummary['progress']['phase'];
+    stopsAhead?: number | null;
+    requestNotes?: string | null;
+    recovery?: CustomerDeliveryRequestSummary['recovery'];
+    map?: boolean;
+}): CustomerDeliveryRequestSummary {
+    const harvest = {
+        ...harvestBase,
+        plantName,
+        tracePath: `/trag/${requestId}`,
+    };
+    const fulfilled = status === 'fulfilled' && deliveredAt !== null;
+    return {
+        mode: 'delivery',
+        lifecycle,
+        requestId,
+        status,
+        statusLabel:
+            lifecycle === 'active'
+                ? phase === 'arrived'
+                    ? 'Vozač je stigao'
+                    : 'Vozač stiže'
+                : fulfilled
+                  ? 'Dostavljeno'
+                  : status === 'failed'
+                    ? 'Dostava nije uspjela'
+                    : 'Dostava potvrđena',
+        requestNotes,
+        slotStartAt,
+        slotEndAt: new Date(
+            Date.parse(slotStartAt) + 2 * 60 * 60 * 1_000,
+        ).toISOString(),
+        eta: {
+            source:
+                lifecycle === 'active' ? 'traffic-route' : 'promised-window',
+            calculatedAt:
+                lifecycle === 'active' ? '2026-07-16T08:45:00.000Z' : null,
+            freshness: lifecycle === 'active' ? 'fresh' : 'fallback',
+            confidence: lifecycle === 'active' ? 'high' : 'approximate',
+            rangeStartAt: slotStartAt,
+            rangeEndAt: new Date(
+                Date.parse(slotStartAt) + 2 * 60 * 60 * 1_000,
+            ).toISOString(),
+            remainingMinSeconds: lifecycle === 'active' ? 600 : null,
+            remainingMaxSeconds: lifecycle === 'active' ? 1_200 : null,
+        },
+        progress: {
+            phase: fulfilled || status === 'failed' ? 'unavailable' : phase,
+            stopsAhead: fulfilled || status === 'failed' ? null : stopsAhead,
+            delayed: false,
+        },
+        deliveredAt,
+        harvest,
+        destination: {
+            recipientName: `Primatelj ${plantName}`,
+            address: 'Ilica 1, 10000 Zagreb, HR',
+            addressLabel: 'Dom',
+        },
+        receipt: fulfilled
+            ? {
+                  requestReference: requestId,
+                  deliveredAt,
+                  verification: 'verified',
+                  harvest,
+              }
+            : null,
+        recovery,
+        tracking: map
+            ? {
+                  status: 'live',
+                  lastAcceptedAt: '2026-07-16T08:45:00.000Z',
+                  mapAvailable: true,
+                  exactLocationExpiresInMs: 110_000,
+              }
+            : null,
+        mapPath: map ? `/api/map/${requestId}` : null,
+    };
+}
+
+function pickup({
+    requestId,
+    plantName,
+    lifecycle,
+    slotStartAt,
+    pickedUpAt = null,
+}: {
+    requestId: string;
+    plantName: string;
+    lifecycle: CustomerPickupRequestSummary['lifecycle'];
+    slotStartAt: string;
+    pickedUpAt?: string | null;
+}): CustomerPickupRequestSummary {
+    return {
+        mode: 'pickup',
+        lifecycle,
+        requestId,
+        status: lifecycle === 'history' ? 'fulfilled' : 'ready',
+        statusLabel:
+            lifecycle === 'history' ? 'Preuzeto' : 'Spremno za preuzimanje',
+        requestNotes: null,
+        slotStartAt,
+        slotEndAt: new Date(
+            Date.parse(slotStartAt) + 2 * 60 * 60 * 1_000,
+        ).toISOString(),
+        harvest: {
+            ...harvestBase,
+            plantName,
+            tracePath: `/trag/${requestId}`,
+        },
+        location: {
+            name: 'Gredice HQ',
+            address: 'Vrtna 1, 10000 Zagreb, HR',
+            instructions: 'Preuzmi urod tijekom odabranog termina.',
+        },
+        pickedUpAt,
+    };
+}
+
+function dashboard(
+    deliveries: CustomerDeliveryDashboardRequest[],
+): CustomerDeliveryDashboard {
+    return {
+        kind: 'customer',
+        user: {
+            id: 'customer-history-4137',
+            displayName: 'Kupac Korina',
+            role: 'user',
+        },
+        deliveries,
+        refreshedAt: '2026-07-16T08:45:00.000Z',
+    };
+}
+
+function StoryDashboard({
+    deliveries,
+}: {
+    deliveries: CustomerDeliveryDashboardRequest[];
+}) {
+    const [requestTiming] = useState(() => ({
+        monotonicMs: performance.now(),
+        wallMs: Date.now(),
+    }));
+    return (
+        <CustomerDashboard
+            dashboard={dashboard(deliveries)}
+            requestTiming={requestTiming}
+        />
+    );
+}
+
+const activeArrived = delivery({
+    requestId: 'active-arrived-4137',
+    plantName: 'Aktivna rajčica',
+    lifecycle: 'active',
+    slotStartAt: '2026-07-16T09:00:00.000Z',
+    phase: 'arrived',
+    requestNotes: 'Pozvoni na portafon i ostavi košaru kod vrata.',
+    map: true,
+});
+
+const activeBulkSibling = delivery({
+    requestId: 'active-bulk-sibling-4137',
+    plantName: 'Aktivni bosiljak',
+    lifecycle: 'active',
+    slotStartAt: '2026-07-16T09:00:00.000Z',
+    phase: 'next',
+});
+
+const history = [
+    delivery({
+        requestId: 'history-recovery-4137',
+        plantName: 'Urod s oporavkom',
+        lifecycle: 'history',
+        status: 'failed',
+        slotStartAt: '2026-06-01T08:00:00.000Z',
+        recovery: { kind: 'support' },
+    }),
+    delivery({
+        requestId: 'history-delivery-1-4137',
+        plantName: 'Dostavljena paprika',
+        lifecycle: 'history',
+        slotStartAt: '2026-07-15T12:00:00.000Z',
+        deliveredAt: '2026-07-15T14:00:00.000Z',
+    }),
+    pickup({
+        requestId: 'history-pickup-1-4137',
+        plantName: 'Preuzeta mrkva',
+        lifecycle: 'history',
+        slotStartAt: '2026-07-15T11:00:00.000Z',
+        pickedUpAt: '2026-07-15T13:00:00.000Z',
+    }),
+    delivery({
+        requestId: 'history-delivery-2-4137',
+        plantName: 'Dostavljena salata',
+        lifecycle: 'history',
+        slotStartAt: '2026-07-15T10:00:00.000Z',
+        deliveredAt: '2026-07-15T12:00:00.000Z',
+    }),
+    pickup({
+        requestId: 'history-pickup-2-4137',
+        plantName: 'Preuzeti krastavac',
+        lifecycle: 'history',
+        slotStartAt: '2026-07-15T09:00:00.000Z',
+        pickedUpAt: '2026-07-15T11:00:00.000Z',
+    }),
+    delivery({
+        requestId: 'history-delivery-3-4137',
+        plantName: 'Dostavljena tikvica',
+        lifecycle: 'history',
+        slotStartAt: '2026-07-15T08:00:00.000Z',
+        deliveredAt: '2026-07-15T10:00:00.000Z',
+    }),
+    pickup({
+        requestId: 'history-pickup-hidden-4137',
+        plantName: 'Skriveni preuzeti grašak',
+        lifecycle: 'history',
+        slotStartAt: '2026-07-15T07:00:00.000Z',
+        pickedUpAt: '2026-07-15T09:00:00.000Z',
+    }),
+    delivery({
+        requestId: 'history-delivery-hidden-4137',
+        plantName: 'Skriveni dostavljeni kelj',
+        lifecycle: 'history',
+        slotStartAt: '2026-07-15T06:00:00.000Z',
+        deliveredAt: '2026-07-15T08:00:00.000Z',
+    }),
+];
+
+const longHistory = Array.from({ length: 14 }, (_, index) => {
+    const day = String(14 - index).padStart(2, '0');
+    return delivery({
+        requestId: `long-history-${index + 1}-4137`,
+        plantName: `Povijesni urod ${index + 1}`,
+        lifecycle: 'history',
+        slotStartAt: `2026-07-${day}T08:00:00.000Z`,
+        deliveredAt: `2026-07-${day}T09:00:00.000Z`,
+    });
+});
+
+export function CustomerDeliverySectionsStory() {
+    return (
+        <StoryDashboard
+            deliveries={[
+                delivery({
+                    requestId: 'upcoming-delivery-4137',
+                    plantName: 'Nadolazeći peršin',
+                    lifecycle: 'upcoming',
+                    slotStartAt: '2026-07-17T11:00:00.000Z',
+                }),
+                activeBulkSibling,
+                pickup({
+                    requestId: 'upcoming-pickup-4137',
+                    plantName: 'Nadolazeća blitva',
+                    lifecycle: 'upcoming',
+                    slotStartAt: '2026-07-17T09:00:00.000Z',
+                }),
+                activeArrived,
+                ...history,
+            ]}
+        />
+    );
+}
+
+export function CustomerDeliveryActiveAndHistoryEmptyStory() {
+    return (
+        <StoryDashboard
+            deliveries={[
+                delivery({
+                    requestId: 'upcoming-only-4137',
+                    plantName: 'Samo nadolazeća rotkvica',
+                    lifecycle: 'upcoming',
+                    slotStartAt: '2026-07-17T10:00:00.000Z',
+                }),
+            ]}
+        />
+    );
+}
+
+export function CustomerDeliveryUpcomingEmptyStory() {
+    return (
+        <StoryDashboard
+            deliveries={[
+                activeArrived,
+                delivery({
+                    requestId: 'history-only-4137',
+                    plantName: 'Dostavljena rikola',
+                    lifecycle: 'history',
+                    slotStartAt: '2026-07-15T12:00:00.000Z',
+                    deliveredAt: '2026-07-15T14:00:00.000Z',
+                }),
+            ]}
+        />
+    );
+}
+
+export function CustomerDeliveryLongHistoryStory() {
+    return <StoryDashboard deliveries={longHistory} />;
+}

--- a/apps/delivery/tests/CustomerDeliveryReceiptStory.tsx
+++ b/apps/delivery/tests/CustomerDeliveryReceiptStory.tsx
@@ -36,6 +36,7 @@ function customerDelivery({
 
     return {
         mode: 'delivery',
+        lifecycle: 'history',
         requestId: requestReference,
         status: 'fulfilled',
         statusLabel: 'Dostavljeno',
@@ -59,6 +60,11 @@ function customerDelivery({
         },
         deliveredAt: '2026-07-16T09:30:00.000Z',
         harvest,
+        destination: {
+            recipientName: 'Korisnik Korina',
+            address: 'Ilica 1, 10000 Zagreb, HR',
+            addressLabel: 'Dom',
+        },
         receipt: {
             requestReference,
             deliveredAt: '2026-07-16T09:30:00.000Z',
@@ -77,6 +83,7 @@ const activeBase = customerDelivery({
 });
 const activeDelivery: CustomerDeliveryRequestSummary = {
     ...activeBase,
+    lifecycle: 'active',
     requestId: 'customer-owned-request-journey-4144',
     status: 'ready',
     statusLabel: 'Vozač stiže',

--- a/apps/delivery/tests/delivery-customer-history.spec.tsx
+++ b/apps/delivery/tests/delivery-customer-history.spec.tsx
@@ -1,0 +1,233 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import {
+    CustomerDeliveryActiveAndHistoryEmptyStory,
+    CustomerDeliveryLongHistoryStory,
+    CustomerDeliverySectionsStory,
+    CustomerDeliveryUpcomingEmptyStory,
+} from './CustomerDeliveryHistoryStory';
+import '../app/globals.css';
+
+test('leads with every active delivery and organizes upcoming requests and bounded history', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({
+        time: new Date('2026-07-16T08:45:10.000Z'),
+    });
+    await mount(<CustomerDeliverySectionsStory />);
+
+    await expect
+        .poll(() =>
+            page
+                .locator(
+                    '[data-testid="customer-active-section"], [data-testid="customer-upcoming-section"], [data-testid="customer-history-section"]',
+                )
+                .evaluateAll((elements) =>
+                    elements.map((element) =>
+                        element.getAttribute('data-testid'),
+                    ),
+                ),
+        )
+        .toEqual([
+            'customer-active-section',
+            'customer-upcoming-section',
+            'customer-history-section',
+        ]);
+
+    const active = page.getByTestId('customer-active-section');
+    await expect(
+        active.getByRole('heading', { level: 3, name: 'Aktivna dostava' }),
+    ).toBeVisible();
+    await expect(active.getByTestId('customer-delivery-card')).toHaveCount(2);
+    await expect(active.getByRole('heading', { level: 4 })).toHaveText([
+        'Aktivna rajčica',
+        'Aktivni bosiljak',
+    ]);
+    await expect(
+        active.getByRole('img', {
+            name: 'Trenutna lokacija vozača i moja dostava',
+        }),
+    ).toHaveAttribute('src', /active-arrived-4137/);
+    await expect(active.getByText('Primatelj Aktivna rajčica')).toBeVisible();
+    await expect(active.getByText('Ilica 1, 10000 Zagreb, HR')).toHaveCount(2);
+    await expect(
+        active.getByText('Pozvoni na portafon i ostavi košaru kod vrata.', {
+            exact: true,
+        }),
+    ).toBeVisible();
+    await expect(
+        active.getByText('Nema posebnih uputa.', { exact: true }),
+    ).toBeVisible();
+
+    const activeSupportHref = await active
+        .getByRole('link', {
+            name: 'Prijavi problem za dostavu: Aktivna rajčica',
+        })
+        .getAttribute('href');
+    if (!activeSupportHref) throw new Error('Active support link is missing.');
+    const activeSupportBody =
+        new URL(activeSupportHref).searchParams.get('body') ?? '';
+    expect(activeSupportBody).toContain('active-arrived-4137');
+    expect(activeSupportBody).not.toMatch(/Ilica|Primatelj/);
+
+    const upcoming = page.getByTestId('customer-upcoming-section');
+    await expect(
+        upcoming.getByRole('heading', {
+            level: 3,
+            name: 'Nadolazeće i potrebne radnje',
+        }),
+    ).toBeVisible();
+    await expect(upcoming.getByRole('heading', { level: 4 })).toHaveText([
+        'Nadolazeća blitva',
+        'Nadolazeći peršin',
+    ]);
+    const pickupSupportHref = await upcoming
+        .getByRole('link', {
+            name: 'Kontaktiraj podršku za preuzimanje: Nadolazeća blitva',
+        })
+        .getAttribute('href');
+    if (!pickupSupportHref) throw new Error('Pickup support link is missing.');
+    const pickupSupportUrl = new URL(pickupSupportHref);
+    expect(pickupSupportUrl.searchParams.get('subject')).toContain(
+        'Pitanje o preuzimanju',
+    );
+    expect(pickupSupportUrl.searchParams.get('body')).toContain(
+        'upcoming-pickup-4137',
+    );
+
+    const history = page.getByTestId('customer-history-section');
+    const historyCards = history.locator(
+        '[data-testid="customer-delivery-card"], [data-testid="customer-pickup-card"]',
+    );
+    await expect(historyCards).toHaveCount(6);
+    await expect(history.getByText('6 od 8', { exact: true })).toBeVisible();
+    await expect(history.getByRole('heading', { level: 4 }).first()).toHaveText(
+        'Urod s oporavkom',
+    );
+    await expect(
+        history.getByText('Skriveni preuzeti grašak', { exact: true }),
+    ).toHaveCount(0);
+    await expect(
+        history.getByText('Skriveni dostavljeni kelj', { exact: true }),
+    ).toHaveCount(0);
+
+    const receipt = history
+        .getByTestId('customer-delivery-card')
+        .filter({ hasText: 'Dostavljena paprika' });
+    await expect(
+        receipt.getByRole('heading', {
+            level: 5,
+            name: /Potvrda o dostavi · Dostavljena paprika/,
+        }),
+    ).toBeVisible();
+    const receiptSupportHref = await receipt
+        .getByRole('link', {
+            name: 'Kontaktiraj podršku za dostavu: Dostavljena paprika',
+        })
+        .getAttribute('href');
+    if (!receiptSupportHref) {
+        throw new Error('Receipt support link is missing.');
+    }
+    expect(new URL(receiptSupportHref).searchParams.get('body')).toContain(
+        'history-delivery-1-4137',
+    );
+
+    const disclosure = history.getByRole('button', {
+        name: 'Prikaži još (2)',
+    });
+    await disclosure.click();
+    await expect(historyCards).toHaveCount(8);
+    await expect(history.getByText('8 od 8', { exact: true })).toBeVisible();
+    await expect(
+        history.getByText('Skriveni preuzeti grašak', { exact: true }),
+    ).toBeVisible();
+    await expect(
+        history.getByRole('article', {
+            name: 'Nova stavka povijesti: Skriveni preuzeti grašak',
+        }),
+    ).toBeFocused();
+    await expect(history.getByRole('status')).toHaveText(
+        'Prikazano 8 od 8 stavki povijesti.',
+    );
+    const collapse = history.getByRole('button', { name: 'Prikaži manje' });
+    await collapse.click();
+    await expect(historyCards).toHaveCount(6);
+    await expect(
+        history.getByRole('button', { name: 'Prikaži još (2)' }),
+    ).toBeFocused();
+});
+
+test('defines active and history empty states around an upcoming request', async ({
+    mount,
+    page,
+}) => {
+    await mount(<CustomerDeliveryActiveAndHistoryEmptyStory />);
+
+    const active = page.getByTestId('customer-active-section');
+    await expect(
+        active.getByText('Trenutačno nema dostave na putu.', { exact: true }),
+    ).toBeVisible();
+    await expect(active.getByTestId('customer-section-empty')).toHaveCount(1);
+
+    const upcoming = page.getByTestId('customer-upcoming-section');
+    await expect(upcoming.getByTestId('customer-delivery-card')).toHaveCount(1);
+    await expect(upcoming.getByTestId('customer-section-empty')).toHaveCount(0);
+
+    const history = page.getByTestId('customer-history-section');
+    await expect(
+        history.getByText('Još nema dovršenih zahtjeva.', { exact: true }),
+    ).toBeVisible();
+    await expect(history.getByTestId('customer-section-empty')).toHaveCount(1);
+});
+
+test('keeps the upcoming empty state between active delivery and history', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({
+        time: new Date('2026-07-16T08:45:10.000Z'),
+    });
+    await mount(<CustomerDeliveryUpcomingEmptyStory />);
+
+    await expect(
+        page
+            .getByTestId('customer-active-section')
+            .getByTestId('customer-delivery-card'),
+    ).toHaveCount(1);
+    await expect(
+        page
+            .getByTestId('customer-upcoming-section')
+            .getByText('Nema nadolazećih termina ni radnji.', { exact: true }),
+    ).toBeVisible();
+    await expect(
+        page
+            .getByTestId('customer-history-section')
+            .getByTestId('customer-delivery-card'),
+    ).toHaveCount(1);
+});
+
+test('can collapse a multi-page history before loading every remaining receipt', async ({
+    mount,
+    page,
+}) => {
+    await mount(<CustomerDeliveryLongHistoryStory />);
+    const history = page.getByTestId('customer-history-section');
+    const historyCards = history.getByTestId('customer-delivery-card');
+
+    await expect(historyCards).toHaveCount(6);
+    await history.getByRole('button', { name: 'Prikaži još (8)' }).click();
+    await expect(historyCards).toHaveCount(12);
+    await expect(
+        history.getByRole('button', { name: 'Prikaži još (2)' }),
+    ).toBeVisible();
+    const collapse = history.getByRole('button', { name: 'Prikaži manje' });
+    await expect(collapse).toBeVisible();
+    await collapse.click();
+    await expect(historyCards).toHaveCount(6);
+    await expect(
+        history.getByRole('button', { name: 'Prikaži još (8)' }),
+    ).toBeVisible();
+    await expect(
+        history.getByRole('button', { name: 'Prikaži manje' }),
+    ).toHaveCount(0);
+});

--- a/apps/delivery/tests/delivery-customer-modes.spec.tsx
+++ b/apps/delivery/tests/delivery-customer-modes.spec.tsx
@@ -163,7 +163,7 @@ test('keeps the user delivery-only heading and tracking experience', async ({
         page.getByRole('heading', { level: 2, name: 'Moje dostave' }),
     ).toBeVisible();
     await expect(
-        page.getByText('Korisnik Korina', { exact: true }),
+        page.getByRole('banner').getByText('Korisnik Korina', { exact: true }),
     ).toBeVisible();
     await expect(page.getByTestId('customer-delivery-card')).toHaveCount(1);
     await expect(page.getByTestId('customer-pickup-card')).toHaveCount(0);

--- a/apps/delivery/tests/delivery-recovery.spec.tsx
+++ b/apps/delivery/tests/delivery-recovery.spec.tsx
@@ -357,14 +357,39 @@ test('renders every customer recovery state with only customer-safe actions', as
     mount,
     page,
 }) => {
+    const requestContext = {
+        requestReference: 'customer-recovery-request-4137',
+        harvest: {
+            plantName: 'Rajčica za oporavak',
+            operationName: 'Berba',
+            raisedBedName: 'Gredica 4',
+            fieldName: 'Polje 2',
+            tracePath: '/trag/customer-recovery-4137',
+        },
+    } as const;
     const component = await mount(
-        <DeliveryCustomerRecovery recovery={{ kind: 'retry-planned' }} />,
+        <DeliveryCustomerRecovery
+            {...requestContext}
+            recovery={{ kind: 'retry-planned' }}
+        />,
     );
     await expect(page.getByText('Ponovni pokušaj je planiran')).toBeVisible();
     await expect(page.getByText(/vratit će se kasnije/)).toBeVisible();
+    const retrySupportHref = await page
+        .getByRole('link', {
+            name: 'Prijavi problem za dostavu: Rajčica za oporavak',
+        })
+        .getAttribute('href');
+    if (!retrySupportHref) {
+        throw new Error('Recovery support link is missing.');
+    }
+    expect(new URL(retrySupportHref).searchParams.get('body')).toContain(
+        'customer-recovery-request-4137',
+    );
 
     await component.update(
         <DeliveryCustomerRecovery
+            {...requestContext}
             recovery={{
                 kind: 'hq-pickup',
                 pickupAddress: 'Konfigurirani HQ, Testna 42, Zagreb',
@@ -380,41 +405,114 @@ test('renders every customer recovery state with only customer-safe actions', as
     ).toBeVisible();
     await expect(page.getByText(/najkasnije/)).toBeVisible();
     await expect(
-        page.getByRole('link', { name: 'Potvrdi preuzimanje' }),
+        page.getByRole('link', {
+            name: 'Potvrdi preuzimanje za dostavu: Rajčica za oporavak',
+        }),
     ).toBeVisible();
     await expect(
-        page.getByRole('link', { name: 'Otvori lokaciju HQ' }),
+        page.getByRole('link', {
+            name: 'Otvori lokaciju HQ za dostavu: Rajčica za oporavak',
+        }),
     ).toHaveAttribute('href', /google\.com\/maps\/dir/);
 
     await component.update(
-        <DeliveryCustomerRecovery recovery={{ kind: 'support' }} />,
+        <DeliveryCustomerRecovery
+            {...requestContext}
+            recovery={{ kind: 'support' }}
+        />,
     );
     await expect(
         page.getByText('Podrška će dogovoriti sljedeći korak'),
     ).toBeVisible();
     await expect(
-        page.getByRole('link', { name: 'Kontaktiraj podršku' }),
+        page.getByRole('link', {
+            name: 'Kontaktiraj podršku za dostavu: Rajčica za oporavak',
+        }),
     ).toBeVisible();
     await expect(
         page.getByText(/harvest-missing|operational-other/),
     ).toHaveCount(0);
 
     await component.update(
-        <DeliveryCustomerRecovery recovery={{ kind: 'hq-pickup-expired' }} />,
+        <DeliveryCustomerRecovery
+            {...requestContext}
+            recovery={{ kind: 'hq-pickup-expired' }}
+        />,
     );
     await expect(
         page.getByText('Rok za osobno preuzimanje je istekao'),
     ).toBeVisible();
     await expect(page.getByText(/više nije aktivan/)).toBeVisible();
     await expect(
-        page.getByRole('link', { name: 'Kontaktiraj podršku' }),
+        page.getByRole('link', {
+            name: 'Kontaktiraj podršku za dostavu: Rajčica za oporavak',
+        }),
     ).toBeVisible();
 
     await component.update(
-        <DeliveryCustomerRecovery recovery={{ kind: 'cancelled' }} />,
+        <DeliveryCustomerRecovery
+            {...requestContext}
+            recovery={{ kind: 'cancelled' }}
+        />,
     );
     await expect(page.getByText('Dostava je otkazana')).toBeVisible();
     await expect(page.getByText(/otkazivanje nisi očekivao/)).toBeVisible();
+});
+
+test('names simultaneous recovery actions by harvest and keeps their request targets separate', async ({
+    mount,
+    page,
+}) => {
+    const firstHarvest = {
+        plantName: 'Rajčica prve dostave',
+        operationName: 'Berba',
+        raisedBedName: 'Gredica 1',
+        fieldName: 'Polje 1',
+        tracePath: '/trag/recovery-first-4137',
+    };
+    const secondHarvest = {
+        ...firstHarvest,
+        plantName: 'Paprika druge dostave',
+        raisedBedName: 'Gredica 2',
+        tracePath: '/trag/recovery-second-4137',
+    };
+    await mount(
+        <div>
+            <DeliveryCustomerRecovery
+                recovery={{ kind: 'support' }}
+                requestReference="recovery-first-request-4137"
+                harvest={firstHarvest}
+            />
+            <DeliveryCustomerRecovery
+                recovery={{ kind: 'cancelled' }}
+                requestReference="recovery-second-request-4137"
+                harvest={secondHarvest}
+            />
+        </div>,
+    );
+
+    const firstLink = page.getByRole('link', {
+        name: 'Kontaktiraj podršku za dostavu: Rajčica prve dostave',
+    });
+    const secondLink = page.getByRole('link', {
+        name: 'Kontaktiraj podršku za dostavu: Paprika druge dostave',
+    });
+    await expect(firstLink).toBeVisible();
+    await expect(secondLink).toBeVisible();
+    const firstHref = await firstLink.getAttribute('href');
+    const secondHref = await secondLink.getAttribute('href');
+    if (!firstHref || !secondHref) {
+        throw new Error('Request-specific recovery links are missing.');
+    }
+    expect(new URL(firstHref).searchParams.get('body')).toContain(
+        'recovery-first-request-4137',
+    );
+    expect(new URL(firstHref).searchParams.get('body')).not.toContain(
+        'recovery-second-request-4137',
+    );
+    expect(new URL(secondHref).searchParams.get('body')).toContain(
+        'recovery-second-request-4137',
+    );
 });
 
 test('keeps terminal siblings as history but excludes them from current delivery work', async ({

--- a/docs/delivery-customer-tracking.md
+++ b/docs/delivery-customer-tracking.md
@@ -11,6 +11,36 @@ The UI must not present an incoming route leg as the remaining time to a
 customer. Driver-only distance and leg-duration fields stay outside the
 customer DTO.
 
+## Dashboard organization and owned context
+
+Each customer request carries a server-derived `lifecycle` value. Deliveries
+on an active run remain `active` even when their detailed progress fails closed
+to unavailable; unresolved requests are `upcoming`; completed, cancelled, and
+non-recoverable failed requests are `history`. A failed request with an active
+HQ pickup window remains upcoming so its deadline is not buried. Pickup
+requests are upcoming or history and never create live-driver expectations.
+
+The dashboard renders the sections in this order:
+
+1. active delivery, including every account-owned harvest at the current bulk
+   stop and the authorized map when available;
+2. upcoming requests and required recovery actions, earliest first;
+3. completed history, newest first, while request-specific recovery entries
+   remain ahead of ordinary receipts.
+
+Only the first six full history cards are mounted initially. The customer can
+progressively reveal the remainder and collapse back to the initial page.
+Empty states are scoped to their section instead of replacing useful content
+from the other sections.
+
+The customer delivery DTO includes only the account-owned recipient name,
+formatted destination address and optional address label. Customer-entered
+delivery instructions remain visible. Phone numbers, driver notes, other
+recipients in a bulk stop, stop identifiers, and run identifiers remain
+excluded. Delivery, pickup, receipt, and recovery support links prefill the
+exact owned request and harvest/trace reference without adding destination or
+recipient data to the message.
+
 ## Promised window
 
 Every delivery card renders the complete `slotStartAt`–`slotEndAt` window. A


### PR DESCRIPTION
## Summary

- add server-derived customer delivery lifecycle states and deterministic active, upcoming, and history organization
- prioritize active route tracking, separate upcoming requests, and progressively reveal delivery history in six-item pages
- show account-owned destination and recipient details while keeping support and recovery actions scoped to the exact request
- document the customer dashboard organization and privacy contract

## Validation

- `corepack pnpm --filter delivery test:unit` — 357 passed
- `corepack pnpm --filter delivery test:component` — 128 passed
- `corepack pnpm --filter delivery typecheck`
- `corepack pnpm --filter delivery build`
- scoped Biome checks
- `git diff --check`

Closes #4137