### PR TITLE
feat(news): add archive sub-navigation

### DIFF
--- a/apps/news/AGENTS.md
+++ b/apps/news/AGENTS.md
@@ -1,0 +1,7 @@
+<!-- BEGIN:nextjs-agent-rules -->
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+<!-- END:nextjs-agent-rules -->

--- a/apps/news/CLAUDE.md
+++ b/apps/news/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/news/app/page.tsx
+++ b/apps/news/app/page.tsx
@@ -3,46 +3,12 @@ import type { Route } from 'next';
 import { redirect } from 'next/navigation';
 import { EmptyNewsState } from '../components/EmptyNewsState';
 import { FilterPills } from '../components/FilterPills';
-import {
-    NewsCard,
-    type NewsCardEntry,
-    type NewsCardKind,
-} from '../components/NewsCard';
-import { NewsTagFilters } from '../components/NewsTagFilters';
-import {
-    getBlogPosts,
-    getChangelogEntries,
-    getPrimaryNewsTags,
-    uniqueNewsValues,
-} from '../lib/news';
+import { NewsArchiveNavigation } from '../components/NewsArchiveNavigation';
+import { NewsCard } from '../components/NewsCard';
+import { getBlogPosts, uniqueNewsValues } from '../lib/news';
 import { getNewsArticleViewTransitionName } from '../lib/viewTransitions';
 
 export const dynamic = 'force-dynamic';
