### PR TITLE
Optimize rain particle lifecycle

### DIFF
--- a/apps/garden/app/debug/profile/game/profileWeather.ts
+++ b/apps/garden/app/debug/profile/game/profileWeather.ts
@@ -2,7 +2,8 @@ import type { GameSceneProps } from '@gredice/game';
 
 export type GameProfileWeatherTransitionRequest =
     | 'clear-to-cloudy'
-    | 'cloudy-to-clear';
+    | 'cloudy-to-clear'
+    | 'rain-to-clear';
 
 export const gameProfileWeatherTransitionEventName =
     'gredice:game-profile-weather-transition';
@@ -31,7 +32,9 @@ export function readGameProfileWeatherTransitionRequest(value: unknown) {
     }
 
     const request = Reflect.get(value, 'request');
-    return request === 'clear-to-cloudy' || request === 'cloudy-to-clear'
+    return request === 'clear-to-cloudy' ||
+        request === 'cloudy-to-clear' ||
+        request === 'rain-to-clear'
         ? request
         : undefined;
 }

--- a/apps/garden/scripts/profile-game-scene.mjs
+++ b/apps/garden/scripts/profile-game-scene.mjs
@@ -336,6 +336,15 @@ const weatherTransitionScenarios = [
         budget: 'weatherMobile',
         weatherTransition: 'cloudy-to-clear',
     },
