### PR TITLE
fix(garden): allow open same-day delivery slots

### DIFF
--- a/apps/garden/tests/DeliverySlotPickerStory.tsx
+++ b/apps/garden/tests/DeliverySlotPickerStory.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import {
+    DeliverySlotPicker,
+    type DeliverySlotPickerProps,
+} from '../../../packages/game/src/shared-ui/delivery/DeliverySlotPicker';
+
+type DeliverySlotPickerStoryProps = Pick<
+    DeliverySlotPickerProps,
+    'autoSelectFirstDeliverySlot' | 'referenceDate' | 'slots'
+>;
+
+export function DeliverySlotPickerStory({
+    autoSelectFirstDeliverySlot,
+    referenceDate,
+    slots,
+}: DeliverySlotPickerStoryProps) {
+    const [value, setValue] = useState<number>();
+
+    return (
+        <div className="w-[44rem] p-6">
+            <DeliverySlotPicker
+                autoFocus={false}
+                autoSelectFirstDeliverySlot={autoSelectFirstDeliverySlot}
+                referenceDate={referenceDate}
+                slots={slots}
+                value={value}
+                onValueChange={setValue}
+            />
+            <output data-testid="selected-delivery-slot">{value ?? ''}</output>
+        </div>
+    );
+}

--- a/apps/garden/tests/delivery-slot-picker.spec.tsx
+++ b/apps/garden/tests/delivery-slot-picker.spec.tsx
@@ -1,0 +1,83 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { DeliverySlotPickerStory } from './DeliverySlotPickerStory';
+
+const referenceDate = '2026-07-17T10:00:00.000Z';
+
+test('allows an open same-day slot while keeping missed days clickable', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <DeliverySlotPickerStory
+            autoSelectFirstDeliverySlot={false}
+            referenceDate={referenceDate}
+            slots={[
+                {
+                    disabled: true,
+                    endAt: '2026-07-16T10:00:00.000Z',
+                    fulfillment: 'delivery',
+                    id: 1,
+                    startAt: '2026-07-16T08:00:00.000Z',
+                },
+                {
+                    endAt: '2026-07-17T15:00:00.000Z',
+                    fulfillment: 'delivery',
+                    id: 2,
+                    startAt: '2026-07-17T13:00:00.000Z',
+                },
+            ]}
+        />,
+    );
+
+    const missedDay = page.getByRole('button', { name: /16\. srpnja/i });
+    await expect(missedDay).toBeEnabled();
+    await missedDay.click();
+    await expect(
+        page.getByRole('button', {
+            name: /10:00 – 12:00, dostava, nije dostupno/i,
+        }),
+    ).toBeDisabled();
+
+    const today = page.getByRole('button', { name: /17\. srpnja.*danas/i });
+    await expect(today).toBeEnabled();
+    await today.click();
+
+    const openSameDaySlot = page.getByRole('button', {
+        name: /15:00 – 17:00, dostava$/i,
+    });
+    await expect(openSameDaySlot).toBeEnabled();
+    await openSameDaySlot.click();
+    await expect(page.getByTestId('selected-delivery-slot')).toHaveText('2');
+});
+
+test('opens on the current week even when its slots are already missed', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <DeliverySlotPickerStory
+            autoSelectFirstDeliverySlot
+            referenceDate={referenceDate}
+            slots={[
+                {
+                    disabled: true,
+                    endAt: '2026-07-16T10:00:00.000Z',
+                    fulfillment: 'delivery',
+                    id: 1,
+                    startAt: '2026-07-16T08:00:00.000Z',
+                },
+                {
+                    endAt: '2026-07-20T10:00:00.000Z',
+                    fulfillment: 'delivery',
+                    id: 2,
+                    startAt: '2026-07-20T08:00:00.000Z',
+                },
+            ]}
+        />,
+    );
+
+    await expect(
+        page.getByText('Tjedan 13. srp – 19. srp 2026.'),
+    ).toBeVisible();
+    await expect(page.getByTestId('selected-delivery-slot')).toHaveText('');
+});