-
-const newsTypeFilters = [
-    { label: 'Blog', value: 'blog' },
-    { label: 'Što je novo', value: 'changelog' },
-] satisfies { label: string; value: NewsCardKind }[];
-
-type NewsLandingItem = {
-    entry: NewsCardEntry;
-    href: Route;
-    kind: NewsCardKind;
-    sortTime: number;
-};
-
-function normalizedTime(value: string | null | undefined) {
-    if (!value) {
-        return 0;
-    }
-
-    const time = new Date(value).getTime();
-    return Number.isNaN(time) ? 0 : time;
-}
-
-function normalizeNewsTypeFilter(value: string | undefined) {
-    return value === 'blog' || value === 'changelog' ? value : undefined;
-}
 
 function normalizeFilterValue(value: string | undefined) {
     return value?.trim().toLocaleLowerCase('hr-HR');
@@ -50,6 +16,13 @@ function normalizeFilterValue(value: string | undefined) {
 
 function changelogTagRedirectPath(tag: string): Route {
     return `/sto-je-novo?tag=${encodeURIComponent(tag)}` as Route;
+}
+
+function blogArchivePath(category: string | undefined): Route {
+    const requestedCategory = category?.trim();
+    return requestedCategory
+        ? (`/?category=${encodeURIComponent(requestedCategory)}` as Route)
+        : '/';
 }
 
 export default async function NewsHomePage({
@@ -63,48 +36,22 @@ export default async function NewsHomePage({
         redirect(changelogTagRedirectPath(requestedTag));
     }
 
-    const activeType = normalizeNewsTypeFilter(type);
-    const activeCategory = activeType === 'changelog' ? undefined : category;
-    const normalizedCategory = normalizeFilterValue(activeCategory);
-    const [allPosts, allChangelogEntries] = await Promise.all([
-        getBlogPosts(),
-        getChangelogEntries(),
-    ]);
-    const allItems: NewsLandingItem[] = [
-        ...allPosts.map((entry) => ({
-            entry,
-            href: `/${entry.slug}` as Route,
-            kind: 'blog' as const,
-            sortTime: normalizedTime(entry.publishedAt),
-        })),
-        ...allChangelogEntries.map((entry) => ({
-            entry,
-            href: `/sto-je-novo/${entry.slug}` as Route,
-            kind: 'changelog' as const,
-            sortTime: normalizedTime(entry.publishedAt),
-        })),
-    ].sort((left, right) => right.sortTime - left.sortTime);
-    const currentFilters = { category: activeCategory, type: activeType };
-    const categories =
-        activeType === 'changelog'
-            ? []
-            : uniqueNewsValues(allPosts, (item) => item.category);
-    const tags = uniqueNewsValues(allChangelogEntries, (item) => item.tags);
-    const primaryTags = getPrimaryNewsTags(allChangelogEntries);
-    const primaryTagKeys = new Set(
-        primaryTags.map((value) => value.toLocaleLowerCase('hr-HR')),
-    );
-    const dropdownTags = tags.filter(
-        (value) => !primaryTagKeys.has(value.toLocaleLowerCase('hr-HR')),
-    );
-    const visibleItems = allItems.filter((item) => {
-        if (activeType && item.kind !== activeType) {
-            return false;
-        }
+    if (type === 'changelog') {
+        redirect('/sto-je-novo');
+    }
+    if (type) {
+        redirect(blogArchivePath(category));
+    }
 
+    const activeCategory = category;
+    const normalizedCategory = normalizeFilterValue(activeCategory);
+    const allPosts = await getBlogPosts();
+    const currentFilters = { category: activeCategory };
+    const categories = uniqueNewsValues(allPosts, (item) => item.category);
+    const visiblePosts = allPosts.filter((post) => {
         if (
             normalizedCategory &&
-            normalizeFilterValue(item.entry.category ?? undefined) !==
+            normalizeFilterValue(post.category ?? undefined) !==
                 normalizedCategory
         ) {
             return false;
@@ -127,44 +74,29 @@ export default async function NewsHomePage({
                     događa u Gredicama.
                 </p>
             </section>
-            <aside className="grid gap-4 rounded-md border bg-muted/15 p-4">
-                <FilterPills
-                    active={activeType}
-                    currentFilters={currentFilters}
-                    label="Vrsta"
-                    param="type"
-                    values={newsTypeFilters}
-                />
-                <FilterPills
-                    active={activeCategory}
-                    currentFilters={currentFilters}
-                    label="Kategorije"
-                    param="category"
-                    values={categories}
-                />
-                {tags.length > 0 ? (
-                    <div className="grid gap-2">
-                        <p className="text-xs font-semibold uppercase text-muted-foreground">
-                            Tagovi
-                        </p>
-                        <NewsTagFilters
-                            dropdownTags={dropdownTags}
-                            primaryTags={primaryTags}
-                        />
-                    </div>
-                ) : null}
-            </aside>
-            {visibleItems.length > 0 ? (
+            <NewsArchiveNavigation active="blog" />
+            {categories.length > 0 ? (
+                <aside className="grid gap-4 rounded-md border bg-muted/15 p-4">
+                    <FilterPills
+                        active={activeCategory}
+                        currentFilters={currentFilters}
+                        label="Kategorije"
+                        param="category"
+                        values={categories}
+                    />
+                </aside>
+            ) : null}
+            {visiblePosts.length > 0 ? (
                 <section className="grid items-start gap-4 md:grid-cols-2">
-                    {visibleItems.map((item) => (
+                    {visiblePosts.map((entry) => (
                         <NewsCard
-                            key={`${item.kind}-${item.href}`}
-                            entry={item.entry}
-                            href={item.href}
-                            kind={item.kind}
+                            key={entry.id}
+                            entry={entry}
+                            href={`/${entry.slug}` as Route}
+                            kind="blog"
                             viewTransitionName={getNewsArticleViewTransitionName(
-                                item.kind,
-                                item.entry.slug,
+                                'blog',
+                                entry.slug,
                             )}
                         />
                     ))}

--- a/apps/news/app/sto-je-novo/page.tsx
+++ b/apps/news/app/sto-je-novo/page.tsx
@@ -2,6 +2,7 @@ import { Container } from '@gredice/ui/Container';
 import { Timeline, TimelineEntry, TimelineGroup } from '@gredice/ui/Timeline';
 import type { Route } from 'next';
 import { EmptyNewsState } from '../../components/EmptyNewsState';
+import { NewsArchiveNavigation } from '../../components/NewsArchiveNavigation';
 import { NewsCard } from '../../components/NewsCard';
 import { NewsTagFilters } from '../../components/NewsTagFilters';
 import {
@@ -108,6 +109,7 @@ export default async function WhatsNewPage({
                     u Gredicama.
                 </p>
             </section>
+            <NewsArchiveNavigation active="changelog" />
             {tags.length > 0 ? (
                 <NewsTagFilters
                     activeTag={tag}

--- a/apps/news/components/FilterPills.tsx
+++ b/apps/news/components/FilterPills.tsx
@@ -1,7 +1,7 @@
 import type { Route } from 'next';
 import Link from 'next/link';
 
-type FilterParam = 'category' | 'tag' | 'type';
+type FilterParam = 'category' | 'tag';
 
 type FilterOption = {
     label: string;
@@ -26,10 +26,6 @@ function filterHref({
     const params = new URLSearchParams();
 
     for (const [key, filterValue] of Object.entries(currentFilters ?? {})) {
-        if (key === 'category' && param === 'type' && value === 'changelog') {
-            continue;
-        }
-
         if (key !== param && filterValue) {
             params.set(key, filterValue);
         }

--- a/apps/news/components/NewsArchiveNavigation.tsx
+++ b/apps/news/components/NewsArchiveNavigation.tsx
@@ -1,0 +1,41 @@
+import type { Route } from 'next';
+import Link from 'next/link';
+
+type NewsArchive = 'blog' | 'changelog';
+
+const newsArchives = [
+    { href: '/', label: 'Blog', value: 'blog' },
+    {
+        href: '/sto-je-novo',
+        label: 'Što je novo',
+        value: 'changelog',
+    },
+] satisfies { href: Route; label: string; value: NewsArchive }[];
+
+export function NewsArchiveNavigation({ active }: { active: NewsArchive }) {
+    return (
+        <nav aria-label="Arhive novosti" className="border-b">
+            <ul className="flex gap-6">
+                {newsArchives.map((archive) => {
+                    const isActive = archive.value === active;
+
+                    return (
+                        <li key={archive.value}>
+                            <Link
+                                aria-current={isActive ? 'page' : undefined}
+                                className={`-mb-px block border-b-2 px-1 pb-3 text-sm font-semibold transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+                                    isActive
+                                        ? 'border-primary text-foreground'
+                                        : 'border-transparent text-muted-foreground hover:border-border hover:text-foreground'
+                                }`}
+                                href={archive.href}
+                            >
+                                {archive.label}
+                            </Link>
+                        </li>
+                    );
+                })}
+            </ul>
+        </nav>
+    );
+}


### PR DESCRIPTION
## Summary

- replace the query-string type filter with archive navigation for Blog and Što je novo
- make `/novosti` the Blog archive while keeping tags on the `/novosti/sto-je-novo` timeline
- preserve old `type` and root `tag` links with canonical redirects
- expose the active archive with `aria-current="page"`

## Why

Blog and Što je novo are separate archives with separate routes. Navigating between those routes gives users the correct page structure and keeps archive-specific filters in the right place.

## Validation

- `corepack pnpm lint --filter news`
- `corepack pnpm typecheck --filter news`
- `corepack pnpm build --filter news`
- desktop and 390px browser checks for both archives, link targets, active state, overflow, and legacy redirects