### PR TITLE
fix(farm): align raised bed position layouts

### DIFF
--- a/apps/farm/app/raised-beds/[raisedBedId]/RaisedBedMobileFieldList.spec.tsx
+++ b/apps/farm/app/raised-beds/[raisedBedId]/RaisedBedMobileFieldList.spec.tsx
@@ -1,0 +1,82 @@
+import { Card } from '@gredice/ui/Card';
+import { expect, test } from '@playwright/experimental-ct-react';
+import '../../globals.css';
+import { RaisedBedMobileFieldList } from './RaisedBedMobileFieldList';
+
+const phoneViewports = [
+    { width: 320, height: 568 },
+    { width: 375, height: 667 },
+    { width: 430, height: 932 },
+] as const;
+
+const longPlantName = 'Krastavac dugi zeleni Long Anglais';
+
+function mobileFieldList() {
+    return (
+        <div className="p-4">
+            <Card>
+                <RaisedBedMobileFieldList
+                    items={[
+                        {
+                            harvestedDate: '—',
+                            key: 'position-1',
+                            plannedDate: '01. 05. 2026.',
+                            plantName: longPlantName,
+                            plantSort: null,
+                            positionNumber: 1,
+                            readyDate: '09. 06. 2026.',
+                            sowingDate: '22. 05. 2026.',
+                            statusControl: (
+                                <button type="button">🌱 Proklijala</button>
+                            ),
+                        },
+                    ]}
+                />
+            </Card>
+        </div>
+    );
+}
+
+for (const viewport of phoneViewports) {
+    test(`keeps raised-bed field details readable at ${viewport.width}px`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize(viewport);
+        const component = await mount(mobileFieldList());
+
+        await expect(component.getByText('Pozicija 1')).toBeVisible();
+        await expect(component.getByText(longPlantName)).toBeVisible();
+        await expect(
+            component.getByRole('button', { name: '🌱 Proklijala' }),
+        ).toBeVisible();
+        await expect(component.getByText('Planirano')).toBeVisible();
+        await expect(component.getByText('Posijano')).toBeVisible();
+        await expect(component.getByText('Spremno')).toBeVisible();
+        await expect(component.getByText('Ubrano')).toBeVisible();
+
+        const plantNameWidth = await component
+            .locator('[data-raised-bed-plant-name]')
+            .evaluate((element) => element.getBoundingClientRect().width);
+        expect(plantNameWidth).toBeGreaterThan(100);
+        expect(
+            await page.evaluate(
+                () =>
+                    document.documentElement.scrollWidth <=
+                    document.documentElement.clientWidth,
+            ),
+        ).toBe(true);
+    });
+}
+
+test('hides the raised-bed mobile list at the desktop breakpoint', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    const component = await mount(mobileFieldList());
+
+    await expect(
+        component.locator('[data-raised-bed-mobile-list]'),
+    ).toBeHidden();
+});