--- a/packages/game/src/hooks/timeSlotsQueryParams.ts
+++ b/packages/game/src/hooks/timeSlotsQueryParams.ts
@@ -1,0 +1,34 @@
+export interface TimeSlotsQueryParams {
+    type?: 'delivery' | 'pickup';
+    from?: string;
+    to?: string;
+    locationId?: number;
+    includeClosed?: boolean;
+    includeArchived?: boolean;
+}
+
+interface SerializedTimeSlotsQueryParams {
+    type?: 'delivery' | 'pickup';
+    from?: string;
+    to?: string;
+    locationId?: string;
+    includeClosed?: 'true';
+    includeArchived?: 'true';
+}
+
+export function serializeTimeSlotsQueryParams(
+    params?: TimeSlotsQueryParams,
+): SerializedTimeSlotsQueryParams {
+    if (!params) {
+        return {};
+    }
+
+    return {
+        type: params.type,
+        from: params.from,
+        to: params.to,
+        locationId: params.locationId?.toString(),
+        includeClosed: params.includeClosed ? 'true' : undefined,
+        includeArchived: params.includeArchived ? 'true' : undefined,
+    };
+}

--- a/packages/game/src/hooks/timeSlotsQueryParams.unit.ts
+++ b/packages/game/src/hooks/timeSlotsQueryParams.unit.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { serializeTimeSlotsQueryParams } from './timeSlotsQueryParams';
+
+test('requests closed and archived slots for historical week context', () => {
+    assert.deepEqual(
+        serializeTimeSlotsQueryParams({
+            from: '2026-07-13T00:00:00.000Z',
+            includeArchived: true,
+            includeClosed: true,
+            locationId: 4,
+            to: '2026-08-17T00:00:00.000Z',
+        }),
+        {
+            from: '2026-07-13T00:00:00.000Z',
+            includeArchived: 'true',
+            includeClosed: 'true',
+            locationId: '4',
+            to: '2026-08-17T00:00:00.000Z',
+            type: undefined,
+        },
+    );
+});

--- a/packages/game/src/hooks/useTimeSlots.ts
+++ b/packages/game/src/hooks/useTimeSlots.ts
@@ -1,28 +1,18 @@
 import { clientPublic } from '@gredice/client';
 import { useQuery } from '@tanstack/react-query';
+import {
+    serializeTimeSlotsQueryParams,
+    type TimeSlotsQueryParams,
+} from './timeSlotsQueryParams';
 
 export const timeSlotsQueryKey = ['delivery', 'timeSlots'];
 
