### PR TITLE
feat(ui): add subtle button press feedback

### DIFF
--- a/apps/garden/tests/button-press-feedback.spec.tsx
+++ b/apps/garden/tests/button-press-feedback.spec.tsx
@@ -1,0 +1,136 @@
+import { Button } from '@gredice/ui/Button';
+import { IconButton } from '@gredice/ui/IconButton';
+import { Search } from '@gredice/ui/icons';
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Locator, Page } from '@playwright/test';
+
+async function pressAndReadStyles(
+    page: Page,
+    control: Locator,
+    expectedScale: string,
+) {
+    const box = await control.boundingBox();
+    if (!box) {
+        throw new Error('Expected the button to have a bounding box.');
+    }
+
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await expect
+        .poll(() =>
+            control.evaluate((node) => window.getComputedStyle(node).scale),
+        )
+        .toBe(expectedScale);
+    const styles = await control.evaluate((node) => {
+        const style = window.getComputedStyle(node);
+        return {
+            scale: style.scale,
+            transitionDuration: style.transitionDuration,
+            transitionProperty: style.transitionProperty,
+            transitionTimingFunction: style.transitionTimingFunction,
+        };
+    });
+    await page.mouse.up();
+
+    return styles;
+}
+
+test.beforeEach(async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+});
+
+test('shared Button and IconButton expose exact pointer press feedback', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <div className="flex gap-4 p-8">
+            <Button data-testid="button">Spremi promjenu</Button>
+            <IconButton aria-label="Pretraga" data-testid="icon-button">
+                <Search className="size-4" />
+            </IconButton>
+        </div>,
+    );
+
+    for (const testId of ['button', 'icon-button']) {
+        const styles = await pressAndReadStyles(
+            page,
+            page.getByTestId(testId),
+            '0.98',
+        );
+        expect(styles.scale).toBe('0.98');
+        expect(styles.transitionDuration).toBe('0.15s');
+        expect(styles.transitionProperty).toContain('scale');
+        expect(styles.transitionTimingFunction).toBe(
+            'cubic-bezier(0, 0, 0.2, 1)',
+        );
+    }
+});
+
+test('reduced motion uses the gentler scale and shorter duration', async ({
+    mount,
+    page,
+}) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await mount(
+        <Button data-testid="button" variant="outlined">
+            Uredi podatke
+        </Button>,
+    );
+
+    const styles = await pressAndReadStyles(
+        page,
+        page.getByTestId('button'),
+        '0.995',
+    );
+    expect(styles.scale).toBe('0.995');
+    expect(styles.transitionDuration).toBe('0.1s');
+    expect(styles.transitionTimingFunction).toBe('cubic-bezier(0, 0, 0.2, 1)');
+});
+
+test('links and unavailable buttons do not receive press feedback', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <div className="flex gap-4 p-8">
+            <Button data-testid="href-link" href="#target" variant="solid">
+                Otvori
+            </Button>
+            <Button data-testid="link-variant" variant="link">
+                Saznaj vise
+            </Button>
+            <Button data-testid="disabled" disabled>
+                Nedostupno
+            </Button>
+            <Button data-testid="loading" loading>
+                Spremanje
+            </Button>
+            <Button aria-disabled data-testid="aria-disabled-boolean">
+                Na cekanju
+            </Button>
+            <Button aria-disabled="true" data-testid="aria-disabled-string">
+                Obrada
+            </Button>
+        </div>,
+    );
+
+    for (const testId of [
+        'href-link',
+        'link-variant',
+        'disabled',
+        'loading',
+        'aria-disabled-boolean',
+        'aria-disabled-string',
+    ]) {
+        await expect(page.getByTestId(testId)).not.toHaveClass(/active:scale-/);
+    }
+
+    for (const testId of ['aria-disabled-boolean', 'aria-disabled-string']) {
+        const control = page.getByTestId(testId);
+        await control.focus();
+        await page.keyboard.down(' ');
+        await expect(control).toHaveCSS('scale', 'none');
+        await page.keyboard.up(' ');
+    }
+});

