### PR TITLE
feat(farm): group harvest tasks at top of schedule

### DIFF
--- a/apps/farm/app/schedule/FarmScheduleDay.tsx
+++ b/apps/farm/app/schedule/FarmScheduleDay.tsx
@@ -11,6 +11,12 @@ import type {
     getFarmSchedulePlantSorts,
 } from './scheduleData';
 import { getFarmScheduleRaisedBedPhotoPreviewsForDay } from './scheduleData';
+import type { FarmScheduleOperationsMode } from './scheduleShared';
+
+const priorityOperationModes = [
+    'watering',
+    'harvest',
+] satisfies FarmScheduleOperationsMode[];
 
 interface FarmScheduleDayProps {
     accountId: string;
@@ -21,7 +27,7 @@ interface FarmScheduleDayProps {
         typeof import('./scheduleData').getFarmScheduleOperationsData
     >;
     plantSortsPromise: ReturnType<typeof getFarmSchedulePlantSorts>;
-    groupWateringOperations: boolean;
+    groupPriorityOperations: boolean;
     selectedDateKey: string;
     sessionIncarnation: string;
     userId: string;
@@ -34,7 +40,7 @@ export function FarmScheduleDay({
     operationsDataPromise,
     plantingsDayDataPromise,
     plantSortsPromise,
-    groupWateringOperations,
+    groupPriorityOperations,
     selectedDateKey,
     sessionIncarnation,
     userId,
@@ -47,23 +53,27 @@ export function FarmScheduleDay({
             <Suspense fallback={null}>
                 <FarmScheduleEmptyState dayDataPromise={dayDataPromise} />
             </Suspense>
-            {groupWateringOperations && (
-                <Suspense fallback={<FarmScheduleSectionSkeleton />}>
-                    <FarmScheduleOperationsSectionContent
-                        accountId={accountId}
-                        dayDataPromise={operationsDayDataPromise}
-                        plantSortsPromise={plantSortsPromise}
-                        operationsDataPromise={operationsDataPromise}
-                        raisedBedPhotoPreviewByIdPromise={
-                            raisedBedPhotoPreviewByIdPromise
-                        }
-                        mode="watering"
-                        selectedDateKey={selectedDateKey}
-                        sessionIncarnation={sessionIncarnation}
-                        userId={userId}
-                    />
-                </Suspense>
-            )}
+            {groupPriorityOperations &&
+                priorityOperationModes.map((mode) => (
+                    <Suspense
+                        key={mode}
+                        fallback={<FarmScheduleSectionSkeleton />}
+                    >
+                        <FarmScheduleOperationsSectionContent
+                            accountId={accountId}
+                            dayDataPromise={operationsDayDataPromise}
+                            plantSortsPromise={plantSortsPromise}
+                            operationsDataPromise={operationsDataPromise}
+                            raisedBedPhotoPreviewByIdPromise={
+                                raisedBedPhotoPreviewByIdPromise
+                            }
+                            mode={mode}
+                            selectedDateKey={selectedDateKey}
+                            sessionIncarnation={sessionIncarnation}
+                            userId={userId}
+                        />
+                    </Suspense>
+                ))}
             <Suspense fallback={<FarmScheduleSectionSkeleton />}>
                 <FarmSchedulePlantingsSectionContent
                     dayDataPromise={plantingsDayDataPromise}
@@ -84,7 +94,11 @@ export function FarmScheduleDay({
                     raisedBedPhotoPreviewByIdPromise={
                         raisedBedPhotoPreviewByIdPromise
                     }
-                    mode={groupWateringOperations ? 'withoutWatering' : 'all'}
+                    mode={
+                        groupPriorityOperations
+                            ? 'withoutGroupedOperations'
+                            : 'all'
+                    }
                     selectedDateKey={selectedDateKey}
                     sessionIncarnation={sessionIncarnation}
                     userId={userId}

--- a/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
@@ -153,8 +153,8 @@ export function FarmScheduleOperationsSection({
         0,
     );
 
-    if (mode === 'watering') {
-        const wateringOperations = raisedBedGroups.flatMap(
+    if (mode === 'harvest' || mode === 'watering') {
+        const groupedOperations = raisedBedGroups.flatMap(
             ({ physicalId, raisedBeds: groupedRaisedBeds }) => {
                 const raisedBedLabel = physicalId
                     ? `Gr ${physicalId}`
@@ -196,23 +196,24 @@ export function FarmScheduleOperationsSection({
                     });
             },
         );
-        const wateringTotalDuration = wateringOperations.reduce(
+        const groupedTotalDuration = groupedOperations.reduce(
             (sum, operation) => sum + operation.durationMinutes,
             0,
         );
+        const sectionTitle = mode === 'harvest' ? 'Berba' : 'Zalijevanje';
 
         return (
             <Stack spacing={2}>
                 <Row spacing={2} className="items-center flex-wrap gap-y-1">
-                    <Typography semiBold>Zalijevanje</Typography>
+                    <Typography semiBold>{sectionTitle}</Typography>
                     <ScheduleSectionSummaryBadges
-                        count={wateringOperations.length}
+                        count={groupedOperations.length}
                         countLabel="zadataka"
-                        durationMinutes={wateringTotalDuration}
+                        durationMinutes={groupedTotalDuration}
                     />
                 </Row>
                 <Stack spacing={2}>
-                    {wateringOperations.map((operation) => (
+                    {groupedOperations.map((operation) => (
                         <FarmScheduleOperationTaskCard
                             key={operation.id}
                             completionAction={

--- a/apps/farm/app/schedule/page.tsx
+++ b/apps/farm/app/schedule/page.tsx
@@ -101,7 +101,7 @@ async function FarmScheduleContent({
                 operationsDayDataPromise={operationsDayDataPromise}
                 operationsDataPromise={operationsDataPromise}
                 plantSortsPromise={plantSortsPromise}
-                groupWateringOperations={
+                groupPriorityOperations={
                     user?.farmScheduleGroupedWateringEnabled ?? true
                 }
                 sessionIncarnation={sessionIncarnation}

--- a/apps/farm/app/schedule/scheduleShared.spec.ts
+++ b/apps/farm/app/schedule/scheduleShared.spec.ts
@@ -1,6 +1,7 @@
 import type { EntityStandardized } from '@gredice/storage';
 import { expect, test } from '@playwright/test';
 import {
+    isHarvestOperationData,
     isWateringOperationData,
     shouldDisplayScheduleOperation,
 } from './scheduleShared';
@@ -9,6 +10,20 @@ const wateringOperationData = {
     id: 167,
     attributes: {
         visualReward: 'watering',
+        stage: {
+            id: 1,
+            information: {
+                name: 'maintenance',
+                label: 'Održavanje',
+            },
+        },
+    },
+} satisfies EntityStandardized;
+
+const harvestOperationData = {
+    id: 169,
+    attributes: {
+        visualReward: 'harvest',
         stage: {
             id: 1,
             information: {
@@ -38,7 +53,13 @@ test('identifies watering from its visual reward regardless of plant stage', () 
     expect(isWateringOperationData(undefined)).toBe(false);
 });
 
-test('moves only raised-bed watering into the grouped schedule section', () => {
+test('identifies harvest from its visual reward regardless of plant stage', () => {
+    expect(isHarvestOperationData(harvestOperationData)).toBe(true);
+    expect(isHarvestOperationData(maintenanceOperationData)).toBe(false);
+    expect(isHarvestOperationData(undefined)).toBe(false);
+});
+
+test('moves only raised-bed watering and harvest into grouped schedule sections', () => {
     const raisedBedOperation = { raisedBedId: 42 };
     const farmOperation = { raisedBedId: null };
 
@@ -53,21 +74,42 @@ test('moves only raised-bed watering into the grouped schedule section', () => {
         shouldDisplayScheduleOperation(
             raisedBedOperation,
             wateringOperationData,
-            'withoutWatering',
+            'withoutGroupedOperations',
+        ),
+    ).toBe(false);
+    expect(
+        shouldDisplayScheduleOperation(
+            raisedBedOperation,
+            harvestOperationData,
+            'harvest',
+        ),
+    ).toBe(true);
+    expect(
+        shouldDisplayScheduleOperation(
+            raisedBedOperation,
+            harvestOperationData,
+            'watering',
+        ),
+    ).toBe(false);
+    expect(
+        shouldDisplayScheduleOperation(
+            raisedBedOperation,
+            harvestOperationData,
+            'withoutGroupedOperations',
         ),
     ).toBe(false);
     expect(
         shouldDisplayScheduleOperation(
             raisedBedOperation,
             maintenanceOperationData,
-            'withoutWatering',
+            'withoutGroupedOperations',
         ),
     ).toBe(true);
     expect(
         shouldDisplayScheduleOperation(
             farmOperation,
-            wateringOperationData,
-            'withoutWatering',
+            harvestOperationData,
+            'withoutGroupedOperations',
         ),
     ).toBe(true);
 });

--- a/apps/farm/app/schedule/scheduleShared.ts
+++ b/apps/farm/app/schedule/scheduleShared.ts
@@ -6,7 +6,11 @@ type FarmRaisedBedField = FarmRaisedBed['fields'][number];
 type FarmOperation = FarmScheduleDayData['scheduledOperations'][number];
 type ScheduleTaskAgeIndicatorLevel = 'warning' | 'critical';
 
-export type FarmScheduleOperationsMode = 'all' | 'watering' | 'withoutWatering';
+export type FarmScheduleOperationsMode =
+    | 'all'
+    | 'harvest'
+    | 'watering'
+    | 'withoutGroupedOperations';
 
 const RAISED_BED_FIELDS_PER_BLOCK = 9;
 export const FARM_SCHEDULE_TIME_ZONE = 'Europe/Zagreb';
@@ -206,12 +210,27 @@ export function isWateringOperationData(
     return operationData?.attributes?.visualReward === 'watering';
 }
 
+export function isHarvestOperationData(
+    operationData: EntityStandardized | undefined,
+) {
+    return operationData?.attributes?.visualReward === 'harvest';
+}
+
 export function isGroupedWateringScheduleOperation(
     operation: Pick<FarmOperation, 'raisedBedId'>,
     operationData: EntityStandardized | undefined,
 ) {
     return (
         operation.raisedBedId !== null && isWateringOperationData(operationData)
+    );
+}
+
+export function isGroupedHarvestScheduleOperation(
+    operation: Pick<FarmOperation, 'raisedBedId'>,
+    operationData: EntityStandardized | undefined,
+) {
+    return (
+        operation.raisedBedId !== null && isHarvestOperationData(operationData)
     );
 }
 
@@ -224,13 +243,21 @@ export function shouldDisplayScheduleOperation(
         operation,
         operationData,
     );
+    const isGroupedHarvest = isGroupedHarvestScheduleOperation(
+        operation,
+        operationData,
+    );
+
+    if (mode === 'harvest') {
+        return isGroupedHarvest;
+    }
 
     if (mode === 'watering') {
         return isGroupedWatering;
     }
 
-    if (mode === 'withoutWatering') {
-        return !isGroupedWatering;
+    if (mode === 'withoutGroupedOperations') {
+        return !isGroupedHarvest && !isGroupedWatering;
     }
 
     return true;

--- a/apps/farm/app/settings/_components/FarmSchedulePreferences.tsx
+++ b/apps/farm/app/settings/_components/FarmSchedulePreferences.tsx
@@ -42,8 +42,8 @@ export function FarmSchedulePreferences({
                             <Switch
                                 checked={enabled}
                                 disabled={isPending}
-                                label="Grupiraj zalijevanje"
-                                description="Prikaži zadatke zalijevanja gredica u zasebnoj grupi na vrhu rasporeda."
+                                label="Grupiraj zalijevanje i berbu"
+                                description="Prikaži zadatke zalijevanja i berbe gredica u zasebnim grupama na vrhu rasporeda."
                                 onCheckedChange={setEnabled}
                             />
                             <Button


### PR DESCRIPTION
## What changed

- add a dedicated `Berba` section beside the existing top-level watering group
- classify raised-bed harvest tasks through the existing `visualReward` operation metadata and remove them from their raised-bed sections when grouping is enabled
- update the Farm schedule preference copy to cover both watering and harvest
- add regression coverage for watering/harvest classification and fallback behavior

## Why

Harvest work was mixed into individual raised-bed sections, making time-sensitive harvesting tasks harder to scan across the daily schedule.

## User impact

Farmers with schedule grouping enabled now see watering first and harvest immediately after it at the top of the schedule. The existing preference still allows the grouped layout to be disabled.

## Validation

- `corepack pnpm --filter farm test:prepare`
- Farm Playwright suite: 362 passed
- `corepack pnpm exec playwright test app/schedule/scheduleShared.spec.ts`: 3 passed
- targeted Biome checks
- `git diff --check`