### PR TITLE
feat(mobile): render apps edge to edge

### DIFF
--- a/apps/api/app/docs/[slug]/page.tsx
+++ b/apps/api/app/docs/[slug]/page.tsx
@@ -7,7 +7,10 @@ export default async function DirectoriesApiPage({
 }) {
     const { slug } = await params;
     return (
-        <div className="[--scalar-custom-header-height:62px]">
+        <div
+            className="[--scalar-custom-header-height:calc(62px+env(safe-area-inset-top,0px))]"
+            data-testid="api-reference"
+        >
             <ApiReference specUrl={`/api/docs/${slug}`} />
         </div>
     );

--- a/apps/api/app/layout.tsx
+++ b/apps/api/app/layout.tsx
@@ -20,6 +20,7 @@ export function generateMetadata(): Metadata {
 export const viewport: Viewport = {
     initialScale: 1,
     themeColor: '#111111',
+    viewportFit: 'cover',
     width: 'device-width',
 };
 
@@ -39,9 +40,9 @@ export default function RootLayout({
         process.env.NEXT_PUBLIC_POSTHOG_HOST;
     const content = (
         <>
-            <Stack className="w-full">
-                <div className="h-[62px]" />
-                <div className="fixed top-0 left-0 z-10 w-full border-white/10 border-b bg-[#111111] px-4 py-2">
+            <Stack className="w-full [padding-right:env(safe-area-inset-right,0px)] [padding-bottom:env(safe-area-inset-bottom,0px)] [padding-left:env(safe-area-inset-left,0px)]">
+                <div className="h-[calc(62px+env(safe-area-inset-top,0px))]" />
+                <header className="fixed top-0 left-0 z-10 w-full border-white/10 border-b bg-[#111111] pb-2 [padding-top:calc(env(safe-area-inset-top,0px)+0.5rem)] [padding-right:calc(env(safe-area-inset-right,0px)+1rem)] [padding-left:calc(env(safe-area-inset-left,0px)+1rem)]">
                     <Link href="/">
                         <Image
                             alt="Gredice Logotype"
@@ -51,7 +52,7 @@ export default function RootLayout({
                             height={44}
                         />
                     </Link>
-                </div>
+                </header>
                 {children}
             </Stack>
             <Analytics />

--- a/apps/api/tests/landing.spec.ts
+++ b/apps/api/tests/landing.spec.ts
@@ -5,6 +5,65 @@ test('has title', async ({ page }) => {
     await expect(page).toHaveTitle(/Gredice API/);
 });
 
+test('keeps the API header inside mobile safe areas', async ({
+    page,
+    request,
+}) => {
+    const safeArea = { bottom: 24, left: 12, right: 12, top: 32 };
+    await page.setViewportSize({ height: 844, width: 390 });
+    const session = await page.context().newCDPSession(page);
+    await session.send('Emulation.setSafeAreaInsetsOverride', {
+        insets: {
+            bottom: safeArea.bottom,
+            bottomMax: safeArea.bottom,
+            left: safeArea.left,
+            leftMax: safeArea.left,
+            right: safeArea.right,
+            rightMax: safeArea.right,
+            top: safeArea.top,
+            topMax: safeArea.top,
+        },
+    });
+
+    await page.goto('/');
+
+    await expect(page.locator('meta[name="viewport"]')).toHaveAttribute(
+        'content',
+        /viewport-fit=cover/u,
+    );
+    const logoBounds = await page
+        .getByRole('img', { name: 'Gredice Logotype' })
+        .boundingBox();
+    expect(logoBounds).not.toBeNull();
+    expect(logoBounds?.x).toBeGreaterThanOrEqual(safeArea.left);
+    expect(logoBounds?.y).toBeGreaterThanOrEqual(safeArea.top);
+    expect((logoBounds?.x ?? 0) + (logoBounds?.width ?? 0)).toBeLessThanOrEqual(
+        390 - safeArea.right,
+    );
+
+    const firstApiLinkBounds = await page
+        .locator('a[href="/test"]')
+        .boundingBox();
+    expect(firstApiLinkBounds).not.toBeNull();
+    expect(firstApiLinkBounds?.x).toBeGreaterThanOrEqual(safeArea.left + 16);
+
+    await page.goto('/docs/auth');
+    await expect(page.getByTestId('api-reference')).toHaveCSS(
+        '--scalar-custom-header-height',
+        `calc(62px + ${safeArea.top}px)`,
+    );
+
+    const manifestResponse = await request.get('/manifest.json');
+    expect(manifestResponse.ok()).toBe(true);
+    const manifest = await manifestResponse.json();
+    expect(manifest).toMatchObject({
+        background_color: '#111111',
+        display: 'minimal-ui',
+        start_url: '/',
+        theme_color: '#111111',
+    });
+});
+
 test('links to MCP test console', async ({ page }) => {
     await page.goto('/');
     await expect(page.locator('a[href="/test"]')).toContainText('/api/mcp');

--- a/apps/delivery/components/DeliveryAppHeader.tsx
+++ b/apps/delivery/components/DeliveryAppHeader.tsx
@@ -30,7 +30,7 @@ export function DeliveryAppHeader({
             <Truck className="size-5" />
         );
     return (
-        <header className="sticky top-0 z-20 border-b bg-background/95 px-4 pb-3 pt-[calc(env(safe-area-inset-top)+0.75rem)] backdrop-blur">
+        <header className="sticky top-0 z-20 border-b bg-background/95 pb-3 [padding-top:calc(env(safe-area-inset-top,0px)+0.75rem)] [padding-right:calc(env(safe-area-inset-right,0px)+1rem)] [padding-left:calc(env(safe-area-inset-left,0px)+1rem)] backdrop-blur">
             <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-3">
                 <div className="flex min-w-0 items-center gap-3">
                     <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground">

--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -1341,7 +1341,7 @@ export function DeliveryDashboard({
     return (
         <>
             {showDriverConnectionWarning ? (
-                <div className="fixed inset-x-4 bottom-[max(1rem,env(safe-area-inset-bottom))] z-50 mx-auto max-w-xl">
+                <div className="fixed bottom-[max(1rem,env(safe-area-inset-bottom,0px))] left-[calc(env(safe-area-inset-left,0px)+1rem)] right-[calc(env(safe-area-inset-right,0px)+1rem)] z-50 mx-auto max-w-xl">
                     <Alert
                         color="warning"
                         startDecorator={<Warning className="size-5" />}
@@ -1352,7 +1352,7 @@ export function DeliveryDashboard({
                 </div>
             ) : null}
             {actionError ? (
-                <div className="fixed inset-x-4 top-[max(1rem,env(safe-area-inset-top))] z-50 mx-auto max-w-xl">
+                <div className="fixed left-[calc(env(safe-area-inset-left,0px)+1rem)] right-[calc(env(safe-area-inset-right,0px)+1rem)] top-[max(1rem,env(safe-area-inset-top,0px))] z-50 mx-auto max-w-xl">
                     <Alert
                         color="danger"
                         startDecorator={<Warning className="size-5" />}
@@ -1362,7 +1362,7 @@ export function DeliveryDashboard({
                 </div>
             ) : null}
             {actionConfirmation ? (
-                <div className="fixed inset-x-4 top-[max(1rem,env(safe-area-inset-top))] z-50 mx-auto max-w-xl">
+                <div className="fixed left-[calc(env(safe-area-inset-left,0px)+1rem)] right-[calc(env(safe-area-inset-right,0px)+1rem)] top-[max(1rem,env(safe-area-inset-top,0px))] z-50 mx-auto max-w-xl">
                     <Alert
                         color="info"
                         endDecorator={
@@ -1382,7 +1382,7 @@ export function DeliveryDashboard({
                 </div>
             ) : null}
             {dashboard.kind === 'driver' && deliveryTarget.kind !== 'none' ? (
-                <div className="fixed inset-x-4 top-[max(1rem,env(safe-area-inset-top))] z-40 mx-auto max-w-xl">
+                <div className="fixed left-[calc(env(safe-area-inset-left,0px)+1rem)] right-[calc(env(safe-area-inset-right,0px)+1rem)] top-[max(1rem,env(safe-area-inset-top,0px))] z-40 mx-auto max-w-xl">
                     <Alert
                         color="warning"
                         data-testid="customer-delivery-deep-link-unavailable"

--- a/apps/delivery/tests/delivery-app-header.spec.tsx
+++ b/apps/delivery/tests/delivery-app-header.spec.tsx
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import '../app/globals.css';
+import { DeliveryAppHeader } from '../components/DeliveryAppHeader';
+
+test('keeps delivery header controls inside mobile safe areas', async ({
+    mount,
+    page,
+}) => {
+    const safeArea = { bottom: 24, left: 12, right: 12, top: 32 };
+    await page.setViewportSize({ height: 844, width: 390 });
+    const session = await page.context().newCDPSession(page);
+    await session.send('Emulation.setSafeAreaInsetsOverride', {
+        insets: {
+            bottom: safeArea.bottom,
+            bottomMax: safeArea.bottom,
+            left: safeArea.left,
+            leftMax: safeArea.left,
+            right: safeArea.right,
+            rightMax: safeArea.right,
+            top: safeArea.top,
+            topMax: safeArea.top,
+        },
+    });
+    const headerProps = {
+        displayName: 'Test Driver',
+        role: 'driver',
+        userId: 'test-driver',
+    } as const;
+
+    await mount(<DeliveryAppHeader {...headerProps} />);
+
+    const header = page.locator('header');
+    const padding = await header.evaluate((element) => {
+        const styles = window.getComputedStyle(element);
+        return {
+            left: Number.parseFloat(styles.paddingLeft),
+            right: Number.parseFloat(styles.paddingRight),
+            top: Number.parseFloat(styles.paddingTop),
+        };
+    });
+    expect(padding.left).toBeGreaterThanOrEqual(safeArea.left + 16);
+    expect(padding.right).toBeGreaterThanOrEqual(safeArea.right + 16);
+    expect(padding.top).toBeGreaterThanOrEqual(safeArea.top + 12);
+
+    const logoutBounds = await page
+        .getByRole('button', { name: 'Odjavi se' })
+        .boundingBox();
+    expect(logoutBounds).not.toBeNull();
+    expect(
+        (logoutBounds?.x ?? 0) + (logoutBounds?.width ?? 0),
+    ).toBeLessThanOrEqual(390 - safeArea.right);
+});

--- a/apps/garden/app/globals.css
+++ b/apps/garden/app/globals.css
@@ -43,6 +43,10 @@
         --radius: 0.5rem;
         --game-scrollbar-thumb: 28 35% 42%;
         --game-scrollbar-thumb-hover: 28 42% 32%;
+        --game-safe-area-top: env(safe-area-inset-top, 0px);
+        --game-safe-area-right: env(safe-area-inset-right, 0px);
+        --game-safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        --game-safe-area-left: env(safe-area-inset-left, 0px);
 
         --light-display: visible;
         --dark-display: none;

--- a/apps/garden/app/layout.tsx
+++ b/apps/garden/app/layout.tsx
@@ -5,7 +5,6 @@ import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import { VercelToolbar } from '@vercel/toolbar/next';
 import { Montserrat } from 'next/font/google';
-import Head from 'next/head';
 import type { ReactNode } from 'react';
 import { ClientAppProvider } from '../components/providers/ClientAppProvider';
 
@@ -18,12 +17,16 @@ export function generateMetadata(): Metadata {
     return {
         title: 'Vrt | Gredice',
         description: 'Gredice vrt - vrt po tvom',
+        other: {
+            'apple-mobile-web-app-title': 'Gredice',
+        },
     };
 }
 
 export const viewport: Viewport = {
     maximumScale: 1,
     initialScale: 1,
+    themeColor: '#2e6f40',
     userScalable: false,
     width: 'device-width',
 };
@@ -56,10 +59,6 @@ export default function RootLayout({
 
     return (
         <html lang="hr" translate="no" suppressHydrationWarning={true}>
-            <Head>
-                <meta name="theme-color" content="#2e6f40" />
-                <meta name="apple-mobile-web-app-title" content="Gredice" />
-            </Head>
             <body className={`${montserrat.variable} antialiased bg-muted`}>
                 {postHogApiKey ? (
                     <PostHogProvider

--- a/apps/garden/app/page.tsx
+++ b/apps/garden/app/page.tsx
@@ -1,4 +1,5 @@
 import { SignedIn, SignedOut } from '@gredice/ui/auth';
+import type { Viewport } from 'next';
 import { cookies } from 'next/headers';
 import type { ComponentProps } from 'react';
 import LoginModal from '../components/auth/LoginModal';
@@ -12,6 +13,17 @@ import {
 } from './flags';
 
 const impersonationFlagCookieName = 'gredice_impersonating';
+
+// Only the game route paints edge to edge. Other Garden routes keep the
+// root viewport behavior so their document UI remains safely contained.
+export const viewport: Viewport = {
+    initialScale: 1,
+    maximumScale: 1,
+    themeColor: '#2e6f40',
+    userScalable: false,
+    viewportFit: 'cover',
+    width: 'device-width',
+};
 
 export default async function Home() {
     const cookieStore = await cookies();

--- a/apps/garden/components/auth/LoginBanner.tsx
+++ b/apps/garden/components/auth/LoginBanner.tsx
@@ -6,7 +6,7 @@ import { Logotype } from '../Logotype';
 
 export default function LoginBanner() {
     return (
-        <div className="flex fixed top-4 left-0 w-full justify-center px-4 sm:px-6 z-[51] pointer-events-none">
+        <div className="pointer-events-none fixed top-[calc(var(--game-safe-area-top,0px)+1rem)] right-[var(--game-safe-area-right,0px)] left-[var(--game-safe-area-left,0px)] z-[51] flex justify-center px-4 sm:px-6">
             <Link
                 href="https://www.gredice.com"
                 className="pointer-events-auto inline-flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:gap-4 rounded-2xl dark:bg-card/90 px-4 sm:px-5 py-3 shadow-xl ring-1 ring-primary/10 backdrop-blur supports-[backdrop-filter]:bg-white/75 transition hover:-translate-y-0.5 hover:shadow-2xl"

--- a/apps/garden/tests/landing.spec.ts
+++ b/apps/garden/tests/landing.spec.ts
@@ -337,6 +337,48 @@ test('renders the whole game edge to edge while keeping HUD controls safe', asyn
     expect(overflow.height).toBeLessThanOrEqual(0);
 });
 
+test('keeps landscape game dialogs inside the safe area', async ({ page }) => {
+    const landscapeSafeArea = { bottom: 18, left: 47, right: 21, top: 0 };
+    await page.setViewportSize({ height: 390, width: 844 });
+    const session = await page.context().newCDPSession(page);
+    await session.send('Emulation.setSafeAreaInsetsOverride', {
+        insets: {
+            bottom: landscapeSafeArea.bottom,
+            bottomMax: landscapeSafeArea.bottom,
+            left: landscapeSafeArea.left,
+            leftMax: landscapeSafeArea.left,
+            right: landscapeSafeArea.right,
+            rightMax: landscapeSafeArea.right,
+            top: landscapeSafeArea.top,
+            topMax: landscapeSafeArea.top,
+        },
+    });
+    await mockGardenApi(page, true);
+
+    const response = await page.goto('/?pregled=generalno');
+
+    expect(response?.ok()).toBe(true);
+    const dialog = page.getByRole('dialog', { name: 'Profil' });
+    await expect(dialog).toBeVisible({ timeout: 15_000 });
+    await expect(dialog).toHaveCSS(
+        'padding-left',
+        `${landscapeSafeArea.left + 24}px`,
+    );
+    await expect(dialog).toHaveCSS(
+        'padding-right',
+        `${landscapeSafeArea.right + 24}px`,
+    );
+
+    const closeBounds = await dialog
+        .getByRole('button', { name: 'Zatvori' })
+        .boundingBox();
+    expect(closeBounds).not.toBeNull();
+    expect(closeBounds?.x).toBeGreaterThanOrEqual(landscapeSafeArea.left);
+    expect(
+        (closeBounds?.x ?? 0) + (closeBounds?.width ?? 0),
+    ).toBeLessThanOrEqual(844 - landscapeSafeArea.right);
+});
+
 test('keeps edge-to-edge viewport behavior scoped to the game route', async ({
     request,
 }) => {

--- a/apps/garden/tests/landing.spec.ts
+++ b/apps/garden/tests/landing.spec.ts
@@ -177,10 +177,35 @@ async function expectNoImmediateRuntimeFailures(
     expect(failures).toEqual([]);
 }
 
+const safeAreaInsets = {
+    bottom: 24,
+    left: 12,
+    right: 12,
+    top: 32,
+};
+
+async function emulateSafeArea(page: Page) {
+    const session = await page.context().newCDPSession(page);
+    await session.send('Emulation.setSafeAreaInsetsOverride', {
+        insets: {
+            bottom: safeAreaInsets.bottom,
+            bottomMax: safeAreaInsets.bottom,
+            left: safeAreaInsets.left,
+            leftMax: safeAreaInsets.left,
+            right: safeAreaInsets.right,
+            rightMax: safeAreaInsets.right,
+            top: safeAreaInsets.top,
+            topMax: safeAreaInsets.top,
+        },
+    });
+}
+
 test('loads signed-out landing page without immediate runtime failures', async ({
     page,
 }) => {
     const failures = collectRuntimeFailures(page);
+    await page.setViewportSize({ height: 844, width: 390 });
+    await emulateSafeArea(page);
     await mockGardenApi(page, false);
 
     const response = await page.goto('/');
@@ -190,6 +215,19 @@ test('loads signed-out landing page without immediate runtime failures', async (
     await expect(
         page.getByRole('button', { name: 'Prijava' }).first(),
     ).toBeVisible();
+    await expect(page.locator('link[rel="manifest"]')).toHaveAttribute(
+        'href',
+        '/manifest.json',
+    );
+    await expect(
+        page.locator('meta[name="apple-mobile-web-app-title"]'),
+    ).toHaveAttribute('content', 'Gredice');
+    const loginBannerBounds = await page
+        .getByText('Posjeti gredice.com')
+        .locator('..')
+        .boundingBox();
+    expect(loginBannerBounds).not.toBeNull();
+    expect(loginBannerBounds?.y).toBeGreaterThanOrEqual(safeAreaInsets.top);
     await expectNoImmediateRuntimeFailures(page, failures);
 });
 
@@ -205,4 +243,156 @@ test('loads signed-in landing page HUD without immediate runtime failures', asyn
     await expect(page).toHaveTitle(/Gredice/);
     await expect(page.getByTitle(/zvuk/u)).toBeVisible({ timeout: 15_000 });
     await expectNoImmediateRuntimeFailures(page, failures);
+});
+
+test('renders the whole game edge to edge while keeping HUD controls safe', async ({
+    context,
+    page,
+}) => {
+    await page.setViewportSize({ height: 844, width: 390 });
+    await emulateSafeArea(page);
+    await context.addCookies([
+        {
+            domain: '127.0.0.1',
+            name: 'gredice_impersonating',
+            path: '/',
+            value: '1',
+        },
+    ]);
+    await mockGardenApi(page, true);
+
+    const response = await page.goto('/');
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.getByTitle(/zvuk/u)).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText('Impersonacija je aktivna.')).toBeVisible();
+
+    const viewportMeta = page.locator('meta[name="viewport"]');
+    await expect(viewportMeta).toHaveCount(1);
+    await expect(viewportMeta).toHaveAttribute(
+        'content',
+        /viewport-fit=cover/u,
+    );
+    await expect(page.locator('meta[name="theme-color"]')).toHaveCount(1);
+    await expect(page.locator('meta[name="theme-color"]')).toHaveAttribute(
+        'content',
+        '#2e6f40',
+    );
+
+    const viewportSize = page.viewportSize();
+    expect(viewportSize).not.toBeNull();
+
+    const gameCanvas = page.locator('canvas').first();
+    await expect
+        .poll(async () => (await gameCanvas.boundingBox())?.width)
+        .toBe(viewportSize?.width);
+    const canvasBounds = await gameCanvas.boundingBox();
+    expect(canvasBounds).not.toBeNull();
+    expect(canvasBounds?.x).toBe(0);
+    expect(canvasBounds?.y).toBe(0);
+    expect(canvasBounds?.width).toBe(viewportSize?.width);
+    expect(canvasBounds?.height).toBe(viewportSize?.height);
+
+    const topLeftBounds = await page
+        .locator('[data-game-hud-top-left]')
+        .boundingBox();
+    expect(topLeftBounds).not.toBeNull();
+    expect(topLeftBounds?.x).toBeGreaterThanOrEqual(safeAreaInsets.left);
+    expect(topLeftBounds?.y).toBeGreaterThanOrEqual(safeAreaInsets.top);
+
+    const topRightBounds = await page
+        .locator('[data-game-hud-top-right]')
+        .boundingBox();
+    expect(topRightBounds).not.toBeNull();
+    expect(
+        (topRightBounds?.x ?? 0) + (topRightBounds?.width ?? 0),
+    ).toBeLessThanOrEqual((viewportSize?.width ?? 0) - safeAreaInsets.right);
+    expect(topRightBounds?.y).toBeGreaterThanOrEqual(safeAreaInsets.top);
+
+    const bottomControlsBounds = await page
+        .locator('[data-game-hud-bottom-controls]')
+        .boundingBox();
+    expect(bottomControlsBounds).not.toBeNull();
+    expect(
+        (bottomControlsBounds?.y ?? 0) + (bottomControlsBounds?.height ?? 0),
+    ).toBeLessThanOrEqual((viewportSize?.height ?? 0) - safeAreaInsets.bottom);
+
+    const impersonationBannerBounds = await page
+        .getByText('Impersonacija je aktivna.')
+        .locator('..')
+        .boundingBox();
+    expect(impersonationBannerBounds).not.toBeNull();
+    expect(impersonationBannerBounds?.x).toBeGreaterThanOrEqual(
+        safeAreaInsets.left,
+    );
+    expect(impersonationBannerBounds?.y).toBeGreaterThanOrEqual(
+        safeAreaInsets.top,
+    );
+
+    const overflow = await page.evaluate(() => ({
+        height: document.documentElement.scrollHeight - window.innerHeight,
+        width: document.documentElement.scrollWidth - window.innerWidth,
+    }));
+    expect(overflow.width).toBeLessThanOrEqual(0);
+    expect(overflow.height).toBeLessThanOrEqual(0);
+});
+
+test('keeps edge-to-edge viewport behavior scoped to the game route', async ({
+    request,
+}) => {
+    const gameResponse = await request.get('/');
+    const documentResponse = await request.get('/pozivnica');
+
+    expect(gameResponse.ok()).toBe(true);
+    expect(documentResponse.ok()).toBe(true);
+
+    const gameHtml = await gameResponse.text();
+    const documentHtml = await documentResponse.text();
+
+    expect(gameHtml.match(/name="viewport"/gu)).toHaveLength(1);
+    expect(gameHtml).toContain('viewport-fit=cover');
+    expect(documentHtml).not.toContain('viewport-fit=cover');
+});
+
+test('preserves the published Garden Android app contract', async ({
+    request,
+}) => {
+    const manifestResponse = await request.get('/manifest.json');
+    const assetLinksResponse = await request.get(
+        '/.well-known/assetlinks.json',
+    );
+
+    expect(manifestResponse.ok()).toBe(true);
+    expect(assetLinksResponse.ok()).toBe(true);
+
+    const manifest = await manifestResponse.json();
+    expect(manifest).toMatchObject({
+        background_color: '#2e6f40',
+        display: 'fullscreen',
+        display_override: ['window-controls-overlay', 'standalone', 'browser'],
+        id: '/',
+        related_applications: [
+            {
+                id: 'com.gredice.vrt.twa',
+                platform: 'play',
+            },
+        ],
+        scope: 'https://vrt.gredice.com',
+        start_url: '/',
+        theme_color: '#2e6f40',
+    });
+
+    const assetLinks = await assetLinksResponse.json();
+    expect(assetLinks).toEqual([
+        {
+            relation: ['delegate_permission/common.handle_all_urls'],
+            target: {
+                namespace: 'android_app',
+                package_name: 'com.gredice.vrt.twa',
+                sha256_cert_fingerprints: [
+                    '33:8A:CB:39:A4:46:2F:AD:42:1B:97:63:F2:76:CE:2E:91:47:01:E0:79:37:61:C2:55:3E:EE:E3:DD:39:77:F2',
+                ],
+            },
+        },
+    ]);
 });

--- a/apps/news/app/globals.css
+++ b/apps/news/app/globals.css
@@ -132,7 +132,7 @@
     }
 
     :target {
-        scroll-margin-top: 4rem;
+        scroll-margin-top: calc(4rem + env(safe-area-inset-top, 0px));
     }
 
     ::selection {

--- a/apps/news/app/layout.tsx
+++ b/apps/news/app/layout.tsx
@@ -28,7 +28,10 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
+    width: 'device-width',
+    initialScale: 1,
     themeColor: '#2e6f40',
+    viewportFit: 'cover',
 };
 
 const montserrat = Montserrat({
@@ -46,12 +49,12 @@ export default function RootLayout({
             <body className={`${montserrat.variable} min-h-dvh antialiased`}>
                 <style>{'@view-transition { navigation: auto; }'}</style>
                 <PublicChromeProvider apiBasePath="/novosti/api/gredice">
-                    <div className="flex min-h-dvh flex-col">
+                    <div className="flex min-h-dvh flex-col [padding-bottom:env(safe-area-inset-bottom,0px)] [padding-left:env(safe-area-inset-left,0px)] [padding-right:env(safe-area-inset-right,0px)]">
                         <PublicHeader
                             apiBasePath="/novosti/api/gredice"
                             linkMode="www-origin"
                         />
-                        <main className="relative mt-16 flex-1">
+                        <main className="relative mt-[calc(4rem+env(safe-area-inset-top,0px))] flex-1">
                             {children}
                         </main>
                         <PublicFooter linkMode="www-origin" />

--- a/apps/status/app/layout.tsx
+++ b/apps/status/app/layout.tsx
@@ -19,7 +19,10 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
+    width: 'device-width',
+    initialScale: 1,
     themeColor: '#2e6f40',
+    viewportFit: 'cover',
 };
 
 export default function RootLayout({

--- a/apps/status/app/page.tsx
+++ b/apps/status/app/page.tsx
@@ -13,8 +13,8 @@ export default async function StatusPage() {
     const data = await getStatusPageData();
 
     return (
-        <main className="min-h-dvh bg-background text-foreground">
-            <div className="mx-auto flex min-h-dvh w-full max-w-5xl flex-col px-4 py-6 sm:px-6 lg:px-8">
+        <main className="flex min-h-dvh bg-background text-foreground [padding-bottom:env(safe-area-inset-bottom,0px)] [padding-left:env(safe-area-inset-left,0px)] [padding-right:env(safe-area-inset-right,0px)] [padding-top:env(safe-area-inset-top,0px)]">
+            <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 py-6 sm:px-6 lg:px-8">
                 <StatusHeader updatedAt={data.updatedAt} />
                 <div className="mt-10 flex flex-1 flex-col gap-5">
                     <OverallStatus

--- a/apps/storybook/stories/packages/ui/ImpersonationBanner.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ImpersonationBanner.stories.tsx
@@ -22,8 +22,15 @@ const meta = {
         ),
     ],
     parameters: {
+        docs: {
+            description: {
+                component:
+                    'A draggable global impersonation notice. Its drag bounds respect device safe-area insets when an app renders edge to edge.',
+            },
+        },
         layout: 'fullscreen',
     },
+    tags: ['autodocs'],
 } satisfies Meta<typeof ImpersonationBanner>;
 
 export default meta;

--- a/apps/storybook/stories/packages/ui/primitives/Nav.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Nav.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
         docs: {
             description: {
                 component:
-                    'PageNav provides the floating public-site navigation shell with glass treatment, mobile menu state, links, and children props.',
+                    'PageNav provides the floating public-site navigation shell with glass treatment, mobile menu state, links, and children props. It keeps navigation controls inside device safe-area insets when a consuming app enables an edge-to-edge viewport.',
             },
         },
     },

--- a/apps/www/app/LandingGameScene.tsx
+++ b/apps/www/app/LandingGameScene.tsx
@@ -188,7 +188,7 @@ export function LandingGameScene() {
             <div
                 className={cx(
                     interactiveMounted
-                        ? 'pointer-events-auto fixed z-50 overflow-hidden bg-background transition-[top,left,width,height,border-radius,box-shadow] duration-700 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[top,left,width,height,border-radius]'
+                        ? 'pointer-events-auto fixed z-50 overflow-hidden bg-background transition-[top,left,width,height,border-radius,box-shadow] duration-700 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[top,left,width,height,border-radius] [--game-safe-area-top:env(safe-area-inset-top,0px)] [--game-safe-area-right:env(safe-area-inset-right,0px)] [--game-safe-area-bottom:env(safe-area-inset-bottom,0px)] [--game-safe-area-left:env(safe-area-inset-left,0px)]'
                         : 'absolute inset-0 overflow-hidden',
                     interactiveMounted &&
                         (interactiveVisible
@@ -236,7 +236,7 @@ export function LandingGameScene() {
                 {interactiveMounted && (
                     <div
                         className={cx(
-                            'pointer-events-none absolute bottom-4 right-4 z-10 flex max-w-[calc(100%-2rem)] flex-col items-end gap-2 transition-[opacity,transform] duration-300 ease-out md:bottom-6 md:right-6 md:max-w-sm',
+                            'pointer-events-none absolute bottom-[calc(var(--game-safe-area-bottom,0px)+1rem)] right-[calc(var(--game-safe-area-right,0px)+1rem)] z-10 flex max-w-[calc(100%-var(--game-safe-area-left,0px)-var(--game-safe-area-right,0px)-2rem)] flex-col items-end gap-2 transition-[opacity,transform] duration-300 ease-out md:bottom-[calc(var(--game-safe-area-bottom,0px)+1.5rem)] md:right-[calc(var(--game-safe-area-right,0px)+1.5rem)] md:max-w-sm',
                             interactiveVisible
                                 ? 'translate-y-0 opacity-100 delay-200'
                                 : 'translate-y-3 opacity-0',

--- a/apps/www/app/cjenik/page.tsx
+++ b/apps/www/app/cjenik/page.tsx
@@ -365,7 +365,7 @@ export default async function PricingPage() {
 
                 <nav
                     aria-label="Dijelovi cjenika"
-                    className="sticky top-16 z-20 -mx-2 flex gap-2 overflow-x-auto rounded-lg border bg-background/95 p-2 shadow-xs backdrop-blur-sm"
+                    className="sticky top-[calc(4rem+env(safe-area-inset-top,0px))] z-20 -mx-2 flex gap-2 overflow-x-auto rounded-lg border bg-background/95 p-2 shadow-xs backdrop-blur-sm"
                 >
                     <Chip color="neutral" href="#suncokreti" variant="soft">
                         Suncokreti

--- a/apps/www/app/globals.css
+++ b/apps/www/app/globals.css
@@ -134,7 +134,7 @@
     }
 
     :target {
-        scroll-margin-top: 4rem;
+        scroll-margin-top: calc(4rem + env(safe-area-inset-top, 0px));
     }
     ::selection {
         background: var(--bg-selection);

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -1,6 +1,6 @@
 import { ImpersonationBanner } from '@gredice/ui/ImpersonationBanner';
 import { Analytics } from '@vercel/analytics/react';
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import { PublicFooter, PublicHeader } from '@gredice/ui/PublicChrome';
 import { Stack } from '@gredice/ui/Stack';
@@ -74,6 +74,13 @@ export function generateMetadata(): Metadata {
     };
 }
 
+export const viewport: Viewport = {
+    width: 'device-width',
+    initialScale: 1,
+    themeColor: '#2e6f40',
+    viewportFit: 'cover',
+};
+
 export default async function RootLayout({
     children,
 }: Readonly<{
@@ -92,9 +99,9 @@ export default async function RootLayout({
     const content = (
         <ClientAppProvider>
             <ImpersonationBanner />
-            <Stack>
+            <Stack className="[padding-bottom:env(safe-area-inset-bottom,0px)] [padding-left:env(safe-area-inset-left,0px)] [padding-right:env(safe-area-inset-right,0px)]">
                 <PublicHeader />
-                <main className="mt-16 relative">
+                <main className="relative mt-[calc(4rem+env(safe-area-inset-top,0px))]">
                     <LayoutContainer>{children}</LayoutContainer>
                 </main>
                 <PublicFooter />
@@ -110,7 +117,6 @@ export default async function RootLayout({
             <Head>
                 <title>Gredice</title>
                 <meta name="apple-mobile-web-app-title" content="Gredice" />
-                <meta name="theme-color" content="#2e6f40" />
                 <link rel="preconnect" href="https://vrt.gredice.com" />
                 {gardenModelPreloadUrls.map((href) => (
                     <link

--- a/apps/www/tests/landing.spec.ts
+++ b/apps/www/tests/landing.spec.ts
@@ -332,6 +332,21 @@ test('logged-in landing game morphs into full screen in place', async ({
 }) => {
     test.slow();
 
+    const safeArea = { bottom: 24, left: 12, right: 12, top: 32 };
+    const session = await page.context().newCDPSession(page);
+    await session.send('Emulation.setSafeAreaInsetsOverride', {
+        insets: {
+            bottom: safeArea.bottom,
+            bottomMax: safeArea.bottom,
+            left: safeArea.left,
+            leftMax: safeArea.left,
+            right: safeArea.right,
+            rightMax: safeArea.right,
+            top: safeArea.top,
+            topMax: safeArea.top,
+        },
+    });
+
     await page.unroute('**/api/gredice/api/auth/current-claims**');
     await page.route(
         '**/api/gredice/api/auth/current-claims**',
@@ -373,4 +388,39 @@ test('logged-in landing game morphs into full screen in place', async ({
     expect(expandedBox.y).toBeLessThanOrEqual(1);
     expect(expandedBox.width).toBeGreaterThanOrEqual(389);
     expect(expandedBox.height).toBeGreaterThanOrEqual(843);
+
+    const topLeftBounds = await scene
+        .locator('[data-game-hud-top-left]')
+        .boundingBox();
+    expect(topLeftBounds).not.toBeNull();
+    expect(topLeftBounds?.x).toBeGreaterThanOrEqual(safeArea.left);
+    expect(topLeftBounds?.y).toBeGreaterThanOrEqual(safeArea.top);
+
+    const topRightBounds = await scene
+        .locator('[data-game-hud-top-right]')
+        .boundingBox();
+    expect(topRightBounds).not.toBeNull();
+    expect(
+        (topRightBounds?.x ?? 0) + (topRightBounds?.width ?? 0),
+    ).toBeLessThanOrEqual(390 - safeArea.right);
+    expect(topRightBounds?.y).toBeGreaterThanOrEqual(safeArea.top);
+
+    const bottomControlsBounds = await scene
+        .locator('[data-game-hud-bottom-controls]')
+        .boundingBox();
+    expect(bottomControlsBounds).not.toBeNull();
+    expect(
+        (bottomControlsBounds?.y ?? 0) + (bottomControlsBounds?.height ?? 0),
+    ).toBeLessThanOrEqual(844 - safeArea.bottom);
+
+    const closeBounds = await page
+        .getByRole('button', { name: 'Zatvori prikaz' })
+        .boundingBox();
+    expect(closeBounds).not.toBeNull();
+    expect(
+        (closeBounds?.x ?? 0) + (closeBounds?.width ?? 0),
+    ).toBeLessThanOrEqual(390 - safeArea.right);
+    expect(
+        (closeBounds?.y ?? 0) + (closeBounds?.height ?? 0),
+    ).toBeLessThanOrEqual(844 - safeArea.bottom);
 });

--- a/apps/www/tests/landing.spec.ts
+++ b/apps/www/tests/landing.spec.ts
@@ -56,6 +56,58 @@ async function expectMobileNavActionsDoNotOverlap(page: Page) {
         .toBeLessThanOrEqual(56);
 }
 
+test('public chrome stays inside mobile safe areas', async ({ page }) => {
+    const safeArea = { bottom: 24, left: 12, right: 12, top: 32 };
+    await page.setViewportSize({ height: 844, width: 390 });
+    const session = await page.context().newCDPSession(page);
+    await session.send('Emulation.setSafeAreaInsetsOverride', {
+        insets: {
+            bottom: safeArea.bottom,
+            bottomMax: safeArea.bottom,
+            left: safeArea.left,
+            leftMax: safeArea.left,
+            right: safeArea.right,
+            rightMax: safeArea.right,
+            top: safeArea.top,
+            topMax: safeArea.top,
+        },
+    });
+
+    await page.goto('/kontakt', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('meta[name="viewport"]')).toHaveAttribute(
+        'content',
+        /viewport-fit=cover/u,
+    );
+
+    const headerBounds = await page.locator('header').boundingBox();
+    expect(headerBounds).not.toBeNull();
+    expect(headerBounds?.x).toBeGreaterThanOrEqual(safeArea.left);
+    expect(headerBounds?.y).toBeGreaterThanOrEqual(safeArea.top);
+    expect(
+        (headerBounds?.x ?? 0) + (headerBounds?.width ?? 0),
+    ).toBeLessThanOrEqual(390 - safeArea.right);
+
+    await page.getByRole('button', { name: 'Pretraga' }).click();
+    const searchBounds = await page
+        .getByRole('dialog', { name: 'Pretraga' })
+        .boundingBox();
+    expect(searchBounds).not.toBeNull();
+    expect(searchBounds?.x).toBeGreaterThanOrEqual(safeArea.left);
+    expect(searchBounds?.y).toBeGreaterThanOrEqual(safeArea.top);
+    expect(
+        (searchBounds?.x ?? 0) + (searchBounds?.width ?? 0),
+    ).toBeLessThanOrEqual(390 - safeArea.right);
+    expect(
+        (searchBounds?.y ?? 0) + (searchBounds?.height ?? 0),
+    ).toBeLessThanOrEqual(844 - safeArea.bottom);
+
+    await expect(page.locator('.site-footer').locator('..')).toHaveCSS(
+        'padding-bottom',
+        `${safeArea.bottom}px`,
+    );
+});
+
 test('has title', async ({ page }) => {
     // The first `/` hit in a shard pays the Next.js SSR cold-start cost,
     // which can exceed the 10s default test timeout. Triple it.

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -35,7 +35,7 @@ import { OverviewModal } from './modals/OverviewModal';
 import { useGameState } from './useGameState';
 
 export const gameHudBottomBarClassName =
-    'pointer-events-none absolute bottom-0 left-0 right-0 flex flex-col items-center md:block';
+    'pointer-events-none absolute bottom-[var(--game-safe-area-bottom,0px)] left-[var(--game-safe-area-left,0px)] right-[var(--game-safe-area-right,0px)] flex flex-col items-center md:block';
 
 export const gameHudBottomControlsClassName =
     'self-start flex flex-row items-end justify-start p-2 motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-4 motion-safe:duration-300 motion-safe:ease-out md:absolute md:bottom-0 md:left-0';
@@ -122,8 +122,9 @@ export function GameHud({
     return (
         <SuncokretChatProvider>
             <div
+                data-game-hud-top-left
                 className={cx(
-                    'absolute top-2 left-2 flex flex-col items-start gap-2',
+                    'absolute top-[calc(var(--game-safe-area-top,0px)+0.5rem)] left-[calc(var(--game-safe-area-left,0px)+0.5rem)] flex flex-col items-start gap-2',
                     gameHudEntranceClassName,
                     'motion-safe:slide-in-from-left-4',
                 )}
@@ -165,8 +166,9 @@ export function GameHud({
                 )}
             </div>
             <div
+                data-game-hud-top-right
                 className={cx(
-                    'absolute top-2 right-2 flex items-end flex-col-reverse gap-1 md:flex-row md:gap-2',
+                    'absolute top-[calc(var(--game-safe-area-top,0px)+0.5rem)] right-[calc(var(--game-safe-area-right,0px)+0.5rem)] flex items-end flex-col-reverse gap-1 md:flex-row md:gap-2',
                     gameHudEntranceClassName,
                     'motion-safe:slide-in-from-right-4',
                 )}

--- a/packages/game/src/hud/GardenVisitSummaryHighlightHud.tsx
+++ b/packages/game/src/hud/GardenVisitSummaryHighlightHud.tsx
@@ -51,10 +51,10 @@ export function GardenVisitSummaryHighlightHud() {
             : highlight.label;
 
     return (
-        <div className="pointer-events-none absolute top-16 left-1/2 z-20 w-[min(calc(100vw-1rem),26rem)] -translate-x-1/2 px-2">
+        <div className="pointer-events-none absolute top-[calc(var(--game-safe-area-top,0px)+4rem)] left-[var(--game-safe-area-left,0px)] right-[var(--game-safe-area-right,0px)] z-20 flex justify-center px-2">
             <Row
                 alignItems="center"
-                className="pointer-events-auto rounded-lg border border-tertiary/50 bg-background/95 p-2 pr-1 shadow-lg backdrop-blur"
+                className="pointer-events-auto w-full max-w-[26rem] rounded-lg border border-tertiary/50 bg-background/95 p-2 pr-1 shadow-lg backdrop-blur"
                 spacing={2}
             >
                 <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-tertiary-foreground">

--- a/packages/game/src/hud/RaisedBedOnboardingModal.tsx
+++ b/packages/game/src/hud/RaisedBedOnboardingModal.tsx
@@ -1109,10 +1109,10 @@ export function RaisedBedOnboardingModal({
             }
             disableMobile
             overlayClassName="bg-black/45 backdrop-blur-md"
-            className="!inset-0 !h-dvh !max-h-dvh !w-screen !max-w-none !translate-x-0 !translate-y-0 !overflow-hidden !rounded-none !border-0 !p-0 md:!inset-auto md:!left-1/2 md:!top-1/2 md:!h-[calc(100dvh-2rem)] md:!w-[calc(100vw-1.5rem)] md:!max-w-none md:!-translate-x-1/2 md:!-translate-y-1/2 md:!rounded-lg md:!border md:!border-green-200 md:!border-b-4 md:!border-b-green-500"
+            className="!inset-0 !h-dvh !max-h-dvh !w-screen !max-w-none !translate-x-0 !translate-y-0 !overflow-hidden !rounded-none !border-0 !p-0 [&>button:last-child]:!top-[calc(var(--game-safe-area-top,0px)+0.25rem)] [&>button:last-child]:!right-[calc(var(--game-safe-area-right,0px)+0.25rem)] md:!inset-auto md:!left-1/2 md:!top-1/2 md:!h-[calc(100dvh-var(--game-safe-area-top,0px)-var(--game-safe-area-bottom,0px)-2rem)] md:!w-[calc(100vw-var(--game-safe-area-left,0px)-var(--game-safe-area-right,0px)-1.5rem)] md:!max-w-none md:!-translate-x-1/2 md:!-translate-y-1/2 md:!rounded-lg md:!border md:!border-green-200 md:!border-b-4 md:!border-b-green-500"
         >
             <div className="flex h-full min-h-0 flex-col bg-gradient-to-br from-green-50 via-background to-white dark:from-green-950/30 dark:via-background dark:to-background">
-                <div className="flex min-h-0 flex-1 overflow-y-auto px-4 py-8 md:px-8 md:py-8">
+                <div className="flex min-h-0 flex-1 overflow-y-auto [padding-top:calc(var(--game-safe-area-top,0px)+2rem)] [padding-right:calc(var(--game-safe-area-right,0px)+1rem)] [padding-bottom:calc(var(--game-safe-area-bottom,0px)+2rem)] [padding-left:calc(var(--game-safe-area-left,0px)+1rem)] md:[padding-right:calc(var(--game-safe-area-right,0px)+2rem)] md:[padding-left:calc(var(--game-safe-area-left,0px)+2rem)]">
                     <Stack
                         spacing={6}
                         className={cx(

--- a/packages/game/src/hud/SuncokretChatHud.tsx
+++ b/packages/game/src/hud/SuncokretChatHud.tsx
@@ -120,7 +120,7 @@ function SuncokretChatPositioner({
         return (
             <Popper
                 align="center"
-                className="!w-[440px] max-w-[calc(100vw-1rem)] border-0 bg-transparent p-0 shadow-none"
+                className="!w-[440px] max-w-[calc(100vw-var(--game-safe-area-left,0px)-var(--game-safe-area-right,0px)-1rem)] border-0 bg-transparent p-0 shadow-none"
                 data-suncokret-placement="anchored"
                 onOpenChange={(nextOpen) => {
                     if (!nextOpen) {
@@ -140,10 +140,10 @@ function SuncokretChatPositioner({
     return (
         <div
             className={cx(
-                'pointer-events-auto fixed inset-x-2 bottom-2 z-50 flex justify-center md:inset-auto md:bottom-2 md:block',
+                'pointer-events-auto fixed bottom-[calc(var(--game-safe-area-bottom,0px)+0.5rem)] left-[calc(var(--game-safe-area-left,0px)+0.5rem)] right-[calc(var(--game-safe-area-right,0px)+0.5rem)] z-50 flex justify-center md:block',
                 isCloseup
-                    ? 'md:right-auto md:left-2'
-                    : 'md:right-2 md:left-auto',
+                    ? 'md:right-auto md:left-[calc(var(--game-safe-area-left,0px)+0.5rem)]'
+                    : 'md:right-[calc(var(--game-safe-area-right,0px)+0.5rem)] md:left-auto',
             )}
             data-suncokret-placement={
                 isCloseup ? 'bottom-left' : 'bottom-right'
@@ -953,7 +953,7 @@ export function SuncokretChatHud() {
                 >
                     <div
                         aria-label="Razgovor sa Suncokretom"
-                        className="flex h-[min(680px,calc(100dvh-1rem))] w-full max-w-[440px] flex-col overflow-hidden rounded-2xl border border-amber-200/80 border-b-4 border-b-amber-400 bg-background/98 shadow-2xl shadow-foreground/15 backdrop-blur-sm dark:border-amber-900/80 dark:border-b-amber-700 md:h-[min(720px,calc(100dvh-5rem))]"
+                        className="flex h-[min(680px,calc(100dvh-var(--game-safe-area-top,0px)-var(--game-safe-area-bottom,0px)-1rem))] w-full max-w-[440px] flex-col overflow-hidden rounded-2xl border border-amber-200/80 border-b-4 border-b-amber-400 bg-background/98 shadow-2xl shadow-foreground/15 backdrop-blur-sm dark:border-amber-900/80 dark:border-b-amber-700 md:h-[min(720px,calc(100dvh-var(--game-safe-area-top,0px)-var(--game-safe-area-bottom,0px)-5rem))]"
                         data-suncokret-chat
                         role="dialog"
                     >

--- a/packages/game/src/hud/WhatsNewWidget.tsx
+++ b/packages/game/src/hud/WhatsNewWidget.tsx
@@ -325,8 +325,8 @@ export function WhatsNewWidget({
     return (
         <>
             {hasUnreadEntries ? (
-                <div className="pointer-events-none absolute bottom-[calc(env(safe-area-inset-bottom)+4.75rem)] left-2 z-20 md:bottom-16">
-                    <div className="pointer-events-auto relative w-[min(21rem,calc(100vw-1rem))] overflow-hidden rounded-lg border bg-background/95 text-foreground shadow-lg backdrop-blur">
+                <div className="pointer-events-none absolute bottom-[calc(var(--game-safe-area-bottom,0px)+4.75rem)] left-[calc(var(--game-safe-area-left,0px)+0.5rem)] z-20 md:bottom-[calc(var(--game-safe-area-bottom,0px)+4rem)]">
+                    <div className="pointer-events-auto relative w-[min(21rem,calc(100vw-var(--game-safe-area-left,0px)-var(--game-safe-area-right,0px)-1rem))] overflow-hidden rounded-lg border bg-background/95 text-foreground shadow-lg backdrop-blur">
                         <button
                             className={cx(
                                 'grid w-full gap-3 px-3 py-2 pr-10 text-left transition-colors hover:bg-card focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',

--- a/packages/game/src/shared-ui/game-modal/GameModal.tsx
+++ b/packages/game/src/shared-ui/game-modal/GameModal.tsx
@@ -31,7 +31,7 @@ export function GameModal({
     return (
         <Modal
             className={cx(
-                'border-tertiary border-b-4',
+                'border-tertiary border-b-4 md:[padding-top:calc(var(--game-safe-area-top,0px)+1.5rem)] md:[padding-right:calc(var(--game-safe-area-right,0px)+1.5rem)] md:[padding-bottom:calc(var(--game-safe-area-bottom,0px)+1.5rem)] md:[padding-left:calc(var(--game-safe-area-left,0px)+1.5rem)] md:[&>button:last-child]:top-[calc(var(--game-safe-area-top,0px)+0.25rem)] md:[&>button:last-child]:right-[calc(var(--game-safe-area-right,0px)+0.25rem)]',
                 hudLayer && 'z-[46]',
                 className,
             )}

--- a/packages/ui/src/ImpersonationBanner/ImpersonationBanner.tsx
+++ b/packages/ui/src/ImpersonationBanner/ImpersonationBanner.tsx
@@ -59,22 +59,38 @@ function clamp(value: number, min: number, max: number) {
     return Math.min(Math.max(value, min), max);
 }
 
+function getSafeAreaInset(element: HTMLElement, side: string) {
+    const value = Number.parseFloat(
+        window
+            .getComputedStyle(element)
+            .getPropertyValue(`--impersonation-safe-area-${side}`),
+    );
+
+    return Number.isFinite(value) ? value : 0;
+}
+
 function getPositionBounds(element: HTMLElement) {
     const width = element.offsetWidth;
     const height = element.offsetHeight;
+    const safeAreaBottom = getSafeAreaInset(element, 'bottom');
+    const safeAreaLeft = getSafeAreaInset(element, 'left');
+    const safeAreaRight = getSafeAreaInset(element, 'right');
+    const safeAreaTop = getSafeAreaInset(element, 'top');
+    const minLeft = safeAreaLeft + bannerOffset;
+    const minTop = safeAreaTop + bannerOffset;
 
     return {
         height,
         maxLeft: Math.max(
-            bannerOffset,
-            window.innerWidth - width - bannerOffset,
+            minLeft,
+            window.innerWidth - safeAreaRight - width - bannerOffset,
         ),
         maxTop: Math.max(
-            bannerOffset,
-            window.innerHeight - height - bannerOffset,
+            minTop,
+            window.innerHeight - safeAreaBottom - height - bannerOffset,
         ),
-        minLeft: bannerOffset,
-        minTop: bannerOffset,
+        minLeft,
+        minTop,
         width,
     };
 }
@@ -199,7 +215,7 @@ export function ImpersonationBanner() {
     return (
         <div
             ref={bannerRef}
-            className="fixed z-[9999] flex max-w-[calc(100vw-1rem)] flex-wrap items-center gap-2 rounded-full border border-yellow-700/70 bg-yellow-400/95 px-2.5 py-1.5 text-xs font-medium text-black shadow-lg backdrop-blur-xs"
+            className="fixed z-[9999] flex max-w-[calc(100vw-var(--impersonation-safe-area-left)-var(--impersonation-safe-area-right)-1rem)] flex-wrap items-center gap-2 rounded-full border border-yellow-700/70 bg-yellow-400/95 px-2.5 py-1.5 text-xs font-medium text-black shadow-lg backdrop-blur-xs [--impersonation-safe-area-top:env(safe-area-inset-top,0px)] [--impersonation-safe-area-right:env(safe-area-inset-right,0px)] [--impersonation-safe-area-bottom:env(safe-area-inset-bottom,0px)] [--impersonation-safe-area-left:env(safe-area-inset-left,0px)]"
             style={{
                 left: position?.left ?? bannerOffset,
                 opacity: position ? 1 : 0,

--- a/packages/ui/src/Nav/Nav.tsx
+++ b/packages/ui/src/Nav/Nav.tsx
@@ -103,7 +103,7 @@ export function PageNav({
     };
 
     return (
-        <div className="pointer-events-none fixed inset-x-0 top-0 z-40">
+        <div className="pointer-events-none fixed inset-x-0 top-0 z-40 [padding-left:env(safe-area-inset-left,0px)] [padding-right:env(safe-area-inset-right,0px)] [padding-top:env(safe-area-inset-top,0px)]">
             <Container
                 padded={false}
                 className={cx(

--- a/packages/ui/src/PublicChrome/NavSearch.tsx
+++ b/packages/ui/src/PublicChrome/NavSearch.tsx
@@ -414,7 +414,7 @@ export function NavSearch({
 
             {isOpen ? (
                 <div
-                    className="fixed left-3 right-3 top-20 z-50 overflow-hidden rounded-xl border border-muted-foreground/20 bg-popover text-popover-foreground shadow-[0_24px_70px_rgba(38,31,24,0.22)] ring-1 ring-muted-foreground/10 dark:border-muted-foreground/30 dark:bg-card dark:text-card-foreground dark:shadow-[0_28px_80px_rgba(0,0,0,0.65)] dark:ring-white/10 xl:absolute xl:left-auto xl:right-0 xl:top-12 xl:w-[28rem]"
+                    className="fixed left-3 right-3 top-20 z-50 flex max-h-[calc(100dvh-env(safe-area-inset-top,0px)-env(safe-area-inset-bottom,0px)-6rem)] flex-col overflow-hidden rounded-xl border border-muted-foreground/20 bg-popover text-popover-foreground shadow-[0_24px_70px_rgba(38,31,24,0.22)] ring-1 ring-muted-foreground/10 dark:border-muted-foreground/30 dark:bg-card dark:text-card-foreground dark:shadow-[0_28px_80px_rgba(0,0,0,0.65)] dark:ring-white/10 xl:absolute xl:left-auto xl:right-0 xl:top-12 xl:max-h-none xl:w-[28rem]"
                     role="dialog"
                     aria-label="Pretraga"
                 >
@@ -469,7 +469,7 @@ export function NavSearch({
                     <div
                         id={resultsId}
                         role="listbox"
-                        className="max-h-[min(32rem,calc(100vh-6rem))] overflow-y-auto p-2"
+                        className="min-h-0 max-h-[min(32rem,calc(100dvh-6rem))] overflow-y-auto p-2"
                     >
                         {isSearching ? (
                             <div className="flex items-center gap-3 px-3 py-5 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary

- render the complete Garden WebGL scene beneath Safari and Android browser chrome while keeping HUD controls, chat, banners, and full-screen dialogs inside safe-area insets
- opt WWW, News, Status, and API into safe edge-to-edge viewports, including public navigation, search, footer, anchor, and Scalar documentation offsets
- harden Delivery's existing edge-to-edge header and fixed alerts for landscape side cutouts
- keep the Admin standalone PWA contained until its authenticated drawers and full-screen panels receive a dedicated safe-area audit

## Why

Farm already used `viewport-fit=cover`, but the other apps did not consistently paint beneath browser chrome or protect interactive controls around notches and gesture navigation. Garden specifically needs the actual game canvas—not only a body background—to participate in the under-chrome effect.

## Mobile and PWA safety

- Garden's edge-to-edge viewport is scoped to the game route; account, auth, survey, and debug routes retain the contained root viewport
- the Garden canvas remains full viewport while only interactive overlays are inset
- Garden's manifest, Play package association, TWA scope, theme/background colors, and Android certificate fingerprint are unchanged
- API and other PWA manifests are unchanged
- no `interactive-widget` behavior was added to Garden

## Validation

- production builds: Garden, WWW, News, Status, API, Delivery
- typechecks: Garden, Game, UI, WWW, News, Storybook, Status, Delivery
- Garden landing browser suite: 5 passed
- API landing browser suite: 4 passed
- focused WWW safe-area browser test passed
- focused Delivery header and impersonation-banner component tests passed
- targeted Biome checks and `git diff --check` passed
