### PR TITLE
fix(www): restore delivery table header corners

### DIFF
--- a/apps/www/app/dostava/page.tsx
+++ b/apps/www/app/dostava/page.tsx
@@ -132,13 +132,13 @@ export default function DeliveryPage() {
                         </caption>
                         <thead>
                             <tr>
-                                <th className="border-border border-r bg-accent px-2 py-2 text-left font-normal text-accent-foreground">
+                                <th className="rounded-tl-xl border-border border-r bg-accent px-2 py-2 text-left font-normal text-accent-foreground">
                                     Mjesto
                                 </th>
                                 <th className="border-border border-r bg-accent px-2 py-2 text-left font-normal text-accent-foreground">
                                     Cijena dostave
                                 </th>
-                                <th className="bg-accent px-2 py-2 text-left font-normal text-accent-foreground">
+                                <th className="rounded-tr-xl bg-accent px-2 py-2 text-left font-normal text-accent-foreground">
                                     Formula
                                 </th>
                             </tr>


### PR DESCRIPTION
## What changed

- restore the top-left radius on the first delivery-table header cell
- restore the top-right radius on the last delivery-table header cell

## Why

Follow-up to #4227. Chromium does not clip the header-cell backgrounds through the rounded `border-separate` table, so the explicit outer-cell radii are required to preserve the rounded table layout.

## Validation

- `pnpm --filter www exec biome check app/dostava/page.tsx`
- `pnpm --filter www typecheck`
- `git diff --check`
- verified `12px` outer header radii on `/dostava` at desktop (1280x800) and mobile (390x844) widths in dark mode
- no browser error overlay or console errors