### PR TITLE
feat(game): animate recommendation sections

### DIFF
--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -1168,13 +1168,40 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         const recommendationsList = dialog.locator(
             '[data-recommended-operation-list]',
         );
-        await expect(recommendationsList).toHaveCount(0);
+        const operationsContent = operationsSection.locator(
+            '[data-recommendation-section-content]',
+        );
+        const operationsCollapse = operationsSection.locator(
+            '[data-collapse-state]',
+        );
+        await expect(operationsContent).toHaveCount(0);
+        await expect(operationsCollapse).toHaveAttribute(
+            'data-collapse-state',
+            'closed',
+        );
+        await expect(operationsCollapse).toHaveCSS(
+            'transition-property',
+            'grid-template-rows, opacity',
+        );
+        await expect(operationsCollapse).toHaveCSS(
+            'transition-duration',
+            '0.2s',
+        );
 
         const operationsHeader = operationsSection.getByRole('button', {
             name: /Radnje/,
         });
         await operationsHeader.click();
 
+        await expect(operationsContent).toHaveAttribute('aria-hidden', 'false');
+        await expect(operationsContent).not.toHaveAttribute('inert', '');
+        await expect(operationsCollapse).toHaveAttribute(
+            'data-collapse-state',
+            'open',
+        );
+        await expect(
+            operationsSection.locator('[data-recommendation-section-count]'),
+        ).toHaveClass(/scale-95 opacity-0/);
         await expect(recommendationsList).toBeVisible();
         await expect(recommendationsList).toContainText('Okopavanje');
         await expect(recommendationsList).toContainText('Uklanjanje korova');
@@ -1186,9 +1213,15 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         ).not.toContainText('Zakazano');
 
         await operationsHeader.click();
-        await expect(operationsSection.getByTitle('2 preporuka')).toBeVisible();
-        await expect(recommendationsList).toHaveCount(0);
+        await expect(operationsSection.getByTitle('2 preporuka')).toHaveClass(
+            /opacity-100/,
+        );
+        await expect(operationsContent).toHaveAttribute('aria-hidden', 'true');
+        await expect(operationsContent).toHaveCount(0);
         await operationsHeader.click();
+        await operationsHeader.click();
+        await operationsHeader.click();
+        await expect(operationsHeader).toHaveAttribute('aria-expanded', 'true');
         await expect(recommendationsList).toBeVisible();
 
         const listItems = recommendationsList.locator(':scope > *');
@@ -1251,7 +1284,10 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         const healthList = healthSection.locator(
             '[data-plant-health-operation-list]',
         );
-        await expect(healthList).toHaveCount(0);
+        const healthContent = healthSection.locator(
+            '[data-recommendation-section-content]',
+        );
+        await expect(healthContent).toHaveCount(0);
         await expect
             .poll(() =>
                 countAnalyticsEvents(
@@ -1266,6 +1302,7 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         });
         await healthHeader.click();
 
+        await expect(healthContent).toHaveAttribute('aria-hidden', 'false');
         await expect(healthSection.getByText('Lisne uši')).toBeVisible();
         await expect(healthList).toBeVisible();
         await expect(healthList).toContainText('Ispiranje biljke od štetnika');
@@ -1279,8 +1316,11 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
             .toBe(1);
 
         await healthHeader.click();
-        await expect(healthSection.getByTitle('1 preporuka')).toBeVisible();
-        await expect(healthList).toHaveCount(0);
+        await expect(healthSection.getByTitle('1 preporuka')).toHaveClass(
+            /opacity-100/,
+        );
+        await expect(healthContent).toHaveAttribute('aria-hidden', 'true');
+        await expect(healthContent).toHaveCount(0);
         await healthHeader.click();
         await expect
             .poll(() =>
@@ -1290,6 +1330,41 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
                 ),
             )
             .toBe(1);
