### PR TITLE
[Delivery Quality] Add operational metrics and rollout runbook

### DIFF
--- a/apps/app/app/admin/delivery/operations/DeliveryOperationalDiagnostics.tsx
+++ b/apps/app/app/admin/delivery/operations/DeliveryOperationalDiagnostics.tsx
@@ -1,0 +1,104 @@
+import type { DeliveryOperationalHealth } from '@gredice/storage';
+import { Card, CardHeader, CardOverflow } from '@gredice/ui/Card';
+import { Chip } from '@gredice/ui/Chip';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { Typography } from '@gredice/ui/Typography';
+import {
+    deliveryOperationalDiagnosticLabel,
+    deliveryOperationalDiagnosticTone,
+    formatDeliveryOperationalDuration,
+} from './deliveryOperationalPresentation';
+
+export function DeliveryOperationalDiagnostics({
+    health,
+}: {
+    health: DeliveryOperationalHealth;
+}) {
+    return (
+        <Card>
+            <CardHeader>
+                <Typography component="h2" level="body1" semiBold>
+                    Operativna dijagnostika
+                </Typography>
+                <Typography level="body3" className="text-muted-foreground">
+                    Prikazani su samo neprozirni ID rute, ograničeni kodovi i
+                    agregirani brojevi. Nema adresa, koordinata ni podataka o
+                    korisniku.
+                </Typography>
+            </CardHeader>
+            <CardOverflow>
+                {health.diagnostics.items.length === 0 ? (
+                    <Typography
+                        className="border-t p-4 text-muted-foreground"
+                        level="body3"
+                    >
+                        Nema operativnih odstupanja u odabranom razdoblju.
+                    </Typography>
+                ) : (
+                    <ol className="divide-y border-t">
+                        {health.diagnostics.items.map((item) => (
+                            <li
+                                className="space-y-2 px-3 py-3 sm:px-4"
+                                key={`${item.runId}:${item.kind}:${item.reasonCode}`}
+                            >
+                                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                                    <Chip
+                                        color={deliveryOperationalDiagnosticTone(
+                                            item.severity,
+                                        )}
+                                        size="sm"
+                                        variant="soft"
+                                    >
+                                        {deliveryOperationalDiagnosticLabel(
+                                            item.kind,
+                                        )}
+                                    </Chip>
+                                    <Typography
+                                        className="min-w-0 break-all text-muted-foreground"
+                                        component="span"
+                                        level="body3"
+                                        mono
+                                    >
+                                        {item.runId}
+                                    </Typography>
+                                    <Typography
+                                        className="ml-auto text-muted-foreground"
+                                        component="span"
+                                        level="body3"
+                                    >
+                                        <LocalDateTime>
+                                            {item.occurredAt}
+                                        </LocalDateTime>
+                                    </Typography>
+                                </div>
+                                <Typography
+                                    className="text-muted-foreground"
+                                    level="body3"
+                                >
+                                    Kod: {item.reasonCode}
+                                    {item.count > 1
+                                        ? ` · Zapisa: ${item.count}`
+                                        : ''}
+                                    {item.ageMs !== undefined
+                                        ? ` · Trajanje: ${formatDeliveryOperationalDuration(
+                                              item.ageMs,
+                                          )}`
+                                        : ''}
+                                </Typography>
+                            </li>
+                        ))}
+                    </ol>
+                )}
+                {health.diagnostics.truncated && (
+                    <Typography
+                        center
+                        className="border-t px-4 py-3 text-muted-foreground"
+                        level="body3"
+                    >
+                        Prikazan je ograničen broj najnovijih zapisa.
+                    </Typography>
+                )}
+            </CardOverflow>
+        </Card>
+    );
+}

--- a/apps/app/app/admin/delivery/operations/DeliveryOperationalExceptions.tsx
+++ b/apps/app/app/admin/delivery/operations/DeliveryOperationalExceptions.tsx
@@ -1,0 +1,54 @@
+import type { DeliveryOperationalHealth } from '@gredice/storage';
+import { Card, CardHeader } from '@gredice/ui/Card';
+import { Chip } from '@gredice/ui/Chip';
+import { Typography } from '@gredice/ui/Typography';
+import {
+    deliveryOperationalExceptionOutcomeLabel,
+    deliveryOperationalExceptionReasonLabel,
+} from './deliveryOperationalPresentation';
+
+export function DeliveryOperationalExceptions({
+    health,
+}: {
+    health: DeliveryOperationalHealth;
+}) {
+    return (
+        <Card>
+            <CardHeader>
+                <Typography component="h2" level="body1" semiBold>
+                    Ishodi iznimki
+                </Typography>
+                <Typography level="body3" className="text-muted-foreground">
+                    Agregirani ishodi i ograničeni razlozi u odabranom
+                    razdoblju, bez bilješki i podataka o korisniku.
+                </Typography>
+            </CardHeader>
+            <div className="flex flex-wrap gap-2 border-t p-4">
+                {health.exceptions.length === 0 ? (
+                    <Typography level="body3" className="text-muted-foreground">
+                        Nema zabilježenih iznimki.
+                    </Typography>
+                ) : (
+                    health.exceptions.map((exception) => (
+                        <Chip
+                            color="neutral"
+                            key={`${exception.outcome}:${exception.reason}`}
+                            size="sm"
+                            variant="outlined"
+                        >
+                            {deliveryOperationalExceptionOutcomeLabel(
+                                exception.outcome,
+                            )}
+                            {' · '}
+                            {deliveryOperationalExceptionReasonLabel(
+                                exception.reason,
+                            )}
+                            {': '}
+                            {exception.count}
+                        </Chip>
+                    ))
+                )}
+            </div>
+        </Card>
+    );
+}

--- a/apps/app/app/admin/delivery/operations/DeliveryOperationalHealthSummary.tsx
+++ b/apps/app/app/admin/delivery/operations/DeliveryOperationalHealthSummary.tsx
@@ -1,0 +1,78 @@
+import type { DeliveryOperationalHealth } from '@gredice/storage';
+import { Card } from '@gredice/ui/Card';
+import { Chip } from '@gredice/ui/Chip';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import {
+    deliveryOperationalSeverityLabel,
+    deliveryOperationalSeverityTone,
+} from './deliveryOperationalPresentation';
+
+export function DeliveryOperationalHealthSummary({
+    health,
+}: {
+    health: DeliveryOperationalHealth;
+}) {
+    return (
+        <Card className="p-4">
+            <Stack spacing={3}>
+                <Row
+                    className="min-w-0 flex-wrap"
+                    justifyContent="space-between"
+                    spacing={2}
+                >
+                    <Typography component="h2" level="body1" semiBold>
+                        Operativno zdravlje dostave
+                    </Typography>
+                    <Chip
+                        color={deliveryOperationalSeverityTone(health.severity)}
+                        size="sm"
+                        variant="soft"
+                    >
+                        {deliveryOperationalSeverityLabel(health.severity)}
+                    </Chip>
+                </Row>
+                <Typography level="body3" className="text-muted-foreground">
+                    <LocalDateTime>{health.from}</LocalDateTime>
+                    {' – '}
+                    <LocalDateTime>{health.to}</LocalDateTime>
+                </Typography>
+                <div className="flex flex-wrap gap-2">
+                    {health.alerts.staleReroute && (
+                        <Chip color="error" size="sm" variant="soft">
+                            Zastarjela preusmjeravanja:{' '}
+                            {health.reroutes.staleCount}
+                        </Chip>
+                    )}
+                    {health.alerts.stalledRun && (
+                        <Chip color="error" size="sm" variant="soft">
+                            Rute bez aktivnosti: {health.runs.stalledCount}
+                        </Chip>
+                    )}
+                    {health.alerts.trackingUnavailable && (
+                        <Chip color="error" size="sm" variant="soft">
+                            Nedostupno praćenje
+                        </Chip>
+                    )}
+                    {health.alerts.elevatedLocalFallback && (
+                        <Chip color="warning" size="sm" variant="soft">
+                            Povišen udio lokalnih procjena
+                        </Chip>
+                    )}
+                    {health.alerts.delayedOfflineReplay && (
+                        <Chip color="warning" size="sm" variant="soft">
+                            Odgođene sinkronizacije
+                        </Chip>
+                    )}
+                    {health.severity === 'healthy' && (
+                        <Chip color="success" size="sm" variant="soft">
+                            Nema operativnih upozorenja
+                        </Chip>
+                    )}
+                </div>
+            </Stack>
+        </Card>
+    );
+}

--- a/apps/app/app/admin/delivery/operations/DeliveryOperationalMetric.tsx
+++ b/apps/app/app/admin/delivery/operations/DeliveryOperationalMetric.tsx
@@ -1,0 +1,21 @@
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+
+export function DeliveryOperationalMetric({
+    label,
+    value,
+}: {
+    label: string;
+    value: string | number;
+}) {
+    return (
+        <Stack spacing={1}>
+            <Typography level="body3" className="text-muted-foreground">
+                {label}
+            </Typography>
+            <Typography level="h6" semiBold>
+                {value}
+            </Typography>
+        </Stack>
+    );
+}

--- a/apps/app/app/admin/delivery/operations/DeliveryOperationalMetrics.tsx
+++ b/apps/app/app/admin/delivery/operations/DeliveryOperationalMetrics.tsx
@@ -1,0 +1,112 @@
+import type { DeliveryOperationalHealth } from '@gredice/storage';
+import { Card } from '@gredice/ui/Card';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { DeliveryOperationalMetric } from './DeliveryOperationalMetric';
+import {
+    formatDeliveryOperationalDuration,
+    formatDeliveryOperationalPercentage,
+} from './deliveryOperationalPresentation';
+
+export function DeliveryOperationalMetrics({
+    health,
+}: {
+    health: DeliveryOperationalHealth;
+}) {
+    return (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <Card className="p-4">
+                <Stack spacing={3}>
+                    <Typography component="h2" level="body1" semiBold>
+                        Rute
+                    </Typography>
+                    <div className="grid grid-cols-3 gap-3">
+                        <DeliveryOperationalMetric
+                            label="Aktivne"
+                            value={health.runs.activeCount}
+                        />
+                        <DeliveryOperationalMetric
+                            label="Završene"
+                            value={health.runs.completedCount}
+                        />
+                        <DeliveryOperationalMetric
+                            label="Napuštene"
+                            value={health.runs.abandonedCount}
+                        />
+                    </div>
+                </Stack>
+            </Card>
+            <Card className="p-4">
+                <Stack spacing={3}>
+                    <Typography component="h2" level="body1" semiBold>
+                        Praćenje aktivnih ruta
+                    </Typography>
+                    <div className="grid grid-cols-2 gap-3">
+                        <DeliveryOperationalMetric
+                            label="Uživo"
+                            value={health.tracking.liveCount}
+                        />
+                        <DeliveryOperationalMetric
+                            label="Odgođeno"
+                            value={health.tracking.delayedCount}
+                        />
+                        <DeliveryOperationalMetric
+                            label="Nedostupno"
+                            value={health.tracking.unavailableCount}
+                        />
+                        <DeliveryOperationalMetric
+                            label="Nije zaprimljeno"
+                            value={health.tracking.notReceivedCount}
+                        />
+                    </div>
+                </Stack>
+            </Card>
+            <Card className="p-4">
+                <Stack spacing={3}>
+                    <Typography component="h2" level="body1" semiBold>
+                        Planiranje rute
+                    </Typography>
+                    <div className="grid grid-cols-2 gap-3">
+                        <DeliveryOperationalMetric
+                            label="Lokalna procjena"
+                            value={`${health.runs.localFallbackCount}/${health.runs.modernPlanCount}`}
+                        />
+                        <DeliveryOperationalMetric
+                            label="Udio"
+                            value={formatDeliveryOperationalPercentage(
+                                health.runs.localFallbackRate,
+                            )}
+                        />
+                        <DeliveryOperationalMetric
+                            label="Čeka preusmjeravanje"
+                            value={health.reroutes.pendingCount}
+                        />
+                        <DeliveryOperationalMetric
+                            label="Zastarjelo"
+                            value={health.reroutes.staleCount}
+                        />
+                    </div>
+                </Stack>
+            </Card>
+            <Card className="p-4">
+                <Stack spacing={3}>
+                    <Typography component="h2" level="body1" semiBold>
+                        Sinkronizirane akcije
+                    </Typography>
+                    <div className="grid grid-cols-2 gap-3">
+                        <DeliveryOperationalMetric
+                            label="Odgođene 5+ min"
+                            value={health.actions.delayedReplayCount}
+                        />
+                        <DeliveryOperationalMetric
+                            label="Najveće kašnjenje"
+                            value={formatDeliveryOperationalDuration(
+                                health.actions.maximumReplayDelayMs,
+                            )}
+                        />
+                    </div>
+                </Stack>
+            </Card>
+        </div>
+    );
+}

--- a/apps/app/app/admin/delivery/operations/deliveryOperationalPresentation.ts
+++ b/apps/app/app/admin/delivery/operations/deliveryOperationalPresentation.ts
@@ -1,0 +1,113 @@
+import type {
+    DeliveryOperationalDiagnostic,
+    DeliveryOperationalHealth,
+} from '@gredice/storage';
+
+export function deliveryOperationalSeverityLabel(
+    severity: DeliveryOperationalHealth['severity'],
+) {
+    switch (severity) {
+        case 'critical':
+            return 'Kritično';
+        case 'warning':
+            return 'Upozorenje';
+        default:
+            return 'Uredno';
+    }
+}
+
+export function deliveryOperationalSeverityTone(
+    severity: DeliveryOperationalHealth['severity'],
+) {
+    switch (severity) {
+        case 'critical':
+            return 'error' as const;
+        case 'warning':
+            return 'warning' as const;
+        default:
+            return 'success' as const;
+    }
+}
+
+export function deliveryOperationalDiagnosticTone(
+    severity: DeliveryOperationalDiagnostic['severity'],
+) {
+    switch (severity) {
+        case 'critical':
+            return 'error' as const;
+        case 'warning':
+            return 'warning' as const;
+        default:
+            return 'neutral' as const;
+    }
+}
+
+export function deliveryOperationalDiagnosticLabel(
+    kind: DeliveryOperationalDiagnostic['kind'],
+) {
+    switch (kind) {
+        case 'abandoned-run':
+            return 'Napuštena ruta';
+        case 'delayed-offline-replay':
+            return 'Odgođena sinkronizacija';
+        case 'exception-outcome':
+            return 'Iznimka dostave';
+        case 'local-route-fallback':
+            return 'Lokalna procjena rute';
+        case 'reroute-stale':
+            return 'Zastarjelo preusmjeravanje';
+        case 'run-stalled':
+            return 'Ruta bez aktivnosti';
+        case 'tracking-delayed':
+            return 'Odgođeno praćenje';
+        case 'tracking-unavailable':
+            return 'Praćenje nije dostupno';
+    }
+}
+
+export function formatDeliveryOperationalPercentage(value: number) {
+    return new Intl.NumberFormat('hr-HR', {
+        maximumFractionDigits: 1,
+        style: 'percent',
+    }).format(value);
+}
+
+export function formatDeliveryOperationalDuration(value: number) {
+    if (value < 60_000) return `${Math.round(value / 1_000)} s`;
+    if (value < 60 * 60_000) return `${Math.round(value / 60_000)} min`;
+    return `${(value / (60 * 60_000)).toFixed(1)} h`;
+}
+
+export function deliveryOperationalExceptionOutcomeLabel(
+    outcome: DeliveryOperationalHealth['exceptions'][number]['outcome'],
+) {
+    switch (outcome) {
+        case 'cancelled':
+            return 'Otkazano';
+        case 'deferred':
+            return 'Odgođeno';
+        case 'failed':
+            return 'Neuspješno';
+    }
+}
+
+export function deliveryOperationalExceptionReasonLabel(
+    reason: DeliveryOperationalHealth['exceptions'][number]['reason'],
+) {
+    switch (reason) {
+        case 'address-inaccessible':
+            return 'Adresa nije dostupna';
+        case 'address-wrong':
+            return 'Adresa nije ispravna';
+        case 'cancellation':
+            return 'Otkazivanje';
+        case 'customer-unavailable':
+            return 'Primatelj nije dostupan';
+        case 'harvest-damaged':
+            return 'Berba je oštećena';
+        case 'harvest-missing':
+            return 'Berba nedostaje';
+        case 'operational-other':
+            return 'Drugi operativni razlog';
+    }
+}

