### PR TITLE
feat(admin): show CMS page cover thumbnails

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPagesTable.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPagesTable.tsx
@@ -2,6 +2,7 @@ import type { SelectCmsPage } from '@gredice/storage';
 import { List, ListItem } from '@gredice/ui/List';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Typography } from '@gredice/ui/Typography';
+import Image from 'next/image';
 import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
 import { KnownPages } from '../../../../src/KnownPages';
 import { CmsPageStateChip } from './CmsPageStateChip';
@@ -70,13 +71,14 @@ export function CmsPagesTable({ pages }: { pages: SelectCmsPage[] }) {
                     startDecorator={
                         page.metaImageUrl ? (
                             <span className="h-10 w-16 shrink-0 overflow-hidden rounded-md border bg-muted">
-                                {/** biome-ignore lint/performance/noImgElement: CMS covers may use arbitrary uploaded image URLs. */}
-                                <img
+                                <Image
                                     alt=""
                                     className="size-full object-cover"
                                     decoding="async"
+                                    height={40}
                                     loading="lazy"
                                     src={page.metaImageUrl}
+                                    width={64}
                                 />
                             </span>
                         ) : undefined

--- a/apps/app/app/admin/cms/pages/CmsPagesTable.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPagesTable.tsx
@@ -67,6 +67,20 @@ export function CmsPagesTable({ pages }: { pages: SelectCmsPage[] }) {
                     key={page.id}
                     href={KnownPages.CmsPageEdit(page.id)}
                     className="rounded-none px-3 py-3 hover:bg-muted/40 sm:px-4"
+                    startDecorator={
+                        page.metaImageUrl ? (
+                            <span className="h-10 w-16 shrink-0 overflow-hidden rounded-md border bg-muted">
+                                {/** biome-ignore lint/performance/noImgElement: CMS covers may use arbitrary uploaded image URLs. */}
+                                <img
+                                    alt=""
+                                    className="size-full object-cover"
+                                    decoding="async"
+                                    loading="lazy"
+                                    src={page.metaImageUrl}
+                                />
+                            </span>
+                        ) : undefined
+                    }
                     label={
                         <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                             <Typography

--- a/apps/app/tests/cms-pages-table.spec.tsx
+++ b/apps/app/tests/cms-pages-table.spec.tsx
@@ -1,0 +1,78 @@
+import type { SelectCmsPage } from '@gredice/storage';
+import { expect, test } from '@playwright/experimental-ct-react';
+import { CmsPagesTable } from '../app/admin/cms/pages/CmsPagesTable';
+
+const coverUrl =
+    'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="160" height="100"%3E%3Cpath fill="%236b8e23" d="M0 0h160v100H0z"/%3E%3C/svg%3E';
+const timestamp = new Date('2026-07-17T08:00:00.000Z');
+
+function cmsPage(
+    values: Pick<SelectCmsPage, 'id' | 'metaImageUrl' | 'title'>,
+): SelectCmsPage {
+    return {
+        id: values.id,
+        slug: `page-${values.id}`,
+        title: values.title,
+        content: null,
+        contentKind: 'changelog',
+        category: null,
+        tags: [],
+        state: 'draft',
+        publishedAt: timestamp,
+        metaTitle: null,
+        metaDescription: null,
+        metaImageUrl: values.metaImageUrl,
+        seoImageUrl: null,
+        canonicalPath: null,
+        noIndex: false,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        isDeleted: false,
+    };
+}
+
+test('shows an available cover thumbnail before the page title', async ({
+    mount,
+}) => {
+    const component = await mount(
+        <CmsPagesTable
+            pages={[
+                cmsPage({
+                    id: 1,
+                    metaImageUrl: coverUrl,
+                    title: 'Objava s naslovnicom',
+                }),
+                cmsPage({
+                    id: 2,
+                    metaImageUrl: null,
+                    title: 'Objava bez naslovnice',
+                }),
+            ]}
+        />,
+    );
+
+    const pageWithCover = component.getByRole('link', {
+        name: /Objava s naslovnicom/,
+    });
+    const pageWithoutCover = component.getByRole('link', {
+        name: /Objava bez naslovnice/,
+    });
+    const thumbnail = pageWithCover.locator('img');
+
+    await expect(thumbnail).toHaveAttribute('src', coverUrl);
+    await expect(pageWithoutCover.locator('img')).toHaveCount(0);
+
+    const thumbnailPrecedesTitle = await thumbnail.evaluate((image) => {
+        const title = [
+            ...(image.closest('a')?.querySelectorAll('span') ?? []),
+        ].find((element) => element.textContent === 'Objava s naslovnicom');
+
+        return Boolean(
+            title &&
+                image.compareDocumentPosition(title) &
+                    Node.DOCUMENT_POSITION_FOLLOWING,
+        );
+    });
+
+    expect(thumbnailPrecedesTitle).toBe(true);
+});

--- a/apps/app/tests/cms-pages-table.spec.tsx
+++ b/apps/app/tests/cms-pages-table.spec.tsx
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/experimental-ct-react';
 import { CmsPagesTable } from '../app/admin/cms/pages/CmsPagesTable';
 
 const coverUrl =
-    'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="160" height="100"%3E%3Cpath fill="%236b8e23" d="M0 0h160v100H0z"/%3E%3C/svg%3E';
+    'https://test.public.blob.vercel-storage.com/cms/pages/1/cover/test.jpg';
 const timestamp = new Date('2026-07-17T08:00:00.000Z');
 
 function cmsPage(
@@ -59,7 +59,14 @@ test('shows an available cover thumbnail before the page title', async ({
     });
     const thumbnail = pageWithCover.locator('img');
 
-    await expect(thumbnail).toHaveAttribute('src', coverUrl);
+    await expect(thumbnail).toHaveAttribute(
+        'src',
+        /\/_next\/image\?url=.*&w=128&q=75$/,
+    );
+    await expect(thumbnail).toHaveAttribute(
+        'srcset',
+        /w=64&q=75 1x, .*w=128&q=75 2x$/,
+    );
     await expect(pageWithoutCover.locator('img')).toHaveCount(0);
 
     const thumbnailPrecedesTitle = await thumbnail.evaluate((image) => {


### PR DESCRIPTION
## Summary

- show each CMS page cover as a compact thumbnail before its title
- keep rows without a cover unchanged
- lazy-load and asynchronously decode thumbnails for the long CMS list
- cover the conditional rendering and thumbnail ordering with a component test

## Validation

- `corepack pnpm --filter app exec biome check app/admin/cms/pages/CmsPagesTable.tsx tests/cms-pages-table.spec.tsx`
- `git diff --check`
- `corepack pnpm --filter app exec playwright test tests/cms-pages-table.spec.tsx`
- `corepack pnpm --filter app build`