--- a/apps/storybook/stories/packages/ui/primitives/Button.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Button.stories.tsx
@@ -88,6 +88,13 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 export const Variants: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'Press and hold each native button to see the shared 150 ms press feedback. The link keeps its navigation treatment without scaling.',
+            },
+        },
+    },
     render: () => (
         <Row className="flex-wrap" spacing={3}>
             <Button>Solid</Button>
@@ -163,6 +170,13 @@ export const Decorators: Story = {
 };
 
 export const LoadingAndDisabled: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'Loading and disabled buttons remain visually stable and do not respond to pointer presses.',
+            },
+        },
+    },
     render: () => (
         <Row className="flex-wrap" spacing={3}>
             <Button loading>Sinkronizacija</Button>
@@ -175,6 +189,29 @@ export const LoadingAndDisabled: Story = {
                 variant="plain"
             >
                 Zakljucano
+            </Button>
+        </Row>
+    ),
+};
+
+export const ReducedMotion: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'This deterministic preview pins the same 0.995 scale and 100 ms duration used when reduced motion is enabled at the operating-system or browser level. Press and hold either action to inspect it.',
+            },
+        },
+    },
+    render: () => (
+        <Row className="flex-wrap" spacing={3}>
+            <Button className="duration-100 active:scale-[0.995]">
+                Potvrdi narudzbu
+            </Button>
+            <Button
+                className="duration-100 active:scale-[0.995]"
+                variant="outlined"
+            >
+                Uredi podatke
             </Button>
         </Row>
     ),

--- a/apps/storybook/stories/packages/ui/primitives/IconButton.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/IconButton.stories.tsx
@@ -29,6 +29,13 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 export const Variants: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'Press and hold the native icon buttons to verify that Button press feedback is inherited without changing their square dimensions.',
+            },
+        },
+    },
     render: () => (
         <Row className="flex-wrap" spacing={3}>
             <IconButton aria-label="Plain search">
@@ -122,9 +129,54 @@ export const LinkUsage: Story = {
     ),
 };
 
-export const Disabled: Story = {
-    args: {
-        disabled: true,
-        variant: 'outlined',
+export const LoadingAndDisabled: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'Loading and disabled icon buttons stay fixed and suppress press feedback through the shared Button state handling.',
+            },
+        },
     },
+    render: () => (
+        <Row className="flex-wrap" spacing={3}>
+            <IconButton aria-label="Ucitavanje postavki" loading>
+                <Settings className="size-4" />
+            </IconButton>
+            <IconButton
+                aria-label="Pretraga nije dostupna"
+                disabled
+                variant="outlined"
+            >
+                <Search className="size-4" />
+            </IconButton>
+        </Row>
+    ),
+};
+
+export const ReducedMotion: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'This deterministic preview pins the same 0.995 scale and 100 ms duration inherited when reduced motion is enabled at the operating-system or browser level. Press and hold either action to inspect it.',
+            },
+        },
+    },
+    render: () => (
+        <Row className="flex-wrap" spacing={3}>
+            <IconButton
+                aria-label="Dodaj novu stavku"
+                className="duration-100 active:scale-[0.995]"
+                variant="solid"
+            >
+                <Add className="size-4" />
+            </IconButton>
+            <IconButton
+                aria-label="Otvori opcije"
+                className="duration-100 active:scale-[0.995]"
+                variant="outlined"
+            >
+                <MoreHorizontal className="size-4" />
+            </IconButton>
+        </Row>
+    ),
 };

--- a/packages/ui/src/Button/Button.tsx
+++ b/packages/ui/src/Button/Button.tsx
@@ -22,7 +22,7 @@ export type ButtonColor =
     | 'neutral';
 
 const buttonClassNames = cva(
-    'relative inline-flex min-w-0 items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50',
+    'relative inline-flex min-w-0 items-center justify-center gap-2 rounded-md text-sm font-medium transition-[color,background-color,border-color,text-decoration-color,fill,stroke,transform,translate,scale,rotate] duration-150 ease-out focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50',
     {
         variants: {
             variant: {
@@ -51,6 +51,9 @@ const buttonClassNames = cva(
         },
     },
 );
+
+const buttonPressClassNames =
+    'active:scale-[0.98] motion-reduce:active:scale-[0.995] motion-reduce:duration-100';
 
 type ButtonOwnProps = VariantProps<typeof buttonClassNames> & {
     variant?: VariantKeys | 'link';
@@ -238,12 +241,20 @@ export function Button(props: ButtonProps) {
         variant,
         ...rest
     } = props;
+    const ariaDisabled =
+        props['aria-disabled'] === true || props['aria-disabled'] === 'true';
+    const hasPressFeedback =
+        variant !== 'link' &&
+        disabled !== true &&
+        loading !== true &&
+        !ariaDisabled;
 
     return (
         <button
             className={cx(
                 buttonClassNames({ fullWidth, size, variant }),
                 buttonColorClassName(variant, color),
+                hasPressFeedback && buttonPressClassNames,
                 className,
             )}
             disabled={disabled || loading}


### PR DESCRIPTION
## Summary

- add subtle transform feedback to eligible shared Button presses
- inherit the behavior in IconButton while excluding links, disabled, and loading states
- document normal, disabled/loading, and reduced-motion expectations in Storybook

## Verification

- focused Biome checks
- `pnpm typecheck --filter @gredice/ui`
- Storybook typecheck and production build
- `pnpm typecheck --filter garden`
- headless Storybook interaction verification
- `git diff --check`

Closes #4263
Part of #4261