--- a/apps/app/app/admin/delivery/operations/page.tsx
+++ b/apps/app/app/admin/delivery/operations/page.tsx
@@ -1,0 +1,69 @@
+import {
+    type DeliveryOperationalHealth,
+    getDeliveryOperationalHealth,
+} from '@gredice/storage';
+import { Alert } from '@gredice/ui/Alert';
+import { Warning } from '@gredice/ui/icons';
+import { Stack } from '@gredice/ui/Stack';
+import Link from 'next/link';
+import {
+    AdminPageHeader,
+    AdminPageTitle,
+} from '../../../../components/admin/navigation';
+import { auth } from '../../../../lib/auth/auth';
+import { KnownPages } from '../../../../src/KnownPages';
+import { DeliveryOperationalDiagnostics } from './DeliveryOperationalDiagnostics';
+import { DeliveryOperationalExceptions } from './DeliveryOperationalExceptions';
+import { DeliveryOperationalHealthSummary } from './DeliveryOperationalHealthSummary';
+import { DeliveryOperationalMetrics } from './DeliveryOperationalMetrics';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AdminDeliveryOperationsPage() {
+    await auth(['admin']);
+
+    let health: DeliveryOperationalHealth | null = null;
+    try {
+        health = await getDeliveryOperationalHealth();
+    } catch {
+        // The page remains an operator entry point when the bounded query is
+        // temporarily unavailable; details stay private and fail closed.
+    }
+
+    return (
+        <Stack spacing={4}>
+            <AdminPageTitle title="Operativno zdravlje dostave" />
+            <AdminPageHeader heading="Operativno zdravlje dostave" />
+
+            <Alert color="warning" startDecorator={<Warning />}>
+                Akcije koje još čekaju samo na uređaju nisu vidljive
+                poslužitelju. Ovdje se prikazuju nakon sinkronizacije kao
+                odgođeni zapisi. Aktivni broj provjeri u aplikaciji vozača.
+                Pouzdanost obavijesti prati se zasebno na{' '}
+                <Link
+                    className="underline"
+                    href={KnownPages.DeliveryNotifications}
+                >
+                    stranici obavijesti dostave
+                </Link>
+                .
+            </Alert>
+
+            {!health && (
+                <Alert color="danger" startDecorator={<Warning />}>
+                    Operativni podaci dostave trenutačno nisu dostupni. Pokušaj
+                    ponovno.
+                </Alert>
+            )}
+
+            {health && (
+                <>
+                    <DeliveryOperationalHealthSummary health={health} />
+                    <DeliveryOperationalMetrics health={health} />
+                    <DeliveryOperationalExceptions health={health} />
+                    <DeliveryOperationalDiagnostics health={health} />
+                </>
+            )}
+        </Stack>
+    );
+}

