### PR TITLE
fix(news): restore styles on Novosti pages

### DIFF
--- a/apps/news/next.config.ts
+++ b/apps/news/next.config.ts
@@ -8,6 +8,7 @@ import {
 const app = getAppByName('news');
 const wwwApp = getAppByName('www');
 const newsBasePath = '/novosti';
+const productionNewsOrigin = 'https://novosti.gredice.com';
 
 function isDevelopmentEnv() {
     return (
@@ -37,6 +38,9 @@ function newsRootRedirectDestination() {
 }
 
 const nextConfig: NextConfig = {
+    assetPrefix: isProductionDeployment()
+        ? `${productionNewsOrigin}${newsBasePath}`
+        : undefined,
     basePath: newsBasePath,
     reactStrictMode: true,
     typedRoutes: true,


### PR DESCRIPTION
## What changed

- serve production Novosti CSS, JavaScript, and font assets from the dedicated `novosti.gredice.com/novosti` deployment
- keep local and preview asset paths unchanged

## Root cause

After the Next.js 16.3 preview upgrade, the rewritten page on `www.gredice.com/novosti` emitted base-path asset URLs under `/novosti/_next/...`. Those requests were handled as static assets by the `www` deployment before the external rewrite and returned 404, leaving the page unstyled.

## User impact

Novosti pages load their full styling and client assets again when served through `www.gredice.com/novosti`.

## Validation

- `VERCEL_ENV=production corepack pnpm --filter news build`
- `corepack pnpm --filter news typecheck`
- `corepack pnpm --filter news exec biome check next.config.ts`
- `git diff --check`
- verified current `/novosti/_next/...` CSS returns 404 on `www.gredice.com` and 200 from `novosti.gredice.com`
- verified the production-configured build emits absolute asset URLs on `novosti.gredice.com/novosti/_next/...`