### PR TITLE
feat(checkout): increase minimum cart amount to €1

### DIFF
--- a/apps/api/MCP_README.md
+++ b/apps/api/MCP_README.md
@@ -152,7 +152,7 @@ Handles shopping cart management, dual currency support, and checkout processes.
 - **Primary**: EUR (Euro)
 - **Secondary**: 🌻 (Sunflowers)
 - **Exchange Rate**: 1 EUR = 1000 🌻
-- **Minimum Cart**: €0.50
+- **Minimum Cart**: €1.00
 - **Sunflower Earning**: 10 🌻 per 1 EUR spent
 
 ### 4. Accounts MCP Server

--- a/apps/api/lib/checkout/cartInfo.node.spec.ts
+++ b/apps/api/lib/checkout/cartInfo.node.spec.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
     getAbandonedRaisedBedCartNote,
+    getMinimumOrderNote,
     getNewRaisedBedPlantingNote,
 } from './cartInfo';
 
@@ -27,5 +28,20 @@ describe('getAbandonedRaisedBedCartNote', () => {
             getAbandonedRaisedBedCartNote('Gredica 12'),
             'Gredica 12 je napuštena zbog neaktivnosti. Nove sjetve i radnje više nisu dostupne za ovu gredicu.',
         );
+    });
+});
+
+describe('getMinimumOrderNote', () => {
+    it('blocks positive EUR totals below one euro', () => {
+        assert.strictEqual(
+            getMinimumOrderNote(0.99),
+            'Minimalna vrijednost narudžbe je 1 €.',
+        );
+    });
+
+    it('allows an empty EUR total and totals of at least one euro', () => {
+        assert.strictEqual(getMinimumOrderNote(0), null);
+        assert.strictEqual(getMinimumOrderNote(1), null);
+        assert.strictEqual(getMinimumOrderNote(1.01), null);
     });
 });

--- a/apps/api/lib/checkout/cartInfo.ts
+++ b/apps/api/lib/checkout/cartInfo.ts
@@ -2,6 +2,7 @@ import {
     isRaisedBedAbandoned,
     RAISED_BED_ABANDONED_ACTIONS_DISABLED_MESSAGE,
 } from '@gredice/js/raisedBeds';
+import { minimumShoppingCartAmountEur } from '@gredice/js/shoppingCart';
 import {
     type EntityStandardized,
     getEntitiesFormatted,
@@ -79,6 +80,17 @@ export function getAbandonedRaisedBedCartNote(raisedBedName?: string | null) {
     const prefix = raisedBedName?.trim() ? raisedBedName.trim() : 'Gredica';
 
     return `${prefix} je napuštena zbog neaktivnosti. ${RAISED_BED_ABANDONED_ACTIONS_DISABLED_MESSAGE}`;
+}
+
+export function getMinimumOrderNote(totalCartValueEur: number) {
+    if (
+        totalCartValueEur <= 0 ||
+        totalCartValueEur >= minimumShoppingCartAmountEur
+    ) {
+        return null;
+    }
+
+    return `Minimalna vrijednost narudžbe je ${minimumShoppingCartAmountEur} €.`;
 }
 
 export async function getCartInfo(
@@ -357,7 +369,6 @@ export async function getCartInfo(
         allowPurchase = false;
     }
 
-    // Minimum order (0.5 EUR)
     const totalCartValue = cartItemsWithShopInfo.reduce((sum, item) => {
         if (item.status !== 'paid' && item.currency === 'eur') {
             const price =
@@ -366,8 +377,9 @@ export async function getCartInfo(
         }
         return sum;
     }, 0);
-    if (totalCartValue > 0 && totalCartValue < 0.5) {
-        notes.push('Minimalna vrijednost narudžbe je 0,50 €.');
+    const minimumOrderNote = getMinimumOrderNote(totalCartValue);
+    if (minimumOrderNote) {
+        notes.push(minimumOrderNote);
         allowPurchase = false;
     }
     // --- End notes logic ---

--- a/apps/www/app/cjenik/page.tsx
+++ b/apps/www/app/cjenik/page.tsx
@@ -1,3 +1,4 @@
+import { minimumShoppingCartAmountEur } from '@gredice/js/shoppingCart';
 import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
@@ -349,6 +350,10 @@ export default async function PricingPage() {
                                     Nije dostupno
                                 </Chip>
                             </div>
+                            <Typography level="body3" secondary>
+                                Minimalna vrijednost narudžbe iznosi{' '}
+                                {formatPrice(minimumShoppingCartAmountEur)}.
+                            </Typography>
                             <Typography level="body3" secondary>
                                 Interne radnje namijenjene su OPG partnerima i
                                 ne naplaćuju se. Cijena 0 € za biljku, sortu ili

--- a/packages/js/src/shoppingCart/index.ts
+++ b/packages/js/src/shoppingCart/index.ts
@@ -1,0 +1,1 @@
+export const minimumShoppingCartAmountEur = 1;


### PR DESCRIPTION
## Summary

- raise the shared minimum EUR shopping-cart amount from €0.50 to €1
- enforce and test the checkout boundary, including allowing exactly €1
- document the €1 minimum on the public pricing page and in the MCP commerce reference

## Validation

- `corepack pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/checkout/cartInfo.node.spec.ts`
- `corepack pnpm --filter api build`
- `corepack pnpm --filter www typecheck`
- `corepack pnpm --filter www build`
- workspace-local Biome checks for all changed TypeScript files
- `git diff --check origin/main...HEAD`