--- a/apps/farm/app/raised-beds/[raisedBedId]/RaisedBedMobileFieldList.tsx
+++ b/apps/farm/app/raised-beds/[raisedBedId]/RaisedBedMobileFieldList.tsx
@@ -1,0 +1,106 @@
+import type { EntityStandardized } from '@gredice/storage';
+import { CardOverflow } from '@gredice/ui/Card';
+import { Sprout } from '@gredice/ui/icons';
+import { PlantOrSortImage } from '@gredice/ui/plants';
+import { Typography } from '@gredice/ui/Typography';
+import type { ReactNode } from 'react';
+
+export type RaisedBedMobileFieldListItem = {
+    harvestedDate: string;
+    key: string;
+    plannedDate: string;
+    plantName: string;
+    plantSort: EntityStandardized | null;
+    positionNumber: number;
+    readyDate: string;
+    sowingDate: string;
+    statusControl: ReactNode;
+};
+
+export function RaisedBedMobileFieldList({
+    items,
+}: {
+    items: RaisedBedMobileFieldListItem[];
+}) {
+    return (
+        <CardOverflow className="md:hidden" data-raised-bed-mobile-list>
+            <div className="divide-y border-t">
+                {items.map((item) => (
+                    <div className="space-y-3 p-4" key={item.key}>
+                        <div className="flex min-w-0 items-start gap-3">
+                            <div className="relative flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-md border bg-muted/30">
+                                {item.plantSort ? (
+                                    <PlantOrSortImage
+                                        alt={item.plantName}
+                                        className="size-12 object-cover"
+                                        height={48}
+                                        plantSort={item.plantSort}
+                                        width={48}
+                                    />
+                                ) : (
+                                    <Sprout
+                                        aria-hidden
+                                        className="size-6 text-muted-foreground/60"
+                                    />
+                                )}
+                            </div>
+                            <div className="min-w-0 flex-1 space-y-2">
+                                <div className="min-w-0">
+                                    <Typography
+                                        className="font-semibold text-primary"
+                                        level="body3"
+                                    >
+                                        Pozicija {item.positionNumber}
+                                    </Typography>
+                                    <Typography
+                                        className="break-words"
+                                        data-raised-bed-plant-name
+                                        level="body1"
+                                        semiBold
+                                    >
+                                        {item.plantName}
+                                    </Typography>
+                                </div>
+                                <div>{item.statusControl}</div>
+                            </div>
+                        </div>
+                        <dl className="grid grid-cols-2 gap-x-4 gap-y-3 border-t pt-3">
+                            <div className="min-w-0 space-y-1">
+                                <dt className="text-sm text-muted-foreground">
+                                    Planirano
+                                </dt>
+                                <dd className="text-sm tabular-nums">
+                                    {item.plannedDate}
+                                </dd>
+                            </div>
+                            <div className="min-w-0 space-y-1">
+                                <dt className="text-sm text-muted-foreground">
+                                    Posijano
+                                </dt>
+                                <dd className="text-sm tabular-nums">
+                                    {item.sowingDate}
+                                </dd>
+                            </div>
+                            <div className="min-w-0 space-y-1">
+                                <dt className="text-sm text-muted-foreground">
+                                    Spremno
+                                </dt>
+                                <dd className="text-sm tabular-nums">
+                                    {item.readyDate}
+                                </dd>
+                            </div>
+                            <div className="min-w-0 space-y-1">
+                                <dt className="text-sm text-muted-foreground">
+                                    Ubrano
+                                </dt>
+                                <dd className="text-sm tabular-nums">
+                                    {item.harvestedDate}
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                ))}
+            </div>
+        </CardOverflow>
+    );
+}

--- a/apps/farm/app/raised-beds/[raisedBedId]/RaisedBedResponsiveLayout.spec.tsx
+++ b/apps/farm/app/raised-beds/[raisedBedId]/RaisedBedResponsiveLayout.spec.tsx
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import '../../globals.css';
+import { RaisedBedResponsiveLayoutHarness } from './RaisedBedResponsiveLayoutHarness';
+
+test('unmounts portalled status menus when crossing the desktop breakpoint', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await mount(<RaisedBedResponsiveLayoutHarness />);
+
+    await page.getByRole('button', { name: 'Otvori mobile status' }).click();
+    await expect(page.getByText('mobile status opcije')).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Otvori desktop status' }),
+    ).toHaveCount(0);
+
+    await page.setViewportSize({ width: 1024, height: 768 });
+
+    await expect(page.getByText('mobile status opcije')).toHaveCount(0);
+    await expect(
+        page.getByRole('button', { name: 'Otvori mobile status' }),
+    ).toHaveCount(0);
+    await page.getByRole('button', { name: 'Otvori desktop status' }).click();
+    await expect(page.getByText('desktop status opcije')).toBeVisible();
+
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    await expect(page.getByText('desktop status opcije')).toHaveCount(0);
+    await expect(
+        page.getByRole('button', { name: 'Otvori desktop status' }),
+    ).toHaveCount(0);
+    await expect(
+        page.getByRole('button', { name: 'Otvori mobile status' }),
+    ).toBeVisible();
+});

