### PR TITLE
fix(farm): improve greenhouse mobile layout

### DIFF
--- a/apps/farm/app/greenhouse/GreenhouseMobilePlantList.spec.tsx
+++ b/apps/farm/app/greenhouse/GreenhouseMobilePlantList.spec.tsx
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import '../globals.css';
+import { Card } from '@gredice/ui/Card';
+import { GreenhouseMobilePlantList } from './GreenhouseMobilePlantList';
+
+const phoneViewports = [
+    { width: 320, height: 568 },
+    { width: 375, height: 667 },
+    { width: 430, height: 932 },
+] as const;
+
+const longPlantName = 'Paprika žuta slatka vrlo dugog naziva';
+
+function greenhouseList() {
+    return (
+        <div className="p-4">
+            <Card>
+                <GreenhouseMobilePlantList
+                    items={[
+                        {
+                            germinationDate: '03. 07. 2026.',
+                            key: 'field-5',
+                            plantName: longPlantName,
+                            plantSort: undefined,
+                            positionNumber: 5,
+                            sowingDate: (
+                                <div className="space-y-0.5">
+                                    <span>25. 06. 2026.</span>
+                                    <div className="text-sm text-muted-foreground">
+                                        8 dana do klijanja
+                                    </div>
+                                </div>
+                            ),
+                            statusColor: 'success',
+                            statusEmoji: '🌱',
+                            statusLabel: 'Proklijalo',
+                        },
+                    ]}
+                />
+            </Card>
+        </div>
+    );
+}
+
+for (const viewport of phoneViewports) {
+    test(`keeps greenhouse seedling details readable at ${viewport.width}px`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize(viewport);
+        const component = await mount(greenhouseList());
+
+        await expect(component.getByText('Polje 5')).toBeVisible();
+        await expect(component.getByText(longPlantName)).toBeVisible();
+        await expect(component.getByText('Proklijalo')).toHaveCount(2);
+        await expect(component.getByText('Posijano')).toBeVisible();
+        await expect(component.getByText('8 dana do klijanja')).toBeVisible();
+
+        const plantNameWidth = await component
+            .locator('[data-greenhouse-plant-name]')
+            .evaluate((element) => element.getBoundingClientRect().width);
+        expect(plantNameWidth).toBeGreaterThan(100);
+
+        expect(
+            await page.evaluate(
+                () =>
+                    document.documentElement.scrollWidth <=
+                    document.documentElement.clientWidth,
+            ),
+        ).toBe(true);
+    });
+}
+
+test('hides the mobile list at the desktop table breakpoint', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    const component = await mount(greenhouseList());
+
+    await expect(
+        component.locator('[data-greenhouse-mobile-list]'),
+    ).toBeHidden();
+});

