### PR TITLE
feat(farm): enable pilot feature flags

### DIFF
--- a/apps/farm/app/flags.ts
+++ b/apps/farm/app/flags.ts
@@ -1,17 +1,10 @@
 import { flag } from 'flags/next';
 import type { FarmOperationCompletionSyncMode } from '../lib/offline/operationCompletionSyncMode';
 
-function isDevOrTestEnvironment() {
-    return (
-        process.env.NODE_ENV === 'development' ||
-        process.env.NODE_ENV === 'test'
-    );
-}
-
 export const showUIFlag = flag<boolean>({
     key: 'showUI',
     description: 'Enable feature-gated UI elements in farm app.',
-    decide: () => isDevOrTestEnvironment(),
+    decide: () => true,
     options: [
         { label: 'Off', value: false },
         { label: 'On', value: true },
@@ -23,7 +16,7 @@ export const farmOperationCompletionSyncModeFlag =
         key: 'farmOperationCompletionSyncMode',
         description:
             'Control local operation-completion queue creation and foreground draining.',
-        decide: () => (isDevOrTestEnvironment() ? 'enabled' : 'off'),
+        decide: () => 'enabled',
         options: [
             { label: 'Off', value: 'off' },
             { label: 'Drain only', value: 'drain_only' },

--- a/docs/farm-offline-operation-completion.md
+++ b/docs/farm-offline-operation-completion.md
@@ -35,9 +35,9 @@ selection are outside its scope.
 | `drain_only` | Uses the legacy online path | Drains in the foreground | Queue and resolution UI remain visible |
 | `enabled` | Persists before any network work | Drains in the foreground | Full queue and resolution UI |
 
-Production defaults to `off`. Development and test default to `enabled`. A
-Vercel flag override can select another mode for a controlled environment or
-pilot.
+Production, development, and test default to `enabled` while Farm is in its
+active pilot. A Vercel flag override can select another mode for rollback or
+targeted testing.
 
 The workflow uses the existing authenticated Farm session and Vercel Blob
 configuration. It adds no database migration and no service-worker background
@@ -168,13 +168,13 @@ and successful receipts without joining them to private farmer content.
 
 ## Rollout and rollback
 
-1. Keep production `off` while automated storage, concurrency, mobile,
-   accessibility, and privacy tests are incomplete.
-2. Enable a small internal cohort and complete GitHub task #4194 on physical
-   iOS standalone and Android Chrome devices, including weak connectivity,
-   background/force-close/reopen, lost response, and logout cases.
+1. Keep production `enabled` while Farm is in its active pilot.
+2. Record physical iOS standalone and Android Chrome results, including weak
+   connectivity, background/force-close/reopen, lost response, and logout
+   cases. Reopen GitHub task #4194 if a formal go/no-go gate is reinstated.
 3. Review controlled telemetry and unreferenced Blob growth.
-4. Expand `enabled` only after the real-device go/no-go record is approved.
+4. Retain `enabled` after the pilot only when the go/no-go record is approved;
+   otherwise use the rollback sequence below.
 
 To stop new queue creation while preserving farmer work, change `enabled` to
 `drain_only`. Keep the app deployed until existing records reach a server


### PR DESCRIPTION
## Summary

- enable every declared Farm feature flag by default during the active pilot
- turn on the full offline operation-completion queue and foreground synchronization
- retain the existing flag variants so operators can still use `drain_only` or `off` for rollback
- update the offline rollout guide for the pilot defaults and the closed physical-pilot issue

## Impact

Farm production users receive `showUI = true` and `farmOperationCompletionSyncMode = enabled` after this reaches production. This affects only `apps/farm`; Garden and public-site flags remain unchanged.

## Validation

- `corepack pnpm --filter farm exec biome check app/flags.ts`
- `corepack pnpm --filter farm exec tsc --noEmit -p tsconfig.json`
- `corepack pnpm --filter farm build`
- targeted Playwright queue/draft/sync suite — 12 passed
- `git diff --check origin/main...HEAD`