--- a/apps/farm/app/raised-beds/[raisedBedId]/RaisedBedResponsiveLayout.tsx
+++ b/apps/farm/app/raised-beds/[raisedBedId]/RaisedBedResponsiveLayout.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { type ReactNode, useSyncExternalStore } from 'react';
+
+const desktopLayoutQuery = '(min-width: 768px)';
+
+function subscribeToDesktopLayout(onChange: () => void) {
+    const mediaQuery = window.matchMedia(desktopLayoutQuery);
+    mediaQuery.addEventListener('change', onChange);
+
+    return () => mediaQuery.removeEventListener('change', onChange);
+}
+
+function desktopLayoutSnapshot() {
+    return window.matchMedia(desktopLayoutQuery).matches;
+}
+
+export function RaisedBedResponsiveLayout({
+    children,
+    layout,
+}: {
+    children: ReactNode;
+    layout: 'mobile' | 'desktop';
+}) {
+    const desktop = useSyncExternalStore(
+        subscribeToDesktopLayout,
+        desktopLayoutSnapshot,
+        () => false,
+    );
+    const activeLayout = desktop ? 'desktop' : 'mobile';
+
+    return layout === activeLayout ? children : null;
+}

--- a/apps/farm/app/raised-beds/[raisedBedId]/RaisedBedResponsiveLayoutHarness.tsx
+++ b/apps/farm/app/raised-beds/[raisedBedId]/RaisedBedResponsiveLayoutHarness.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Popper } from '@gredice/ui/Popper';
+import { useState } from 'react';
+import { RaisedBedResponsiveLayout } from './RaisedBedResponsiveLayout';
+
+function StatusControl({ layout }: { layout: 'mobile' | 'desktop' }) {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <Popper
+            onOpenChange={setOpen}
+            open={open}
+            trigger={<button type="button">Otvori {layout} status</button>}
+        >
+            <div>{layout} status opcije</div>
+        </Popper>
+    );
+}
+
+export function RaisedBedResponsiveLayoutHarness() {
+    return (
+        <>
+            <RaisedBedResponsiveLayout layout="mobile">
+                <StatusControl layout="mobile" />
+            </RaisedBedResponsiveLayout>
+            <RaisedBedResponsiveLayout layout="desktop">
+                <StatusControl layout="desktop" />
+            </RaisedBedResponsiveLayout>
+        </>
+    );
+}

--- a/apps/farm/app/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/farm/app/raised-beds/[raisedBedId]/page.tsx
@@ -22,6 +22,7 @@ import { HomeButton } from '../../../components/HomeButton';
 import { auth } from '../../../lib/auth/auth';
 import { PlantStateRequestForm } from './PlantStateRequestForm';
 import { RaisedBedMobileFieldList } from './RaisedBedMobileFieldList';
+import { RaisedBedResponsiveLayout } from './RaisedBedResponsiveLayout';
 
 export const dynamic = 'force-dynamic';
 