+    });
+
+    test('recommendation sections use reduced-motion opacity transitions', async ({
+        mount,
+        page,
+    }) => {
+        await page.emulateMedia({ reducedMotion: 'reduce' });
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedGrowingWithRecommendedOperationsScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        await page.getByRole('button').first().click();
+
+        const section = page.locator(
+            '[data-recommendation-section="operations"]',
+        );
+        const collapse = section.locator('[data-collapse-state]');
+        const count = section.locator('[data-recommendation-section-count]');
+        const chevron = section.locator('svg.lucide-chevron-down');
+
+        await expect(collapse).toHaveCSS(
+            'transition-property',
+            'opacity, grid-template-rows',
+        );
+        await expect(collapse).toHaveCSS('transition-duration', '0.12s, 0s');
+        await expect(collapse).toHaveCSS('transition-delay', '0s, 0.12s');
+        await expect(count).toHaveCSS('transition-property', 'opacity');
+        await expect(count).toHaveCSS('transition-duration', '0.12s');
+        await expect(chevron).toHaveCSS('transition-property', 'none');
+
+        await section.getByRole('button', { name: /Radnje/ }).click();
+        await expect(collapse).toHaveCSS('transition-delay', '0s, 0s');
     });
 
     test('favorite operations are ranked first in recommendations and operation choices', async ({

--- a/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
@@ -1660,6 +1660,8 @@ function GardenWorkspaceShowcase() {
 }
 
 function AccountAndStatesShowcase() {
+    const [collapseOpen, setCollapseOpen] = useState(false);
+
     return (
         <Container className="py-8" maxWidth="xl">
             <Stack spacing={8}>
@@ -1798,13 +1800,30 @@ function AccountAndStatesShowcase() {
                             <div className="grid gap-4 lg:grid-cols-2">
                                 <Card variant="secondary">
                                     <CardHeader>
-                                        <CardTitle>Collapsed state</CardTitle>
+                                        <CardTitle>
+                                            Collapse transition
+                                        </CardTitle>
                                     </CardHeader>
                                     <CardContent>
-                                        <Collapse appear={false}>
+                                        <Button
+                                            aria-expanded={collapseOpen}
+                                            className="mb-3"
+                                            onClick={() =>
+                                                setCollapseOpen(
+                                                    (current) => !current,
+                                                )
+                                            }
+                                            size="sm"
+                                            variant="outlined"
+                                        >
+                                            {collapseOpen
+                                                ? 'Sakrij detalje'
+                                                : 'Prikaži detalje'}
+                                        </Button>
+                                        <Collapse appear={collapseOpen}>
                                             <Typography>
-                                                Hidden content remains in the
-                                                flow only when expanded.
+                                                Skriveni sadržaj ostaje miran i
+                                                dostupan tek kada je proširen.
                                             </Typography>
                                         </Collapse>
                                         <NoDataPlaceholder />

--- a/packages/game/src/hud/raisedBed/RecommendationSection.module.css
+++ b/packages/game/src/hud/raisedBed/RecommendationSection.module.css
@@ -1,0 +1,12 @@
+@media (prefers-reduced-motion: reduce) {
+    .reducedMotionCollapse[data-collapse-state] {
+        transition-property: opacity, grid-template-rows;
+        transition-duration: 120ms, 0ms;
+        transition-timing-function: ease-out, linear;
+        transition-delay: 0ms, 120ms;
+    }
+
+    .reducedMotionCollapse[data-collapse-state="open"] {
+        transition-delay: 0ms, 0ms;
+    }
+}

--- a/packages/game/src/hud/raisedBed/RecommendationSection.tsx
+++ b/packages/game/src/hud/raisedBed/RecommendationSection.tsx
@@ -1,8 +1,10 @@
+import { Collapse } from '@gredice/ui/Collapse';
 import { ExpandDown } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
-import type { ReactNode } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
+import styles from './RecommendationSection.module.css';
 
 type RecommendationSectionKind = 'operations' | 'health';
 
@@ -23,6 +25,14 @@ export function RecommendationSection({
     open: boolean;
     title: string;
 }) {
+    const [contentMounted, setContentMounted] = useState(open);
+
+    useEffect(() => {
+        if (open) {
+            setContentMounted(true);
+        }
+    }, [open]);
+
     return (
         <div data-recommendation-section={kind}>
             <button
@@ -42,26 +52,53 @@ export function RecommendationSection({
                         <Typography level="body2" semiBold noWrap>
                             {title}
                         </Typography>
-                        {!open && (
-                            <span
-                                className="inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-green-100 text-[11px] font-semibold leading-none text-green-700 dark:bg-green-900/50 dark:text-green-200"
-                                data-recommendation-section-count
-                                title={`${count} preporuka`}
-                            >
-                                {count}
-                            </span>
-                        )}
+                        <span
+                            aria-hidden={open}
+                            className={cx(
+                                'inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-green-100 text-[11px] font-semibold leading-none text-green-700 transition-[opacity,transform] duration-150 ease-out motion-reduce:!scale-100 motion-reduce:!transition-opacity motion-reduce:!duration-[120ms] dark:bg-green-900/50 dark:text-green-200',
+                                open
+                                    ? 'scale-95 opacity-0'
+                                    : 'scale-100 opacity-100',
+                            )}
+                            data-recommendation-section-count
+                            title={`${count} preporuka`}
+                        >
+                            {count}
+                        </span>
                     </Row>
                     <ExpandDown
                         aria-hidden
                         className={cx(
-                            'size-5 shrink-0 transition-transform',
+                            'size-5 shrink-0 transition-transform motion-reduce:transition-none',
                             open && '-scale-y-100',
                         )}
                     />
                 </Row>
             </button>
-            {open && <div className="px-2 pt-2 pb-4">{children}</div>}
+            <Collapse
+                appear={open}
+                className={styles.reducedMotionCollapse}
+                onTransitionEnd={(event) => {
+                    if (
+                        !open &&
+                        event.currentTarget === event.target &&
+                        event.propertyName === 'opacity'
+                    ) {
+                        setContentMounted(false);
+                    }
+                }}
+            >
+                {(open || contentMounted) && (
+                    <div
+                        aria-hidden={!open}
+                        className="px-2 pt-2 pb-4"
+                        data-recommendation-section-content
+                        inert={!open}
+                    >
+                        {children}
+                    </div>
+                )}
+            </Collapse>
         </div>
     );
 }

--- a/packages/ui/src/Collapse/Collapse.tsx
+++ b/packages/ui/src/Collapse/Collapse.tsx
@@ -1,21 +1,44 @@
-import type { PropsWithChildren } from 'react';
+import type {
+    CSSProperties,
+    PropsWithChildren,
+    TransitionEventHandler,
+} from 'react';
 import { cx } from '../utils';
+
+type CollapseStyle = CSSProperties & {
+    '--collapse-duration': string;
+};
 
 export type CollapseProps = PropsWithChildren<{
     appear: boolean;
+    className?: string;
     duration?: number;
+    onTransitionEnd?: TransitionEventHandler<HTMLDivElement>;
 }>;
 
-export function Collapse({ appear, children, duration = 200 }: CollapseProps) {
+export function Collapse({
+    appear,
+    children,
+    className,
+    duration = 200,
+    onTransitionEnd,
+}: CollapseProps) {
+    const style: CollapseStyle = {
+        '--collapse-duration': `${duration}ms`,
+    };
+
     return (
         <div
+            data-collapse-state={appear ? 'open' : 'closed'}
             className={cx(
-                'grid overflow-hidden transition-[grid-template-rows,opacity]',
+                'grid overflow-hidden transition-[grid-template-rows,opacity] [transition-duration:var(--collapse-duration)]',
                 appear
                     ? 'grid-rows-[1fr] opacity-100'
                     : 'grid-rows-[0fr] opacity-0',
+                className,
             )}
-            style={{ transitionDuration: `${duration}ms` }}
+            onTransitionEnd={onTransitionEnd}
+            style={style}
         >
             <div className="min-h-0">{children}</div>
         </div>


### PR DESCRIPTION
## Summary

- animate recommendation sections with the shared collapse primitive and stable count-badge space
- lazy-mount hidden section content and preserve it through exit without starting background hooks while closed
- use opacity-only reduced motion and keep the chevron static
- document the shared collapse interaction in Storybook

## Verification

- focused Garden Playwright component tests: 3/3
- `@gredice/ui`, `@gredice/game`, Garden, and Storybook typechecks
- targeted Biome checks
- Storybook production build
- `@gredice/game` unit tests: 421/421
- `git diff --check`

Closes #4265
Part of #4261