### PR TITLE
[Delivery Notifications] Define lifecycle events, preferences, and idempotency

### DIFF
--- a/apps/api/app/api/[...route]/notificationsRoutes.ts
+++ b/apps/api/app/api/[...route]/notificationsRoutes.ts
@@ -29,6 +29,7 @@ import {
     sanitizeGrediceLinkUrl,
     validateHostedImageUrl,
 } from '../../../lib/http/safeUrls';
+import { notificationPreferenceUpdateSchema } from '../../../lib/notifications/notificationPreferences';
 import { notificationRolloutFlags } from '../../../lib/notifications/notificationRollout';
 import { notificationCenterRoles } from '../../../lib/notifications/notificationRouteRoles';
 import {
@@ -766,31 +767,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
         zValidator(
             'json',
             z.object({
-                preferences: z.array(
-                    z.object({
-                        scope: z.enum(['global', 'account']),
-                        category: z.string().min(1),
-                        channel: z.enum(['in_app', 'email', 'push', 'sms']),
-                        enabled: z.boolean(),
-                        quietHoursStartMinute: z
-                            .number()
-                            .int()
-                            .min(0)
-                            .max(1439)
-                            .nullable()
-                            .optional(),
-                        quietHoursEndMinute: z
-                            .number()
-                            .int()
-                            .min(0)
-                            .max(1439)
-                            .nullable()
-                            .optional(),
-                        digestFrequency: z
-                            .enum(['off', 'hourly', 'daily', 'weekly'])
-                            .optional(),
-                    }),
-                ),
+                preferences: z.array(notificationPreferenceUpdateSchema),
             }),
         ),
         async (context) => {
@@ -815,6 +792,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                             preference.quietHoursStartMinute ?? null,
                         quietHoursEndMinute:
                             preference.quietHoursEndMinute ?? null,
+                        timezone: preference.timezone,
                         digestFrequency: preference.digestFrequency ?? 'off',
                     })
                     .onConflictDoUpdate({
@@ -841,6 +819,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                                 preference.quietHoursStartMinute ?? null,
                             quietHoursEndMinute:
                                 preference.quietHoursEndMinute ?? null,
+                            timezone: preference.timezone,
                             ...(preference.digestFrequency === undefined
                                 ? {}
                                 : {

--- a/apps/api/lib/notifications/notificationPreferences.node.spec.ts
+++ b/apps/api/lib/notifications/notificationPreferences.node.spec.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    isValidNotificationTimeZone,
+    notificationPreferenceUpdateSchema,
+} from './notificationPreferences';
+
+test('accepts IANA notification time zones and rejects invalid values', () => {
+    assert.equal(isValidNotificationTimeZone('Europe/Zagreb'), true);
+    assert.equal(isValidNotificationTimeZone('UTC'), true);
+    assert.equal(isValidNotificationTimeZone('not/a-time-zone'), false);
+});
+
+const preference = {
+    scope: 'global' as const,
+    category: 'delivery_updates',
+    channel: 'push' as const,
+    enabled: true,
+    digestFrequency: 'off' as const,
+};
+
+test('accepts disabled quiet hours or a complete localized window', () => {
+    assert.deepEqual(notificationPreferenceUpdateSchema.parse(preference), {
+        ...preference,
+        quietHoursStartMinute: null,
+        quietHoursEndMinute: null,
+        timezone: null,
+    });
+    assert.deepEqual(
+        notificationPreferenceUpdateSchema.parse({
+            ...preference,
+            quietHoursStartMinute: null,
+        }),
+        {
+            ...preference,
+            quietHoursStartMinute: null,
+            quietHoursEndMinute: null,
+            timezone: null,
+        },
+    );
+    assert.equal(
+        notificationPreferenceUpdateSchema.safeParse({
+            ...preference,
+            quietHoursStartMinute: 22 * 60,
+            quietHoursEndMinute: 7 * 60,
+            timezone: 'Europe/Zagreb',
+        }).success,
+        true,
+    );
+});
+
+test('rejects partial quiet-hours windows and windows without a valid time zone', () => {
+    for (const input of [
+        {
+            ...preference,
+            quietHoursStartMinute: 22 * 60,
+        },
+        {
+            ...preference,
+            quietHoursStartMinute: 22 * 60,
+            quietHoursEndMinute: 7 * 60,
+        },
+        {
+            ...preference,
+            quietHoursStartMinute: 22 * 60,
+            quietHoursEndMinute: 7 * 60,
+            timezone: null,
+        },
+        {
+            ...preference,
+            quietHoursStartMinute: null,
+            quietHoursEndMinute: null,
+            timezone: 'Europe/Zagreb',
+        },
+        {
+            ...preference,
+            quietHoursStartMinute: 22 * 60,
+            quietHoursEndMinute: 7 * 60,
+            timezone: 'not/a-time-zone',
+        },
+    ]) {
+        assert.equal(
+            notificationPreferenceUpdateSchema.safeParse(input).success,
+            false,
+        );
+    }
+});

--- a/apps/api/lib/notifications/notificationPreferences.ts
+++ b/apps/api/lib/notifications/notificationPreferences.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+
+export function isValidNotificationTimeZone(timeZone: string) {
+    try {
+        new Intl.DateTimeFormat('en-US', { timeZone }).format(new Date());
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+const notificationTimeZoneSchema = z
+    .string()
+    .trim()
+    .min(1)
+    .max(100)
+    .refine(isValidNotificationTimeZone, 'Invalid IANA time zone.');
+
+export const notificationPreferenceUpdateSchema = z
+    .object({
+        scope: z.enum(['global', 'account']),
+        category: z.string().min(1),
+        channel: z.enum(['in_app', 'email', 'push', 'sms']),
+        enabled: z.boolean(),
+        quietHoursStartMinute: z
+            .number()
+            .int()
+            .min(0)
+            .max(1439)
+            .nullable()
+            .optional(),
+        quietHoursEndMinute: z
+            .number()
+            .int()
+            .min(0)
+            .max(1439)
+            .nullable()
+            .optional(),
+        timezone: notificationTimeZoneSchema.nullable().optional(),
+        digestFrequency: z
+            .enum(['off', 'hourly', 'daily', 'weekly'])
+            .optional(),
+    })
+    .superRefine((preference, context) => {
+        const hasStart = typeof preference.quietHoursStartMinute === 'number';
+        const hasEnd = typeof preference.quietHoursEndMinute === 'number';
+        const hasTimeZone = typeof preference.timezone === 'string';
+
+        if (hasStart === hasEnd && hasEnd === hasTimeZone) {
+            return;
+        }
+
+        context.addIssue({
+            code: 'custom',
+            message:
+                'Quiet hours require start minute, end minute, and IANA time zone together.',
+            path: ['quietHoursStartMinute'],
+        });
+    })
+    .transform((preference) => {
+        const quietHoursEnabled =
+            typeof preference.quietHoursStartMinute === 'number';
+        return {
+            ...preference,
+            quietHoursStartMinute: quietHoursEnabled
+                ? preference.quietHoursStartMinute
+                : null,
+            quietHoursEndMinute: quietHoursEnabled
+                ? (preference.quietHoursEndMinute ?? null)
+                : null,
+            timezone: quietHoursEnabled ? (preference.timezone ?? null) : null,
+        };
+    });

--- a/apps/garden/tests/notifications-tab.spec.tsx
+++ b/apps/garden/tests/notifications-tab.spec.tsx
@@ -49,6 +49,7 @@ const defaultPreferences = [
         quietHoursEndMinute: 7 * 60,
         quietHoursStartMinute: 22 * 60,
         scope: 'global',
+        timezone: 'Europe/Zagreb',
     },
     {
         category: 'admin_campaigns',
@@ -355,6 +356,7 @@ test('notification settings explains required groups and hydrates saved preferen
         page.getByText('Plaćanja, računi i potvrde narudžbi'),
     ).toBeVisible();
     await expect(page.getByText('Vrste obavijesti')).toBeVisible();
+    await expect(page.getByText(/ažuriranja dostave/i)).toHaveCount(0);
     await expect(
         page.getByRole('switch', {
             name: /Obavezna obavijest sigurnost računa/u,
@@ -376,6 +378,94 @@ test('notification settings explains required groups and hydrates saved preferen
         '07:00',
     );
     await expect(page.getByText('Tjedno')).toBeVisible();
+});
+
+test('global quiet hours include hidden delivery channels without exposing their controls', async ({
+    mount,
+    page,
+}) => {
+    const recorded = await mockNotificationSettingsApi(page, {
+        preferences: { body: { preferences: [] } },
+    });
+
+    await mount(<NotificationsTabStory />);
+    await page.getByRole('tab', { name: 'Postavke' }).click();
+
+    await expect(page.getByText(/ažuriranja dostave/i)).toHaveCount(0);
+    const timeZone = await page.evaluate(
+        () => Intl.DateTimeFormat().resolvedOptions().timeZone,
+    );
+    await page.getByRole('switch', { name: 'Uključi ne ometaj' }).click();
+
+    await expect.poll(() => recorded.preferencesUpdates.length).toBe(1);
+    expect(recorded.preferencesUpdates[0]).toEqual({
+        preferences: expect.arrayContaining([
+            {
+                category: 'delivery_updates',
+                channel: 'email',
+                digestFrequency: 'off',
+                enabled: true,
+                quietHoursEndMinute: 420,
+                quietHoursStartMinute: 1320,
+                scope: 'global',
+                timezone: timeZone,
+            },
+            {
+                category: 'delivery_updates',
+                channel: 'in_app',
+                digestFrequency: 'off',
+                enabled: true,
+                quietHoursEndMinute: 420,
+                quietHoursStartMinute: 1320,
+                scope: 'global',
+                timezone: timeZone,
+            },
+            {
+                category: 'delivery_updates',
+                channel: 'push',
+                digestFrequency: 'off',
+                enabled: true,
+                quietHoursEndMinute: 420,
+                quietHoursStartMinute: 1320,
+                scope: 'global',
+                timezone: timeZone,
+            },
+        ]),
+    });
+});
+
+test('quiet hours stay disabled when the browser time zone is unavailable', async ({
+    mount,
+    page,
+}) => {
+    const recorded = await mockNotificationSettingsApi(page, {
+        preferences: { body: { preferences: [] } },
+    });
+
+    await mount(<NotificationsTabStory />);
+    await page.getByRole('tab', { name: 'Postavke' }).click();
+    await page.evaluate(() => {
+        const resolvedOptions = Intl.DateTimeFormat.prototype.resolvedOptions;
+        Intl.DateTimeFormat.prototype.resolvedOptions = function () {
+            return {
+                ...resolvedOptions.call(this),
+                timeZone: '',
+            };
+        };
+    });
+
+    const quietHoursSwitch = page.getByRole('switch', {
+        name: 'Uključi ne ometaj',
+    });
+    await quietHoursSwitch.click();
+
+    await expect(
+        page.getByRole('alert').filter({
+            hasText: 'Vremenska zona preglednika nije dostupna.',
+        }),
+    ).toBeVisible();
+    await expect(quietHoursSwitch).not.toBeChecked();
+    expect(recorded.preferencesUpdates).toEqual([]);
 });
 
 test('notification settings keeps switch thumbs inside their tracks', async ({
@@ -557,6 +647,7 @@ test('notification settings calls preference, device, and test notification APIs
                 quietHoursEndMinute: 420,
                 quietHoursStartMinute: 1320,
                 scope: 'global',
+                timezone: 'Europe/Zagreb',
             },
         ],
     });

--- a/docs/delivery-notification-lifecycle.md
+++ b/docs/delivery-notification-lifecycle.md
@@ -1,0 +1,75 @@
+# Delivery notification lifecycle
+
+This contract defines the customer-safe facts that can become delivery updates.
+It does not send customer messages by itself. Croatian templates, deep links,
+and channel producers consume these events in the next implementation slice.
+Internal Slack notifications remain a separate workflow.
+
+## Milestones and authoritative triggers
+
+| Milestone | Authoritative trigger | Idempotency scope |
+|---|---|---|
+| `route-started` | Delivery run enters its started state | delivery request + run |
+| `near-arrival` | The route's maximum ETA first enters 30 minutes or less | delivery request + run + retry attempt |
+| `next-stop` | The request's physical stop becomes next (`stopsAhead` enters zero) | delivery request + run + retry attempt |
+| `delayed` | Route lateness first reaches 15 minutes | delivery request + run + retry attempt |
+| `arrived` | The server applies the driver's arrival operation | delivery request + run + retry attempt |
+| `delivered` | The server fulfills the delivery request | delivery request + run |
+| `exception` | The server applies a bounded stop exception outcome and reason | delivery request + run + retry attempt |
+| `recovery` | The server opens the next retry attempt for an excepted stop | delivery request + run + new retry attempt |
+
+Every event uses the optional `delivery_updates` preference category. Its
+in-app, email, and push defaults are enabled, non-required, and non-digestible.
+Configured quiet hours defer delivery through the existing notification router.
+Customer-facing controls remain hidden until the templates and producers ship,
+so this contract does not promise messages before the next slice is enabled.
+
+## Ordering, thresholds, and retries
+
+Route progress is ignored before `route-started`, while an exception is active,
+and after arrival or delivery. Arrival must precede delivery, and delivery is
+terminal. Recovery is valid only for the next retry attempt and resets the
+near-arrival, next-stop, and delay threshold latches for that attempt.
+
+Near-arrival emits once when the maximum ETA is at most 30 minutes. Delay enters
+at 15 minutes late and clears only after lateness falls to 5 minutes or less.
+The stable idempotency key still permits at most one notification for each
+threshold and retry attempt, so ETA oscillation cannot repeatedly notify a
+customer. A source replay produces the same key; ETA values, source identifiers,
+timestamps, and route revisions are deliberately excluded from it.
+
+`route-started` and `delivered` keys span all attempts. The remaining keys add
+the retry attempt. All keys include opaque account, run, stop, and delivery
+request identifiers with a versioned milestone. The storage repository hashes
+this key into a bounded notification ID and reuses the first row on a repeated
+domain event. The repository serializes the notification row, router attempts,
+and push queue attempts under one database advisory lock. Concurrent retries
+and replays therefore reuse one customer notification and one attempt per
+channel.
+
+## Minimal payload and retention
+
+The event envelope contains only:
+
+- contract version and milestone;
+- opaque account, request, run, and stop identifiers;
+- retry attempt and canonical occurrence timestamp;
+- opaque authoritative source ID, source kind, and source version;
+- the bounded exception outcome and reason for `exception` only;
+- the idempotency key.
+
+It must not contain coordinates, an address, access instructions, customer or
+driver contact details, raw QR values, harvest trace tokens, or data about other
+customers. Templates resolve any needed display data only at the authenticated
+delivery boundary.
+
+Notification delivery attempts and delivery events use the existing 180-day
+cleanup policy. Notification rows continue to follow the platform's existing
+notification-retention behavior; this contract does not claim or add a new row
+deletion schedule.
+
+Before producers are enabled, the rollout must materialize the new defaults for
+existing users. Newly inserted delivery preferences inherit the user's newest
+complete global quiet-hours window, while existing delivery overrides remain
+untouched. The backfill also preserves legacy master email opt-outs; runtime
+fallback defaults alone do not consult the legacy email setting.

--- a/docs/notification-preference-matrix.md
+++ b/docs/notification-preference-matrix.md
@@ -14,7 +14,7 @@ schema/API/UI/router/bulk implementation for:
 
 Every notification must carry the following dimensions:
 
-- `domain`: `garden` | `weather_alerts` | `account_security` | `billing_order_delivery` | `reminders` | `digests` | `admin_campaigns` | `promotional`
+- `domain`: `garden` | `weather_alerts` | `account_security` | `billing_order_delivery` | `delivery_updates` | `reminders` | `digests` | `admin_campaigns` | `promotional`
 - `eventType`: stable machine key for a concrete trigger.
 - `priority`: `critical` | `high` | `normal` | `low`.
 - `audienceType`: `single_user` | `segment` | `all_users`.
@@ -48,7 +48,7 @@ Per eventType, each channel gets one of:
 | `account_security` | `auth_new_sign_in`, `auth_password_changed`, `auth_recovery_used`, `auth_mfa_changed` | critical | ✅ | ❌ | ❌ | ❌ | required | required | required | never | never |
 | `account_security` | `legal_policy_update`, `privacy_incident_notice` | high | ✅ | ❌ | ❌ | ❌ | required | required | default_on | never | never |
 | `billing_order_delivery` | `payment_failed`, `payment_refund_issued`, `invoice_ready` | high | ✅ | ❌ | ❌ | ❌ | required | required | default_on | never | never |
-| `billing_order_delivery` | `delivery_status_changed`, `delivery_delay`, `delivery_ready` | high | ❌ | ✅ | ❌ | ✅ | default_on | default_on | default_on | never | never |
+| `delivery_updates` | `route-started`, `near-arrival`, `next-stop`, `delayed`, `arrived`, `delivered`, `exception`, `recovery` | high | ❌ | ✅ | ❌ | ✅ | default_on | default_on | default_on | never | never |
 | `billing_order_delivery` | `order_confirmation` | high | ✅ | ❌ | ❌ | ❌ | required | required | default_on | never | never |
 | `garden` | `operation_scheduled`, `operation_rescheduled`, `operation_completed`, `operation_canceled` | high | ❌ | ✅ | ✅ | ✅ | default_on | default_on | default_on | default_on | never |
 | `garden` | `garden_health_alert` | high | ❌ | ✅ | ❌ | ❌ | default_on | default_on | default_on | never | never |
@@ -82,11 +82,14 @@ preference categories that are safe to adjust from the customer UI:
 - `admin_campaigns`
 - `promotional`
 
-`account_security` and the required portions of `billing_order_delivery` are
-shown as always-on explanatory rows instead of toggles. Event-level controls for
-mixed domains, such as delivery-status updates versus required billing/order
-messages, should be added only after the storage/API contract supports
-event-level overrides.
+`account_security` and `billing_order_delivery` are shown as always-on
+explanatory rows for required account, payment, invoice, refund, and order
+messages. Optional delivery progress is kept in the separate
+`delivery_updates` category. Its in-app, email, and push policy is registered
+before producers are enabled, but customer-facing controls stay hidden until
+the lifecycle templates and channel producers ship. Delivery updates never
+enter a digest; global quiet-hour changes still propagate to the hidden
+delivery channels and produce a distinct deferred routing outcome.
 
 Weather risk alerts are opt-in before notification creation. The weather alert
 producer must create user-scoped notification rows only for users with an enabled

--- a/docs/notification-workflows.md
+++ b/docs/notification-workflows.md
@@ -45,6 +45,11 @@ Implementation spans the admin actions in
 `apps/api/app/api/[...route]/deliveryRoutes.ts` as well as checkout automation in
 `apps/api/lib/stripe/processCheckoutSession.ts`.
 
+Customer-facing run progress uses the separate, preference-aware contract in
+[Delivery notification lifecycle](./delivery-notification-lifecycle.md). This
+contract defines safe events and idempotency before channel templates are wired;
+the Slack workflow above remains unchanged.
+
 ## User registration
 
 Whenever a new account is created—either through the email/password registration

--- a/packages/game/src/modals/components/NotificationsTab.tsx
+++ b/packages/game/src/modals/components/NotificationsTab.tsx
@@ -66,11 +66,22 @@ type NotificationPreferenceItem = {
     quietHoursEligible: boolean;
 };
 
+type NotificationPreferencePolicy = Pick<
+    NotificationPreferenceItem,
+    | 'category'
+    | 'channel'
+    | 'defaultEnabled'
+    | 'digestEligible'
+    | 'quietHoursEligible'
+>;
+
 const notificationDevicesKey = ['notifications', 'devices'];
 const notificationPushStatusKey = ['notifications', 'push-status'];
 const pushDeviceIdKey = 'game:push:device-id';
 const defaultQuietHoursStartMinute = 22 * 60;
 const defaultQuietHoursEndMinute = 7 * 60;
+const quietHoursTimeZoneUnavailableMessage =
+    'Vremenska zona preglednika nije dostupna. Provjeri postavke uređaja i pokušaj ponovno.';
 
 function readBooleanFlag(value: string | undefined, defaultValue: boolean) {
     const normalizedValue = value?.trim().toLowerCase();
@@ -86,6 +97,14 @@ function readCurrentPushDeviceId() {
     }
 
     return window.localStorage.getItem(pushDeviceIdKey) ?? undefined;
+}
+
+function readCurrentTimeZone() {
+    try {
+        return Intl.DateTimeFormat().resolvedOptions().timeZone || null;
+    } catch {
+        return null;
+    }
 }
 
 const premiumNotificationControlsEnabled = readBooleanFlag(
@@ -163,6 +182,35 @@ const categoryPreferences: NotificationPreferenceItem[] = [
         label: 'Promotivne ponude i sezonske preporuke',
         quietHoursEligible: true,
     },
+];
+
+const hiddenDeliveryPreferencePolicies: NotificationPreferencePolicy[] = [
+    {
+        category: 'delivery_updates',
+        channel: 'in_app',
+        defaultEnabled: true,
+        digestEligible: false,
+        quietHoursEligible: true,
+    },
+    {
+        category: 'delivery_updates',
+        channel: 'email',
+        defaultEnabled: true,
+        digestEligible: false,
+        quietHoursEligible: true,
+    },
+    {
+        category: 'delivery_updates',
+        channel: 'push',
+        defaultEnabled: true,
+        digestEligible: false,
+        quietHoursEligible: true,
+    },
+];
+
+const globalPreferencePolicies: NotificationPreferencePolicy[] = [
+    ...categoryPreferences,
+    ...hiddenDeliveryPreferencePolicies,
 ];
 
 const digestFrequencyItems: Array<{
@@ -252,6 +300,12 @@ export function NotificationsTab({
     const [quietHoursEndMinute, setQuietHoursEndMinute] = useState(
         defaultQuietHoursEndMinute,
     );
+    const [quietHoursTimeZone, setQuietHoursTimeZone] = useState<string | null>(
+        null,
+    );
+    const [quietHoursTimeZoneError, setQuietHoursTimeZoneError] = useState<
+        string | null
+    >(null);
     const [digestEnabled, setDigestEnabled] = useState(false);
     const [digestFrequency, setDigestFrequency] =
         useState<DigestPeriod>('daily');
@@ -336,26 +390,32 @@ export function NotificationsTab({
 
         const quietHoursPreference = preferencesQuery.data.find(
             (preference) =>
-                categoryPreferences.some(
+                globalPreferencePolicies.some(
                     (item) =>
                         item.quietHoursEligible &&
                         item.category === preference.category &&
                         item.channel === preference.channel,
                 ) &&
                 preference.quietHoursStartMinute !== null &&
-                preference.quietHoursEndMinute !== null,
+                preference.quietHoursEndMinute !== null &&
+                typeof preference.timezone === 'string' &&
+                preference.timezone.length > 0,
         );
         if (
             typeof quietHoursPreference?.quietHoursStartMinute === 'number' &&
-            typeof quietHoursPreference.quietHoursEndMinute === 'number'
+            typeof quietHoursPreference.quietHoursEndMinute === 'number' &&
+            typeof quietHoursPreference.timezone === 'string'
         ) {
             setQuietHoursEnabled(true);
             setQuietHoursStartMinute(
                 quietHoursPreference.quietHoursStartMinute,
             );
             setQuietHoursEndMinute(quietHoursPreference.quietHoursEndMinute);
+            setQuietHoursTimeZone(quietHoursPreference.timezone);
+            setQuietHoursTimeZoneError(null);
         } else {
             setQuietHoursEnabled(false);
+            setQuietHoursTimeZone(null);
         }
 
         const digestPreference = preferencesQuery.data.find(
@@ -380,7 +440,7 @@ export function NotificationsTab({
         }
     }, [preferencesQuery.data]);
 
-    function findPreference(item: (typeof categoryPreferences)[number]) {
+    function findPreference(item: NotificationPreferencePolicy) {
         return preferencesQuery.data?.find(
             (preference) =>
                 preference.category === item.category &&
@@ -390,12 +450,13 @@ export function NotificationsTab({
     }
 
     function buildPreferenceUpdate(
-        item: (typeof categoryPreferences)[number],
+        item: NotificationPreferencePolicy,
         enabled: boolean,
         options: {
             quietEnabled?: boolean;
             quietStart?: number;
             quietEnd?: number;
+            quietTimeZone?: string;
             summaryEnabled?: boolean;
             summaryFrequency?: DigestPeriod;
         } = {},
@@ -416,6 +477,10 @@ export function NotificationsTab({
                 item.quietHoursEligible && nextQuietEnabled
                     ? (options.quietEnd ?? quietHoursEndMinute)
                     : null,
+            timezone:
+                item.quietHoursEligible && nextQuietEnabled
+                    ? (options.quietTimeZone ?? quietHoursTimeZone)
+                    : null,
             digestFrequency:
                 item.digestEligible && nextSummaryEnabled
                     ? (options.summaryFrequency ?? digestFrequency)
@@ -426,15 +491,32 @@ export function NotificationsTab({
     function saveAllPreferenceSettings(
         options: Parameters<typeof buildPreferenceUpdate>[2] = {},
     ) {
+        const nextQuietEnabled = options.quietEnabled ?? quietHoursEnabled;
+        const nextQuietTimeZone = nextQuietEnabled
+            ? (options.quietTimeZone ??
+              quietHoursTimeZone ??
+              readCurrentTimeZone())
+            : null;
+        if (nextQuietEnabled && !nextQuietTimeZone) {
+            setQuietHoursTimeZoneError(quietHoursTimeZoneUnavailableMessage);
+            return false;
+        }
+
+        setQuietHoursTimeZoneError(null);
+        setQuietHoursTimeZone(nextQuietTimeZone);
         savePreferencesMutation.mutate(
-            categoryPreferences.map((item) =>
+            globalPreferencePolicies.map((item) =>
                 buildPreferenceUpdate(
                     item,
                     findPreference(item)?.enabled ?? item.defaultEnabled,
-                    options,
+                    {
+                        ...options,
+                        quietTimeZone: nextQuietTimeZone ?? undefined,
+                    },
                 ),
             ),
         );
+        return true;
     }
 
     const handleEnablePush = async () => {
@@ -832,15 +914,46 @@ export function NotificationsTab({
                                                 checked={quietHoursEnabled}
                                                 disabled={settingsBusy}
                                                 onCheckedChange={(checked) => {
-                                                    setQuietHoursEnabled(
-                                                        checked,
-                                                    );
+                                                    if (checked) {
+                                                        const timeZone =
+                                                            readCurrentTimeZone();
+                                                        if (!timeZone) {
+                                                            setQuietHoursTimeZoneError(
+                                                                quietHoursTimeZoneUnavailableMessage,
+                                                            );
+                                                            return;
+                                                        }
+                                                        setQuietHoursEnabled(
+                                                            true,
+                                                        );
+                                                        saveAllPreferenceSettings(
+                                                            {
+                                                                quietEnabled: true,
+                                                                quietTimeZone:
+                                                                    timeZone,
+                                                            },
+                                                        );
+                                                        return;
+                                                    }
+
+                                                    setQuietHoursEnabled(false);
+                                                    setQuietHoursTimeZone(null);
                                                     saveAllPreferenceSettings({
-                                                        quietEnabled: checked,
+                                                        quietEnabled: false,
                                                     });
                                                 }}
                                             />
                                         </Row>
+                                        {quietHoursTimeZoneError && (
+                                            <div role="alert">
+                                                <Typography
+                                                    level="body3"
+                                                    secondary
+                                                >
+                                                    {quietHoursTimeZoneError}
+                                                </Typography>
+                                            </div>
+                                        )}
                                         {quietHoursEnabled && (
                                             <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
                                                 <Input

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -11,7 +11,8 @@
     "scripts": {
         "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
-        "lint:migrate": "biome migrate --write"
+        "lint:migrate": "biome migrate --write",
+        "test": "node --conditions=react-server --import tsx --test ./src/**/*.node.spec.ts"
     },
     "dependencies": {
         "@gredice/directory-types": "workspace:*",
@@ -21,6 +22,7 @@
     "devDependencies": {
         "@biomejs/biome": "2.5.3",
         "@types/node": "24.12.4",
+        "tsx": "4.23.0",
         "typescript": "6.0.3"
     }
 }

--- a/packages/notifications/src/deliveryLifecycle.node.spec.ts
+++ b/packages/notifications/src/deliveryLifecycle.node.spec.ts
@@ -1,0 +1,403 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+    applyDeliveryLifecycleObservation,
+    createDeliveryLifecycleState,
+    type DeliveryLifecycleContext,
+    type DeliveryLifecycleObservation,
+    type DeliveryLifecycleSource,
+    type DeliveryLifecycleState,
+    deliveryLifecycleIdempotencyKey,
+    deliveryLifecycleMilestones,
+    deliveryLifecyclePolicies,
+    deliveryLifecyclePreferenceCategory,
+    deliveryLifecycleRetentionPolicy,
+    deliveryLifecycleThresholds,
+} from './deliveryLifecycle';
+
+const context: DeliveryLifecycleContext = {
+    accountId: 'account:1',
+    requestId: 'request:1',
+    runId: 'run:1',
+    stopId: 'stop:1',
+};
+
+const occurredAt = '2026-07-16T10:00:00.000Z';
+
+type ObservationInput<T> = T extends DeliveryLifecycleObservation
+    ? Omit<T, 'occurredAt' | 'source'>
+    : never;
+
+type DeliveryLifecycleObservationInput =
+    ObservationInput<DeliveryLifecycleObservation>;
+
+function observation(
+    value: DeliveryLifecycleObservationInput,
+): DeliveryLifecycleObservation {
+    const sourceKind: DeliveryLifecycleSource['kind'] = (() => {
+        switch (value.kind) {
+            case 'route-started':
+                return 'run-state';
+            case 'route-progress':
+                return 'route-progress';
+            case 'arrived':
+            case 'delivered':
+                return 'stop-operation';
+            case 'exception':
+                return 'exception-operation';
+            case 'recovery':
+                return 'retry-state';
+        }
+    })();
+    const source: DeliveryLifecycleSource = {
+        id: 'domain-operation-1',
+        kind: sourceKind,
+        version: 1,
+    };
+    const result = {
+        ...value,
+        occurredAt,
+        source,
+    };
+    return result;
+}
+
+function apply(
+    state: DeliveryLifecycleState,
+    value: DeliveryLifecycleObservationInput,
+) {
+    return applyDeliveryLifecycleObservation(state, observation(value));
+}
+
+describe('delivery lifecycle contract', () => {
+    test('defines every milestone, authoritative trigger, preference, and retention policy', () => {
+        assert.deepEqual(deliveryLifecycleMilestones, [
+            'route-started',
+            'near-arrival',
+            'next-stop',
+            'delayed',
+            'arrived',
+            'delivered',
+            'exception',
+            'recovery',
+        ]);
+        for (const milestone of deliveryLifecycleMilestones) {
+            const policy = deliveryLifecyclePolicies[milestone];
+            assert.ok(policy.trigger.length > 0);
+            assert.equal(
+                policy.preferenceCategory,
+                deliveryLifecyclePreferenceCategory,
+            );
+            assert.equal(policy.quietHoursEligible, true);
+        }
+        assert.deepEqual(deliveryLifecycleRetentionPolicy, {
+            auditAttemptsAndEventsDays: 180,
+            notificationRows: 'existing-notification-retention-policy',
+        });
+    });
+
+    test('uses stable request keys without volatile ETA or source revisions', () => {
+        const first = deliveryLifecycleIdempotencyKey(
+            context,
+            'near-arrival',
+            0,
+        );
+        const replay = deliveryLifecycleIdempotencyKey(
+            context,
+            'near-arrival',
+            0,
+        );
+        const retry = deliveryLifecycleIdempotencyKey(
+            context,
+            'near-arrival',
+            1,
+        );
+        assert.equal(first, replay);
+        assert.notEqual(first, retry);
+        assert.doesNotMatch(first, /eta|source|revision/i);
+        assert.equal(
+            deliveryLifecycleIdempotencyKey(context, 'route-started', 0),
+            deliveryLifecycleIdempotencyKey(context, 'route-started', 4),
+        );
+        assert.equal(
+            deliveryLifecycleIdempotencyKey(context, 'delivered', 0),
+            deliveryLifecycleIdempotencyKey(context, 'delivered', 4),
+        );
+    });
+
+    test('enforces event ordering and emits threshold milestones in canonical order', () => {
+        let state = createDeliveryLifecycleState(context);
+        let result = apply(state, {
+            kind: 'route-progress',
+            etaMaxSeconds: 60,
+            lateBySeconds: 2_000,
+            retryAttempt: 0,
+            stopsAhead: 0,
+        });
+        assert.deepEqual(result.events, []);
+
+        result = apply(result.state, { kind: 'route-started' });
+        assert.deepEqual(
+            result.events.map((event) => event.milestone),
+            ['route-started'],
+        );
+        state = result.state;
+
+        result = apply(state, {
+            kind: 'route-progress',
+            etaMaxSeconds: deliveryLifecycleThresholds.nearArrivalEnterSeconds,
+            lateBySeconds: deliveryLifecycleThresholds.delayEnterSeconds,
+            retryAttempt: 0,
+            stopsAhead: 0,
+        });
+        assert.deepEqual(
+            result.events.map((event) => event.milestone),
+            ['near-arrival', 'next-stop', 'delayed'],
+        );
+        state = result.state;
+
+        result = apply(state, {
+            kind: 'route-progress',
+            etaMaxSeconds:
+                deliveryLifecycleThresholds.nearArrivalEnterSeconds + 90,
+            lateBySeconds: deliveryLifecycleThresholds.delayEnterSeconds - 1,
+            retryAttempt: 0,
+            stopsAhead: 1,
+        });
+        assert.deepEqual(result.events, []);
+        result = apply(result.state, {
+            kind: 'route-progress',
+            etaMaxSeconds:
+                deliveryLifecycleThresholds.nearArrivalEnterSeconds - 90,
+            lateBySeconds: deliveryLifecycleThresholds.delayEnterSeconds + 1,
+            retryAttempt: 0,
+            stopsAhead: 0,
+        });
+        assert.deepEqual(result.events, []);
+
+        result = apply(result.state, {
+            kind: 'route-progress',
+            etaMaxSeconds: 60,
+            lateBySeconds: deliveryLifecycleThresholds.delayClearSeconds,
+            retryAttempt: 0,
+            stopsAhead: 0,
+        });
+        assert.deepEqual(result.events, []);
+        result = apply(result.state, {
+            kind: 'route-progress',
+            etaMaxSeconds: 60,
+            lateBySeconds: deliveryLifecycleThresholds.delayEnterSeconds,
+            retryAttempt: 0,
+            stopsAhead: 0,
+        });
+        assert.deepEqual(result.events, []);
+
+        result = apply(result.state, { kind: 'delivered', retryAttempt: 0 });
+        assert.deepEqual(result.events, []);
+        result = apply(result.state, { kind: 'arrived', retryAttempt: 0 });
+        assert.deepEqual(
+            result.events.map((event) => event.milestone),
+            ['arrived'],
+        );
+        result = apply(result.state, { kind: 'delivered', retryAttempt: 0 });
+        assert.deepEqual(
+            result.events.map((event) => event.milestone),
+            ['delivered'],
+        );
+        result = apply(result.state, {
+            kind: 'route-progress',
+            etaMaxSeconds: 1,
+            lateBySeconds: 9_999,
+            retryAttempt: 0,
+            stopsAhead: 0,
+        });
+        assert.deepEqual(result.events, []);
+    });
+
+    test('opens one new milestone scope only after an exception recovery attempt', () => {
+        let result = apply(createDeliveryLifecycleState(context), {
+            kind: 'route-started',
+        });
+        const firstAttemptProgress = observation({
+            kind: 'route-progress',
+            etaMaxSeconds: 300,
+            lateBySeconds: 1_000,
+            retryAttempt: 0,
+            stopsAhead: 0,
+        });
+        result = applyDeliveryLifecycleObservation(
+            result.state,
+            firstAttemptProgress,
+        );
+        const firstAttemptKeys = result.events.map(
+            (event) => event.idempotencyKey,
+        );
+        result = apply(result.state, {
+            kind: 'exception',
+            outcome: 'deferred',
+            reason: 'customer-unavailable',
+            retryAttempt: 0,
+        });
+        const exceptionEvent = result.events[0];
+        assert.ok(exceptionEvent);
+        if (exceptionEvent.milestone !== 'exception') {
+            assert.fail('Expected an exception event.');
+        }
+        assert.deepEqual(exceptionEvent.exception, {
+            outcome: 'deferred',
+            reason: 'customer-unavailable',
+        });
+        result = apply(result.state, {
+            kind: 'exception',
+            outcome: 'deferred',
+            reason: 'customer-unavailable',
+            retryAttempt: 0,
+        });
+        assert.deepEqual(result.events, []);
+        result = apply(result.state, { kind: 'recovery', retryAttempt: 1 });
+        assert.equal(result.events[0]?.milestone, 'recovery');
+        result = applyDeliveryLifecycleObservation(
+            result.state,
+            firstAttemptProgress,
+        );
+        assert.deepEqual(result.events, []);
+        result = apply(result.state, {
+            kind: 'route-progress',
+            etaMaxSeconds: 300,
+            lateBySeconds: 1_000,
+            retryAttempt: 1,
+            stopsAhead: 0,
+        });
+        assert.deepEqual(
+            result.events.map((event) => event.milestone),
+            ['near-arrival', 'next-stop', 'delayed'],
+        );
+        assert.equal(
+            result.events.some((event) =>
+                firstAttemptKeys.includes(event.idempotencyKey),
+            ),
+            false,
+        );
+    });
+
+    test('keeps customer events minimal and free of address, coordinate, and contact data', () => {
+        let result = apply(createDeliveryLifecycleState(context), {
+            kind: 'route-started',
+        });
+        result = apply(result.state, {
+            kind: 'exception',
+            outcome: 'failed',
+            reason: 'address-inaccessible',
+            retryAttempt: 0,
+        });
+        const event = result.events[0];
+        assert.ok(event);
+        if (event.milestone !== 'exception') {
+            assert.fail('Expected an exception event.');
+        }
+        assert.deepEqual(Object.keys(event).sort(), [
+            'accountId',
+            'eventVersion',
+            'exception',
+            'idempotencyKey',
+            'milestone',
+            'occurredAt',
+            'requestId',
+            'retryAttempt',
+            'runId',
+            'source',
+            'stopId',
+        ]);
+        const payloadFieldNames = [
+            ...Object.keys(event),
+            ...Object.keys(event.source),
+            ...Object.keys(event.exception),
+        ];
+        for (const forbiddenField of [
+            'address',
+            'coordinates',
+            'latitude',
+            'longitude',
+            'email',
+            'phone',
+            'customerId',
+            'driverId',
+            'userId',
+        ]) {
+            assert.equal(payloadFieldNames.includes(forbiddenField), false);
+        }
+    });
+
+    test('rejects malformed identifiers, timestamps, revisions, and route metrics', () => {
+        assert.throws(
+            () => createDeliveryLifecycleState({ ...context, requestId: ' ' }),
+            /requestId/,
+        );
+        const state = createDeliveryLifecycleState(context);
+        assert.throws(
+            () =>
+                applyDeliveryLifecycleObservation(state, {
+                    ...observation({ kind: 'route-started' }),
+                    occurredAt: '2026-07-16',
+                }),
+            /canonical ISO timestamp/,
+        );
+        assert.throws(
+            () =>
+                applyDeliveryLifecycleObservation(state, {
+                    ...observation({ kind: 'route-started' }),
+                    source: {
+                        id: 'operation',
+                        kind: 'run-state',
+                        version: -1,
+                    },
+                }),
+            /source.version/,
+        );
+        assert.throws(
+            () =>
+                applyDeliveryLifecycleObservation(state, {
+                    ...observation({ kind: 'route-started' }),
+                    source: {
+                        id: 'operation',
+                        kind: 'stop-operation',
+                        version: 1,
+                    },
+                }),
+            /authoritative run-state source/,
+        );
+        const validException = observation({
+            kind: 'exception',
+            outcome: 'failed',
+            reason: 'operational-other',
+            retryAttempt: 0,
+        });
+        assert.throws(
+            () =>
+                Reflect.apply(applyDeliveryLifecycleObservation, undefined, [
+                    state,
+                    { ...validException, outcome: 'unbounded-outcome' },
+                ]),
+            /bounded outcome/,
+        );
+        assert.throws(
+            () =>
+                Reflect.apply(applyDeliveryLifecycleObservation, undefined, [
+                    state,
+                    { ...validException, reason: 'unbounded-reason' },
+                ]),
+            /bounded reason/,
+        );
+        assert.throws(
+            () =>
+                apply(state, {
+                    kind: 'route-progress',
+                    etaMaxSeconds: -1,
+                    lateBySeconds: 0,
+                    retryAttempt: 0,
+                    stopsAhead: 0,
+                }),
+            /etaMaxSeconds/,
+        );
+    });
+});

--- a/packages/notifications/src/deliveryLifecycle.ts
+++ b/packages/notifications/src/deliveryLifecycle.ts
@@ -1,0 +1,480 @@
+import {
+    type DeliveryRunExceptionOutcome,
+    DeliveryRunExceptionOutcomes,
+    type DeliveryRunExceptionReason,
+    DeliveryRunExceptionReasons,
+} from '@gredice/storage';
+
+export const deliveryLifecycleMilestones = [
+    'route-started',
+    'near-arrival',
+    'next-stop',
+    'delayed',
+    'arrived',
+    'delivered',
+    'exception',
+    'recovery',
+] as const;
+
+export type DeliveryLifecycleMilestone =
+    (typeof deliveryLifecycleMilestones)[number];
+
+export const deliveryLifecyclePreferenceCategory = 'delivery_updates';
+
+export const deliveryLifecycleThresholds = {
+    nearArrivalEnterSeconds: 30 * 60,
+    delayEnterSeconds: 15 * 60,
+    delayClearSeconds: 5 * 60,
+} as const;
+
+export const deliveryLifecycleRetentionPolicy = {
+    auditAttemptsAndEventsDays: 180,
+    notificationRows: 'existing-notification-retention-policy',
+} as const;
+
+type DeliveryLifecycleIdempotencyScope = 'request-run' | 'request-run-attempt';
+
+type DeliveryLifecycleTrigger =
+    | 'delivery-run-started'
+    | 'route-eta-entered-near-window'
+    | 'route-stop-became-next'
+    | 'route-lateness-entered-delay-window'
+    | 'stop-arrival-applied'
+    | 'delivery-request-fulfilled'
+    | 'stop-exception-applied'
+    | 'stop-retry-opened';
+
+export type DeliveryLifecyclePolicy = {
+    idempotencyScope: DeliveryLifecycleIdempotencyScope;
+    preferenceCategory: typeof deliveryLifecyclePreferenceCategory;
+    quietHoursEligible: true;
+    trigger: DeliveryLifecycleTrigger;
+};
+
+export const deliveryLifecyclePolicies = {
+    'route-started': {
+        idempotencyScope: 'request-run',
+        preferenceCategory: deliveryLifecyclePreferenceCategory,
+        quietHoursEligible: true,
+        trigger: 'delivery-run-started',
+    },
+    'near-arrival': {
+        idempotencyScope: 'request-run-attempt',
+        preferenceCategory: deliveryLifecyclePreferenceCategory,
+        quietHoursEligible: true,
+        trigger: 'route-eta-entered-near-window',
+    },
+    'next-stop': {
+        idempotencyScope: 'request-run-attempt',
+        preferenceCategory: deliveryLifecyclePreferenceCategory,
+        quietHoursEligible: true,
+        trigger: 'route-stop-became-next',
+    },
+    delayed: {
+        idempotencyScope: 'request-run-attempt',
+        preferenceCategory: deliveryLifecyclePreferenceCategory,
+        quietHoursEligible: true,
+        trigger: 'route-lateness-entered-delay-window',
+    },
+    arrived: {
+        idempotencyScope: 'request-run-attempt',
+        preferenceCategory: deliveryLifecyclePreferenceCategory,
+        quietHoursEligible: true,
+        trigger: 'stop-arrival-applied',
+    },
+    delivered: {
+        idempotencyScope: 'request-run',
+        preferenceCategory: deliveryLifecyclePreferenceCategory,
+        quietHoursEligible: true,
+        trigger: 'delivery-request-fulfilled',
+    },
+    exception: {
+        idempotencyScope: 'request-run-attempt',
+        preferenceCategory: deliveryLifecyclePreferenceCategory,
+        quietHoursEligible: true,
+        trigger: 'stop-exception-applied',
+    },
+    recovery: {
+        idempotencyScope: 'request-run-attempt',
+        preferenceCategory: deliveryLifecyclePreferenceCategory,
+        quietHoursEligible: true,
+        trigger: 'stop-retry-opened',
+    },
+} as const satisfies Record<
+    DeliveryLifecycleMilestone,
+    DeliveryLifecyclePolicy
+>;
+
+export type DeliveryLifecycleContext = {
+    accountId: string;
+    requestId: string;
+    runId: string;
+    stopId: string;
+};
+
+export type DeliveryLifecycleSource = {
+    id: string;
+    kind:
+        | 'run-state'
+        | 'route-progress'
+        | 'stop-operation'
+        | 'exception-operation'
+        | 'retry-state';
+    version: number;
+};
+
+type DeliveryLifecycleObservationBase = {
+    occurredAt: string;
+    source: DeliveryLifecycleSource;
+};
+
+type DeliveryLifecycleAttemptObservationBase =
+    DeliveryLifecycleObservationBase & {
+        retryAttempt: number;
+    };
+
+export type DeliveryLifecycleObservation =
+    | (DeliveryLifecycleObservationBase & {
+          kind: 'route-started';
+      })
+    | (DeliveryLifecycleAttemptObservationBase & {
+          etaMaxSeconds: number | null;
+          kind: 'route-progress';
+          lateBySeconds: number;
+          stopsAhead: number;
+      })
+    | (DeliveryLifecycleAttemptObservationBase & {
+          kind: 'arrived';
+      })
+    | (DeliveryLifecycleAttemptObservationBase & {
+          kind: 'delivered';
+      })
+    | (DeliveryLifecycleAttemptObservationBase & {
+          kind: 'exception';
+          outcome: DeliveryRunExceptionOutcome;
+          reason: DeliveryRunExceptionReason;
+      })
+    | (DeliveryLifecycleObservationBase & {
+          kind: 'recovery';
+          retryAttempt: number;
+      });
+
+type DeliveryLifecycleEventBase = DeliveryLifecycleContext & {
+    eventVersion: 1;
+    idempotencyKey: string;
+    occurredAt: string;
+    retryAttempt: number;
+    source: DeliveryLifecycleSource;
+};
+
+export type DeliveryLifecycleEvent = DeliveryLifecycleEventBase &
+    (
+        | {
+              milestone: Exclude<DeliveryLifecycleMilestone, 'exception'>;
+          }
+        | {
+              exception: {
+                  outcome: DeliveryRunExceptionOutcome;
+                  reason: DeliveryRunExceptionReason;
+              };
+              milestone: 'exception';
+          }
+    );
+
+export type DeliveryLifecycleState = {
+    context: DeliveryLifecycleContext;
+    delayActive: boolean;
+    emittedIdempotencyKeys: string[];
+    exceptionActive: boolean;
+    lastStopsAhead: number | null;
+    nearArrivalActive: boolean;
+    retryAttempt: number;
+    status: 'pending' | 'in-route' | 'arrived' | 'delivered';
+};
+
+function assertNonEmptyIdentifier(value: string, field: string) {
+    if (value.trim().length === 0) {
+        throw new Error(`${field} must be a non-empty identifier.`);
+    }
+}
+
+function assertSafeInteger(value: number, field: string) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+        throw new Error(`${field} must be a non-negative safe integer.`);
+    }
+}
+
+function assertCanonicalTimestamp(value: string) {
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== value) {
+        throw new Error('occurredAt must be a canonical ISO timestamp.');
+    }
+}
+
+function assertSource(source: DeliveryLifecycleSource) {
+    assertNonEmptyIdentifier(source.id, 'source.id');
+    assertSafeInteger(source.version, 'source.version');
+}
+
+function expectedSourceKind(
+    observation: DeliveryLifecycleObservation,
+): DeliveryLifecycleSource['kind'] {
+    switch (observation.kind) {
+        case 'route-started':
+            return 'run-state';
+        case 'route-progress':
+            return 'route-progress';
+        case 'arrived':
+        case 'delivered':
+            return 'stop-operation';
+        case 'exception':
+            return 'exception-operation';
+        case 'recovery':
+            return 'retry-state';
+    }
+}
+
+function encoded(value: string) {
+    return encodeURIComponent(value);
+}
+
+export function deliveryLifecycleIdempotencyKey(
+    context: DeliveryLifecycleContext,
+    milestone: DeliveryLifecycleMilestone,
+    retryAttempt: number,
+) {
+    assertDeliveryLifecycleContext(context);
+    assertSafeInteger(retryAttempt, 'retryAttempt');
+    const scope = deliveryLifecyclePolicies[milestone].idempotencyScope;
+    const attempt =
+        scope === 'request-run-attempt' ? String(retryAttempt) : 'all';
+    return [
+        'delivery-lifecycle',
+        'v1',
+        milestone,
+        encoded(context.accountId),
+        encoded(context.runId),
+        encoded(context.stopId),
+        encoded(context.requestId),
+        attempt,
+    ].join(':');
+}
+
+export function assertDeliveryLifecycleContext(
+    context: DeliveryLifecycleContext,
+) {
+    assertNonEmptyIdentifier(context.accountId, 'accountId');
+    assertNonEmptyIdentifier(context.requestId, 'requestId');
+    assertNonEmptyIdentifier(context.runId, 'runId');
+    assertNonEmptyIdentifier(context.stopId, 'stopId');
+}
+
+export function createDeliveryLifecycleState(
+    context: DeliveryLifecycleContext,
+): DeliveryLifecycleState {
+    assertDeliveryLifecycleContext(context);
+    return {
+        context: { ...context },
+        delayActive: false,
+        emittedIdempotencyKeys: [],
+        exceptionActive: false,
+        lastStopsAhead: null,
+        nearArrivalActive: false,
+        retryAttempt: 0,
+        status: 'pending',
+    };
+}
+
+function validateObservation(observation: DeliveryLifecycleObservation) {
+    assertCanonicalTimestamp(observation.occurredAt);
+    assertSource(observation.source);
+    if (observation.source.kind !== expectedSourceKind(observation)) {
+        throw new Error(
+            `${observation.kind} requires an authoritative ${expectedSourceKind(observation)} source.`,
+        );
+    }
+    if (observation.kind === 'route-progress') {
+        if (observation.etaMaxSeconds !== null) {
+            assertSafeInteger(observation.etaMaxSeconds, 'etaMaxSeconds');
+        }
+        assertSafeInteger(observation.lateBySeconds, 'lateBySeconds');
+        assertSafeInteger(observation.stopsAhead, 'stopsAhead');
+    }
+    if (observation.kind === 'exception') {
+        if (
+            !Object.values(DeliveryRunExceptionOutcomes).includes(
+                observation.outcome,
+            )
+        ) {
+            throw new Error('exception.outcome must be a bounded outcome.');
+        }
+        if (
+            !Object.values(DeliveryRunExceptionReasons).includes(
+                observation.reason,
+            )
+        ) {
+            throw new Error('exception.reason must be a bounded reason.');
+        }
+    }
+    if (observation.kind !== 'route-started') {
+        assertSafeInteger(observation.retryAttempt, 'retryAttempt');
+    }
+}
+
+function appendEvent(
+    state: DeliveryLifecycleState,
+    observation: DeliveryLifecycleObservation,
+    milestone: DeliveryLifecycleMilestone,
+    exception?: {
+        outcome: DeliveryRunExceptionOutcome;
+        reason: DeliveryRunExceptionReason;
+    },
+) {
+    const idempotencyKey = deliveryLifecycleIdempotencyKey(
+        state.context,
+        milestone,
+        state.retryAttempt,
+    );
+    if (state.emittedIdempotencyKeys.includes(idempotencyKey)) {
+        return null;
+    }
+    state.emittedIdempotencyKeys.push(idempotencyKey);
+    const base: DeliveryLifecycleEventBase = {
+        ...state.context,
+        eventVersion: 1,
+        idempotencyKey,
+        occurredAt: observation.occurredAt,
+        retryAttempt: state.retryAttempt,
+        source: { ...observation.source },
+    };
+    if (milestone === 'exception') {
+        if (!exception) {
+            throw new Error('Exception milestone requires a bounded outcome.');
+        }
+        return { ...base, exception, milestone };
+    }
+    return { ...base, milestone };
+}
+
+export function applyDeliveryLifecycleObservation(
+    currentState: DeliveryLifecycleState,
+    observation: DeliveryLifecycleObservation,
+): {
+    events: DeliveryLifecycleEvent[];
+    state: DeliveryLifecycleState;
+} {
+    validateObservation(observation);
+    const state: DeliveryLifecycleState = {
+        ...currentState,
+        context: { ...currentState.context },
+        emittedIdempotencyKeys: [...currentState.emittedIdempotencyKeys],
+    };
+    assertDeliveryLifecycleContext(state.context);
+    const events: DeliveryLifecycleEvent[] = [];
+    const emit = (
+        milestone: DeliveryLifecycleMilestone,
+        exception?: {
+            outcome: DeliveryRunExceptionOutcome;
+            reason: DeliveryRunExceptionReason;
+        },
+    ) => {
+        const event = appendEvent(state, observation, milestone, exception);
+        if (event) events.push(event);
+    };
+
+    if (observation.kind === 'route-started') {
+        if (state.status === 'pending') {
+            state.status = 'in-route';
+            emit('route-started');
+        }
+        return { events, state };
+    }
+
+    if (
+        observation.kind !== 'recovery' &&
+        observation.retryAttempt !== state.retryAttempt
+    ) {
+        return { events, state };
+    }
+
+    if (observation.kind === 'route-progress') {
+        if (state.status !== 'in-route' || state.exceptionActive) {
+            return { events, state };
+        }
+        if (
+            !state.nearArrivalActive &&
+            observation.etaMaxSeconds !== null &&
+            observation.etaMaxSeconds <=
+                deliveryLifecycleThresholds.nearArrivalEnterSeconds
+        ) {
+            state.nearArrivalActive = true;
+            emit('near-arrival');
+        }
+        if (observation.stopsAhead === 0 && state.lastStopsAhead !== 0) {
+            emit('next-stop');
+        }
+        state.lastStopsAhead = observation.stopsAhead;
+        if (
+            state.delayActive &&
+            observation.lateBySeconds <=
+                deliveryLifecycleThresholds.delayClearSeconds
+        ) {
+            state.delayActive = false;
+        }
+        if (
+            !state.delayActive &&
+            observation.lateBySeconds >=
+                deliveryLifecycleThresholds.delayEnterSeconds
+        ) {
+            state.delayActive = true;
+            emit('delayed');
+        }
+        return { events, state };
+    }
+
+    if (observation.kind === 'arrived') {
+        if (state.status === 'in-route' && !state.exceptionActive) {
+            state.status = 'arrived';
+            emit('arrived');
+        }
+        return { events, state };
+    }
+
+    if (observation.kind === 'delivered') {
+        if (state.status === 'arrived' && !state.exceptionActive) {
+            state.status = 'delivered';
+            emit('delivered');
+        }
+        return { events, state };
+    }
+
+    if (observation.kind === 'exception') {
+        if (
+            state.status !== 'pending' &&
+            state.status !== 'delivered' &&
+            !state.exceptionActive
+        ) {
+            state.exceptionActive = true;
+            emit('exception', {
+                outcome: observation.outcome,
+                reason: observation.reason,
+            });
+        }
+        return { events, state };
+    }
+
+    if (
+        state.exceptionActive &&
+        observation.retryAttempt === state.retryAttempt + 1 &&
+        state.status !== 'delivered'
+    ) {
+        state.retryAttempt = observation.retryAttempt;
+        state.exceptionActive = false;
+        state.delayActive = false;
+        state.lastStopsAhead = null;
+        state.nearArrivalActive = false;
+        if (state.status === 'arrived') state.status = 'in-route';
+        emit('recovery');
+    }
+    return { events, state };
+}

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -19,6 +19,8 @@ import {
     type OperationSchedulePayload,
 } from '@gredice/storage';
 
+export * from './deliveryLifecycle';
+
 type OperationEventType =
     | 'scheduled'
     | 'rescheduled'

--- a/packages/storage/src/repositories/notificationsRepo.ts
+++ b/packages/storage/src/repositories/notificationsRepo.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import {
     and,
     asc,
@@ -36,7 +36,12 @@ import {
 } from '../schema';
 
 type DeliveryChannel = 'email' | 'in_app' | 'push';
-type DeliveryOutcome = 'immediate' | 'digest' | 'suppressed' | 'required';
+type DeliveryOutcome =
+    | 'immediate'
+    | 'deferred'
+    | 'digest'
+    | 'suppressed'
+    | 'required';
 type DeliveryAttemptStatus = 'accepted' | 'queued' | 'dropped';
 type NotificationCampaignQueueStatus = 'queued' | 'scheduled';
 type NotificationDigestFrequency = 'off' | 'hourly' | 'daily' | 'weekly';
@@ -44,6 +49,11 @@ type NotificationCampaignExplicitRecipient = Extract<
     NotificationCampaignAudience,
     { type: 'explicit' }
 >['recipients'][number];
+type StorageClient = ReturnType<typeof storage>;
+type TransactionClient = Parameters<
+    Parameters<StorageClient['transaction']>[0]
+>[0];
+type NotificationDatabaseClient = StorageClient | TransactionClient;
 
 // Croatian fallback label for legacy web-push subscriptions without client device metadata.
 export const notificationRolloutDefaultDeviceLabel = 'Web preglednik';
@@ -120,8 +130,19 @@ export type NotificationRolloutDiagnostics = {
 };
 
 export type CreateNotificationOptions = {
+    idempotencyKey?: string;
+    now?: Date;
     routeDelivery?: boolean;
 };
+
+async function acquireNotificationDeliveryLock(
+    db: TransactionClient,
+    notificationId: string,
+) {
+    await db.execute(
+        sql`select pg_advisory_xact_lock(hashtext(${`notification-delivery:${notificationId}`}));`,
+    );
+}
 
 type NotificationRolloutPreferenceDefault = {
     category: string;
@@ -129,6 +150,12 @@ type NotificationRolloutPreferenceDefault = {
     defaultEnabled: boolean;
     digestEligible: boolean;
     required: boolean;
+};
+
+type NotificationQuietHoursWindow = {
+    endMinute: number;
+    startMinute: number;
+    timezone: string;
 };
 
 type NotificationDeliveryRecipient = {
@@ -179,6 +206,27 @@ const notificationRolloutPreferenceDefaults: NotificationRolloutPreferenceDefaul
             defaultEnabled: true,
             digestEligible: false,
             required: true,
+        },
+        {
+            category: 'delivery_updates',
+            channel: 'in_app',
+            defaultEnabled: true,
+            digestEligible: false,
+            required: false,
+        },
+        {
+            category: 'delivery_updates',
+            channel: 'email',
+            defaultEnabled: true,
+            digestEligible: false,
+            required: false,
+        },
+        {
+            category: 'delivery_updates',
+            channel: 'push',
+            defaultEnabled: true,
+            digestEligible: false,
+            required: false,
         },
         {
             category: 'garden',
@@ -359,10 +407,12 @@ function notificationPreferenceDefault(
 
 function notificationRolloutPreferenceRows({
     dailyDigest,
+    deliveryUpdatesQuietHours,
     emailEnabled,
     userId,
 }: {
     dailyDigest: boolean | null;
+    deliveryUpdatesQuietHours?: NotificationQuietHoursWindow;
     emailEnabled: boolean | null;
     userId: string;
 }): (typeof notificationUserChannelPreferences.$inferInsert)[] {
@@ -379,6 +429,10 @@ function notificationRolloutPreferenceRows({
             dailyDigest === true
                 ? 'daily'
                 : 'off';
+        const quietHours =
+            preference.category === 'delivery_updates'
+                ? deliveryUpdatesQuietHours
+                : undefined;
 
         return {
             userId,
@@ -389,10 +443,43 @@ function notificationRolloutPreferenceRows({
             enabled,
             required: preference.required,
             digestFrequency,
-            quietHoursStartMinute: null,
-            quietHoursEndMinute: null,
+            quietHoursStartMinute: quietHours?.startMinute ?? null,
+            quietHoursEndMinute: quietHours?.endMinute ?? null,
+            timezone: quietHours?.timezone ?? null,
         };
     });
+}
+
+function inheritedGlobalQuietHours(
+    preferences: Array<
+        Pick<
+            SelectNotificationUserChannelPreference,
+            | 'quietHoursEndMinute'
+            | 'quietHoursStartMinute'
+            | 'required'
+            | 'timezone'
+        >
+    >,
+): NotificationQuietHoursWindow | undefined {
+    for (const preference of preferences) {
+        const timezone = preference.timezone?.trim();
+        if (
+            preference.required ||
+            preference.quietHoursStartMinute === null ||
+            preference.quietHoursEndMinute === null ||
+            !timezone
+        ) {
+            continue;
+        }
+
+        return {
+            startMinute: preference.quietHoursStartMinute,
+            endMinute: preference.quietHoursEndMinute,
+            timezone,
+        };
+    }
+
+    return undefined;
 }
 
 async function countWebPushSubscriptionsWhere(where: SQL | undefined) {
@@ -447,31 +534,36 @@ export async function backfillNotificationRolloutDefaults({
     let defaultPreferencesAlreadyPresent = 0;
 
     for (const user of userRows) {
-        const rows = notificationRolloutPreferenceRows(user);
+        const existingPreferences = await storage()
+            .select({
+                category: notificationUserChannelPreferences.category,
+                channel: notificationUserChannelPreferences.channel,
+                quietHoursEndMinute:
+                    notificationUserChannelPreferences.quietHoursEndMinute,
+                quietHoursStartMinute:
+                    notificationUserChannelPreferences.quietHoursStartMinute,
+                required: notificationUserChannelPreferences.required,
+                timezone: notificationUserChannelPreferences.timezone,
+            })
+            .from(notificationUserChannelPreferences)
+            .where(
+                and(
+                    eq(notificationUserChannelPreferences.userId, user.userId),
+                    eq(notificationUserChannelPreferences.scope, 'global'),
+                ),
+            )
+            .orderBy(
+                desc(notificationUserChannelPreferences.updatedAt),
+                desc(notificationUserChannelPreferences.id),
+            );
+        const rows = notificationRolloutPreferenceRows({
+            ...user,
+            deliveryUpdatesQuietHours:
+                inheritedGlobalQuietHours(existingPreferences),
+        });
         defaultPreferencesExpected += rows.length;
 
         if (dryRun) {
-            const existingPreferences = await storage()
-                .select({
-                    category: notificationUserChannelPreferences.category,
-                    channel: notificationUserChannelPreferences.channel,
-                })
-                .from(notificationUserChannelPreferences)
-                .where(
-                    and(
-                        eq(
-                            notificationUserChannelPreferences.userId,
-                            user.userId,
-                        ),
-                        eq(notificationUserChannelPreferences.scope, 'global'),
-                        inArray(
-                            notificationUserChannelPreferences.category,
-                            notificationRolloutPreferenceDefaults.map(
-                                (preference) => preference.category,
-                            ),
-                        ),
-                    ),
-                );
             const existingKeys = new Set(
                 existingPreferences.map((preference) =>
                     notificationPreferenceKey({
@@ -986,12 +1078,16 @@ function decideDeliveryOutcome({
     if (!required && preference && isInsideQuietHours(nowMinute, preference)) {
         return {
             channel,
-            outcome: 'digest',
+            outcome: 'deferred',
             reason: 'quiet_hours',
             required: false,
         };
     }
-    if (!required && (preference?.digestFrequency ?? 'off') !== 'off') {
+    if (
+        !required &&
+        (defaultPreference?.digestEligible ?? true) &&
+        (preference?.digestFrequency ?? 'off') !== 'off'
+    ) {
         return {
             channel,
             outcome: 'digest',
@@ -1011,7 +1107,7 @@ function deliveryAttemptStatusForOutcome(
     outcome: DeliveryOutcome,
 ): DeliveryAttemptStatus {
     if (outcome === 'suppressed') return 'dropped';
-    if (outcome === 'digest') return 'queued';
+    if (outcome === 'deferred' || outcome === 'digest') return 'queued';
     return 'accepted';
 }
 
@@ -1190,13 +1286,20 @@ export async function cancelNotificationCampaign({
     return result[0];
 }
 
-export async function getNotification(
+async function getNotificationWithDatabase(
+    db: NotificationDatabaseClient,
     id: string,
 ): Promise<SelectNotification | undefined> {
-    const result = await storage().query.notifications.findFirst({
+    const result = await db.query.notifications.findFirst({
         where: eq(notifications.id, id),
     });
     return result;
+}
+
+export async function getNotification(
+    id: string,
+): Promise<SelectNotification | undefined> {
+    return await getNotificationWithDatabase(storage(), id);
 }
 
 function shouldQueuePushDelivery(decisions: NotificationDeliveryDecision[]) {
@@ -1224,24 +1327,48 @@ function queueablePushDeliveryUserIds(
     );
 }
 
-export async function createNotification(
+async function createNotificationWithDatabase(
+    db: NotificationDatabaseClient,
     notification: InsertNotification,
-    options: CreateNotificationOptions = {},
+    options: CreateNotificationOptions,
+    notificationId: string,
 ) {
-    const result = await storage()
+    const result = await db
         .insert(notifications)
         .values({
-            id: randomUUID(),
+            id: notificationId,
             ...notification,
         })
+        .onConflictDoNothing({ target: notifications.id })
         .returning({ id: notifications.id });
-    const notificationId = result[0].id;
+    const insertedId = result[0]?.id;
+
+    if (!insertedId) {
+        const existing = await getNotificationWithDatabase(db, notificationId);
+        if (
+            !existing ||
+            existing.accountId !== notification.accountId ||
+            existing.userId !== (notification.userId ?? null) ||
+            existing.category !== (notification.category ?? 'general') ||
+            existing.type !== (notification.type ?? 'general')
+        ) {
+            throw new Error(
+                'Notification idempotency key was reused for a different target.',
+            );
+        }
+
+        return notificationId;
+    }
 
     if (options.routeDelivery !== false) {
-        const decisions = await routeNotificationDelivery(notificationId);
+        const decisions = await routeNotificationDeliveryWithDatabase(
+            db,
+            notificationId,
+            { now: options.now },
+        );
         const pushUserIds = queueablePushDeliveryUserIds(decisions);
         if (pushUserIds.length > 0) {
-            await enqueuePushDeliveryAttemptsForNotification({
+            await enqueuePushDeliveryAttemptsWithDatabase(db, {
                 notificationId,
                 userIds: pushUserIds,
             });
@@ -1251,27 +1378,66 @@ export async function createNotification(
     return notificationId;
 }
 
-export async function enqueuePushDeliveryAttemptsForNotification({
-    notificationId,
-    batchSize = 100,
-    userIds,
-}: {
-    notificationId: string;
-    batchSize?: number;
-    userIds?: string[];
-}) {
-    const notification = await getNotification(notificationId);
+export async function createNotification(
+    notification: InsertNotification,
+    options: CreateNotificationOptions = {},
+) {
+    const normalizedIdempotencyKey = options.idempotencyKey?.trim();
+    if (options.idempotencyKey !== undefined && !normalizedIdempotencyKey) {
+        throw new Error('Notification idempotency key must not be empty.');
+    }
+    const notificationId = normalizedIdempotencyKey
+        ? `notification:${createHash('sha256')
+              .update(normalizedIdempotencyKey)
+              .digest('hex')}`
+        : randomUUID();
+
+    if (!normalizedIdempotencyKey) {
+        return await createNotificationWithDatabase(
+            storage(),
+            notification,
+            options,
+            notificationId,
+        );
+    }
+
+    return await storage().transaction(async (tx) => {
+        await acquireNotificationDeliveryLock(tx, notificationId);
+        return await createNotificationWithDatabase(
+            tx,
+            notification,
+            options,
+            notificationId,
+        );
+    });
+}
+
+async function enqueuePushDeliveryAttemptsWithDatabase(
+    db: NotificationDatabaseClient,
+    {
+        notificationId,
+        batchSize = 100,
+        userIds,
+    }: {
+        notificationId: string;
+        batchSize?: number;
+        userIds?: string[];
+    },
+) {
+    const notification = await getNotificationWithDatabase(db, notificationId);
     if (!notification) return { queued: 0, skipped: 0 };
     const targetUserIds = userIds
         ? uniqueStrings(userIds)
         : uniqueStrings(
-              (await getNotificationDeliveryRecipients(notification)).flatMap(
-                  (recipient) => (recipient.userId ? [recipient.userId] : []),
+              (
+                  await getNotificationDeliveryRecipients(db, notification)
+              ).flatMap((recipient) =>
+                  recipient.userId ? [recipient.userId] : [],
               ),
           );
     if (targetUserIds.length === 0) return { queued: 0, skipped: 0 };
 
-    const subscriptions = await storage().query.webPushSubscriptions.findMany({
+    const subscriptions = await db.query.webPushSubscriptions.findMany({
         where: and(
             eq(webPushSubscriptions.enabled, true),
             eq(webPushSubscriptions.permissionState, 'granted'),
@@ -1284,7 +1450,7 @@ export async function enqueuePushDeliveryAttemptsForNotification({
 
     if (!subscriptions.length) return { queued: 0, skipped: 0 };
 
-    const existing = await storage()
+    const existing = await db
         .select({
             pushSubscriptionId: notificationDeliveryAttempts.pushSubscriptionId,
         })
@@ -1324,14 +1490,23 @@ export async function enqueuePushDeliveryAttemptsForNotification({
             providerResponseCode: 'queued_background',
         }));
 
-    await storage()
-        .insert(notificationDeliveryAttempts)
-        .values(deliveryAttempts);
+    await db.insert(notificationDeliveryAttempts).values(deliveryAttempts);
 
     return {
         queued: pending.length,
         skipped: subscriptions.length - pending.length,
     };
+}
+
+export async function enqueuePushDeliveryAttemptsForNotification(args: {
+    notificationId: string;
+    batchSize?: number;
+    userIds?: string[];
+}) {
+    return await storage().transaction(async (tx) => {
+        await acquireNotificationDeliveryLock(tx, args.notificationId);
+        return await enqueuePushDeliveryAttemptsWithDatabase(tx, args);
+    });
 }
 
 function hasPushSubscriptionUserId(
@@ -1343,6 +1518,7 @@ function hasPushSubscriptionUserId(
 }
 
 async function getNotificationDeliveryRecipients(
+    db: NotificationDatabaseClient,
     notification: Pick<SelectNotification, 'accountId' | 'userId'>,
 ): Promise<NotificationDeliveryRecipient[]> {
     if (notification.userId) {
@@ -1354,7 +1530,7 @@ async function getNotificationDeliveryRecipients(
         ];
     }
 
-    const rows = await storage()
+    const rows = await db
         .select({ userId: accountUsers.userId })
         .from(accountUsers)
         .where(eq(accountUsers.accountId, notification.accountId));
@@ -1381,12 +1557,18 @@ function notificationDeliveryRoutingKey(decision: {
     return `${decision.userId ?? 'account'}:${decision.channel}`;
 }
 
-export async function routeNotificationDelivery(notificationId: string) {
-    const notification = await getNotification(notificationId);
+async function routeNotificationDeliveryWithDatabase(
+    db: NotificationDatabaseClient,
+    notificationId: string,
+    { now = new Date() }: { now?: Date } = {},
+) {
+    const notification = await getNotificationWithDatabase(db, notificationId);
     if (!notification) return [];
-    const now = new Date();
     const targetChannels: DeliveryChannel[] = ['in_app', 'email', 'push'];
-    const recipients = await getNotificationDeliveryRecipients(notification);
+    const recipients = await getNotificationDeliveryRecipients(
+        db,
+        notification,
+    );
     const recipientUserIds = uniqueStrings(
         recipients.flatMap((recipient) =>
             recipient.userId ? [recipient.userId] : [],
@@ -1394,18 +1576,16 @@ export async function routeNotificationDelivery(notificationId: string) {
     );
     const preferences =
         recipientUserIds.length > 0
-            ? await storage().query.notificationUserChannelPreferences.findMany(
-                  {
-                      where: inArray(
-                          notificationUserChannelPreferences.userId,
-                          recipientUserIds,
-                      ),
-                  },
-              )
+            ? await db.query.notificationUserChannelPreferences.findMany({
+                  where: inArray(
+                      notificationUserChannelPreferences.userId,
+                      recipientUserIds,
+                  ),
+              })
             : [];
     const pushSubscriptionRows =
         recipientUserIds.length > 0
-            ? await storage()
+            ? await db
                   .select({ userId: webPushSubscriptions.userId })
                   .from(webPushSubscriptions)
                   .where(
@@ -1470,7 +1650,7 @@ export async function routeNotificationDelivery(notificationId: string) {
     );
 
     if (notification.userId || notification.accountId) {
-        const existingRouterAttempts = await storage()
+        const existingRouterAttempts = await db
             .select({
                 channel: notificationDeliveryAttempts.channel,
                 userId: notificationDeliveryAttempts.userId,
@@ -1494,25 +1674,35 @@ export async function routeNotificationDelivery(notificationId: string) {
         );
 
         if (unroutedDecisions.length > 0) {
-            await storage()
-                .insert(notificationDeliveryAttempts)
-                .values(
-                    unroutedDecisions.map((decision) => ({
-                        notificationId,
-                        userId: decision.userId,
-                        accountId: decision.accountId,
-                        channel: decision.channel,
-                        status: deliveryAttemptStatusForOutcome(
-                            decision.outcome,
-                        ),
-                        provider: 'router',
-                        providerResponseCode: decision.reason,
-                    })),
-                );
+            await db.insert(notificationDeliveryAttempts).values(
+                unroutedDecisions.map((decision) => ({
+                    notificationId,
+                    userId: decision.userId,
+                    accountId: decision.accountId,
+                    channel: decision.channel,
+                    status: deliveryAttemptStatusForOutcome(decision.outcome),
+                    provider: 'router',
+                    providerResponseCode: decision.reason,
+                })),
+            );
         }
     }
 
     return decisions;
+}
+
+export async function routeNotificationDelivery(
+    notificationId: string,
+    options: { now?: Date } = {},
+) {
+    return await storage().transaction(async (tx) => {
+        await acquireNotificationDeliveryLock(tx, notificationId);
+        return await routeNotificationDeliveryWithDatabase(
+            tx,
+            notificationId,
+            options,
+        );
+    });
 }
 
 export async function recordNotificationDeliveryEvent({

--- a/packages/storage/tests/notificationsRepo.node.spec.ts
+++ b/packages/storage/tests/notificationsRepo.node.spec.ts
@@ -25,10 +25,11 @@ import {
     recordNotificationDeliveryEvent,
     routeNotificationDelivery,
     storage,
+    userNotificationSettings,
     users,
     webPushSubscriptions,
 } from '@gredice/storage';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import {
     createTestAccount,
     createTestGarden,
@@ -54,6 +55,316 @@ test('createNotification and getNotificationsByAccount basic usage', async () =>
     );
     assert.ok(Array.isArray(notifications));
     assert.ok(notifications.some((n) => n.id === notificationId));
+});
+
+test('createNotification reuses a bounded opaque identity for repeated domain events', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const idempotencyKey = `delivery-lifecycle:${randomUUID()}`;
+    const notification = {
+        accountId,
+        header: 'Dostava je krenula',
+        content: 'Pratite status dostave.',
+        category: 'delivery_updates',
+        type: 'route-started',
+        timestamp: new Date(),
+    };
+
+    const firstId = await createNotification(notification, { idempotencyKey });
+    const replayId = await createNotification(notification, { idempotencyKey });
+
+    assert.equal(firstId, replayId);
+    assert.equal(firstId.startsWith('notification:'), true);
+    assert.equal(firstId.length <= 128, true);
+    assert.equal(firstId.includes(idempotencyKey), false);
+
+    const storedRows = await storage()
+        .select({ id: notifications.id })
+        .from(notifications)
+        .where(eq(notifications.id, firstId));
+    assert.equal(storedRows.length, 1);
+
+    const attempts = await storage()
+        .select({ provider: notificationDeliveryAttempts.provider })
+        .from(notificationDeliveryAttempts)
+        .where(eq(notificationDeliveryAttempts.notificationId, firstId));
+    assert.equal(
+        attempts.filter((attempt) => attempt.provider === 'router').length,
+        3,
+    );
+});
+
+test('createNotification rejects empty or cross-target idempotency key reuse', async () => {
+    createTestDb();
+    const firstAccountId = await createTestAccount();
+    const secondAccountId = await createTestAccount();
+    const idempotencyKey = `delivery-lifecycle:${randomUUID()}`;
+    const notification = {
+        accountId: firstAccountId,
+        header: 'Dostava',
+        content: 'Status dostave.',
+        category: 'delivery_updates',
+        type: 'route-started',
+        timestamp: new Date(),
+    };
+
+    await assert.rejects(
+        createNotification(notification, { idempotencyKey: '   ' }),
+        /must not be empty/,
+    );
+    await createNotification(notification, {
+        idempotencyKey,
+        routeDelivery: false,
+    });
+    await assert.rejects(
+        createNotification(
+            { ...notification, accountId: secondAccountId },
+            { idempotencyKey, routeDelivery: false },
+        ),
+        /different target/,
+    );
+});
+
+test('repeated keyed customer events queue each delivery channel once', async () => {
+    createTestDb();
+    await ensureFarmId();
+    const userId = await createUserWithPassword(
+        `delivery-idempotency-${randomUUID()}@example.com`,
+        'password',
+    );
+    const user = await getUser(userId);
+    assert.ok(user);
+    const accountId = user.accounts[0]?.accountId;
+    assert.ok(accountId);
+    const subscriptionId = randomUUID();
+    await storage()
+        .insert(webPushSubscriptions)
+        .values({
+            id: subscriptionId,
+            accountId,
+            userId,
+            endpoint: `https://example.com/${subscriptionId}`,
+            p256dh: 'k',
+            auth: 'a',
+            enabled: true,
+            permissionState: 'granted',
+        });
+    const notification = {
+        accountId,
+        userId,
+        header: 'Dostava je krenula',
+        content: 'Pratite status dostave.',
+        category: 'delivery_updates',
+        type: 'route-started',
+        timestamp: new Date(),
+    };
+    const idempotencyKey = `delivery-lifecycle:${randomUUID()}`;
+
+    const notificationIds = await Promise.all(
+        Array.from(
+            { length: 10 },
+            async () =>
+                await createNotification(notification, { idempotencyKey }),
+        ),
+    );
+    assert.equal(new Set(notificationIds).size, 1);
+    const notificationId = notificationIds[0];
+    assert.ok(notificationId);
+
+    const attempts = await storage()
+        .select({
+            channel: notificationDeliveryAttempts.channel,
+            provider: notificationDeliveryAttempts.provider,
+        })
+        .from(notificationDeliveryAttempts)
+        .where(eq(notificationDeliveryAttempts.notificationId, notificationId));
+    assert.equal(
+        attempts.filter((attempt) => attempt.provider === 'router').length,
+        3,
+    );
+    assert.deepEqual(
+        attempts
+            .filter((attempt) => attempt.provider === 'web_push_queue')
+            .map((attempt) => attempt.channel),
+        ['push'],
+    );
+
+    await storage()
+        .update(notificationDeliveryAttempts)
+        .set({ createdAt: new Date('2020-01-01T00:00:00.000Z') })
+        .where(eq(notificationDeliveryAttempts.notificationId, notificationId));
+    const cleanup = await cleanupNotificationRetention({
+        deleteDeliveryAttemptsOlderThanDays: 180,
+    });
+    assert.equal(cleanup.deliveryAttemptsDeleted, 4);
+
+    const retainedNotificationId = await createNotification(notification, {
+        idempotencyKey,
+    });
+    assert.equal(retainedNotificationId, notificationId);
+    const attemptsAfterRetainedReplay = await storage()
+        .select({ id: notificationDeliveryAttempts.id })
+        .from(notificationDeliveryAttempts)
+        .where(eq(notificationDeliveryAttempts.notificationId, notificationId));
+    assert.deepEqual(attemptsAfterRetainedReplay, []);
+});
+
+test('delivery updates use optional defaults and account preferences override global preferences', async () => {
+    createTestDb();
+    await ensureFarmId();
+    const userId = await createUserWithPassword(
+        `delivery-preference-${randomUUID()}@example.com`,
+        'password',
+    );
+    const user = await getUser(userId);
+    assert.ok(user);
+    const accountId = user.accounts[0]?.accountId;
+    assert.ok(accountId);
+    const subscriptionId = randomUUID();
+    await storage()
+        .insert(webPushSubscriptions)
+        .values({
+            id: subscriptionId,
+            accountId,
+            userId,
+            endpoint: `https://example.com/${subscriptionId}`,
+            p256dh: 'k',
+            auth: 'a',
+            enabled: true,
+            permissionState: 'granted',
+        });
+
+    const defaultNotificationId = await createNotification(
+        {
+            accountId,
+            userId,
+            header: 'Dostava',
+            content: 'Ažuriranje dostave.',
+            category: 'delivery_updates',
+            timestamp: new Date(),
+        },
+        { routeDelivery: false },
+    );
+    const defaultDecisions = await routeNotificationDelivery(
+        defaultNotificationId,
+    );
+    assert.deepEqual(
+        defaultDecisions
+            .map(({ channel, outcome, required }) => ({
+                channel,
+                outcome,
+                required,
+            }))
+            .sort((left, right) => left.channel.localeCompare(right.channel)),
+        [
+            { channel: 'email', outcome: 'immediate', required: false },
+            { channel: 'in_app', outcome: 'immediate', required: false },
+            { channel: 'push', outcome: 'immediate', required: false },
+        ],
+    );
+
+    await storage()
+        .insert(notificationUserChannelPreferences)
+        .values([
+            {
+                userId,
+                category: 'delivery_updates',
+                channel: 'push',
+                enabled: true,
+            },
+            {
+                userId,
+                accountId,
+                scope: 'account',
+                category: 'delivery_updates',
+                channel: 'push',
+                enabled: false,
+            },
+        ]);
+    const accountOverrideId = await createNotification(
+        {
+            accountId,
+            userId,
+            header: 'Dostava',
+            content: 'Ažuriranje dostave.',
+            category: 'delivery_updates',
+            timestamp: new Date(),
+        },
+        { routeDelivery: false },
+    );
+    const overrideDecisions =
+        await routeNotificationDelivery(accountOverrideId);
+    assert.ok(
+        overrideDecisions.some(
+            (decision) =>
+                decision.channel === 'push' &&
+                decision.outcome === 'suppressed' &&
+                decision.reason === 'preference_disabled' &&
+                decision.required === false,
+        ),
+    );
+});
+
+test('delivery update quiet hours use an injected clock across midnight', async () => {
+    createTestDb();
+    await ensureFarmId();
+    const userId = await createUserWithPassword(
+        `delivery-quiet-hours-${randomUUID()}@example.com`,
+        'password',
+    );
+    const user = await getUser(userId);
+    assert.ok(user);
+    const accountId = user.accounts[0]?.accountId;
+    assert.ok(accountId);
+    await storage()
+        .insert(notificationUserChannelPreferences)
+        .values({
+            userId,
+            category: 'delivery_updates',
+            channel: 'email',
+            digestFrequency: 'daily',
+            enabled: true,
+            quietHoursStartMinute: 22 * 60,
+            quietHoursEndMinute: 6 * 60,
+            timezone: 'UTC',
+        });
+
+    const createUnrouted = async () =>
+        await createNotification(
+            {
+                accountId,
+                userId,
+                header: 'Dostava',
+                content: 'Ažuriranje dostave.',
+                category: 'delivery_updates',
+                timestamp: new Date(),
+            },
+            { routeDelivery: false },
+        );
+    const quietDecisions = await routeNotificationDelivery(
+        await createUnrouted(),
+        { now: new Date('2026-07-16T23:00:00.000Z') },
+    );
+    const daytimeDecisions = await routeNotificationDelivery(
+        await createUnrouted(),
+        { now: new Date('2026-07-16T12:00:00.000Z') },
+    );
+    assert.ok(
+        quietDecisions.some(
+            (decision) =>
+                decision.channel === 'email' &&
+                decision.outcome === 'deferred' &&
+                decision.reason === 'quiet_hours',
+        ),
+    );
+    assert.ok(
+        daytimeDecisions.some(
+            (decision) =>
+                decision.channel === 'email' &&
+                decision.outcome === 'immediate' &&
+                decision.reason === 'eligible_immediate',
+        ),
+    );
 });
 
 test('createNotification routes and queues deliverable push by default', async () => {
@@ -1229,6 +1540,7 @@ test('backfillNotificationRolloutDefaults limits subscription updates with batch
     createTestDb();
     const defaultSubscriptionIds: string[] = [];
     const deniedSubscriptionIds: string[] = [];
+    const rolloutUserIds: string[] = [];
     const rolloutUserDates = [
         '1900-01-01T00:00:00.000Z',
         '1900-01-02T00:00:00.000Z',
@@ -1239,6 +1551,7 @@ test('backfillNotificationRolloutDefaults limits subscription updates with batch
             `rollout-limit-${suffix}-${randomUUID()}@example.com`,
             'password',
         );
+        rolloutUserIds.push(userId);
         await storage()
             .update(users)
             .set({ createdAt: new Date(rolloutUserDates[index]) })
@@ -1312,6 +1625,50 @@ test('backfillNotificationRolloutDefaults limits subscription updates with batch
         ],
     );
 
+    const deliveryUpdatePreferences = await storage()
+        .select({
+            channel: notificationUserChannelPreferences.channel,
+            digestFrequency: notificationUserChannelPreferences.digestFrequency,
+            enabled: notificationUserChannelPreferences.enabled,
+            required: notificationUserChannelPreferences.required,
+            userId: notificationUserChannelPreferences.userId,
+        })
+        .from(notificationUserChannelPreferences)
+        .where(
+            eq(notificationUserChannelPreferences.category, 'delivery_updates'),
+        );
+    assert.deepEqual(
+        deliveryUpdatePreferences
+            .filter((preference) => preference.userId === rolloutUserIds[0])
+            .map((preference) => ({
+                channel: preference.channel,
+                digestFrequency: preference.digestFrequency,
+                enabled: preference.enabled,
+                required: preference.required,
+            }))
+            .sort((left, right) => left.channel.localeCompare(right.channel)),
+        [
+            {
+                channel: 'email',
+                digestFrequency: 'off',
+                enabled: true,
+                required: false,
+            },
+            {
+                channel: 'in_app',
+                digestFrequency: 'off',
+                enabled: true,
+                required: false,
+            },
+            {
+                channel: 'push',
+                digestFrequency: 'off',
+                enabled: true,
+                required: false,
+            },
+        ],
+    );
+
     const subscriptions = await storage()
         .select({
             id: webPushSubscriptions.id,
@@ -1367,5 +1724,156 @@ test('backfillNotificationRolloutDefaults limits subscription updates with batch
                 !subscription.revokedAt,
         ).length,
         1,
+    );
+});
+
+test('delivery preference backfill inherits global quiet hours without replacing explicit overrides', async () => {
+    createTestDb();
+    await ensureFarmId();
+    const userId = await createUserWithPassword(
+        `delivery-backfill-quiet-hours-${randomUUID()}@example.com`,
+        'password',
+    );
+    const user = await getUser(userId);
+    assert.ok(user);
+    const accountId = user.accounts[0]?.accountId;
+    assert.ok(accountId);
+
+    await storage()
+        .update(users)
+        .set({ createdAt: new Date('1800-01-01T00:00:00.000Z') })
+        .where(eq(users.id, userId));
+    await storage().insert(userNotificationSettings).values({
+        userId,
+        emailEnabled: false,
+        dailyDigest: true,
+    });
+    await storage()
+        .insert(notificationUserChannelPreferences)
+        .values([
+            {
+                userId,
+                category: 'reminders',
+                channel: 'in_app',
+                enabled: true,
+                quietHoursStartMinute: 22 * 60,
+                quietHoursEndMinute: 6 * 60,
+                timezone: 'UTC',
+            },
+            {
+                userId,
+                category: 'delivery_updates',
+                channel: 'push',
+                enabled: false,
+                timezone: 'Europe/Zagreb',
+            },
+        ]);
+    const subscriptionId = randomUUID();
+    await storage()
+        .insert(webPushSubscriptions)
+        .values({
+            id: subscriptionId,
+            accountId,
+            userId,
+            endpoint: `https://example.com/${subscriptionId}`,
+            p256dh: 'k',
+            auth: 'a',
+            enabled: true,
+            permissionState: 'granted',
+        });
+
+    const result = await backfillNotificationRolloutDefaults({ limit: 1 });
+    assert.equal(result.usersScanned, 1);
+
+    const deliveryPreferences = await storage()
+        .select({
+            channel: notificationUserChannelPreferences.channel,
+            digestFrequency: notificationUserChannelPreferences.digestFrequency,
+            enabled: notificationUserChannelPreferences.enabled,
+            quietHoursEndMinute:
+                notificationUserChannelPreferences.quietHoursEndMinute,
+            quietHoursStartMinute:
+                notificationUserChannelPreferences.quietHoursStartMinute,
+            timezone: notificationUserChannelPreferences.timezone,
+        })
+        .from(notificationUserChannelPreferences)
+        .where(
+            and(
+                eq(notificationUserChannelPreferences.userId, userId),
+                eq(
+                    notificationUserChannelPreferences.category,
+                    'delivery_updates',
+                ),
+            ),
+        );
+    assert.deepEqual(
+        deliveryPreferences.sort((left, right) =>
+            left.channel.localeCompare(right.channel),
+        ),
+        [
+            {
+                channel: 'email',
+                digestFrequency: 'off',
+                enabled: false,
+                quietHoursEndMinute: 6 * 60,
+                quietHoursStartMinute: 22 * 60,
+                timezone: 'UTC',
+            },
+            {
+                channel: 'in_app',
+                digestFrequency: 'off',
+                enabled: true,
+                quietHoursEndMinute: 6 * 60,
+                quietHoursStartMinute: 22 * 60,
+                timezone: 'UTC',
+            },
+            {
+                channel: 'push',
+                digestFrequency: 'off',
+                enabled: false,
+                quietHoursEndMinute: null,
+                quietHoursStartMinute: null,
+                timezone: 'Europe/Zagreb',
+            },
+        ],
+    );
+
+    const notificationId = await createNotification(
+        {
+            accountId,
+            userId,
+            header: 'Dostava',
+            content: 'Ažuriranje dostave.',
+            category: 'delivery_updates',
+            timestamp: new Date('2026-07-16T23:00:00.000Z'),
+        },
+        { routeDelivery: false },
+    );
+    const decisions = await routeNotificationDelivery(notificationId, {
+        now: new Date('2026-07-16T23:00:00.000Z'),
+    });
+    assert.ok(
+        decisions.some(
+            (decision) =>
+                decision.channel === 'in_app' &&
+                decision.outcome === 'deferred' &&
+                decision.reason === 'quiet_hours',
+        ),
+    );
+    assert.ok(
+        decisions.some(
+            (decision) =>
+                decision.channel === 'email' &&
+                decision.outcome === 'suppressed' &&
+                decision.reason === 'preference_disabled',
+        ),
+    );
+    assert.ok(
+        decisions.some(
+            (decision) =>
+                decision.channel === 'push' &&
+                decision.outcome === 'suppressed' &&
+                decision.reason === 'preference_disabled',
+        ),
     );
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1411,6 +1411,9 @@ importers:
       '@types/node':
         specifier: 24.12.4
         version: 24.12.4
+      tsx:
+        specifier: 4.23.0
+        version: 4.23.0
       typescript:
         specifier: 6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

- define a versioned, retry-aware delivery lifecycle with authoritative milestones, stable idempotency keys, ordering, and ETA hysteresis
- add transaction-safe notification identity, preference-aware quiet-hour deferral, hidden delivery preference propagation, and rollout backfill compatibility
- validate canonical IANA quiet-hour windows and document the minimal payload, retention, producer boundary, and rollout contract

## Validation

- notifications lifecycle tests: 6 passed
- storage notification repository tests: 25 passed
- API Node tests: 212 passed
- garden notification component tests: 12 passed
- API production build
- garden production build
- scoped Biome checks
- frozen lockfile install
- git diff --check

No schema or migration changes.

Closes #4139