### PR TITLE
[Delivery Quality] Add driver, scanner, tracking, and customer journey tests

### DIFF
--- a/apps/delivery/package.json
+++ b/apps/delivery/package.json
@@ -12,9 +12,11 @@
         "build": "next build",
         "start": "node ../../scripts/run-app-command.mjs start",
         "test": "pnpm run test:run",
+        "test:prepare": "turbo build --filter=delivery",
         "test:unit": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server\" node --import tsx --test lib/*.node.spec.ts",
         "test:component": "playwright test --project=chromium",
-        "test:run": "pnpm run test:unit && pnpm run test:component",
+        "test:e2e": "playwright test --config=playwright-e2e.config.ts --project=chromium",
+        "test:run": "pnpm run test:unit && pnpm run test:component && pnpm run test:prepare && pnpm run test:e2e",
         "test-ui": "playwright test --project=chromium --ui",
         "test:local": "pnpm run test:run"
     },

--- a/apps/delivery/playwright-e2e.config.ts
+++ b/apps/delivery/playwright-e2e.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig, devices } from '@playwright/test';
+import {
+    getAppByName,
+    getPlaywrightBaseUrl,
+    shouldReusePlaywrightServer,
+} from '../../scripts/app-registry.ts';
+import { deliveryQualityJwtSignSecret } from './tests/e2e/deliveryTestSession';
+
+const app = getAppByName('delivery');
+
+export default defineConfig({
+    testDir: './tests/e2e',
+    timeout: 30 * 1_000,
+    expect: { timeout: 5 * 1_000 },
+    fullyParallel: true,
+    forbidOnly: Boolean(process.env.CI),
+    retries: process.env.CI ? 1 : 0,
+    workers: process.env.CI ? 1 : undefined,
+    reporter: [
+        ['list'],
+        ['html', { open: 'never', outputFolder: 'playwright-report/e2e' }],
+    ],
+    outputDir: 'test-results/e2e',
+    use: {
+        baseURL: getPlaywrightBaseUrl(app),
+        trace: 'on-first-retry',
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+    webServer: {
+        command: 'node ../../scripts/run-app-command.mjs start',
+        env: {
+            COOKIE_DOMAIN: '',
+            GREDICE_DETACH_CHILD_PROCESS: 'false',
+            GREDICE_JWT_SIGN_SECRET: deliveryQualityJwtSignSecret,
+            GREDICE_SECURE_AUTH_COOKIES: 'false',
+        },
+        gracefulShutdown: { signal: 'SIGTERM', timeout: 5_000 },
+        url: getPlaywrightBaseUrl(app),
+        reuseExistingServer: shouldReusePlaywrightServer(),
+    },
+});

--- a/apps/delivery/playwright.config.ts
+++ b/apps/delivery/playwright.config.ts
@@ -11,6 +11,9 @@ import {
 
 const app = getAppByName('delivery');
 const deliveryRoot = fileURLToPath(new URL('.', import.meta.url));
+const zxingTestDouble = fileURLToPath(
+    new URL('./playwright/mocks/zxing.ts', import.meta.url),
+);
 const reporter: PlaywrightTestConfig['reporter'] = [
     ['list'],
     ['html', { open: 'never' }],
@@ -18,6 +21,7 @@ const reporter: PlaywrightTestConfig['reporter'] = [
 
 export const config: PlaywrightTestConfig = {
     testDir: './tests',
+    testIgnore: /e2e\//,
     snapshotDir: './__snapshots__',
     timeout: 10 * 1000,
     fullyParallel: true,
@@ -33,6 +37,9 @@ export const config: PlaywrightTestConfig = {
                 postcss: deliveryRoot,
             },
             resolve: {
+                alias: {
+                    '@zxing/library': zxingTestDouble,
+                },
                 dedupe: ['react', 'react-dom'],
             },
         },

--- a/apps/delivery/playwright/mocks/zxing.ts
+++ b/apps/delivery/playwright/mocks/zxing.ts
@@ -1,0 +1,57 @@
+type DecodeResult = {
+    getText: () => string;
+};
+
+type DecodeCallback = (
+    result: DecodeResult | undefined,
+    error: Error | undefined,
+) => void;
+
+type ScanEvent = CustomEvent<{ value: string }>;
+type ErrorEvent = CustomEvent<{ name: string }>;
+
+export class NotFoundException extends Error {}
+export class ChecksumException extends Error {}
+export class FormatException extends Error {}
+
+export class BrowserQRCodeReader {
+    private callback: DecodeCallback | null = null;
+    private stream: MediaStream | null = null;
+
+    private readonly handleScan = (event: Event) => {
+        if (!(event instanceof CustomEvent)) return;
+        const scanEvent: ScanEvent = event;
+        if (typeof scanEvent.detail?.value !== 'string') return;
+        this.callback?.({ getText: () => scanEvent.detail.value }, undefined);
+    };
+
+    private readonly handleError = (event: Event) => {
+        if (!(event instanceof CustomEvent)) return;
+        const errorEvent: ErrorEvent = event;
+        const error = new Error('Synthetic QR decode failure.');
+        error.name = errorEvent.detail?.name ?? 'DecodeError';
+        this.callback?.(undefined, error);
+    };
+
+    async decodeFromConstraints(
+        constraints: MediaStreamConstraints,
+        _video: HTMLVideoElement,
+        callback: DecodeCallback,
+    ) {
+        this.callback = callback;
+        if (document.documentElement.dataset.cameraRequestCount !== undefined) {
+            this.stream =
+                await navigator.mediaDevices.getUserMedia(constraints);
+        }
+        window.addEventListener('delivery-test-qr-scan', this.handleScan);
+        window.addEventListener('delivery-test-qr-error', this.handleError);
+    }
+
+    reset() {
+        window.removeEventListener('delivery-test-qr-scan', this.handleScan);
+        window.removeEventListener('delivery-test-qr-error', this.handleError);
+        for (const track of this.stream?.getTracks() ?? []) track.stop();
+        this.stream = null;
+        this.callback = null;
+    }
+}

--- a/apps/delivery/tests/HarvestTraceScannerStory.tsx
+++ b/apps/delivery/tests/HarvestTraceScannerStory.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import { HarvestTraceScanner } from '../components/HarvestTraceScanner';
+
+function scanResult(value: string) {
+    if (value.includes('tomato')) {
+        return {
+            status: 'selected' as const,
+            tracePath: '/trag/tomato-quality-4146',
+            plantName: 'Rajčica Roma',
+            contactName: 'Ana Anić',
+            deliveryCount: 2,
+            newlySelectedCount: 2,
+            nextSelectedRequestIds: ['request-tomato-1', 'request-tomato-2'],
+        };
+    }
+    if (value.includes('basil')) {
+        return {
+            status: 'selected' as const,
+            tracePath: '/trag/basil-quality-4146',
+            plantName: 'Bosiljak Genovese',
+            contactName: 'Borna Barić',
+            deliveryCount: 1,
+            newlySelectedCount: 1,
+            nextSelectedRequestIds: ['request-basil'],
+        };
+    }
+    return { status: 'invalid' as const };
+}
+
+export function HarvestTraceScannerStory() {
+    const [calls, setCalls] = useState<string[]>([]);
+    const [selectedCount, setSelectedCount] = useState(0);
+
+    return (
+        <main className="p-4">
+            <output data-testid="scanner-calls">{calls.join('|')}</output>
+            <HarvestTraceScanner
+                variant="pickup"
+                availableTraceCount={3}
+                completedTraceCount={selectedCount}
+                disabled={false}
+                onScan={async (value) => {
+                    setCalls((current) => [...current, value]);
+                    const result = scanResult(value);
+                    if (result.status === 'selected') {
+                        setSelectedCount(
+                            (current) => current + result.deliveryCount,
+                        );
+                    }
+                    return result;
+                }}
+            />
+        </main>
+    );
+}

--- a/apps/delivery/tests/delivery-scanner-live.spec.tsx
+++ b/apps/delivery/tests/delivery-scanner-live.spec.tsx
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import {
+    emitQrDecodeError,
+    emitQrScan,
+    installCameraDouble,
+} from './deliveryBrowserDoubles';
+import { HarvestTraceScannerStory } from './HarvestTraceScannerStory';
+import '../app/globals.css';
+
+test('live camera scanning deduplicates rapid QR frames and keeps the polite scan log current', async ({
+    mount,
+    page,
+}) => {
+    await installCameraDouble(page);
+    await mount(<HarvestTraceScannerStory />);
+
+    const trigger = page.getByRole('button', { name: 'Skeniraj QR kodove' });
+    await trigger.focus();
+    await trigger.press('Enter');
+    const scanner = page.getByRole('dialog', {
+        name: 'Skeniranje tragova uroda',
+    });
+    await expect(scanner).toBeVisible();
+    await expect(scanner.getByLabel('Ručni unos')).toBeFocused();
+    await expect(scanner.getByText(/Kamera je aktivna/)).toBeVisible();
+
+    const tomato = 'https://www.gredice.com/trag/tomato-quality-4146';
+    await Promise.all([
+        emitQrScan(page, tomato),
+        emitQrScan(page, tomato),
+        emitQrScan(page, tomato),
+    ]);
+    await emitQrScan(page, '/trag/basil-quality-4146');
+
+    await expect(page.getByTestId('scanner-calls')).toHaveText(
+        `${tomato}|/trag/basil-quality-4146`,
+    );
+    await expect(scanner).toContainText('2 očitano');
+    await expect(scanner).toContainText('3 odabrano');
+    const scanLog = scanner.getByRole('log', {
+        name: 'Posljednja očitanja',
+    });
+    await expect(scanLog).toHaveAttribute('aria-live', 'polite');
+    await expect(scanLog).toContainText('Rajčica Roma');
+    await expect(scanLog).toContainText('Bosiljak Genovese');
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-camera-vibration-count',
+        '2',
+    );
+
+    await scanner.getByRole('button', { name: 'Završi skeniranje' }).click();
+    await expect(scanner).toHaveCount(0);
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-camera-track-stop-count',
+        '1',
+    );
+});
+
+test('camera and decoder failures retain keyboard-operable manual scanning and parent progress', async ({
+    mount,
+    page,
+}) => {
+    await installCameraDouble(page, { errorName: 'NotAllowedError' });
+    await mount(<HarvestTraceScannerStory />);
+
+    await page.getByRole('button', { name: 'Skeniraj QR kodove' }).click();
+    const scanner = page.getByRole('dialog', {
+        name: 'Skeniranje tragova uroda',
+    });
+    await expect(scanner).toContainText('Dopusti pristup kameri');
+    const input = scanner.getByLabel('Ručni unos');
+    await input.fill('/trag/tomato-quality-4146');
+    await input.press('Enter');
+    await expect(scanner).toContainText('2 odabrano');
+    await scanner.getByRole('button', { name: 'Završi skeniranje' }).click();
+
+    await page.getByRole('button', { name: 'Skeniraj QR kodove' }).click();
+    await expect(scanner).toContainText('2 odabrano');
+    await scanner.getByRole('button', { name: 'Završi skeniranje' }).click();
+
+    await installCameraDouble(page);
+    await page.getByRole('button', { name: 'Skeniraj QR kodove' }).click();
+    await expect(scanner.getByText(/Kamera je aktivna/)).toBeVisible();
+    await emitQrDecodeError(page);
+    await expect(scanner).toContainText('QR kod nije moguće očitati');
+    await expect(input).toBeEnabled();
+});

--- a/apps/delivery/tests/deliveryBrowserDoubles.ts
+++ b/apps/delivery/tests/deliveryBrowserDoubles.ts
@@ -1,0 +1,164 @@
+import type { Page } from '@playwright/test';
+
+export async function installCameraDouble(
+    page: Page,
+    options: { errorName?: string } = {},
+) {
+    await page.evaluate(({ errorName }) => {
+        let requestCount = 0;
+        let stopCount = 0;
+        let vibrationCount = 0;
+        const root = document.documentElement;
+        const syncMetrics = () => {
+            root.dataset.cameraRequestCount = String(requestCount);
+            root.dataset.cameraTrackStopCount = String(stopCount);
+            root.dataset.cameraVibrationCount = String(vibrationCount);
+        };
+        Object.defineProperty(navigator, 'vibrate', {
+            configurable: true,
+            value: () => {
+                vibrationCount += 1;
+                syncMetrics();
+                return true;
+            },
+        });
+        Object.defineProperty(navigator, 'mediaDevices', {
+            configurable: true,
+            value: {
+                getUserMedia: async () => {
+                    requestCount += 1;
+                    syncMetrics();
+                    if (errorName) {
+                        throw new DOMException(
+                            'Synthetic camera access failure.',
+                            errorName,
+                        );
+                    }
+                    return {
+                        getTracks: () => [
+                            {
+                                stop: () => {
+                                    stopCount += 1;
+                                    syncMetrics();
+                                },
+                            },
+                        ],
+                    };
+                },
+            },
+        });
+        syncMetrics();
+    }, options);
+}
+
+export async function emitQrScan(page: Page, value: string) {
+    await page.evaluate((scanValue) => {
+        window.dispatchEvent(
+            new CustomEvent('delivery-test-qr-scan', {
+                detail: { value: scanValue },
+            }),
+        );
+    }, value);
+}
+
+export async function emitQrDecodeError(page: Page, name = 'DecodeError') {
+    await page.evaluate((errorName) => {
+        window.dispatchEvent(
+            new CustomEvent('delivery-test-qr-error', {
+                detail: { name: errorName },
+            }),
+        );
+    }, name);
+}
+
+export async function installGeolocationDouble(page: Page) {
+    await page.addInitScript(() => {
+        type Watcher = {
+            success: PositionCallback;
+            error: PositionErrorCallback | null;
+        };
+        const watchers = new Map<number, Watcher>();
+        let nextWatchId = 1;
+        const permissionStatus = {
+            state: 'granted' as PermissionState,
+            onchange: null,
+            addEventListener: () => undefined,
+            removeEventListener: () => undefined,
+            dispatchEvent: () => true,
+        };
+        Object.defineProperty(navigator, 'permissions', {
+            configurable: true,
+            value: {
+                query: async () => permissionStatus,
+            },
+        });
+        Object.defineProperty(navigator, 'geolocation', {
+            configurable: true,
+            value: {
+                watchPosition(
+                    success: PositionCallback,
+                    error: PositionErrorCallback | null,
+                ) {
+                    const watchId = nextWatchId;
+                    nextWatchId += 1;
+                    watchers.set(watchId, { success, error });
+                    document.documentElement.dataset.geolocationWatchCount =
+                        String(watchers.size);
+                    return watchId;
+                },
+                clearWatch(watchId: number) {
+                    watchers.delete(watchId);
+                    document.documentElement.dataset.geolocationWatchCount =
+                        String(watchers.size);
+                },
+                getCurrentPosition(success: PositionCallback) {
+                    watchers.set(0, { success, error: null });
+                },
+            },
+        });
+        window.addEventListener('delivery-test-geolocation', (event) => {
+            if (!(event instanceof CustomEvent)) return;
+            const detail: unknown = event.detail;
+            if (typeof detail !== 'object' || detail === null) return;
+            const latitude = Reflect.get(detail, 'latitude');
+            const longitude = Reflect.get(detail, 'longitude');
+            const timestamp = Reflect.get(detail, 'timestamp');
+            if (
+                typeof latitude !== 'number' ||
+                typeof longitude !== 'number' ||
+                typeof timestamp !== 'number'
+            ) {
+                return;
+            }
+            const position = {
+                coords: {
+                    latitude,
+                    longitude,
+                    accuracy: 6,
+                    altitude: null,
+                    altitudeAccuracy: null,
+                    heading: 90,
+                    speed: 5,
+                    toJSON: () => ({}),
+                },
+                timestamp,
+                toJSON: () => ({}),
+            };
+            for (const watcher of watchers.values()) {
+                watcher.success(position);
+            }
+            watchers.delete(0);
+        });
+    });
+}
+
+export async function emitGeolocation(
+    page: Page,
+    position: { latitude: number; longitude: number; timestamp: number },
+) {
+    await page.evaluate((detail) => {
+        window.dispatchEvent(
+            new CustomEvent('delivery-test-geolocation', { detail }),
+        );
+    }, position);
+}

--- a/apps/delivery/tests/e2e/delivery-journeys.spec.ts
+++ b/apps/delivery/tests/e2e/delivery-journeys.spec.ts
@@ -1,0 +1,378 @@
+import { expect, test } from '@playwright/test';
+import {
+    emitGeolocation,
+    installGeolocationDouble,
+} from '../deliveryBrowserDoubles';
+import {
+    customerJourneyDashboard,
+    driverActiveDashboard,
+    driverPlanningDashboard,
+} from './deliveryJourneyFixtures';
+import { installDeliveryTestSession } from './deliveryTestSession';
+
+function json(body: object, status = 200) {
+    return {
+        body: JSON.stringify(body),
+        contentType: 'application/json',
+        status,
+    };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+const operatorCases = [
+    {
+        displayName: 'Admin Dostavljač',
+        role: 'admin',
+        roleLabel: 'Admin vozač',
+    },
+    {
+        displayName: 'Vozač Dostavljač',
+        role: 'driver',
+        roleLabel: 'Vozač',
+    },
+] as const;
+
+for (const operator of operatorCases) {
+    test(`${operator.role} recovers a local start failure, starts a bulk route, uploads GPS, and completes the stop`, async ({
+        baseURL,
+        page,
+    }) => {
+        if (!baseURL) throw new Error('Delivery E2E requires a baseURL.');
+        await installGeolocationDouble(page);
+        await installDeliveryTestSession({
+            baseURL,
+            page,
+            role: operator.role,
+            userId: `${operator.role}-quality-4146`,
+        });
+        let active = false;
+        let preflightCalls = 0;
+        const selectedRequestIds: string[][] = [];
+        const locationBodies: object[] = [];
+        const deliveryBodies: Array<Record<string, unknown>> = [];
+
+        await page.route('**/api/users/current-claims', (route) =>
+            route.fulfill(
+                json({
+                    id: `${operator.role}-quality-4146`,
+                    userName: operator.displayName,
+                    role: operator.role,
+                    accounts: [{ accountId: 'account-delivery-quality-4146' }],
+                }),
+            ),
+        );
+        await page.route('**/api/dashboard**', (route) =>
+            route.fulfill(
+                json(
+                    active
+                        ? driverActiveDashboard(operator.role)
+                        : driverPlanningDashboard(operator.role),
+                ),
+            ),
+        );
+        await page.route('**/api/driver/runs/preflight', async (route) => {
+            preflightCalls += 1;
+            const body: unknown = route.request().postDataJSON();
+            if (
+                typeof body === 'object' &&
+                body !== null &&
+                'deliveryRequestIds' in body &&
+                Array.isArray(body.deliveryRequestIds)
+            ) {
+                selectedRequestIds.push(
+                    body.deliveryRequestIds.filter(
+                        (value): value is string => typeof value === 'string',
+                    ),
+                );
+            }
+            if (preflightCalls === 1) {
+                await route.fulfill(
+                    json({ error: 'Privremena pogreška pripreme.' }, 503),
+                );
+                return;
+            }
+            await route.fulfill(
+                json({
+                    preparationToken: 'preparation-quality-4146',
+                    expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+                }),
+            );
+        });
+        await page.route('**/api/driver/runs', async (route) => {
+            active = true;
+            await route.fulfill(json({ runId: 'run-quality-4146' }));
+        });
+        await page.route(
+            '**/api/driver/runs/run-quality-4146/location',
+            async (route) => {
+                const body: unknown = route.request().postDataJSON();
+                if (typeof body === 'object' && body !== null) {
+                    locationBodies.push(body);
+                }
+                const acceptedAt = new Date().toISOString();
+                await route.fulfill(
+                    json({
+                        status: 'live',
+                        acceptedAt,
+                        refreshedAt: acceptedAt,
+                        replayed: false,
+                    }),
+                );
+            },
+        );
+        await page.route(
+            '**/api/driver/runs/run-quality-4146/stops/101/handoff/mutations',
+            (route) =>
+                route.fulfill(
+                    json({
+                        runId: 'run-quality-4146',
+                        targetStopId: 101,
+                        version: 1,
+                        retryAttempt: 0,
+                        items: [
+                            {
+                                stopId: 101,
+                                deliveryRequestId:
+                                    'request-tomato-quality-4146',
+                                retryAttempt: 0,
+                                traceLinkId: 1,
+                                qrAvailable: true,
+                                state: 'unverified',
+                                reason: null,
+                                verifiedAt: null,
+                            },
+                            {
+                                stopId: 102,
+                                deliveryRequestId: 'request-basil-quality-4146',
+                                retryAttempt: 0,
+                                traceLinkId: 2,
+                                qrAvailable: true,
+                                state: 'unverified',
+                                reason: null,
+                                verifiedAt: null,
+                            },
+                        ],
+                        expectedCount: 2,
+                        scannedCount: 0,
+                        unverifiedCount: 2,
+                        noLabelCount: 0,
+                        missingCount: 0,
+                        skippedCount: 0,
+                    }),
+                ),
+        );
+        await page.route(
+            '**/api/driver/runs/run-quality-4146/stops/101/deliver',
+            async (route) => {
+                const body: unknown = route.request().postDataJSON();
+                if (!isRecord(body)) {
+                    await route.abort();
+                    return;
+                }
+                deliveryBodies.push(body);
+                const clientOperationId = Reflect.get(
+                    body,
+                    'clientOperationId',
+                );
+                await route.fulfill(
+                    json({
+                        clientOperationId,
+                        replayed: false,
+                        result: {
+                            kind: 'deliver',
+                            targetStopId: 101,
+                            affectedStopIds: [101, 102],
+                            routeRevision: 2,
+                            reroutePending: false,
+                            runCompleted: true,
+                            override: {
+                                reason: 'manual-handoff',
+                                bypassed: ['handoff-review'],
+                            },
+                        },
+                    }),
+                );
+            },
+        );
+
+        const response = await page.goto('/');
+        expect(response?.ok()).toBe(true);
+        await expect(
+            page.getByText(operator.roleLabel, { exact: true }),
+        ).toBeVisible();
+        await expect(page.getByText('Još nije spremno')).toBeVisible();
+
+        const selectReady = page.getByRole('button', {
+            name: 'Odaberi sve spremne',
+        });
+        await selectReady.focus();
+        await selectReady.press('Enter');
+        await expect(page.getByText('2 uroda', { exact: true })).toBeVisible();
+        const startRoute = page.getByRole('button', {
+            name: /Pokreni rutu s 2/,
+        });
+        await startRoute.click();
+        await expect(
+            page
+                .getByRole('alert')
+                .filter({ hasText: 'Privremena pogreška pripreme.' }),
+        ).toBeVisible();
+        await expect(startRoute).toBeEnabled();
+        await startRoute.click();
+
+        await expect(
+            page.getByRole('heading', { name: '2 uroda · skupna dostava' }),
+        ).toBeVisible();
+        expect(selectedRequestIds).toEqual([
+            ['request-tomato-quality-4146', 'request-basil-quality-4146'],
+            ['request-tomato-quality-4146', 'request-basil-quality-4146'],
+        ]);
+
+        await expect(page.locator('html')).toHaveAttribute(
+            'data-geolocation-watch-count',
+            '1',
+        );
+        const capturedAt = await page.evaluate(() => Date.now());
+        await emitGeolocation(page, {
+            latitude: 45.815,
+            longitude: 15.982,
+            timestamp: capturedAt,
+        });
+        await expect(
+            page.getByRole('group', { name: 'Status GPS praćenja' }),
+        ).toContainText('GPS praćenje je aktivno');
+        expect(locationBodies).toHaveLength(1);
+
+        await page.getByRole('button', { name: 'Dostavi 2 · dalje' }).click();
+        const confirmation = page.getByRole('dialog', {
+            name: 'Potvrdi dostavu',
+        });
+        await expect(confirmation.getByRole('status')).toContainText(
+            '2 očekivana uroda',
+        );
+        await confirmation
+            .getByLabel('Razlog operativne iznimke')
+            .selectOption('manual-handoff');
+        await confirmation
+            .getByRole('button', { name: 'Potvrdi iznimku i dostavu' })
+            .click();
+        await expect(
+            page.getByRole('status').filter({ hasText: 'Ruta je završena' }),
+        ).toBeVisible();
+        expect(deliveryBodies).toHaveLength(1);
+        expect(deliveryBodies[0]).toMatchObject({
+            expectedRouteRevision: 1,
+            completionOverride: { reason: 'manual-handoff' },
+        });
+    });
+}
+
+test('customer browser journey keeps live tracking and history visible through a failed refresh and focused recovery', async ({
+    baseURL,
+    page,
+}) => {
+    if (!baseURL) throw new Error('Delivery E2E requires a baseURL.');
+    await installDeliveryTestSession({
+        baseURL,
+        page,
+        role: 'user',
+        userId: 'user-quality-4146',
+    });
+    let failRefresh = false;
+    let releaseInitialDashboard: () => void = () => undefined;
+    const initialDashboardGate = new Promise<void>((resolve) => {
+        releaseInitialDashboard = resolve;
+    });
+    let dashboardCalls = 0;
+
+    await page.route('**/api/users/current-claims', (route) =>
+        route.fulfill(
+            json({
+                id: 'user-quality-4146',
+                userName: 'Korisnik Korina',
+                role: 'user',
+                accounts: [{ accountId: 'account-delivery-quality-4146' }],
+            }),
+        ),
+    );
+    await page.route('**/api/dashboard**', async (route) => {
+        dashboardCalls += 1;
+        if (dashboardCalls === 1) await initialDashboardGate;
+        await route.fulfill(
+            failRefresh
+                ? json({ error: 'Synthetic refresh failure.' }, 503)
+                : json(customerJourneyDashboard()),
+        );
+    });
+    await page.route('**/api/map/run-customer-quality-4146**', (route) =>
+        route.fulfill({
+            body: Buffer.from('R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=', 'base64'),
+            contentType: 'image/gif',
+            status: 200,
+        }),
+    );
+
+    const response = await page.goto('/');
+    expect(response?.ok()).toBe(true);
+    await expect(
+        page.getByText('Učitavanje dostava…', { exact: true }),
+    ).toBeVisible();
+    releaseInitialDashboard();
+
+    await expect(
+        page.getByRole('heading', { name: 'Moje dostave' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('status').filter({
+            hasText: 'Lokacija vozača je uživo.',
+        }),
+    ).toBeVisible();
+    await expect(
+        page
+            .getByRole('alert')
+            .filter({ hasText: 'Vozač je stigao na lokaciju dostave.' }),
+    ).toBeVisible();
+
+    const history = page.getByTestId('customer-history-section');
+    const revealHistory = history.getByRole('button', {
+        name: 'Prikaži još (1)',
+    });
+    await revealHistory.focus();
+    await revealHistory.press('Enter');
+    await expect(
+        history.getByRole('article', {
+            name: 'Nova stavka povijesti: Dostavljeni urod 7',
+        }),
+    ).toBeFocused();
+    await expect(history.getByRole('status')).toHaveText(
+        'Prikazano 7 od 7 stavki povijesti.',
+    );
+
+    failRefresh = true;
+    const callsBeforeFailedRefresh = dashboardCalls;
+    await expect
+        .poll(() => dashboardCalls, { timeout: 12_000 })
+        .toBeGreaterThan(callsBeforeFailedRefresh);
+    await expect(
+        page.getByRole('alert').filter({ hasText: 'Podaci nisu ažurni' }),
+    ).toContainText('Prikazujemo zadnje potvrđene podatke', {
+        timeout: 10_000,
+    });
+    await expect(
+        page.getByRole('heading', { name: 'Aktivna rajčica' }),
+    ).toBeVisible();
+
+    failRefresh = false;
+    const refresh = page.getByRole('button', { name: 'Osvježi podatke' });
+    await refresh.focus();
+    await refresh.press('Enter');
+    const recovered = page.getByRole('status', {
+        name: 'Podaci su ponovno ažurni',
+    });
+    await expect(recovered).toBeVisible();
+    await expect(recovered).toBeFocused();
+    expect(dashboardCalls).toBeGreaterThanOrEqual(3);
+});

--- a/apps/delivery/tests/e2e/deliveryJourneyFixtures.ts
+++ b/apps/delivery/tests/e2e/deliveryJourneyFixtures.ts
@@ -1,0 +1,331 @@
+import type {
+    CustomerDeliveryDashboard,
+    CustomerDeliveryRequestSummary,
+    DriverDeliveryDashboard,
+} from '../../lib/deliveryDashboardTypes';
+
+const transparentMap =
+    'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
+
+function isoAt(timestamp: number) {
+    return new Date(timestamp).toISOString();
+}
+
+const tomatoHarvest = {
+    plantName: 'Rajčica Roma',
+    operationName: 'Berba',
+    raisedBedName: 'Gredica A',
+    fieldName: 'Polje 1',
+    tracePath: '/trag/tomato-quality-4146',
+};
+
+const basilHarvest = {
+    ...tomatoHarvest,
+    plantName: 'Bosiljak Genovese',
+    raisedBedName: 'Gredica B',
+    tracePath: '/trag/basil-quality-4146',
+};
+
+function driverUser(role: 'admin' | 'driver') {
+    return {
+        id: `${role}-quality-4146`,
+        displayName: role === 'admin' ? 'Admin Dostavljač' : 'Vozač Dostavljač',
+        role,
+    };
+}
+
+export function driverPlanningDashboard(
+    role: 'admin' | 'driver' = 'admin',
+): DriverDeliveryDashboard {
+    const now = Date.now();
+    const stopKey = 'zagreb-ilica-42-slot-4146';
+    return {
+        kind: 'driver',
+        user: driverUser(role),
+        activeRun: null,
+        batches: [
+            {
+                slotId: 4146,
+                startAt: isoAt(now - 30 * 60_000),
+                endAt: isoAt(now + 90 * 60_000),
+                pickupLocationId: 1,
+                pickupLocationName: 'Gredice HQ',
+                pickupAddress: 'Ulica Julija Knifera 3, Zagreb',
+                deliveryCount: 3,
+                stopCount: 1,
+                orders: [
+                    {
+                        requestId: 'request-tomato-quality-4146',
+                        stopKey,
+                        readyForPickup: true,
+                        pickupStatusLabel: 'Spremno',
+                        contactName: 'Ana Anić',
+                        address: 'Ilica 42, Zagreb',
+                        addressLabel: 'Dvorišni ulaz',
+                        requestNotes: 'Pozvoni dva puta.',
+                        harvest: tomatoHarvest,
+                    },
+                    {
+                        requestId: 'request-basil-quality-4146',
+                        stopKey,
+                        readyForPickup: true,
+                        pickupStatusLabel: 'Spremno',
+                        contactName: 'Ana Anić',
+                        address: 'Ilica 42, Zagreb',
+                        addressLabel: 'Dvorišni ulaz',
+                        requestNotes: null,
+                        harvest: basilHarvest,
+                    },
+                    {
+                        requestId: 'request-lettuce-quality-4146',
+                        stopKey,
+                        readyForPickup: false,
+                        pickupStatusLabel: 'Još nije spremno',
+                        contactName: 'Ana Anić',
+                        address: 'Ilica 42, Zagreb',
+                        addressLabel: 'Dvorišni ulaz',
+                        requestNotes: null,
+                        harvest: {
+                            ...tomatoHarvest,
+                            plantName: 'Salata puterica',
+                            raisedBedName: 'Gredica C',
+                            tracePath: '/trag/lettuce-quality-4146',
+                        },
+                    },
+                ],
+            },
+        ],
+        maximumRouteStops: 24,
+        maximumRouteWindowHours: 12,
+        refreshedAt: isoAt(now),
+    };
+}
+
+export function driverActiveDashboard(
+    role: 'admin' | 'driver' = 'admin',
+): DriverDeliveryDashboard {
+    const now = Date.now();
+    const deliveries = [
+        {
+            stopId: 101,
+            stopState: 'arrived',
+            requestId: 'request-tomato-quality-4146',
+            requestState: 'in_delivery',
+            contactName: 'Ana Anić',
+            phone: '+385 91 111 1111',
+            addressLabel: 'Dvorišni ulaz',
+            requestNotes: 'Pozvoni dva puta.',
+            deliveryNotes: null,
+            harvest: tomatoHarvest,
+            exception: null,
+        },
+        {
+            stopId: 102,
+            stopState: 'arrived',
+            requestId: 'request-basil-quality-4146',
+            requestState: 'in_delivery',
+            contactName: 'Ana Anić',
+            phone: '+385 91 111 1111',
+            addressLabel: 'Dvorišni ulaz',
+            requestNotes: null,
+            deliveryNotes: null,
+            harvest: basilHarvest,
+            exception: null,
+        },
+    ];
+    const stop = {
+        id: 101,
+        requestId: deliveries[0].requestId,
+        sequence: 1,
+        stopState: 'arrived',
+        requestState: 'in_delivery',
+        statusLabel: 'Vozač je stigao',
+        isCurrent: true,
+        contactName: 'Ana Anić',
+        phone: '+385 91 111 1111',
+        address: 'Ilica 42, Zagreb',
+        addressLabel: 'Dvorišni ulaz',
+        requestNotes: 'Pozvoni dva puta.',
+        deliveryNotes: null,
+        slotStartAt: isoAt(now - 30 * 60_000),
+        slotEndAt: isoAt(now + 90 * 60_000),
+        estimatedArrivalAt: isoAt(now + 5 * 60_000),
+        estimatedTravelSeconds: 600,
+        estimatedDistanceMeters: 3_200,
+        reroutePending: false,
+        arrivedAt: isoAt(now - 60_000),
+        deliveredAt: null,
+        harvest: tomatoHarvest,
+        recovery: null,
+        tracking: null,
+        runId: 'run-quality-4146',
+        deliveryCount: deliveries.length,
+        recipientCount: 1,
+        deliveries,
+        actionState: 'current' as const,
+        lockedReason: null,
+    };
+    return {
+        kind: 'driver',
+        user: driverUser(role),
+        activeRun: {
+            id: 'run-quality-4146',
+            state: 'active',
+            startedAt: isoAt(now - 15 * 60_000),
+            completedAt: null,
+            totalDistanceMeters: 3_200,
+            totalDurationSeconds: 600,
+            routePlanVersion: 1,
+            routeRevision: 1,
+            reroutePending: false,
+            estimateSource: 'google',
+            tracking: {
+                status: 'unavailable',
+                lastAcceptedAt: null,
+                mapAvailable: false,
+            },
+            location: null,
+            estimatesUpdatedAt: isoAt(now),
+            mapUrl: transparentMap,
+            deliveryCount: deliveries.length,
+            stops: [stop],
+            routeSteps: [
+                {
+                    kind: 'delivery',
+                    itinerarySequence: 1,
+                    retryLaneRank: null,
+                    retryAttempt: 0,
+                    actionState: 'current',
+                    lockedReason: null,
+                    stop,
+                },
+            ],
+        },
+        batches: [],
+        maximumRouteStops: 24,
+        maximumRouteWindowHours: 12,
+        refreshedAt: isoAt(now),
+    };
+}
+
+function customerDelivery({
+    deliveredAt = null,
+    lifecycle,
+    map = false,
+    now,
+    plantName,
+    requestId,
+}: {
+    deliveredAt?: string | null;
+    lifecycle: CustomerDeliveryRequestSummary['lifecycle'];
+    map?: boolean;
+    now: number;
+    plantName: string;
+    requestId: string;
+}): CustomerDeliveryRequestSummary {
+    const active = lifecycle === 'active';
+    const harvest = {
+        ...tomatoHarvest,
+        plantName,
+        tracePath: `/trag/${requestId}`,
+    };
+    const slotStartAt = active
+        ? isoAt(now - 30 * 60_000)
+        : isoAt(now - 24 * 60 * 60_000);
+    const slotEndAt = active
+        ? isoAt(now + 90 * 60_000)
+        : isoAt(now - 23 * 60 * 60_000);
+    return {
+        mode: 'delivery',
+        lifecycle,
+        requestId,
+        status: active ? 'in_delivery' : 'fulfilled',
+        statusLabel: active ? 'Vozač je stigao' : 'Dostavljeno',
+        requestNotes: active ? 'Pozvoni dva puta.' : null,
+        slotStartAt,
+        slotEndAt,
+        eta: active
+            ? {
+                  source: 'traffic-route',
+                  calculatedAt: isoAt(now),
+                  freshness: 'fresh',
+                  confidence: 'high',
+                  rangeStartAt: isoAt(now),
+                  rangeEndAt: isoAt(now + 10 * 60_000),
+                  remainingMinSeconds: 0,
+                  remainingMaxSeconds: 600,
+              }
+            : {
+                  source: 'promised-window',
+                  calculatedAt: null,
+                  freshness: 'unavailable',
+                  confidence: 'none',
+                  rangeStartAt: null,
+                  rangeEndAt: null,
+                  remainingMinSeconds: null,
+                  remainingMaxSeconds: null,
+              },
+        progress: {
+            phase: active ? 'arrived' : 'unavailable',
+            stopsAhead: active ? 0 : null,
+            delayed: false,
+        },
+        deliveredAt,
+        harvest,
+        destination: {
+            recipientName: 'Korisnik Korina',
+            address: 'Ilica 42, Zagreb',
+            addressLabel: 'Dom',
+        },
+        receipt: deliveredAt
+            ? {
+                  requestReference: requestId,
+                  deliveredAt,
+                  verification: 'verified',
+                  harvest,
+              }
+            : null,
+        recovery: null,
+        tracking: map
+            ? {
+                  status: 'live',
+                  lastAcceptedAt: isoAt(now),
+                  mapAvailable: true,
+                  exactLocationExpiresInMs: 110_000,
+              }
+            : null,
+        mapPath: map ? '/api/map/run-customer-quality-4146' : null,
+    };
+}
+
+export function customerJourneyDashboard(): CustomerDeliveryDashboard {
+    const now = Date.now();
+    const history = Array.from({ length: 7 }, (_, index) =>
+        customerDelivery({
+            deliveredAt: isoAt(now - (index + 1) * 24 * 60 * 60_000),
+            lifecycle: 'history',
+            now,
+            plantName: `Dostavljeni urod ${index + 1}`,
+            requestId: `history-quality-4146-${index + 1}`,
+        }),
+    );
+    return {
+        kind: 'customer',
+        user: {
+            id: 'user-quality-4146',
+            displayName: 'Korisnik Korina',
+            role: 'user',
+        },
+        deliveries: [
+            customerDelivery({
+                lifecycle: 'active',
+                map: true,
+                now,
+                plantName: 'Aktivna rajčica',
+                requestId: 'active-quality-4146',
+            }),
+            ...history,
+        ],
+        refreshedAt: isoAt(now),
+    };
+}

--- a/apps/delivery/tests/e2e/deliveryTestSession.ts
+++ b/apps/delivery/tests/e2e/deliveryTestSession.ts
@@ -1,0 +1,65 @@
+import { createHmac } from 'node:crypto';
+import type { Page } from '@playwright/test';
+
+const deliveryQualitySecretValue = 'delivery-quality-4146-test-secret-material';
+export const deliveryQualityJwtSignSecret = Buffer.from(
+    deliveryQualitySecretValue,
+).toString('base64');
+
+function encodeJwtPart(value: Record<string, unknown>) {
+    return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+function createDeliveryTestJwt({
+    role,
+    userId,
+}: {
+    role: 'admin' | 'driver' | 'user';
+    userId: string;
+}) {
+    const issuedAt = Math.floor(Date.now() / 1_000);
+    const signingInput = [
+        encodeJwtPart({ alg: 'HS256' }),
+        encodeJwtPart({
+            aud: 'urn:gredice:audience:web',
+            exp: issuedAt + 60 * 60,
+            gredice: {
+                accountIds: ['account-delivery-quality-4146'],
+                role,
+                userName: `Test ${role}`,
+            },
+            iat: issuedAt,
+            iss: 'urn:gredice:issuer:api',
+            sub: userId,
+        }),
+    ].join('.');
+    const signature = createHmac(
+        'sha256',
+        Buffer.from(deliveryQualityJwtSignSecret, 'base64'),
+    )
+        .update(signingInput)
+        .digest('base64url');
+    return `${signingInput}.${signature}`;
+}
+
+export async function installDeliveryTestSession({
+    baseURL,
+    page,
+    role,
+    userId,
+}: {
+    baseURL: string;
+    page: Page;
+    role: 'admin' | 'driver' | 'user';
+    userId: string;
+}) {
+    await page.context().addCookies([
+        {
+            name: 'gredice_session',
+            value: createDeliveryTestJwt({ role, userId }),
+            url: baseURL,
+            httpOnly: true,
+            sameSite: 'Lax',
+        },
+    ]);
+}


### PR DESCRIPTION
## Summary

- wire deterministic built-app delivery E2E into the delivery CI test path
- cover the complete ready-only bulk route journey independently for signed admin and driver sessions
- cover customer loading, live/arrived tracking, keyboard history reveal, stale-data retention, and focused recovery
- add stable camera, QR decoder, and geolocation doubles
- cover rapid live QR deduplication, camera/decoder fallback, cleanup, focus, and live-region announcements

## Quality and scope

- test and test-infrastructure changes only under `apps/delivery`
- no production, schema, migration, dependency, or lockfile changes
- runtime-relative fixture dates avoid expiring CI data
- built-app sessions are signed with an isolated test-only secret

## Validation

- delivery unit suite: 398/398
- delivery component suite in CI configuration: 152/152
- focused scanner and handoff component slice: 8/8
- built-app E2E: 3/3 (admin, driver, customer)
- Next TypeScript check
- delivery production build
- exact Biome checks and `git diff --check`
- independent final audit: SHIP

Closes #4146