### PR TITLE
feat(game): animate checkout steps

### DIFF
--- a/apps/garden/tests/ShoppingCartStepTransitionStory.tsx
+++ b/apps/garden/tests/ShoppingCartStepTransitionStory.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { ShoppingCartStepTransition } from '../../../packages/game/src/hud/components/shopping-cart/ShoppingCartStepTransition';
+
+export function ShoppingCartStepTransitionStory() {
+    const [step, setStep] = useState<'cart' | 'delivery'>('cart');
+    const [cartUpdateCount, setCartUpdateCount] = useState(0);
+    const [proceedCount, setProceedCount] = useState(0);
+
+    return (
+        <div className="w-80 p-8">
+            <ShoppingCartStepTransition step={step}>
+                {step === 'cart' ? (
+                    <div>
+                        <button
+                            type="button"
+                            onClick={() =>
+                                setCartUpdateCount((count) => count + 1)
+                            }
+                        >
+                            Ažuriraj košaricu
+                        </button>
+                        <output aria-label="Broj ažuriranja košarice">
+                            {cartUpdateCount}
+                        </output>
+                        <button
+                            type="button"
+                            onClick={() => setStep('delivery')}
+                        >
+                            Dostava
+                        </button>
+                    </div>
+                ) : (
+                    <div>
+                        <button type="button" onClick={() => setStep('cart')}>
+                            Natrag
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() =>
+                                setProceedCount((count) => count + 1)
+                            }
+                        >
+                            Nastavi
+                        </button>
+                        <output aria-label="Broj nastavaka">
+                            {proceedCount}
+                        </output>
+                    </div>
+                )}
+            </ShoppingCartStepTransition>
+        </div>
+    );
+}

