### PR TITLE
feat(game): animate cart item changes

### DIFF
--- a/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
+++ b/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
@@ -2,9 +2,17 @@ import * as ReactQuery from '@tanstack/react-query';
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
 import { type PropsWithChildren, useMemo } from 'react';
 import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/GameAnalyticsContext';
-import type { ShoppingCartItemData } from '../../../packages/game/src/hooks/useShoppingCart';
-import { useShoppingCart } from '../../../packages/game/src/hooks/useShoppingCart';
+import {
+    type ShoppingCartData,
+    type ShoppingCartItemData,
+    useShoppingCart,
+    useShoppingCartQueryKey,
+} from '../../../packages/game/src/hooks/useShoppingCart';
 import { ShoppingCartItem } from '../../../packages/game/src/hud/components/shopping-cart/ShoppingCartItem';
+import {
+    ShoppingCart,
+    ShoppingCartHud,
+} from '../../../packages/game/src/hud/ShoppingCartHud';
 import {
     createGameState,
     GameStateContext,
@@ -44,6 +52,52 @@ const cartItem = {
         },
     },
 } as unknown as ShoppingCartItemData;
+
+function createOperationCartItem({
+    id,
+    name,
+    price,
+}: {
+    id: number;
+    name: string;
+    price: number;
+}) {
+    return {
+        ...cartItem,
+        id,
+        entityId: `operation-${id}`,
+        shopData: {
+            ...cartItem.shopData,
+            name,
+            price,
+        },
+        entityData: {
+            ...cartItem.entityData,
+            id,
+            slug: `mock-operation-${id}`,
+            information: {
+                ...cartItem.entityData.information,
+                label: name,
+                name,
+            },
+        },
+    } as unknown as ShoppingCartItemData;
+}
+
+const basilCartItem = createOperationCartItem({
+    id: 2,
+    name: 'Sadnja bosiljka',
+    price: 3.5,
+});
+const mintCartItem = createOperationCartItem({
+    id: 3,
+    name: 'Sadnja metvice',
+    price: 4.5,
+});
+const onePresenceItem = [cartItem];
+const twoPresenceItems = [cartItem, basilCartItem];
+const basilAndMintPresenceItems = [basilCartItem, mintCartItem];
+const noPresenceItems: ShoppingCartItemData[] = [];
 
 function createOutletCartItem() {
     const plantSortItem = createPlantSortCartItem();
@@ -129,7 +183,15 @@ function createPlantSortCartItem() {
     } as unknown as ShoppingCartItemData;
 }
 