--- a/apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx
+++ b/apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx
@@ -181,6 +181,10 @@ const breadcrumbSections: {
                 icon: <Truck className="size-4" />,
             },
             {
+                ...adminPages.DeliveryOperations,
+                icon: <Graph className="size-4" />,
+            },
+            {
                 ...adminPages.DeliveryNotifications,
                 icon: <Graph className="size-4" />,
             },

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -98,6 +98,7 @@ function quickActionIcon(quickAction: { href: string; icon?: string | null }) {
         case KnownPages.DeliveryRequests:
         case KnownPages.DeliverySlots:
             return <Truck className="size-5" />;
+        case KnownPages.DeliveryOperations:
         case KnownPages.DeliveryNotifications:
             return <Graph className="size-5" />;
         case KnownPages.FarmerPayouts:
@@ -696,6 +697,7 @@ export function Nav({
                     forceOpen={includesSelectedPath(pathname, [
                         adminPages.DeliverySlots.href,
                         adminPages.DeliveryRequests.href,
+                        adminPages.DeliveryOperations.href,
                         adminPages.DeliveryNotifications.href,
                     ])}
                     compact={compact}
@@ -712,6 +714,14 @@ export function Nav({
                         href={adminPages.DeliveryRequests.href}
                         label={adminPages.DeliveryRequests.label}
                         icon={<Truck className="size-5" />}
+                        onClick={onItemClick}
+                        compact={compact}
+                        nested
+                    />
+                    <NavItem
+                        href={adminPages.DeliveryOperations.href}
+                        label={adminPages.DeliveryOperations.label}
+                        icon={<Graph className="size-5" />}
                         onClick={onItemClick}
                         compact={compact}
                         nested

--- a/apps/app/components/admin/navigation/adminPages.ts
+++ b/apps/app/components/admin/navigation/adminPages.ts
@@ -63,6 +63,10 @@ export const adminPages = {
         href: KnownPages.DeliveryNotifications,
         label: 'Dostava - Obavijesti',
     },
+    DeliveryOperations: {
+        href: KnownPages.DeliveryOperations,
+        label: 'Dostava - Operacije',
+    },
     CommunicationInbox: {
         href: KnownPages.CommunicationInbox,
         label: 'Sandučić',
@@ -119,6 +123,7 @@ export const adminBreadcrumbPages = [
     adminPages.SowingStatistics,
     adminPages.DeliverySlots,
     adminPages.DeliveryRequests,
+    adminPages.DeliveryOperations,
     adminPages.DeliveryNotifications,
     adminPages.CommunicationInbox,
     adminPages.CommunicationEmails,

--- a/apps/app/src/KnownPages.ts
+++ b/apps/app/src/KnownPages.ts
@@ -145,6 +145,7 @@ export const KnownPages = {
     // Delivery management
     DeliverySlots: '/admin/delivery/slots',
     DeliveryRequests: '/admin/delivery/requests',
+    DeliveryOperations: '/admin/delivery/operations',
     DeliveryNotifications: '/admin/delivery/notifications',
 
     // External links

--- a/apps/delivery/app/api/driver/runs/[runId]/exceptions/route.ts
+++ b/apps/delivery/app/api/driver/runs/[runId]/exceptions/route.ts
@@ -4,6 +4,10 @@ import {
     DeliveryMutationRequestError,
     parseDeliveryExceptionMutation,
 } from '../../../../../../lib/deliveryMutationRequest';
+import {
+    deliveryOperationalOpaqueId,
+    deliveryOperationFailureLogContext,
+} from '../../../../../../lib/deliveryOperationalLogging';
 import { deliveryRunExecutionErrorDetails } from '../../../../../../lib/deliveryRunExecutionError';
 
 const privateNoStore = { 'Cache-Control': 'private, no-store' };
@@ -41,10 +45,11 @@ export async function POST(
             const executionError = deliveryRunExecutionErrorDetails(error);
             if (!executionError) {
                 console.error('Failed to record delivery exceptions', {
-                    runId,
-                    userId,
-                    errorType:
-                        error instanceof Error ? error.name : typeof error,
+                    ...deliveryOperationFailureLogContext({
+                        error,
+                        mutationCount: mutation.exceptions.length,
+                    }),
+                    runId: deliveryOperationalOpaqueId(runId),
                 });
             }
             return Response.json(

--- a/apps/delivery/app/api/driver/runs/[runId]/pickups/[pickupNodeId]/mutations/route.ts
+++ b/apps/delivery/app/api/driver/runs/[runId]/pickups/[pickupNodeId]/mutations/route.ts
@@ -1,6 +1,11 @@
 import { DeliveryRunExecutionError } from '@gredice/storage';
 import { withAuth } from '../../../../../../../../lib/auth/auth';
 import { applyDriverDeliveryRunPickupMutations } from '../../../../../../../../lib/deliveryDashboard';
+import {
+    deliveryOperationalOpaqueId,
+    deliveryOperationFailureLogContext,
+    deliveryOperationRejectionLogContext,
+} from '../../../../../../../../lib/deliveryOperationalLogging';
 import { parseDeliveryPickupMutationRequest } from '../../../../../../../../lib/deliveryPickupMutationRequest';
 
 const privateNoStoreHeaders = {
@@ -78,11 +83,12 @@ export async function POST(
                     : 'pickup-mutation-failed';
             if (error instanceof DeliveryRunExecutionError) {
                 console.warn('Delivery pickup mutation rejected', {
-                    code,
-                    runId,
-                    pickupNodeId,
-                    mutationCount: mutations.length,
-                    userId,
+                    ...deliveryOperationRejectionLogContext({
+                        errorCode: code,
+                        mutationCount: mutations.length,
+                    }),
+                    runId: deliveryOperationalOpaqueId(runId),
+                    pickupNodeId: deliveryOperationalOpaqueId(pickupNodeId),
                 });
                 return Response.json(
                     { error: executionErrorMessage(code), code },
@@ -90,11 +96,12 @@ export async function POST(
                 );
             }
             console.error('Delivery pickup mutation failed', {
-                error,
-                runId,
-                pickupNodeId,
-                mutationCount: mutations.length,
-                userId,
+                ...deliveryOperationFailureLogContext({
+                    error,
+                    mutationCount: mutations.length,
+                }),
+                runId: deliveryOperationalOpaqueId(runId),
+                pickupNodeId: deliveryOperationalOpaqueId(pickupNodeId),
             });
             return Response.json(
                 {

--- a/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/arrive/route.ts
+++ b/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/arrive/route.ts
@@ -6,6 +6,11 @@ import {
     parseDeliveryStopMutation,
 } from '../../../../../../../../lib/deliveryMutationRequest';
 import {
+    deliveryOperationalOpaqueId,
+    deliveryOperationFailureLogContext,
+    deliveryOperationRejectionLogContext,
+} from '../../../../../../../../lib/deliveryOperationalLogging';
+import {
     deliveryRunExecutionErrorDetails,
     deliveryRunExecutionErrorStatus,
 } from '../../../../../../../../lib/deliveryRunExecutionError';
@@ -56,17 +61,21 @@ export async function POST(
             return Response.json(result, { headers: privateNoStore });
         } catch (error) {
             const executionError = deliveryRunExecutionErrorDetails(error);
-            const logContext = { runId, stopId, userId };
+            const logContext = {
+                runId: deliveryOperationalOpaqueId(runId),
+                stopId,
+            };
             if (executionError) {
                 console.warn('Delivery stop arrival rejected', {
                     ...logContext,
-                    code: executionError.code,
+                    ...deliveryOperationRejectionLogContext({
+                        errorCode: executionError.code,
+                    }),
                 });
             } else {
                 console.error('Failed to mark delivery stop arrived', {
                     ...logContext,
-                    errorType:
-                        error instanceof Error ? error.name : typeof error,
+                    ...deliveryOperationFailureLogContext({ error }),
                 });
             }
             return Response.json(

--- a/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/deliver/route.ts
+++ b/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/deliver/route.ts
@@ -6,6 +6,11 @@ import {
     parseDeliveryStopMutation,
 } from '../../../../../../../../lib/deliveryMutationRequest';
 import {
+    deliveryOperationalOpaqueId,
+    deliveryOperationFailureLogContext,
+    deliveryOperationRejectionLogContext,
+} from '../../../../../../../../lib/deliveryOperationalLogging';
+import {
     deliveryRunExecutionErrorDetails,
     deliveryRunExecutionErrorStatus,
 } from '../../../../../../../../lib/deliveryRunExecutionError';
@@ -58,17 +63,21 @@ export async function POST(
             return Response.json(result, { headers: privateNoStore });
         } catch (error) {
             const executionError = deliveryRunExecutionErrorDetails(error);
-            const logContext = { runId, stopId, userId };
+            const logContext = {
+                runId: deliveryOperationalOpaqueId(runId),
+                stopId,
+            };
             if (executionError) {
                 console.warn('Delivery stop completion rejected', {
                     ...logContext,
-                    code: executionError.code,
+                    ...deliveryOperationRejectionLogContext({
+                        errorCode: executionError.code,
+                    }),
                 });
             } else {
                 console.error('Failed to deliver stop', {
                     ...logContext,
-                    errorType:
-                        error instanceof Error ? error.name : typeof error,
+                    ...deliveryOperationFailureLogContext({ error }),
                 });
             }
             return Response.json(

--- a/apps/delivery/app/api/driver/runs/preflight/route.ts
+++ b/apps/delivery/app/api/driver/runs/preflight/route.ts
@@ -47,7 +47,6 @@ export async function POST(request: Request) {
                 console.warn('Delivery run preflight rejected', {
                     ...context,
                     requestCount: deliveryRequestIds.length,
-                    userId,
                 });
                 return Response.json(
                     {
@@ -69,7 +68,6 @@ export async function POST(request: Request) {
             console.error('Delivery run preflight failed', {
                 ...context,
                 requestCount: deliveryRequestIds.length,
-                userId,
             });
             return Response.json(
                 {

--- a/apps/delivery/app/api/driver/runs/route.ts
+++ b/apps/delivery/app/api/driver/runs/route.ts
@@ -40,7 +40,6 @@ export async function POST(request: Request) {
             console.error('Failed to start delivery run', {
                 ...deliveryRunStartErrorLogContext(error),
                 requestCount: deliveryRequestIds.length,
-                userId,
             });
             return Response.json(
                 {

--- a/apps/delivery/lib/deliveryDashboard.node.spec.ts
+++ b/apps/delivery/lib/deliveryDashboard.node.spec.ts
@@ -8,6 +8,7 @@ import {
     deliveryMutationRouteState,
     deliveryProgressMilestoneOccurredAt,
     deliveryRecipientCount,
+    deliveryRunStartErrorLogContext,
     deliveryStatusLabel,
     deliveryTrackingStopIds,
     expandLegacyCurrentDeliveryStopIds,
@@ -18,6 +19,38 @@ import {
     visibleDeliveryRunTotals,
     visibleDeliveryStopEstimates,
 } from './deliveryDashboard';
+import { DeliveryRoutePlanningError } from './deliveryRouting';
+import { DeliveryRunPreparationError } from './deliveryRunPlanning';
+
+test('route start log context excludes request, user, address, and raw error data', () => {
+    const planningContext = deliveryRunStartErrorLogContext(
+        new DeliveryRoutePlanningError(
+            'Private Street 12 cannot be routed',
+            'delivery-address-not-found',
+            'private-request-id',
+        ),
+    );
+    const preparationContext = deliveryRunStartErrorLogContext(
+        new DeliveryRunPreparationError('Private preparation failed', {
+            code: 'delivery-not-ready',
+            deliveryAddress: 'Private Street 12',
+            deliveryRequestId: 'private-request-id',
+        }),
+    );
+
+    assert.deepEqual(planningContext, {
+        errorCode: 'delivery-address-not-found',
+        errorName: 'DeliveryRoutePlanningError',
+    });
+    assert.deepEqual(preparationContext, {
+        errorCode: 'delivery-not-ready',
+        errorName: 'DeliveryRunPreparationError',
+    });
+    assert.doesNotMatch(
+        JSON.stringify({ planningContext, preparationContext }),
+        /Private Street|private-request-id/u,
+    );
+});
 
 test('route progress cannot occur before refreshed estimates', () => {
     const refreshedAt = new Date('2026-07-16T10:00:02.000Z');

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -71,6 +71,7 @@ import {
     driverDeliveryExceptionSummary,
 } from './deliveryExceptionPresentation';
 import { deliveryMapStopGroupSelectionId } from './deliveryMapData';
+import { deliveryOperationalErrorContext } from './deliveryOperationalLogging';
 import { refreshFixedPickupAwareDeliveryRoute } from './deliveryPickupRouting';
 import {
     configuredDeliveryHqAddress,
@@ -2338,15 +2339,13 @@ export function deliveryRunStartErrorLogContext(error: unknown) {
         return {
             errorName: error.name,
             errorCode: error.code,
-            deliveryRequestId: error.deliveryRequestId,
         };
     }
     if (error instanceof DeliveryRunPreparationError) {
         return {
             errorName: error.name,
             errorCode: error.code,
-            deliveryRequestId: error.conflict.deliveryRequestId,
         };
     }
-    return { error };
+    return deliveryOperationalErrorContext(error);
 }

--- a/apps/delivery/lib/deliveryHandoffRoute.node.spec.ts
+++ b/apps/delivery/lib/deliveryHandoffRoute.node.spec.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { createDeliveryHandoffRouteHandlers } from './deliveryHandoffRoute';
 
-const runId = 'delivery-run-1';
+const runId = '123e4567-e89b-42d3-a456-426614174000';
 const targetStopId = 42;
 const expectedRetryAttempt = 3;
 const occurredAt = '2026-07-16T08:30:00.000Z';
@@ -210,14 +210,17 @@ test('POST keeps admins constrained to the assigned-driver mutation contract and
         [
             'Delivery handoff mutation rejected',
             {
-                code: 'active-run-not-found',
+                errorCode: 'active-run-not-found',
                 runId,
                 stopId: targetStopId,
                 mutationCount: 1,
-                userId: 'admin-user',
             },
         ],
     ]);
+    assert.doesNotMatch(
+        JSON.stringify(warnings),
+        /admin-user|private-user-id/u,
+    );
 });
 
 test('POST maps a retry-attempt mismatch to a localized conflict', async () => {
@@ -286,11 +289,15 @@ test('GET maps unexpected failures to a sanitized private response and safe log 
         [
             'Delivery handoff manifest failed',
             {
-                errorType: 'Error',
+                errorCode: 'unclassified',
+                errorName: 'Error',
                 runId,
                 stopId: targetStopId,
-                userId: 'driver-user',
             },
         ],
     ]);
+    assert.doesNotMatch(
+        JSON.stringify(errors),
+        /driver-user|secret-user|secret-password/u,
+    );
 });

--- a/apps/delivery/lib/deliveryHandoffRoute.ts
+++ b/apps/delivery/lib/deliveryHandoffRoute.ts
@@ -1,4 +1,9 @@
 import { parseDeliveryHandoffMutationRequest } from './deliveryHandoffMutationRequest';
+import {
+    deliveryOperationalOpaqueId,
+    deliveryOperationFailureLogContext,
+    deliveryOperationRejectionLogContext,
+} from './deliveryOperationalLogging';
 
 const privateNoStoreHeaders = {
     'Cache-Control': 'private, no-store',
@@ -145,18 +150,17 @@ export function createDeliveryHandoffRouteHandlers({
                 const code = executionErrorCode(error);
                 if (code) {
                     logger.warn('Delivery handoff manifest rejected', {
-                        code,
-                        runId,
+                        ...deliveryOperationRejectionLogContext({
+                            errorCode: code,
+                        }),
+                        runId: deliveryOperationalOpaqueId(runId),
                         stopId,
-                        userId,
                     });
                 } else {
                     logger.error('Delivery handoff manifest failed', {
-                        errorType:
-                            error instanceof Error ? error.name : typeof error,
-                        runId,
+                        ...deliveryOperationFailureLogContext({ error }),
+                        runId: deliveryOperationalOpaqueId(runId),
                         stopId,
-                        userId,
                     });
                 }
                 return executionErrorResponse(code, 'handoff-manifest-failed');
@@ -198,20 +202,21 @@ export function createDeliveryHandoffRouteHandlers({
                 const code = executionErrorCode(error);
                 if (code) {
                     logger.warn('Delivery handoff mutation rejected', {
-                        code,
-                        runId,
+                        ...deliveryOperationRejectionLogContext({
+                            errorCode: code,
+                            mutationCount: mutations.length,
+                        }),
+                        runId: deliveryOperationalOpaqueId(runId),
                         stopId,
-                        mutationCount: mutations.length,
-                        userId,
                     });
                 } else {
                     logger.error('Delivery handoff mutation failed', {
-                        errorType:
-                            error instanceof Error ? error.name : typeof error,
-                        runId,
+                        ...deliveryOperationFailureLogContext({
+                            error,
+                            mutationCount: mutations.length,
+                        }),
+                        runId: deliveryOperationalOpaqueId(runId),
                         stopId,
-                        mutationCount: mutations.length,
-                        userId,
                     });
                 }
                 return executionErrorResponse(code, 'handoff-mutation-failed');

--- a/apps/delivery/lib/deliveryOperationalLogging.node.spec.ts
+++ b/apps/delivery/lib/deliveryOperationalLogging.node.spec.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    deliveryOperationalErrorContext,
+    deliveryOperationalOpaqueId,
+    deliveryOperationFailureLogContext,
+    deliveryOperationRejectionLogContext,
+    deliveryRouteFallbackLogContext,
+    deliveryRouteFallbackLogMessage,
+} from './deliveryOperationalLogging';
+
+test('builds stable privacy-safe route fallback metadata without raw errors', () => {
+    const privateMessage =
+        'Customer at Private Street 12, coordinates 45.8, 15.9 failed';
+    const error = Object.assign(new Error(privateMessage), {
+        code: 'routes-provider-unavailable',
+    });
+
+    const context = deliveryRouteFallbackLogContext({
+        error,
+        nodeCount: 12,
+        phase: 'reroute',
+    });
+
+    assert.equal(
+        deliveryRouteFallbackLogMessage,
+        'Delivery route fallback selected',
+    );
+    assert.deepEqual(context, {
+        errorCode: 'routes-provider-unavailable',
+        errorName: 'Error',
+        fallback: 'local',
+        nodeCount: 12,
+        phase: 'reroute',
+        provider: 'google',
+    });
+    assert.doesNotMatch(JSON.stringify(context), /Private Street|45\.8|15\.9/u);
+    assert.equal('error' in context, false);
+    assert.equal('message' in context, false);
+    assert.equal('stack' in context, false);
+});
+
+test('builds bounded driver-operation contexts without identities or raw errors', () => {
+    const privateMessage =
+        'Driver private-user at Private Street 12 failed for customer 099123';
+
+    const failure = deliveryOperationFailureLogContext({
+        error: Object.assign(new Error(privateMessage), {
+            code: 'storage-unavailable',
+        }),
+        mutationCount: 14,
+    });
+    const rejection = deliveryOperationRejectionLogContext({
+        errorCode: 'route-revision-conflict',
+        mutationCount: 3,
+    });
+
+    assert.deepEqual(failure, {
+        errorCode: 'storage-unavailable',
+        errorName: 'Error',
+        mutationCount: 14,
+    });
+    assert.deepEqual(rejection, {
+        errorCode: 'route-revision-conflict',
+        mutationCount: 3,
+    });
+    assert.doesNotMatch(
+        JSON.stringify(failure),
+        /private-user|Private Street/u,
+    );
+    assert.equal('error' in failure, false);
+    assert.deepEqual(
+        deliveryOperationFailureLogContext({
+            error: privateMessage,
+            mutationCount: 10_001,
+        }),
+        { errorCode: 'unclassified', errorName: 'UnknownError' },
+    );
+    assert.deepEqual(
+        deliveryOperationRejectionLogContext({
+            errorCode: 'private address / invalid',
+            mutationCount: -1,
+        }),
+        { errorCode: 'unclassified' },
+    );
+});
+
+test('retains only bounded opaque operational identifiers', () => {
+    const opaqueId = '123e4567-e89b-42d3-a456-426614174000';
+    assert.equal(deliveryOperationalOpaqueId(opaqueId), opaqueId);
+    assert.equal(
+        deliveryOperationalOpaqueId('run_01JZ:pickup-2'),
+        'id-unavailable',
+    );
+    assert.equal(
+        deliveryOperationalOpaqueId('Private Street 12 / customer'),
+        'id-unavailable',
+    );
+    assert.equal(
+        deliveryOperationalOpaqueId('x'.repeat(129)),
+        'id-unavailable',
+    );
+});
+
+test('normalizes unknown or unsafe error fields to bounded tokens', () => {
+    assert.deepEqual(
+        deliveryOperationalErrorContext({
+            code: 'contains customer address / private',
+            name: 'not-used',
+        }),
+        { errorCode: 'unclassified', errorName: 'UnknownError' },
+    );
+    assert.deepEqual(deliveryOperationalErrorContext(null), {
+        errorCode: 'unclassified',
+        errorName: 'UnknownError',
+    });
+    assert.equal(
+        deliveryRouteFallbackLogContext({
+            error: new Error('private provider response'),
+            nodeCount: 1,
+            phase: 'initial-route',
+        }).errorCode,
+        'google-initial-route-failed',
+    );
+});

--- a/apps/delivery/lib/deliveryOperationalLogging.ts
+++ b/apps/delivery/lib/deliveryOperationalLogging.ts
@@ -1,0 +1,102 @@
+import 'server-only';
+
+export const deliveryRouteFallbackLogMessage =
+    'Delivery route fallback selected';
+
+export type DeliveryRouteFallbackPhase =
+    | 'initial-route'
+    | 'live-eta'
+    | 'reroute';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function boundedToken(value: unknown, fallback: string) {
+    return typeof value === 'string' &&
+        value.length > 0 &&
+        value.length <= 64 &&
+        /^[A-Za-z0-9][A-Za-z0-9._:-]*$/u.test(value)
+        ? value
+        : fallback;
+}
+
+function boundedMutationCount(value: number | undefined) {
+    return value !== undefined &&
+        Number.isSafeInteger(value) &&
+        value >= 0 &&
+        value <= 10_000
+        ? { mutationCount: value }
+        : {};
+}
+
+export function deliveryOperationalOpaqueId(value: unknown) {
+    return typeof value === 'string' &&
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu.test(
+            value,
+        )
+        ? value
+        : 'id-unavailable';
+}
+
+export function deliveryOperationalErrorContext(error: unknown) {
+    return {
+        errorCode: boundedToken(
+            isRecord(error) ? error.code : undefined,
+            'unclassified',
+        ),
+        errorName: boundedToken(
+            error instanceof Error ? error.name : undefined,
+            'UnknownError',
+        ),
+    };
+}
+
+export function deliveryOperationRejectionLogContext({
+    errorCode,
+    mutationCount,
+}: {
+    errorCode: unknown;
+    mutationCount?: number;
+}) {
+    return {
+        errorCode: boundedToken(errorCode, 'unclassified'),
+        ...boundedMutationCount(mutationCount),
+    };
+}
+
+export function deliveryOperationFailureLogContext({
+    error,
+    mutationCount,
+}: {
+    error: unknown;
+    mutationCount?: number;
+}) {
+    return {
+        ...deliveryOperationalErrorContext(error),
+        ...boundedMutationCount(mutationCount),
+    };
+}
+
+export function deliveryRouteFallbackLogContext({
+    error,
+    nodeCount,
+    phase,
+}: {
+    error: unknown;
+    nodeCount: number;
+    phase: DeliveryRouteFallbackPhase;
+}) {
+    const errorContext = deliveryOperationalErrorContext(error);
+    return {
+        ...errorContext,
+        errorCode:
+            errorContext.errorCode === 'unclassified'
+                ? `google-${phase}-failed`
+                : errorContext.errorCode,
+        fallback: 'local' as const,
+        nodeCount,
+        phase,
+        provider: 'google' as const,
+    };
+}

--- a/apps/delivery/lib/deliveryPickupRouting.ts
+++ b/apps/delivery/lib/deliveryPickupRouting.ts
@@ -1,5 +1,9 @@
 import 'server-only';
 import {
+    deliveryRouteFallbackLogContext,
+    deliveryRouteFallbackLogMessage,
+} from './deliveryOperationalLogging';
+import {
     type DeliveryRouteGraphLeg,
     type DeliveryRouteGraphNode,
     type DeliveryRouteGraphPlan,
@@ -1085,8 +1089,12 @@ export async function planPickupAwareDeliveryRoute({
         if (error instanceof DeliveryRoutePlanningError) throw error;
         if (!(error instanceof GoogleRouteServiceError)) throw error;
         console.warn(
-            'Google pickup-aware route planning failed; using local fallback',
-            { nodeCount: nodes.length, error },
+            deliveryRouteFallbackLogMessage,
+            deliveryRouteFallbackLogContext({
+                error,
+                nodeCount: nodes.length,
+                phase: 'initial-route',
+            }),
         );
     }
 
@@ -1408,8 +1416,12 @@ export async function refreshFixedPickupAwareDeliveryRoute({
     } catch (error) {
         if (!(error instanceof GoogleRouteServiceError)) throw error;
         console.warn(
-            'Google live ETA refresh failed; using fixed-order local fallback',
-            { nodeCount: fixedNodes.length, error },
+            deliveryRouteFallbackLogMessage,
+            deliveryRouteFallbackLogContext({
+                error,
+                nodeCount: fixedNodes.length,
+                phase: 'live-eta',
+            }),
         );
         return formatRemainingRoutePlan({
             plan: localPlan,
@@ -1510,8 +1522,12 @@ export async function recalculatePickupAwareDeliveryRoute({
         if (error instanceof DeliveryRoutePlanningError) throw error;
         if (!(error instanceof GoogleRouteServiceError)) throw error;
         console.warn(
-            'Google delivery reroute failed; using persisted-coordinate fallback',
-            { nodeCount: baseGraph.graphNodes.length, error },
+            deliveryRouteFallbackLogMessage,
+            deliveryRouteFallbackLogContext({
+                error,
+                nodeCount: baseGraph.graphNodes.length,
+                phase: 'reroute',
+            }),
         );
         estimateSource = 'local';
         legs = localRouteLegs(normalGraphNodes);
@@ -1548,8 +1564,12 @@ export async function recalculatePickupAwareDeliveryRoute({
         } catch (error) {
             if (error instanceof GoogleRouteServiceError) {
                 console.warn(
-                    'Google delivery reroute failed; using persisted-coordinate fallback',
-                    { nodeCount: baseGraph.graphNodes.length, error },
+                    deliveryRouteFallbackLogMessage,
+                    deliveryRouteFallbackLogContext({
+                        error,
+                        nodeCount: baseGraph.graphNodes.length,
+                        phase: 'reroute',
+                    }),
                 );
                 estimateSource = 'local';
                 legs = localRouteLegs(normalGraphNodes);

--- a/apps/delivery/lib/deliveryRouting.node.spec.ts
+++ b/apps/delivery/lib/deliveryRouting.node.spec.ts
@@ -150,6 +150,7 @@ test('falls back to a local route estimate when Google Routes is unavailable', a
     const originalHqAddress = process.env.GREDICE_DELIVERY_HQ_ADDRESS;
     let routesRequestCount = 0;
     let fallbackWarningCount = 0;
+    let fallbackContext: unknown;
     process.env.GREDICE_GOOGLE_MAPS_SERVER_API_KEY = 'test-key';
     process.env.GREDICE_DELIVERY_HQ_ADDRESS =
         'Ulica Julija Knifera 3, 10000 Zagreb, HR';
@@ -180,11 +181,10 @@ test('falls back to a local route estimate when Google Routes is unavailable', a
         }
         return new Response(null, { status: 404 });
     };
-    console.warn = (message) => {
-        if (
-            message === 'Google route optimization failed; using local fallback'
-        ) {
+    console.warn = (message, context) => {
+        if (message === 'Delivery route fallback selected') {
             fallbackWarningCount += 1;
+            fallbackContext = context;
         }
     };
 
@@ -203,6 +203,14 @@ test('falls back to a local route estimate when Google Routes is unavailable', a
 
         assert.equal(routesRequestCount, 1);
         assert.equal(fallbackWarningCount, 1);
+        assert.deepEqual(fallbackContext, {
+            errorCode: 'google-initial-route-failed',
+            errorName: 'Error',
+            fallback: 'local',
+            nodeCount: 1,
+            phase: 'initial-route',
+            provider: 'google',
+        });
         assert.equal(plan.encodedPolyline, undefined);
         assert.ok(plan.totalDistanceMeters > 0);
         assert.equal(plan.stops[0]?.deliveryRequestId, 'delivery-1');

--- a/apps/delivery/lib/deliveryRouting.ts
+++ b/apps/delivery/lib/deliveryRouting.ts
@@ -1,5 +1,9 @@
 import 'server-only';
 import { formatDeliveryDateTime } from './deliveryFormatting';
+import {
+    deliveryRouteFallbackLogContext,
+    deliveryRouteFallbackLogMessage,
+} from './deliveryOperationalLogging';
 
 export type DeliveryCoordinates = {
     latitude: number;
@@ -772,10 +776,14 @@ export async function planDeliveryRoute({
         if (error instanceof DeliveryRoutePlanningError) {
             throw error;
         }
-        console.warn('Google route optimization failed; using local fallback', {
-            error,
-            stopCount: orderedStops.length,
-        });
+        console.warn(
+            deliveryRouteFallbackLogMessage,
+            deliveryRouteFallbackLogContext({
+                error,
+                nodeCount: orderedStops.length,
+                phase: 'initial-route',
+            }),
+        );
         return estimateDeliveryRoute({
             origin,
             stops: orderedStops,
@@ -812,10 +820,14 @@ export async function recalculateDeliveryRoute({
             enforceTimeWindows: false,
         });
     } catch (error) {
-        console.warn('Google ETA refresh failed; using local estimate', {
-            error,
-            stopCount: stops.length,
-        });
+        console.warn(
+            deliveryRouteFallbackLogMessage,
+            deliveryRouteFallbackLogContext({
+                error,
+                nodeCount: stops.length,
+                phase: 'live-eta',
+            }),
+        );
         return estimateDeliveryRoute({
             origin,
             stops,

--- a/docs/delivery-production-rollout.md
+++ b/docs/delivery-production-rollout.md
@@ -1,0 +1,261 @@
+# Delivery production rollout and evidence runbook
+
+This runbook is the release gate for the delivery epic
+[#4120](https://github.com/gredice/gredice/issues/4120). It covers the driver,
+admin, customer, route, tracking, offline, exception, QR, and notification
+flows. Automated checks establish code behavior; they do not replace a
+physical-device run against the deployed production build.
+
+## Operational entry points
+
+- `/admin/delivery/operations` is admin-only. It shows a bounded 24-hour view
+  of active and recent routes, tracking freshness, reroute age, persisted route
+  source, abandoned routes, exception outcomes, and action replay delay.
+- `/admin/delivery/notifications` is the existing admin-only notification
+  health and diagnostics view. Do not duplicate notification receipts or
+  provider details in the route view.
+- The delivery project's server logs emit the stable message
+  `Delivery route fallback selected`. Group it by `phase` and `errorCode`.
+  Allowed dimensions are `provider`, `fallback`, `phase`, `errorName`,
+  `errorCode`, and `nodeCount`.
+- Pickup, handoff, arrival, completion, and exception command failures use
+  their existing named log messages with bounded `errorName`, `errorCode`, and
+  mutation counts. They may include only an opaque route, stop, or pickup-node
+  ID needed for private diagnosis; they never include the authenticated driver
+  ID or a raw error.
+- Notification health logs use the stable messages documented in
+  [Delivery notification lifecycle](./delivery-notification-lifecycle.md),
+  including `Delivery notification systemic channel failure`,
+  `Delivery notification retries exhausted`, and
+  `Delivery notification eligible queue is stale`.
+
+The operations view and server log streams are private operational surfaces.
+Do not publish them in customer APIs or analytics dashboards.
+
+## Data minimization contract
+
+Aggregate health contains counts, rates, bounded age values, state/source
+enums, and time windows only. The admin diagnostic list additionally contains
+an opaque route ID because an operator needs it to recover a specific route.
+Exception receipts are reduced inside PostgreSQL to bounded `outcome` and
+`reason` values before application code receives them; the query never selects
+the stored request or stop identifiers. These operational projections and the
+named logs above must never select or log:
+
+- exact or rounded GPS coordinates, polylines, addresses, contact details, or
+  customer/account/driver identifiers;
+- delivery notes, exception notes, abandonment reasons, provider response
+  bodies, raw `Error` objects, stack traces, or preparation summaries;
+- QR/trace values, queue entries, client operation IDs, or payload digests.
+
+Diagnostics default to the last 24 hours, reject windows over 30 days, cap the
+result at 200 records, and fail closed for invalid limits or dates. The admin
+page does not accept an unbounded search parameter.
+
+Pending actions that have not left a phone are not known to the server. The
+driver UI is the source of truth for the live local queue count. Once an action
+reaches the server, the operations view can identify a replay delayed by five
+minutes or more from its data-minimized receipt. An absent receipt means
+**unknown**, not zero pending actions.
+
+## Initial thresholds and operator response
+
+These thresholds are release gates for the first canary. Revisit them only from
+recorded evidence; do not loosen them during an incident.
+
+| Signal | Initial classification | Operator query and response |
+| --- | --- | --- |
+| Tracking receipt age at most 30 seconds | Healthy | Confirm `Uživo` in `/admin/delivery/operations`; no action. |
+| Tracking receipt age over 30 through 120 seconds | Warning | Open the opaque route diagnostic; ask the driver to keep the route visible and confirm GPS/network recovery. |
+| Tracking receipt age over 120 seconds, or no first receipt 120 seconds after start | Critical | Treat exact customer tracking as unavailable. Confirm the driver UI says delayed/offline and use the recovery protocol below. |
+| Reroute pending for 10 minutes | Critical | Inspect route state by opaque route ID. Retry or recover through the existing admin workflow; never edit route rows manually. |
+| Active route without server activity for 60 minutes | Critical | Contact the driver, inspect their local queue state, then recover, reassign, or abandon through audited controls. |
+| Local route source at least 25% of at least four modern active/recent plans | Warning | Search `Delivery route fallback selected`, group by `phase,errorCode`, and verify Google Maps credentials/quota/provider health. Local routing remains a supported fallback, not a silent success. |
+| Applied action replayed five minutes or more after it occurred | Warning | Confirm connectivity recovery and that the driver queue drains without conflict. Use the route ID only in private diagnostics. |
+| Abandoned route or bounded exception outcome | Informational | Reconcile the audited outcome and recovery state. Alert only on a sustained canary pattern, not a single expected exception. |
+| Notification systemic failure, exhausted retry, stale eligible queue, or ambiguous acceptance | Existing notification severity | Use `/admin/delivery/notifications` and the notification runbook; do not infer delivery failure from channel failure alone. |
+
+### Log query recipes
+
+Run these in the private log explorer for the named Vercel project and deployed
+commit. Save a shareable private query URL or screenshot with customer data
+redacted.
+
+1. Delivery route fallbacks: exact message
+   `Delivery route fallback selected`, time range matching the canary, grouped
+   by `phase` and `errorCode`. Compare the result with the persisted local
+   source numerator and modern-plan denominator on the admin page.
+2. Route start failures: exact messages `Delivery run preflight rejected`,
+   `Delivery run preflight failed`, and `Failed to start delivery run`, grouped
+   by the bounded `errorName` and `errorCode` fields.
+3. Notification failures: exact messages listed above, grouped only by channel,
+   counts, rates, and bounded window. Use the notification admin timeline for
+   an authorized per-request diagnosis.
+
+If any query includes an address, coordinate, customer/driver identity, raw
+provider response, exception message, or stack, stop the rollout and treat it
+as a privacy incident.
+
+## Pre-deployment gate
+
+- [ ] The change has a reviewed PR, green required checks, and an immutable
+      commit SHA for the candidate deployment.
+- [ ] Delivery, API, app, storage, and affected shared-package tests pass for
+      the candidate SHA.
+- [ ] `/admin/delivery/operations` and `/admin/delivery/notifications` return
+      private, no-customer-data diagnostics to an admin and reject a normal
+      user.
+- [ ] The route fallback test proves that raw error messages, addresses, and
+      coordinates are absent from structured metadata.
+- [ ] The driver and customer journey suite from
+      [#4146](https://github.com/gredice/gredice/issues/4146) is linked. If that
+      issue is still open, the rollout cannot advance beyond synthetic testing.
+- [ ] All rows in the physical-device matrix below have deployed-build
+      evidence. Pending is a release blocker, not an implicit pass.
+- [ ] Notification producers remain disabled until their defaults/backfill and
+      separate channel gate in the
+      [notification runbook](./delivery-notification-lifecycle.md) are complete.
+
+## Staged rollout
+
+### Stage 0 — deployed, no production route assignment
+
+1. Deploy the candidate SHA and verify both admin views with an admin account.
+2. Run a synthetic route with non-customer addresses and accounts. Exercise
+   pickup QR, advisory handoff QR, arrival, delivery, exception/retry, and
+   abandonment recovery.
+3. Confirm the operations view changes only through bounded metadata and that
+   the notification view remains independent.
+4. Complete the existing
+   [driver action checklist](./delivery-driver-mobile-validation.md) and
+   [tracking protocol](./delivery-tracking-mobile-validation.md) on every
+   supported target.
+
+Exit only when there are no critical alerts, every synthetic action is
+reconciled, and the four physical rows are signed off.
+
+### Stage 1 — one controlled route
+
+1. Assign one trained driver/admin to one operationally selected route and time
+   slot. Do not broaden the user's role or expose the admin diagnostics.
+2. Observe route planning, every pickup, GPS freshness, current-stop actions,
+   customer live/stale/recovery behavior, and the final receipt from both
+   perspectives.
+3. Record the candidate SHA, deployment URL, time window, generic tester role,
+   device/browser versions, and sanitized outcomes in the evidence ledger.
+4. Hold for one full route plus 30 minutes so delayed replays, reroutes, and
+   notification receipts can settle.
+
+Exit only with zero critical alerts, no unresolved local queue items, no
+privacy leak, and all expected customer states reconciled.
+
+### Stage 2 — limited delivery wave
+
+1. Expand by operational assignment to one delivery wave while preserving a
+   clear control group and the existing manual recovery process.
+2. Review the admin operations and notification views before the wave, during
+   every active route, and 30 minutes after the last completion.
+3. Calculate fallback and exception rates only when their minimum denominator
+   is met. Preserve the exact private log query and time window as evidence.
+4. Repeat one weak-connectivity recovery and one customer stale/recovery check
+   without using real customer data in screenshots or notes.
+
+Exit only after two consecutive waves meet the initial thresholds.
+
+### Stage 3 — general availability
+
+1. Expand normal route assignment only after Stages 0–2 and every feature row
+   in the evidence ledger are signed off.
+2. Enable notification producer/email/reconciliation flags only through their
+   coordinated, default-off rollout. Enable notification health monitoring at
+   the same time.
+3. Review alerts daily for the first seven delivery days. Any threshold change
+   needs a dated evidence link and reviewer.
+
+## Rollback checklist
+
+Trigger rollback for any privacy leak, inaccessible primary driver action,
+incorrect delivery completion, unreconciled duplicate, repeated critical GPS
+or reroute signal, systemic notification failure, or failed physical-device
+gate.
+
+- [ ] Stop assigning new delivery routes; do not delete active or historical
+      route records.
+- [ ] Tell active drivers to keep the route visible and finish only if the
+      current state is safe and reconciled. Otherwise use audited admin
+      reassign, recover, retry, or abandon controls.
+- [ ] Disable `GREDICE_DELIVERY_NOTIFICATIONS_ENABLED` in both delivery and API
+      projects before disabling email or reconciliation workers. Preserve
+      receipts for diagnosis.
+- [ ] If code rollback is required, promote the last known-good Vercel
+      deployment for each affected project. Record both SHAs and deployment
+      URLs; do not mix unverified app/API/storage versions.
+- [ ] Confirm customer tracking becomes truthfully delayed/offline and retains
+      only its permitted cached summary; never claim a stale point is live.
+- [ ] Re-run both admin queries for the incident window, save sanitized
+      aggregate evidence, and link the incident/issue.
+- [ ] Re-enter at Stage 0 after the fix. A previous physical-device pass does
+      not cover a changed camera, GPS, offline queue, or primary action flow.
+
+## Physical driver and customer evidence matrix
+
+Follow the detailed protocols in
+[Delivery driver mobile validation](./delivery-driver-mobile-validation.md) and
+[Delivery mobile tracking validation](./delivery-tracking-mobile-validation.md).
+Use the production deployment, not emulation. Camera testing must include fast
+multi-scan pickup and advisory destination verification. Weak-connectivity
+testing must prove queued actions remain idempotent and the UI never reports an
+unknown server state as synchronized.
+
+| Supported target | Driver route, camera, and current stop | Weak network and queue recovery | GPS foreground, resume, and truthful stale state | Customer live, stale/recovery, and receipt | Evidence | Sign-off |
+| --- | --- | --- | --- | --- | --- | --- |
+| iPhone, Safari tab | Pending | Pending | Pending | Pending | Pending | Pending |
+| iPhone, Home Screen | Pending | Pending | Pending | Pending | Pending | Pending |
+| Android, Chrome tab | Pending | Pending | Pending | Pending | Pending | Pending |
+| Android, installed PWA | Pending | Pending | Pending | Pending | Pending | Pending |
+
+For each row record device model, exact OS/browser version, installation mode,
+candidate SHA, deployment URL, date/time window, anonymized tester role,
+sanitized observations, and evidence links. Never record a serial/device name,
+account ID, route ID, address, coordinate, or raw log payload.
+
+## Feature evidence ledger
+
+Every row needs an exact green CI run or test artifact and a deployed-build
+evidence link before the epic closes. A closed implementation issue is not by
+itself production evidence. Keep `Pending` until a person has run and reviewed
+the deployed flow.
+
+| Feature issue | Automated validation | Deployed production evidence |
+| --- | --- | --- |
+| [#4121](https://github.com/gredice/gredice/issues/4121) mixed pickup preflight | [PR #4170](https://github.com/gredice/gredice/pull/4170) and [checks](https://github.com/gredice/gredice/pull/4170/checks) | [Verified deployed descendant](https://github.com/gredice/gredice/issues/4125#issuecomment-4980317995) |
+| [#4122](https://github.com/gredice/gredice/issues/4122) persisted pickup nodes/slots | [PR #4172](https://github.com/gredice/gredice/pull/4172) and [checks](https://github.com/gredice/gredice/pull/4172/checks) | [Verified deployed descendant](https://github.com/gredice/gredice/issues/4125#issuecomment-4980317995) |
+| [#4123](https://github.com/gredice/gredice/issues/4123) pickup/customer route plan | [PR #4174](https://github.com/gredice/gredice/pull/4174) and [checks](https://github.com/gredice/gredice/pull/4174/checks) | [Verified deployed descendant](https://github.com/gredice/gredice/issues/4125#issuecomment-4980317995) |
+| [#4124](https://github.com/gredice/gredice/issues/4124) pickup manifests | [PR #4179](https://github.com/gredice/gredice/pull/4179) and [checks](https://github.com/gredice/gredice/pull/4179/checks) | [Verified deployed descendant](https://github.com/gredice/gredice/issues/4125#issuecomment-4980317995) |
+| [#4125](https://github.com/gredice/gredice/issues/4125) exception outcomes/audit | [PR #4181](https://github.com/gredice/gredice/pull/4181) and [checks](https://github.com/gredice/gredice/pull/4181/checks) | [Exact production evidence](https://github.com/gredice/gredice/issues/4125#issuecomment-4980317995) |
+| [#4126](https://github.com/gredice/gredice/issues/4126) retry/reroute | [PR #4182](https://github.com/gredice/gredice/pull/4182) and [checks](https://github.com/gredice/gredice/pull/4182/checks) | [Exact API/app and delivery descendant](https://github.com/gredice/gredice/issues/4126#issuecomment-4981679742) |
+| [#4127](https://github.com/gredice/gredice/issues/4127) recovery UX | [PR #4187](https://github.com/gredice/gredice/pull/4187) and [checks](https://github.com/gredice/gredice/pull/4187/checks) | [Exact production evidence](https://github.com/gredice/gredice/issues/4127#issuecomment-4982492033) |
+| [#4128](https://github.com/gredice/gredice/issues/4128) tracking privacy/retention | [PR #4190](https://github.com/gredice/gredice/pull/4190) and [checks](https://github.com/gredice/gredice/pull/4190/checks) | [Exact production evidence](https://github.com/gredice/gredice/issues/4128#issuecomment-4982958711) |
+| [#4129](https://github.com/gredice/gredice/issues/4129) GPS retry/sync state | [PR #4192](https://github.com/gredice/gredice/pull/4192) and [checks](https://github.com/gredice/gredice/pull/4192/checks) | [Exact production evidence](https://github.com/gredice/gredice/issues/4129#issuecomment-4983531400) |
+| [#4130](https://github.com/gredice/gredice/issues/4130) offline route/actions | [PR #4196](https://github.com/gredice/gredice/pull/4196) and [checks](https://github.com/gredice/gredice/pull/4196/checks) | [Verified deployed descendant](https://github.com/gredice/gredice/issues/4132#issuecomment-4986615548) |
+| [#4131](https://github.com/gredice/gredice/issues/4131) visibility/wake lock | [PR #4198](https://github.com/gredice/gredice/pull/4198) and [checks](https://github.com/gredice/gredice/pull/4198/checks) | [Code deployed; physical tracking and battery evidence pending](https://github.com/gredice/gredice/issues/4131#issuecomment-4985469863) |
+| [#4132](https://github.com/gredice/gredice/issues/4132) current-stop command center | [PR #4199](https://github.com/gredice/gredice/pull/4199) and [checks](https://github.com/gredice/gredice/pull/4199/checks) | [Exact production evidence](https://github.com/gredice/gredice/issues/4132#issuecomment-4986615548) |
+| [#4133](https://github.com/gredice/gredice/issues/4133) compact progress | [PR #4200](https://github.com/gredice/gredice/pull/4200) and [checks](https://github.com/gredice/gredice/pull/4200/checks) | [Exact production evidence](https://github.com/gredice/gredice/issues/4133#issuecomment-4986667738) |
+| [#4134](https://github.com/gredice/gredice/issues/4134) bulk/mobile accessibility | [PR #4204](https://github.com/gredice/gredice/pull/4204) and [CI run](https://github.com/gredice/gredice/actions/runs/29483868107) | [Code deployed; physical one-handed evidence pending](https://github.com/gredice/gredice/issues/4134#issuecomment-4989939719) |
+| [#4135](https://github.com/gredice/gredice/issues/4135) customer-safe DTO | [PR #4216](https://github.com/gredice/gredice/pull/4216) and [checks](https://github.com/gredice/gredice/pull/4216/checks) | [Exact production evidence](https://github.com/gredice/gredice/issues/4135#issuecomment-4990986564) |
+| [#4136](https://github.com/gredice/gredice/issues/4136) ETA/progress/freshness | [PR #4219](https://github.com/gredice/gredice/pull/4219) and [checks](https://github.com/gredice/gredice/pull/4219/checks) | [Exact production evidence](https://github.com/gredice/gredice/issues/4136#issuecomment-4992052356) |
+| [#4137](https://github.com/gredice/gredice/issues/4137) active/upcoming/history | [PR #4220](https://github.com/gredice/gredice/pull/4220) and [checks](https://github.com/gredice/gredice/pull/4220/checks) | [Exact production evidence](https://github.com/gredice/gredice/issues/4137#issuecomment-4992355307) |
+| [#4138](https://github.com/gredice/gredice/issues/4138) cached/accessibility state | [PR #4221](https://github.com/gredice/gredice/pull/4221) and [checks](https://github.com/gredice/gredice/pull/4221/checks) | [Exact production evidence](https://github.com/gredice/gredice/issues/4138#issuecomment-4993055466) |
+| [#4139](https://github.com/gredice/gredice/issues/4139) notification lifecycle | [PR #4222](https://github.com/gredice/gredice/pull/4222) and [checks](https://github.com/gredice/gredice/pull/4222/checks) | [Exact production evidence](https://github.com/gredice/gredice/issues/4139#issuecomment-4993726554) |
+| [#4140](https://github.com/gredice/gredice/issues/4140) notification channels | [PR #4223](https://github.com/gredice/gredice/pull/4223) and [checks](https://github.com/gredice/gredice/pull/4223/checks) | [Exact production evidence](https://github.com/gredice/gredice/issues/4140#issuecomment-4995657261) |
+| [#4141](https://github.com/gredice/gredice/issues/4141) notification observability | [PR #4225](https://github.com/gredice/gredice/pull/4225), [checks](https://github.com/gredice/gredice/pull/4225/checks), and [main CI](https://github.com/gredice/gredice/actions/runs/29539025068) | [Exact production evidence](https://github.com/gredice/gredice/issues/4141#issuecomment-4997218230) |
+| [#4142](https://github.com/gredice/gredice/issues/4142) handoff audit data | [PR #4201 checks](https://github.com/gredice/gredice/pull/4201/checks) and [corrective PR #4202 checks](https://github.com/gredice/gredice/pull/4202/checks) | [Exact corrective production evidence](https://github.com/gredice/gredice/issues/4142#issuecomment-4987340588) |
+| [#4143](https://github.com/gredice/gredice/issues/4143) resilient handoff manifest | [PR #4203](https://github.com/gredice/gredice/pull/4203) and [checks](https://github.com/gredice/gredice/pull/4203/checks) | [Production deployment evidence](https://github.com/gredice/gredice/issues/4143#issuecomment-4987761051) |
+| [#4144](https://github.com/gredice/gredice/issues/4144) customer handoff receipt | [PR #4206](https://github.com/gredice/gredice/pull/4206) and [checks](https://github.com/gredice/gredice/pull/4206/checks) | [Exact production evidence](https://github.com/gredice/gredice/issues/4144#issuecomment-4990821783) |
+| [#4145](https://github.com/gredice/gredice/issues/4145) orchestration characterization | [PR #4168](https://github.com/gredice/gredice/pull/4168) and [checks](https://github.com/gredice/gredice/pull/4168/checks) | [Verified deployed descendant](https://github.com/gredice/gredice/issues/4125#issuecomment-4980317995) |
+| [#4146](https://github.com/gredice/gredice/issues/4146) driver/customer journeys | [Owner-approved exact-tree local gate](https://github.com/gredice/gredice/pull/4226#issuecomment-4997376332) after a GitHub REST outage | [Exact production evidence](https://github.com/gredice/gredice/issues/4146#issuecomment-4997395607) |
+| [#4147](https://github.com/gredice/gredice/issues/4147) observability/rollout | Operations projection/log privacy tests and this checklist | Pending until this change is merged and deployed |
+
+Evidence is complete only when the linked artifact identifies the tested SHA
+and the production record identifies the same deployed SHA. If they differ,
+repeat the affected checks.

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -40,6 +40,7 @@ export * from './repositories/deliveryAddressesRepo';
 export * from './repositories/deliveryDispatchRepo';
 export * from './repositories/deliveryLifecycleNotificationsRepo';
 export * from './repositories/deliveryNotificationObservabilityRepo';
+export * from './repositories/deliveryOperationalObservabilityRepo';
 export * from './repositories/deliveryRequestsRepo';
 export * from './repositories/deliveryRunAssignmentsRepo';
 export * from './repositories/deliveryRunsRepo';

--- a/packages/storage/src/repositories/deliveryOperationalObservabilityRepo.ts
+++ b/packages/storage/src/repositories/deliveryOperationalObservabilityRepo.ts
@@ -1,0 +1,791 @@
+import { and, eq, gte, inArray, lte, or, sql } from 'drizzle-orm';
+import 'server-only';
+import {
+    deliveryRunExactLocationTtlMs,
+    deliveryRunTrackingLiveThresholdMs,
+} from '../deliveryTrackingPolicy';
+import {
+    type DeliveryRunEstimateSource,
+    type DeliveryRunExceptionReason,
+    DeliveryRunExceptionReasons,
+    type DeliveryRunState,
+    DeliveryRunStates,
+    type DeliveryRunStopState,
+    deliveryRunExceptionOperations,
+    deliveryRunHandoffOperations,
+    deliveryRunPickupOperations,
+    deliveryRunStopOperations,
+    deliveryRuns,
+} from '../schema';
+import { storage } from '../storage';
+
+const defaultWindowMs = 24 * 60 * 60 * 1000;
+const maximumWindowMs = 30 * 24 * 60 * 60 * 1000;
+const defaultDiagnosticLimit = 100;
+const maximumDiagnosticLimit = 200;
+const maximumExceptionOutcomesPerReceipt = 200;
+
+export const deliveryOperationalStaleRerouteMs = 10 * 60 * 1000;
+export const deliveryOperationalStalledRunMs = 60 * 60 * 1000;
+export const deliveryOperationalDelayedReplayMs = 5 * 60 * 1000;
+export const deliveryOperationalFallbackWarningRate = 0.25;
+export const deliveryOperationalFallbackMinimumSample = 4;
+
+export type DeliveryOperationalSeverity = 'healthy' | 'warning' | 'critical';
+
+export type DeliveryOperationalDiagnosticKind =
+    | 'abandoned-run'
+    | 'delayed-offline-replay'
+    | 'exception-outcome'
+    | 'local-route-fallback'
+    | 'reroute-stale'
+    | 'run-stalled'
+    | 'tracking-delayed'
+    | 'tracking-unavailable';
+
+export type DeliveryOperationalReplayKind =
+    | 'pickup'
+    | 'handoff'
+    | 'exception'
+    | 'stop';
+
+export type DeliveryOperationalDiagnostic = {
+    ageMs?: number;
+    count: number;
+    kind: DeliveryOperationalDiagnosticKind;
+    occurredAt: Date;
+    reasonCode: string;
+    runId: string;
+    severity: 'info' | 'warning' | 'critical';
+};
+
+export type DeliveryOperationalExceptionMetric = {
+    count: number;
+    outcome: Extract<DeliveryRunStopState, 'deferred' | 'failed' | 'cancelled'>;
+    reason: DeliveryRunExceptionReason;
+};
+
+export type DeliveryOperationalHealth = {
+    actions: {
+        delayedReplayCount: number;
+        maximumReplayDelayMs: number;
+    };
+    alerts: {
+        delayedOfflineReplay: boolean;
+        elevatedLocalFallback: boolean;
+        staleReroute: boolean;
+        stalledRun: boolean;
+        trackingUnavailable: boolean;
+    };
+    diagnostics: {
+        items: DeliveryOperationalDiagnostic[];
+        truncated: boolean;
+    };
+    exceptions: DeliveryOperationalExceptionMetric[];
+    from: Date;
+    reroutes: {
+        pendingCount: number;
+        staleCount: number;
+    };
+    runs: {
+        abandonedCount: number;
+        activeCount: number;
+        completedCount: number;
+        localFallbackCount: number;
+        localFallbackRate: number;
+        modernPlanCount: number;
+        stalledCount: number;
+    };
+    severity: DeliveryOperationalSeverity;
+    to: Date;
+    tracking: {
+        delayedCount: number;
+        liveCount: number;
+        notReceivedCount: number;
+        unavailableCount: number;
+    };
+};
+
+export type DeliveryOperationalRunSample = {
+    completedAt: Date | null;
+    currentLocationReceivedAt: Date | null;
+    estimateSource: DeliveryRunEstimateSource;
+    estimatesUpdatedAt: Date | null;
+    id: string;
+    rerouteAttemptedAt: Date | null;
+    rerouteRequiredAt: Date | null;
+    routePlanVersion: number;
+    startedAt: Date;
+    state: DeliveryRunState;
+    updatedAt: Date;
+};
+
+export type DeliveryOperationalExceptionSample = {
+    occurredAt: Date;
+    outcome: Extract<DeliveryRunStopState, 'deferred' | 'failed' | 'cancelled'>;
+    reason: DeliveryRunExceptionReason;
+    runId: string;
+};
+
+export type DeliveryOperationalReplaySample = {
+    appliedAt: Date;
+    kind: DeliveryOperationalReplayKind;
+    occurredAt: Date;
+    runId: string;
+};
+
+export type DeliveryOperationalHealthProjectionInput = {
+    diagnosticLimit?: number;
+    exceptionSamples: DeliveryOperationalExceptionSample[];
+    from: Date;
+    now: Date;
+    replaySamples: DeliveryOperationalReplaySample[];
+    runSamples: DeliveryOperationalRunSample[];
+    to: Date;
+};
+
+function maximumDate(values: Array<Date | null>) {
+    return values.reduce<Date | null>((latest, value) => {
+        if (!value) return latest;
+        return !latest || value > latest ? value : latest;
+    }, null);
+}
+
+function nonnegativeAgeMs(now: Date, occurredAt: Date) {
+    return Math.max(0, now.getTime() - occurredAt.getTime());
+}
+
+function boundedOpaqueRunId(value: string) {
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu.test(
+        value,
+    )
+        ? value
+        : 'run-id-unavailable';
+}
+
+function diagnosticLimit(value: number | undefined) {
+    if (value === undefined) return defaultDiagnosticLimit;
+    if (!Number.isInteger(value) || value < 1) {
+        throw new Error('diagnosticLimit must be a positive integer.');
+    }
+    return Math.min(value, maximumDiagnosticLimit);
+}
+
+function diagnosticKey(runId: string, outcome: string, reason: string) {
+    return `${runId}\u0000${outcome}\u0000${reason}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function isDeliveryOperationalExceptionReason(
+    value: unknown,
+): value is DeliveryRunExceptionReason {
+    return Object.values(DeliveryRunExceptionReasons).some(
+        (reason) => reason === value,
+    );
+}
+
+export function deliveryOperationalExceptionSamplesFromProjection({
+    occurredAt,
+    outcomes,
+    runId,
+}: {
+    occurredAt: Date;
+    outcomes: unknown;
+    runId: string;
+}): DeliveryOperationalExceptionSample[] {
+    if (!Array.isArray(outcomes)) return [];
+    if (outcomes.length > maximumExceptionOutcomesPerReceipt) return [];
+
+    return outcomes.flatMap((outcome) =>
+        isRecord(outcome) &&
+        isDeliveryOperationalExceptionOutcome(outcome.outcome) &&
+        isDeliveryOperationalExceptionReason(outcome.reason)
+            ? [
+                  {
+                      occurredAt,
+                      outcome: outcome.outcome,
+                      reason: outcome.reason,
+                      runId,
+                  },
+              ]
+            : [],
+    );
+}
+
+export function projectDeliveryOperationalHealth({
+    diagnosticLimit: requestedDiagnosticLimit,
+    exceptionSamples,
+    from,
+    now,
+    replaySamples,
+    runSamples,
+    to,
+}: DeliveryOperationalHealthProjectionInput): DeliveryOperationalHealth {
+    const limit = diagnosticLimit(requestedDiagnosticLimit);
+    const diagnostics: DeliveryOperationalDiagnostic[] = [];
+    const activeRuns = runSamples.filter(
+        (run) => run.state === DeliveryRunStates.ACTIVE,
+    );
+    const modernRuns = runSamples.filter((run) => run.routePlanVersion >= 2);
+    const localFallbackRuns = modernRuns.filter(
+        (run) => run.estimateSource === 'local',
+    );
+    const latestAppliedReceiptByRunId = new Map<string, Date>();
+    for (const sample of replaySamples) {
+        const latest = latestAppliedReceiptByRunId.get(sample.runId);
+        if (!latest || sample.appliedAt > latest) {
+            latestAppliedReceiptByRunId.set(sample.runId, sample.appliedAt);
+        }
+    }
+    const elevatedLocalFallback =
+        modernRuns.length >= deliveryOperationalFallbackMinimumSample &&
+        localFallbackRuns.length / modernRuns.length >=
+            deliveryOperationalFallbackWarningRate;
+
+    let trackingLiveCount = 0;
+    let trackingDelayedCount = 0;
+    let trackingUnavailableCount = 0;
+    let trackingNotReceivedCount = 0;
+    let trackingNotReceivedWarning = false;
+    let staleRerouteCount = 0;
+    let stalledRunCount = 0;
+    let trackingUnavailableAlert = false;
+
+    for (const run of activeRuns) {
+        const runId = boundedOpaqueRunId(run.id);
+        const runAgeMs = nonnegativeAgeMs(now, run.startedAt);
+        const locationAgeMs = run.currentLocationReceivedAt
+            ? nonnegativeAgeMs(now, run.currentLocationReceivedAt)
+            : null;
+
+        if (locationAgeMs === null) {
+            trackingNotReceivedCount += 1;
+            if (runAgeMs > deliveryRunTrackingLiveThresholdMs) {
+                trackingNotReceivedWarning = true;
+                const unavailable = runAgeMs > deliveryRunExactLocationTtlMs;
+                trackingUnavailableAlert ||= unavailable;
+                diagnostics.push({
+                    ageMs: runAgeMs,
+                    count: 1,
+                    kind: 'tracking-unavailable',
+                    occurredAt: run.startedAt,
+                    reasonCode: 'tracking-not-received',
+                    runId,
+                    severity: unavailable ? 'critical' : 'warning',
+                });
+            }
+        } else if (locationAgeMs <= deliveryRunTrackingLiveThresholdMs) {
+            trackingLiveCount += 1;
+        } else if (locationAgeMs <= deliveryRunExactLocationTtlMs) {
+            trackingDelayedCount += 1;
+            diagnostics.push({
+                ageMs: locationAgeMs,
+                count: 1,
+                kind: 'tracking-delayed',
+                occurredAt: run.currentLocationReceivedAt ?? run.startedAt,
+                reasonCode: 'tracking-delayed',
+                runId,
+                severity: 'warning',
+            });
+        } else {
+            trackingUnavailableCount += 1;
+            trackingUnavailableAlert = true;
+            diagnostics.push({
+                ageMs: locationAgeMs,
+                count: 1,
+                kind: 'tracking-unavailable',
+                occurredAt: run.currentLocationReceivedAt ?? run.startedAt,
+                reasonCode: 'tracking-offline',
+                runId,
+                severity: 'critical',
+            });
+        }
+
+        if (run.rerouteRequiredAt) {
+            const rerouteAgeMs = nonnegativeAgeMs(now, run.rerouteRequiredAt);
+            if (rerouteAgeMs >= deliveryOperationalStaleRerouteMs) {
+                staleRerouteCount += 1;
+                diagnostics.push({
+                    ageMs: rerouteAgeMs,
+                    count: 1,
+                    kind: 'reroute-stale',
+                    occurredAt: run.rerouteRequiredAt,
+                    reasonCode: run.rerouteAttemptedAt
+                        ? 'reroute-attempt-stale'
+                        : 'reroute-not-attempted',
+                    runId,
+                    severity: 'critical',
+                });
+            }
+        }
+
+        const lastActivityAt = maximumDate([
+            run.startedAt,
+            run.updatedAt,
+            run.currentLocationReceivedAt,
+            run.estimatesUpdatedAt,
+            latestAppliedReceiptByRunId.get(run.id) ?? null,
+        ]);
+        if (
+            lastActivityAt &&
+            nonnegativeAgeMs(now, lastActivityAt) >=
+                deliveryOperationalStalledRunMs
+        ) {
+            const ageMs = nonnegativeAgeMs(now, lastActivityAt);
+            stalledRunCount += 1;
+            diagnostics.push({
+                ageMs,
+                count: 1,
+                kind: 'run-stalled',
+                occurredAt: lastActivityAt,
+                reasonCode: 'no-recent-run-activity',
+                runId,
+                severity: 'critical',
+            });
+        }
+    }
+
+    for (const run of localFallbackRuns) {
+        diagnostics.push({
+            count: 1,
+            kind: 'local-route-fallback',
+            occurredAt:
+                run.estimatesUpdatedAt ?? run.completedAt ?? run.startedAt,
+            reasonCode: 'estimate-source-local',
+            runId: boundedOpaqueRunId(run.id),
+            severity: elevatedLocalFallback ? 'warning' : 'info',
+        });
+    }
+
+    for (const run of runSamples) {
+        if (run.state !== DeliveryRunStates.CANCELLED || !run.completedAt) {
+            continue;
+        }
+        diagnostics.push({
+            count: 1,
+            kind: 'abandoned-run',
+            occurredAt: run.completedAt,
+            reasonCode: 'route-abandoned',
+            runId: boundedOpaqueRunId(run.id),
+            severity: 'info',
+        });
+    }
+
+    const delayedReplays = replaySamples.filter(
+        (sample) =>
+            sample.appliedAt.getTime() - sample.occurredAt.getTime() >=
+            deliveryOperationalDelayedReplayMs,
+    );
+    const replayGroups = new Map<
+        string,
+        {
+            count: number;
+            kind: DeliveryOperationalReplayKind;
+            latestAppliedAt: Date;
+            maximumDelayMs: number;
+            runId: string;
+        }
+    >();
+    for (const sample of delayedReplays) {
+        const runId = boundedOpaqueRunId(sample.runId);
+        const key = `${runId}\u0000${sample.kind}`;
+        const delayMs =
+            sample.appliedAt.getTime() - sample.occurredAt.getTime();
+        const existing = replayGroups.get(key);
+        replayGroups.set(key, {
+            count: (existing?.count ?? 0) + 1,
+            kind: sample.kind,
+            latestAppliedAt:
+                existing && existing.latestAppliedAt > sample.appliedAt
+                    ? existing.latestAppliedAt
+                    : sample.appliedAt,
+            maximumDelayMs: Math.max(existing?.maximumDelayMs ?? 0, delayMs),
+            runId,
+        });
+    }
+    for (const group of replayGroups.values()) {
+        diagnostics.push({
+            ageMs: group.maximumDelayMs,
+            count: group.count,
+            kind: 'delayed-offline-replay',
+            occurredAt: group.latestAppliedAt,
+            reasonCode: `delayed-${group.kind}-replay`,
+            runId: group.runId,
+            severity: 'warning',
+        });
+    }
+
+    const exceptionGroups = new Map<
+        string,
+        DeliveryOperationalExceptionMetric & {
+            latestOccurredAt: Date;
+            runId: string;
+        }
+    >();
+    for (const sample of exceptionSamples) {
+        const runId = boundedOpaqueRunId(sample.runId);
+        const key = diagnosticKey(runId, sample.outcome, sample.reason);
+        const existing = exceptionGroups.get(key);
+        exceptionGroups.set(key, {
+            count: (existing?.count ?? 0) + 1,
+            latestOccurredAt:
+                existing && existing.latestOccurredAt > sample.occurredAt
+                    ? existing.latestOccurredAt
+                    : sample.occurredAt,
+            outcome: sample.outcome,
+            reason: sample.reason,
+            runId,
+        });
+    }
+    for (const group of exceptionGroups.values()) {
+        diagnostics.push({
+            count: group.count,
+            kind: 'exception-outcome',
+            occurredAt: group.latestOccurredAt,
+            reasonCode: `${group.outcome}:${group.reason}`,
+            runId: group.runId,
+            severity: 'info',
+        });
+    }
+
+    const exceptionsByOutcome = new Map<
+        string,
+        DeliveryOperationalExceptionMetric
+    >();
+    for (const sample of exceptionSamples) {
+        const key = `${sample.outcome}\u0000${sample.reason}`;
+        const existing = exceptionsByOutcome.get(key);
+        exceptionsByOutcome.set(key, {
+            count: (existing?.count ?? 0) + 1,
+            outcome: sample.outcome,
+            reason: sample.reason,
+        });
+    }
+
+    const delayedOfflineReplay = delayedReplays.length > 0;
+    const staleReroute = staleRerouteCount > 0;
+    const stalledRun = stalledRunCount > 0;
+    const hasCritical = staleReroute || stalledRun || trackingUnavailableAlert;
+    const hasWarning =
+        elevatedLocalFallback ||
+        delayedOfflineReplay ||
+        trackingDelayedCount > 0 ||
+        trackingNotReceivedWarning;
+    const severityRank = { critical: 0, warning: 1, info: 2 } as const;
+    const sortedDiagnostics = diagnostics.sort(
+        (first, second) =>
+            severityRank[first.severity] - severityRank[second.severity] ||
+            second.occurredAt.getTime() - first.occurredAt.getTime() ||
+            first.runId.localeCompare(second.runId) ||
+            first.kind.localeCompare(second.kind),
+    );
+
+    return {
+        actions: {
+            delayedReplayCount: delayedReplays.length,
+            maximumReplayDelayMs: delayedReplays.reduce(
+                (maximum, sample) =>
+                    Math.max(
+                        maximum,
+                        sample.appliedAt.getTime() -
+                            sample.occurredAt.getTime(),
+                    ),
+                0,
+            ),
+        },
+        alerts: {
+            delayedOfflineReplay,
+            elevatedLocalFallback,
+            staleReroute,
+            stalledRun,
+            trackingUnavailable: trackingUnavailableAlert,
+        },
+        diagnostics: {
+            items: sortedDiagnostics.slice(0, limit),
+            truncated: sortedDiagnostics.length > limit,
+        },
+        exceptions: [...exceptionsByOutcome.values()].sort(
+            (first, second) =>
+                first.outcome.localeCompare(second.outcome) ||
+                first.reason.localeCompare(second.reason),
+        ),
+        from,
+        reroutes: {
+            pendingCount: activeRuns.filter(
+                (run) => run.rerouteRequiredAt !== null,
+            ).length,
+            staleCount: staleRerouteCount,
+        },
+        runs: {
+            abandonedCount: runSamples.filter(
+                (run) => run.state === DeliveryRunStates.CANCELLED,
+            ).length,
+            activeCount: activeRuns.length,
+            completedCount: runSamples.filter(
+                (run) => run.state === DeliveryRunStates.COMPLETED,
+            ).length,
+            localFallbackCount: localFallbackRuns.length,
+            localFallbackRate:
+                modernRuns.length === 0
+                    ? 0
+                    : localFallbackRuns.length / modernRuns.length,
+            modernPlanCount: modernRuns.length,
+            stalledCount: stalledRunCount,
+        },
+        severity: hasCritical ? 'critical' : hasWarning ? 'warning' : 'healthy',
+        to,
+        tracking: {
+            delayedCount: trackingDelayedCount,
+            liveCount: trackingLiveCount,
+            notReceivedCount: trackingNotReceivedCount,
+            unavailableCount: trackingUnavailableCount,
+        },
+    };
+}
+
+function validDate(value: Date, field: string) {
+    if (Number.isNaN(value.getTime())) {
+        throw new Error(`${field} must be a valid date.`);
+    }
+    return value;
+}
+
+function normalizedWindow({
+    from,
+    now = new Date(),
+    to,
+}: {
+    from?: Date;
+    now?: Date;
+    to?: Date;
+}) {
+    const normalizedNow = validDate(now, 'now');
+    const normalizedTo = validDate(to ?? normalizedNow, 'to');
+    const normalizedFrom = validDate(
+        from ?? new Date(normalizedTo.getTime() - defaultWindowMs),
+        'from',
+    );
+    if (normalizedFrom > normalizedTo) {
+        throw new Error('from must be before or equal to to.');
+    }
+    if (normalizedTo.getTime() - normalizedFrom.getTime() > maximumWindowMs) {
+        throw new Error('Delivery operational window cannot exceed 30 days.');
+    }
+    return { from: normalizedFrom, now: normalizedNow, to: normalizedTo };
+}
+
+function isDeliveryRunState(value: string): value is DeliveryRunState {
+    return Object.values(DeliveryRunStates).some((state) => state === value);
+}
+
+function isDeliveryOperationalExceptionOutcome(
+    value: unknown,
+): value is DeliveryOperationalExceptionSample['outcome'] {
+    return value === 'deferred' || value === 'failed' || value === 'cancelled';
+}
+
+function relevantDeliveryRunCondition(from: Date, to: Date) {
+    return or(
+        eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+        and(
+            inArray(deliveryRuns.state, [
+                DeliveryRunStates.COMPLETED,
+                DeliveryRunStates.CANCELLED,
+            ]),
+            gte(deliveryRuns.completedAt, from),
+            lte(deliveryRuns.completedAt, to),
+        ),
+    );
+}
+
+// Reduce durable exception receipts inside PostgreSQL. The application never
+// receives stop IDs, delivery request IDs, payload hashes, or any other receipt
+// fields. Oversized and malformed receipts fail closed to an empty projection.
+const deliveryOperationalExceptionOutcomesProjection = sql<unknown>`
+    case
+        when jsonb_typeof(${deliveryRunExceptionOperations.result}->'outcomes') = 'array'
+        then case
+            when jsonb_array_length(${deliveryRunExceptionOperations.result}->'outcomes') <= ${maximumExceptionOutcomesPerReceipt}
+            then coalesce(
+                (
+                    select jsonb_agg(
+                        jsonb_build_object(
+                            'outcome', exception_outcome.value->>'outcome',
+                            'reason', exception_outcome.value->>'reason'
+                        )
+                        order by exception_outcome.ordinality
+                    )
+                    from jsonb_array_elements(
+                        ${deliveryRunExceptionOperations.result}->'outcomes'
+                    ) with ordinality as exception_outcome(value, ordinality)
+                    where jsonb_typeof(exception_outcome.value) = 'object'
+                        and exception_outcome.value->>'outcome' in (
+                            'deferred', 'failed', 'cancelled'
+                        )
+                        and exception_outcome.value->>'reason' in (
+                            'customer-unavailable',
+                            'address-inaccessible',
+                            'address-wrong',
+                            'harvest-damaged',
+                            'harvest-missing',
+                            'cancellation',
+                            'operational-other'
+                        )
+                ),
+                '[]'::jsonb
+            )
+            else '[]'::jsonb
+        end
+        else '[]'::jsonb
+    end
+`;
+
+export async function getDeliveryOperationalHealth({
+    diagnosticLimit: requestedDiagnosticLimit,
+    from,
+    now,
+    to,
+}: {
+    diagnosticLimit?: number;
+    from?: Date;
+    now?: Date;
+    to?: Date;
+} = {}): Promise<DeliveryOperationalHealth> {
+    const window = normalizedWindow({ from, now, to });
+    const [
+        runRows,
+        pickupRows,
+        handoffRows,
+        exceptionOperations,
+        stopOperationRows,
+    ] = await Promise.all([
+        storage()
+            .select({
+                completedAt: deliveryRuns.completedAt,
+                currentLocationReceivedAt:
+                    deliveryRuns.currentLocationReceivedAt,
+                estimateSource: deliveryRuns.estimateSource,
+                estimatesUpdatedAt: deliveryRuns.estimatesUpdatedAt,
+                id: deliveryRuns.id,
+                rerouteAttemptedAt: deliveryRuns.rerouteAttemptedAt,
+                rerouteRequiredAt: deliveryRuns.rerouteRequiredAt,
+                routePlanVersion: deliveryRuns.routePlanVersion,
+                startedAt: deliveryRuns.startedAt,
+                state: deliveryRuns.state,
+                updatedAt: deliveryRuns.updatedAt,
+            })
+            .from(deliveryRuns)
+            .where(relevantDeliveryRunCondition(window.from, window.to)),
+        storage()
+            .select({
+                appliedAt: deliveryRunPickupOperations.appliedAt,
+                occurredAt: deliveryRunPickupOperations.occurredAt,
+                runId: deliveryRunPickupOperations.runId,
+            })
+            .from(deliveryRunPickupOperations)
+            .innerJoin(
+                deliveryRuns,
+                eq(deliveryRunPickupOperations.runId, deliveryRuns.id),
+            )
+            .where(
+                and(
+                    relevantDeliveryRunCondition(window.from, window.to),
+                    gte(deliveryRunPickupOperations.appliedAt, window.from),
+                    lte(deliveryRunPickupOperations.appliedAt, window.to),
+                ),
+            ),
+        storage()
+            .select({
+                appliedAt: deliveryRunHandoffOperations.appliedAt,
+                occurredAt: deliveryRunHandoffOperations.occurredAt,
+                runId: deliveryRunHandoffOperations.runId,
+            })
+            .from(deliveryRunHandoffOperations)
+            .innerJoin(
+                deliveryRuns,
+                eq(deliveryRunHandoffOperations.runId, deliveryRuns.id),
+            )
+            .where(
+                and(
+                    relevantDeliveryRunCondition(window.from, window.to),
+                    gte(deliveryRunHandoffOperations.appliedAt, window.from),
+                    lte(deliveryRunHandoffOperations.appliedAt, window.to),
+                ),
+            ),
+        storage()
+            .select({
+                appliedAt: deliveryRunExceptionOperations.appliedAt,
+                occurredAt: deliveryRunExceptionOperations.occurredAt,
+                outcomes: deliveryOperationalExceptionOutcomesProjection,
+                runId: deliveryRunExceptionOperations.runId,
+            })
+            .from(deliveryRunExceptionOperations)
+            .innerJoin(
+                deliveryRuns,
+                eq(deliveryRunExceptionOperations.runId, deliveryRuns.id),
+            )
+            .where(
+                and(
+                    relevantDeliveryRunCondition(window.from, window.to),
+                    gte(deliveryRunExceptionOperations.appliedAt, window.from),
+                    lte(deliveryRunExceptionOperations.appliedAt, window.to),
+                ),
+            ),
+        storage()
+            .select({
+                appliedAt: deliveryRunStopOperations.appliedAt,
+                occurredAt: deliveryRunStopOperations.occurredAt,
+                runId: deliveryRunStopOperations.runId,
+            })
+            .from(deliveryRunStopOperations)
+            .innerJoin(
+                deliveryRuns,
+                eq(deliveryRunStopOperations.runId, deliveryRuns.id),
+            )
+            .where(
+                and(
+                    relevantDeliveryRunCondition(window.from, window.to),
+                    gte(deliveryRunStopOperations.appliedAt, window.from),
+                    lte(deliveryRunStopOperations.appliedAt, window.to),
+                ),
+            ),
+    ]);
+
+    const exceptionSamples = exceptionOperations.flatMap((row) =>
+        row.occurredAt >= window.from && row.occurredAt <= window.to
+            ? deliveryOperationalExceptionSamplesFromProjection({
+                  occurredAt: row.occurredAt,
+                  outcomes: row.outcomes,
+                  runId: row.runId,
+              })
+            : [],
+    );
+    const runSamples = runRows.flatMap((row) =>
+        isDeliveryRunState(row.state) ? [{ ...row, state: row.state }] : [],
+    );
+    const replaySamples: DeliveryOperationalReplaySample[] = [
+        ...pickupRows.map((row) => ({ ...row, kind: 'pickup' as const })),
+        ...handoffRows.map((row) => ({ ...row, kind: 'handoff' as const })),
+        ...exceptionOperations.map((row) => ({
+            appliedAt: row.appliedAt,
+            kind: 'exception' as const,
+            occurredAt: row.occurredAt,
+            runId: row.runId,
+        })),
+        ...stopOperationRows.map((row) => ({
+            ...row,
+            kind: 'stop' as const,
+        })),
+    ];
+
+    return projectDeliveryOperationalHealth({
+        diagnosticLimit: requestedDiagnosticLimit,
+        exceptionSamples,
+        replaySamples,
+        runSamples,
+        ...window,
+    });
+}

--- a/packages/storage/tests/deliveryOperationalObservabilityRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryOperationalObservabilityRepo.node.spec.ts
@@ -1,0 +1,506 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    type DeliveryOperationalRunSample,
+    deliveryOperationalDelayedReplayMs,
+    deliveryOperationalExceptionSamplesFromProjection,
+    deliveryOperationalStaleRerouteMs,
+    deliveryOperationalStalledRunMs,
+    deliveryRunExceptionOperations,
+    deliveryRuns,
+    getDeliveryOperationalHealth,
+    pickupLocations,
+    projectDeliveryOperationalHealth,
+    storage,
+    timeSlots,
+    users,
+} from '@gredice/storage';
+import { createTestDb } from './testDb';
+
+const now = new Date('2046-07-17T12:00:00.000Z');
+const from = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+function runSample(
+    id: string,
+    values: Partial<DeliveryOperationalRunSample> = {},
+): DeliveryOperationalRunSample {
+    return {
+        completedAt: null,
+        currentLocationReceivedAt: new Date(now.getTime() - 10_000),
+        estimateSource: 'google',
+        estimatesUpdatedAt: new Date(now.getTime() - 10_000),
+        id,
+        rerouteAttemptedAt: null,
+        rerouteRequiredAt: null,
+        routePlanVersion: 2,
+        startedAt: new Date(now.getTime() - 30 * 60 * 1000),
+        state: 'active',
+        updatedAt: new Date(now.getTime() - 10_000),
+        ...values,
+    };
+}
+
+test('projects route, tracking, reroute, exception, abandonment, and delayed replay health without private payloads', () => {
+    const privateValue = 'PRIVATE CUSTOMER ADDRESS 45.8, 15.9';
+    const health = projectDeliveryOperationalHealth({
+        diagnosticLimit: 100,
+        exceptionSamples: [
+            {
+                occurredAt: new Date(now.getTime() - 15_000),
+                outcome: 'failed',
+                reason: 'address-inaccessible',
+                runId: privateValue,
+            },
+            {
+                occurredAt: new Date(now.getTime() - 10_000),
+                outcome: 'failed',
+                reason: 'address-inaccessible',
+                runId: privateValue,
+            },
+        ],
+        from,
+        now,
+        replaySamples: [
+            {
+                appliedAt: now,
+                kind: 'stop',
+                occurredAt: new Date(
+                    now.getTime() - deliveryOperationalDelayedReplayMs,
+                ),
+                runId: 'run-replay',
+            },
+        ],
+        runSamples: [
+            runSample(privateValue, {
+                currentLocationReceivedAt: new Date(
+                    now.getTime() - deliveryOperationalStalledRunMs,
+                ),
+                estimateSource: 'local',
+                estimatesUpdatedAt: new Date(
+                    now.getTime() - deliveryOperationalStalledRunMs,
+                ),
+                rerouteAttemptedAt: new Date(
+                    now.getTime() - deliveryOperationalStaleRerouteMs,
+                ),
+                rerouteRequiredAt: new Date(
+                    now.getTime() - deliveryOperationalStaleRerouteMs,
+                ),
+                startedAt: new Date(
+                    now.getTime() - deliveryOperationalStalledRunMs * 2,
+                ),
+                updatedAt: new Date(
+                    now.getTime() - deliveryOperationalStalledRunMs,
+                ),
+            }),
+            runSample('run-completed-1', {
+                completedAt: new Date(now.getTime() - 20_000),
+                state: 'completed',
+            }),
+            runSample('run-completed-2', {
+                completedAt: new Date(now.getTime() - 30_000),
+                state: 'completed',
+            }),
+            runSample('run-abandoned', {
+                completedAt: new Date(now.getTime() - 40_000),
+                state: 'cancelled',
+            }),
+        ],
+        to: now,
+    });
+
+    assert.equal(health.severity, 'critical');
+    assert.deepEqual(health.alerts, {
+        delayedOfflineReplay: true,
+        elevatedLocalFallback: true,
+        staleReroute: true,
+        stalledRun: true,
+        trackingUnavailable: true,
+    });
+    assert.deepEqual(health.runs, {
+        abandonedCount: 1,
+        activeCount: 1,
+        completedCount: 2,
+        localFallbackCount: 1,
+        localFallbackRate: 0.25,
+        modernPlanCount: 4,
+        stalledCount: 1,
+    });
+    assert.deepEqual(health.tracking, {
+        delayedCount: 0,
+        liveCount: 0,
+        notReceivedCount: 0,
+        unavailableCount: 1,
+    });
+    assert.equal(health.reroutes.pendingCount, 1);
+    assert.equal(health.reroutes.staleCount, 1);
+    assert.equal(health.actions.delayedReplayCount, 1);
+    assert.equal(
+        health.actions.maximumReplayDelayMs,
+        deliveryOperationalDelayedReplayMs,
+    );
+    assert.deepEqual(health.exceptions, [
+        {
+            count: 2,
+            outcome: 'failed',
+            reason: 'address-inaccessible',
+        },
+    ]);
+    assert.ok(
+        health.diagnostics.items.some(
+            (item) => item.kind === 'exception-outcome' && item.count === 2,
+        ),
+    );
+    assert.ok(
+        health.diagnostics.items.some(
+            (item) => item.runId === 'run-id-unavailable',
+        ),
+    );
+    assert.ok(
+        health.diagnostics.items.every(
+            (item) =>
+                Object.keys(item).sort().join(',') ===
+                [
+                    ...(item.ageMs === undefined ? [] : ['ageMs']),
+                    'count',
+                    'kind',
+                    'occurredAt',
+                    'reasonCode',
+                    'runId',
+                    'severity',
+                ]
+                    .sort()
+                    .join(','),
+        ),
+    );
+    assert.doesNotMatch(JSON.stringify(health), new RegExp(privateValue));
+});
+
+test('keeps a newly started run without a location below alert thresholds', () => {
+    const health = projectDeliveryOperationalHealth({
+        exceptionSamples: [],
+        from,
+        now,
+        replaySamples: [],
+        runSamples: [
+            runSample('run-new', {
+                currentLocationReceivedAt: null,
+                startedAt: new Date(now.getTime() - 10_000),
+                updatedAt: new Date(now.getTime() - 10_000),
+            }),
+        ],
+        to: now,
+    });
+
+    assert.equal(health.severity, 'healthy');
+    assert.equal(health.tracking.notReceivedCount, 1);
+    assert.equal(health.alerts.trackingUnavailable, false);
+    assert.deepEqual(health.diagnostics.items, []);
+});
+
+test('timestamps persisted local fallback diagnostics from the estimate update', () => {
+    const estimatesUpdatedAt = new Date(now.getTime() - 5 * 60 * 1000);
+    const health = projectDeliveryOperationalHealth({
+        exceptionSamples: [],
+        from,
+        now,
+        replaySamples: [],
+        runSamples: [
+            runSample('run-local-fallback', {
+                completedAt: new Date(now.getTime() - 60_000),
+                estimateSource: 'local',
+                estimatesUpdatedAt,
+                state: 'completed',
+            }),
+        ],
+        to: now,
+    });
+
+    const fallback = health.diagnostics.items.find(
+        (item) => item.kind === 'local-route-fallback',
+    );
+    assert.equal(fallback?.occurredAt, estimatesUpdatedAt);
+});
+
+test('treats a freshly applied operation receipt as run activity even when GPS and run timestamps are stale', () => {
+    const runId = 'run-receipt-active';
+    const health = projectDeliveryOperationalHealth({
+        exceptionSamples: [],
+        from,
+        now,
+        replaySamples: [
+            {
+                appliedAt: new Date(now.getTime() - 10_000),
+                kind: 'stop',
+                occurredAt: new Date(now.getTime() - 10_000),
+                runId,
+            },
+        ],
+        runSamples: [
+            runSample(runId, {
+                currentLocationReceivedAt: new Date(
+                    now.getTime() - deliveryOperationalStalledRunMs * 2,
+                ),
+                estimatesUpdatedAt: new Date(
+                    now.getTime() - deliveryOperationalStalledRunMs * 2,
+                ),
+                startedAt: new Date(
+                    now.getTime() - deliveryOperationalStalledRunMs * 2,
+                ),
+                updatedAt: new Date(
+                    now.getTime() - deliveryOperationalStalledRunMs * 2,
+                ),
+            }),
+        ],
+        to: now,
+    });
+
+    assert.equal(health.alerts.trackingUnavailable, true);
+    assert.equal(health.alerts.stalledRun, false);
+    assert.equal(health.runs.stalledCount, 0);
+    assert.equal(
+        health.diagnostics.items.some((item) => item.kind === 'run-stalled'),
+        false,
+    );
+});
+
+test('parses only bounded exception outcome data from immutable operation receipts', () => {
+    const privateValue = 'Private Street 12 and customer phone 0991234567';
+    const samples = deliveryOperationalExceptionSamplesFromProjection({
+        occurredAt: now,
+        outcomes: [
+            {
+                deliveryRequestId: privateValue,
+                note: privateValue,
+                outcome: 'failed',
+                reason: 'harvest-missing',
+                stopId: 41,
+            },
+            {
+                outcome: 'unknown-private-outcome',
+                reason: 'operational-other',
+            },
+        ],
+        runId: 'run-recovered',
+    });
+
+    assert.deepEqual(samples, [
+        {
+            occurredAt: now,
+            outcome: 'failed',
+            reason: 'harvest-missing',
+            runId: 'run-recovered',
+        },
+    ]);
+    assert.doesNotMatch(JSON.stringify(samples), new RegExp(privateValue));
+});
+
+test('bounds diagnostics and rejects invalid diagnostic limits', () => {
+    const input = {
+        exceptionSamples: [],
+        from,
+        now,
+        replaySamples: [],
+        runSamples: Array.from({ length: 220 }, (_, index) =>
+            runSample(`run-${index.toString().padStart(3, '0')}`, {
+                completedAt: new Date(now.getTime() - index * 1_000),
+                estimateSource: 'local',
+                state: 'cancelled',
+            }),
+        ),
+        to: now,
+    };
+
+    const health = projectDeliveryOperationalHealth({
+        ...input,
+        diagnosticLimit: 500,
+    });
+    assert.equal(health.diagnostics.items.length, 200);
+    assert.equal(health.diagnostics.truncated, true);
+    assert.throws(
+        () =>
+            projectDeliveryOperationalHealth({
+                ...input,
+                diagnosticLimit: 0,
+            }),
+        /positive integer/u,
+    );
+});
+
+test('keeps older critical and warning diagnostics ahead of newer info when the list is capped', () => {
+    const health = projectDeliveryOperationalHealth({
+        diagnosticLimit: 200,
+        exceptionSamples: [],
+        from,
+        now,
+        replaySamples: [],
+        runSamples: [
+            runSample('run-critical', {
+                rerouteRequiredAt: new Date(
+                    now.getTime() - deliveryOperationalStaleRerouteMs,
+                ),
+            }),
+            runSample('run-warning', {
+                currentLocationReceivedAt: new Date(now.getTime() - 60_000),
+            }),
+            ...Array.from({ length: 220 }, (_, index) =>
+                runSample(`run-info-${index.toString().padStart(3, '0')}`, {
+                    completedAt: new Date(now.getTime() - index * 1_000),
+                    state: 'cancelled',
+                }),
+            ),
+        ],
+        to: now,
+    });
+
+    assert.equal(health.diagnostics.items.length, 200);
+    assert.equal(health.diagnostics.truncated, true);
+    assert.equal(health.diagnostics.items[0]?.kind, 'reroute-stale');
+    assert.equal(health.diagnostics.items[0]?.severity, 'critical');
+    assert.equal(health.diagnostics.items[1]?.kind, 'tracking-delayed');
+    assert.equal(health.diagnostics.items[1]?.severity, 'warning');
+    assert.ok(
+        health.diagnostics.items
+            .slice(2)
+            .every((item) => item.severity === 'info'),
+    );
+});
+
+test('queries an empty operational window through the real storage schema', async () => {
+    createTestDb();
+    const health = await getDeliveryOperationalHealth({ from, now, to: now });
+
+    assert.equal(health.severity, 'healthy');
+    assert.equal(health.runs.activeCount, 0);
+    assert.deepEqual(health.diagnostics, { items: [], truncated: false });
+});
+
+test('rejects invalid and unbounded operational windows before reading storage', async () => {
+    await assert.rejects(
+        getDeliveryOperationalHealth({
+            from: now,
+            now,
+            to: new Date(now.getTime() - 1),
+        }),
+        /from must be before/u,
+    );
+    await assert.rejects(
+        getDeliveryOperationalHealth({
+            from: new Date(now.getTime() - 31 * 24 * 60 * 60 * 1000),
+            now,
+            to: now,
+        }),
+        /cannot exceed 30 days/u,
+    );
+    await assert.rejects(
+        getDeliveryOperationalHealth({ now: new Date('invalid') }),
+        /now must be a valid date/u,
+    );
+});
+
+test('maps an active route and retains a recovered exception from its immutable receipt', async () => {
+    createTestDb();
+    const driverUserId = randomUUID();
+    await storage()
+        .insert(users)
+        .values({
+            id: driverUserId,
+            userName: `driver-${driverUserId}@example.test`,
+            displayName: 'Private Driver Name',
+            role: 'driver',
+        });
+    const [pickupLocation] = await storage()
+        .insert(pickupLocations)
+        .values({
+            city: 'Private City',
+            countryCode: 'HR',
+            name: 'Private HQ',
+            postalCode: '10000',
+            street1: 'Private Street 12',
+        })
+        .returning({ id: pickupLocations.id });
+    assert.ok(pickupLocation);
+    const [timeSlot] = await storage()
+        .insert(timeSlots)
+        .values({
+            endAt: new Date(now.getTime() + 60 * 60 * 1000),
+            locationId: pickupLocation.id,
+            startAt: new Date(now.getTime() - 60 * 60 * 1000),
+            type: 'delivery',
+        })
+        .returning({ id: timeSlots.id });
+    assert.ok(timeSlot);
+    const runId = randomUUID();
+    await storage()
+        .insert(deliveryRuns)
+        .values({
+            currentLocationReceivedAt: new Date(now.getTime() - 10_000),
+            driverUserId,
+            estimateSource: 'local',
+            id: runId,
+            routePlanVersion: 2,
+            startedAt: new Date(now.getTime() - 10 * 60 * 1000),
+            timeSlotId: timeSlot.id,
+            updatedAt: new Date(now.getTime() - 10_000),
+        });
+    await storage()
+        .insert(deliveryRunExceptionOperations)
+        .values({
+            appliedAt: new Date(now.getTime() - 5_000),
+            clientOperationId: `exception-${randomUUID()}`,
+            driverUserId,
+            occurredAt: new Date(now.getTime() - 10_000),
+            payloadHash: 'private-payload-digest',
+            result: {
+                outcomes: [
+                    {
+                        deliveryRequestId: 'private-request-id',
+                        outcome: 'failed',
+                        reason: 'harvest-missing',
+                        retryAttempt: 0,
+                        stopId: 123,
+                    },
+                ],
+                reroutePending: false,
+                routeRevision: 2,
+                runCompleted: false,
+            },
+            runId,
+        });
+    await storage()
+        .insert(deliveryRunExceptionOperations)
+        .values({
+            appliedAt: new Date(now.getTime() - 4_000),
+            clientOperationId: `exception-oversized-${randomUUID()}`,
+            driverUserId,
+            occurredAt: new Date(now.getTime() - 9_000),
+            payloadHash: 'second-private-payload-digest',
+            result: {
+                outcomes: Array.from({ length: 201 }, (_, index) => ({
+                    deliveryRequestId: `private-oversized-request-${index}`,
+                    outcome: 'failed' as const,
+                    reason: 'address-inaccessible' as const,
+                    retryAttempt: 0,
+                    stopId: index + 1,
+                })),
+                reroutePending: false,
+                routeRevision: 2,
+                runCompleted: false,
+            },
+            runId,
+        });
+
+    const health = await getDeliveryOperationalHealth({ from, now, to: now });
+
+    assert.equal(health.severity, 'healthy');
+    assert.equal(health.runs.activeCount, 1);
+    assert.equal(health.runs.localFallbackCount, 1);
+    assert.equal(health.tracking.liveCount, 1);
+    assert.deepEqual(health.exceptions, [
+        { count: 1, outcome: 'failed', reason: 'harvest-missing' },
+    ]);
+    assert.doesNotMatch(
+        JSON.stringify(health),
+        /Private Driver|Private Street|Private City|Private HQ|private-request-id|private-payload-digest|private-oversized/u,
+    );
+});


### PR DESCRIPTION
## Summary

Adds privacy-safe operational observability and the staged production rollout gate for the delivery epic.

## Changes

- adds an admin-only `/admin/delivery/operations` view for bounded route, tracking, reroute, exception, replay, and fallback health;
- derives recovered exception outcomes from immutable receipts while projecting only bounded outcome/reason fields inside PostgreSQL;
- prioritizes critical diagnostics, treats fresh receipts/estimate refreshes as activity, and exposes only opaque route diagnostics;
- standardizes privacy-safe route fallback and driver mutation logs without raw errors, addresses, GPS, request IDs, or driver identities;
- documents alert thresholds, operator queries, staged rollout, rollback, physical-device verification, and per-feature evidence;
- adds no schema, migration, dependency, or lockfile changes.

## Validation

Exact head `24d9faff3f5b6ab7cfa78b5be750f1a56ebd0396`:

- storage real-Postgres observability: 10/10;
- delivery unit: 403/403;
- focused delivery observability/logging/routing suites: 71/71 before the final rebase;
- delivery typecheck and production build;
- admin app production build, including `/admin/delivery/operations`;
- app, delivery, and storage targeted Biome checks;
- `git diff --check`;
- independent privacy/query audit: SHIP; PostgreSQL EXPLAIN confirmed the intended index-backed plans.

## Rollout

The code and runbook are ready to merge and deploy. The issue intentionally remains open after the code merge until the documented physical iPhone/Android, weak-network, GPS, camera, customer, and battery evidence is attached.

Refs #4147