### PR TITLE
feat(admin): add grouped delivery statistics

### DIFF
--- a/apps/app/app/admin/statistics/delivery-requests/DeliveryRequestStatisticsCharts.tsx
+++ b/apps/app/app/admin/statistics/delivery-requests/DeliveryRequestStatisticsCharts.tsx
@@ -20,16 +20,20 @@ import {
 } from 'recharts';
 import type { DeliveryRequestStatistics } from './deliveryRequestStatistics';
 
-const chartColors = [
-    'hsl(var(--primary))',
-    '#22c55e',
-    '#3b82f6',
-    '#f59e0b',
-    '#8b5cf6',
-    '#ec4899',
-    '#ef4444',
-    '#64748b',
-];
+const pastelBlue = '#a9bfd4';
+const pastelGreen = '#b8cdb7';
+const pastelColors = [
+    pastelBlue,
+    pastelGreen,
+    '#dac7a3',
+    '#c8bdd8',
+    '#d8b7bd',
+    '#b4cdca',
+    '#d2beb1',
+    '#bdc2c9',
+] as const;
+
+const pastelTrend = '#8ea8c0';
 
 const tooltipStyle = {
     border: '1px solid hsl(var(--border))',
@@ -42,8 +46,8 @@ export function DeliveryRequestStatisticsCharts({
 }: {
     statistics: DeliveryRequestStatistics;
 }) {
-    const hasSlotData = statistics.popularSlots.length > 0;
-    const hasTimeWindowData = statistics.timeWindows.length > 0;
+    const hasDeliverySizeData = statistics.deliverySizes.length > 0;
+    const hasTimeWindowData = statistics.deliveryTimeWindows.length > 0;
     const hasTrendData = statistics.trend.length > 0;
     const hasStateData = statistics.states.length > 0;
     const hasModeData = statistics.modes.length > 0;
@@ -55,74 +59,77 @@ export function DeliveryRequestStatisticsCharts({
                     <Stack spacing={4} className="p-4">
                         <Stack spacing={1}>
                             <Typography level="h4" component="h2">
-                                Najtraženiji pojedinačni termini
+                                Veličina grupiranih dostava
                             </Typography>
                             <Typography
                                 level="body3"
                                 className="text-muted-foreground"
                             >
-                                Osam termina s najviše zahtjeva, prema
-                                trenutačno odabranom terminu svakog zahtjeva
+                                Broj dostava prema broju zahtjeva istog
+                                korisnika u istom terminu
                             </Typography>
                         </Stack>
-                        {!hasSlotData ? (
+                        {!hasDeliverySizeData ? (
                             <Typography
                                 level="body2"
                                 className="text-muted-foreground"
                             >
-                                Nema zahtjeva povezanih s terminom.
+                                Nema grupiranih dostava za prikaz.
                             </Typography>
                         ) : (
                             <div
-                                className="h-80 w-full"
+                                className="h-72 w-full"
                                 role="img"
-                                aria-label="Stupčasti graf najtraženijih pojedinačnih termina dostave"
+                                aria-label="Stupčasti graf grupiranih dostava prema broju zahtjeva u dostavi"
                             >
                                 <ResponsiveContainer width="100%" height="100%">
                                     <BarChart
-                                        data={statistics.popularSlots.toReversed()}
-                                        layout="vertical"
+                                        data={statistics.deliverySizes}
                                         margin={{
                                             top: 8,
-                                            right: 24,
-                                            left: 8,
-                                            bottom: 0,
+                                            right: 8,
+                                            left: -16,
+                                            bottom: 8,
                                         }}
                                     >
                                         <CartesianGrid
                                             strokeDasharray="3 3"
                                             className="stroke-border"
-                                            horizontal={false}
                                         />
                                         <XAxis
-                                            type="number"
+                                            dataKey="label"
+                                            tickLine={false}
+                                            axisLine={false}
+                                            tick={{ fontSize: 12 }}
+                                            label={{
+                                                value: 'Zahtjeva u dostavi',
+                                                position: 'insideBottom',
+                                                offset: -4,
+                                                fontSize: 12,
+                                            }}
+                                            height={44}
+                                        />
+                                        <YAxis
                                             allowDecimals={false}
                                             tickLine={false}
                                             axisLine={false}
                                             tick={{ fontSize: 12 }}
-                                        />
-                                        <YAxis
-                                            type="category"
-                                            dataKey="shortLabel"
-                                            tickLine={false}
-                                            axisLine={false}
-                                            tick={{ fontSize: 12 }}
-                                            width={184}
+                                            width={28}
                                         />
                                         <Tooltip
                                             cursor={{
-                                                fill: 'hsl(var(--primary) / 0.08)',
+                                                fill: 'hsl(var(--muted))',
                                             }}
                                             contentStyle={tooltipStyle}
                                             formatter={(value) => [
-                                                `${value} zahtjeva`,
-                                                'Zahtjevi',
+                                                `${value} dostava`,
+                                                'Dostave',
                                             ]}
                                         />
                                         <Bar
                                             dataKey="count"
-                                            fill="hsl(var(--primary) / 0.72)"
-                                            radius={[0, 6, 6, 0]}
+                                            fill={pastelBlue}
+                                            radius={[6, 6, 0, 0]}
                                         />
                                     </BarChart>
                                 </ResponsiveContainer>
@@ -137,7 +144,7 @@ export function DeliveryRequestStatisticsCharts({
                     <Stack spacing={4} className="p-4">
                         <Stack spacing={1}>
                             <Typography level="h4" component="h2">
-                                Zahtjevi po danu u tjednu
+                                Dostave po danu u tjednu
                             </Typography>
                             <Typography
                                 level="body3"
@@ -149,11 +156,11 @@ export function DeliveryRequestStatisticsCharts({
                         <div
                             className="h-72 w-full"
                             role="img"
-                            aria-label="Stupčasti graf zahtjeva za dostavu po danima u tjednu"
+                            aria-label="Stupčasti graf grupiranih dostava po danima u tjednu"
                         >
                             <ResponsiveContainer width="100%" height="100%">
                                 <BarChart
-                                    data={statistics.weekdays}
+                                    data={statistics.deliveryWeekdays}
                                     margin={{
                                         top: 8,
                                         right: 8,
@@ -180,17 +187,17 @@ export function DeliveryRequestStatisticsCharts({
                                     />
                                     <Tooltip
                                         cursor={{
-                                            fill: 'hsl(var(--primary) / 0.08)',
+                                            fill: 'hsl(var(--muted))',
                                         }}
                                         contentStyle={tooltipStyle}
                                         formatter={(value) => [
-                                            `${value} zahtjeva`,
-                                            'Zahtjevi',
+                                            `${value} dostava`,
+                                            'Dostave',
                                         ]}
                                     />
                                     <Bar
                                         dataKey="count"
-                                        fill="#3b82f6"
+                                        fill={pastelBlue}
                                         radius={[6, 6, 0, 0]}
                                     />
                                 </BarChart>
@@ -205,13 +212,13 @@ export function DeliveryRequestStatisticsCharts({
                     <Stack spacing={4} className="p-4">
                         <Stack spacing={1}>
                             <Typography level="h4" component="h2">
-                                Najtraženija vremena
+                                Dostave po vremenu termina
                             </Typography>
                             <Typography
                                 level="body3"
                                 className="text-muted-foreground"
                             >
-                                Zahtjevi grupirani po vremenskom rasponu termina
+                                Grupirane dostave po vremenskom rasponu termina
                             </Typography>
                         </Stack>
                         {!hasTimeWindowData ? (
@@ -219,17 +226,17 @@ export function DeliveryRequestStatisticsCharts({
                                 level="body2"
                                 className="text-muted-foreground"
                             >
-                                Nema zahtjeva povezanih s terminom.
+                                Nema grupiranih dostava povezanih s terminom.
                             </Typography>
                         ) : (
                             <div
                                 className="h-72 w-full"
                                 role="img"
-                                aria-label="Stupčasti graf najtraženijih vremenskih raspona dostave"
+                                aria-label="Stupčasti graf grupiranih dostava po vremenskim rasponima termina"
                             >
                                 <ResponsiveContainer width="100%" height="100%">
                                     <BarChart
-                                        data={statistics.timeWindows}
+                                        data={statistics.deliveryTimeWindows}
                                         margin={{
                                             top: 8,
                                             right: 8,
@@ -256,17 +263,17 @@ export function DeliveryRequestStatisticsCharts({
                                         />
                                         <Tooltip
                                             cursor={{
-                                                fill: 'hsl(var(--primary) / 0.08)',
+                                                fill: 'hsl(var(--muted))',
                                             }}
                                             contentStyle={tooltipStyle}
                                             formatter={(value) => [
-                                                `${value} zahtjeva`,
-                                                'Zahtjevi',
+                                                `${value} dostava`,
+                                                'Dostave',
                                             ]}
                                         />
                                         <Bar
                                             dataKey="count"
-                                            fill="#22c55e"
+                                            fill={pastelGreen}
                                             radius={[6, 6, 0, 0]}
                                         />
                                     </BarChart>
@@ -324,12 +331,12 @@ export function DeliveryRequestStatisticsCharts({
                                             >
                                                 <stop
                                                     offset="5%"
-                                                    stopColor="hsl(var(--primary))"
-                                                    stopOpacity={0.35}
+                                                    stopColor={pastelTrend}
+                                                    stopOpacity={0.3}
                                                 />
                                                 <stop
                                                     offset="95%"
-                                                    stopColor="hsl(var(--primary))"
+                                                    stopColor={pastelTrend}
                                                     stopOpacity={0.02}
                                                 />
                                             </linearGradient>
@@ -361,7 +368,7 @@ export function DeliveryRequestStatisticsCharts({
                                         <Area
                                             type="monotone"
                                             dataKey="count"
-                                            stroke="hsl(var(--primary))"
+                                            stroke={pastelTrend}
                                             strokeWidth={2}
                                             fill="url(#deliveryRequestTrend)"
                                         />
@@ -415,9 +422,9 @@ export function DeliveryRequestStatisticsCharts({
                                                     <Cell
                                                         key={state.label}
                                                         fill={
-                                                            chartColors[
+                                                            pastelColors[
                                                                 index %
-                                                                    chartColors.length
+                                                                    pastelColors.length
                                                             ]
                                                         }
                                                     />
@@ -485,9 +492,9 @@ export function DeliveryRequestStatisticsCharts({
                                                     <Cell
                                                         key={mode.label}
                                                         fill={
-                                                            chartColors[
+                                                            pastelColors[
                                                                 (index + 1) %
-                                                                    chartColors.length
+                                                                    pastelColors.length
                                                             ]
                                                         }
                                                     />

--- a/apps/app/app/admin/statistics/delivery-requests/deliveryRequestStatistics.ts
+++ b/apps/app/app/admin/statistics/delivery-requests/deliveryRequestStatistics.ts
@@ -1,3 +1,5 @@
+import { groupDeliveryRequests } from '../../delivery/requests/DeliveryRequestGroups';
+
 const deliveryStatisticsTimeZone = 'Europe/Zagreb';
 
 const weekdayOrder = [
@@ -23,6 +25,7 @@ const stateOrder = [
 
 type DeliveryStatisticsRequest = {
     id: string;
+    accountId?: string | null;
     state: string;
     mode?: 'delivery' | 'pickup';
     createdAt: Date;
@@ -30,9 +33,6 @@ type DeliveryStatisticsRequest = {
         id: number;
         startAt: Date;
         endAt: Date;
-        location?: {
-            name: string;
-        };
     };
 };
 
@@ -42,13 +42,6 @@ export type DeliveryRequestStatistics = ReturnType<
 
 const weekdayKeyFormatter = new Intl.DateTimeFormat('en-US', {
     weekday: 'short',
-    timeZone: deliveryStatisticsTimeZone,
-});
-
-const slotDateFormatter = new Intl.DateTimeFormat('hr-HR', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
     timeZone: deliveryStatisticsTimeZone,
 });
 
@@ -119,15 +112,6 @@ function formatTimeWindow(startAt: Date, endAt: Date) {
     return `${timeFormatter.format(startAt)}–${timeFormatter.format(endAt)}`;
 }
 
-function formatSlotLabel(request: DeliveryStatisticsRequest) {
-    const slot = request.slot;
-    if (!slot) return '';
-
-    const location = slot.location?.name.trim();
-    const dateAndTime = `${slotDateFormatter.format(slot.startAt)} · ${formatTimeWindow(slot.startAt, slot.endAt)}`;
-    return location ? `${dateAndTime} · ${location}` : dateAndTime;
-}
-
 export function buildDeliveryRequestStatistics(
     requests: DeliveryStatisticsRequest[],
 ) {
@@ -138,40 +122,19 @@ export function buildDeliveryRequestStatistics(
             slot: NonNullable<DeliveryStatisticsRequest['slot']>;
         } => Boolean(request.slot),
     );
-    const slotCounts = new Map<
-        number,
-        { id: number; label: string; shortLabel: string; count: number }
-    >();
-
-    for (const request of requestsWithSlots) {
-        const existing = slotCounts.get(request.slot.id);
-        if (existing) {
-            existing.count += 1;
-            continue;
-        }
-
-        const label = formatSlotLabel(request);
-
-        slotCounts.set(request.slot.id, {
-            id: request.slot.id,
-            label,
-            shortLabel: label,
-            count: 1,
-        });
-    }
-
-    const popularSlots = Array.from(slotCounts.values())
-        .sort(
-            (left, right) =>
-                right.count - left.count ||
-                left.label.localeCompare(right.label, 'hr-HR'),
-        )
-        .slice(0, 8);
-    const weekdayCounts = countByKey(requestsWithSlots, (request) =>
+    const deliveryGroups = groupDeliveryRequests(requestsWithSlots);
+    const deliveryRepresentatives = deliveryGroups.flatMap((group) => {
+        const request = group.requests[0];
+        return request ? [request] : [];
+    });
+    const weekdayCounts = countByKey(deliveryRepresentatives, (request) =>
         weekdayKeyFormatter.format(request.slot.startAt),
     );
-    const timeWindowCounts = countByKey(requestsWithSlots, (request) =>
+    const timeWindowCounts = countByKey(deliveryRepresentatives, (request) =>
         formatTimeWindow(request.slot.startAt, request.slot.endAt),
+    );
+    const deliverySizeCounts = countByKey(deliveryGroups, (group) =>
+        String(group.requests.length),
     );
     const stateCounts = countByKey(requests, (request) => request.state);
     const trendCounts = countByKey(requests, (request) =>
@@ -180,6 +143,10 @@ export function buildDeliveryRequestStatistics(
     const fulfilledRequests = stateCounts.get('fulfilled') ?? 0;
     const cancelledRequests = stateCounts.get('cancelled') ?? 0;
     const totalRequests = requests.length;
+    const totalDeliveries = deliveryGroups.length;
+    const multiRequestDeliveries = deliveryGroups.filter(
+        (group) => group.requests.length > 1,
+    ).length;
     const observedTrendMonths = Array.from(trendCounts.keys()).sort(
         (left, right) => left.localeCompare(right),
     );
@@ -194,7 +161,27 @@ export function buildDeliveryRequestStatistics(
         summary: {
             totalRequests,
             assignedRequests: requestsWithSlots.length,
-            uniqueSlots: slotCounts.size,
+            totalDeliveries,
+            uniqueSlots: new Set(
+                requestsWithSlots.map((request) => request.slot.id),
+            ).size,
+            averageRequestsPerDelivery:
+                totalDeliveries === 0
+                    ? 0
+                    : Math.round(
+                          (requestsWithSlots.length / totalDeliveries) * 10,
+                      ) / 10,
+            multiRequestDeliveries,
+            multiRequestDeliveryRate:
+                totalDeliveries === 0
+                    ? 0
+                    : Math.round(
+                          (multiRequestDeliveries / totalDeliveries) * 100,
+                      ),
+            largestDeliverySize: deliveryGroups.reduce(
+                (largest, group) => Math.max(largest, group.requests.length),
+                0,
+            ),
             fulfilledRequests,
             cancelledRequests,
             completionRate:
@@ -205,14 +192,20 @@ export function buildDeliveryRequestStatistics(
                 totalRequests === 0
                     ? 0
                     : Math.round((cancelledRequests / totalRequests) * 100),
-            mostPopularSlot: popularSlots[0] ?? null,
         },
-        popularSlots,
-        weekdays: weekdayOrder.map(({ key, label }) => ({
+        deliverySizes: Array.from(
+            deliverySizeCounts,
+            ([requestCount, count]) => ({
+                requestCount: Number(requestCount),
+                label: requestCount,
+                count,
+            }),
+        ).sort((left, right) => left.requestCount - right.requestCount),
+        deliveryWeekdays: weekdayOrder.map(({ key, label }) => ({
             label,
             count: weekdayCounts.get(key) ?? 0,
         })),
-        timeWindows: Array.from(timeWindowCounts, ([label, count]) => ({
+        deliveryTimeWindows: Array.from(timeWindowCounts, ([label, count]) => ({
             label,
             count,
         })).sort(

--- a/apps/app/app/admin/statistics/delivery-requests/deliveryRequestStatistics.unit.ts
+++ b/apps/app/app/admin/statistics/delivery-requests/deliveryRequestStatistics.unit.ts
@@ -2,21 +2,15 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { buildDeliveryRequestStatistics } from './deliveryRequestStatistics';
 
-function slot(
-    id: number,
-    startAt: string,
-    endAt: string,
-    locationName = 'Gredice Zagreb',
-) {
+function slot(id: number, startAt: string, endAt: string) {
     return {
         id,
         startAt: new Date(startAt),
         endAt: new Date(endAt),
-        location: { name: locationName },
     };
 }
 
-test('aggregates delivery demand by slot, weekday, time, state, mode and month', () => {
+test('aggregates requests into deliveries by account and slot', () => {
     const mondayMorning = slot(
         11,
         '2026-07-06T06:00:00.000Z',
@@ -31,6 +25,7 @@ test('aggregates delivery demand by slot, weekday, time, state, mode and month',
     const statistics = buildDeliveryRequestStatistics([
         {
             id: 'request-1',
+            accountId: 'account-1',
             state: 'fulfilled',
             mode: 'delivery',
             createdAt: new Date('2026-06-20T10:00:00.000Z'),
@@ -38,6 +33,7 @@ test('aggregates delivery demand by slot, weekday, time, state, mode and month',
         },
         {
             id: 'request-2',
+            accountId: 'account-1',
             state: 'fulfilled',
             mode: 'delivery',
             createdAt: new Date('2026-07-01T10:00:00.000Z'),
@@ -45,6 +41,7 @@ test('aggregates delivery demand by slot, weekday, time, state, mode and month',
         },
         {
             id: 'request-3',
+            accountId: 'account-2',
             state: 'cancelled',
             mode: 'pickup',
             createdAt: new Date('2026-07-02T10:00:00.000Z'),
@@ -52,6 +49,7 @@ test('aggregates delivery demand by slot, weekday, time, state, mode and month',
         },
         {
             id: 'request-4',
+            accountId: 'account-3',
             state: 'pending',
             mode: 'delivery',
             createdAt: new Date('2026-07-03T10:00:00.000Z'),
@@ -59,6 +57,7 @@ test('aggregates delivery demand by slot, weekday, time, state, mode and month',
         },
         {
             id: 'request-5',
+            accountId: 'account-4',
             state: 'ready',
             createdAt: new Date('2026-07-04T10:00:00.000Z'),
         },
@@ -67,29 +66,32 @@ test('aggregates delivery demand by slot, weekday, time, state, mode and month',
     assert.deepEqual(statistics.summary, {
         totalRequests: 5,
         assignedRequests: 4,
+        totalDeliveries: 3,
         uniqueSlots: 2,
+        averageRequestsPerDelivery: 1.3,
+        multiRequestDeliveries: 1,
+        multiRequestDeliveryRate: 33,
+        largestDeliverySize: 2,
         fulfilledRequests: 2,
         cancelledRequests: 1,
         completionRate: 40,
         cancellationRate: 20,
-        mostPopularSlot: {
-            id: 11,
-            label: '06. 07. 2026. · 08:00–10:00 · Gredice Zagreb',
-            shortLabel: '06. 07. 2026. · 08:00–10:00 · Gredice Zagreb',
-            count: 3,
-        },
     });
     assert.equal(
-        statistics.weekdays.find((item) => item.label === 'Pon')?.count,
-        3,
+        statistics.deliveryWeekdays.find((item) => item.label === 'Pon')?.count,
+        2,
     );
     assert.equal(
-        statistics.weekdays.find((item) => item.label === 'Uto')?.count,
+        statistics.deliveryWeekdays.find((item) => item.label === 'Uto')?.count,
         1,
     );
-    assert.deepEqual(statistics.timeWindows, [
-        { label: '08:00–10:00', count: 3 },
+    assert.deepEqual(statistics.deliveryTimeWindows, [
+        { label: '08:00–10:00', count: 2 },
         { label: '10:00–12:00', count: 1 },
+    ]);
+    assert.deepEqual(statistics.deliverySizes, [
+        { requestCount: 1, label: '1', count: 2 },
+        { requestCount: 2, label: '2', count: 1 },
     ]);
     assert.deepEqual(statistics.modes, [
         { label: 'Dostava', count: 3 },
@@ -101,50 +103,6 @@ test('aggregates delivery demand by slot, weekday, time, state, mode and month',
         [
             { month: '2026-06', count: 1 },
             { month: '2026-07', count: 4 },
-        ],
-    );
-});
-
-test('keeps locations visible for slots with the same date and time', () => {
-    const statistics = buildDeliveryRequestStatistics([
-        {
-            id: 'request-zagreb',
-            state: 'pending',
-            createdAt: new Date('2026-07-01T10:00:00.000Z'),
-            slot: slot(
-                21,
-                '2026-07-06T06:00:00.000Z',
-                '2026-07-06T08:00:00.000Z',
-                'Gredice Zagreb',
-            ),
-        },
-        {
-            id: 'request-split',
-            state: 'pending',
-            createdAt: new Date('2026-07-01T10:00:00.000Z'),
-            slot: slot(
-                22,
-                '2026-07-06T06:00:00.000Z',
-                '2026-07-06T08:00:00.000Z',
-                'Gredice Split',
-            ),
-        },
-    ]);
-
-    assert.deepEqual(
-        statistics.popularSlots.map(({ id, shortLabel }) => ({
-            id,
-            shortLabel,
-        })),
-        [
-            {
-                id: 22,
-                shortLabel: '06. 07. 2026. · 08:00–10:00 · Gredice Split',
-            },
-            {
-                id: 21,
-                shortLabel: '06. 07. 2026. · 08:00–10:00 · Gredice Zagreb',
-            },
         ],
     );
 });
@@ -178,14 +136,16 @@ test('returns stable empty chart series when there are no requests', () => {
     const statistics = buildDeliveryRequestStatistics([]);
 
     assert.equal(statistics.summary.totalRequests, 0);
+    assert.equal(statistics.summary.totalDeliveries, 0);
+    assert.equal(statistics.summary.averageRequestsPerDelivery, 0);
+    assert.equal(statistics.summary.multiRequestDeliveryRate, 0);
     assert.equal(statistics.summary.completionRate, 0);
     assert.equal(statistics.summary.cancellationRate, 0);
-    assert.equal(statistics.summary.mostPopularSlot, null);
     assert.deepEqual(
-        statistics.weekdays.map((item) => item.count),
+        statistics.deliveryWeekdays.map((item) => item.count),
         [0, 0, 0, 0, 0, 0, 0],
     );
-    assert.deepEqual(statistics.popularSlots, []);
+    assert.deepEqual(statistics.deliverySizes, []);
     assert.deepEqual(statistics.states, []);
     assert.deepEqual(statistics.trend, []);
 });

--- a/apps/app/app/admin/statistics/delivery-requests/page.tsx
+++ b/apps/app/app/admin/statistics/delivery-requests/page.tsx
@@ -39,11 +39,25 @@ export default async function DeliveryRequestStatisticsPage() {
                   detail: `${statistics.summary.assignedRequests} s odabranim terminom`,
               },
               {
-                  label: 'Korišteni termini',
-                  value: statistics.summary.uniqueSlots.toString(),
-                  detail: statistics.summary.mostPopularSlot
-                      ? `Najtraženiji: ${statistics.summary.mostPopularSlot.count} zahtjeva`
-                      : 'Nema odabranih termina',
+                  label: 'Grupirane dostave',
+                  value: statistics.summary.totalDeliveries.toString(),
+                  detail: `${statistics.summary.uniqueSlots} korištena termina`,
+              },
+              {
+                  label: 'Zahtjeva po dostavi',
+                  value: statistics.summary.averageRequestsPerDelivery.toLocaleString(
+                      'hr-HR',
+                      {
+                          minimumFractionDigits: 1,
+                          maximumFractionDigits: 1,
+                      },
+                  ),
+                  detail: 'Prosjek po korisniku i terminu',
+              },
+              {
+                  label: 'Dostave s više zahtjeva',
+                  value: statistics.summary.multiRequestDeliveries.toString(),
+                  detail: `${statistics.summary.multiRequestDeliveryRate}% grupiranih · najviše ${statistics.summary.largestDeliverySize}`,
               },
               {
                   label: 'Ispunjeno',
@@ -68,8 +82,8 @@ export default async function DeliveryRequestStatisticsPage() {
                     Statistika zahtjeva za dostavu
                 </Typography>
                 <Typography level="body2" className="text-muted-foreground">
-                    Potražnja po terminima, danima i vremenu te pregled trendova
-                    i ishoda zahtjeva.
+                    Zahtjevi, grupirane dostave te potražnja po danima i vremenu
+                    uz pregled trendova i ishoda.
                 </Typography>
                 <div>
                     <Chip color="neutral" variant="soft">
@@ -97,7 +111,7 @@ export default async function DeliveryRequestStatisticsPage() {
 
             {statistics && statistics.summary.totalRequests > 0 && (
                 <>
-                    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
                         {summaryCards.map((card) => (
                             <Card key={card.label}>
                                 <CardOverflow>
@@ -125,17 +139,6 @@ export default async function DeliveryRequestStatisticsPage() {
                             </Card>
                         ))}
                     </div>
-
-                    {statistics.summary.mostPopularSlot && (
-                        <Alert color="info">
-                            Najtraženiji termin je{' '}
-                            <strong>
-                                {statistics.summary.mostPopularSlot.label}
-                            </strong>{' '}
-                            s {statistics.summary.mostPopularSlot.count}{' '}
-                            zahtjeva.
-                        </Alert>
-                    )}
 
                     <DeliveryRequestStatisticsCharts statistics={statistics} />
                 </>


### PR DESCRIPTION
## Summary
- group assigned plant requests into deliveries using the existing account-and-slot rule
- add grouped delivery count, average requests per delivery, multi-request delivery count, and largest delivery size
- replace the individual-slot ranking with a delivery-size distribution
- base weekday and time-window charts on grouped deliveries and use a softer pastel palette throughout

## Impact
Admins can now see operational delivery volume without inflating it by the number of plants or harvest requests included in each delivery. Existing request status, mode, and monthly trend metrics remain request-based.

## Validation
- `corepack pnpm --filter app test:unit` — 120 tests passed
- `NEXT_TELEMETRY_DISABLED=1 corepack pnpm --filter app build`
- focused Biome check for the four changed files
- `git diff --check`
- responsive browser verification at 1440 px and 390 px: all six charts rendered with no horizontal overflow or framework error overlay