+    {
+        name: 'game-weather-rain-to-clear-mobile',
+        path: '/debug/profile/game?mode=rain&quality=medium',
+        viewport: { width: 390, height: 844 },
+        dpr: 3,
+        isMobile: true,
+        budget: 'weatherMobile',
+        weatherTransition: 'rain-to-clear',
+    },
 ];
 
 const scenarioSets = {
@@ -1041,6 +1050,13 @@ async function measureScenario(browser, baseUrl, scenario, options) {
             const intervals = [];
             const start = performance.now();
             let last = start;
+            const rainParticleCountAtStart =
+                typeof globalThis.__grediceGameProfile?.rainParticleCount ===
+                'number'
+                    ? globalThis.__grediceGameProfile.rainParticleCount
+                    : null;
+            const rainMountedAtStart = (rainParticleCountAtStart ?? 0) > 0;
+            let rainUnmountMs = null;
             const weatherTransitionDispatched = weatherTransitionRequest
                 ? globalThis.dispatchEvent(
                       new CustomEvent(weatherTransitionEventName, {
@@ -1053,6 +1069,15 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 const step = (now) => {
                     intervals.push(now - last);
                     last = now;
+                    const rainParticleCount =
+                        globalThis.__grediceGameProfile?.rainParticleCount;
+                    if (
+                        rainMountedAtStart &&
+                        rainUnmountMs === null &&
+                        rainParticleCount === 0
+                    ) {
+                        rainUnmountMs = now - start;
+                    }
                     if (now - start >= sampleMs) {
                         resolveSample();
                         return;
@@ -1115,6 +1140,14 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 p50FrameMs: percentile(0.5),
                 p95FrameMs: percentile(0.95),
                 p99FrameMs: percentile(0.99),
+                rainMountedAtStart,
+                rainParticleCountAtEnd:
+                    typeof globalThis.__grediceGameProfile
+                        ?.rainParticleCount === 'number'
+                        ? globalThis.__grediceGameProfile.rainParticleCount
+                        : null,
+                rainParticleCountAtStart,
+                rainUnmountMs,
                 reportedDpr: globalThis.devicePixelRatio,
                 renderedFps: renderedFrames / elapsedSeconds,
                 renderedFrames,
@@ -1391,6 +1424,7 @@ function roundSample(sample) {
         p50FrameMs: round(sample.p50FrameMs),
         p95FrameMs: round(sample.p95FrameMs),
         p99FrameMs: round(sample.p99FrameMs),
+        rainUnmountMs: round(sample.rainUnmountMs),
         renderedFps: round(sample.renderedFps, 1),
         trianglesPerFrame: Math.round(sample.trianglesPerFrame),
         trianglesPerRenderedFrame: Math.round(sample.trianglesPerRenderedFrame),
@@ -1445,8 +1479,8 @@ function buildMarkdown(report) {
         '',
         `Budget status: ${report.summary.failedScenarios === 0 ? 'pass' : 'fail'}`,
         '',
-        '| Scenario | Mode | Profile | Details | Controls | HUD | Debug HUD | Motion | Quality | Canvas | Shadow | Rain/Snow | Overlays/Decor | Browser FPS | Rendered FPS | p95 | Max | Draw/frame | Triangles/frame | Long tasks | Heap | Budget | Screenshot |',
-        '| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |',
+        '| Scenario | Mode | Profile | Details | Controls | HUD | Debug HUD | Motion | Quality | Canvas | Shadow | Rain/Snow | Rain off | Overlays/Decor | Browser FPS | Rendered FPS | p95 | Max | Draw/frame | Triangles/frame | Long tasks | Heap | Budget | Screenshot |',
+        '| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |',
     ];
 
     for (const scenario of report.scenarios) {
@@ -1462,12 +1496,16 @@ function buildMarkdown(report) {
         const weather = scenario.runtime
             ? `${scenario.runtime.rainParticleCount ?? 0}/${scenario.runtime.snowParticleCount ?? 0}`
             : 'n/a';
+        const rainUnmount =
+            scenario.sample.rainUnmountMs === null
+                ? 'n/a'
+                : `${scenario.sample.rainUnmountMs} ms`;
         const detailCounts = scenario.runtime
             ? `${scenario.runtime.instancedSnowOverlayCount ?? 0}+${scenario.runtime.raisedBedMulchOverlayCount ?? 0}/${scenario.runtime.groundDecorationCount ?? 0} decor, visible ${scenario.runtime.groundDecorationVisibleCount ?? 'n/a'}, pages ${scenario.runtime.groundDecorationAtlasPageCount ?? 'n/a'}, chunks ${scenario.runtime.groundDecorationChunkCount ?? 'n/a'}, surface materials/uniforms snow ${scenario.runtime.snowOverlayMaterialConsumerCount ?? 'n/a'}/${scenario.runtime.snowOverlayDistinctUniformCount ?? 'n/a'}, rain ${scenario.runtime.rainWetOverlayMaterialConsumerCount ?? 'n/a'}/${scenario.runtime.rainWetOverlayDistinctUniformCount ?? 'n/a'}`
             : 'n/a';
         const screenshot = scenario.screenshotPath ?? 'n/a';
         lines.push(
-            `| ${scenario.name} | ${scenario.requested.mode} | ${scenario.requested.gardenProfile} | ${scenario.requested.details} | ${scenario.requested.controls} | ${scenario.requested.hud} | ${scenario.requested.debugHud} | ${scenario.requested.motion} | ${quality} | ${canvas} | ${shadow} | ${weather} | ${detailCounts} | ${scenario.sample.fps} | ${scenario.sample.renderedFps} | ${scenario.sample.p95FrameMs} ms | ${scenario.sample.maxFrameMs} ms | ${scenario.sample.drawCallsPerFrame} | ${scenario.sample.trianglesPerFrame} | ${scenario.sample.longTaskCount} | ${scenario.sample.jsHeapMb ?? 'n/a'} MB | ${scenario.budget.pass ? 'pass' : 'fail'} | ${screenshot} |`,
+            `| ${scenario.name} | ${scenario.requested.mode} | ${scenario.requested.gardenProfile} | ${scenario.requested.details} | ${scenario.requested.controls} | ${scenario.requested.hud} | ${scenario.requested.debugHud} | ${scenario.requested.motion} | ${quality} | ${canvas} | ${shadow} | ${weather} | ${rainUnmount} | ${detailCounts} | ${scenario.sample.fps} | ${scenario.sample.renderedFps} | ${scenario.sample.p95FrameMs} ms | ${scenario.sample.maxFrameMs} ms | ${scenario.sample.drawCallsPerFrame} | ${scenario.sample.trianglesPerFrame} | ${scenario.sample.longTaskCount} | ${scenario.sample.jsHeapMb ?? 'n/a'} MB | ${scenario.budget.pass ? 'pass' : 'fail'} | ${screenshot} |`,
         );
     }
 

--- a/docs/game-performance-optimization-results.md
+++ b/docs/game-performance-optimization-results.md
@@ -67,6 +67,7 @@ baseline and the preceding row.
 | 11 | Centralize dense-garden block indexes and instance selection | Complete | Dense + camera motion | Camera canvas-ready `-5.5%`, script time `-2.7%`, p95 `-2.6%`; static dense task time `-4.0%` |
 | 12 | Make sky astronomy and projection event-driven | Complete | Clear + dense cloudy mobile | Clear p95 `-23%`, task time `-5.6%`; dense cloudy neutral with all eight clouds/casters retained |
 | 13 | Crop unused decoration-atlas page rows | Complete | Dense mobile + renderer memory + screenshots | Estimated mipmapped RGBA8 residency `42.7 -> 32.0 MiB` (`-25%`); all 914 decorations and render work retained |
+| 14 | Fade rain intensity and stop invisible transition-tail particles | Complete | Clear + rain-to-clear mobile | Rain unmounted `49%` sooner; transition calls/s `-3.2%` and triangles/s `-5.5%`; steady clear render work unchanged |
 
 ### Step 01: generated-plant batch effect
 
@@ -330,6 +331,31 @@ screenshots.
   directionally positive, but the guaranteed result is the measured texture
   allocation reduction.
 
+### Step 14: intensity-aware rain lifecycle
+
+Reports: `steps/14-rain-lifecycle-before/latest.json` and
+`steps/14-rain-lifecycle-after/latest.json`.
+
+- The profiler now includes a warmed rain-to-clear transition and records the
+  first frame where the rain particle count reaches zero.
+- Rain intensity is clamped and passed through the existing shader progress
+  uniform instead of remaining fixed at full strength throughout the fade.
+- The particle system unmounts once intensity reaches `0.03`. At that point the
+  shader's maximum possible alpha is already below its existing fragment
+  discard threshold, so the cutoff removes invisible work without shortening
+  the visible effect.
+- Rain unmounted at `2,798.7 -> 1,422.8 ms`, `49.2%` sooner. Across the same
+  five-second transition, calls/s fell `792.1 -> 767.0` (`-3.2%`) and
+  triangles/s fell `47,812 -> 45,162` (`-5.5%`). Calls and triangles per
+  rendered frame fell `52.6 -> 51.8` and `3,178 -> 3,049`.
+- Steady clear remained exact: zero rain particles, 40 calls/render, and 2,620
+  triangles/render in both samples. Its rendered FPS and p95 movement
+  (`19.7 -> 19.4`, `46.5 -> 46.9 ms`) is treated as headless variance.
+- A custom quality multiplier of zero no longer mounts a zero-instance rain
+  mesh. The static JavaScript import remains intentional: lazy-loading this
+  small shader path could delay the first visible rain and would not address
+  the sustained GPU workload behind the thermal report.
+
 ## Final validation and headless soak
 
 Report: `steps/final-soak/latest.json`. Each scenario warmed for 5 seconds,
@@ -351,7 +377,10 @@ soaked for 15 seconds, and sampled for 10 seconds in the production build.
   headless environment, which reports synchronous `ReadPixels` GPU stalls.
   This is not treated as release clearance; the physical thermal gates below
   remain mandatory.
-- Final validation passed: 480 game unit tests, game and garden typechecks,
+- The steady-state soak predates Step 14. That step does not change steady rain
+  or clear render work and is covered by the dedicated production
+  rain-to-clear profile above.
+- Final validation passed: 484 game unit tests, game and garden typechecks,
   the offscreen public-garden preview capture browser test, targeted Biome
   checks across all changed source files, production build, generated-atlas
   synchronization, and `git diff --check`.

--- a/docs/game-scene-performance.md
+++ b/docs/game-scene-performance.md
@@ -100,7 +100,7 @@ Measured from the current workspace on 2026-04-29:
 | `castShadow` / `receiveShadow` occurrences | 109 | coarse source count in `packages/game/src` |
 | Directional shadow map | low: off, medium: 2048, high: 4096 | legacy default was 8192 |
 | Canvas DPR policy | low: cap 1, medium: cap 1.5, high: cap 2 | set as a DPR cap, not a forced upscale |
-| Weather particle policy | low: 35% rain / 30% snow, medium: 70% / 60%, high: 100% | profiler reports active rain/snow counts |
+| Weather particle policy | low: 35% rain / 30% snow, medium: 70% / 60%, high: 100% | rain fades through shader intensity and unmounts below the visible threshold; profiler reports active rain/snow counts |
 | Ground decoration policy | low: off, medium: 50%, high: 100% | skipped in far zoom and reported in profile metadata |
 | Snow overlay policy | low: min coverage 0.35, medium: 0.08, high: 0.02 | overlays are not mounted below the tier threshold |
 
@@ -173,6 +173,13 @@ Run every profiler scenario together:
 ```bash
 cd apps/garden
 pnpm run profile:game:all
+```
+
+Run the weather-transition matrix, including the rain-to-clear cutoff timing:
+
+```bash
+cd apps/garden
+GAME_PROFILE_SCENARIO_SET=weather-transitions pnpm run profile:game
 ```
 
 Run the same production build/start flow as a CI gate with budget failures
@@ -268,6 +275,7 @@ GAME_PROFILE_BASE_URL=http://localhost:3001 pnpm run profile:game:existing
 GAME_PROFILE_BASE_URL=http://localhost:3201 pnpm run profile:game
 GAME_PROFILE_SCENARIO_SET=dense pnpm run profile:game
 GAME_PROFILE_SCENARIO_SET=dense-mobile pnpm run profile:game
+GAME_PROFILE_SCENARIO_SET=weather-transitions pnpm run profile:game
 GAME_PROFILE_SCENARIO_SET=all pnpm run profile:game
 pnpm run profile:game -- --scenario game-dense-25x25-rain-mobile
 GAME_PROFILE_SCENARIOS=game-dense-25x25-rain-mobile pnpm run profile:game

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -20,6 +20,7 @@ import {
 } from './gameQuality';
 import { getMoonlitNightScales } from './moonlight';
 import { Drops } from './Rain/Drops';
+import { resolveRainParticleState } from './Rain/rainParticles';
 import { useSceneTimeInvalidation } from './SceneTime';
 import { ShadowMapController } from './ShadowMapController';
 import { SkyGradientBackground } from './SkyGradientBackground';
@@ -789,10 +790,8 @@ export function Environment({
 
     // Handle rain
     const rain = blendedWeather?.rainy ?? 0;
-    const baseRainParticleCount = rain < 0.4 ? 200 : rain > 0.9 ? 2000 : 600;
-    const rainParticleCount = Math.round(
-        baseRainParticleCount * qualityProfile.rainParticleMultiplier,
-    );
+    const { activeCount: rainParticleCount, intensity: rainParticleIntensity } =
+        resolveRainParticleState(rain, qualityProfile.rainParticleMultiplier);
 
     // Handle snow particles - based on current weather (snowy intensity 0-1)
     const snowParticles = blendedWeather?.snowy ?? 0;
@@ -805,7 +804,9 @@ export function Environment({
     useEffect(() => {
         updateGameProfileMetadata({
             rainParticleCount:
-                !weatherDisabled && rain > 0 ? rainParticleCount : 0,
+                !weatherDisabled && rainParticleCount > 0
+                    ? rainParticleCount
+                    : 0,
             shadowMapSize: qualityProfile.shadowMapSize,
             shadowsEnabled: qualityProfile.shadows,
             snowParticleCapacity:
@@ -821,7 +822,6 @@ export function Environment({
     }, [
         qualityProfile.shadowMapSize,
         qualityProfile.shadows,
-        rain,
         rainParticleCount,
         snowParticleCapacity,
         snowParticleCount,
@@ -1079,8 +1079,11 @@ export function Environment({
             {!weatherDisabled && fog > 0 && (
                 <fog attach="fog" args={[fogColor, fogNear, 190]} />
             )}
-            {!weatherDisabled && rain > 0 && (
-                <Drops count={rainParticleCount} />
+            {!weatherDisabled && rainParticleCount > 0 && (
+                <Drops
+                    count={rainParticleCount}
+                    intensity={rainParticleIntensity}
+                />
             )}
             {!weatherDisabled && snowParticleCount > 0 && (
                 <Snow

--- a/packages/game/src/scene/Rain/Drops.tsx
+++ b/packages/game/src/scene/Rain/Drops.tsx
@@ -10,18 +10,27 @@ import * as THREE from 'three';
 import { useGameState } from '../../useGameState';
 import { createPrecipitationMaterial } from '../PrecipitationMaterial';
 import { useSceneTimeInvalidation, useSceneTimeUniform } from '../SceneTime';
+import { normalizeRainParticleIntensity } from './rainParticles';
 import { rainFragmentShader } from './rainShaders';
 
 interface DropsProps {
     count?: number;
+    intensity: number;
 }
 
-export const Drops = ({ count = 2000 }: DropsProps) => {
+export const Drops = ({ count = 2000, intensity }: DropsProps) => {
     const fref = useRef<THREE.Group>(null);
     const camera = useThree((state) => state.camera);
     const gameCamera = useGameState((state) => state.gameCamera);
     const timeUniform = useSceneTimeUniform();
     useSceneTimeInvalidation();
+    const rainProgressUniformRef = useRef<THREE.IUniform<number> | null>(null);
+    if (!rainProgressUniformRef.current) {
+        rainProgressUniformRef.current = {
+            value: normalizeRainParticleIntensity(intensity),
+        };
+    }
+    const rainProgressUniform = rainProgressUniformRef.current;
 
     const size = 40;
     const speed = 15;
@@ -72,6 +81,10 @@ export const Drops = ({ count = 2000 }: DropsProps) => {
     }, [count]);
 
     useEffect(() => () => geometry.dispose(), [geometry]);
+
+    useLayoutEffect(() => {
+        rainProgressUniform.value = normalizeRainParticleIntensity(intensity);
+    }, [intensity, rainProgressUniform]);
 
     const updateRainFieldPosition = useCallback((x: number, z: number) => {
         const group = fref.current;
@@ -146,11 +159,11 @@ export const Drops = ({ count = 2000 }: DropsProps) => {
                 timeUniform,
                 uniforms: {
                     uRainFieldSize: { value: size },
-                    uRainProgress: { value: 1 },
+                    uRainProgress: rainProgressUniform,
                 },
                 vertexShader,
             }),
-        [timeUniform, vertexShader],
+        [rainProgressUniform, timeUniform, vertexShader],
     );
 
     useEffect(() => () => material.dispose(), [material]);

--- a/packages/game/src/scene/Rain/rainParticles.ts
+++ b/packages/game/src/scene/Rain/rainParticles.ts
@@ -1,0 +1,46 @@
+export const rainParticleVisibilityThreshold = 0.03;
+
+const lightRainParticleCount = 200;
+const mediumRainParticleCount = 600;
+const heavyRainParticleCount = 2000;
+
+export function normalizeRainParticleIntensity(intensity: number) {
+    if (!Number.isFinite(intensity)) {
+        return 0;
+    }
+
+    return Math.min(1, Math.max(0, intensity));
+}
+
+function resolveBaseRainParticleCount(intensity: number) {
+    if (intensity < 0.4) {
+        return lightRainParticleCount;
+    }
+
+    if (intensity > 0.9) {
+        return heavyRainParticleCount;
+    }
+
+    return mediumRainParticleCount;
+}
+
+export function resolveRainParticleState(
+    intensity: number,
+    particleMultiplier: number,
+) {
+    const normalizedIntensity = normalizeRainParticleIntensity(intensity);
+    const normalizedMultiplier =
+        normalizeRainParticleIntensity(particleMultiplier);
+    const particleCount = Math.round(
+        resolveBaseRainParticleCount(normalizedIntensity) *
+            normalizedMultiplier,
+    );
+    const visible =
+        normalizedIntensity > rainParticleVisibilityThreshold &&
+        particleCount > 0;
+
+    return {
+        activeCount: visible ? particleCount : 0,
+        intensity: normalizedIntensity,
+    };
+}

--- a/packages/game/src/scene/Rain/rainParticles.unit.ts
+++ b/packages/game/src/scene/Rain/rainParticles.unit.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    normalizeRainParticleIntensity,
+    rainParticleVisibilityThreshold,
+    resolveRainParticleState,
+} from './rainParticles';
+
+test('normalizes rain particle intensity to a finite unit value', () => {
+    assert.equal(normalizeRainParticleIntensity(Number.NaN), 0);
+    assert.equal(normalizeRainParticleIntensity(Number.POSITIVE_INFINITY), 0);
+    assert.equal(normalizeRainParticleIntensity(-0.5), 0);
+    assert.equal(normalizeRainParticleIntensity(0.5), 0.5);
+    assert.equal(normalizeRainParticleIntensity(2), 1);
+});
+
+test('stops particles at the shader visibility threshold', () => {
+    assert.deepEqual(
+        resolveRainParticleState(rainParticleVisibilityThreshold, 1),
+        {
+            activeCount: 0,
+            intensity: rainParticleVisibilityThreshold,
+        },
+    );
+    assert.deepEqual(
+        resolveRainParticleState(rainParticleVisibilityThreshold + 0.001, 1),
+        {
+            activeCount: 200,
+            intensity: rainParticleVisibilityThreshold + 0.001,
+        },
+    );
+});
+
+test('preserves quality-scaled particle tiers while rain is visible', () => {
+    assert.deepEqual(resolveRainParticleState(0.2, 0.5), {
+        activeCount: 100,
+        intensity: 0.2,
+    });
+    assert.deepEqual(resolveRainParticleState(0.5, 0.7), {
+        activeCount: 420,
+        intensity: 0.5,
+    });
+    assert.deepEqual(resolveRainParticleState(1, 1), {
+        activeCount: 2000,
+        intensity: 1,
+    });
+});
+
+test('does not mount a zero-count particle system', () => {
+    assert.deepEqual(resolveRainParticleState(1, 0), {
+        activeCount: 0,
+        intensity: 1,
+    });
+});


### PR DESCRIPTION
## What changed

- drive rain opacity from the blended weather intensity instead of keeping particles at full shader strength during transitions
- unmount the rain particle mesh once intensity reaches `0.03`, where its maximum alpha is already below the shader's existing discard threshold
- avoid mounting a zero-instance rain mesh when a custom quality multiplier disables rain particles
- add focused lifecycle tests and a production `rain-to-clear` profiling scenario that records the first zero-particle frame
- document the implementation and its measured impact

## Why

Follow-up to #4274. Rain was absent during steady clear weather, but the particle mesh stayed mounted and animated through the full weather fade-out even after every fragment had become visually discarded. That invisible transition-tail work still submitted draw calls and vertices to the GPU.

This keeps the complete visible rain fade and all other atmosphere effects while stopping only work that can no longer produce a visible pixel.

## Measured impact

On the identical production mobile rain-to-clear profile:

- rain particle unmount: `2,798.7 -> 1,422.8 ms` (`49.2%` sooner)
- draw calls per second: `792.1 -> 767.0` (`-3.2%`)
- triangles per second: `47,812 -> 45,162` (`-5.5%`)
- calls/render: `52.6 -> 51.8`
- triangles/render: `3,178 -> 3,049`

Steady clear render work remained exact in both samples: zero rain particles, 40 calls/render, and 2,620 triangles/render. Headless frame-time and rendered-FPS movement was treated as noise because Chromium reports synchronous `ReadPixels` stalls in this environment.

## Validation

- 484 `@gredice/game` unit tests
- `@gredice/game`, Garden, and WWW typechecks
- targeted Biome checks for all changed source files
- two production Garden builds through the before/after profiles
- production baseline and rain-to-clear before/after profiles
- `git diff --check`
- React lifecycle review: stable shader uniform, unconditional hooks, complete dependencies, and retained Three.js disposal cleanup

A 10-minute thermal soak on a representative mid-range iPhone and Android device remains the release gate.