### PR TITLE
[Delivery Customer] Preserve cached status and accessible live updates

### DIFF
--- a/apps/delivery/components/CustomerDashboard.tsx
+++ b/apps/delivery/components/CustomerDashboard.tsx
@@ -12,6 +12,10 @@ import type {
     CustomerDeliveryDashboardRequest,
     CustomerDeliveryRequestSummary,
 } from '../lib/deliveryDashboardTypes';
+import {
+    CustomerDashboardFreshness,
+    type CustomerDashboardFreshnessFailure,
+} from './CustomerDashboardFreshness';
 import { CustomerDeliveryCard } from './CustomerDeliveryCard';
 import {
     CustomerDeliveryTracking,
@@ -23,12 +27,15 @@ import { DeliveryAppHeader } from './DeliveryAppHeader';
 function CustomerRequestCard({
     request,
     emphasized = false,
+    announceArrival = false,
 }: {
     request: CustomerDeliveryDashboardRequest;
     emphasized?: boolean;
+    announceArrival?: boolean;
 }) {
     return request.mode === 'delivery' ? (
         <CustomerDeliveryCard
+            announceArrival={announceArrival}
             delivery={request}
             emphasized={emphasized}
             headingLevel="h4"
@@ -54,9 +61,14 @@ function CustomerSectionEmpty({ children }: { children: string }) {
 export function CustomerDashboard({
     dashboard,
     requestTiming,
+    freshness,
 }: {
     dashboard: CustomerDeliveryDashboard;
     requestTiming: CustomerDeliveryTrackingRequestTiming | null;
+    freshness?: {
+        failure: CustomerDashboardFreshnessFailure;
+        onRetry: () => Promise<boolean>;
+    };
 }) {
     const hasDelivery = dashboard.deliveries.some(
         (request) => request.mode === 'delivery',
@@ -147,6 +159,13 @@ export function CustomerDashboard({
                 context={headerContext}
             />
             <main className="mx-auto w-full max-w-5xl space-y-6 px-4 py-5 sm:py-8">
+                {freshness ? (
+                    <CustomerDashboardFreshness
+                        failure={freshness.failure}
+                        refreshedAt={dashboard.refreshedAt}
+                        onRetry={freshness.onRetry}
+                    />
+                ) : null}
                 <div>
                     <Typography level="h2" semiBold>
                         {heading}
@@ -213,6 +232,9 @@ export function CustomerDashboard({
                                                         }
                                                     >
                                                         <CustomerRequestCard
+                                                            announceArrival={
+                                                                index === 0
+                                                            }
                                                             request={request}
                                                             emphasized={
                                                                 index === 0

--- a/apps/delivery/components/CustomerDashboardFreshness.tsx
+++ b/apps/delivery/components/CustomerDashboardFreshness.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { LoaderSpinner, Reset, Success, Warning } from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import { useEffect, useRef, useState } from 'react';
+import type { CustomerDashboardFreshnessFailure } from '../lib/customerDashboardFreshness';
+import { formatDeliveryDateTime } from '../lib/deliveryFormatting';
+
+export type { CustomerDashboardFreshnessFailure } from '../lib/customerDashboardFreshness';
+
+export function CustomerDashboardFreshness({
+    failure,
+    refreshedAt,
+    onRetry,
+}: {
+    failure: CustomerDashboardFreshnessFailure;
+    refreshedAt: string;
+    onRetry: () => Promise<boolean>;
+}) {
+    const stale = failure !== null;
+    const previousStaleRef = useRef(stale);
+    const manualRetryRef = useRef(false);
+    const recoveredRef = useRef<HTMLDivElement>(null);
+    const [retrying, setRetrying] = useState(false);
+    const [retryFailed, setRetryFailed] = useState(false);
+    const [showRecovered, setShowRecovered] = useState(false);
+
+    useEffect(() => {
+        const wasStale = previousStaleRef.current;
+        previousStaleRef.current = stale;
+        if (stale) {
+            setShowRecovered(false);
+            return;
+        }
+        if (!wasStale) return;
+
+        setRetryFailed(false);
+        setShowRecovered(true);
+        const focusRecovery = manualRetryRef.current;
+        manualRetryRef.current = false;
+        if (focusRecovery) {
+            window.requestAnimationFrame(() => recoveredRef.current?.focus());
+        }
+    }, [stale]);
+
+    const retry = async () => {
+        if (retrying) return;
+        manualRetryRef.current = true;
+        setRetryFailed(false);
+        setRetrying(true);
+        let recovered = false;
+        try {
+            recovered = await onRetry();
+        } catch {
+            recovered = false;
+        } finally {
+            setRetrying(false);
+            if (!recovered) {
+                manualRetryRef.current = false;
+                setRetryFailed(true);
+            }
+        }
+    };
+
+    if (stale) {
+        return (
+            <div className="space-y-2">
+                <Alert
+                    aria-atomic="true"
+                    color="warning"
+                    role="alert"
+                    startDecorator={<Warning className="size-5" />}
+                >
+                    <div>
+                        <Typography level="body2" semiBold>
+                            Podaci nisu ažurni
+                        </Typography>
+                        <Typography level="body3" className="mt-1">
+                            {failure === 'offline'
+                                ? 'Uređaj je izvan mreže. Prikazujemo zadnje potvrđene podatke.'
+                                : 'Osvježavanje nije uspjelo. Prikazujemo zadnje potvrđene podatke.'}
+                        </Typography>
+                        <Typography
+                            level="body3"
+                            className="mt-1 text-muted-foreground"
+                        >
+                            Zadnje uspješno osvježavanje:{' '}
+                            <time dateTime={refreshedAt}>
+                                {formatDeliveryDateTime(refreshedAt)}
+                            </time>
+                        </Typography>
+                    </div>
+                </Alert>
+                <Button
+                    aria-busy={retrying}
+                    aria-label="Osvježi podatke"
+                    className="min-h-11"
+                    disabled={retrying}
+                    size="sm"
+                    startDecorator={
+                        retrying ? (
+                            <LoaderSpinner className="size-4 animate-spin" />
+                        ) : (
+                            <Reset className="size-4" />
+                        )
+                    }
+                    variant="outlined"
+                    onClick={() => void retry()}
+                >
+                    {retrying ? 'Osvježavanje…' : 'Osvježi podatke'}
+                </Button>
+                {retryFailed ? (
+                    <div
+                        aria-atomic="true"
+                        aria-label="Osvježavanje nije uspjelo"
+                        aria-live="polite"
+                        className="rounded-lg bg-muted px-3 py-2 text-sm text-muted-foreground"
+                        role="status"
+                    >
+                        Osvježavanje nije uspjelo. Spremljeni podaci ostaju
+                        prikazani; pokušaj ponovno kad veza bude dostupna.
+                    </div>
+                ) : null}
+            </div>
+        );
+    }
+
+    if (!showRecovered) return null;
+
+    return (
+        <div
+            ref={recoveredRef}
+            aria-atomic="true"
+            aria-label="Podaci su ponovno ažurni"
+            aria-live="polite"
+            className="rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            role="status"
+            tabIndex={-1}
+        >
+            <Alert
+                color="success"
+                role="group"
+                startDecorator={<Success className="size-5" />}
+            >
+                Veza je obnovljena. Prikazani podaci ponovno su ažurni.
+            </Alert>
+        </div>
+    );
+}

--- a/apps/delivery/components/CustomerDeliveryCard.tsx
+++ b/apps/delivery/components/CustomerDeliveryCard.tsx
@@ -49,10 +49,12 @@ export function CustomerDeliveryCard({
     delivery,
     emphasized = false,
     headingLevel = 'h3',
+    announceArrival = true,
 }: {
     delivery: CustomerDeliveryRequestSummary;
     emphasized?: boolean;
     headingLevel?: 'h3' | 'h4';
+    announceArrival?: boolean;
 }) {
     const showDeliveryPromise =
         delivery.status !== 'fulfilled' &&
@@ -139,6 +141,7 @@ export function CustomerDeliveryCard({
 
                 {showDeliveryPromise ? (
                     <CustomerDeliveryPromise
+                        announceArrival={announceArrival}
                         eta={delivery.eta}
                         progress={delivery.progress}
                         promisedWindowStartAt={delivery.slotStartAt}

--- a/apps/delivery/components/CustomerDeliveryPromise.tsx
+++ b/apps/delivery/components/CustomerDeliveryPromise.tsx
@@ -59,17 +59,14 @@ function deliveryPromiseAnnouncement(
     const expiredPromise = progress.delayed && !range;
     return [
         range
-            ? eta.source === 'promised-window'
-                ? `Procijenjeni dolazak od ${range.startLabel} do ${range.endLabel}.`
-                : `Procijenjeni dolazak do ${formatDeliveryDateTime(range.endAt)}.`
+            ? `Procijenjeni dolazak od ${range.startLabel} do ${range.endLabel}.`
             : expiredPromise
               ? 'Odabrani termin je prošao, a nova procjena dolaska trenutačno nije dostupna.'
               : 'Procjena dolaska trenutačno nije dostupna.',
-        range ? etaSourceLabel(eta) : null,
+        range ? `${etaSourceLabel(eta)}.` : null,
         eta.freshness === 'stale'
             ? 'Procjena rute nije ažurna; prikazujemo odabrani termin.'
             : null,
-        progressMessage(progress),
         progress.delayed && range
             ? 'Procjena dolaska je nakon završetka odabranog termina.'
             : null,
@@ -82,10 +79,12 @@ export function CustomerDeliveryPromise({
     eta,
     progress,
     promisedWindowStartAt,
+    announceArrival = true,
 }: {
     eta: CustomerDeliveryEtaSummary;
     progress: CustomerDeliveryProgressSummary;
     promisedWindowStartAt: string | null;
+    announceArrival?: boolean;
 }) {
     const range = formatDeliveryDateTimeRange(
         eta.rangeStartAt,
@@ -97,17 +96,15 @@ export function CustomerDeliveryPromise({
         eta.remainingMinSeconds,
         eta.remainingMaxSeconds,
     );
+    const routineAnnouncement = deliveryPromiseAnnouncement(
+        eta,
+        progress,
+        range,
+    );
+    const arrived = progress.phase === 'arrived';
 
     return (
         <div data-testid="customer-delivery-promise" className="space-y-3">
-            <span
-                className="sr-only"
-                role="status"
-                aria-atomic="true"
-                aria-live="polite"
-            >
-                {deliveryPromiseAnnouncement(eta, progress, range)}
-            </span>
             {hasRange ? (
                 <div className="rounded-lg bg-muted/70 p-3">
                     <div className="flex flex-wrap items-start justify-between gap-2">
@@ -196,9 +193,27 @@ export function CustomerDeliveryPromise({
                 </Alert>
             )}
 
-            <div className="flex items-start gap-2 text-sm">
+            <div
+                aria-atomic="true"
+                aria-live={
+                    arrived
+                        ? announceArrival
+                            ? 'assertive'
+                            : undefined
+                        : 'polite'
+                }
+                className="flex items-start gap-2 text-sm"
+                role={
+                    arrived ? (announceArrival ? 'alert' : undefined) : 'status'
+                }
+            >
                 <Tally3 className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
                 <span>{progressMessage(progress)}</span>
+                {!arrived && routineAnnouncement ? (
+                    <span className="sr-only">
+                        Ažuriranje statusa: {routineAnnouncement}
+                    </span>
+                ) : null}
             </div>
 
             {progress.delayed && hasRange ? (

--- a/apps/delivery/components/CustomerDeliveryTracking.tsx
+++ b/apps/delivery/components/CustomerDeliveryTracking.tsx
@@ -4,6 +4,7 @@ import {
 } from '@gredice/storage/deliveryTrackingPolicy';
 import { Alert } from '@gredice/ui/Alert';
 import { MyLocation, Timer, Warning } from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
 import { useEffect, useState } from 'react';
 import type { CustomerDeliveryTrackingSummary } from '../lib/deliveryDashboardTypes';
 import { formatDeliveryDateTime } from '../lib/deliveryFormatting';
@@ -16,22 +17,13 @@ export type CustomerDeliveryTrackingRequestTiming = {
 };
 
 function trackingMessage(tracking: CustomerDeliveryTrackingSummary) {
-    const lastUpdate = tracking.lastAcceptedAt
-        ? formatDeliveryDateTime(tracking.lastAcceptedAt)
-        : null;
     switch (tracking.status) {
         case 'live':
-            return lastUpdate
-                ? `Lokacija vozača je uživo. Zadnje ažuriranje: ${lastUpdate}.`
-                : 'Lokacija vozača je uživo.';
+            return 'Lokacija vozača je uživo.';
         case 'delayed':
-            return lastUpdate
-                ? `Lokacija vozača kasni. Zadnje potvrđeno ažuriranje: ${lastUpdate}.`
-                : 'Lokacija vozača kasni.';
+            return 'Lokacija vozača kasni.';
         case 'offline':
-            return lastUpdate
-                ? `Praćenje je trenutačno izvan mreže. Zadnje potvrđeno ažuriranje: ${lastUpdate}.`
-                : 'Praćenje je trenutačno izvan mreže.';
+            return 'Praćenje je trenutačno izvan mreže.';
         case 'unavailable':
             return 'Lokacija vozača još nije dostupna. Status dostave i procjena dolaska i dalje će se ažurirati.';
     }
@@ -191,9 +183,9 @@ export function CustomerDeliveryTracking({
     return (
         <section className="space-y-3">
             <Alert
-                role="status"
-                aria-live="polite"
+                aria-label="Status praćenja lokacije"
                 color={delayed || offline ? 'warning' : 'info'}
+                role="group"
                 startDecorator={
                     offline ? (
                         <Warning className="size-5" />
@@ -204,7 +196,26 @@ export function CustomerDeliveryTracking({
                     )
                 }
             >
-                {trackingMessage(visibleTracking)}
+                <div>
+                    <span aria-atomic="true" aria-live="polite" role="status">
+                        {trackingMessage(visibleTracking)}
+                    </span>
+                    {visibleTracking.lastAcceptedAt ? (
+                        <Typography
+                            level="body3"
+                            className="mt-1 text-muted-foreground"
+                        >
+                            {visibleTracking.status === 'live'
+                                ? 'Zadnje ažuriranje:'
+                                : 'Zadnje potvrđeno ažuriranje:'}{' '}
+                            <time dateTime={visibleTracking.lastAcceptedAt}>
+                                {formatDeliveryDateTime(
+                                    visibleTracking.lastAcceptedAt,
+                                )}
+                            </time>
+                        </Typography>
+                    ) : null}
+                </div>
             </Alert>
             {showMap ? (
                 <DeliveryMap

--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -21,6 +21,13 @@ import { useDriverTracking } from '../hooks/useDriverTracking';
 import { useOfflineRouteCache } from '../hooks/useOfflineRouteCache';
 import { usePickupManifestSync } from '../hooks/usePickupManifestSync';
 import {
+    customerDashboardFreshnessFailureForRender,
+    initialCustomerDashboardFreshnessState,
+    nextCustomerDashboardFreshnessState,
+    shouldShowDeliveryDashboardLoading,
+} from '../lib/customerDashboardFreshness';
+import {
+    isCanonicalIsoTimestamp,
     isCustomerDeliveryEtaSummary,
     isCustomerDeliveryTrackingSummary,
 } from '../lib/customerDeliveryValidation';
@@ -63,6 +70,7 @@ import {
     createWebStoragePickupManifestQueuePersistence,
 } from '../lib/pickupManifestQueue';
 import { CustomerDashboard } from './CustomerDashboard';
+import { DeliveryDashboardInitialError } from './DeliveryDashboardInitialError';
 import { DriverDashboard } from './DriverDashboard';
 import { OfflineRouteRecovery } from './OfflineRouteRecovery';
 
@@ -139,7 +147,9 @@ function isDeliveryDashboard(value: unknown): value is DeliveryDashboardData {
         !('displayName' in value.user) ||
         typeof value.user.displayName !== 'string' ||
         !('role' in value.user) ||
-        typeof value.user.role !== 'string'
+        typeof value.user.role !== 'string' ||
+        !('refreshedAt' in value) ||
+        !isCanonicalIsoTimestamp(value.refreshedAt)
     ) {
         return false;
     }
@@ -705,6 +715,9 @@ export function DeliveryDashboard({
     );
     const [networkOnline, setNetworkOnline] = useState(true);
     const [offlineFallbackReady, setOfflineFallbackReady] = useState(false);
+    const [customerFreshnessState, setCustomerFreshnessState] = useState(
+        initialCustomerDashboardFreshnessState,
+    );
     const [logoutState, setLogoutState] = useState<
         'idle' | 'pending' | 'failed'
     >('idle');
@@ -715,13 +728,21 @@ export function DeliveryDashboard({
     const offlineSessionReady = offlineSessionUserId === authenticatedUserId;
     const sessionOperational = offlineSessionReady && logoutState === 'idle';
     const query = useQuery({
-        queryKey: ['delivery-dashboard'],
+        queryKey: ['delivery-dashboard', authenticatedUserId],
         queryFn: readDashboard,
         enabled: sessionOperational,
         refetchInterval: 10_000,
     });
     const refetchDashboard = query.refetch;
     const dashboardData = query.data?.dashboard;
+    const customerSuccessVersion = query.data?.requestTiming.monotonicMs ?? 0;
+    const hasCustomerDashboard = dashboardData?.kind === 'customer';
+    const renderedCustomerFreshnessFailure =
+        customerDashboardFreshnessFailureForRender(customerFreshnessState, {
+            scopeKey: authenticatedUserId,
+            networkOnline,
+            isRefetchError: query.isRefetchError,
+        });
     const driverDashboard: DriverDeliveryDashboard | null =
         dashboardData?.kind === 'driver' ? dashboardData : null;
     const authenticatedDriverUserId =
@@ -827,6 +848,26 @@ export function DeliveryDashboard({
             window.removeEventListener('offline', update);
         };
     }, []);
+
+    useEffect(() => {
+        setCustomerFreshnessState((current) =>
+            nextCustomerDashboardFreshnessState(current, {
+                scopeKey: authenticatedUserId,
+                hasCustomerDashboard,
+                networkOnline,
+                isRefetchError: query.isRefetchError,
+                isSuccess: query.isSuccess,
+                successVersion: customerSuccessVersion,
+            }),
+        );
+    }, [
+        authenticatedUserId,
+        customerSuccessVersion,
+        hasCustomerDashboard,
+        networkOnline,
+        query.isRefetchError,
+        query.isSuccess,
+    ]);
 
     useEffect(() => {
         const clearVisibleSession = () => {
@@ -1209,8 +1250,13 @@ export function DeliveryDashboard({
     }
 
     if (
-        query.isPending &&
-        !(offlineRoute && (!networkOnline || offlineFallbackReady))
+        shouldShowDeliveryDashboardLoading({
+            isPending: query.isPending,
+            networkOnline,
+            waitForOfflineRoute: authenticatedDriverUserId !== null,
+            hasOfflineRoute: Boolean(offlineRoute),
+            offlineFallbackReady,
+        })
     ) {
         return (
             <main className="flex min-h-[100dvh] items-center justify-center bg-background p-4">
@@ -1235,34 +1281,34 @@ export function DeliveryDashboard({
             );
         }
         return (
-            <main className="flex min-h-[100dvh] items-center justify-center bg-background p-4">
-                <Card className="w-full max-w-md">
-                    <CardContent noHeader className="space-y-4 p-6 text-center">
-                        <Warning className="mx-auto size-9 text-warning" />
-                        <Typography level="h3" semiBold>
-                            Dostave nisu dostupne
-                        </Typography>
-                        <Typography className="text-muted-foreground">
-                            {query.error instanceof Error
-                                ? query.error.message
-                                : 'Pokušaj ponovno za nekoliko trenutaka.'}
-                        </Typography>
-                        <Button
-                            startDecorator={<Reset className="size-4" />}
-                            onClick={() => void query.refetch()}
-                        >
-                            Pokušaj ponovno
-                        </Button>
-                    </CardContent>
-                </Card>
-            </main>
+            <DeliveryDashboardInitialError
+                message={
+                    !networkOnline
+                        ? 'Uređaj je izvan mreže. Za prvi prikaz potrebna je internetska veza.'
+                        : query.error instanceof Error
+                          ? query.error.message
+                          : 'Pokušaj ponovno za nekoliko trenutaka.'
+                }
+                retrying={query.isFetching}
+                retryUnavailableMessage={
+                    !networkOnline
+                        ? 'Ponovni pokušaj bit će dostupan kada se internetska veza obnovi.'
+                        : null
+                }
+                onRetry={async () => {
+                    if (!networkOnline) return;
+                    await query.refetch();
+                }}
+            />
         );
     }
 
     const dashboard = dashboardData;
+    const showDriverConnectionWarning =
+        dashboard.kind === 'driver' && (!networkOnline || query.isError);
     return (
         <>
-            {!networkOnline || query.isError ? (
+            {showDriverConnectionWarning ? (
                 <div className="fixed inset-x-4 bottom-[max(1rem,env(safe-area-inset-bottom))] z-50 mx-auto max-w-xl">
                     <Alert
                         color="warning"
@@ -1329,9 +1375,24 @@ export function DeliveryDashboard({
                 <CustomerDashboard
                     dashboard={dashboard}
                     requestTiming={query.data?.requestTiming ?? null}
+                    freshness={{
+                        failure: renderedCustomerFreshnessFailure,
+                        onRetry: async () => {
+                            if (!networkOnline) return false;
+                            const previousSuccessVersion =
+                                query.data?.requestTiming.monotonicMs ?? 0;
+                            const result = await refetchDashboard();
+                            const nextSuccessVersion =
+                                result.data?.requestTiming.monotonicMs ?? 0;
+                            return (
+                                result.isSuccess &&
+                                nextSuccessVersion > previousSuccessVersion
+                            );
+                        },
+                    }}
                 />
             )}
-            {!networkOnline || query.isError ? (
+            {showDriverConnectionWarning ? (
                 <div aria-hidden="true" className="h-32 sm:h-24" />
             ) : null}
         </>

--- a/apps/delivery/components/DeliveryDashboardInitialError.tsx
+++ b/apps/delivery/components/DeliveryDashboardInitialError.tsx
@@ -1,0 +1,76 @@
+import { Button } from '@gredice/ui/Button';
+import { Card, CardContent } from '@gredice/ui/Card';
+import { LoaderSpinner, Reset, Warning } from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+
+export function DeliveryDashboardInitialError({
+    message,
+    retrying,
+    retryUnavailableMessage = null,
+    onRetry,
+}: {
+    message: string;
+    retrying: boolean;
+    retryUnavailableMessage?: string | null;
+    onRetry: () => void | Promise<void>;
+}) {
+    return (
+        <main className="flex min-h-[100dvh] items-center justify-center bg-background p-4">
+            <Card className="w-full max-w-md">
+                <CardContent noHeader className="space-y-4 p-6 text-center">
+                    <div aria-atomic="true" role="alert">
+                        <Warning className="mx-auto size-9 text-warning" />
+                        <Typography className="mt-4" level="h3" semiBold>
+                            Dostave nisu dostupne
+                        </Typography>
+                        <Typography className="mt-4 text-muted-foreground">
+                            {message}
+                        </Typography>
+                    </div>
+                    <Button
+                        aria-busy={retrying}
+                        aria-label={
+                            retryUnavailableMessage
+                                ? 'Pokušaj ponovno nije dostupan bez internetske veze'
+                                : 'Pokušaj ponovno'
+                        }
+                        className="min-h-11"
+                        disabled={retrying || Boolean(retryUnavailableMessage)}
+                        startDecorator={
+                            retrying ? (
+                                <LoaderSpinner className="size-4 animate-spin" />
+                            ) : (
+                                <Reset className="size-4" />
+                            )
+                        }
+                        onClick={() => void onRetry()}
+                    >
+                        {retryUnavailableMessage
+                            ? 'Čeka se internetska veza'
+                            : retrying
+                              ? 'Pokušaj u tijeku…'
+                              : 'Pokušaj ponovno'}
+                    </Button>
+                    {retryUnavailableMessage ? (
+                        <Typography
+                            className="text-muted-foreground"
+                            level="body3"
+                        >
+                            {retryUnavailableMessage}
+                        </Typography>
+                    ) : null}
+                    {retrying ? (
+                        <span
+                            aria-atomic="true"
+                            aria-live="polite"
+                            className="sr-only"
+                            role="status"
+                        >
+                            Ponovno učitavanje dostava je u tijeku.
+                        </span>
+                    ) : null}
+                </CardContent>
+            </Card>
+        </main>
+    );
+}

--- a/apps/delivery/lib/customerDashboardFreshness.node.spec.ts
+++ b/apps/delivery/lib/customerDashboardFreshness.node.spec.ts
@@ -1,0 +1,203 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    customerDashboardFreshnessFailureForRender,
+    initialCustomerDashboardFreshnessState,
+    nextCustomerDashboardFreshnessState,
+    shouldShowDeliveryDashboardLoading,
+} from './customerDashboardFreshness';
+
+const freshInput = {
+    scopeKey: 'customer-a',
+    hasCustomerDashboard: true,
+    networkOnline: true,
+    isRefetchError: false,
+    isSuccess: true,
+    successVersion: 100,
+};
+
+test('keeps an offline dashboard stale until a newer request succeeds', () => {
+    const offline = nextCustomerDashboardFreshnessState(
+        initialCustomerDashboardFreshnessState,
+        { ...freshInput, networkOnline: false },
+    );
+    assert.deepEqual(offline, {
+        scopeKey: 'customer-a',
+        failure: 'offline',
+        staleSuccessVersion: 100,
+    });
+
+    const reconnecting = nextCustomerDashboardFreshnessState(offline, {
+        ...freshInput,
+        networkOnline: true,
+    });
+    assert.equal(reconnecting, offline);
+
+    const failed = nextCustomerDashboardFreshnessState(reconnecting, {
+        ...freshInput,
+        isRefetchError: true,
+    });
+    assert.deepEqual(failed, {
+        scopeKey: 'customer-a',
+        failure: 'refresh',
+        staleSuccessVersion: 100,
+    });
+
+    const recovered = nextCustomerDashboardFreshnessState(failed, {
+        ...freshInput,
+        successVersion: 101,
+    });
+    assert.deepEqual(recovered, {
+        scopeKey: 'customer-a',
+        failure: null,
+        staleSuccessVersion: null,
+    });
+});
+
+test('does not turn a paused or cached retry into a false recovery', () => {
+    const stale = {
+        scopeKey: 'customer-a',
+        failure: 'offline' as const,
+        staleSuccessVersion: 100,
+    };
+    assert.equal(nextCustomerDashboardFreshnessState(stale, freshInput), stale);
+    assert.equal(
+        nextCustomerDashboardFreshnessState(stale, {
+            ...freshInput,
+            isSuccess: false,
+            successVersion: 101,
+        }),
+        stale,
+    );
+});
+
+test('resets the stale latch when the authenticated account changes', () => {
+    const staleAccountA = nextCustomerDashboardFreshnessState(
+        initialCustomerDashboardFreshnessState,
+        { ...freshInput, networkOnline: false },
+    );
+    const cachedAccountB = nextCustomerDashboardFreshnessState(staleAccountA, {
+        ...freshInput,
+        scopeKey: 'customer-b',
+        successVersion: 50,
+    });
+    assert.deepEqual(cachedAccountB, {
+        scopeKey: 'customer-b',
+        failure: null,
+        staleSuccessVersion: null,
+    });
+    assert.deepEqual(
+        nextCustomerDashboardFreshnessState(cachedAccountB, {
+            ...freshInput,
+            scopeKey: 'customer-b',
+            networkOnline: false,
+            successVersion: 50,
+        }),
+        {
+            scopeKey: 'customer-b',
+            failure: 'offline',
+            staleSuccessVersion: 50,
+        },
+    );
+});
+
+test('renders current failures immediately while retaining a reconnect latch', () => {
+    const stale = {
+        scopeKey: 'customer-a',
+        failure: 'offline' as const,
+        staleSuccessVersion: 100,
+    };
+    assert.equal(
+        customerDashboardFreshnessFailureForRender(
+            initialCustomerDashboardFreshnessState,
+            {
+                scopeKey: 'customer-a',
+                networkOnline: false,
+                isRefetchError: false,
+            },
+        ),
+        'offline',
+    );
+    assert.equal(
+        customerDashboardFreshnessFailureForRender(stale, {
+            scopeKey: 'customer-a',
+            networkOnline: true,
+            isRefetchError: true,
+        }),
+        'refresh',
+    );
+    assert.equal(
+        customerDashboardFreshnessFailureForRender(stale, {
+            scopeKey: 'customer-a',
+            networkOnline: true,
+            isRefetchError: false,
+        }),
+        'offline',
+    );
+    assert.equal(
+        customerDashboardFreshnessFailureForRender(stale, {
+            scopeKey: 'customer-b',
+            networkOnline: true,
+            isRefetchError: false,
+        }),
+        null,
+    );
+});
+
+test('routes an initial offline query to failure instead of an endless loader', () => {
+    assert.equal(
+        shouldShowDeliveryDashboardLoading({
+            isPending: true,
+            networkOnline: false,
+            waitForOfflineRoute: false,
+            hasOfflineRoute: false,
+            offlineFallbackReady: false,
+        }),
+        false,
+    );
+    assert.equal(
+        shouldShowDeliveryDashboardLoading({
+            isPending: true,
+            networkOnline: true,
+            waitForOfflineRoute: false,
+            hasOfflineRoute: false,
+            offlineFallbackReady: false,
+        }),
+        true,
+    );
+    assert.equal(
+        shouldShowDeliveryDashboardLoading({
+            isPending: true,
+            networkOnline: true,
+            waitForOfflineRoute: true,
+            hasOfflineRoute: true,
+            offlineFallbackReady: true,
+        }),
+        false,
+    );
+});
+
+test('gives a cold offline driver cache a bounded loading grace', () => {
+    const coldDriver = {
+        isPending: true,
+        networkOnline: false,
+        waitForOfflineRoute: true,
+        hasOfflineRoute: false,
+        offlineFallbackReady: false,
+    };
+    assert.equal(shouldShowDeliveryDashboardLoading(coldDriver), true);
+    assert.equal(
+        shouldShowDeliveryDashboardLoading({
+            ...coldDriver,
+            hasOfflineRoute: true,
+        }),
+        false,
+    );
+    assert.equal(
+        shouldShowDeliveryDashboardLoading({
+            ...coldDriver,
+            offlineFallbackReady: true,
+        }),
+        false,
+    );
+});

--- a/apps/delivery/lib/customerDashboardFreshness.ts
+++ b/apps/delivery/lib/customerDashboardFreshness.ts
@@ -1,0 +1,101 @@
+export type CustomerDashboardFreshnessFailure = 'offline' | 'refresh' | null;
+
+export type CustomerDashboardFreshnessState = {
+    scopeKey: string | null;
+    failure: CustomerDashboardFreshnessFailure;
+    staleSuccessVersion: number | null;
+};
+
+export const initialCustomerDashboardFreshnessState: CustomerDashboardFreshnessState =
+    {
+        scopeKey: null,
+        failure: null,
+        staleSuccessVersion: null,
+    };
+
+function freshState(scopeKey: string): CustomerDashboardFreshnessState {
+    return { scopeKey, failure: null, staleSuccessVersion: null };
+}
+
+function staleState(
+    current: CustomerDashboardFreshnessState,
+    failure: Exclude<CustomerDashboardFreshnessFailure, null>,
+    successVersion: number,
+) {
+    const staleSuccessVersion = current.staleSuccessVersion ?? successVersion;
+    if (
+        current.failure === failure &&
+        current.staleSuccessVersion === staleSuccessVersion
+    ) {
+        return current;
+    }
+    return { ...current, failure, staleSuccessVersion };
+}
+
+export function nextCustomerDashboardFreshnessState(
+    current: CustomerDashboardFreshnessState,
+    input: {
+        scopeKey: string;
+        hasCustomerDashboard: boolean;
+        networkOnline: boolean;
+        isRefetchError: boolean;
+        isSuccess: boolean;
+        successVersion: number;
+    },
+): CustomerDashboardFreshnessState {
+    const scopedCurrent =
+        current.scopeKey === input.scopeKey
+            ? current
+            : freshState(input.scopeKey);
+    if (!input.hasCustomerDashboard) {
+        return scopedCurrent.failure === null &&
+            scopedCurrent.staleSuccessVersion === null
+            ? scopedCurrent
+            : freshState(input.scopeKey);
+    }
+    if (!input.networkOnline) {
+        return staleState(scopedCurrent, 'offline', input.successVersion);
+    }
+    if (input.isRefetchError) {
+        return staleState(scopedCurrent, 'refresh', input.successVersion);
+    }
+    if (scopedCurrent.staleSuccessVersion === null) return scopedCurrent;
+    if (
+        input.isSuccess &&
+        input.successVersion > scopedCurrent.staleSuccessVersion
+    ) {
+        return freshState(input.scopeKey);
+    }
+    return scopedCurrent;
+}
+
+export function customerDashboardFreshnessFailureForRender(
+    state: CustomerDashboardFreshnessState,
+    input: {
+        scopeKey: string;
+        networkOnline: boolean;
+        isRefetchError: boolean;
+    },
+): CustomerDashboardFreshnessFailure {
+    if (!input.networkOnline) return 'offline';
+    if (input.isRefetchError) return 'refresh';
+    return state.scopeKey === input.scopeKey ? state.failure : null;
+}
+
+export function shouldShowDeliveryDashboardLoading(input: {
+    isPending: boolean;
+    networkOnline: boolean;
+    waitForOfflineRoute: boolean;
+    hasOfflineRoute: boolean;
+    offlineFallbackReady: boolean;
+}) {
+    if (!input.isPending) return false;
+    if (!input.networkOnline) {
+        return (
+            input.waitForOfflineRoute &&
+            !input.hasOfflineRoute &&
+            !input.offlineFallbackReady
+        );
+    }
+    return !(input.hasOfflineRoute && input.offlineFallbackReady);
+}

--- a/apps/delivery/lib/customerDeliveryValidation.node.spec.ts
+++ b/apps/delivery/lib/customerDeliveryValidation.node.spec.ts
@@ -1,9 +1,24 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    isCanonicalIsoTimestamp,
     isCustomerDeliveryEtaSummary,
     isCustomerDeliveryTrackingSummary,
 } from './customerDeliveryValidation';
+
+test('accepts only canonical ISO timestamps for customer dashboard data', () => {
+    assert.equal(isCanonicalIsoTimestamp('2026-07-16T09:59:00.000Z'), true);
+    for (const value of [
+        1,
+        '1',
+        '2026-07-16',
+        '2026-07-16T09:59:00Z',
+        '2026-02-30T09:59:00.000Z',
+        'not-a-date',
+    ]) {
+        assert.equal(isCanonicalIsoTimestamp(value), false);
+    }
+});
 
 const validTrafficEta = {
     source: 'traffic-route',

--- a/apps/delivery/lib/customerDeliveryValidation.ts
+++ b/apps/delivery/lib/customerDeliveryValidation.ts
@@ -4,14 +4,14 @@ import type {
     CustomerDeliveryTrackingSummary,
 } from './deliveryDashboardTypes';
 
-function canonicalIsoTimestamp(value: unknown): value is string {
+export function isCanonicalIsoTimestamp(value: unknown): value is string {
     if (typeof value !== 'string') return false;
     const time = Date.parse(value);
     return Number.isFinite(time) && new Date(time).toISOString() === value;
 }
 
 function nullableCanonicalIsoTimestamp(value: unknown): value is string | null {
-    return value === null || canonicalIsoTimestamp(value);
+    return value === null || isCanonicalIsoTimestamp(value);
 }
 
 export function isCustomerDeliveryTrackingSummary(

--- a/apps/delivery/tests/CustomerDashboardResilienceStory.tsx
+++ b/apps/delivery/tests/CustomerDashboardResilienceStory.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { CustomerDashboard } from '../components/CustomerDashboard';
+import type { CustomerDashboardFreshnessFailure } from '../components/CustomerDashboardFreshness';
+import { DeliveryDashboardInitialError } from '../components/DeliveryDashboardInitialError';
+import type { CustomerDeliveryDashboard } from '../lib/deliveryDashboardTypes';
+
+const dashboard: CustomerDeliveryDashboard = {
+    kind: 'customer',
+    user: {
+        id: 'customer-resilience-4138',
+        displayName: 'Korisnik Resilient',
+        role: 'user',
+    },
+    deliveries: [
+        {
+            mode: 'delivery',
+            lifecycle: 'active',
+            requestId: 'delivery-resilience-4138',
+            status: 'ready',
+            statusLabel: 'U dostavi',
+            requestNotes: 'Pozvoni na portafon.',
+            slotStartAt: '2026-07-16T08:00:00.000Z',
+            slotEndAt: '2026-07-16T10:00:00.000Z',
+            eta: {
+                source: 'promised-window',
+                calculatedAt: null,
+                freshness: 'fallback',
+                confidence: 'approximate',
+                rangeStartAt: '2026-07-16T08:00:00.000Z',
+                rangeEndAt: '2026-07-16T10:00:00.000Z',
+                remainingMinSeconds: 900,
+                remainingMaxSeconds: 1_800,
+            },
+            progress: {
+                phase: 'on-route',
+                stopsAhead: 2,
+                delayed: false,
+            },
+            deliveredAt: null,
+            harvest: {
+                plantName: 'Rajčica iz spremljenog prikaza',
+                operationName: 'Berba',
+                raisedBedName: 'Gredica 4',
+                fieldName: 'Polje 2',
+                tracePath: '/trag/delivery-resilience-4138',
+            },
+            destination: {
+                recipientName: 'Korisnik Resilient',
+                address: 'Ilica 1, 10000 Zagreb, HR',
+                addressLabel: 'Dom',
+            },
+            receipt: null,
+            recovery: null,
+            tracking: null,
+            mapPath: null,
+        },
+    ],
+    refreshedAt: '2026-07-16T09:15:00.000Z',
+};
+
+function wait(milliseconds: number) {
+    return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+}
+
+export function CustomerDashboardResilienceStory({
+    failure = 'refresh',
+    retrySucceeds = true,
+    retryDelayMs = 500,
+}: {
+    failure?: CustomerDashboardFreshnessFailure;
+    retrySucceeds?: boolean;
+    retryDelayMs?: number;
+}) {
+    const [currentFailure, setCurrentFailure] =
+        useState<CustomerDashboardFreshnessFailure>(failure);
+
+    useEffect(() => setCurrentFailure(failure), [failure]);
+
+    return (
+        <CustomerDashboard
+            dashboard={dashboard}
+            requestTiming={null}
+            freshness={{
+                failure: currentFailure,
+                onRetry: async () => {
+                    await wait(retryDelayMs);
+                    if (retrySucceeds) setCurrentFailure(null);
+                    return retrySucceeds;
+                },
+            }}
+        />
+    );
+}
+
+export function InitialDashboardErrorStory({ retryDelayMs = 500 }) {
+    const [retrying, setRetrying] = useState(false);
+    const [attempts, setAttempts] = useState(0);
+
+    return (
+        <>
+            <DeliveryDashboardInitialError
+                message="Podatke o dostavama trenutačno nije moguće učitati."
+                retrying={retrying}
+                onRetry={async () => {
+                    setRetrying(true);
+                    await wait(retryDelayMs);
+                    setAttempts((current) => current + 1);
+                    setRetrying(false);
+                }}
+            />
+            <output data-testid="initial-retry-attempts">{attempts}</output>
+        </>
+    );
+}
+
+export function InitialDashboardErrorStateStory({
+    retrying = false,
+    retryUnavailableMessage = null,
+}: {
+    retrying?: boolean;
+    retryUnavailableMessage?: string | null;
+}) {
+    return (
+        <DeliveryDashboardInitialError
+            message="Podatke o dostavama trenutačno nije moguće učitati."
+            retrying={retrying}
+            retryUnavailableMessage={retryUnavailableMessage}
+            onRetry={() => undefined}
+        />
+    );
+}

--- a/apps/delivery/tests/CustomerDeliveryEtaStory.tsx
+++ b/apps/delivery/tests/CustomerDeliveryEtaStory.tsx
@@ -243,11 +243,17 @@ export function InvalidCustomerWindowStory({
 }
 
 export function UpdatingCustomerEtaStory({
+    arrived = false,
     delayed = false,
+    rangeStartAt = baseDelivery.slotStartAt,
+    rangeEndAt = baseDelivery.slotEndAt,
     remainingMinSeconds = 3_600,
     remainingMaxSeconds = 10_800,
 }: {
+    arrived?: boolean;
     delayed?: boolean;
+    rangeStartAt?: string | null;
+    rangeEndAt?: string | null;
     remainingMinSeconds?: number;
     remainingMaxSeconds?: number;
 }) {
@@ -272,22 +278,28 @@ export function UpdatingCustomerEtaStory({
                           calculatedAt: null,
                           freshness: 'fallback',
                           confidence: 'approximate',
-                          rangeStartAt: baseDelivery.slotStartAt,
-                          rangeEndAt: baseDelivery.slotEndAt,
+                          rangeStartAt,
+                          rangeEndAt,
                           remainingMinSeconds,
                           remainingMaxSeconds,
                       },
-                progress: delayed
+                progress: arrived
                     ? {
-                          phase: 'on-route',
-                          stopsAhead: 1,
-                          delayed: true,
-                      }
-                    : {
-                          phase: 'on-route',
-                          stopsAhead: 3,
+                          phase: 'arrived',
+                          stopsAhead: 0,
                           delayed: false,
-                      },
+                      }
+                    : delayed
+                      ? {
+                            phase: 'on-route',
+                            stopsAhead: 1,
+                            delayed: true,
+                        }
+                      : {
+                            phase: 'on-route',
+                            stopsAhead: 3,
+                            delayed: false,
+                        },
             }}
         />
     );

--- a/apps/delivery/tests/CustomerDeliveryHistoryStory.tsx
+++ b/apps/delivery/tests/CustomerDeliveryHistoryStory.tsx
@@ -199,7 +199,7 @@ const activeBulkSibling = delivery({
     plantName: 'Aktivni bosiljak',
     lifecycle: 'active',
     slotStartAt: '2026-07-16T09:00:00.000Z',
-    phase: 'next',
+    phase: 'arrived',
 });
 
 const history = [
@@ -283,7 +283,6 @@ export function CustomerDeliverySectionsStory() {
                     lifecycle: 'upcoming',
                     slotStartAt: '2026-07-17T11:00:00.000Z',
                 }),
-                activeBulkSibling,
                 pickup({
                     requestId: 'upcoming-pickup-4137',
                     plantName: 'Nadolazeća blitva',
@@ -291,6 +290,7 @@ export function CustomerDeliverySectionsStory() {
                     slotStartAt: '2026-07-17T09:00:00.000Z',
                 }),
                 activeArrived,
+                activeBulkSibling,
                 ...history,
             ]}
         />

--- a/apps/delivery/tests/delivery-customer-eta.spec.tsx
+++ b/apps/delivery/tests/delivery-customer-eta.spec.tsx
@@ -180,6 +180,9 @@ test('keeps a stable polite announcement for meaningful ETA and progress updates
     await expect(announcement).toContainText(
         '3 zaustavljanja prije tvoje dostave.',
     );
+    await expect(announcement).toContainText(
+        'Procijenjeni dolazak od 10:00 do 12:00.',
+    );
     const initialAnnouncement = await announcement.textContent();
     await component.update(
         <UpdatingCustomerEtaStory
@@ -191,12 +194,41 @@ test('keeps a stable polite announcement for meaningful ETA and progress updates
         component.getByText('Preostalo: 5 min – 15 min', { exact: true }),
     ).toBeVisible();
     await expect(announcement).toHaveText(initialAnnouncement ?? '');
+    await component.update(
+        <UpdatingCustomerEtaStory
+            rangeStartAt="2026-07-16T09:15:00.000Z"
+            rangeEndAt="2026-07-16T09:30:00.000Z"
+        />,
+    );
+    await expect(announcement).not.toHaveText(initialAnnouncement ?? '');
+    await expect(announcement).toContainText(
+        'Procijenjeni dolazak od 11:15 do 11:30.',
+    );
     await component.update(<UpdatingCustomerEtaStory delayed />);
     await expect(announcement).toContainText(
         'Procjena dolaska je nakon završetka odabranog termina.',
     );
     await expect(announcement).toHaveAttribute('aria-atomic', 'true');
     await expect(component.getByRole('alert')).toHaveCount(0);
+});
+
+test('announces driver arrival assertively without duplicating a routine update', async ({
+    mount,
+}) => {
+    const component = await mount(<UpdatingCustomerEtaStory />);
+    await expect(component.getByRole('status')).toHaveCount(1);
+
+    await component.update(<UpdatingCustomerEtaStory arrived />);
+
+    await expect(component.getByRole('alert')).toHaveText(
+        'Vozač je stigao na lokaciju dostave.',
+    );
+    await expect(component.getByRole('status')).toHaveCount(0);
+    await expect(
+        component.getByText('Vozač je stigao na lokaciju dostave.', {
+            exact: true,
+        }),
+    ).toBeVisible();
 });
 
 test.describe('customer ETA on a narrow touch screen', () => {

--- a/apps/delivery/tests/delivery-customer-history.spec.tsx
+++ b/apps/delivery/tests/delivery-customer-history.spec.tsx
@@ -39,6 +39,15 @@ test('leads with every active delivery and organizes upcoming requests and bound
         active.getByRole('heading', { level: 3, name: 'Aktivna dostava' }),
     ).toBeVisible();
     await expect(active.getByTestId('customer-delivery-card')).toHaveCount(2);
+    await expect(active.getByRole('alert')).toHaveCount(1);
+    await expect(active.getByRole('alert')).toHaveText(
+        'Vozač je stigao na lokaciju dostave.',
+    );
+    await expect(
+        active.getByText('Vozač je stigao na lokaciju dostave.', {
+            exact: true,
+        }),
+    ).toHaveCount(2);
     await expect(active.getByRole('heading', { level: 4 })).toHaveText([
         'Aktivna rajčica',
         'Aktivni bosiljak',

--- a/apps/delivery/tests/delivery-customer-resilience.spec.tsx
+++ b/apps/delivery/tests/delivery-customer-resilience.spec.tsx
@@ -1,0 +1,171 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import {
+    CustomerDashboardResilienceStory,
+    InitialDashboardErrorStateStory,
+    InitialDashboardErrorStory,
+} from './CustomerDashboardResilienceStory';
+import '../app/globals.css';
+
+test('announces an initial failure and offers a truthful retry state', async ({
+    mount,
+    page,
+}) => {
+    await mount(<InitialDashboardErrorStory />);
+
+    await expect(page.getByRole('alert')).toContainText(
+        'Dostave nisu dostupne',
+    );
+    const retry = page.getByRole('button', { name: 'Pokušaj ponovno' });
+    await retry.click();
+    await expect(retry).toBeDisabled();
+    await expect(retry).toHaveAttribute('aria-busy', 'true');
+    await expect(retry).toContainText('Pokušaj u tijeku');
+    await expect(page.getByTestId('initial-retry-attempts')).toHaveText('1');
+    await expect(retry).toBeEnabled();
+});
+
+test('keeps the initial failure alert stable while retry progress is announced politely', async ({
+    mount,
+    page,
+}) => {
+    const component = await mount(<InitialDashboardErrorStateStory />);
+    const alert = page.getByRole('alert');
+    const initialAlertMarkup = await alert.innerHTML();
+
+    await component.update(<InitialDashboardErrorStateStory retrying />);
+
+    expect(await alert.innerHTML()).toBe(initialAlertMarkup);
+    await expect(
+        page.getByRole('status').filter({
+            hasText: 'Ponovno učitavanje dostava je u tijeku.',
+        }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Pokušaj ponovno' }),
+    ).toBeDisabled();
+});
+
+test('keeps an offline initial retry truthful until connectivity returns', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <InitialDashboardErrorStateStory retryUnavailableMessage="Ponovni pokušaj bit će dostupan kada se internetska veza obnovi." />,
+    );
+
+    await expect(
+        page.getByRole('button', {
+            name: 'Pokušaj ponovno nije dostupan bez internetske veze',
+        }),
+    ).toBeDisabled();
+    await expect(
+        page.getByText(
+            'Ponovni pokušaj bit će dostupan kada se internetska veza obnovi.',
+            { exact: true },
+        ),
+    ).toBeVisible();
+});
+
+test('keeps last-known customer content visible with refresh failure context', async ({
+    mount,
+    page,
+}) => {
+    await mount(<CustomerDashboardResilienceStory />);
+
+    await expect(
+        page.getByText('Rajčica iz spremljenog prikaza', { exact: true }),
+    ).toBeVisible();
+    const warning = page.getByRole('alert');
+    await expect(warning).toContainText('Prikazujemo zadnje potvrđene podatke');
+    await expect(warning.locator('time')).toHaveAttribute(
+        'datetime',
+        '2026-07-16T09:15:00.000Z',
+    );
+    await expect(
+        page.getByRole('button', { name: 'Osvježi podatke' }),
+    ).toBeVisible();
+});
+
+test('marks an offline cached dashboard without replacing its content', async ({
+    mount,
+    page,
+}) => {
+    await mount(<CustomerDashboardResilienceStory failure="offline" />);
+
+    await expect(
+        page.getByText('Rajčica iz spremljenog prikaza', { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByRole('alert')).toContainText(
+        'Uređaj je izvan mreže',
+    );
+});
+
+test('retries in place and focuses the recovered state after a user action', async ({
+    mount,
+    page,
+}) => {
+    await mount(<CustomerDashboardResilienceStory />);
+
+    const retry = page.getByRole('button', { name: 'Osvježi podatke' });
+    const alert = page.getByRole('alert');
+    const initialAlertMarkup = await alert.innerHTML();
+    await retry.click();
+    await expect(retry).toBeDisabled();
+    await expect(retry).toHaveAttribute('aria-busy', 'true');
+    await expect(retry).toContainText('Osvježavanje');
+    expect(await alert.innerHTML()).toBe(initialAlertMarkup);
+
+    const recovered = page.getByRole('status', {
+        name: 'Podaci su ponovno ažurni',
+    });
+    await expect(recovered).toBeVisible();
+    await expect(recovered).toBeFocused();
+    await expect(page.getByRole('alert')).toHaveCount(0);
+    await expect(
+        page.getByText('Rajčica iz spremljenog prikaza', { exact: true }),
+    ).toBeVisible();
+});
+
+test('automatic recovery announces politely without stealing focus', async ({
+    mount,
+    page,
+}) => {
+    const component = await mount(<CustomerDashboardResilienceStory />);
+    await expect(page.getByRole('alert')).toBeVisible();
+    const traceLink = page.getByRole('link', {
+        name: 'Otvori trag uroda: Rajčica iz spremljenog prikaza',
+    });
+    await traceLink.focus();
+    await expect(traceLink).toBeFocused();
+
+    await component.update(<CustomerDashboardResilienceStory failure={null} />);
+
+    const recovered = page.getByRole('status', {
+        name: 'Podaci su ponovno ažurni',
+    });
+    await expect(recovered).toBeVisible();
+    await expect(recovered).not.toBeFocused();
+    await expect(traceLink).toBeFocused();
+    await expect(page.getByRole('alert')).toHaveCount(0);
+});
+
+test('failed retry leaves the cached dashboard and recovery action available', async ({
+    mount,
+    page,
+}) => {
+    await mount(<CustomerDashboardResilienceStory retrySucceeds={false} />);
+
+    const retry = page.getByRole('button', { name: 'Osvježi podatke' });
+    await retry.click();
+
+    await expect(retry).toBeEnabled();
+    await expect(page.getByRole('alert')).toBeVisible();
+    await expect(
+        page.getByRole('status', {
+            name: 'Osvježavanje nije uspjelo',
+        }),
+    ).toContainText('Spremljeni podaci ostaju prikazani');
+    await expect(
+        page.getByText('Rajčica iz spremljenog prikaza', { exact: true }),
+    ).toBeVisible();
+});

--- a/apps/delivery/tests/delivery-tracking.spec.tsx
+++ b/apps/delivery/tests/delivery-tracking.spec.tsx
@@ -33,6 +33,57 @@ test('customer sees a live server-acknowledged location and map', async ({
     ).toBeVisible();
 });
 
+test('keeps polling timestamps outside the polite tracking announcement', async ({
+    mount,
+}) => {
+    const component = await mount(
+        <CustomerDeliveryTrackingFromRequest
+            mapPath="/api/map/run-announcement"
+            tracking={{
+                status: 'live',
+                lastAcceptedAt,
+                mapAvailable: true,
+                exactLocationExpiresInMs: 110_000,
+            }}
+        />,
+    );
+    const announcement = component.getByRole('status');
+
+    await expect(announcement).toHaveText('Lokacija vozača je uživo.');
+    const initialAnnouncement = await announcement.textContent();
+    await component.update(
+        <CustomerDeliveryTrackingFromRequest
+            mapPath="/api/map/run-announcement"
+            tracking={{
+                status: 'live',
+                lastAcceptedAt: '2026-07-15T10:00:10.000Z',
+                mapAvailable: true,
+                exactLocationExpiresInMs: 110_000,
+            }}
+        />,
+    );
+
+    await expect(announcement).toHaveText(initialAnnouncement ?? '');
+    await expect(component.locator('time')).toHaveAttribute(
+        'datetime',
+        '2026-07-15T10:00:10.000Z',
+    );
+
+    await component.update(
+        <CustomerDeliveryTrackingFromRequest
+            mapPath="/api/map/run-announcement"
+            tracking={{
+                status: 'delayed',
+                lastAcceptedAt: '2026-07-15T10:00:10.000Z',
+                mapAvailable: true,
+                exactLocationExpiresInMs: 60_000,
+            }}
+        />,
+    );
+    await expect(announcement).toHaveText('Lokacija vozača kasni.');
+    await expect(component.getByRole('alert')).toHaveCount(0);
+});
+
 test('ages a live location to delayed when dashboard polling stalls', async ({
     mount,
     page,

--- a/docs/delivery-customer-tracking.md
+++ b/docs/delivery-customer-tracking.md
@@ -41,6 +41,34 @@ excluded. Delivery, pickup, receipt, and recovery support links prefill the
 exact owned request and harvest/trace reference without adding destination or
 recipient data to the message.
 
+## Cached dashboard and announcements
+
+The customer dashboard keeps the last successful React Query response mounted
+during an offline period or transient background refresh failure. This is an
+authenticated, in-memory session cache only: customer recipient, destination,
+harvest, and tracking data are not persisted to local storage. The query key is
+scoped to the authenticated user, and logout removes delivery-dashboard query
+data before another session can render.
+
+A full-screen error is reserved for the initial request when no dashboard has
+ever loaded. When last-known content exists, a customer-specific warning shows
+the server-provided `refreshedAt` time and offers an in-place retry without
+unmounting active, upcoming, or historical requests. Invalid refresh timestamps
+fail the runtime response guard. Reconnecting keeps the warning visible until a
+newer server response succeeds; a cached or paused query cannot produce a false
+recovery. A cold offline customer request goes directly to the initial error,
+while drivers get a bounded grace period for their persisted route to load.
+Successful automatic recovery is announced politely without moving focus;
+recovery after a customer-triggered retry moves focus to the confirmation so
+the completed action is unambiguous.
+
+Routine ETA, progress, and tracking-state changes use polite status regions.
+Polling-only GPS timestamps and ETA calculation timestamps remain visible as
+ordinary `<time>` content outside those live regions, so a refresh does not
+reannounce an otherwise unchanged state. Driver arrival and loss of a usable
+dashboard remain assertive. These announcement rules do not extend exact-map
+retention: an already-rendered map still unmounts at the server-calculated TTL.
+
 ## Promised window
 
 Every delivery card renders the complete `slotStartAt`–`slotEndAt` window. A


### PR DESCRIPTION
## Summary

- preserve the last successful, user-scoped customer dashboard through offline periods and background refresh failures, with canonical refresh timestamps and a newer-success recovery latch
- keep cold-start and retry states truthful while preserving the driver offline-route loading grace
- stabilize ETA and tracking live regions, preserve focus on automatic recovery, and announce a bulk-stop arrival only once
- document the in-memory cache, privacy boundary, recovery behavior, and announcement policy

## Validation

- `corepack pnpm --filter delivery test:unit` (364 passed)
- `corepack pnpm --filter delivery test:component` (138 passed)
- `corepack pnpm --filter delivery typecheck`
- `corepack pnpm --filter delivery build`
- scoped Biome check and `git diff --check`

Closes #4138