### PR TITLE
feat(game): animate tutorial completion

### DIFF
--- a/apps/garden/tests/tutorial-checklist-hud.spec.tsx
+++ b/apps/garden/tests/tutorial-checklist-hud.spec.tsx
@@ -303,7 +303,89 @@ test('tutorial checklist modal uses readable dark mode surfaces', async ({
     expect(titleColor).toBe(tokenColors.foreground);
 });
 
-test('tutorial checklist completed state shows a green checkmark and can be hidden', async ({
+test('tutorial checklist animates only a newly completed cluster', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+    const component = await mount(<TutorialChecklistHudStory />);
+
+    await page.locator('[data-tutorial-checklist-trigger="true"]').click();
+    const dialog = page.getByRole('dialog', { name: 'Zadaci za novi vrt' });
+    await expect(dialog).toBeVisible();
+
+    await component.update(<TutorialChecklistHudStory variant="completed" />);
+
+    const completeBanner = dialog.locator(
+        '[data-tutorial-checklist-complete-banner="true"]',
+    );
+    const badge = completeBanner.locator(
+        '[data-tutorial-checklist-complete-badge="true"]',
+    );
+    const completionCopy = completeBanner.locator(
+        '[data-tutorial-checklist-complete-text="true"]',
+    );
+    const dismissAction = completeBanner.getByRole('button', {
+        name: 'Sakrij popis',
+    });
+
+    await expect(completeBanner).toBeVisible();
+    await expect(badge).toBeVisible();
+    await expect(completionCopy).toBeVisible();
+    await expect(dismissAction).toBeEnabled();
+
+    const badgeAnimation = await badge.evaluate((node) => {
+        const animation = node.getAnimations()[0];
+        const effect = animation?.effect;
+        if (!(effect instanceof KeyframeEffect)) {
+            return null;
+        }
+
+        return {
+            delay: effect.getTiming().delay,
+            duration: effect.getTiming().duration,
+            frames: effect.getKeyframes().map((frame) => ({
+                opacity: frame.opacity,
+                transform: frame.transform,
+            })),
+            timingFunction:
+                window.getComputedStyle(node).animationTimingFunction,
+        };
+    });
+    expect(badgeAnimation).toMatchObject({
+        delay: 0,
+        duration: 260,
+        frames: [
+            { opacity: '0', transform: 'scale(0.95)' },
+            { opacity: '1', transform: 'scale(1)' },
+        ],
+        timingFunction: 'cubic-bezier(0.16, 1, 0.3, 1)',
+    });
+
+    const staggerDelays = await Promise.all(
+        [completionCopy, dismissAction].map((part) =>
+            part.evaluate((node) => {
+                const effect = node.getAnimations()[0]?.effect;
+                return effect instanceof KeyframeEffect
+                    ? effect.getTiming().delay
+                    : null;
+            }),
+        ),
+    );
+    expect(staggerDelays).toEqual([40, 80]);
+
+    const staticRegionAnimationCounts = await Promise.all([
+        completeBanner.evaluate((node) => node.getAnimations().length),
+        dialog
+            .locator('[data-tutorial-checklist-group]')
+            .first()
+            .evaluate((node) => node.getAnimations().length),
+    ]);
+    expect(staticRegionAnimationCounts).toEqual([0, 0]);
+});
+
+test('tutorial checklist already completed state renders settled', async ({
     mount,
     page,
 }) => {
@@ -345,11 +427,99 @@ test('tutorial checklist completed state shows a green checkmark and can be hidd
     );
     expect(completeBannerClassName).toContain('bg-green-600');
 
-    await completeBanner.getByRole('button', { name: 'Sakrij popis' }).click();
+    const completionAnimationCounts = await Promise.all([
+        completeBanner
+            .locator('[data-tutorial-checklist-complete-badge="true"]')
+            .evaluate((node) => node.getAnimations().length),
+        completeBanner
+            .locator('[data-tutorial-checklist-complete-text="true"]')
+            .evaluate((node) => node.getAnimations().length),
+        completeBanner
+            .getByRole('button', { name: 'Sakrij popis' })
+            .evaluate((node) => node.getAnimations().length),
+    ]);
+    expect(completionAnimationCounts).toEqual([0, 0, 0]);
+});
+
+test('tutorial checklist completion dismissal is immediately actionable and persists', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+    const component = await mount(<TutorialChecklistHudStory />);
+
+    await page.locator('[data-tutorial-checklist-trigger="true"]').click();
+    await component.update(<TutorialChecklistHudStory variant="completed" />);
+
+    const dismissAction = page
+        .getByRole('dialog', { name: 'Zadaci za novi vrt' })
+        .getByRole('button', { name: 'Sakrij popis' });
+    await expect(dismissAction).toBeEnabled();
+    await dismissAction.click({ force: true });
 
     await expect(
         page.locator('[data-tutorial-checklist-trigger="true"]'),
     ).toHaveCount(0);
+    await expect
+        .poll(() =>
+            page.evaluate(() =>
+                window.localStorage.getItem(
+                    'game:tutorial-checklist:completed-dismissed-v1',
+                ),
+            ),
+        )
+        .not.toBeNull();
+});
+
+test('tutorial checklist completion uses an opacity-only reduced-motion entrance', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    const component = await mount(<TutorialChecklistHudStory />);
+
+    await page.locator('[data-tutorial-checklist-trigger="true"]').click();
+    await component.update(<TutorialChecklistHudStory variant="completed" />);
+
+    const completeBanner = page.locator(
+        '[data-tutorial-checklist-complete-banner="true"]',
+    );
+    const completionParts = [
+        completeBanner.locator(
+            '[data-tutorial-checklist-complete-badge="true"]',
+        ),
+        completeBanner.locator(
+            '[data-tutorial-checklist-complete-text="true"]',
+        ),
+        completeBanner.getByRole('button', { name: 'Sakrij popis' }),
+    ];
+    const animations = await Promise.all(
+        completionParts.map((part) =>
+            part.evaluate((node) => {
+                const animation = node.getAnimations()[0];
+                const effect = animation?.effect;
+                if (!(effect instanceof KeyframeEffect)) {
+                    return null;
+                }
+
+                return {
+                    delay: effect.getTiming().delay,
+                    duration: effect.getTiming().duration,
+                    framesHaveTransform: effect
+                        .getKeyframes()
+                        .some((frame) => frame.transform !== undefined),
+                };
+            }),
+        ),
+    );
+
+    expect(animations).toEqual([
+        { delay: 0, duration: 120, framesHaveTransform: false },
+        { delay: 40, duration: 120, framesHaveTransform: false },
+        { delay: 80, duration: 120, framesHaveTransform: false },
+    ]);
 });
 
 test('tutorial checklist completed dismissal returns when the task set changes', async ({

--- a/packages/game/src/hud/TutorialChecklistHud.module.css
+++ b/packages/game/src/hud/TutorialChecklistHud.module.css
@@ -46,9 +46,57 @@
     }
 }
 
+.completionBadge {
+    transform-origin: center;
+    animation: tutorial-checklist-completion-enter 260ms
+        cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.completionCopy {
+    transform-origin: center;
+    animation: tutorial-checklist-completion-enter 260ms
+        cubic-bezier(0.16, 1, 0.3, 1) 40ms both;
+}
+
+.completionAction {
+    transform-origin: center;
+    animation: tutorial-checklist-completion-enter 260ms
+        cubic-bezier(0.16, 1, 0.3, 1) 80ms both;
+}
+
+@keyframes tutorial-checklist-completion-enter {
+    from {
+        opacity: 0;
+        transform: scale(0.95);
+    }
+
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+@keyframes tutorial-checklist-completion-fade {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .claimableTask::before {
         animation: none;
+    }
+
+    .completionBadge,
+    .completionCopy,
+    .completionAction {
+        animation-name: tutorial-checklist-completion-fade;
+        animation-duration: 120ms;
+        animation-timing-function: ease-out;
     }
 }
 

--- a/packages/game/src/hud/TutorialChecklistHud.tsx
+++ b/packages/game/src/hud/TutorialChecklistHud.tsx
@@ -12,7 +12,7 @@ import { cx } from '@gredice/ui/utils';
 import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import { parseAsString, useQueryState } from 'nuqs';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useShoppingCart } from '../hooks/useShoppingCart';
@@ -553,10 +553,12 @@ function TutorialChecklistTaskRow({
 
 function TutorialChecklistContent({
     allTasksFinished,
+    animateCompletion,
     onDismissCompleted,
     onOpenChange,
 }: {
     allTasksFinished: boolean;
+    animateCompletion: boolean;
     onDismissCompleted: () => void;
     onOpenChange: (open: boolean) => void;
 }) {
@@ -649,7 +651,11 @@ function TutorialChecklistContent({
                         allTasksFinished
                             ? 'border-white/30 bg-white/15 text-white'
                             : 'bg-background text-foreground',
+                        animateCompletion && styles.completionBadge,
                     )}
+                    data-tutorial-checklist-complete-badge={
+                        allTasksFinished ? 'true' : 'false'
+                    }
                 >
                     {allTasksFinished ? (
                         <Check className="size-7" />
@@ -683,14 +689,20 @@ function TutorialChecklistContent({
                 {allTasksFinished ? (
                     <>
                         <Typography
-                            className="max-w-lg text-green-50"
+                            className={cx(
+                                'max-w-lg text-green-50',
+                                animateCompletion && styles.completionCopy,
+                            )}
                             data-tutorial-checklist-complete-text="true"
                             level="body2"
                         >
                             Svi zadaci su dovršeni.
                         </Typography>
                         <Button
-                            className="bg-white px-4 font-bold text-green-800 hover:bg-green-50 dark:bg-white dark:text-green-900 dark:hover:bg-green-50"
+                            className={cx(
+                                'bg-white px-4 font-bold text-green-800 hover:bg-green-50 dark:bg-white dark:text-green-900 dark:hover:bg-green-50',
+                                animateCompletion && styles.completionAction,
+                            )}
                             color="success"
                             data-tutorial-checklist-hide-completed="true"
                             onClick={onDismissCompleted}
@@ -818,6 +830,8 @@ function TutorialChecklistContent({
 
 export function TutorialChecklistHud() {
     const [isOpen, setIsOpen] = useState(false);
+    const [animateCompletion, setAnimateCompletion] = useState(false);
+    const previouslyObservedCompletion = useRef<boolean | null>(null);
     const queryClient = useQueryClient();
     const { data } = useTutorialChecklist();
     const { track } = useGameAnalytics();
@@ -828,6 +842,28 @@ export function TutorialChecklistHud() {
         dismiss: dismissCompletedChecklist,
         isDismissed,
     } = useCompletedChecklistDismissal(data);
+    const hasChecklist = Boolean(data);
+    const completionTransitionObserved =
+        hasChecklist &&
+        allTasksFinished &&
+        previouslyObservedCompletion.current === false;
+    const shouldAnimateCompletion =
+        animateCompletion || completionTransitionObserved;
+
+    useEffect(() => {
+        if (!hasChecklist) {
+            return;
+        }
+
+        if (completionTransitionObserved) {
+            setAnimateCompletion(true);
+        } else if (!allTasksFinished) {
+            setAnimateCompletion(false);
+        }
+
+        previouslyObservedCompletion.current = allTasksFinished;
+    }, [allTasksFinished, completionTransitionObserved, hasChecklist]);
+
     const progressLabel = useMemo(() => {
         if (!data || allTasksFinished) return null;
         const firstActiveGroup = data.groups.find(
@@ -838,6 +874,7 @@ export function TutorialChecklistHud() {
     }, [allTasksFinished, data]);
 
     const handleDismissCompleted = useCallback(() => {
+        setAnimateCompletion(false);
         dismissCompletedChecklist();
         setIsOpen(false);
         track('game_tutorial_checklist_completed_dismissed', {
@@ -858,6 +895,7 @@ export function TutorialChecklistHud() {
                 queryKey: tutorialChecklistKeys,
             });
         } else if (isOpen) {
+            setAnimateCompletion(false);
             track('game_tutorial_checklist_closed', {
                 ...checklistProgressProperties(data),
             });
@@ -939,6 +977,7 @@ export function TutorialChecklistHud() {
             >
                 <TutorialChecklistContent
                     allTasksFinished={allTasksFinished}
+                    animateCompletion={shouldAnimateCompletion}
                     onDismissCompleted={handleDismissCompleted}
                     onOpenChange={handleOpenChange}
                 />


### PR DESCRIPTION
## Summary

- animate only newly observed tutorial completion states
- stage the badge, completion copy, and dismissal action with the approved timing
- keep already-complete renders settled and provide an opacity-only reduced-motion path
- preserve immediate dismissal, persistence, analytics, and task behavior

## Verification

- tutorial checklist component tests: 8/8
- `pnpm test --filter @gredice/game`: 421/421
- focused Game and Garden Biome checks
- typecheck: `@gredice/game`, `garden`, and `www`
- Garden production build
- `git diff --check`

Closes #4264
Part of #4261