### PR TITLE
fix(game): prevent delivery slot overflow on mobile

### DIFF
--- a/apps/garden/tests/DeliverySlotPickerStory.tsx
+++ b/apps/garden/tests/DeliverySlotPickerStory.tsx
@@ -7,17 +7,20 @@ import {
 type DeliverySlotPickerStoryProps = Pick<
     DeliverySlotPickerProps,
     'autoSelectFirstDeliverySlot' | 'referenceDate' | 'slots'
->;
+> & {
+    containerClassName?: string;
+};
 
 export function DeliverySlotPickerStory({
     autoSelectFirstDeliverySlot,
+    containerClassName = 'w-[44rem]',
     referenceDate,
     slots,
 }: DeliverySlotPickerStoryProps) {
     const [value, setValue] = useState<number>();
 
     return (
-        <div className="w-[44rem] p-6">
+        <div className={`${containerClassName} p-6`}>
             <DeliverySlotPicker
                 autoFocus={false}
                 autoSelectFirstDeliverySlot={autoSelectFirstDeliverySlot}

--- a/apps/garden/tests/delivery-slot-picker.spec.tsx
+++ b/apps/garden/tests/delivery-slot-picker.spec.tsx
@@ -81,3 +81,48 @@ test('opens on the current week even when its slots are already missed', async (
     ).toBeVisible();
     await expect(page.getByTestId('selected-delivery-slot')).toHaveText('');
 });
+
+test('keeps time slots within a mobile-width container', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <div data-testid="mobile-container" style={{ width: '18rem' }}>
+            <DeliverySlotPickerStory
+                referenceDate={referenceDate}
+                slots={[
+                    {
+                        endAt: '2026-07-17T17:00:00.000Z',
+                        fulfillment: 'delivery',
+                        id: 1,
+                        startAt: '2026-07-17T15:00:00.000Z',
+                    },
+                    {
+                        endAt: '2026-07-17T19:00:00.000Z',
+                        fulfillment: 'pickup',
+                        id: 2,
+                        startAt: '2026-07-17T17:00:00.000Z',
+                    },
+                    {
+                        endAt: '2026-07-17T21:00:00.000Z',
+                        fulfillment: 'delivery',
+                        id: 3,
+                        startAt: '2026-07-17T19:00:00.000Z',
+                    },
+                ]}
+            />
+        </div>,
+    );
+
+    const timeSlots = page.getByRole('group', {
+        name: /Odaberi vrijeme za/i,
+    });
+    await expect(timeSlots).toBeVisible();
+    await expect
+        .poll(() =>
+            timeSlots.evaluate(
+                (element) => element.scrollWidth <= element.clientWidth,
+            ),
+        )
+        .toBe(true);
+});

--- a/apps/garden/tests/delivery-slot-picker.spec.tsx
+++ b/apps/garden/tests/delivery-slot-picker.spec.tsx
@@ -87,31 +87,30 @@ test('keeps time slots within a mobile-width container', async ({
     page,
 }) => {
     await mount(
-        <div data-testid="mobile-container" style={{ width: '18rem' }}>
-            <DeliverySlotPickerStory
-                referenceDate={referenceDate}
-                slots={[
-                    {
-                        endAt: '2026-07-17T17:00:00.000Z',
-                        fulfillment: 'delivery',
-                        id: 1,
-                        startAt: '2026-07-17T15:00:00.000Z',
-                    },
-                    {
-                        endAt: '2026-07-17T19:00:00.000Z',
-                        fulfillment: 'pickup',
-                        id: 2,
-                        startAt: '2026-07-17T17:00:00.000Z',
-                    },
-                    {
-                        endAt: '2026-07-17T21:00:00.000Z',
-                        fulfillment: 'delivery',
-                        id: 3,
-                        startAt: '2026-07-17T19:00:00.000Z',
-                    },
-                ]}
-            />
-        </div>,
+        <DeliverySlotPickerStory
+            containerClassName="w-[21rem]"
+            referenceDate={referenceDate}
+            slots={[
+                {
+                    endAt: '2026-07-17T17:00:00.000Z',
+                    fulfillment: 'delivery',
+                    id: 1,
+                    startAt: '2026-07-17T15:00:00.000Z',
+                },
+                {
+                    endAt: '2026-07-17T19:00:00.000Z',
+                    fulfillment: 'pickup',
+                    id: 2,
+                    startAt: '2026-07-17T17:00:00.000Z',
+                },
+                {
+                    endAt: '2026-07-17T21:00:00.000Z',
+                    fulfillment: 'delivery',
+                    id: 3,
+                    startAt: '2026-07-17T19:00:00.000Z',
+                },
+            ]}
+        />,
     );
 
     const timeSlots = page.getByRole('group', {

--- a/packages/game/src/shared-ui/delivery/DeliverySlotPicker.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliverySlotPicker.tsx
@@ -532,7 +532,7 @@ export function DeliverySlotPicker({
                                 </Typography>
                             </div>
                             <fieldset
-                                className="m-0 grid min-w-0 grid-cols-2 gap-2 border-0 p-0 sm:grid-cols-3"
+                                className="m-0 grid min-w-0 grid-cols-[repeat(auto-fit,minmax(min(100%,10rem),1fr))] gap-2 border-0 p-0"
                                 disabled={disabled}
                             >
                                 <legend className="sr-only">


### PR DESCRIPTION
## Summary

- size delivery time-slot columns from the picker container instead of the viewport breakpoint
- keep slot controls within narrow mobile cards while preserving multi-column layouts when space allows
- add a component regression test for an 18rem-wide container

## Root cause

The grid used a viewport-based `sm:grid-cols-3` breakpoint. Storybook’s preview viewport was wide even when the picker was constrained to a 21rem card, forcing three time-slot columns into the narrow component.

## Validation

- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter storybook typecheck`
- `corepack pnpm --filter garden typecheck`
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/delivery-slot-picker.spec.tsx`
- targeted Biome checks for both changed files
- `git diff --check`