@@ -196,14 +197,16 @@ async function RaisedBedDetailPageContent({
                             readyDate: formatDate(field?.plantReadyDate),
                             sowingDate: formatDate(field?.plantSowDate),
                             statusControl: field?.plantStatus ? (
-                                <PlantStateRequestForm
-                                    currentStatus={field.plantStatus}
-                                    pendingRequestedStatus={
-                                        pendingRequestedStatus
-                                    }
-                                    positionIndex={positionIndex}
-                                    raisedBedId={raisedBed.id}
-                                />
+                                <RaisedBedResponsiveLayout layout="mobile">
+                                    <PlantStateRequestForm
+                                        currentStatus={field.plantStatus}
+                                        pendingRequestedStatus={
+                                            pendingRequestedStatus
+                                        }
+                                        positionIndex={positionIndex}
+                                        raisedBedId={raisedBed.id}
+                                    />
+                                </RaisedBedResponsiveLayout>
                             ) : (
                                 <Typography
                                     className="text-muted-foreground"
@@ -266,20 +269,22 @@ async function RaisedBedDetailPageContent({
                                             </Table.Cell>
                                             <Table.Cell>
                                                 {field?.plantStatus ? (
-                                                    <PlantStateRequestForm
-                                                        raisedBedId={
-                                                            raisedBed.id
-                                                        }
-                                                        positionIndex={
-                                                            positionIndex
-                                                        }
-                                                        currentStatus={
-                                                            field.plantStatus
-                                                        }
-                                                        pendingRequestedStatus={
-                                                            pendingRequestedStatus
-                                                        }
-                                                    />
+                                                    <RaisedBedResponsiveLayout layout="desktop">
+                                                        <PlantStateRequestForm
+                                                            raisedBedId={
+                                                                raisedBed.id
+                                                            }
+                                                            positionIndex={
+                                                                positionIndex
+                                                            }
+                                                            currentStatus={
+                                                                field.plantStatus
+                                                            }
+                                                            pendingRequestedStatus={
+                                                                pendingRequestedStatus
+                                                            }
+                                                        />
+                                                    </RaisedBedResponsiveLayout>
                                                 ) : (
                                                     <Typography
                                                         level="body3"

--- a/apps/farm/app/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/farm/app/raised-beds/[raisedBedId]/page.tsx
@@ -6,9 +6,14 @@ import {
     getFarmUserRaisedBeds,
 } from '@gredice/storage';
 import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
-import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardOverflow,
+    CardTitle,
+} from '@gredice/ui/Card';
 import { PlantOrSortImage } from '@gredice/ui/plants';
-import { Stack } from '@gredice/ui/Stack';
 import { Table } from '@gredice/ui/Table';
 import { Typography } from '@gredice/ui/Typography';
 import { notFound } from 'next/navigation';
@@ -16,6 +21,7 @@ import LoginDialog from '../../../components/auth/LoginDialog';
 import { HomeButton } from '../../../components/HomeButton';
 import { auth } from '../../../lib/auth/auth';
 import { PlantStateRequestForm } from './PlantStateRequestForm';
+import { RaisedBedMobileFieldList } from './RaisedBedMobileFieldList';
 
 export const dynamic = 'force-dynamic';
 
@@ -120,6 +126,36 @@ async function RaisedBedDetailPageContent({
             .filter((field) => field.active)
             .map((field) => [field.positionIndex, field]),
     );
+    const fieldRows = orderedPositions.map((positionIndex) => {
+        const field = activeFieldsByPosition.get(positionIndex);
+        const pendingRequest = getPendingPlantStatusRequest(
+            pendingPlantStatusRequests,
+            raisedBed.id,
+            positionIndex,
+        );
+        const currentStatus = field?.plantStatus ?? null;
+        const activePendingRequest = isRequestForCurrentStatus(
+            pendingRequest,
+            currentStatus,
+        )
+            ? pendingRequest
+            : undefined;
+        const pendingRequestedStatus =
+            activePendingRequest?.target.kind === 'raisedBedField.plantStatus'
+                ? activePendingRequest.target.requestedStatus
+                : null;
+        const plantSort = field?.plantSortId
+            ? (plantSortsById.get(field.plantSortId) ?? null)
+            : null;
+
+        return {
+            field,
+            pendingRequestedStatus,
+            plantName: resolvePlantName(field?.plantSortId, plantSort),
+            plantSort,
+            positionIndex,
+        };
+    });
 
     return (
         <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
@@ -135,63 +171,72 @@ async function RaisedBedDetailPageContent({
                     <CardTitle>Detalji polja</CardTitle>
                 </CardHeader>
                 <CardContent>
-                    <Stack spacing={4}>
-                        <Typography
-                            level="body2"
-                            className="text-muted-foreground"
-                        >
-                            Pregled svih pozicija i stanja biljaka u odabranoj
-                            gredici.
-                        </Typography>
-                        <Table>
-                            <Table.Header>
-                                <Table.Row>
-                                    <Table.Head>Pozicija</Table.Head>
-                                    <Table.Head>Biljka</Table.Head>
-                                    <Table.Head>Status</Table.Head>
-                                    <Table.Head>Planirano</Table.Head>
-                                    <Table.Head>Posijano</Table.Head>
-                                    <Table.Head>Spremno</Table.Head>
-                                    <Table.Head>Ubrano</Table.Head>
-                                </Table.Row>
-                            </Table.Header>
-                            <Table.Body>
-                                {orderedPositions.map((positionIndex) => {
-                                    const field =
-                                        activeFieldsByPosition.get(
-                                            positionIndex,
-                                        );
-                                    const pendingRequest =
-                                        getPendingPlantStatusRequest(
-                                            pendingPlantStatusRequests,
-                                            raisedBed.id,
-                                            positionIndex,
-                                        );
-                                    const currentStatus =
-                                        field?.plantStatus ?? null;
-                                    const activePendingRequest =
-                                        isRequestForCurrentStatus(
-                                            pendingRequest,
-                                            currentStatus,
-                                        )
-                                            ? pendingRequest
-                                            : undefined;
-                                    const pendingRequestedStatus =
-                                        activePendingRequest?.target.kind ===
-                                        'raisedBedField.plantStatus'
-                                            ? activePendingRequest.target
-                                                  .requestedStatus
-                                            : null;
-                                    const plantSort = field?.plantSortId
-                                        ? (plantSortsById.get(
-                                              field.plantSortId,
-                                          ) ?? null)
-                                        : null;
-                                    const plantName = resolvePlantName(
-                                        field?.plantSortId,
-                                        plantSort,
-                                    );
-
+                    <Typography level="body2" className="text-muted-foreground">
+                        Pregled svih pozicija i stanja biljaka u odabranoj
+                        gredici.
+                    </Typography>
+                </CardContent>
+                <RaisedBedMobileFieldList
+                    items={fieldRows.map(
+                        ({
+                            field,
+                            pendingRequestedStatus,
+                            plantName,
+                            plantSort,
+                            positionIndex,
+                        }) => ({
+                            harvestedDate: formatDate(
+                                field?.plantHarvestedDate,
+                            ),
+                            key: `position-${positionIndex}`,
+                            plannedDate: formatDate(field?.plantScheduledDate),
+                            plantName,
+                            plantSort,
+                            positionNumber: positionIndex + 1,
+                            readyDate: formatDate(field?.plantReadyDate),
+                            sowingDate: formatDate(field?.plantSowDate),
+                            statusControl: field?.plantStatus ? (
+                                <PlantStateRequestForm
+                                    currentStatus={field.plantStatus}
+                                    pendingRequestedStatus={
+                                        pendingRequestedStatus
+                                    }
+                                    positionIndex={positionIndex}
+                                    raisedBedId={raisedBed.id}
+                                />
+                            ) : (
+                                <Typography
+                                    className="text-muted-foreground"
+                                    level="body3"
+                                >
+                                    —
+                                </Typography>
+                            ),
+                        }),
+                    )}
+                />
+                <CardOverflow className="hidden md:block">
+                    <Table>
+                        <Table.Header>
+                            <Table.Row>
+                                <Table.Head>Pozicija</Table.Head>
+                                <Table.Head>Biljka</Table.Head>
+                                <Table.Head>Status</Table.Head>
+                                <Table.Head>Planirano</Table.Head>
+                                <Table.Head>Posijano</Table.Head>
+                                <Table.Head>Spremno</Table.Head>
+                                <Table.Head>Ubrano</Table.Head>
+                            </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                            {fieldRows.map(
+                                ({
+                                    field,
+                                    pendingRequestedStatus,
+                                    plantName,
+                                    plantSort,
+                                    positionIndex,
+                                }) => {
                                     return (
                                         <Table.Row key={positionIndex}>
                                             <Table.Cell>
@@ -266,11 +311,11 @@ async function RaisedBedDetailPageContent({
                                             </Table.Cell>
                                         </Table.Row>
                                     );
-                                })}
-                            </Table.Body>
-                        </Table>
-                    </Stack>
-                </CardContent>
+                                },
+                            )}
+                        </Table.Body>
+                    </Table>
+                </CardOverflow>
             </Card>
         </div>
     );

--- a/apps/farm/app/raised-beds/page.tsx
+++ b/apps/farm/app/raised-beds/page.tsx
@@ -17,6 +17,7 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import LoginDialog from '../../components/auth/LoginDialog';
 import { auth } from '../../lib/auth/auth';
+import { getRaisedBedPositionIndexesDescending } from './raisedBedPositionOrder';
 
 export const dynamic = 'force-dynamic';
 
@@ -38,47 +39,41 @@ function getFieldPreviews(
             .filter((field) => field.active)
             .map((field) => [field.positionIndex, field]),
     );
-    const highestPositionIndex = Math.max(
-        8,
-        ...fields.map((field) => field.positionIndex),
-    );
+    return getRaisedBedPositionIndexesDescending(
+        fields.map((field) => field.positionIndex),
+    ).map((positionIndex) => {
+        const field = activeFieldsByPosition.get(positionIndex);
+        const plantSortId = field?.plantSortId;
+        const hasPlant = typeof plantSortId === 'number';
+        const plantSort = hasPlant ? plantSortsById.get(plantSortId) : null;
+        const status = hasPlant ? field?.plantStatus : undefined;
+        const statusLabel = status
+            ? plantFieldStatusLabel(status).shortLabel
+            : null;
 
-    return Array.from(
-        { length: highestPositionIndex + 1 },
-        (_, positionIndex) => {
-            const field = activeFieldsByPosition.get(positionIndex);
-            const plantSortId = field?.plantSortId;
-            const hasPlant = typeof plantSortId === 'number';
-            const plantSort = hasPlant ? plantSortsById.get(plantSortId) : null;
-            const status = hasPlant ? field?.plantStatus : undefined;
-            const statusLabel = status
-                ? plantFieldStatusLabel(status).shortLabel
-                : null;
-
-            if (!hasPlant) {
-                return {
-                    hasPlant,
-                    key: `position-${positionIndex}`,
-                    label: `Polje ${positionIndex + 1} prazno`,
-                    plantSort: null,
-                    status: null,
-                    statusLabel: null,
-                };
-            }
-
+        if (!hasPlant) {
             return {
                 hasPlant,
-                key: field ? `field-${field.id}` : `position-${positionIndex}`,
-                label:
-                    plantSort?.information?.label ??
-                    plantSort?.information?.name ??
-                    `Sorta #${plantSortId}`,
-                plantSort: plantSort ?? null,
-                status,
-                statusLabel,
+                key: `position-${positionIndex}`,
+                label: `Polje ${positionIndex + 1} prazno`,
+                plantSort: null,
+                status: null,
+                statusLabel: null,
             };
-        },
-    );
+        }
+
+        return {
+            hasPlant,
+            key: field ? `field-${field.id}` : `position-${positionIndex}`,
+            label:
+                plantSort?.information?.label ??
+                plantSort?.information?.name ??
+                `Sorta #${plantSortId}`,
+            plantSort: plantSort ?? null,
+            status,
+            statusLabel,
+        };
+    });
 }
 
 function comparePhysicalIdsDescending(

--- a/apps/farm/app/raised-beds/raisedBedPositionOrder.spec.ts
+++ b/apps/farm/app/raised-beds/raisedBedPositionOrder.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { getRaisedBedPositionIndexesDescending } from './raisedBedPositionOrder';
+
+test('places position 18 top-left and position 1 bottom-right', () => {
+    expect(
+        getRaisedBedPositionIndexesDescending(
+            Array.from({ length: 18 }, (_, index) => index),
+        ),
+    ).toEqual(Array.from({ length: 18 }, (_, index) => 17 - index));
+});
+
+test('keeps the minimum three-by-three preview for sparse raised beds', () => {
+    expect(getRaisedBedPositionIndexesDescending([0, 2])).toEqual([
+        8, 7, 6, 5, 4, 3, 2, 1, 0,
+    ]);
+});

--- a/apps/farm/app/raised-beds/raisedBedPositionOrder.ts
+++ b/apps/farm/app/raised-beds/raisedBedPositionOrder.ts
@@ -1,0 +1,10 @@
+export function getRaisedBedPositionIndexesDescending(
+    positionIndexes: number[],
+) {
+    const highestPositionIndex = Math.max(8, ...positionIndexes);
+
+    return Array.from(
+        { length: highestPositionIndex + 1 },
+        (_, displayIndex) => highestPositionIndex - displayIndex,
+    );
+}


### PR DESCRIPTION
## Summary

- render raised-bed overview tiles in descending physical order so position 18 is top-left and position 1 is bottom-right
- replace the seven-column detail table on phones with a readable field list that keeps plant images, status-change actions, and all dates visible
- retain the dense desktop detail table from the medium breakpoint onward
- add regression coverage for physical ordering, 320-430px layouts, overflow, and desktop breakpoint behavior

## Root cause

The overview generated position indexes in ascending row-major order, which placed position 1 in the top-left. The detail route rendered the full seven-column table at every viewport width, forcing plant names into extremely narrow columns on phones.

## Impact

Farmers now see each raised bed in its physical orientation and can read and update individual plant positions from the detail page without horizontal overflow or vertically broken names.

## Validation

- `corepack pnpm --filter farm exec tsc --noEmit`
- focused Biome checks and `git diff --check`
- `corepack pnpm --filter farm exec playwright test app/raised-beds app/greenhouse/GreenhouseMobilePlantList.spec.tsx` (10 passed)
- `corepack pnpm --filter farm build`