-function createOptimisticToggleQueryClient(item = cartItem) {
+function cartTotal(items: ShoppingCartItemData[]) {
+    return items.reduce(
+        (total, item) =>
+            total + (item.shopData.discountPrice ?? item.shopData.price ?? 0),
+        0,
+    );
+}
+
+function createOptimisticToggleQueryClient(items = onePresenceItem) {
     const queryClient = new ReactQuery.QueryClient({
         defaultOptions: {
             queries: { retry: false, staleTime: Infinity },
@@ -164,9 +226,9 @@ function createOptimisticToggleQueryClient(item = cartItem) {
         allowPurchase: true,
         hasDeliverableItems: false,
         id: 1,
-        items: [item],
+        items,
         notes: [],
-        total: 2.5,
+        total: cartTotal(items),
         totalSunflowers: 0,
     });
 
@@ -175,11 +237,21 @@ function createOptimisticToggleQueryClient(item = cartItem) {
 
 function ShoppingCartOptimisticToggleProviders({
     children,
+    hasMemory = false,
     item,
-}: PropsWithChildren<{ item?: ShoppingCartItemData }>) {
+    items,
+}: PropsWithChildren<{
+    hasMemory?: boolean;
+    item?: ShoppingCartItemData;
+    items?: ShoppingCartItemData[];
+}>) {
+    const initialItems = useMemo(
+        () => items ?? (item ? [item] : onePresenceItem),
+        [item, items],
+    );
     const queryClient = useMemo(
-        () => createOptimisticToggleQueryClient(item),
-        [item],
+        () => createOptimisticToggleQueryClient(initialItems),
+        [initialItems],
     );
     const gameStore = useMemo(
         () =>
@@ -193,7 +265,7 @@ function ShoppingCartOptimisticToggleProviders({
     );
 
     return (
-        <NuqsTestingAdapter>
+        <NuqsTestingAdapter hasMemory={hasMemory}>
             <ReactQuery.QueryClientProvider client={queryClient}>
                 <GameStateContext.Provider value={gameStore}>
                     <GameAnalyticsProvider capture={() => undefined}>
@@ -202,6 +274,95 @@ function ShoppingCartOptimisticToggleProviders({
                 </GameStateContext.Provider>
             </ReactQuery.QueryClientProvider>
         </NuqsTestingAdapter>
+    );
+}
+
+function setPresenceItems(
+    queryClient: ReactQuery.QueryClient,
+    items: ShoppingCartItemData[],
+) {
+    queryClient.setQueryData<ShoppingCartData | null>(
+        useShoppingCartQueryKey,
+        (cart) =>
+            cart
+                ? {
+                      ...cart,
+                      items,
+                      total: cartTotal(items),
+                  }
+                : cart,
+    );
+}
+
+function ShoppingCartItemsPresencePanel({
+    useProductionHud = false,
+}: {
+    useProductionHud?: boolean;
+}) {
+    const queryClient = ReactQuery.useQueryClient();
+    const { data: cart } = useShoppingCart();
+
+    return (
+        <div className="w-[40rem] max-w-full p-8">
+            <div className="flex flex-wrap gap-2 mb-4">
+                <button
+                    data-testid="cart-set-one"
+                    type="button"
+                    onClick={() =>
+                        setPresenceItems(queryClient, onePresenceItem)
+                    }
+                >
+                    Jedna stavka
+                </button>
+                <button
+                    data-testid="cart-set-two"
+                    type="button"
+                    onClick={() =>
+                        setPresenceItems(queryClient, twoPresenceItems)
+                    }
+                >
+                    Dvije stavke
+                </button>
+                <button
+                    data-testid="cart-set-basil"
+                    type="button"
+                    onClick={() =>
+                        setPresenceItems(queryClient, [basilCartItem])
+                    }
+                >
+                    Samo bosiljak
+                </button>
+                <button
+                    data-testid="cart-set-basil-mint"
+                    type="button"
+                    onClick={() =>
+                        setPresenceItems(queryClient, basilAndMintPresenceItems)
+                    }
+                >
+                    Bosiljak i metvica
+                </button>
+                <button
+                    data-testid="cart-set-empty"
+                    type="button"
+                    onClick={() =>
+                        setPresenceItems(queryClient, noPresenceItems)
+                    }
+                >
+                    Prazna košara
+                </button>
+            </div>
+            <output data-testid="cart-source-item-ids">
+                {cart?.items.map((item) => item.id).join(',') || 'empty'}
+            </output>
+            {useProductionHud ? (
+                <ShoppingCartHud />
+            ) : (
+                <ShoppingCart
+                    showDeliveryStep={false}
+                    onShowDeliveryStepChange={() => undefined}
+                />
+            )}
+        </div>
     );
 }
 
@@ -260,6 +421,36 @@ export function ShoppingCartPlantSortStory() {
     return (
         <ShoppingCartOptimisticToggleProviders item={item}>
             <ShoppingCartOptimisticTogglePanel />
+        </ShoppingCartOptimisticToggleProviders>
+    );
+}
+
+export function ShoppingCartItemsPresenceStory({
+    initialItemCount = 1,
+}: {
+    initialItemCount?: 0 | 1 | 2;
+}) {
+    const items =
+        initialItemCount === 0
+            ? noPresenceItems
+            : initialItemCount === 2
+              ? twoPresenceItems
+              : onePresenceItem;
+
+    return (
+        <ShoppingCartOptimisticToggleProviders items={items}>
+            <ShoppingCartItemsPresencePanel />
+        </ShoppingCartOptimisticToggleProviders>
+    );
+}
+
+export function ShoppingCartHudItemsPresenceStory() {
+    return (
+        <ShoppingCartOptimisticToggleProviders
+            hasMemory
+            items={onePresenceItem}
+        >
+            <ShoppingCartItemsPresencePanel useProductionHud />
         </ShoppingCartOptimisticToggleProviders>
     );
 }

--- a/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
+++ b/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
@@ -1,10 +1,48 @@
 import { expect, test } from '@playwright/experimental-ct-react';
+import type { Locator } from '@playwright/test';
 import {
+    ShoppingCartHudItemsPresenceStory,
+    ShoppingCartItemsPresenceStory,
     ShoppingCartOptimisticToggleStory,
     ShoppingCartOutletCountdownStory,
     ShoppingCartPaidItemStory,
     ShoppingCartPlantSortStory,
 } from './ShoppingCartOptimisticToggleStory';
+
+async function getPresenceAnimation(locator: Locator) {
+    return locator.evaluate((node) => {
+        const style = window.getComputedStyle(node);
+        const keyframes = Array.from(document.styleSheets)
+            .flatMap((styleSheet) => Array.from(styleSheet.cssRules))
+            .find(
+                (rule) =>
+                    rule instanceof CSSKeyframesRule &&
+                    rule.name === style.animationName,
+            );
+
+        return {
+            animationDuration: style.animationDuration,
+            animationName: style.animationName,
+            animationTimingFunction: style.animationTimingFunction,
+            keyframes:
+                keyframes instanceof CSSKeyframesRule
+                    ? Array.from(keyframes.cssRules).flatMap((keyframe) =>
+                          keyframe instanceof CSSKeyframeRule
+                              ? [
+                                    {
+                                        opacity:
+                                            keyframe.style.opacity || undefined,
+                                        transform:
+                                            keyframe.style.transform ||
+                                            undefined,
+                                    },
+                                ]
+                              : [],
+                      )
+                    : [],
+        };
+    });
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -250,4 +288,364 @@ test('shopping cart outlet item shows a live reservation countdown', async ({
     const payload = await postedPayload;
     expect(payload.currency).toBe('sunflower');
     expect(payload.outletOfferId).toBe(1);
+});
+
+test.describe('shopping cart item presence', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.emulateMedia({ reducedMotion: 'no-preference' });
+    });
+
+    test('keeps initial rows settled and animates only an inserted row', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<ShoppingCartItemsPresenceStory initialItemCount={1} />);
+
+        const firstItem = page.locator('[data-shopping-cart-item-id="1"]');
+        await expect(firstItem).toHaveAttribute(
+            'data-shopping-cart-presence-state',
+            'settled',
+        );
+        expect(await getPresenceAnimation(firstItem)).toEqual({
+            animationDuration: '0s',
+            animationName: 'none',
+            animationTimingFunction: 'ease',
+            keyframes: [],
+        });
+
+        await page.getByTestId('cart-set-two').dispatchEvent('click');
+
+        await expect(page.getByTestId('cart-source-item-ids')).toHaveText(
+            '1,2',
+        );
+        const insertedItem = page.locator('[data-shopping-cart-item-id="2"]');
+        await expect(insertedItem).toHaveAttribute(
+            'data-shopping-cart-presence-state',
+            'entering',
+        );
+        expect(await getPresenceAnimation(insertedItem)).toEqual({
+            animationDuration: '0.15s',
+            animationName: expect.stringContaining('shopping-cart-item-enter'),
+            animationTimingFunction: 'ease-out',
+            keyframes: [
+                { opacity: '0', transform: 'translateY(4px)' },
+                { opacity: '1', transform: 'translateY(0px)' },
+            ],
+        });
+        await expect(firstItem).toHaveAttribute(
+            'data-shopping-cart-presence-state',
+            'settled',
+        );
+        await expect(insertedItem).toHaveAttribute(
+            'data-shopping-cart-presence-state',
+            'settled',
+        );
+        await expect(page.locator('[data-shopping-cart-summary]')).toHaveCSS(
+            'animation-name',
+            'none',
+        );
+    });
+
+    test('keeps siblings and summary stable while a removed row exits inert', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<ShoppingCartItemsPresenceStory initialItemCount={2} />);
+
+        const removedItem = page.locator('[data-shopping-cart-item-id="1"]');
+        const unaffectedItem = page.locator('[data-shopping-cart-item-id="2"]');
+        const summary = page.locator('[data-shopping-cart-summary]');
+        const unaffectedBefore = await unaffectedItem.boundingBox();
+        const summaryBefore = await summary.boundingBox();
+
+        await page.getByTestId('cart-set-basil').dispatchEvent('click');
+
+        await expect(page.getByTestId('cart-source-item-ids')).toHaveText('2');
+        await expect(removedItem).toHaveAttribute(
+            'data-shopping-cart-presence-state',
+            'exiting',
+        );
+        await expect(removedItem).toHaveAttribute('aria-hidden', 'true');
+        await expect(removedItem).toHaveAttribute('inert', '');
+        expect(
+            await removedItem.locator('[role="switch"]').evaluate((element) => {
+                if (!(element instanceof HTMLElement)) {
+                    return false;
+                }
+                element.focus();
+                return document.activeElement === element;
+            }),
+        ).toBe(false);
+        expect(await getPresenceAnimation(removedItem)).toEqual({
+            animationDuration: '0.15s',
+            animationName: expect.stringContaining('shopping-cart-item-exit'),
+            animationTimingFunction: 'ease-in',
+            keyframes: [
+                { opacity: '1', transform: 'translateY(0px)' },
+                { opacity: '0', transform: 'translateY(4px)' },
+            ],
+        });
+        expect(await unaffectedItem.boundingBox()).toEqual(unaffectedBefore);
+        expect(await summary.boundingBox()).toEqual(summaryBefore);
+        await expect(unaffectedItem).toHaveAttribute(
+            'data-shopping-cart-presence-state',
+            'settled',
+        );
+        await expect(summary).toHaveCSS('animation-name', 'none');
+        await expect(removedItem).toHaveCount(0);
+    });
+
+    test('shows the empty state and updates cart actions before the final row finishes exiting', async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize({ height: 844, width: 390 });
+        await mount(<ShoppingCartItemsPresenceStory initialItemCount={1} />);
+
+        const summary = page.locator('[data-shopping-cart-summary]');
+        const summaryBefore = await summary.boundingBox();
+        await page.getByTestId('cart-set-empty').dispatchEvent('click');
+
+        const summaryDuringCrossfade = await summary.evaluate(
+            async (element) => {
+                await new Promise<void>((resolve) =>
+                    window.setTimeout(resolve, 75),
+                );
+                const bounds = element.getBoundingClientRect();
+                return {
+                    height: bounds.height,
+                    width: bounds.width,
+                    x: bounds.x,
+                    y: bounds.y,
+                };
+            },
+        );
+        expect(summaryBefore).not.toBeNull();
+        expect(summaryDuringCrossfade.x).toBeCloseTo(summaryBefore?.x ?? 0, 1);
+        expect(summaryDuringCrossfade.y).toBeCloseTo(summaryBefore?.y ?? 0, 1);
+        expect(summaryDuringCrossfade.width).toBeCloseTo(
+            summaryBefore?.width ?? 0,
+            1,
+        );
+        expect(summaryDuringCrossfade.height).toBeCloseTo(
+            summaryBefore?.height ?? 0,
+            1,
+        );
+        await expect(page.getByTestId('cart-source-item-ids')).toHaveText(
+            'empty',
+        );
+        const exitingItem = page.locator('[data-shopping-cart-item-id="1"]');
+        const emptyState = page.locator(
+            '[data-shopping-cart-presence="empty"]',
+        );
+        await expect(exitingItem).toHaveAttribute(
+            'data-shopping-cart-presence-state',
+            'exiting',
+        );
+        await expect(emptyState).toHaveAttribute(
+            'data-shopping-cart-presence-state',
+            'entering',
+        );
+        await expect(emptyState).toContainText('Košara je prazna');
+        await expect(
+            page.getByRole('button', { name: 'Očisti košaru' }),
+        ).toBeDisabled();
+        await expect(
+            page.getByRole('button', { name: 'Plati' }),
+        ).toBeDisabled();
+
+        await expect(exitingItem).toHaveCount(0);
+        await expect(emptyState).toHaveAttribute(
+            'data-shopping-cart-presence-state',
+            'settled',
+        );
+        await expect(
+            page.locator('[data-shopping-cart-presence="item"]'),
+        ).toHaveCount(0);
+    });
+
+    test('keeps the production HUD mounted while the final row exits', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<ShoppingCartHudItemsPresenceStory />);
+
+        const cartTrigger = page.getByTitle('Košara');
+        await cartTrigger.click();
+        const cartDialog = page.getByRole('dialog', { name: 'Košara' });
+        await expect(cartDialog).toBeVisible();
+
+        const finalItem = page.locator('[data-shopping-cart-item-id="1"]');
+        await expect(finalItem).toHaveAttribute(
+            'data-shopping-cart-presence-state',
+            'settled',
+        );
+
+        await page.getByTestId('cart-set-empty').dispatchEvent('click');
+
+        await expect(page.getByTestId('cart-source-item-ids')).toHaveText(
+            'empty',
+        );
+        await expect(finalItem).toHaveAttribute(
+            'data-shopping-cart-presence-state',
+            'exiting',
+        );
+        const emptyState = page.locator(
+            '[data-shopping-cart-presence="empty"]',
+        );
+        await expect(emptyState).toContainText('Košara je prazna');
+        await expect(
+            page.getByRole('button', { name: 'Očisti košaru' }),
+        ).toBeDisabled();
+        await expect(
+            page.getByRole('button', { name: 'Plati' }),
+        ).toBeDisabled();
+        await expect(
+            page.locator('[data-shopping-cart-summary]'),
+        ).toContainText('0.00 €');
+
+        await expect(finalItem).toHaveCount(0);
+        await expect(emptyState).toHaveAttribute(
+            'data-shopping-cart-presence-state',
+            'settled',
+        );
+        await expect(cartDialog).toBeVisible();
+
+        await page.getByRole('button', { name: 'Zatvori' }).click();
+
+        await expect(cartDialog).toHaveCount(0);
+        await expect(cartTrigger).toHaveCount(0);
+    });
+
+    test('reuses an exiting row when an optimistic removal rolls back', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<ShoppingCartItemsPresenceStory initialItemCount={1} />);
+
+        const suggestion = page.locator(
+            '[data-shopping-cart-sunflowers-suggestion]',
+        );
+        const summary = page.locator('[data-shopping-cart-summary]');
+        const suggestionBefore = await suggestion.boundingBox();
+        const summaryBefore = await summary.boundingBox();
+        const firstItem = page.locator('[data-shopping-cart-item-id="1"]');
+        await page.getByTestId('cart-set-empty').dispatchEvent('click');
+        await expect(firstItem).toHaveAttribute(
+            'data-shopping-cart-presence-state',
+            'exiting',
+        );
+
+        await page.getByTestId('cart-set-one').dispatchEvent('click');
+
+        await expect(page.getByTestId('cart-source-item-ids')).toHaveText('1');
+        await expect(firstItem).toHaveCount(1);
+        await expect(firstItem).toHaveAttribute(
+            'data-shopping-cart-presence-state',
+            'entering',
+        );
+        await expect(firstItem).not.toHaveAttribute('aria-hidden', 'true');
+        await expect(firstItem).not.toHaveAttribute('inert', '');
+        await expect(firstItem).toHaveAttribute(
+            'data-shopping-cart-presence-state',
+            'settled',
+        );
+        await expect(firstItem).toHaveCount(1);
+        await page.waitForTimeout(175);
+        await expect(suggestion).toHaveCSS('opacity', '1');
+        expect(await suggestion.boundingBox()).toEqual(suggestionBefore);
+        expect(await summary.boundingBox()).toEqual(summaryBefore);
+        await expect(
+            page.locator('[data-shopping-cart-presence="empty"]'),
+        ).toHaveCount(0);
+    });
+
+    test('does not leave duplicate or stale rows after rapid cart changes', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<ShoppingCartItemsPresenceStory initialItemCount={2} />);
+
+        await page.getByTestId('cart-set-basil').dispatchEvent('click');
+        await page.getByTestId('cart-set-basil-mint').dispatchEvent('click');
+        await page.getByTestId('cart-set-two').dispatchEvent('click');
+        await page.getByTestId('cart-set-basil').dispatchEvent('click');
+
+        await expect(page.getByTestId('cart-source-item-ids')).toHaveText('2');
+        for (const id of ['1', '2', '3']) {
+            expect(
+                await page
+                    .locator(`[data-shopping-cart-item-id="${id}"]`)
+                    .count(),
+            ).toBeLessThanOrEqual(1);
+        }
+
+        await expect(
+            page.locator('[data-shopping-cart-presence="item"]'),
+        ).toHaveCount(1);
+        await expect(
+            page.locator('[data-shopping-cart-item-id="2"]'),
+        ).toHaveAttribute('data-shopping-cart-presence-state', 'settled');
+        await expect(
+            page.locator('[data-shopping-cart-item-id="1"]'),
+        ).toHaveCount(0);
+        await expect(
+            page.locator('[data-shopping-cart-item-id="3"]'),
+        ).toHaveCount(0);
+    });
+
+    test('uses 100ms opacity-only presence transitions for reduced motion', async ({
+        mount,
+        page,
+    }) => {
+        await page.emulateMedia({ reducedMotion: 'reduce' });
+        await mount(<ShoppingCartItemsPresenceStory initialItemCount={0} />);
+
+        await page.getByTestId('cart-set-one').dispatchEvent('click');
+
+        const enteredItem = page.locator('[data-shopping-cart-item-id="1"]');
+        const exitingEmptyState = page.locator(
+            '[data-shopping-cart-presence="empty"]',
+        );
+        expect(await getPresenceAnimation(enteredItem)).toEqual({
+            animationDuration: '0.1s',
+            animationName: expect.stringContaining(
+                'shopping-cart-item-fade-in',
+            ),
+            animationTimingFunction: 'ease-out',
+            keyframes: [
+                { opacity: '0', transform: undefined },
+                { opacity: '1', transform: undefined },
+            ],
+        });
+        expect(await getPresenceAnimation(exitingEmptyState)).toEqual({
+            animationDuration: '0.1s',
+            animationName: expect.stringContaining(
+                'shopping-cart-item-fade-out',
+            ),
+            animationTimingFunction: 'ease-in',
+            keyframes: [
+                { opacity: '1', transform: undefined },
+                { opacity: '0', transform: undefined },
+            ],
+        });
+        await expect(enteredItem).toHaveAttribute(
+            'data-shopping-cart-presence-state',
+            'settled',
+        );
+
+        await page.getByTestId('cart-set-empty').dispatchEvent('click');
+
+        expect(await getPresenceAnimation(enteredItem)).toMatchObject({
+            animationDuration: '0.1s',
+            animationName: expect.stringContaining(
+                'shopping-cart-item-fade-out',
+            ),
+            animationTimingFunction: 'ease-in',
+            keyframes: [
+                { opacity: '1', transform: undefined },
+                { opacity: '0', transform: undefined },
+            ],
+        });
+    });
 });

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -9,12 +9,11 @@ import {
     Truck,
 } from '@gredice/ui/icons';
 import { ModalConfirm } from '@gredice/ui/ModalConfirm';
