### PR TITLE
fix(checkout): compare minimum cart amount in cents

### DIFF
--- a/apps/api/lib/checkout/cartInfo.node.spec.ts
+++ b/apps/api/lib/checkout/cartInfo.node.spec.ts
@@ -4,6 +4,7 @@ import {
     getAbandonedRaisedBedCartNote,
     getMinimumOrderNote,
     getNewRaisedBedPlantingNote,
+    getTotalCartValueCents,
 } from './cartInfo';
 
 describe('getNewRaisedBedPlantingNote', () => {
@@ -32,16 +33,44 @@ describe('getAbandonedRaisedBedCartNote', () => {
 });
 
 describe('getMinimumOrderNote', () => {
-    it('blocks positive EUR totals below one euro', () => {
+    it('blocks positive totals below one euro', () => {
         assert.strictEqual(
-            getMinimumOrderNote(0.99),
+            getMinimumOrderNote(99),
             'Minimalna vrijednost narudžbe je 1 €.',
         );
     });
 
-    it('allows an empty EUR total and totals of at least one euro', () => {
+    it('allows an empty total and totals of at least one euro', () => {
         assert.strictEqual(getMinimumOrderNote(0), null);
-        assert.strictEqual(getMinimumOrderNote(1), null);
-        assert.strictEqual(getMinimumOrderNote(1.01), null);
+        assert.strictEqual(getMinimumOrderNote(100), null);
+        assert.strictEqual(getMinimumOrderNote(101), null);
+    });
+});
+
+describe('getTotalCartValueCents', () => {
+    it('sums cent-denominated line items without floating-point drift', () => {
+        const totalCartValueCents = getTotalCartValueCents([
+            {
+                amount: 1,
+                currency: 'eur',
+                shopData: { price: 0.06 },
+                status: 'new',
+            },
+            {
+                amount: 1,
+                currency: 'eur',
+                shopData: { price: 0.57 },
+                status: 'new',
+            },
+            {
+                amount: 1,
+                currency: 'eur',
+                shopData: { price: 0.37 },
+                status: 'new',
+            },
+        ]);
+
+        assert.strictEqual(totalCartValueCents, 100);
+        assert.strictEqual(getMinimumOrderNote(totalCartValueCents), null);
     });
 });

--- a/apps/api/lib/checkout/cartInfo.ts
+++ b/apps/api/lib/checkout/cartInfo.ts
@@ -2,7 +2,10 @@ import {
     isRaisedBedAbandoned,
     RAISED_BED_ABANDONED_ACTIONS_DISABLED_MESSAGE,
 } from '@gredice/js/raisedBeds';
-import { minimumShoppingCartAmountEur } from '@gredice/js/shoppingCart';
+import {
+    minimumShoppingCartAmountCents,
+    minimumShoppingCartAmountEur,
+} from '@gredice/js/shoppingCart';
 import {
     type EntityStandardized,
     getEntitiesFormatted,
@@ -44,6 +47,11 @@ export type ShoppingCartItemWithShopData = SelectShoppingCartItem & {
     inventoryAvailable?: number;
 };
 
+type CartValueItem = Pick<
+    ShoppingCartItemWithShopData,
+    'amount' | 'currency' | 'shopData' | 'status'
+>;
+
 const RAISED_BED_BLOCKS_PER_BED = 2;
 const REQUIRED_PLANT_ITEMS_PER_NEW_RAISED_BED = 9;
 
@@ -82,10 +90,24 @@ export function getAbandonedRaisedBedCartNote(raisedBedName?: string | null) {
     return `${prefix} je napuštena zbog neaktivnosti. ${RAISED_BED_ABANDONED_ACTIONS_DISABLED_MESSAGE}`;
 }
 
-export function getMinimumOrderNote(totalCartValueEur: number) {
+export function getTotalCartValueCents(items: CartValueItem[]) {
+    return items.reduce((sum, item) => {
+        if (item.status !== 'paid' && item.currency === 'eur') {
+            const priceEur =
+                item.shopData.discountPrice ?? item.shopData.price ?? 0;
+            const priceCents = Math.round(priceEur * 100);
+
+            return sum + priceCents * item.amount;
+        }
+
+        return sum;
+    }, 0);
+}
+
+export function getMinimumOrderNote(totalCartValueCents: number) {
     if (
-        totalCartValueEur <= 0 ||
-        totalCartValueEur >= minimumShoppingCartAmountEur
+        totalCartValueCents <= 0 ||
+        totalCartValueCents >= minimumShoppingCartAmountCents
     ) {
         return null;
     }
@@ -369,15 +391,8 @@ export async function getCartInfo(
         allowPurchase = false;
     }
 
-    const totalCartValue = cartItemsWithShopInfo.reduce((sum, item) => {
-        if (item.status !== 'paid' && item.currency === 'eur') {
-            const price =
-                item.shopData.discountPrice ?? item.shopData.price ?? 0;
-            return sum + price * item.amount;
-        }
-        return sum;
-    }, 0);
-    const minimumOrderNote = getMinimumOrderNote(totalCartValue);
+    const totalCartValueCents = getTotalCartValueCents(cartItemsWithShopInfo);
+    const minimumOrderNote = getMinimumOrderNote(totalCartValueCents);
     if (minimumOrderNote) {
         notes.push(minimumOrderNote);
         allowPurchase = false;

--- a/packages/js/src/shoppingCart/index.ts
+++ b/packages/js/src/shoppingCart/index.ts
@@ -1,1 +1,3 @@
-export const minimumShoppingCartAmountEur = 1;
+export const minimumShoppingCartAmountCents = 100;
+export const minimumShoppingCartAmountEur =
+    minimumShoppingCartAmountCents / 100;


### PR DESCRIPTION
## Summary

- follow up on the Codex review from #4235
- calculate eligible EUR cart totals in integer cents before checking the €1 minimum
- keep the shared minimum in cents while deriving its EUR display value
- add the reported `€0.06 + €0.57 + €0.37 = €1.00` regression case

## Validation

- `corepack pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/checkout/cartInfo.node.spec.ts`
- `corepack pnpm --filter api build`
- `corepack pnpm --filter www typecheck`
- `corepack pnpm --filter www build`
- workspace-local Biome checks for all changed TypeScript files
- `git diff --check origin/main...HEAD`