### PR TITLE
feat(skills): standardize changelog cover style

### DIFF
--- a/.agents/skills/gredice-review-changelog-post/SKILL.md
+++ b/.agents/skills/gredice-review-changelog-post/SKILL.md
@@ -45,12 +45,21 @@ Na stranici [Dostava](https://www.gredice.com/dostava) moÅ¾ete pregledati podruÄ
 
 ### 4. Create a meaningful cover
 
+- Establish the visual baseline before creating anything. Open at least three recent accepted changelog covers, including one from the same product area when available, and compare their composition, typography, palette, spacing, treatment of product UI, and image bounds. Treat the repeated visual system as a contract, not loose inspiration.
+- Default to the established Gredice editorial cover template:
+  - a full-bleed warm ivory-to-pale-sage or pale-blue background with one restrained, oversized low-contrast arc entering from the top or right;
+  - a left editorial column with a short green rule and uppercase eyebrow, a bold dark-forest Croatian headline, and one short muted-green benefit statement;
+  - one dominant white rounded product panel on the right with a soft diffused shadow, containing the exact component, asset, or supported state that explains the change;
+  - a consistent landscape split, typographic hierarchy, outer margins, internal spacing, corner radius, and shadow language across every cover in the batch.
+- Use the accepted covers as visual references when generating a new cover. The subject may change, but the editorial grid and art direction must remain recognizably from the same series.
+- Do not default to photography, photorealistic scenes, free-floating objects, stock-style illustrations, collages, or decorative garden scenery. Do not use a device mockup unless the post specifically concerns device or edge-to-edge behavior. A conceptually relevant image still fails review when it does not match the established cover system.
 - Inspect the implemented feature before designing its cover. Check the live page and, when useful, the responsible app components, stories, fixtures, and checked-in assets to identify the real controls, states, labels, and visual language.
 - Use actual in-app components when applicable. Prefer rendering the real component or page state with privacy-safe props or fixtures, then compose that rendered result with exact product assets inside the cover artboard.
 - Do not create screenshot-like fictional UI. Any visible button, field, status, metric, or interaction must exist in the product and use a plausible supported state; verify important labels against the implementation or omit them.
 - Use neutral mock data only through real component contracts and supported states. Never imply that a capability, screen, or control exists when it does not.
-- Create a new visual from scratch when the post describes an abstract benefit, transition, relationship, or multi-step idea that the current UI cannot show clearly. Make it visibly illustrative rather than a fake product screen, using accurate assets, icons, arrows, diagrams, or restrained conceptual motifs.
+- When the post describes an abstract benefit, transition, relationship, or multi-step idea that the current UI cannot show clearly, explain it inside the established editorial template with restrained diagrams or verified assets in the right product panel. Do not replace the template with a standalone illustration.
 - Use a live screenshot when the exact changed UI is available, privacy-safe, and communicates the feature more clearly than a composition. Capture the user-facing feature, not the admin editor.
+- Reserve a full-frame screenshot exception for a spatial or visual change whose truth would be lost inside the editorial template, such as an exact map extent or a scene-wide rendering change. Record why the exception is stronger, and keep the screenshot feature-specific and privacy-safe.
 - Match the cover subject to the post's exact claim. A post about a specific block or entity must show that block or entity; a generic garden, list, gallery, or product-area page is not an acceptable substitute.
 - In a batch, compare the existing covers before composing replacements. Do not reuse one screenshot, including `/vrtovi`, across unrelated posts merely because it belongs to the same product area.
 - Protect privacy before composition. Prefer public pages, public demo content, mock data, or a neutral empty state over authenticated live account, farm, garden, delivery, or admin data.
@@ -63,9 +72,11 @@ Na stranici [Dostava](https://www.gredice.com/dostava) moÅ¾ete pregledati podruÄ
 - Prefer PNG for crisp UI. If transfer size is unreliable, use JPEG quality 90-92 while retaining the high pixel dimensions.
 - Reuse an existing accurate component or asset when it is stronger than a screenshot. Do not invent a generic scene or substitute a loosely related product page.
 - Search the app components, Storybook stories, and checked-in product assets first, including `apps/www/public/assets/blocks`. Compose only verified components and exact mentioned renders on a temporary, privacy-safe artboard with a fixed 16:9 frame, balanced internal spacing, and the visual group centered within the frame.
+- Keep generated Croatian text short enough to render reliably. Verify every diacritic, amount, date, label, and line break at natural size. Regenerate or compose exact text deterministically when any word is misspelled, malformed, clipped, or visually ambiguous.
 - Make the outer artboard a full-bleed, opaque rectangle. Do not give the artboard itself rounded corners or include page/body padding around it. Inner cards may be rounded, but every output corner must be painted by the artboard background; JPEG output must not contain differently colored corner wedges, and PNG output must not rely on transparent outer corners.
 - Capture the artboard element's exact bounds rather than the surrounding page. Confirm all four edges and corners belong to the intended background before upload.
 - For a release centered on one entity, use its exact render as the dominant hero. Capture the artboard element at high density so the uploaded cover is at least 1920 x 1080 when the source assets support it.
+- Before upload, compare the finished cover side by side with the accepted references. Reject it when the series identity, headline hierarchy, left-right balance, product grounding, text accuracy, edge treatment, or privacy standard is weaker than the references. In a batch, compare all finished covers together as well as individually.
 - Remove temporary composition pages and stop local preview servers after the cover is attached unless the user asks to keep them.
 
 Attach the result as `Naslovna slika`, not `SEO slika`, unless the user explicitly asks for a custom SEO image. If direct Chrome file upload is unavailable, use the CMS image dialog's clipboard-paste path.


### PR DESCRIPTION
## Summary

- make recent accepted changelog covers the required visual baseline
- codify the ivory and sage editorial grid with Croatian copy on the left and a grounded product panel on the right
- reject photography, stock-style illustration, and unconstrained compositions by default
- require natural-size text checks and side-by-side review before upload

## Context

The six unpublished changelog drafts from the 2026-07-18 automation run have already received replacement covers that follow this template.

## Validation

- skill creator quick validator: passed
- git diff --check: passed
- six replacement covers reviewed at 1672 x 941 and verified in CMS as draft changelog entries