-export function useTimeSlots(params?: {
-    type?: 'delivery' | 'pickup';
-    from?: string;
-    to?: string;
-    locationId?: number;
-}) {
+export function useTimeSlots(params?: TimeSlotsQueryParams) {
     return useQuery({
         queryKey: [...timeSlotsQueryKey, params],
         queryFn: async () => {
-            const queryParams = params
-                ? {
-                      type: params.type,
-                      from: params.from,
-                      to: params.to,
-                      locationId: params.locationId?.toString(),
-                  }
-                : {};
-
             const response = await clientPublic().api.delivery.slots.$get({
-                query: queryParams,
+                query: serializeTimeSlotsQueryParams(params),
             });
             if (response.status !== 200) {
                 throw new Error('Failed to fetch time slots');

--- a/packages/game/src/shared-ui/delivery/DeliverySlotPicker.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliverySlotPicker.tsx
@@ -22,6 +22,7 @@ export interface DeliverySlotPickerSlot {
     startAt: Date | string;
     endAt: Date | string;
     fulfillment: 'delivery' | 'pickup';
+    disabled?: boolean;
 }
 
 export interface DeliverySlotPickerProps {
@@ -141,10 +142,8 @@ export function DeliverySlotPicker({
         }),
         [locale, timeZone],
     );
-    const todayKey = dateKey(
-        formatters.dateKey,
-        referenceDate ? new Date(referenceDate) : initialDate,
-    );
+    const currentDate = referenceDate ? new Date(referenceDate) : initialDate;
+    const todayKey = dateKey(formatters.dateKey, currentDate);
     const days = useMemo(() => {
         const groupedDays = new Map<string, SlotDay>();
 
@@ -224,33 +223,25 @@ export function DeliverySlotPicker({
     const selectedSlotDayKey = selectedSlotDate
         ? dateKey(formatters.dateKey, selectedSlotDate)
         : undefined;
-    const availableSelectedSlotDayKey =
-        selectedSlotDayKey && selectedSlotDayKey > todayKey
-            ? selectedSlotDayKey
-            : undefined;
     const selectedSlotWeekKey =
-        selectedSlotDate && availableSelectedSlotDayKey
+        selectedSlotDate && selectedSlotDayKey
             ? weekKey(formatters.dateKey, selectedSlotDate)
             : undefined;
     const [preferredWeekKey, setPreferredWeekKey] = useState<string>();
     const [preferredDayKey, setPreferredDayKey] = useState<string>();
     const firstAvailableWeekKey = weeks.find((week) =>
-        week.days.some(
-            (day) =>
-                day.key > todayKey &&
-                day.slots.some((slot) => slot.fulfillment === 'delivery'),
+        week.days.some((day) =>
+            day.slots.some(
+                (slot) => slot.fulfillment === 'delivery' && !slot.disabled,
+            ),
         ),
     )?.key;
-    const firstFutureWeekKey = weeks.find((week) =>
-        week.days.some((day) => day.key > todayKey),
-    )?.key;
+    const currentWeekKey = weekKey(formatters.dateKey, currentDate);
     const selectedWeekKey =
         selectedSlotWeekKey ??
         weeks.find((week) => week.key === preferredWeekKey)?.key ??
-        (autoSelectFirstDeliverySlot
-            ? firstAvailableWeekKey
-            : firstFutureWeekKey) ??
-        firstFutureWeekKey ??
+        weeks.find((week) => week.key === currentWeekKey)?.key ??
+        firstAvailableWeekKey ??
         weeks[0]?.key;
     const selectedWeekIndex = Math.max(
         weeks.findIndex((week) => week.key === selectedWeekKey),
@@ -258,22 +249,22 @@ export function DeliverySlotPicker({
     );
     const selectedWeek = weeks[selectedWeekIndex];
     const selectedDayKey =
-        availableSelectedSlotDayKey ??
-        selectedWeek?.days.find(
-            (day) => day.key === preferredDayKey && day.key > todayKey,
-        )?.key ??
+        selectedSlotDayKey ??
+        selectedWeek?.days.find((day) => day.key === preferredDayKey)?.key ??
         (autoSelectFirstDeliverySlot
-            ? selectedWeek?.days.find(
-                  (day) =>
-                      day.key > todayKey &&
-                      day.slots.some((slot) => slot.fulfillment === 'delivery'),
+            ? selectedWeek?.days.find((day) =>
+                  day.slots.some(
+                      (slot) =>
+                          slot.fulfillment === 'delivery' && !slot.disabled,
+                  ),
               )?.key
             : undefined) ??
-        selectedWeek?.days.find((day) => day.key > todayKey)?.key;
+        selectedWeek?.days.find((day) => day.key === todayKey)?.key ??
+        selectedWeek?.days[0]?.key;
     const selectedDay = selectedWeek?.days.find(
         (day) => day.key === selectedDayKey,
     );
-    const focusTargetKey = availableSelectedSlotDayKey
+    const focusTargetKey = selectedSlotDayKey
         ? `slot-${value?.toString()}`
         : selectedDayKey
           ? `day-${selectedDayKey}`
@@ -281,7 +272,7 @@ export function DeliverySlotPicker({
     const focusTargetRef = useRef<HTMLButtonElement>(null);
     const autoSelectedSlotRef = useRef<number | undefined>(undefined);
     const firstAvailableDeliverySlotId = selectedDay?.slots.find(
-        (slot) => slot.fulfillment === 'delivery',
+        (slot) => slot.fulfillment === 'delivery' && !slot.disabled,
     )?.id;
 
     useEffect(() => {
@@ -325,15 +316,15 @@ export function DeliverySlotPicker({
         setPreferredWeekKey(nextWeek.key);
         setPreferredDayKey(
             (autoSelectFirstDeliverySlot
-                ? nextWeek.days.find(
-                      (day) =>
-                          day.key > todayKey &&
-                          day.slots.some(
-                              (slot) => slot.fulfillment === 'delivery',
-                          ),
+                ? nextWeek.days.find((day) =>
+                      day.slots.some(
+                          (slot) =>
+                              slot.fulfillment === 'delivery' && !slot.disabled,
+                      ),
                   )?.key
                 : undefined) ??
-                nextWeek.days.find((day) => day.key > todayKey)?.key,
+                nextWeek.days.find((day) => day.key === todayKey)?.key ??
+                nextWeek.days[0]?.key,
         );
 
         if (selectedSlotWeekKey && selectedSlotWeekKey !== nextWeek.key) {
@@ -447,7 +438,6 @@ export function DeliverySlotPicker({
                             {selectedWeek.days.map((day) => {
                                 const isSelected = day.key === selectedDay?.key;
                                 const isToday = day.key === todayKey;
-                                const isUnavailable = day.key <= todayKey;
 
                                 return (
                                     <button
@@ -455,20 +445,17 @@ export function DeliverySlotPicker({
                                         aria-current={
                                             isToday ? 'date' : undefined
                                         }
-                                        aria-label={`${formatters.fullDate.format(day.date)}, ${slotCountLabel(day.slots.length)}${isToday ? ', danas' : ''}${isUnavailable ? ', nije dostupno' : ''}`}
+                                        aria-label={`${formatters.fullDate.format(day.date)}, ${slotCountLabel(day.slots.length)}${isToday ? ', danas' : ''}`}
                                         aria-pressed={isSelected}
                                         className={cx(
                                             'relative flex min-h-[5.5rem] min-w-[5rem] flex-1 flex-col items-center justify-center rounded-lg border px-2.5 py-2 text-center transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-not-allowed',
                                             isSelected
                                                 ? 'border-primary bg-primary/10 text-primary ring-1 ring-inset ring-primary/40'
                                                 : 'border-border bg-background text-foreground hover:border-primary/50 hover:bg-muted/50',
-                                            isUnavailable &&
-                                                'border-border/60 bg-muted/30 text-foreground/50 hover:border-border/60 hover:bg-muted/30',
                                         )}
-                                        disabled={disabled || isUnavailable}
+                                        disabled={disabled}
                                         ref={
-                                            !availableSelectedSlotDayKey &&
-                                            isSelected
+                                            !selectedSlotDayKey && isSelected
                                                 ? focusTargetRef
                                                 : undefined
                                         }
@@ -495,8 +482,6 @@ export function DeliverySlotPicker({
                                                 'absolute right-1.5 top-1.5 flex size-5 items-center justify-center rounded-full bg-muted text-[0.6rem] font-bold text-foreground/70',
                                                 isSelected &&
                                                     'bg-primary text-primary-foreground',
-                                                isUnavailable &&
-                                                    'bg-muted-foreground/10 text-foreground/50',
                                             )}
                                         >
                                             {day.slots.length}
@@ -558,6 +543,12 @@ export function DeliverySlotPicker({
                                 </legend>
                                 {selectedDay.slots.map((slot) => {
                                     const isSelected = slot.id === value;
+                                    const startAtLabel = formatters.time.format(
+                                        new Date(slot.startAt),
+                                    );
+                                    const endAtLabel = formatters.time.format(
+                                        new Date(slot.endAt),
+                                    );
                                     const FulfillmentIcon =
                                         slot.fulfillment === 'delivery'
                                             ? Truck
@@ -570,6 +561,7 @@ export function DeliverySlotPicker({
                                     return (
                                         <button
                                             key={slot.id}
+                                            aria-label={`${startAtLabel} – ${endAtLabel}, ${fulfillmentLabel}${slot.disabled ? ', nije dostupno' : ''}`}
                                             aria-pressed={isSelected}
                                             className={cx(
                                                 'flex min-h-14 items-center gap-2 rounded-lg border px-3 py-2 text-sm tabular-nums transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
@@ -577,7 +569,7 @@ export function DeliverySlotPicker({
                                                     ? 'border-primary bg-primary/10 text-primary ring-1 ring-inset ring-primary/40'
                                                     : 'border-border bg-background text-foreground hover:border-primary/60 hover:bg-primary/5',
                                             )}
-                                            disabled={disabled}
+                                            disabled={disabled || slot.disabled}
                                             ref={
                                                 isSelected
                                                     ? focusTargetRef
@@ -598,13 +590,15 @@ export function DeliverySlotPicker({
                                             />
                                             <span className="min-w-0 flex-1 text-left">
                                                 <span className="block whitespace-nowrap font-semibold">
-                                                    {formatters.time.format(
-                                                        new Date(slot.startAt),
-                                                    )}{' '}
-                                                    –{' '}
-                                                    {formatters.time.format(
-                                                        new Date(slot.endAt),
-                                                    )}
+                                                    <span
+                                                        className={cx(
+                                                            slot.disabled &&
+                                                                'line-through',
+                                                        )}
+                                                    >
+                                                        {startAtLabel} –{' '}
+                                                        {endAtLabel}
+                                                    </span>
                                                 </span>
                                                 <span
                                                     className={cx(
@@ -615,6 +609,8 @@ export function DeliverySlotPicker({
                                                     )}
                                                 >
                                                     {fulfillmentLabel}
+                                                    {slot.disabled &&
+                                                        ' · Nije dostupno'}
                                                 </span>
                                             </span>
                                             {isSelected && (

--- a/packages/game/src/shared-ui/delivery/DeliveryStep.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliveryStep.tsx
@@ -19,6 +19,7 @@ import {
     DeliverySlotPicker,
     type DeliverySlotPickerSlot,
 } from './DeliverySlotPicker';
+import { isDeliverySlotAvailable } from './deliverySlotAvailability';
 
 export interface DeliverySelectionData {
     mode: 'delivery' | 'pickup';
@@ -48,24 +49,30 @@ export function DeliveryStep({
     });
     const [manageAddresses, setManageAddresses] = useState(false);
     const [slotRange] = useState(() => {
-        const from = new Date();
+        const referenceDate = new Date();
+        const from = new Date(referenceDate);
         const daysFromMonday = (from.getDay() + 6) % 7;
         from.setDate(from.getDate() - daysFromMonday);
         from.setHours(0, 0, 0, 0);
 
-        const to = new Date();
+        const to = new Date(referenceDate);
         to.setMonth(to.getMonth() + 1);
 
         return {
             from: from.toISOString(),
+            referenceDate: referenceDate.toISOString(),
             to: to.toISOString(),
         };
     });
     const { data: cart } = useShoppingCart();
     const { data: addresses, isLoading: isLoadingAddresses } =
         useDeliveryAddresses();
-    const { data: timeSlots, isLoading: slotsLoading } =
-        useTimeSlots(slotRange);
+    const { data: timeSlots, isLoading: slotsLoading } = useTimeSlots({
+        from: slotRange.from,
+        includeArchived: true,
+        includeClosed: true,
+        to: slotRange.to,
+    });
     const pickerSlots = useMemo<DeliverySlotPickerSlot[]>(
         () =>
             (timeSlots ?? []).flatMap((slot) => {
@@ -79,10 +86,14 @@ export function DeliveryStep({
                         startAt: slot.startAt,
                         endAt: slot.endAt,
                         fulfillment: slot.type,
+                        disabled: !isDeliverySlotAvailable(
+                            slot,
+                            slotRange.referenceDate,
+                        ),
                     },
                 ];
             }),
-        [timeSlots],
+        [slotRange.referenceDate, timeSlots],
     );
     const selectedTimeSlot = timeSlots?.find(
         (slot) => slot.id === selection.slotId,
@@ -190,6 +201,7 @@ export function DeliveryStep({
                 emptyMessage="Trenutno nema dostupnih termina dostave ili osobnog preuzimanja."
                 label={null}
                 loading={slotsLoading}
+                referenceDate={slotRange.referenceDate}
                 slots={pickerSlots}
                 value={selection.slotId}
                 onValueChange={handleSlotChange}

--- a/packages/game/src/shared-ui/delivery/deliverySlotAvailability.ts
+++ b/packages/game/src/shared-ui/delivery/deliverySlotAvailability.ts
@@ -1,0 +1,18 @@
+interface DeliverySlotAvailability {
+    effectiveClosesAt: Date | string;
+    startAt: Date | string;
+    status: string;
+}
+
+export function isDeliverySlotAvailable(
+    slot: DeliverySlotAvailability,
+    referenceDate: Date | string,
+) {
+    const referenceTime = new Date(referenceDate).getTime();
+
+    return (
+        slot.status === 'scheduled' &&
+        new Date(slot.startAt).getTime() > referenceTime &&
+        new Date(slot.effectiveClosesAt).getTime() > referenceTime
+    );
+}

--- a/packages/game/src/shared-ui/delivery/deliverySlotAvailability.unit.ts
+++ b/packages/game/src/shared-ui/delivery/deliverySlotAvailability.unit.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { isDeliverySlotAvailable } from './deliverySlotAvailability';
+
+const referenceDate = new Date('2026-07-17T10:00:00.000Z');
+
+test('keeps an explicitly open same-day slot available before it starts', () => {
+    assert.equal(
+        isDeliverySlotAvailable(
+            {
+                effectiveClosesAt: '2026-07-17T11:00:00.000Z',
+                startAt: '2026-07-17T12:00:00.000Z',
+                status: 'scheduled',
+            },
+            referenceDate,
+        ),
+        true,
+    );
+});
+
+test('disables closed, expired, and already-started slots', () => {
+    const futureSlot = {
+        effectiveClosesAt: '2026-07-17T11:00:00.000Z',
+        startAt: '2026-07-17T12:00:00.000Z',
+        status: 'scheduled',
+    };
+
+    assert.equal(
+        isDeliverySlotAvailable(
+            { ...futureSlot, status: 'closed' },
+            referenceDate,
+        ),
+        false,
+    );
+    assert.equal(
+        isDeliverySlotAvailable(
+            {
+                ...futureSlot,
+                effectiveClosesAt: '2026-07-17T09:00:00.000Z',
+            },
+            referenceDate,
+        ),
+        false,
+    );
+    assert.equal(
+        isDeliverySlotAvailable(
+            { ...futureSlot, startAt: '2026-07-17T09:00:00.000Z' },
+            referenceDate,
+        ),
+        false,
+    );
+});


### PR DESCRIPTION
## Summary

- fetch closed and archived delivery slots from the start of the current week so missed slots remain visible for context
- keep every displayed day clickable and disable only slots that are closed, expired, or already started
- allow explicitly open same-day slots and keep the current week as the initial view
- add unit and browser component regressions for same-day selection and historical week navigation

## Root cause

The garden delivery picker disabled every day whose calendar date was today or earlier. That made a deliberately reopened slot later today impossible to select. The checkout request also fetched only scheduled slots, so closed and archived slots from earlier in the week disappeared instead of providing the same context as the public delivery-slots page.

## User impact

Users can now select any still-open slot later today. They can also browse the full set of displayed slot days for the current week and review missed slots without those historical slots becoming selectable.

## Validation

- `corepack pnpm --filter @gredice/game test`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter garden typecheck`
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/delivery-slot-picker.spec.tsx --project=chromium`
- file-scoped Biome checks and `git diff --check`
