### PR TITLE
feat(skills): ground changelog visuals in app components

### DIFF
--- a/.agents/skills/gredice-review-changelog-post/SKILL.md
+++ b/.agents/skills/gredice-review-changelog-post/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gredice-review-changelog-post
-description: "Review and prepare individual Gredice CMS changelog posts through the admin UI: simplify Croatian public copy, add relevant inline links, create and attach sharp privacy-safe screenshots or visuals, validate metadata and cover rendering, and move drafts to review without publishing. Use when given a Gredice /admin/cms/pages/PAGE_ID/edit URL or asked to polish, illustrate, link, or mark a changelog post ready for review."
+description: "Review and prepare individual Gredice CMS changelog posts through the admin UI: simplify Croatian public copy, add relevant inline links, create and attach sharp privacy-safe component-grounded screenshots or visuals, validate metadata and cover rendering, and move drafts to review without publishing. Use when given a Gredice /admin/cms/pages/PAGE_ID/edit URL or asked to polish, illustrate, link, or mark a changelog post ready for review."
 ---
 
 # Gredice Changelog Post Review
@@ -45,8 +45,12 @@ Na stranici [Dostava](https://www.gredice.com/dostava) moÅ¾ete pregledati podruÄ
 
 ### 4. Create a meaningful cover
 
-- Default to a feature-specific illustrated composition. Use the exact checked-in product assets plus simplified, privacy-safe UI motifs or neutral mock data that explain the visible change at a glance.
-- Use a live screenshot only when the exact changed UI is available, privacy-safe, and communicates the feature more clearly than an illustration. Capture the user-facing feature, not the admin editor.
+- Inspect the implemented feature before designing its cover. Check the live page and, when useful, the responsible app components, stories, fixtures, and checked-in assets to identify the real controls, states, labels, and visual language.
+- Use actual in-app components when applicable. Prefer rendering the real component or page state with privacy-safe props or fixtures, then compose that rendered result with exact product assets inside the cover artboard.
+- Do not create screenshot-like fictional UI. Any visible button, field, status, metric, or interaction must exist in the product and use a plausible supported state; verify important labels against the implementation or omit them.
+- Use neutral mock data only through real component contracts and supported states. Never imply that a capability, screen, or control exists when it does not.
+- Create a new visual from scratch when the post describes an abstract benefit, transition, relationship, or multi-step idea that the current UI cannot show clearly. Make it visibly illustrative rather than a fake product screen, using accurate assets, icons, arrows, diagrams, or restrained conceptual motifs.
+- Use a live screenshot when the exact changed UI is available, privacy-safe, and communicates the feature more clearly than a composition. Capture the user-facing feature, not the admin editor.
 - Match the cover subject to the post's exact claim. A post about a specific block or entity must show that block or entity; a generic garden, list, gallery, or product-area page is not an acceptable substitute.
 - In a batch, compare the existing covers before composing replacements. Do not reuse one screenshot, including `/vrtovi`, across unrelated posts merely because it belongs to the same product area.
 - Protect privacy before composition. Prefer public pages, public demo content, mock data, or a neutral empty state over authenticated live account, farm, garden, delivery, or admin data.
@@ -57,8 +61,8 @@ Na stranici [Dostava](https://www.gredice.com/dostava) moÅ¾ete pregledati podruÄ
 - Prefer a landscape image suitable for changelog cards. Capture at least 1200 pixels wide when the source supports it.
 - For a high-density browser capture, use a wide desktop viewport and a 2x screenshot scale when supported. Reset temporary viewport overrides afterward.
 - Prefer PNG for crisp UI. If transfer size is unreliable, use JPEG quality 90-92 while retaining the high pixel dimensions.
-- Reuse an existing accurate asset when it is stronger than a screenshot. Do not invent a generic scene or substitute a loosely related product page.
-- Search the checked-in product assets first, including `apps/www/public/assets/blocks`. Compose only the exact mentioned renders on a temporary, privacy-safe HTML artboard with a fixed 16:9 frame, balanced internal spacing, and the visual group centered within the frame.
+- Reuse an existing accurate component or asset when it is stronger than a screenshot. Do not invent a generic scene or substitute a loosely related product page.
+- Search the app components, Storybook stories, and checked-in product assets first, including `apps/www/public/assets/blocks`. Compose only verified components and exact mentioned renders on a temporary, privacy-safe artboard with a fixed 16:9 frame, balanced internal spacing, and the visual group centered within the frame.
 - Make the outer artboard a full-bleed, opaque rectangle. Do not give the artboard itself rounded corners or include page/body padding around it. Inner cards may be rounded, but every output corner must be painted by the artboard background; JPEG output must not contain differently colored corner wedges, and PNG output must not rely on transparent outer corners.
 - Capture the artboard element's exact bounds rather than the surrounding page. Confirm all four edges and corners belong to the intended background before upload.
 - For a release centered on one entity, use its exact render as the dominant hero. Capture the artboard element at high density so the uploaded cover is at least 1920 x 1080 when the source assets support it.

--- a/.agents/skills/gredice-review-changelog-post/agents/openai.yaml
+++ b/.agents/skills/gredice-review-changelog-post/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Gredice Changelog Post Review"
-  short_description: "Review, illustrate, and submit changelog posts"
-  default_prompt: "Use $gredice-review-changelog-post to review a Gredice changelog post, add relevant links and a sharp privacy-safe cover, and mark it ready for review."
+  short_description: "Review posts with accurate component-grounded visuals"
+  default_prompt: "Use $gredice-review-changelog-post to review a Gredice changelog post, add relevant links, create a sharp privacy-safe cover grounded in real app components when applicable, and mark it ready for review."


### PR DESCRIPTION
## Summary

- prefer real app components, stories, fixtures, and supported states when creating changelog covers
- prevent screenshot-like fictional UI and unsupported controls or capabilities
- keep original illustrations available for abstract concepts when they are clearly conceptual
- update the skill metadata to reflect component-grounded visuals

## Why

Illustrated covers should remain attractive without showing screens or controls that do not actually exist in the product. The updated guidance uses real app components whenever practical while preserving room for clearly illustrative visuals.

## Validation

- skill-creator quick_validate.py
- git diff --check