--- a/apps/garden/tests/shopping-cart-step-transition.spec.tsx
+++ b/apps/garden/tests/shopping-cart-step-transition.spec.tsx
@@ -1,0 +1,158 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Locator } from '@playwright/test';
+import { ShoppingCartStepTransitionStory } from './ShoppingCartStepTransitionStory';
+
+async function getAnimationDetails(locator: Locator) {
+    return locator.evaluate((node) => {
+        const style = window.getComputedStyle(node);
+        const keyframes = Array.from(document.styleSheets)
+            .flatMap((styleSheet) => Array.from(styleSheet.cssRules))
+            .find(
+                (rule) =>
+                    rule instanceof CSSKeyframesRule &&
+                    rule.name === style.animationName,
+            );
+
+        return {
+            animationDuration: style.animationDuration,
+            animationName: style.animationName,
+            animationTimingFunction: style.animationTimingFunction,
+            keyframes:
+                keyframes instanceof CSSKeyframesRule
+                    ? Array.from(keyframes.cssRules).flatMap((keyframe) =>
+                          keyframe instanceof CSSKeyframeRule
+                              ? [
+                                    {
+                                        opacity:
+                                            keyframe.style.opacity || undefined,
+                                        transform:
+                                            keyframe.style.transform ||
+                                            undefined,
+                                    },
+                                ]
+                              : [],
+                      )
+                    : [],
+        };
+    });
+}
+
+test.describe('shopping cart step transition', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.emulateMedia({ reducedMotion: 'no-preference' });
+    });
+
+    test('keeps the initial cart content settled', async ({ mount, page }) => {
+        await mount(<ShoppingCartStepTransitionStory />);
+
+        const transition = page.locator('[data-shopping-cart-step="cart"]');
+        expect(await getAnimationDetails(transition)).toEqual({
+            animationDuration: '0s',
+            animationName: 'none',
+            animationTimingFunction: 'ease',
+            keyframes: [],
+        });
+
+        await page.getByRole('button', { name: 'Ažuriraj košaricu' }).click();
+        await expect(page.getByLabel('Broj ažuriranja košarice')).toHaveText(
+            '1',
+        );
+        expect(await getAnimationDetails(transition)).toEqual({
+            animationDuration: '0s',
+            animationName: 'none',
+            animationTimingFunction: 'ease',
+            keyframes: [],
+        });
+    });
+
+    test('uses the forward checkout motion without delaying controls', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<ShoppingCartStepTransitionStory />);
+
+        await page.getByRole('button', { name: 'Dostava' }).click();
+
+        const transition = page.locator('[data-shopping-cart-step="delivery"]');
+        await expect(transition).toHaveAttribute(
+            'data-step-direction',
+            'forward',
+        );
+        expect(await getAnimationDetails(transition)).toEqual({
+            animationDuration: '0.26s',
+            animationName: expect.stringContaining(
+                'shopping-cart-step-forward',
+            ),
+            animationTimingFunction: 'cubic-bezier(0.16, 1, 0.3, 1)',
+            keyframes: [
+                {
+                    opacity: '0',
+                    transform: 'translateX(26px) scale(0.985)',
+                },
+                {
+                    opacity: '1',
+                    transform: 'translateX(0px) scale(1)',
+                },
+            ],
+        });
+
+        const proceed = page.getByRole('button', { name: 'Nastavi' });
+        await proceed.focus();
+        await expect(proceed).toBeFocused();
+        await proceed.dispatchEvent('click');
+        await expect(page.getByLabel('Broj nastavaka')).toHaveText('1');
+    });
+
+    test('uses the reverse motion when returning to the cart', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<ShoppingCartStepTransitionStory />);
+        await page.getByRole('button', { name: 'Dostava' }).click();
+        await page.getByRole('button', { name: 'Natrag' }).click();
+
+        const transition = page.locator('[data-shopping-cart-step="cart"]');
+        await expect(transition).toHaveAttribute(
+            'data-step-direction',
+            'backward',
+        );
+        expect(await getAnimationDetails(transition)).toEqual({
+            animationDuration: '0.26s',
+            animationName: expect.stringContaining(
+                'shopping-cart-step-backward',
+            ),
+            animationTimingFunction: 'cubic-bezier(0.16, 1, 0.3, 1)',
+            keyframes: [
+                {
+                    opacity: '0',
+                    transform: 'translateX(-26px) scale(0.985)',
+                },
+                {
+                    opacity: '1',
+                    transform: 'translateX(0px) scale(1)',
+                },
+            ],
+        });
+    });
+
+    test('uses an opacity-only transition for reduced motion', async ({
+        mount,
+        page,
+    }) => {
+        await page.emulateMedia({ reducedMotion: 'reduce' });
+        await mount(<ShoppingCartStepTransitionStory />);
+
+        await page.getByRole('button', { name: 'Dostava' }).click();
+
+        const transition = page.locator('[data-shopping-cart-step="delivery"]');
+        expect(await getAnimationDetails(transition)).toEqual({
+            animationDuration: '0.12s',
+            animationName: expect.stringContaining('shopping-cart-step-fade'),
+            animationTimingFunction: 'ease-out',
+            keyframes: [
+                { opacity: '0', transform: undefined },
+                { opacity: '1', transform: undefined },
+            ],
+        });
+    });
+});

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -34,6 +34,7 @@ import {
 import { HudCard } from './components/HudCard';
 import { ButtonConfirmPayment } from './components/shopping-cart/ButtonConfirmPayment';
 import { ShoppingCartItem } from './components/shopping-cart/ShoppingCartItem';
+import { ShoppingCartStepTransition } from './components/shopping-cart/ShoppingCartStepTransition';
 
 interface ShoppingCartProps {
     showDeliveryStep: boolean;
@@ -129,17 +130,19 @@ export function ShoppingCart({
     // Show delivery step if user clicked on checkout with deliverable items
     if (showDeliveryStep) {
         return (
-            <DeliveryStep
-                onSelectionChange={setDeliverySelection}
-                onBack={handleBackToCart}
-                onProceed={handleDeliveryProceed}
-                checkout={checkout}
-                isValid={isCompleteDeliverySelection(deliverySelection)}
-            />
+            <ShoppingCartStepTransition step="delivery">
+                <DeliveryStep
+                    onSelectionChange={setDeliverySelection}
+                    onBack={handleBackToCart}
+                    onProceed={handleDeliveryProceed}
+                    checkout={checkout}
+                    isValid={isCompleteDeliverySelection(deliverySelection)}
+                />
+            </ShoppingCartStepTransition>
         );
     }
 
-    return (
+    const cartStep = (
         <Stack spacing={4}>
             <Stack>
                 <div
@@ -285,6 +288,12 @@ export function ShoppingCart({
                 </Stack>
             </Stack>
         </Stack>
+    );
+
+    return (
+        <ShoppingCartStepTransition step="cart">
+            {cartStep}
+        </ShoppingCartStepTransition>
     );
 }
 

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartStepTransition.module.css
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartStepTransition.module.css
@@ -1,0 +1,50 @@
+.step {
+    width: 100%;
+    animation: shopping-cart-step-forward 260ms cubic-bezier(0.16, 1, 0.3, 1);
+    transform-origin: center center;
+}
+
+.step[data-step-direction="backward"] {
+    animation-name: shopping-cart-step-backward;
+}
+
+@keyframes shopping-cart-step-forward {
+    from {
+        opacity: 0;
+        transform: translateX(26px) scale(0.985);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateX(0) scale(1);
+    }
+}
+
+@keyframes shopping-cart-step-backward {
+    from {
+        opacity: 0;
+        transform: translateX(-26px) scale(0.985);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateX(0) scale(1);
+    }
+}
+
+@keyframes shopping-cart-step-fade {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .step,
+    .step[data-step-direction="backward"] {
+        animation: shopping-cart-step-fade 120ms ease-out;
+    }
+}

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartStepTransition.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartStepTransition.tsx
@@ -1,0 +1,47 @@
+import { type ReactNode, useEffect, useState } from 'react';
+import styles from './ShoppingCartStepTransition.module.css';
+
+interface ShoppingCartStepTransitionProps {
+    children: ReactNode;
+    step: 'cart' | 'delivery';
+}
+
+interface ShoppingCartStepContentProps extends ShoppingCartStepTransitionProps {
+    animate: boolean;
+}
+
+function ShoppingCartStepContent({
+    animate,
+    children,
+    step,
+}: ShoppingCartStepContentProps) {
+    const [shouldAnimate] = useState(animate);
+    const direction = step === 'delivery' ? 'forward' : 'backward';
+
+    return (
+        <div
+            className={shouldAnimate ? styles.step : undefined}
+            data-shopping-cart-step={step}
+            data-step-direction={direction}
+        >
+            {children}
+        </div>
+    );
+}
+
+export function ShoppingCartStepTransition({
+    children,
+    step,
+}: ShoppingCartStepTransitionProps) {
+    const [hasMounted, setHasMounted] = useState(false);
+
+    useEffect(() => {
+        setHasMounted(true);
+    }, []);
+
+    return (
+        <ShoppingCartStepContent animate={hasMounted} key={step} step={step}>
+            {children}
+        </ShoppingCartStepContent>
+    );
+}


### PR DESCRIPTION
## Summary

- add directional keyed transitions between cart and delivery content while leaving the modal shell untouched
- reuse the existing wizard motion vocabulary for forward and Back navigation with an opacity-only reduced-motion path
- keep controls immediately available and prevent initial or same-step cart updates from replaying motion

## Verification

- focused Garden Playwright component tests: 4/4
- existing shopping-cart regression tests: 9/9
- `@gredice/game` unit tests: 421/421
- `@gredice/game` and Garden typechecks
- targeted Biome checks
- independent lifecycle review
- `git diff --check`

Closes #4262
Part of #4261