--- a/apps/farm/app/greenhouse/GreenhouseMobilePlantList.tsx
+++ b/apps/farm/app/greenhouse/GreenhouseMobilePlantList.tsx
@@ -1,0 +1,91 @@
+import type { EntityStandardized } from '@gredice/storage';
+import { CardOverflow } from '@gredice/ui/Card';
+import { Chip, type ColorPaletteProp } from '@gredice/ui/Chip';
+import { PlantOrSortImage } from '@gredice/ui/plants';
+import { Typography } from '@gredice/ui/Typography';
+import type { ReactNode } from 'react';
+
+export type GreenhouseMobilePlantListItem = {
+    germinationDate: string;
+    key: string;
+    plantName: string;
+    plantSort: EntityStandardized | undefined;
+    positionNumber: number;
+    sowingDate: ReactNode;
+    statusColor: ColorPaletteProp;
+    statusEmoji: string;
+    statusLabel: string;
+};
+
+export function GreenhouseMobilePlantList({
+    items,
+}: {
+    items: GreenhouseMobilePlantListItem[];
+}) {
+    return (
+        <CardOverflow className="md:hidden" data-greenhouse-mobile-list>
+            <div className="divide-y border-t">
+                {items.map((item) => (
+                    <div className="space-y-3 p-4" key={item.key}>
+                        <div className="flex min-w-0 items-start gap-3">
+                            <div className="relative size-12 shrink-0 overflow-hidden rounded-md border bg-muted/30">
+                                <PlantOrSortImage
+                                    plantSort={item.plantSort}
+                                    alt={item.plantName}
+                                    width={48}
+                                    height={48}
+                                    className="size-12 object-cover"
+                                />
+                            </div>
+                            <div className="min-w-0 flex-1 space-y-2">
+                                <div className="min-w-0">
+                                    <Typography
+                                        level="body3"
+                                        className="text-muted-foreground"
+                                    >
+                                        Polje {item.positionNumber}
+                                    </Typography>
+                                    <Typography
+                                        level="body1"
+                                        semiBold
+                                        className="break-words"
+                                        data-greenhouse-plant-name
+                                    >
+                                        {item.plantName}
+                                    </Typography>
+                                </div>
+                                <Chip
+                                    color={item.statusColor}
+                                    size="sm"
+                                    startDecorator={
+                                        <span aria-hidden="true">
+                                            {item.statusEmoji}
+                                        </span>
+                                    }
+                                >
+                                    {item.statusLabel}
+                                </Chip>
+                            </div>
+                        </div>
+                        <dl className="grid grid-cols-2 gap-3 border-t pt-3">
+                            <div className="min-w-0 space-y-1">
+                                <dt className="text-sm text-muted-foreground">
+                                    Posijano
+                                </dt>
+                                <dd className="text-sm">{item.sowingDate}</dd>
+                            </div>
+                            <div className="min-w-0 space-y-1">
+                                <dt className="text-sm text-muted-foreground">
+                                    Proklijalo
+                                </dt>
+                                <dd className="text-sm tabular-nums">
+                                    {item.germinationDate}
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                ))}
+            </div>
+        </CardOverflow>
+    );
+}

--- a/apps/farm/app/greenhouse/page.tsx
+++ b/apps/farm/app/greenhouse/page.tsx
@@ -26,6 +26,7 @@ import Link from 'next/link';
 import LoginDialog from '../../components/auth/LoginDialog';
 import { auth } from '../../lib/auth/auth';
 import { KnownPages } from '../../src/KnownPages';
+import { GreenhouseMobilePlantList } from './GreenhouseMobilePlantList';
 
 export const dynamic = 'force-dynamic';
 
@@ -325,7 +326,41 @@ async function GreenhousePageContent() {
                                     </Chip>
                                 </Row>
                             </CardHeader>
-                            <CardOverflow>
+                            <GreenhouseMobilePlantList
+                                items={raisedBed.fields.map((field) => {
+                                    const plantSort = plantSortById.get(
+                                        field.plantSortId,
+                                    );
+
+                                    return {
+                                        germinationDate: formatDate(
+                                            field.plantGrowthDate,
+                                        ),
+                                        key: `${raisedBed.id}-${field.id}`,
+                                        plantName: getPlantName(
+                                            plantSort,
+                                            field.plantSortId,
+                                        ),
+                                        plantSort,
+                                        positionNumber: field.positionIndex + 1,
+                                        sowingDate: sowingDateCell(
+                                            field.plantSowDate,
+                                            field.plantGrowthDate,
+                                            today,
+                                        ),
+                                        statusColor: getStatusColor(
+                                            field.plantStatus,
+                                        ),
+                                        statusEmoji: plantFieldStatusEmoji(
+                                            field.plantStatus ?? undefined,
+                                        ),
+                                        statusLabel: getStatusLabel(
+                                            field.plantStatus,
+                                        ),
+                                    };
+                                })}
+                            />
+                            <CardOverflow className="hidden md:block">
                                 <Table>
                                     <Table.Header>
                                         <Table.Row>


### PR DESCRIPTION
## Summary

- replace the squeezed mobile greenhouse table with a responsive seedling list
- keep plant identity, status, sowing age, and germination date readable on narrow screens
- retain the existing table layout from the medium breakpoint upward
- add component coverage for 320 px, 375 px, 430 px, and desktop breakpoint behavior

## Root cause

The five-column table had no mobile presentation, so narrow screens compressed the plant-name column to nearly one character wide and pushed later fields outside the useful viewport.

## Validation

- `corepack pnpm lint --filter farm`
- `corepack pnpm --filter farm test:run app/greenhouse/GreenhouseMobilePlantList.spec.tsx`
- `corepack pnpm --filter farm test:prepare`
- `git diff --check`