### PR TITLE
feat(garden): animate auth form transitions

### DIFF
--- a/apps/garden/components/auth/EmailPasswordForm.tsx
+++ b/apps/garden/components/auth/EmailPasswordForm.tsx
@@ -6,12 +6,14 @@ import { type FormEvent, useEffect, useState } from 'react';
 interface EmailPasswordFormProps {
     onSubmit: (email: string, password: string) => Promise<void>;
     submitText: string;
+    autoFocusEmail?: boolean;
     registration?: boolean;
 }
 
 export function EmailPasswordForm({
     onSubmit,
     submitText,
+    autoFocusEmail = false,
     registration = false,
 }: EmailPasswordFormProps) {
     const [email, setEmail] = useState('');
@@ -45,6 +47,7 @@ export function EmailPasswordForm({
                     id="email"
                     type="email"
                     label="Email"
+                    autoFocus={autoFocusEmail}
                     fullWidth
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}

--- a/apps/garden/components/auth/LoginModal.tsx
+++ b/apps/garden/components/auth/LoginModal.tsx
@@ -21,6 +21,13 @@ import LoginBanner from './LoginBanner';
 
 type AuthTab = 'login' | 'register';
 
+const authContentTransitionClassName =
+    'w-full animate-in fade-in-0 duration-200 ease-out motion-reduce:duration-[120ms]';
+const authContentDirectionClassNames = {
+    email: 'motion-safe:slide-in-from-bottom-2',
+    providers: 'motion-safe:slide-in-from-top-2',
+};
+
 export default function LoginModal() {
     const posthog = usePostHog();
     const router = useRouter();
@@ -28,6 +35,8 @@ export default function LoginModal() {
     const [error, setError] = useState<string>();
     const [activeTab, setActiveTab] = useState<AuthTab>('login');
     const [emailExpanded, setEmailExpanded] = useState(false);
+    const [shouldAnimateAuthContent, setShouldAnimateAuthContent] =
+        useState(false);
     const fetchLastLogin = useCallback(
         () => clientPublic().api.auth['last-login'].$get(),
         [],
@@ -152,13 +161,20 @@ export default function LoginModal() {
 
     const handleTabChange = (value: string) => {
         if (value === 'login' || value === 'register') {
+            setShouldAnimateAuthContent(emailExpanded);
             setActiveTab(value);
             setEmailExpanded(false);
             setError(undefined);
         }
     };
 
+    const handleEmailExpand = () => {
+        setShouldAnimateAuthContent(true);
+        setEmailExpanded(true);
+    };
+
     const authActionLabel = activeTab === 'login' ? 'prijava' : 'registracija';
+    const authContent = emailExpanded ? 'email' : 'providers';
 
     return (
         <>
@@ -183,69 +199,99 @@ export default function LoginModal() {
                         </TabsList>
                     </div>
                     <Stack spacing={4} className="mt-4">
-                        {!emailExpanded && (
-                            <Stack spacing={2}>
-                                <GoogleLoginButton
-                                    onClick={() => handleOAuthLogin('google')}
-                                    lastUsed={lastLoginProvider === 'google'}
-                                >
-                                    Google {authActionLabel}
-                                </GoogleLoginButton>
-                                <FacebookLoginButton
-                                    onClick={() => handleOAuthLogin('facebook')}
-                                    lastUsed={lastLoginProvider === 'facebook'}
-                                >
-                                    Facebook {authActionLabel}
-                                </FacebookLoginButton>
-                                <Button
-                                    type="button"
-                                    variant="outlined"
-                                    color="neutral"
-                                    fullWidth
-                                    startDecorator={
-                                        <Mail className="h-4 w-4 shrink-0" />
-                                    }
-                                    onClick={() => setEmailExpanded(true)}
-                                >
-                                    Email {authActionLabel}
-                                </Button>
-                            </Stack>
-                        )}
-                        {emailExpanded && (
-                            <>
-                                <TabsContent value="login" className="mt-0">
-                                    <div className="px-1">
-                                        <Stack spacing={4}>
-                                            <EmailPasswordForm
-                                                onSubmit={handleLogin}
-                                                submitText="Prijava"
-                                            />
-                                            {error && (
-                                                <Alert color="danger">
-                                                    {error}
-                                                </Alert>
-                                            )}
-                                        </Stack>
-                                    </div>
-                                </TabsContent>
-                                <TabsContent value="register" className="mt-0">
-                                    <div className="px-1">
-                                        <Stack spacing={4}>
-                                            <EmailPasswordForm
-                                                onSubmit={handleRegister}
-                                                submitText="Registriraj se"
-                                                registration
-                                            />
-                                            {error && (
-                                                <Alert color="danger">
-                                                    {error}
-                                                </Alert>
-                                            )}
-                                        </Stack>
-                                    </div>
-                                </TabsContent>
-                            </>
-                        )}
+                        <div className="w-full">
+                            <div
+                                key={authContent}
+                                className={
+                                    shouldAnimateAuthContent
+                                        ? `${authContentTransitionClassName} ${authContentDirectionClassNames[authContent]}`
+                                        : 'w-full'
+                                }
+                                data-auth-content={authContent}
+                                data-testid="auth-content-transition"
+                            >
+                                {!emailExpanded ? (
+                                    <Stack spacing={2}>
+                                        <GoogleLoginButton
+                                            onClick={() =>
+                                                handleOAuthLogin('google')
+                                            }
+                                            lastUsed={
+                                                lastLoginProvider === 'google'
+                                            }
+                                        >
+                                            Google {authActionLabel}
+                                        </GoogleLoginButton>
+                                        <FacebookLoginButton
+                                            onClick={() =>
+                                                handleOAuthLogin('facebook')
+                                            }
+                                            lastUsed={
+                                                lastLoginProvider === 'facebook'
+                                            }
+                                        >
+                                            Facebook {authActionLabel}
+                                        </FacebookLoginButton>
+                                        <Button
+                                            type="button"
+                                            variant="outlined"
+                                            color="neutral"
+                                            fullWidth
+                                            startDecorator={
+                                                <Mail className="h-4 w-4 shrink-0" />
+                                            }
+                                            onClick={handleEmailExpand}
+                                        >
+                                            Email {authActionLabel}
+                                        </Button>
+                                    </Stack>
+                                ) : (
+                                    <>
+                                        <TabsContent
+                                            value="login"
+                                            className="mt-0"
+                                        >
+                                            <div className="px-1">
+                                                <Stack spacing={4}>
+                                                    <EmailPasswordForm
+                                                        autoFocusEmail
+                                                        onSubmit={handleLogin}
+                                                        submitText="Prijava"
+                                                    />
+                                                    {error && (
+                                                        <Alert color="danger">
+                                                            {error}
+                                                        </Alert>
+                                                    )}
+                                                </Stack>
+                                            </div>
+                                        </TabsContent>
+                                        <TabsContent
+                                            value="register"
+                                            className="mt-0"
+                                        >
+                                            <div className="px-1">
+                                                <Stack spacing={4}>
+                                                    <EmailPasswordForm
+                                                        autoFocusEmail
+                                                        onSubmit={
+                                                            handleRegister
+                                                        }
+                                                        submitText="Registriraj se"
+                                                        registration
+                                                    />
+                                                    {error && (
+                                                        <Alert color="danger">
+                                                            {error}
+                                                        </Alert>
+                                                    )}
+                                                </Stack>
+                                            </div>
+                                        </TabsContent>
+                                    </>
+                                )}
+                            </div>
+                        </div>
                     </Stack>
                 </Tabs>
             </Modal>

--- a/apps/garden/tests/LoginModalStory.tsx
+++ b/apps/garden/tests/LoginModalStory.tsx
@@ -1,0 +1,45 @@
+import * as ReactQuery from '@tanstack/react-query';
+import {
+    AppRouterContext,
+    type AppRouterInstance,
+} from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import { useMemo, useState } from 'react';
+import LoginModal from '../components/auth/LoginModal';
+
+function createLoginModalQueryClient() {
+    return new ReactQuery.QueryClient({
+        defaultOptions: {
+            mutations: { retry: false },
+            queries: { retry: false },
+        },
+    });
+}
+
+export function LoginModalStory() {
+    const [lastRoute, setLastRoute] = useState('none');
+    const queryClient = useMemo(createLoginModalQueryClient, []);
+    const router = useMemo(
+        () =>
+            ({
+                back: () => undefined,
+                bfcacheId: 'login-modal-test',
+                forward: () => undefined,
+                prefetch: () => undefined,
+                push: (href) => setLastRoute(href),
+                refresh: () => undefined,
+                replace: () => undefined,
+            }) satisfies AppRouterInstance,
+        [],
+    );
+
+    return (
+        <AppRouterContext.Provider value={router}>
+            <ReactQuery.QueryClientProvider client={queryClient}>
+                <LoginModal />
+                <output className="sr-only" data-testid="last-router-push">
+                    {lastRoute}
+                </output>
+            </ReactQuery.QueryClientProvider>
+        </AppRouterContext.Provider>
+    );
+}

--- a/apps/garden/tests/login-modal.spec.tsx
+++ b/apps/garden/tests/login-modal.spec.tsx
@@ -1,0 +1,312 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Locator, Page, Route } from '@playwright/test';
+import { LoginModalStory } from './LoginModalStory';
+
+type AuthResponse = {
+    body: unknown;
+    status: number;
+};
+
+type AuthApiOptions = {
+    login?: AuthResponse;
+    register?: AuthResponse;
+};
+
+async function fulfillJson(route: Route, response: AuthResponse) {
+    await route.fulfill({
+        body: JSON.stringify(response.body),
+        contentType: 'application/json',
+        status: response.status,
+    });
+}
+
+async function mockAuthApi(page: Page, options: AuthApiOptions = {}) {
+    const loginRequests: unknown[] = [];
+    const registerRequests: unknown[] = [];
+
+    await page.route('**/api/gredice/**', async (route) => {
+        const request = route.request();
+        const { pathname } = new URL(request.url());
+
+        if (pathname.endsWith('/api/auth/last-login')) {
+            await fulfillJson(route, { body: {}, status: 200 });
+            return;
+        }
+
+        if (pathname.endsWith('/api/auth/login')) {
+            loginRequests.push(request.postDataJSON());
+            await fulfillJson(
+                route,
+                options.login ?? { body: {}, status: 200 },
+            );
+            return;
+        }
+
+        if (pathname.endsWith('/api/auth/register')) {
+            registerRequests.push(request.postDataJSON());
+            await fulfillJson(
+                route,
+                options.register ?? { body: {}, status: 201 },
+            );
+            return;
+        }
+
+        throw new Error(`Unexpected authentication request: ${pathname}`);
+    });
+
+    return { loginRequests, registerRequests };
+}
+
+async function inspectEnterAnimation(locator: Locator) {
+    return locator.evaluate((element) => {
+        if (!(element instanceof HTMLElement)) {
+            throw new Error('Expected an HTML transition element');
+        }
+
+        const animation = element.getAnimations()[0];
+        if (!animation) {
+            throw new Error('Expected an active content transition');
+        }
+
+        animation.pause();
+        animation.currentTime = 0;
+
+        const timing = animation.effect?.getTiming();
+        const duration = Number(timing?.duration ?? 0);
+        const initialStyle = window.getComputedStyle(element);
+        const initialTransform = initialStyle.transform;
+        const initialTranslateY =
+            initialTransform === 'none'
+                ? 0
+                : new DOMMatrix(initialTransform).m42;
+        const initialOpacity = Number(initialStyle.opacity);
+
+        animation.currentTime = duration;
+
+        const finalStyle = window.getComputedStyle(element);
+        const finalTransform = finalStyle.transform;
+        const finalTranslateY =
+            finalTransform === 'none' ? 0 : new DOMMatrix(finalTransform).m42;
+
+        return {
+            duration,
+            easing: initialStyle.animationTimingFunction,
+            finalOpacity: Number(finalStyle.opacity),
+            finalTranslateY,
+            initialOpacity,
+            initialTranslateY,
+        };
+    });
+}
+
+async function inspectKeyboardFocus(locator: Locator) {
+    return locator.evaluate((element) => {
+        if (!(element instanceof HTMLElement)) {
+            throw new Error('Expected an HTML focus target');
+        }
+
+        const clippingAncestors: string[] = [];
+        let ancestor = element.parentElement;
+
+        while (ancestor && ancestor.getAttribute('role') !== 'dialog') {
+            const style = window.getComputedStyle(ancestor);
+            if (
+                style.overflowX === 'hidden' ||
+                style.overflowX === 'clip' ||
+                style.overflowY === 'hidden' ||
+                style.overflowY === 'clip'
+            ) {
+                clippingAncestors.push(
+                    ancestor.getAttribute('data-testid') ??
+                        ancestor.className ??
+                        ancestor.tagName,
+                );
+            }
+            ancestor = ancestor.parentElement;
+        }
+
+        return {
+            boxShadow: window.getComputedStyle(element).boxShadow,
+            clippingAncestors,
+            focused: document.activeElement === element,
+        };
+    });
+}
+
+function centerY(bounds: { height: number; y: number } | null) {
+    if (!bounds) {
+        throw new Error('Expected modal bounds');
+    }
+
+    return bounds.y + bounds.height / 2;
+}
+
+test.beforeEach(async ({ page }) => {
+    await mockAuthApi(page);
+});
+
+test('animates login providers into the email form and focuses email', async ({
+    mount,
+    page,
+}) => {
+    await mount(<LoginModalStory />);
+
+    const dialog = page.getByRole('dialog', { name: 'Prijava' });
+    const content = page.getByTestId('auth-content-transition');
+    await expect(dialog).toBeVisible();
+    await expect(content).toHaveAttribute('data-auth-content', 'providers');
+    await expect(
+        page.getByRole('button', { name: 'Google prijava' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Facebook prijava' }),
+    ).toBeVisible();
+    expect(
+        await content.evaluate((element) => element.getAnimations().length),
+    ).toBe(0);
+
+    await page.waitForTimeout(220);
+    const modalCenterBefore = centerY(await dialog.boundingBox());
+
+    await page.getByRole('button', { name: 'Email prijava' }).click();
+
+    await expect(content).toHaveAttribute('data-auth-content', 'email');
+    await expect(page.getByLabel('Email')).toBeFocused();
+    expect(await inspectEnterAnimation(content)).toMatchObject({
+        duration: 200,
+        easing: 'cubic-bezier(0, 0, 0.2, 1)',
+        finalOpacity: 1,
+        finalTranslateY: 0,
+        initialOpacity: 0,
+        initialTranslateY: 8,
+    });
+    expect(centerY(await dialog.boundingBox())).toBeCloseTo(
+        modalCenterBefore,
+        0,
+    );
+});
+
+test('animates back to registration providers and into registration email', async ({
+    mount,
+    page,
+}) => {
+    await mount(<LoginModalStory />);
+
+    const content = page.getByTestId('auth-content-transition');
+    await page.getByRole('button', { name: 'Email prijava' }).click();
+    await expect(page.getByLabel('Email')).toBeFocused();
+
+    await page.getByRole('tab', { name: 'Registracija' }).click();
+
+    await expect(content).toHaveAttribute('data-auth-content', 'providers');
+    const googleRegistration = page.getByRole('button', {
+        name: 'Google registracija',
+    });
+    await expect(googleRegistration).toBeVisible();
+    expect(await inspectEnterAnimation(content)).toMatchObject({
+        duration: 200,
+        easing: 'cubic-bezier(0, 0, 0.2, 1)',
+        finalOpacity: 1,
+        finalTranslateY: 0,
+        initialOpacity: 0,
+        initialTranslateY: -8,
+    });
+
+    await page.keyboard.press('Tab');
+    const focusPresentation = await inspectKeyboardFocus(googleRegistration);
+    expect(focusPresentation.focused).toBe(true);
+    expect(focusPresentation.boxShadow).not.toBe('none');
+    expect(focusPresentation.clippingAncestors).toEqual([]);
+
+    await page.getByRole('button', { name: 'Email registracija' }).click();
+
+    await expect(content).toHaveAttribute('data-auth-content', 'email');
+    await expect(page.getByLabel('Email')).toBeFocused();
+    await expect(page.getByLabel('Ponovi zaporku')).toBeVisible();
+    expect(await inspectEnterAnimation(content)).toMatchObject({
+        duration: 200,
+        initialOpacity: 0,
+        initialTranslateY: 8,
+    });
+});
+
+test('preserves login submission and error feedback', async ({
+    mount,
+    page,
+}) => {
+    await page.unrouteAll({ behavior: 'wait' });
+    const recorded = await mockAuthApi(page, {
+        login: {
+            body: { errorCode: 'invalid_credentials', leftAttempts: 2 },
+            status: 401,
+        },
+    });
+    await mount(<LoginModalStory />);
+
+    await page.getByRole('button', { name: 'Email prijava' }).click();
+    await page.getByLabel('Email').fill('vrtlar@example.com');
+    await page.getByLabel('Zaporka').fill('pogresna-zaporka');
+    await page.getByRole('button', { name: 'Prijava' }).click();
+
+    await expect(
+        page.getByText('Prijava nije uspjela. Preostalo pokušaja: 2.'),
+    ).toBeVisible();
+    expect(recorded.loginRequests).toEqual([
+        { email: 'vrtlar@example.com', password: 'pogresna-zaporka' },
+    ]);
+});
+
+test('preserves registration submission and error feedback', async ({
+    mount,
+    page,
+}) => {
+    await page.unrouteAll({ behavior: 'wait' });
+    const recorded = await mockAuthApi(page, {
+        register: { body: {}, status: 500 },
+    });
+    await mount(<LoginModalStory />);
+
+    await page.getByRole('tab', { name: 'Registracija' }).click();
+    await page.getByRole('button', { name: 'Email registracija' }).click();
+    await page.getByLabel('Email').fill('nova@example.com');
+    await page.getByLabel('Zaporka').fill('sigurna-zaporka');
+    await page.getByLabel('Ponovi zaporku').fill('sigurna-zaporka');
+    await page.getByRole('button', { name: 'Registriraj se' }).click();
+
+    await expect(
+        page.getByText('Registracija nije uspjela. Pokušaj ponovno.'),
+    ).toBeVisible();
+    expect(recorded.registerRequests).toEqual([
+        { email: 'nova@example.com', password: 'sigurna-zaporka' },
+    ]);
+    await expect(page.getByTestId('last-router-push')).toHaveText('none');
+});
+
+test('uses opacity-only 120 ms transitions with reduced motion in both directions', async ({
+    mount,
+    page,
+}) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await mount(<LoginModalStory />);
+
+    const content = page.getByTestId('auth-content-transition');
+    await page.getByRole('button', { name: 'Email prijava' }).click();
+
+    expect(await inspectEnterAnimation(content)).toMatchObject({
+        duration: 120,
+        easing: 'cubic-bezier(0, 0, 0.2, 1)',
+        finalOpacity: 1,
+        finalTranslateY: 0,
+        initialOpacity: 0,
+        initialTranslateY: 0,
+    });
+
+    await page.getByRole('tab', { name: 'Registracija' }).click();
+
+    await expect(content).toHaveAttribute('data-auth-content', 'providers');
+    expect(await inspectEnterAnimation(content)).toMatchObject({
+        duration: 120,
+        initialOpacity: 0,
+        initialTranslateY: 0,
+    });
+});


### PR DESCRIPTION
## Summary

- add keyed, direction-aware provider-to-email and email-to-provider transitions inside the existing auth modal
- keep the modal shell stable and preserve keyboard focus rings and immediate email focus
- use opacity-only reduced motion while retaining existing tabs, OAuth, submissions, errors, analytics, and routing

## Verification

- focused Garden Playwright component tests: 5/5
- Garden typecheck
- targeted Biome checks
- Garden production build
- `git diff --check`

Closes #4266
Part of #4261