### PR TITLE
feat(farm): compact daily task workflow

### DIFF
--- a/apps/farm/app/FarmTodayTaskCard.tsx
+++ b/apps/farm/app/FarmTodayTaskCard.tsx
@@ -183,23 +183,28 @@ export function FarmTodayTaskCard({
                 >
                     {task.label}
                 </div>
-                <ScheduleTaskLocation
-                    positionNumber={
-                        task.location.kind === 'farm'
-                            ? null
-                            : task.location.positionNumber
-                    }
-                    raisedBedLabel={raisedBedLabel}
-                />
                 <div className="flex min-w-0 flex-wrap gap-1.5">
-                    {renderActionableStateChip(task)}
-                    {renderAssignmentChip(task.assignment)}
-                    <ScheduleTaskDateChip scheduledDate={task.scheduledDate} />
+                    <ScheduleTaskLocation
+                        inline
+                        positionNumber={
+                            task.location.kind === 'farm'
+                                ? null
+                                : task.location.positionNumber
+                        }
+                        raisedBedLabel={raisedBedLabel}
+                    />
                     {task.durationMinutes === null ? null : (
                         <ScheduleTaskDurationChip
+                            compact
                             minutes={task.durationMinutes}
                         />
                     )}
+                    <ScheduleTaskDateChip
+                        compact
+                        scheduledDate={task.scheduledDate}
+                    />
+                    {renderActionableStateChip(task)}
+                    {renderAssignmentChip(task.assignment)}
                 </div>
                 {renderProofRequirements(task)}
                 {task.blocker ? (

--- a/apps/farm/app/FarmTodayView.spec.tsx
+++ b/apps/farm/app/FarmTodayView.spec.tsx
@@ -77,6 +77,7 @@ function buildOperationTask(
         },
         occurredAt: null,
         operationId: 701,
+        operationGroup: null,
         operationDefinitionAvailable: true,
         overdue: false,
         proofRequirements: { images: 'none', notes: 'none' },
@@ -373,16 +374,22 @@ for (const viewport of phoneViewports) {
             ) - nextTaskBounds.y,
         ).toBeGreaterThanOrEqual(Math.min(44, nextTaskBounds.height));
 
-        await expect(
-            nextTaskCard.getByRole('button', {
-                name: `Dovrši radnju: ${nextTask.label}`,
-            }),
-        ).toBeVisible();
-        await expect(
-            nextTaskCard.getByRole('button', {
-                name: `Ne mogu dovršiti radnju: ${nextTask.label}`,
-            }),
-        ).toBeVisible();
+        const completionButton = nextTaskCard.getByRole('button', {
+            name: `Dovrši radnju: ${nextTask.label}`,
+        });
+        const blockerButton = nextTaskCard.getByRole('button', {
+            name: `Ne mogu dovršiti radnju: ${nextTask.label}`,
+        });
+        await expect(completionButton).toBeVisible();
+        await expect(blockerButton).toBeVisible();
+        const [completionBounds, blockerBounds] = await Promise.all([
+            completionButton.boundingBox(),
+            blockerButton.boundingBox(),
+        ]);
+        expect(completionBounds?.y).toBeCloseTo(
+            blockerBounds?.y ?? Number.NaN,
+            0,
+        );
         await expect(component.getByRole('checkbox')).toHaveCount(0);
 
         await expect(component.getByText('Kasni 4 dana')).toBeVisible();
@@ -445,6 +452,80 @@ test('opens the existing completion and blocker flows from Today', async ({
     await expect(
         page.getByRole('dialog', { name: 'Prijavi prepreku' }),
     ).toBeVisible();
+});
+
+test('groups watering and harvest across raised beds like Schedule', async ({
+    mount,
+}) => {
+    const wateringFirst = buildOperationTask({
+        key: 'operation:watering-1',
+        label: 'Zalijevanje prve gredice',
+        location: {
+            farmId: 1,
+            groupKey: '1|garden-1|account-1',
+            kind: 'raisedBed',
+            label: 'Gredica 1',
+            physicalId: '1',
+            positionIndex: null,
+            positionNumber: null,
+            raisedBedId: 1,
+        },
+        operationGroup: 'watering',
+    });
+    const harvest = buildOperationTask({
+        key: 'operation:harvest-1',
+        label: 'Berba druge gredice',
+        location: {
+            farmId: 1,
+            groupKey: '2|garden-1|account-1',
+            kind: 'raisedBed',
+            label: 'Gredica 2 · pozicija 4',
+            physicalId: '2',
+            positionIndex: 3,
+            positionNumber: 4,
+            raisedBedId: 2,
+        },
+        operationGroup: 'harvest',
+    });
+    const wateringSecond = buildOperationTask({
+        key: 'operation:watering-2',
+        label: 'Zalijevanje treće gredice',
+        location: {
+            farmId: 1,
+            groupKey: '3|garden-1|account-1',
+            kind: 'raisedBed',
+            label: 'Gredica 3',
+            physicalId: '3',
+            positionIndex: null,
+            positionNumber: null,
+            raisedBedId: 3,
+        },
+        operationGroup: 'watering',
+    });
+    const component = await mount(
+        todayView(
+            buildAvailableData({
+                focusQueue: [wateringFirst, harvest, wateringSecond],
+                summary: buildSummary({
+                    assignedToMe: 3,
+                    remaining: 3,
+                    remainingDuration: { complete: true, minutes: 60 },
+                }),
+                workState: 'hasWork',
+            }),
+        ),
+    );
+
+    const wateringGroup = component.getByRole('region', {
+        name: 'Zalijevanje',
+    });
+    const harvestGroup = component.getByRole('region', { name: 'Berba' });
+    await expect(
+        wateringGroup.locator('[data-farm-today-task-card]'),
+    ).toHaveCount(2);
+    await expect(
+        harvestGroup.locator('[data-farm-today-task-card]'),
+    ).toHaveCount(1);
 });
 
 test('keeps a partial result actionable while explaining incomplete counts', async ({

--- a/apps/farm/app/FarmTodayView.tsx
+++ b/apps/farm/app/FarmTodayView.tsx
@@ -1,5 +1,5 @@
 import { Alert } from '@gredice/ui/Alert';
-import { MapPin, Warning } from '@gredice/ui/icons';
+import { Droplet, MapPin, Sprout, Warning } from '@gredice/ui/icons';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import type { ReactNode } from 'react';
@@ -23,17 +23,27 @@ type FarmTodayViewProps = {
 };
 
 type FarmTodayTaskGroup = {
+    kind: 'harvest' | 'location' | 'watering';
     key: string;
     label: string;
     tasks: FarmTodayTask[];
 };
 
 function getTaskGroup(task: FarmTodayTask) {
+    if (task.kind === 'operation' && task.operationGroup) {
+        return {
+            key: `operation-group:${task.operationGroup}`,
+            kind: task.operationGroup,
+            label: task.operationGroup === 'watering' ? 'Zalijevanje' : 'Berba',
+        } as const;
+    }
+
     if (task.location.kind === 'farm') {
         return {
             key: `farm:${task.location.farmId}`,
+            kind: 'location',
             label: task.location.label,
-        };
+        } as const;
     }
 
     const raisedBedLabel = task.location.physicalId
@@ -42,20 +52,26 @@ function getTaskGroup(task: FarmTodayTask) {
 
     return {
         key: `raised-bed:${task.location.groupKey}`,
+        kind: 'location',
         label: raisedBedLabel,
-    };
+    } as const;
 }
 
 function groupTasks(tasks: FarmTodayTask[]) {
     const groups = new Map<string, FarmTodayTaskGroup>();
 
     for (const task of tasks) {
-        const { key, label } = getTaskGroup(task);
+        const { key, kind, label } = getTaskGroup(task);
         const group = groups.get(key);
         if (group) {
             group.tasks.push(task);
         } else {
-            groups.set(key, { key, label, tasks: [task] });
+            groups.set(key, {
+                key,
+                kind,
+                label,
+                tasks: [task],
+            });
         }
     }
 
@@ -165,6 +181,12 @@ export function FarmTodayView({
                     <Stack spacing={4}>
                         {taskGroups.map((group, groupIndex) => {
                             const groupTitleId = `farm-today-task-group-${groupIndex}`;
+                            const GroupIcon =
+                                group.kind === 'watering'
+                                    ? Droplet
+                                    : group.kind === 'harvest'
+                                      ? Sprout
+                                      : MapPin;
 
                             return (
                                 <section
@@ -177,7 +199,7 @@ export function FarmTodayView({
                                             className="inline-flex min-h-9 min-w-0 items-center gap-1.5 rounded-md bg-primary/10 px-2.5 text-base font-bold text-primary [overflow-wrap:anywhere]"
                                             id={groupTitleId}
                                         >
-                                            <MapPin
+                                            <GroupIcon
                                                 aria-hidden
                                                 className="size-4 shrink-0"
                                             />

--- a/apps/farm/app/farmTodayModel.spec.ts
+++ b/apps/farm/app/farmTodayModel.spec.ts
@@ -101,14 +101,16 @@ function buildDefinition({
     duration = 20,
     id = 701,
     label = `Radnja ${id}`,
+    visualReward,
 }: {
     duration?: number;
     id?: number;
     label?: string;
+    visualReward?: 'harvest' | 'watering';
 } = {}): EntityStandardized {
     return {
         id,
-        attributes: { duration },
+        attributes: { duration, visualReward },
         information: { label },
     };
 }
@@ -212,7 +214,11 @@ test('composes mixed operation and planting work without merging pending into co
     });
     const operationDefinitions = [
         {
-            ...buildDefinition({ id: 701, duration: 20 }),
+            ...buildDefinition({
+                id: 701,
+                duration: 20,
+                visualReward: 'watering',
+            }),
             conditions: {
                 completionAttachImagesRequired: true,
                 completionAttachNotes: true,
@@ -295,6 +301,11 @@ test('composes mixed operation and planting work without merging pending into co
         notes: 'optional',
     });
     expect(operationTask?.href).toBe('/operations/701');
+    expect(
+        operationTask?.kind === 'operation'
+            ? operationTask.operationGroup
+            : null,
+    ).toBe('watering');
     expect(operationTask?.actionTarget).toEqual({
         expectedEntityId: 701,
         expectedTaskVersionEventId: 1101,

--- a/apps/farm/app/farmTodayModel.ts
+++ b/apps/farm/app/farmTodayModel.ts
@@ -8,6 +8,8 @@ import {
     getFieldPhysicalPositionIndex,
     getOperationDurationMinutes,
     getScheduleTaskAgeIndicator,
+    isGroupedHarvestScheduleOperation,
+    isGroupedWateringScheduleOperation,
     isScheduleDatePast,
     PLANTING_TASK_DURATION_MINUTES,
     type ScheduleTaskAgeIndicator,
@@ -158,6 +160,7 @@ export type FarmTodayOperationTask = FarmTodayTaskBase & {
     > | null;
     completionConditions?: EntityStandardized['conditions'];
     kind: 'operation';
+    operationGroup: 'harvest' | 'watering' | null;
     operationDefinitionAvailable: boolean;
     operationId: number;
     proofRequirements: ScheduleOperationCompletionRequirements;
@@ -689,6 +692,17 @@ function buildOperationCandidates({
                     : operation.completedAt,
             ),
             operationId: operation.id,
+            operationGroup: isGroupedWateringScheduleOperation(
+                operation,
+                operationDefinition,
+            )
+                ? 'watering'
+                : isGroupedHarvestScheduleOperation(
+                        operation,
+                        operationDefinition,
+                    )
+                  ? 'harvest'
+                  : null,
             operationDefinitionAvailable: Boolean(operationDefinition),
             proofRequirements: getScheduleOperationCompletionRequirements(
                 operationDefinition,

--- a/apps/farm/app/schedule/FarmScheduleOperationTaskCard.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationTaskCard.tsx
@@ -96,53 +96,60 @@ export function FarmScheduleOperationTaskCard({
         (Boolean(operation.completionNotes?.trim()) ||
             Boolean(operation.imageUrls?.some((url) => url.trim().length > 0)));
     const detailsContent = (
-        <Row spacing={2} className="min-w-0 items-start justify-between gap-3">
-            <Stack spacing={1} className="min-w-0 grow">
+        <Stack spacing={1} className="min-w-0">
+            <Row
+                spacing={2}
+                className="min-w-0 items-start justify-between gap-3"
+            >
                 <Typography
                     id={taskLabelId}
-                    className={
+                    className={cx(
+                        'min-w-0 grow',
                         taskPresentation.isCompleted
                             ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
-                            : '[overflow-wrap:anywhere]'
-                    }
+                            : '[overflow-wrap:anywhere]',
+                    )}
                 >
                     {operation.label}
                 </Typography>
+                {operation.assignedUser && (
+                    <div
+                        className="shrink-0"
+                        title={`Dodijeljeno: ${operation.assignedUser.displayName ?? operation.assignedUser.userName}`}
+                    >
+                        <UserAvatar
+                            avatarUrl={operation.assignedUser.avatarUrl}
+                            displayName={
+                                operation.assignedUser.displayName ??
+                                operation.assignedUser.userName
+                            }
+                            className="size-7 rounded-full"
+                        />
+                    </div>
+                )}
+            </Row>
+            <Row spacing={1} className="items-center flex-wrap gap-y-1">
                 <ScheduleTaskLocation
+                    inline
                     positionNumber={operation.positionNumber}
                     raisedBedLabel={operation.raisedBedLabel}
                 />
-                <Row spacing={2} className="items-center flex-wrap gap-y-1">
-                    <ScheduleTaskStatusChip state={taskState} />
-                    <ScheduleTaskDurationChip
-                        minutes={operation.durationMinutes}
-                    />
-                    <ScheduleTaskDateChip
+                <ScheduleTaskDurationChip
+                    compact
+                    minutes={operation.durationMinutes}
+                />
+                <ScheduleTaskDateChip
+                    compact
+                    scheduledDate={operation.scheduledDate}
+                />
+                <ScheduleTaskStatusChip state={taskState} />
+                {taskPresentation.showAgeIndicator && (
+                    <ScheduleTaskAgeIndicatorChip
                         scheduledDate={operation.scheduledDate}
                     />
-                    {taskPresentation.showAgeIndicator && (
-                        <ScheduleTaskAgeIndicatorChip
-                            scheduledDate={operation.scheduledDate}
-                        />
-                    )}
-                </Row>
-            </Stack>
-            {operation.assignedUser && (
-                <div
-                    className="shrink-0"
-                    title={`Dodijeljeno: ${operation.assignedUser.displayName ?? operation.assignedUser.userName}`}
-                >
-                    <UserAvatar
-                        avatarUrl={operation.assignedUser.avatarUrl}
-                        displayName={
-                            operation.assignedUser.displayName ??
-                            operation.assignedUser.userName
-                        }
-                        className="size-7 rounded-full"
-                    />
-                </div>
-            )}
-        </Row>
+                )}
+            </Row>
+        </Stack>
     );
 
     return (
@@ -199,6 +206,7 @@ export function FarmScheduleOperationTaskCard({
                     ) : undefined
                 }
                 label={operation.label}
+                layout="inline"
                 state={taskState}
                 unavailableTitle={
                     operationData

--- a/apps/farm/app/schedule/FarmSchedulePlantingTaskCard.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingTaskCard.tsx
@@ -93,58 +93,65 @@ export function FarmSchedulePlantingTaskCard({
     const taskAnchorId = getScheduleTaskAnchorId('planting', field.id);
     const taskLabelId = getScheduleTaskLabelId('planting', field.id);
     const detailsContent = (
-        <Row spacing={2} className="min-w-0 items-start justify-between gap-3">
-            <SchedulePlantVisual plantSort={plantSort} label={label} />
-            <Stack spacing={1} className="min-w-0 grow">
+        <Stack spacing={1} className="min-w-0">
+            <Row
+                spacing={2}
+                className="min-w-0 items-start justify-between gap-3"
+            >
+                <SchedulePlantVisual plantSort={plantSort} label={label} />
                 <Typography
                     id={taskLabelId}
-                    className={
+                    className={cx(
+                        'min-w-0 grow',
                         taskPresentation.isCompleted
                             ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
-                            : '[overflow-wrap:anywhere]'
-                    }
+                            : '[overflow-wrap:anywhere]',
+                    )}
                 >
                     {label}
                 </Typography>
+                {field.assignedUserId && (
+                    <Suspense
+                        fallback={
+                            <Skeleton className="size-7 shrink-0 rounded-full" />
+                        }
+                    >
+                        <PlantingAssignedUserAvatar
+                            assignedUserByFieldIdPromise={
+                                assignedUserByFieldIdPromise
+                            }
+                            fieldId={field.id}
+                        />
+                    </Suspense>
+                )}
+            </Row>
+            <Row spacing={1} className="items-center flex-wrap gap-y-1">
                 <ScheduleTaskLocation
+                    inline
                     positionNumber={positionNumber}
                     raisedBedLabel={raisedBedLabel}
                 />
-                <Row spacing={2} className="items-center flex-wrap gap-y-1">
-                    <ScheduleTaskStatusChip state={taskState} />
-                    <ScheduleTaskDurationChip
-                        minutes={PLANTING_TASK_DURATION_MINUTES}
-                    />
-                    {greenhouseSowing && (
-                        <Chip size="sm" color="success" variant="soft">
-                            Staklenik
-                        </Chip>
-                    )}
-                    <ScheduleTaskDateChip
+                <ScheduleTaskDurationChip
+                    compact
+                    minutes={PLANTING_TASK_DURATION_MINUTES}
+                />
+                <ScheduleTaskDateChip
+                    compact
+                    scheduledDate={field.plantScheduledDate}
+                />
+                <ScheduleTaskStatusChip state={taskState} />
+                {greenhouseSowing && (
+                    <Chip size="sm" color="success" variant="soft">
+                        Staklenik
+                    </Chip>
+                )}
+                {taskPresentation.showAgeIndicator && (
+                    <ScheduleTaskAgeIndicatorChip
                         scheduledDate={field.plantScheduledDate}
                     />
-                    {taskPresentation.showAgeIndicator && (
-                        <ScheduleTaskAgeIndicatorChip
-                            scheduledDate={field.plantScheduledDate}
-                        />
-                    )}
-                </Row>
-            </Stack>
-            {field.assignedUserId && (
-                <Suspense
-                    fallback={
-                        <Skeleton className="size-7 shrink-0 rounded-full" />
-                    }
-                >
-                    <PlantingAssignedUserAvatar
-                        assignedUserByFieldIdPromise={
-                            assignedUserByFieldIdPromise
-                        }
-                        fieldId={field.id}
-                    />
-                </Suspense>
-            )}
-        </Row>
+                )}
+            </Row>
+        </Stack>
     );
 
     return (
@@ -188,6 +195,7 @@ export function FarmSchedulePlantingTaskCard({
                     ) : undefined
                 }
                 label={label}
+                layout="inline"
                 state={taskState}
                 unavailableTitle={
                     plantingIdentity

--- a/apps/farm/app/schedule/FarmScheduleTaskCards.spec.tsx
+++ b/apps/farm/app/schedule/FarmScheduleTaskCards.spec.tsx
@@ -129,23 +129,22 @@ async function assertPrimaryTargetsAreTouchable(component: Locator) {
     expect(undersizedTargets).toEqual([]);
 }
 
-async function assertTaskActionsAreFullWidth(card: Locator) {
+async function assertTaskActionsShareRow(card: Locator) {
     const actionArea = card.locator(
         '[data-schedule-task-completion="available"]',
     );
     const actionButtons = actionArea.getByRole('button');
 
     await expect(actionButtons).toHaveCount(2);
-    expect(
-        await actionArea.evaluate((area) => {
-            const availableWidth = area.getBoundingClientRect().width;
-            return Array.from(area.querySelectorAll('button')).every(
-                (button) =>
-                    Math.abs(
-                        button.getBoundingClientRect().width - availableWidth,
-                    ) <= 1,
-            );
+    const bounds = await actionButtons.evaluateAll((buttons) =>
+        buttons.map((button) => {
+            const rect = button.getBoundingClientRect();
+            return { height: rect.height, width: rect.width, y: rect.y };
         }),
+    );
+    expect(bounds[0]?.y).toBeCloseTo(bounds[1]?.y ?? Number.NaN, 0);
+    expect(
+        bounds.every(({ height, width }) => height >= 44 && width >= 44),
     ).toBe(true);
 }
 
@@ -241,7 +240,19 @@ test('keeps location before completion and exposes no manual links', async ({
     await expect(completionButton).toBeFocused();
     await page.keyboard.press('Tab');
     await expect(blockerButton).toBeFocused();
-    await assertTaskActionsAreFullWidth(component);
+    const metadataLabels = ['Gr 15', 'Pozicija 8', '15 min', '15. 07.'];
+    const metadataCenterY = await Promise.all(
+        metadataLabels.map(async (label) => {
+            const bounds = await component
+                .getByText(label, { exact: true })
+                .boundingBox();
+            return bounds ? bounds.y + bounds.height / 2 : Number.NaN;
+        }),
+    );
+    expect(
+        Math.max(...metadataCenterY) - Math.min(...metadataCenterY),
+    ).toBeLessThanOrEqual(1);
+    await assertTaskActionsShareRow(component);
     await assertCardsStayWithinViewport(component);
     await assertPrimaryTargetsAreTouchable(component);
 });
@@ -516,7 +527,7 @@ test('keeps loading completion explicit, disabled, and phone-sized', async ({
             name: /Ne mogu dovršiti sijanje/,
         }),
     ).toBeVisible();
-    await assertTaskActionsAreFullWidth(component);
+    await assertTaskActionsShareRow(component);
     await assertCardsStayWithinViewport(component);
     await assertPrimaryTargetsAreTouchable(component);
 });
@@ -709,7 +720,7 @@ for (const width of [320, 375, 390, 430, 1280]) {
             }),
         ).toBeVisible();
         await expect(actionableCard.getByRole('link')).toHaveCount(0);
-        await assertTaskActionsAreFullWidth(actionableCard);
+        await assertTaskActionsShareRow(actionableCard);
 
         await assertCardsStayWithinViewport(component);
         await assertPrimaryTargetsAreTouchable(component);
@@ -817,7 +828,7 @@ for (const width of [320, 375, 390, 430, 1280]) {
             }),
         ).toBeVisible();
         await expect(actionableCard.getByRole('link')).toHaveCount(0);
-        await assertTaskActionsAreFullWidth(actionableCard);
+        await assertTaskActionsShareRow(actionableCard);
 
         await assertCardsStayWithinViewport(component);
         await assertPrimaryTargetsAreTouchable(component);

--- a/apps/farm/app/schedule/ScheduleTaskDateChip.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskDateChip.tsx
@@ -1,13 +1,16 @@
 import { Chip } from '@gredice/ui/Chip';
 import { Calendar } from '@gredice/ui/icons';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { cx } from '@gredice/ui/utils';
 import { getScheduleDateFormat, isScheduleDatePast } from './scheduleShared';
 
 interface ScheduleTaskDateChipProps {
+    compact?: boolean;
     scheduledDate: Date | string | null | undefined;
 }
 
 export function ScheduleTaskDateChip({
+    compact = false,
     scheduledDate,
 }: ScheduleTaskDateChipProps) {
     const isPast = isScheduleDatePast(scheduledDate);
@@ -18,8 +21,13 @@ export function ScheduleTaskDateChip({
             color={isPast ? 'warning' : 'neutral'}
             variant="soft"
             title={isPast ? 'Planirani datum je u prošlosti' : 'Planirano'}
-            className={isPast ? undefined : 'bg-muted/60 text-muted-foreground'}
-            startDecorator={<Calendar aria-hidden="true" />}
+            className={cx(
+                compact && 'px-1',
+                !isPast && 'bg-muted/60 text-muted-foreground',
+            )}
+            startDecorator={
+                compact ? undefined : <Calendar aria-hidden="true" />
+            }
         >
             {scheduledDate ? (
                 <LocalDateTime

--- a/apps/farm/app/schedule/ScheduleTaskDurationChip.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskDurationChip.tsx
@@ -1,12 +1,15 @@
 import { Chip } from '@gredice/ui/Chip';
 import { Timer } from '@gredice/ui/icons';
+import { cx } from '@gredice/ui/utils';
 import { formatMinutes } from './scheduleShared';
 
 interface ScheduleTaskDurationChipProps {
+    compact?: boolean;
     minutes: number;
 }
 
 export function ScheduleTaskDurationChip({
+    compact = false,
     minutes,
 }: ScheduleTaskDurationChipProps) {
     if (minutes <= 0) {
@@ -19,8 +22,11 @@ export function ScheduleTaskDurationChip({
             color="neutral"
             variant="soft"
             title="Trajanje"
-            className="bg-muted/60 text-muted-foreground"
-            startDecorator={<Timer aria-hidden="true" />}
+            className={cx(
+                'bg-muted/60 text-muted-foreground',
+                compact && 'px-1',
+            )}
+            startDecorator={compact ? undefined : <Timer aria-hidden="true" />}
         >
             {formatMinutes(minutes)}
         </Chip>

--- a/apps/farm/app/schedule/ScheduleTaskLocation.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskLocation.tsx
@@ -1,11 +1,13 @@
 import { MapPin } from '@gredice/ui/icons';
 
 type ScheduleTaskLocationProps = {
+    inline?: boolean;
     positionNumber?: number | null;
     raisedBedLabel?: string | null;
 };
 
 export function ScheduleTaskLocation({
+    inline = false,
     positionNumber,
     raisedBedLabel,
 }: ScheduleTaskLocationProps) {
@@ -18,17 +20,21 @@ export function ScheduleTaskLocation({
 
     return (
         <div
-            className="flex min-w-0 flex-wrap items-center gap-1.5 text-sm font-semibold text-foreground"
+            className={
+                inline
+                    ? 'contents text-sm font-semibold text-foreground'
+                    : 'flex min-w-0 flex-wrap items-center gap-1.5 text-sm font-semibold text-foreground'
+            }
             data-schedule-task-location
         >
             {raisedBedLabel ? (
-                <span className="inline-flex min-h-8 min-w-0 items-center gap-1 rounded-md bg-primary/10 px-2 text-primary [overflow-wrap:anywhere]">
+                <span className="inline-flex min-h-7 min-w-0 items-center gap-1 rounded-md bg-primary/10 px-1.5 text-primary [overflow-wrap:anywhere]">
                     <MapPin aria-hidden className="size-4 shrink-0" />
                     {raisedBedLabel}
                 </span>
             ) : null}
             {positionNumber === null || positionNumber === undefined ? null : (
-                <span className="inline-flex min-h-8 items-center rounded-md bg-amber-100 px-2 font-bold text-amber-950 dark:bg-amber-950/50 dark:text-amber-100">
+                <span className="inline-flex min-h-7 items-center rounded-md bg-amber-100 px-1.5 font-bold text-amber-950 dark:bg-amber-950/50 dark:text-amber-100">
                     Pozicija {positionNumber}
                 </span>
             )}

--- a/apps/farm/components/analytics/FarmAnalyticsProvider.spec.tsx
+++ b/apps/farm/components/analytics/FarmAnalyticsProvider.spec.tsx
@@ -145,6 +145,7 @@ function buildOperationTask(
         },
         occurredAt: null,
         operationId: 987654321,
+        operationGroup: null,
         operationDefinitionAvailable: true,
         overdue: false,
         proofRequirements: { images: 'required', notes: 'optional' },

--- a/apps/farm/generate/PwaInstallPreview.tsx
+++ b/apps/farm/generate/PwaInstallPreview.tsx
@@ -40,6 +40,7 @@ const focusTask = {
     },
     occurredAt: null,
     operationId: 701,
+    operationGroup: null,
     operationDefinitionAvailable: true,
     overdue: false,
     proofRequirements: { images: 'required', notes: 'optional' },


### PR DESCRIPTION
## Summary

- group watering and harvest operations across raised beds into Zalijevanje and Berba sections on Today, matching Schedule
- keep raised-bed and position badges prominent while placing location, duration, and date on one compact metadata row
- place complete and cannot-complete actions side by side on Today and Schedule while preserving 44px phone touch targets
- preserve the existing raised-bed grouping and physical-position ordering for all other work

## Impact

Farmers can scan the same task categories on Today and Schedule, identify the exact bed and position faster, and complete or decline work without the cards becoming unnecessarily tall on phones.

## Validation

- `corepack pnpm --filter farm exec tsc --noEmit`
- focused Biome checks and `git diff --check`
- `corepack pnpm --filter farm exec playwright test app/farmTodayModel.spec.ts app/FarmTodayView.spec.tsx app/schedule/FarmScheduleTaskCards.spec.tsx app/schedule/ScheduleTaskStateControl.spec.tsx app/schedule/FarmScheduleOperationsSection.spec.ts components/analytics/FarmAnalyticsProvider.spec.tsx` (60 passed)
- `corepack pnpm --filter farm build`