-import { NoDataPlaceholder } from '@gredice/ui/NoDataPlaceholder';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
-import { useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { isCompleteDeliverySelection, useCheckout } from '../hooks/useCheckout';
 import { useCurrentAccount } from '../hooks/useCurrentAccount';
@@ -33,8 +32,35 @@ import {
 } from '../utils/sunflowerPricing';
 import { HudCard } from './components/HudCard';
 import { ButtonConfirmPayment } from './components/shopping-cart/ButtonConfirmPayment';
-import { ShoppingCartItem } from './components/shopping-cart/ShoppingCartItem';
+import { ShoppingCartItemsPresence } from './components/shopping-cart/ShoppingCartItemsPresence';
 import { ShoppingCartStepTransition } from './components/shopping-cart/ShoppingCartStepTransition';
+
+const sunflowerSuggestionLayoutExitDelayMs = 150;
+
+function useSunflowerSuggestionLayout(showSuggestion: boolean) {
+    const [reserveLayout, setReserveLayout] = useState(showSuggestion);
+
+    useLayoutEffect(() => {
+        if (showSuggestion) {
+            if (!reserveLayout) {
+                setReserveLayout(true);
+            }
+            return;
+        }
+
+        if (!reserveLayout) {
+            return;
+        }
+
+        const timeout = window.setTimeout(() => {
+            setReserveLayout(false);
+        }, sunflowerSuggestionLayoutExitDelayMs);
+
+        return () => window.clearTimeout(timeout);
+    }, [reserveLayout, showSuggestion]);
+
+    return reserveLayout;
+}
 
 interface ShoppingCartProps {
     showDeliveryStep: boolean;
@@ -55,16 +81,20 @@ export function ShoppingCart({
     const [deliverySelection, setDeliverySelection] =
         useState<DeliverySelectionData | null>(null);
 
-    const showSunflowersSuggestion =
+    const showSunflowersSuggestion = Boolean(
         !cart?.items.some((item) => item.currency === 'sunflower') &&
-        cart?.items.some(
-            (item) =>
-                (account?.sunflowers.amount ?? 0) >=
-                calculateSunflowerAmountFromPrices({
-                    price: item.shopData.price,
-                    discountPrice: item.shopData.discountPrice,
-                }),
-        );
+            cart?.items.some(
+                (item) =>
+                    (account?.sunflowers.amount ?? 0) >=
+                    calculateSunflowerAmountFromPrices({
+                        price: item.shopData.price,
+                        discountPrice: item.shopData.discountPrice,
+                    }),
+            ),
+    );
+    const reserveSunflowersSuggestionLayout = useSunflowerSuggestionLayout(
+        showSunflowersSuggestion,
+    );
 
     function handleCheckout() {
         if (!cart?.id) {
@@ -147,11 +177,15 @@ export function ShoppingCart({
             <Stack>
                 <div
                     className={cx(
-                        'opacity-0 h-0 transition-all duration-150',
+                        'opacity-0 transition-opacity duration-150',
+                        reserveSunflowersSuggestionLayout
+                            ? 'h-auto mb-4'
+                            : 'h-0',
                         showSunflowersSuggestion
-                            ? 'opacity-100 h-auto mb-4'
+                            ? 'opacity-100'
                             : 'pointer-events-none',
                     )}
+                    data-shopping-cart-sunflowers-suggestion
                 >
                     <Alert color="primary">
                         Dio košare možeš platiti u{' '}
@@ -172,22 +206,17 @@ export function ShoppingCart({
                                 Greška prilikom učitavanja košare
                             </Typography>
                         )}
-                        {!isLoading &&
-                            !isError &&
-                            (cart?.items.length ? (
-                                cart.items.map((item) => (
-                                    <ShoppingCartItem
-                                        key={item.id}
-                                        item={item}
-                                    />
-                                ))
-                            ) : (
-                                <NoDataPlaceholder>
-                                    Košara je prazna
-                                </NoDataPlaceholder>
-                            ))}
+                        {!isLoading && !isError ? (
+                            <ShoppingCartItemsPresence
+                                items={cart?.items ?? []}
+                            />
+                        ) : null}
                     </Stack>
-                    <Stack className="border-t mt-4 pt-2" spacing={2}>
+                    <Stack
+                        className="border-t mt-4 pt-2"
+                        data-shopping-cart-summary
+                        spacing={2}
+                    >
                         <Row
                             justifyContent="space-between"
                             alignItems="start"
@@ -304,7 +333,7 @@ export function ShoppingCartHud() {
     const [showDeliveryStep, setShowDeliveryStep] = useState(false);
     const showTransientHub = useShoppingCartTransientHub(isOpen);
 
-    if (!cart?.items.length && !showTransientHub) {
+    if (!cart?.items.length && !showTransientHub && !isOpen) {
         return null;
     }
 

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartItemsPresence.module.css
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartItemsPresence.module.css
@@ -1,0 +1,88 @@
+.presence {
+    display: grid;
+    min-width: 0;
+}
+
+.items,
+.empty {
+    grid-area: 1 / 1;
+    min-width: 0;
+}
+
+.items {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.empty {
+    align-self: start;
+}
+
+.slot {
+    min-width: 0;
+    width: 100%;
+}
+
+.entering {
+    animation: shopping-cart-item-enter 150ms ease-out both;
+}
+
+.exiting {
+    animation: shopping-cart-item-exit 150ms ease-in both;
+    pointer-events: none;
+}
+
+@keyframes shopping-cart-item-enter {
+    from {
+        opacity: 0;
+        transform: translateY(4px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes shopping-cart-item-exit {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+
+    to {
+        opacity: 0;
+        transform: translateY(4px);
+    }
+}
+
+@keyframes shopping-cart-item-fade-in {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes shopping-cart-item-fade-out {
+    from {
+        opacity: 1;
+    }
+
+    to {
+        opacity: 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .entering {
+        animation: shopping-cart-item-fade-in 100ms ease-out both;
+    }
+
+    .exiting {
+        animation: shopping-cart-item-fade-out 100ms ease-in both;
+    }
+}

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartItemsPresence.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartItemsPresence.tsx
@@ -1,0 +1,307 @@
+import { NoDataPlaceholder } from '@gredice/ui/NoDataPlaceholder';
+import { cx } from '@gredice/ui/utils';
+import {
+    type ReactNode,
+    useCallback,
+    useEffect,
+    useLayoutEffect,
+    useState,
+} from 'react';
+import type { ShoppingCartItemData } from '../../../hooks/useShoppingCart';
+import { ShoppingCartItem } from './ShoppingCartItem';
+import styles from './ShoppingCartItemsPresence.module.css';
+
+type PresenceState = 'entering' | 'exiting' | 'settled';
+
+interface PresenceTransition {
+    state: PresenceState;
+    transitionId: number;
+}
+
+interface ShoppingCartItemPresence extends PresenceTransition {
+    item: ShoppingCartItemData;
+}
+
+interface ShoppingCartPresenceModel {
+    empty: PresenceTransition | null;
+    items: ShoppingCartItemPresence[];
+    nextTransitionId: number;
+}
+
+interface ShoppingCartItemsPresenceProps {
+    items: ShoppingCartItemData[];
+}
+
+interface PresenceSlotProps extends PresenceTransition {
+    children: ReactNode;
+    itemId?: ShoppingCartItemData['id'];
+    kind: 'empty' | 'item';
+    onFinish: (
+        kind: 'empty' | 'item',
+        itemId: ShoppingCartItemData['id'] | undefined,
+        state: PresenceState,
+        transitionId: number,
+    ) => void;
+}
+
+function uniqueItems(items: ShoppingCartItemData[]) {
+    return [...new Map(items.map((item) => [item.id, item])).values()];
+}
+
+function initialPresenceModel(
+    items: ShoppingCartItemData[],
+): ShoppingCartPresenceModel {
+    const initialItems = uniqueItems(items);
+
+    return {
+        empty:
+            initialItems.length === 0
+                ? { state: 'settled', transitionId: 0 }
+                : null,
+        items: initialItems.map((item) => ({
+            item,
+            state: 'settled',
+            transitionId: 0,
+        })),
+        nextTransitionId: 0,
+    };
+}
+
+function reconcilePresenceModel(
+    current: ShoppingCartPresenceModel,
+    items: ShoppingCartItemData[],
+): ShoppingCartPresenceModel {
+    const incomingItems = uniqueItems(items);
+    const incomingById = new Map(incomingItems.map((item) => [item.id, item]));
+    const retainedIds = new Set<ShoppingCartItemData['id']>();
+    let nextTransitionId = current.nextTransitionId;
+
+    const presentItems = current.items.flatMap((entry) => {
+        if (retainedIds.has(entry.item.id)) {
+            return [];
+        }
+        retainedIds.add(entry.item.id);
+
+        const incomingItem = incomingById.get(entry.item.id);
+        if (!incomingItem) {
+            if (entry.state === 'exiting') {
+                return [entry];
+            }
+
+            nextTransitionId += 1;
+            return [
+                {
+                    ...entry,
+                    state: 'exiting' as const,
+                    transitionId: nextTransitionId,
+                },
+            ];
+        }
+
+        if (entry.state === 'exiting') {
+            nextTransitionId += 1;
+            return [
+                {
+                    item: incomingItem,
+                    state: 'entering' as const,
+                    transitionId: nextTransitionId,
+                },
+            ];
+        }
+
+        return [{ ...entry, item: incomingItem }];
+    });
+
+    for (const [itemIndex, item] of incomingItems.entries()) {
+        if (retainedIds.has(item.id)) {
+            continue;
+        }
+
+        nextTransitionId += 1;
+        const nextEntry: ShoppingCartItemPresence = {
+            item,
+            state: 'entering',
+            transitionId: nextTransitionId,
+        };
+        const laterItem = incomingItems
+            .slice(itemIndex + 1)
+            .find((candidate) =>
+                presentItems.some((entry) => entry.item.id === candidate.id),
+            );
+
+        if (laterItem) {
+            const insertionIndex = presentItems.findIndex(
+                (entry) => entry.item.id === laterItem.id,
+            );
+            presentItems.splice(insertionIndex, 0, nextEntry);
+        } else {
+            presentItems.push(nextEntry);
+        }
+        retainedIds.add(item.id);
+    }
+
+    let empty = current.empty;
+    if (incomingItems.length === 0) {
+        if (!empty || empty.state === 'exiting') {
+            nextTransitionId += 1;
+            empty = {
+                state: 'entering',
+                transitionId: nextTransitionId,
+            };
+        }
+    } else if (empty && empty.state !== 'exiting') {
+        nextTransitionId += 1;
+        empty = {
+            state: 'exiting',
+            transitionId: nextTransitionId,
+        };
+    }
+
+    return {
+        empty,
+        items: presentItems,
+        nextTransitionId,
+    };
+}
+
+function PresenceSlot({
+    children,
+    itemId,
+    kind,
+    onFinish,
+    state,
+    transitionId,
+}: PresenceSlotProps) {
+    useEffect(() => {
+        if (state === 'settled') {
+            return;
+        }
+
+        const reducedMotion = window.matchMedia(
+            '(prefers-reduced-motion: reduce)',
+        ).matches;
+        const durationMs = reducedMotion ? 100 : 150;
+        const timeout = window.setTimeout(() => {
+            onFinish(kind, itemId, state, transitionId);
+        }, durationMs + 50);
+
+        return () => window.clearTimeout(timeout);
+    }, [itemId, kind, onFinish, state, transitionId]);
+
+    return (
+        <div
+            aria-hidden={state === 'exiting' || undefined}
+            className={cx(
+                styles.slot,
+                state === 'entering' && styles.entering,
+                state === 'exiting' && styles.exiting,
+            )}
+            data-shopping-cart-item-id={itemId}
+            data-shopping-cart-presence={kind}
+            data-shopping-cart-presence-state={state}
+            inert={state === 'exiting' || undefined}
+            onAnimationEnd={(event) => {
+                if (event.target === event.currentTarget) {
+                    onFinish(kind, itemId, state, transitionId);
+                }
+            }}
+        >
+            {children}
+        </div>
+    );
+}
+
+export function ShoppingCartItemsPresence({
+    items,
+}: ShoppingCartItemsPresenceProps) {
+    const [presence, setPresence] = useState(() => initialPresenceModel(items));
+
+    useLayoutEffect(() => {
+        setPresence((current) => reconcilePresenceModel(current, items));
+    }, [items]);
+
+    const handlePresenceFinished = useCallback(
+        (
+            kind: 'empty' | 'item',
+            itemId: ShoppingCartItemData['id'] | undefined,
+            state: PresenceState,
+            transitionId: number,
+        ) => {
+            setPresence((current) => {
+                if (kind === 'empty') {
+                    if (
+                        !current.empty ||
+                        current.empty.state !== state ||
+                        current.empty.transitionId !== transitionId
+                    ) {
+                        return current;
+                    }
+
+                    return {
+                        ...current,
+                        empty:
+                            state === 'exiting'
+                                ? null
+                                : { ...current.empty, state: 'settled' },
+                    };
+                }
+
+                const itemIndex = current.items.findIndex(
+                    (entry) => entry.item.id === itemId,
+                );
+                const entry = current.items[itemIndex];
+                if (
+                    !entry ||
+                    entry.state !== state ||
+                    entry.transitionId !== transitionId
+                ) {
+                    return current;
+                }
+
+                const nextItems = [...current.items];
+                if (state === 'exiting') {
+                    nextItems.splice(itemIndex, 1);
+                } else {
+                    nextItems[itemIndex] = { ...entry, state: 'settled' };
+                }
+
+                return { ...current, items: nextItems };
+            });
+        },
+        [],
+    );
+
+    return (
+        <div className={styles.presence} data-shopping-cart-items-presence>
+            {presence.items.length > 0 ? (
+                <div className={styles.items}>
+                    {presence.items.map((entry) => (
+                        <PresenceSlot
+                            itemId={entry.item.id}
+                            key={entry.item.id}
+                            kind="item"
+                            onFinish={handlePresenceFinished}
+                            state={entry.state}
+                            transitionId={entry.transitionId}
+                        >
+                            <ShoppingCartItem item={entry.item} />
+                        </PresenceSlot>
+                    ))}
+                </div>
+            ) : null}
+            {presence.empty ? (
+                <div className={styles.empty}>
+                    <PresenceSlot
+                        key="empty"
+                        kind="empty"
+                        onFinish={handlePresenceFinished}
+                        state={presence.empty.state}
+                        transitionId={presence.empty.transitionId}
+                    >
+                        <NoDataPlaceholder>Košara je prazna</NoDataPlaceholder>
+                    </PresenceSlot>
+                </div>
+            ) : null}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

- add keyed enter/exit presence for shopping-cart rows without changing pricing, mutations, totals, or action state
- keep exiting rows inert and preserve surrounding geometry through rapid removal, rollback, and re-removal sequences
- keep the production cart HUD mounted while an open cart transitions to empty, then remove the inactive HUD when the modal closes
- use 150 ms directional motion and a 100 ms opacity-only reduced-motion fallback
- cover mobile midpoint layout stability, empty-cart transitions, duplicate/stale-row prevention, and optimistic rollback

## Validation

- `pnpm --filter @gredice/ui typecheck`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter storybook typecheck`
- `pnpm --filter @gredice/game test` (421 passed)
- `pnpm --filter garden build`
- `pnpm --filter garden exec playwright test tests/button-press-feedback.spec.tsx tests/login-modal.spec.tsx tests/raised-bed-field-hud.spec.tsx tests/shopping-cart-optimistic-toggle.spec.tsx tests/shopping-cart-step-transition.spec.tsx tests/tutorial-checklist-hud.spec.tsx --project=chromium` (92 passed)
- focused Biome check and `git diff --check`

Closes #4267
Part of #4261