### PR TITLE
[Garden] Add user-selected default gardens

### DIFF
--- a/apps/api/app/api/[...route]/accountsRoutes.ts
+++ b/apps/api/app/api/[...route]/accountsRoutes.ts
@@ -26,6 +26,7 @@ import {
     getSunflowersHistory,
     getTutorialChecklistState,
     getUser,
+    getUserDefaultGarden,
     grediceCached,
     grediceCacheKeys,
     knownEventTypes,
@@ -41,8 +42,11 @@ import {
     redeemReferralCodeForAccount,
     SUNFLOWER_DROP_BLOCK_NAME,
     setReferralCodeForAccount,
+    setUserDefaultGarden,
     TutorialChecklistTaskNotClaimableError,
     TutorialChecklistTaskNotFoundError,
+    UserDefaultGardenNotAccessibleError,
+    UserDefaultGardenSandboxError,
     updateAccountTimeZone,
 } from '@gredice/storage';
 import AccountDeleteConfirmationTemplate from '@gredice/transactional/emails/Account/delete-confirmation';
@@ -1066,7 +1070,10 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 user,
                 userId,
             } = context.get('authContext');
-            const currentUser = await getUser(userId);
+            const [currentUser, defaultGarden] = await Promise.all([
+                getUser(userId),
+                getUserDefaultGarden(userId),
+            ]);
             const fallbackEmail = currentUser?.userName ?? 'Gredice';
             const orderedAccountIds = [
                 currentAccountId,
@@ -1091,6 +1098,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                         gardens: gardens.map((garden) => ({
                             id: garden.id,
                             name: garden.name,
+                            isDefault: garden.id === defaultGarden?.id,
                             isSandbox: garden.isSandbox,
                             createdAt: garden.createdAt,
                         })),
@@ -1099,6 +1107,47 @@ const app = new Hono<{ Variables: AuthVariables }>()
             );
 
             return context.json(accountGardenGroups);
+        },
+    )
+    .put(
+        '/gardens/default',
+        describeRoute({
+            description:
+                'Set the real garden that opens by default for the current user.',
+            security: authSecurity,
+        }),
+        zValidator(
+            'json',
+            z.object({
+                gardenId: z.number().int().positive(),
+            }),
+        ),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { userId } = context.get('authContext');
+            const { gardenId } = context.req.valid('json');
+
+            try {
+                const garden = await setUserDefaultGarden({
+                    gardenId,
+                    userId,
+                });
+                return context.json({
+                    accountId: garden.accountId,
+                    gardenId: garden.id,
+                });
+            } catch (error) {
+                if (error instanceof UserDefaultGardenSandboxError) {
+                    return context.json(
+                        { error: 'Sandbox gardens cannot be the default' },
+                        400,
+                    );
+                }
+                if (error instanceof UserDefaultGardenNotAccessibleError) {
+                    return context.json({ error: 'Garden not found' }, 404);
+                }
+                throw error;
+            }
         },
     )
     .post(

--- a/apps/garden/tests/GardenAccountMenuItemsStory.tsx
+++ b/apps/garden/tests/GardenAccountMenuItemsStory.tsx
@@ -47,6 +47,7 @@ const otherAccountGarden = {
 
 type GardenAccountMenuStoryOptions = {
     defaultGardenId?: number;
+    emptyCurrentAccount?: boolean;
     includeOtherAccount?: boolean;
     initialGardenId?: number;
     sandboxFirst?: boolean;
@@ -55,6 +56,7 @@ type GardenAccountMenuStoryOptions = {
 
 function createGardenAccountMenuQueryClient({
     defaultGardenId,
+    emptyCurrentAccount = false,
     includeOtherAccount = true,
     sandboxFirst = false,
     seedOtherGardenDetails = true,
@@ -71,11 +73,12 @@ function createGardenAccountMenuQueryClient({
         ...garden,
         isDefault: garden.id === defaultGardenId,
     });
-    const currentAccountGardens = (
-        sandboxFirst
-            ? [sandboxGarden, currentGarden]
-            : [currentGarden, sandboxGarden]
-    ).map(withDefaultState);
+    const currentAccountGardens = emptyCurrentAccount
+        ? []
+        : (sandboxFirst
+              ? [sandboxGarden, currentGarden]
+              : [currentGarden, sandboxGarden]
+          ).map(withDefaultState);
     const currentAccountGroup = {
         accountId: 'test-account',
         name: 'test@example.com račun',
@@ -94,7 +97,9 @@ function createGardenAccountMenuQueryClient({
         currentAccountGroup,
         ...(includeOtherAccount ? [otherAccountGroup] : []),
     ]);
-    const seededGardens = [currentGarden, sandboxGarden];
+    const seededGardens = emptyCurrentAccount
+        ? []
+        : [currentGarden, sandboxGarden];
     if (seedOtherGardenDetails) {
         seededGardens.push(otherAccountGarden);
     }
@@ -122,6 +127,7 @@ function GardenAccountMenuItemsTestProviders({
 }>) {
     const {
         defaultGardenId,
+        emptyCurrentAccount,
         includeOtherAccount,
         initialGardenId,
         sandboxFirst,
@@ -131,6 +137,7 @@ function GardenAccountMenuItemsTestProviders({
         () =>
             createGardenAccountMenuQueryClient({
                 defaultGardenId,
+                emptyCurrentAccount,
                 includeOtherAccount,
                 initialGardenId,
                 sandboxFirst,
@@ -138,6 +145,7 @@ function GardenAccountMenuItemsTestProviders({
             }),
         [
             defaultGardenId,
+            emptyCurrentAccount,
             includeOtherAccount,
             initialGardenId,
             sandboxFirst,
@@ -303,6 +311,7 @@ export function SingleRealGardenAccountMenuItemsStory() {
 export function DefaultGardenSelectionGateStory() {
     const options = {
         defaultGardenId: otherAccountGarden.id,
+        emptyCurrentAccount: true,
         seedOtherGardenDetails: false,
     };
 

--- a/apps/garden/tests/GardenAccountMenuItemsStory.tsx
+++ b/apps/garden/tests/GardenAccountMenuItemsStory.tsx
@@ -6,8 +6,12 @@ import {
 } from '@gredice/ui/Menu';
 import * as ReactQuery from '@tanstack/react-query';
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
-import { type PropsWithChildren, useMemo } from 'react';
-import { currentGardenKeys } from '../../../packages/game/src/hooks/useCurrentGarden';
+import { type PropsWithChildren, StrictMode, useMemo } from 'react';
+import { GardenSelectionGate } from '../../../packages/game/src/GardenSelectionGate';
+import {
+    currentGardenKeys,
+    useCurrentGarden,
+} from '../../../packages/game/src/hooks/useCurrentGarden';
 import { gardenAccountGroupsKeys } from '../../../packages/game/src/hooks/useGardenAccountGroups';
 import { useGardensKeys } from '../../../packages/game/src/hooks/useGardens';
 import { GardenAccountMenuItems } from '../../../packages/game/src/hud/GardenAccountMenuItems';
@@ -20,6 +24,7 @@ import { useCurrentGardenIdParam } from '../../../packages/game/src/useUrlState'
 const currentGarden = {
     id: 1,
     name: 'Test',
+    isDefault: true,
     isSandbox: false,
     createdAt: '2026-06-01T00:00:00.000Z',
 };
@@ -27,6 +32,7 @@ const currentGarden = {
 const sandboxGarden = {
     id: 2,
     name: 'Vrt za igru 1',
+    isDefault: false,
     isSandbox: true,
     createdAt: '2026-06-01T00:00:00.000Z',
 };
@@ -34,46 +40,110 @@ const sandboxGarden = {
 const otherAccountGarden = {
     id: 3,
     name: 'Drugi vrt',
+    isDefault: false,
     isSandbox: false,
     createdAt: '2026-06-01T00:00:00.000Z',
 };
 
-function createGardenAccountMenuQueryClient() {
+type GardenAccountMenuStoryOptions = {
+    defaultGardenId?: number;
+    includeOtherAccount?: boolean;
+    initialGardenId?: number;
+    sandboxFirst?: boolean;
+    seedOtherGardenDetails?: boolean;
+};
+
+function createGardenAccountMenuQueryClient({
+    defaultGardenId,
+    includeOtherAccount = true,
+    sandboxFirst = false,
+    seedOtherGardenDetails = true,
+}: GardenAccountMenuStoryOptions = {}) {
     const queryClient = new ReactQuery.QueryClient({
         defaultOptions: {
             queries: { retry: false, staleTime: Infinity },
         },
     });
 
-    queryClient.setQueryData(useGardensKeys, [currentGarden, sandboxGarden]);
-    queryClient.setQueryData(gardenAccountGroupsKeys, [
-        {
-            accountId: 'test-account',
-            name: 'test@example.com račun',
-            isCurrent: true,
-            gardens: [currentGarden, sandboxGarden],
-        },
-        {
-            accountId: 'other-account',
-            name: 'other@example.com račun',
-            isCurrent: false,
-            gardens: [otherAccountGarden],
-        },
-    ]);
-    queryClient.setQueryData(currentGardenKeys('summer', currentGarden.id), {
-        id: currentGarden.id,
-        name: currentGarden.name,
-        isSandbox: currentGarden.isSandbox,
-        stacks: [],
-        location: { lat: 45.739, lon: 16.572 },
-        raisedBeds: [],
+    const withDefaultState = <TGarden extends typeof currentGarden>(
+        garden: TGarden,
+    ) => ({
+        ...garden,
+        isDefault: garden.id === defaultGardenId,
     });
+    const currentAccountGardens = (
+        sandboxFirst
+            ? [sandboxGarden, currentGarden]
+            : [currentGarden, sandboxGarden]
+    ).map(withDefaultState);
+    const currentAccountGroup = {
+        accountId: 'test-account',
+        name: 'test@example.com račun',
+        isCurrent: true,
+        gardens: currentAccountGardens,
+    };
+    const otherAccountGroup = {
+        accountId: 'other-account',
+        name: 'other@example.com račun',
+        isCurrent: false,
+        gardens: [withDefaultState(otherAccountGarden)],
+    };
+
+    queryClient.setQueryData(useGardensKeys, currentAccountGardens);
+    queryClient.setQueryData(gardenAccountGroupsKeys, [
+        currentAccountGroup,
+        ...(includeOtherAccount ? [otherAccountGroup] : []),
+    ]);
+    const seededGardens = [currentGarden, sandboxGarden];
+    if (seedOtherGardenDetails) {
+        seededGardens.push(otherAccountGarden);
+    }
+    for (const garden of seededGardens) {
+        queryClient.setQueryData(currentGardenKeys('summer', garden.id), {
+            id: garden.id,
+            name: garden.name,
+            isSandbox: garden.isSandbox,
+            stacks: [],
+            location: { lat: 45.739, lon: 16.572 },
+            raisedBeds: [],
+        });
+    }
 
     return queryClient;
 }
 
-function GardenAccountMenuItemsTestProviders({ children }: PropsWithChildren) {
-    const queryClient = useMemo(createGardenAccountMenuQueryClient, []);
+function GardenAccountMenuItemsTestProviders({
+    children,
+    options,
+    showSelectionOutputs = true,
+}: PropsWithChildren<{
+    options?: GardenAccountMenuStoryOptions;
+    showSelectionOutputs?: boolean;
+}>) {
+    const {
+        defaultGardenId,
+        includeOtherAccount,
+        initialGardenId,
+        sandboxFirst,
+        seedOtherGardenDetails,
+    } = options ?? {};
+    const queryClient = useMemo(
+        () =>
+            createGardenAccountMenuQueryClient({
+                defaultGardenId,
+                includeOtherAccount,
+                initialGardenId,
+                sandboxFirst,
+                seedOtherGardenDetails,
+            }),
+        [
+            defaultGardenId,
+            includeOtherAccount,
+            initialGardenId,
+            sandboxFirst,
+            seedOtherGardenDetails,
+        ],
+    );
     const gameState = useMemo(
         () =>
             createGameState({
@@ -85,9 +155,19 @@ function GardenAccountMenuItemsTestProviders({ children }: PropsWithChildren) {
     );
 
     return (
-        <NuqsTestingAdapter hasMemory>
+        <NuqsTestingAdapter
+            hasMemory
+            searchParams={
+                initialGardenId
+                    ? `vrt=${initialGardenId.toString()}`
+                    : undefined
+            }
+        >
             <ReactQuery.QueryClientProvider client={queryClient}>
-                <GardenAccountMenuItemsTestContent gameState={gameState}>
+                <GardenAccountMenuItemsTestContent
+                    gameState={gameState}
+                    showSelectionOutputs={showSelectionOutputs}
+                >
                     {children}
                 </GardenAccountMenuItemsTestContent>
             </ReactQuery.QueryClientProvider>
@@ -98,11 +178,11 @@ function GardenAccountMenuItemsTestProviders({ children }: PropsWithChildren) {
 function GardenAccountMenuItemsTestContent({
     children,
     gameState,
+    showSelectionOutputs,
 }: PropsWithChildren<{
     gameState: ReturnType<typeof createGameState>;
+    showSelectionOutputs: boolean;
 }>) {
-    const [selectedGardenId] = useCurrentGardenIdParam();
-
     // Keep one active refetch pending so the switcher test can prove that URL
     // selection no longer waits for every invalidated query to settle.
     ReactQuery.useQuery({
@@ -115,10 +195,45 @@ function GardenAccountMenuItemsTestContent({
     return (
         <GameStateContext.Provider value={gameState}>
             {children}
+            {showSelectionOutputs && <GardenSelectionOutputs />}
+        </GameStateContext.Provider>
+    );
+}
+
+function GardenSelectionOutputs() {
+    const [selectedGardenId] = useCurrentGardenIdParam();
+    const { data: selectedGarden } = useCurrentGarden();
+
+    return (
+        <>
             <output className="sr-only" data-testid="selected-garden-id">
                 {selectedGardenId ?? 'default'}
             </output>
-        </GameStateContext.Provider>
+            <output className="sr-only" data-testid="current-garden-id">
+                {selectedGarden?.id ?? 'loading'}
+            </output>
+            <output className="sr-only" data-testid="current-garden-kind">
+                {selectedGarden
+                    ? selectedGarden.isSandbox
+                        ? 'sandbox'
+                        : 'real'
+                    : 'loading'}
+            </output>
+        </>
+    );
+}
+
+function CrossAccountUrlSelectionControl() {
+    const [, setSelectedGardenId] = useCurrentGardenIdParam();
+
+    return (
+        <Button
+            onClick={() => {
+                void setSelectedGardenId(otherAccountGarden.id);
+            }}
+        >
+            Otvori drugi vrt putem URL-a
+        </Button>
     );
 }
 
@@ -136,5 +251,123 @@ export function GardenAccountMenuItemsStory() {
                 </DropdownMenu>
             </GardenAccountMenuItemsTestProviders>
         </div>
+    );
+}
+
+export function SandboxFirstGardenAccountMenuItemsStory() {
+    const options = {
+        initialGardenId: sandboxGarden.id,
+        sandboxFirst: true,
+        seedOtherGardenDetails: false,
+    };
+
+    return (
+        <div className="min-h-96 p-4">
+            <GardenAccountMenuItemsTestProviders options={options}>
+                <GardenSelectionGate>
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button>Otvori izbornik</Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent className="w-80 p-4" align="start">
+                            <GardenAccountMenuItems />
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                </GardenSelectionGate>
+            </GardenAccountMenuItemsTestProviders>
+        </div>
+    );
+}
+
+export function SingleRealGardenAccountMenuItemsStory() {
+    const options = {
+        includeOtherAccount: false,
+    };
+
+    return (
+        <div className="min-h-96 p-4">
+            <GardenAccountMenuItemsTestProviders options={options}>
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <Button>Otvori izbornik</Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent className="w-80 p-4" align="start">
+                        <GardenAccountMenuItems />
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            </GardenAccountMenuItemsTestProviders>
+        </div>
+    );
+}
+
+export function DefaultGardenSelectionGateStory() {
+    const options = {
+        defaultGardenId: otherAccountGarden.id,
+        seedOtherGardenDetails: false,
+    };
+
+    return (
+        <GardenAccountMenuItemsTestProviders
+            options={options}
+            showSelectionOutputs={false}
+        >
+            <StrictMode>
+                <GardenSelectionGate>
+                    <output data-testid="default-garden-ready">
+                        Zadani vrt je spreman
+                    </output>
+                    <GardenSelectionOutputs />
+                </GardenSelectionGate>
+            </StrictMode>
+        </GardenAccountMenuItemsTestProviders>
+    );
+}
+
+export function DefaultGardenMutationGateStory() {
+    const options = {
+        defaultGardenId: currentGarden.id,
+    };
+
+    return (
+        <GardenAccountMenuItemsTestProviders
+            options={options}
+            showSelectionOutputs={false}
+        >
+            <GardenSelectionGate>
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <Button>Otvori izbornik</Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent className="w-80 p-4" align="start">
+                        <GardenAccountMenuItems />
+                    </DropdownMenuContent>
+                </DropdownMenu>
+                <GardenSelectionOutputs />
+            </GardenSelectionGate>
+        </GardenAccountMenuItemsTestProviders>
+    );
+}
+
+export function PostStartupCrossAccountSelectionStory() {
+    const options = {
+        defaultGardenId: currentGarden.id,
+        seedOtherGardenDetails: false,
+    };
+
+    return (
+        <GardenAccountMenuItemsTestProviders
+            options={options}
+            showSelectionOutputs={false}
+        >
+            <CrossAccountUrlSelectionControl />
+            <StrictMode>
+                <GardenSelectionGate>
+                    <output data-testid="post-startup-selection-ready">
+                        Odabrani vrt je spreman
+                    </output>
+                    <GardenSelectionOutputs />
+                </GardenSelectionGate>
+            </StrictMode>
+        </GardenAccountMenuItemsTestProviders>
     );
 }

--- a/apps/garden/tests/GardenVisitSummaryModalStory.tsx
+++ b/apps/garden/tests/GardenVisitSummaryModalStory.tsx
@@ -10,6 +10,7 @@ import {
 import { currentGardenKeys } from '../../../packages/game/src/hooks/useCurrentGarden';
 import { queryKey as currentUserQueryKey } from '../../../packages/game/src/hooks/useCurrentUser';
 import { dailyRewardKeys } from '../../../packages/game/src/hooks/useDailyReward';
+import { gardenAccountGroupsKeys } from '../../../packages/game/src/hooks/useGardenAccountGroups';
 import { useGardensKeys } from '../../../packages/game/src/hooks/useGardens';
 import { whatsNewEntriesQueryKey } from '../../../packages/game/src/hooks/useWhatsNewEntries';
 import {
@@ -202,6 +203,21 @@ function createOpeningFlowQueryClient({
 
     queryClient.setQueryData(useGardensKeys, [
         { id: TEST_GARDEN_ID, name: garden.name },
+    ]);
+    queryClient.setQueryData(gardenAccountGroupsKeys, [
+        {
+            accountId: 'test-account',
+            name: 'test@example.com račun',
+            isCurrent: true,
+            gardens: [
+                {
+                    id: TEST_GARDEN_ID,
+                    name: garden.name,
+                    isDefault: true,
+                    isSandbox: false,
+                },
+            ],
+        },
     ]);
     queryClient.setQueryData(
         currentGardenKeys('summer', TEST_GARDEN_ID),

--- a/apps/garden/tests/garden-account-menu-items.spec.tsx
+++ b/apps/garden/tests/garden-account-menu-items.spec.tsx
@@ -424,6 +424,10 @@ test.describe('Garden account menu items', () => {
         const accountSwitchCanComplete = new Promise<void>((resolve) => {
             completeAccountSwitch = resolve;
         });
+        let completeGardenListRefresh: () => void = () => undefined;
+        const gardenListRefreshCanComplete = new Promise<void>((resolve) => {
+            completeGardenListRefresh = resolve;
+        });
         await page.route(
             '**/api/gredice/api/accounts/switch',
             async (route) => {
@@ -446,6 +450,7 @@ test.describe('Garden account menu items', () => {
             });
         });
         await page.route('**/api/gredice/api/gardens', async (route) => {
+            await gardenListRefreshCanComplete;
             await route.fulfill({
                 contentType: 'application/json',
                 body: JSON.stringify(otherAccountGardenList),
@@ -463,6 +468,7 @@ test.describe('Garden account menu items', () => {
         await expect(page.getByTestId('default-garden-ready')).toBeVisible();
         await expect(page.getByTestId('current-garden-id')).toHaveText('3');
         await expect.poll(() => gardenDetailRequests.length).toBe(1);
+        completeGardenListRefresh();
         expect(accountSwitchRequests).toEqual([
             JSON.stringify({ accountId: 'other-account' }),
         ]);

--- a/apps/garden/tests/garden-account-menu-items.spec.tsx
+++ b/apps/garden/tests/garden-account-menu-items.spec.tsx
@@ -1,5 +1,85 @@
 import { expect, test } from '@playwright/experimental-ct-react';
-import { GardenAccountMenuItemsStory } from './GardenAccountMenuItemsStory';
+import {
+    DefaultGardenMutationGateStory,
+    DefaultGardenSelectionGateStory,
+    GardenAccountMenuItemsStory,
+    PostStartupCrossAccountSelectionStory,
+    SandboxFirstGardenAccountMenuItemsStory,
+    SingleRealGardenAccountMenuItemsStory,
+} from './GardenAccountMenuItemsStory';
+
+const accountGroupsWithOtherDefault = [
+    {
+        accountId: 'test-account',
+        name: 'test@example.com račun',
+        isCurrent: true,
+        gardens: [
+            {
+                id: 1,
+                name: 'Test',
+                isDefault: false,
+                isSandbox: false,
+                createdAt: '2026-06-01T00:00:00.000Z',
+            },
+            {
+                id: 2,
+                name: 'Vrt za igru 1',
+                isDefault: false,
+                isSandbox: true,
+                createdAt: '2026-06-01T00:00:00.000Z',
+            },
+        ],
+    },
+    {
+        accountId: 'other-account',
+        name: 'other@example.com račun',
+        isCurrent: false,
+        gardens: [
+            {
+                id: 3,
+                name: 'Drugi vrt',
+                isDefault: true,
+                isSandbox: false,
+                createdAt: '2026-06-01T00:00:00.000Z',
+            },
+        ],
+    },
+];
+
+const accountGroupsWithCurrentDefault = accountGroupsWithOtherDefault.map(
+    (group) => ({
+        ...group,
+        gardens: group.gardens.map((garden) => ({
+            ...garden,
+            isDefault: garden.id === 1,
+        })),
+    }),
+);
+
+const otherAccountGardenList = [
+    {
+        id: 3,
+        name: 'Drugi vrt',
+        isSandbox: false,
+        createdAt: '2026-06-01T00:00:00.000Z',
+    },
+];
+
+const otherAccountGardenDetail = {
+    id: 3,
+    name: 'Drugi vrt',
+    isSandbox: false,
+    isPublic: false,
+    backgroundPalette: 'current',
+    homeCamera: null,
+    farmId: null,
+    latitude: 45.739,
+    longitude: 16.572,
+    previewImage: null,
+    previewSourceRevision: null,
+    stacks: {},
+    raisedBeds: [],
+};
 
 test.describe('Garden account menu items', () => {
     test('switches gardens in both directions before account queries refresh', async ({
@@ -23,14 +103,16 @@ test.describe('Garden account menu items', () => {
         await mount(<GardenAccountMenuItemsStory />);
 
         await page.getByRole('button', { name: 'Otvori izbornik' }).click();
-        await page.getByRole('menuitem', { name: /Drugi vrt/ }).click();
+        await page
+            .getByRole('menuitem', { name: 'Drugi vrt', exact: true })
+            .click();
 
         await expect(page.getByTestId('selected-garden-id')).toHaveText('3', {
             timeout: 1_000,
         });
 
         await page.getByRole('button', { name: 'Otvori izbornik' }).click();
-        await page.getByRole('menuitem', { name: /Test/ }).click();
+        await page.getByRole('menuitem', { name: 'Test', exact: true }).click();
 
         await expect(page.getByTestId('selected-garden-id')).toHaveText('1', {
             timeout: 1_000,
@@ -61,5 +143,395 @@ test.describe('Garden account menu items', () => {
         expect(
             (sandboxGardenBox?.x ?? 0) + (sandboxGardenBox?.width ?? 0),
         ).toBeLessThanOrEqual(600);
+    });
+
+    test('switches from a raw-first sandbox to a real garden', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<SandboxFirstGardenAccountMenuItemsStory />);
+
+        await expect(page.getByTestId('current-garden-id')).toHaveText('2');
+        await expect(page.getByTestId('current-garden-kind')).toHaveText(
+            'sandbox',
+        );
+
+        await page.getByRole('button', { name: 'Otvori izbornik' }).click();
+        await page.getByRole('menuitem', { name: /^Test$/ }).click();
+
+        await expect(page.getByTestId('selected-garden-id')).toHaveText('1');
+        await expect(page.getByTestId('current-garden-id')).toHaveText('1');
+        await expect(page.getByTestId('current-garden-kind')).toHaveText(
+            'real',
+        );
+    });
+
+    test('switches from a sandbox to a real garden on another account', async ({
+        mount,
+        page,
+    }) => {
+        const accountSwitchRequests: string[] = [];
+        const gardenDetailRequests: string[] = [];
+        let completeAccountSwitch: () => void = () => undefined;
+        const accountSwitchCanComplete = new Promise<void>((resolve) => {
+            completeAccountSwitch = resolve;
+        });
+        await page.route(
+            '**/api/gredice/api/accounts/switch',
+            async (route) => {
+                accountSwitchRequests.push(route.request().postData() ?? '');
+                await accountSwitchCanComplete;
+                await route.fulfill({
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        success: true,
+                        accountId: 'other-account',
+                    }),
+                });
+            },
+        );
+        await page.route('**/api/gredice/api/gardens/3', async (route) => {
+            gardenDetailRequests.push(route.request().url());
+            await route.fulfill({
+                contentType: 'application/json',
+                body: JSON.stringify(otherAccountGardenDetail),
+            });
+        });
+        await page.route('**/api/gredice/api/gardens', async (route) => {
+            await route.fulfill({
+                contentType: 'application/json',
+                body: JSON.stringify(otherAccountGardenList),
+            });
+        });
+        await mount(<SandboxFirstGardenAccountMenuItemsStory />);
+
+        await page.getByRole('button', { name: 'Otvori izbornik' }).click();
+        await page
+            .getByRole('menuitem', { name: 'Drugi vrt', exact: true })
+            .click();
+
+        await expect.poll(() => accountSwitchRequests.length).toBe(1);
+        await expect(page.getByTestId('selected-garden-id')).toHaveText('2');
+        await expect(page.getByTestId('current-garden-id')).toHaveText('2');
+        expect(gardenDetailRequests).toEqual([]);
+
+        completeAccountSwitch();
+
+        await expect(page.getByTestId('selected-garden-id')).toHaveText('3');
+        await expect(page.getByTestId('current-garden-id')).toHaveText('3');
+        await expect(page.getByTestId('current-garden-kind')).toHaveText(
+            'real',
+        );
+        await expect.poll(() => gardenDetailRequests.length).toBe(1);
+        expect(accountSwitchRequests).toEqual([
+            JSON.stringify({ accountId: 'other-account' }),
+        ]);
+    });
+
+    test('marks only real gardens as default without switching gardens', async ({
+        mount,
+        page,
+    }) => {
+        const defaultGardenRequests: string[] = [];
+        const accountSwitchRequests: string[] = [];
+        await page.route(
+            '**/api/gredice/api/accounts/gardens/default',
+            async (route) => {
+                defaultGardenRequests.push(route.request().postData() ?? '');
+                await route.fulfill({
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        accountId: 'other-account',
+                        gardenId: 3,
+                    }),
+                });
+            },
+        );
+        await page.route(
+            '**/api/gredice/api/accounts/gardens',
+            async (route) => {
+                await route.fulfill({
+                    contentType: 'application/json',
+                    body: JSON.stringify(accountGroupsWithOtherDefault),
+                });
+            },
+        );
+        await page.route(
+            '**/api/gredice/api/accounts/switch',
+            async (route) => {
+                accountSwitchRequests.push(route.request().postData() ?? '');
+                await route.fulfill({
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        success: true,
+                        accountId: 'other-account',
+                    }),
+                });
+            },
+        );
+        await mount(<SandboxFirstGardenAccountMenuItemsStory />);
+
+        await page.getByRole('button', { name: 'Otvori izbornik' }).click();
+        await expect(
+            page.getByTitle('Postavi Test kao zadani vrt'),
+        ).toBeVisible();
+        await expect(
+            page.getByTitle('Postavi Drugi vrt kao zadani vrt'),
+        ).toBeVisible();
+        await expect(
+            page.getByTitle(/Postavi Vrt za igru 1 kao zadani vrt/),
+        ).toHaveCount(0);
+
+        await page.getByTitle('Postavi Drugi vrt kao zadani vrt').click();
+
+        await expect
+            .poll(() => defaultGardenRequests)
+            .toEqual([JSON.stringify({ gardenId: 3 })]);
+        expect(accountSwitchRequests).toEqual([]);
+        await expect(page.getByTestId('selected-garden-id')).toHaveText('2');
+        await expect(page.getByTestId('current-garden-id')).toHaveText('2');
+        await expect(
+            page.getByTitle('Drugi vrt je zadani vrt'),
+        ).toHaveAttribute('data-default-garden', 'true');
+    });
+
+    test('reaches a default-garden action with menu keyboard navigation', async ({
+        mount,
+        page,
+    }) => {
+        const defaultGardenRequests: string[] = [];
+        await page.route(
+            '**/api/gredice/api/accounts/gardens/default',
+            async (route) => {
+                defaultGardenRequests.push(route.request().postData() ?? '');
+                await route.fulfill({
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        accountId: 'test-account',
+                        gardenId: 1,
+                    }),
+                });
+            },
+        );
+        await page.route(
+            '**/api/gredice/api/accounts/gardens',
+            async (route) => {
+                await route.fulfill({
+                    contentType: 'application/json',
+                    body: JSON.stringify(accountGroupsWithCurrentDefault),
+                });
+            },
+        );
+        await mount(<GardenAccountMenuItemsStory />);
+
+        const trigger = page.getByRole('button', {
+            name: 'Otvori izbornik',
+        });
+        await trigger.focus();
+        await page.keyboard.press('Enter');
+        await expect(
+            page.getByRole('menuitem', { name: 'Test', exact: true }),
+        ).toBeFocused();
+
+        await page.keyboard.press('ArrowDown');
+        await expect(
+            page.getByTitle('Postavi Test kao zadani vrt'),
+        ).toBeFocused();
+        await page.keyboard.press('Enter');
+
+        await expect
+            .poll(() => defaultGardenRequests)
+            .toEqual([JSON.stringify({ gardenId: 1 })]);
+    });
+
+    test('keeps the current garden open while changing the default', async ({
+        mount,
+        page,
+    }) => {
+        const defaultGardenRequests: string[] = [];
+        const accountSwitchRequests: string[] = [];
+        await page.route(
+            '**/api/gredice/api/accounts/gardens/default',
+            async (route) => {
+                defaultGardenRequests.push(route.request().postData() ?? '');
+                await route.fulfill({
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        accountId: 'other-account',
+                        gardenId: 3,
+                    }),
+                });
+            },
+        );
+        await page.route(
+            '**/api/gredice/api/accounts/gardens',
+            async (route) => {
+                await route.fulfill({
+                    contentType: 'application/json',
+                    body: JSON.stringify(accountGroupsWithOtherDefault),
+                });
+            },
+        );
+        await page.route(
+            '**/api/gredice/api/accounts/switch',
+            async (route) => {
+                accountSwitchRequests.push(route.request().postData() ?? '');
+                await route.fulfill({
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        success: true,
+                        accountId: 'other-account',
+                    }),
+                });
+            },
+        );
+
+        await mount(<DefaultGardenMutationGateStory />);
+        await expect(page.getByTestId('selected-garden-id')).toHaveText(
+            'default',
+        );
+        await expect(page.getByTestId('current-garden-id')).toHaveText('1');
+
+        await page.getByRole('button', { name: 'Otvori izbornik' }).click();
+        await page.getByTitle('Postavi Drugi vrt kao zadani vrt').click();
+
+        await expect(page.getByTestId('selected-garden-id')).toHaveText('1');
+        await expect(page.getByTestId('current-garden-id')).toHaveText('1');
+        await expect
+            .poll(() => defaultGardenRequests)
+            .toEqual([JSON.stringify({ gardenId: 3 })]);
+        expect(accountSwitchRequests).toEqual([]);
+    });
+
+    test('hides default controls when only one real garden is accessible', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<SingleRealGardenAccountMenuItemsStory />);
+
+        await page.getByRole('button', { name: 'Otvori izbornik' }).click();
+
+        await expect(page.getByTitle(/zadani vrt/)).toHaveCount(0);
+    });
+
+    test('switches accounts before opening a cross-account default garden', async ({
+        mount,
+        page,
+    }) => {
+        const accountSwitchRequests: string[] = [];
+        const gardenDetailRequests: string[] = [];
+        let completeAccountSwitch: () => void = () => undefined;
+        const accountSwitchCanComplete = new Promise<void>((resolve) => {
+            completeAccountSwitch = resolve;
+        });
+        await page.route(
+            '**/api/gredice/api/accounts/switch',
+            async (route) => {
+                accountSwitchRequests.push(route.request().postData() ?? '');
+                await accountSwitchCanComplete;
+                await route.fulfill({
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        success: true,
+                        accountId: 'other-account',
+                    }),
+                });
+            },
+        );
+        await page.route('**/api/gredice/api/gardens/3', async (route) => {
+            gardenDetailRequests.push(route.request().url());
+            await route.fulfill({
+                contentType: 'application/json',
+                body: JSON.stringify(otherAccountGardenDetail),
+            });
+        });
+        await page.route('**/api/gredice/api/gardens', async (route) => {
+            await route.fulfill({
+                contentType: 'application/json',
+                body: JSON.stringify(otherAccountGardenList),
+            });
+        });
+
+        await mount(<DefaultGardenSelectionGateStory />);
+
+        await expect.poll(() => accountSwitchRequests.length).toBe(1);
+        await expect(page.getByTestId('default-garden-ready')).toHaveCount(0);
+        expect(gardenDetailRequests).toEqual([]);
+
+        completeAccountSwitch();
+
+        await expect(page.getByTestId('default-garden-ready')).toBeVisible();
+        await expect(page.getByTestId('current-garden-id')).toHaveText('3');
+        await expect.poll(() => gardenDetailRequests.length).toBe(1);
+        expect(accountSwitchRequests).toEqual([
+            JSON.stringify({ accountId: 'other-account' }),
+        ]);
+    });
+
+    test('switches accounts after a post-startup cross-account URL change', async ({
+        mount,
+        page,
+    }) => {
+        const accountSwitchRequests: string[] = [];
+        const gardenDetailRequests: string[] = [];
+        let completeAccountSwitch: () => void = () => undefined;
+        const accountSwitchCanComplete = new Promise<void>((resolve) => {
+            completeAccountSwitch = resolve;
+        });
+        await page.route(
+            '**/api/gredice/api/accounts/switch',
+            async (route) => {
+                accountSwitchRequests.push(route.request().postData() ?? '');
+                await accountSwitchCanComplete;
+                await route.fulfill({
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        success: true,
+                        accountId: 'other-account',
+                    }),
+                });
+            },
+        );
+        await page.route('**/api/gredice/api/gardens/3', async (route) => {
+            gardenDetailRequests.push(route.request().url());
+            await route.fulfill({
+                contentType: 'application/json',
+                body: JSON.stringify(otherAccountGardenDetail),
+            });
+        });
+        await page.route('**/api/gredice/api/gardens', async (route) => {
+            await route.fulfill({
+                contentType: 'application/json',
+                body: JSON.stringify(otherAccountGardenList),
+            });
+        });
+
+        await mount(<PostStartupCrossAccountSelectionStory />);
+        await expect(
+            page.getByTestId('post-startup-selection-ready'),
+        ).toBeVisible();
+        await expect(page.getByTestId('current-garden-id')).toHaveText('1');
+
+        await page
+            .getByRole('button', { name: 'Otvori drugi vrt putem URL-a' })
+            .click();
+
+        await expect.poll(() => accountSwitchRequests.length).toBe(1);
+        await expect(
+            page.getByTestId('post-startup-selection-ready'),
+        ).toHaveCount(0);
+        expect(gardenDetailRequests).toEqual([]);
+
+        completeAccountSwitch();
+
+        await expect(
+            page.getByTestId('post-startup-selection-ready'),
+        ).toBeVisible();
+        await expect(page.getByTestId('selected-garden-id')).toHaveText('3');
+        await expect(page.getByTestId('current-garden-id')).toHaveText('3');
+        await expect.poll(() => gardenDetailRequests.length).toBe(1);
+        expect(accountSwitchRequests).toEqual([
+            JSON.stringify({ accountId: 'other-account' }),
+        ]);
     });
 });

--- a/packages/game/src/GameSceneWrapper.tsx
+++ b/packages/game/src/GameSceneWrapper.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react';
 import { groundGameAssetNames, primaryGameAssetNames } from './data/models';
 import { GameFlagsContext } from './GameFlagsContext';
 import { GameScene, type GameSceneProps } from './GameScene';
+import { GardenSelectionGate } from './GardenSelectionGate';
 import { GameProfileController } from './scene/GameProfileController';
 import {
     createGameState,
@@ -82,8 +83,14 @@ export function GameSceneWrapper({
     return (
         <GameStateContext.Provider value={storeRef.current}>
             <GameFlagsContext.Provider value={flags ?? {}}>
-                <GameScene flags={flags} {...rest} />
-                {enableGameProfileController ? <GameProfileController /> : null}
+                <GardenSelectionGate
+                    disabled={Boolean(mockGarden || localSandboxStorageKey)}
+                >
+                    <GameScene flags={flags} {...rest} />
+                    {enableGameProfileController ? (
+                        <GameProfileController />
+                    ) : null}
+                </GardenSelectionGate>
             </GameFlagsContext.Provider>
         </GameStateContext.Provider>
     );

--- a/packages/game/src/GardenSelectionGate.tsx
+++ b/packages/game/src/GardenSelectionGate.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { type PropsWithChildren, useEffect, useRef, useState } from 'react';
+import {
+    resolveExplicitGarden,
+    resolvePreferredGarden,
+} from './hooks/gardenSelection';
+import {
+    type GardenAccountGroups,
+    gardenAccountGroupsKeys,
+    useGardenAccountGroups,
+} from './hooks/useGardenAccountGroups';
+import { useGardensKeys } from './hooks/useGardens';
+import { useSwitchGardenAccount } from './hooks/useSwitchGardenAccount';
+import { useCurrentGardenIdParam } from './useUrlState';
+
+export function GardenSelectionGate({
+    children,
+    disabled = false,
+}: PropsWithChildren<{
+    disabled?: boolean;
+}>) {
+    const queryClient = useQueryClient();
+    const [selectedGardenId] = useCurrentGardenIdParam();
+    const [selectionResolved, setSelectionResolved] = useState(disabled);
+    const preferredAccountIdRef = useRef<string | null | undefined>(undefined);
+    const switchingAccountIdRef = useRef<string | null>(null);
+    const lastSelectedGardenIdRef = useRef(selectedGardenId);
+    const {
+        data: accountGroups,
+        isError: accountGroupsError,
+        isLoading: accountGroupsLoading,
+    } = useGardenAccountGroups(disabled);
+    const { mutate: switchGardenAccount } = useSwitchGardenAccount();
+
+    if (
+        preferredAccountIdRef.current === undefined &&
+        accountGroups !== undefined
+    ) {
+        preferredAccountIdRef.current =
+            resolvePreferredGarden(accountGroups, selectedGardenId)
+                ?.accountId ?? null;
+    }
+
+    const preferredAccountId = preferredAccountIdRef.current;
+    const preferredAccountIsCurrent = accountGroups?.some(
+        (group) => group.accountId === preferredAccountId && group.isCurrent,
+    );
+    const targetAccountId =
+        !selectionResolved &&
+        preferredAccountId &&
+        preferredAccountIsCurrent === false
+            ? preferredAccountId
+            : null;
+
+    useEffect(() => {
+        if (
+            disabled ||
+            !selectionResolved ||
+            selectedGardenId === lastSelectedGardenIdRef.current
+        ) {
+            return;
+        }
+
+        if (selectedGardenId === null) {
+            lastSelectedGardenIdRef.current = null;
+            return;
+        }
+
+        const cachedAccountGroups =
+            queryClient.getQueryData<GardenAccountGroups | null>(
+                gardenAccountGroupsKeys,
+            );
+        const availableAccountGroups =
+            cachedAccountGroups === undefined
+                ? accountGroups
+                : cachedAccountGroups;
+        if (availableAccountGroups === undefined) {
+            return;
+        }
+
+        const explicitGarden = resolveExplicitGarden(
+            availableAccountGroups,
+            selectedGardenId,
+        );
+        lastSelectedGardenIdRef.current = selectedGardenId;
+        if (!explicitGarden || explicitGarden.isCurrent) {
+            return;
+        }
+
+        preferredAccountIdRef.current = explicitGarden.accountId;
+        switchingAccountIdRef.current = null;
+        setSelectionResolved(false);
+    }, [
+        accountGroups,
+        disabled,
+        queryClient,
+        selectedGardenId,
+        selectionResolved,
+    ]);
+
+    useEffect(() => {
+        if (disabled || selectionResolved) {
+            return;
+        }
+
+        if (accountGroupsError) {
+            setSelectionResolved(true);
+            return;
+        }
+
+        if (accountGroupsLoading || preferredAccountId === undefined) {
+            return;
+        }
+
+        if (!targetAccountId) {
+            setSelectionResolved(true);
+            return;
+        }
+
+        if (switchingAccountIdRef.current === targetAccountId) {
+            return;
+        }
+        switchingAccountIdRef.current = targetAccountId;
+
+        switchGardenAccount(
+            { accountId: targetAccountId },
+            {
+                onError: (error) => {
+                    console.error(
+                        'Failed to switch to the preferred garden account:',
+                        error,
+                    );
+                    switchingAccountIdRef.current = null;
+                    setSelectionResolved(true);
+                },
+                onSuccess: () => {
+                    queryClient.setQueryData<GardenAccountGroups>(
+                        gardenAccountGroupsKeys,
+                        (groups) =>
+                            groups?.map((group) => ({
+                                ...group,
+                                isCurrent: group.accountId === targetAccountId,
+                            })),
+                    );
+                    void queryClient.invalidateQueries({
+                        exact: true,
+                        queryKey: useGardensKeys,
+                    });
+                    switchingAccountIdRef.current = null;
+                    setSelectionResolved(true);
+                },
+            },
+        );
+    }, [
+        accountGroupsError,
+        accountGroupsLoading,
+        disabled,
+        preferredAccountId,
+        queryClient,
+        selectionResolved,
+        switchGardenAccount,
+        targetAccountId,
+    ]);
+
+    const isResolvingSelection =
+        !disabled && !selectionResolved && !accountGroupsError;
+
+    return isResolvingSelection ? null : children;
+}

--- a/packages/game/src/hooks/gardenSelection.ts
+++ b/packages/game/src/hooks/gardenSelection.ts
@@ -1,0 +1,126 @@
+type GardenSelectionCandidate = {
+    id: number;
+    isDefault?: boolean;
+    isSandbox: boolean;
+};
+
+type GardenSelectionGroup<
+    TGarden extends GardenSelectionCandidate = GardenSelectionCandidate,
+> = {
+    accountId: string;
+    gardens: readonly TGarden[];
+    isCurrent: boolean;
+};
+
+export type ResolvedGardenSelection<
+    TGarden extends GardenSelectionCandidate = GardenSelectionCandidate,
+> = {
+    accountId: string;
+    garden: TGarden;
+    isCurrent: boolean;
+};
+
+export function resolveExplicitGarden<TGarden extends GardenSelectionCandidate>(
+    groups: readonly GardenSelectionGroup<TGarden>[] | null | undefined,
+    gardenId: number,
+): ResolvedGardenSelection<TGarden> | null {
+    if (!groups) {
+        return null;
+    }
+
+    for (const group of groups) {
+        const garden = group.gardens.find(
+            (candidate) => candidate.id === gardenId,
+        );
+        if (garden) {
+            return {
+                accountId: group.accountId,
+                garden,
+                isCurrent: group.isCurrent,
+            };
+        }
+    }
+
+    return null;
+}
+
+export function resolvePreferredGarden<
+    TGarden extends GardenSelectionCandidate,
+>(
+    groups: readonly GardenSelectionGroup<TGarden>[] | null | undefined,
+    selectedGardenId: number | null,
+): ResolvedGardenSelection<TGarden> | null {
+    if (!groups || groups.length === 0) {
+        return null;
+    }
+    const availableGroups = groups;
+
+    function findGarden(
+        predicate: (garden: TGarden) => boolean,
+        candidateGroups = availableGroups,
+    ) {
+        for (const group of candidateGroups) {
+            const garden = group.gardens.find(predicate);
+            if (garden) {
+                return {
+                    accountId: group.accountId,
+                    garden,
+                    isCurrent: group.isCurrent,
+                };
+            }
+        }
+        return null;
+    }
+
+    if (selectedGardenId !== null) {
+        const selectedGarden = resolveExplicitGarden(groups, selectedGardenId);
+        if (selectedGarden) {
+            return selectedGarden;
+        }
+    }
+
+    const defaultGarden = findGarden(
+        (garden) => !garden.isSandbox && garden.isDefault === true,
+    );
+    if (defaultGarden) {
+        return defaultGarden;
+    }
+
+    const currentGroups = groups.filter((group) => group.isCurrent);
+    return (
+        findGarden((garden) => !garden.isSandbox, currentGroups) ??
+        findGarden((garden) => !garden.isSandbox) ??
+        findGarden(() => true, currentGroups) ??
+        findGarden(() => true)
+    );
+}
+
+export function resolveCurrentAccountGardenId<
+    TAccountGarden extends GardenSelectionCandidate,
+    TCurrentGarden extends GardenSelectionCandidate,
+>({
+    accountGroups,
+    currentAccountGardens,
+    selectedGardenId,
+}: {
+    accountGroups:
+        | readonly GardenSelectionGroup<TAccountGarden>[]
+        | null
+        | undefined;
+    currentAccountGardens: readonly TCurrentGarden[] | null | undefined;
+    selectedGardenId: number | null;
+}) {
+    const preferredGarden = resolvePreferredGarden(
+        accountGroups,
+        selectedGardenId,
+    );
+    if (preferredGarden?.isCurrent) {
+        return preferredGarden.garden.id;
+    }
+
+    return (
+        currentAccountGardens?.find((garden) => !garden.isSandbox)?.id ??
+        currentAccountGardens?.[0]?.id ??
+        null
+    );
+}

--- a/packages/game/src/hooks/gardenSelection.unit.ts
+++ b/packages/game/src/hooks/gardenSelection.unit.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    resolveCurrentAccountGardenId,
+    resolveExplicitGarden,
+    resolvePreferredGarden,
+} from './gardenSelection';
+
+const sandboxGarden = {
+    id: 1,
+    isDefault: false,
+    isSandbox: true,
+};
+const currentRealGarden = {
+    id: 2,
+    isDefault: false,
+    isSandbox: false,
+};
+const defaultGarden = {
+    id: 3,
+    isDefault: true,
+    isSandbox: false,
+};
+
+const accountGroups = [
+    {
+        accountId: 'current-account',
+        gardens: [sandboxGarden, currentRealGarden],
+        isCurrent: true,
+    },
+    {
+        accountId: 'default-account',
+        gardens: [defaultGarden],
+        isCurrent: false,
+    },
+];
+
+test('resolves an explicit garden before the persisted default', () => {
+    assert.deepEqual(resolvePreferredGarden(accountGroups, sandboxGarden.id), {
+        accountId: 'current-account',
+        garden: sandboxGarden,
+        isCurrent: true,
+    });
+});
+
+test('does not fall back when an explicit garden is unavailable', () => {
+    assert.equal(resolveExplicitGarden(accountGroups, 999_999), null);
+});
+
+test('resolves a persisted real garden from another accessible account', () => {
+    assert.deepEqual(resolvePreferredGarden(accountGroups, null), {
+        accountId: 'default-account',
+        garden: defaultGarden,
+        isCurrent: false,
+    });
+});
+
+test('never treats a sandbox as the implicit default', () => {
+    const groupsWithSandboxMarkedDefault = accountGroups.map((group) => ({
+        ...group,
+        gardens: group.gardens.map((garden) => ({
+            ...garden,
+            isDefault: garden.id === sandboxGarden.id,
+        })),
+    }));
+    const groupsWithoutDefault = accountGroups.map((group) => ({
+        ...group,
+        gardens: group.gardens.map((garden) => ({
+            ...garden,
+            isDefault: false,
+        })),
+    }));
+
+    assert.equal(
+        resolvePreferredGarden(groupsWithSandboxMarkedDefault, null)?.garden.id,
+        currentRealGarden.id,
+    );
+    assert.equal(
+        resolvePreferredGarden(groupsWithoutDefault, null)?.garden.id,
+        currentRealGarden.id,
+    );
+    assert.equal(
+        resolveCurrentAccountGardenId({
+            accountGroups: groupsWithoutDefault,
+            currentAccountGardens: [sandboxGarden, currentRealGarden],
+            selectedGardenId: null,
+        }),
+        currentRealGarden.id,
+    );
+});
+
+test('falls back to a current-account real garden while an account switch is pending', () => {
+    assert.equal(
+        resolveCurrentAccountGardenId({
+            accountGroups,
+            currentAccountGardens: [sandboxGarden, currentRealGarden],
+            selectedGardenId: null,
+        }),
+        currentRealGarden.id,
+    );
+});

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -1223,20 +1223,20 @@ export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | nu
                 return mockGarden(winterMode, mockGardenProfile);
             }
 
-            if (!gardens) {
-                console.error('Failed to load gardens.');
-                throw new Error('Failed to load gardens');
-            }
-
-            if (gardens.length <= 0) {
-                console.warn(
-                    'No gardens found. Number of available gardens:',
-                    gardens?.length,
-                );
-                return null;
-            }
-
             if (currentGardenId == null) {
+                if (!gardens) {
+                    console.error('Failed to load gardens.');
+                    throw new Error('Failed to load gardens');
+                }
+
+                if (gardens.length <= 0) {
+                    console.warn(
+                        'No gardens found. Number of available gardens:',
+                        gardens.length,
+                    );
+                    return null;
+                }
+
                 console.error('No garden ID available.');
                 return null;
             }
@@ -1308,7 +1308,11 @@ export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | nu
         structuralSharing: shareCurrentGardenQueryData,
         retry: false,
         staleTime: 1000 * 60, // 1m
-        enabled: isLocalSandbox || isMock || Boolean(gardens),
+        enabled:
+            isLocalSandbox ||
+            isMock ||
+            (gardens !== null &&
+                (currentGardenId !== null || gardens !== undefined)),
     });
 }
 

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -34,7 +34,9 @@ import {
 } from '../useGameState';
 import { useCurrentGardenIdParam } from '../useUrlState';
 import { shareCurrentGardenQueryData } from './currentGardenStructuralSharing';
+import { resolveCurrentAccountGardenId } from './gardenSelection';
 import { resolveMockGardenProfileReferenceDate } from './mockGardenProfileFixtures';
+import { useGardenAccountGroups } from './useGardenAccountGroups';
 import { useGardens, useGardensKeys } from './useGardens';
 
 const GARDEN_POSITION_X_OFFSET = -1;
@@ -1184,6 +1186,9 @@ export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | nu
     const winterMode = useGameState((state) => state.winterMode);
     const isLocalSandbox = localSandboxStorageKey !== null;
     const { data: gardens } = useGardens(isMock || isLocalSandbox);
+    const { data: accountGroups } = useGardenAccountGroups(
+        isMock || isLocalSandbox,
+    );
     let selectedGardenId: number | null = null;
     if (!isMock && !isLocalSandbox) {
         // biome-ignore lint/correctness/useHookAtTopLevel: store mode is fixed when the game state is created.
@@ -1191,10 +1196,13 @@ export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | nu
         selectedGardenId = gardenId;
     }
 
-    // Use the selected garden ID from URL, or default to the first garden
-    const currentGardenId =
-        (isLocalSandbox ? localSandboxGardenId : selectedGardenId) ??
-        (gardens && gardens.length > 0 ? gardens[0].id : null);
+    const currentGardenId = isLocalSandbox
+        ? localSandboxGardenId
+        : resolveCurrentAccountGardenId({
+              accountGroups,
+              currentAccountGardens: gardens,
+              selectedGardenId,
+          });
 
     return useQuery({
         queryKey: currentGardenKeys(
@@ -1314,15 +1322,22 @@ export function useCurrentGardenCache() {
     const winterMode = useGameState((state) => state.winterMode);
     const isLocalSandbox = localSandboxStorageKey !== null;
     const { data: gardens } = useGardens(isMock || isLocalSandbox);
+    const { data: accountGroups } = useGardenAccountGroups(
+        isMock || isLocalSandbox,
+    );
     let selectedGardenId: number | null = null;
     if (!isMock && !isLocalSandbox) {
         // biome-ignore lint/correctness/useHookAtTopLevel: store mode is fixed when the game state is created.
         const [gardenId] = useCurrentGardenIdParam();
         selectedGardenId = gardenId;
     }
-    const currentGardenId =
-        (isLocalSandbox ? localSandboxGardenId : selectedGardenId) ??
-        (gardens && gardens.length > 0 ? gardens[0].id : null);
+    const currentGardenId = isLocalSandbox
+        ? localSandboxGardenId
+        : resolveCurrentAccountGardenId({
+              accountGroups,
+              currentAccountGardens: gardens,
+              selectedGardenId,
+          });
     const gardenQueryKey = useMemo(
         () =>
             currentGardenKeys(

--- a/packages/game/src/hooks/useGardenAccountGroups.ts
+++ b/packages/game/src/hooks/useGardenAccountGroups.ts
@@ -24,3 +24,7 @@ export function useGardenAccountGroups(disabled?: boolean) {
         staleTime: 1000 * 60 * 5,
     });
 }
+
+export type GardenAccountGroups = NonNullable<
+    ReturnType<typeof useGardenAccountGroups>['data']
+>;

--- a/packages/game/src/hooks/useSetDefaultGarden.ts
+++ b/packages/game/src/hooks/useSetDefaultGarden.ts
@@ -1,0 +1,65 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+    type GardenAccountGroups,
+    gardenAccountGroupsKeys,
+} from './useGardenAccountGroups';
+
+type SetDefaultGardenVariables = {
+    gardenId: number;
+};
+
+export function useSetDefaultGarden() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({ gardenId }: SetDefaultGardenVariables) => {
+            const response =
+                await clientAuthenticated().api.accounts.gardens.default.$put({
+                    json: { gardenId },
+                });
+            if (!response.ok) {
+                throw new Error(
+                    `Failed to set default garden: ${response.status} ${response.statusText}`,
+                );
+            }
+            return response.json();
+        },
+        onMutate: async ({ gardenId }) => {
+            await queryClient.cancelQueries({
+                queryKey: gardenAccountGroupsKeys,
+            });
+            const previousGroups =
+                queryClient.getQueryData<GardenAccountGroups>(
+                    gardenAccountGroupsKeys,
+                );
+
+            queryClient.setQueryData<GardenAccountGroups>(
+                gardenAccountGroupsKeys,
+                (groups) =>
+                    groups?.map((group) => ({
+                        ...group,
+                        gardens: group.gardens.map((garden) => ({
+                            ...garden,
+                            isDefault: garden.id === gardenId,
+                        })),
+                    })),
+            );
+
+            return { previousGroups };
+        },
+        onError: (error, _variables, context) => {
+            console.error('Failed to set default garden:', error);
+            queryClient.setQueryData(
+                gardenAccountGroupsKeys,
+                context?.previousGroups,
+            );
+        },
+        onSettled: () => {
+            void queryClient.invalidateQueries({
+                exact: true,
+                queryKey: gardenAccountGroupsKeys,
+            });
+        },
+    });
+}

--- a/packages/game/src/hooks/useSwitchGardenAccount.ts
+++ b/packages/game/src/hooks/useSwitchGardenAccount.ts
@@ -20,5 +20,6 @@ export function useSwitchGardenAccount() {
 
             return response.json();
         },
+        retry: 1,
     });
 }

--- a/packages/game/src/hud/GardenAccountMenuItems.tsx
+++ b/packages/game/src/hud/GardenAccountMenuItems.tsx
@@ -1,6 +1,7 @@
 import { IconButton } from '@gredice/ui/IconButton';
 import {
     Add,
+    Bookmark,
     Check,
     Delete,
     FileText,
@@ -29,6 +30,7 @@ import {
     useGardenAccountGroups,
 } from '../hooks/useGardenAccountGroups';
 import { useGardens } from '../hooks/useGardens';
+import { useSetDefaultGarden } from '../hooks/useSetDefaultGarden';
 import { useSwitchGardenAccount } from '../hooks/useSwitchGardenAccount';
 import { useCurrentGardenIdParam } from '../useUrlState';
 
@@ -58,6 +60,7 @@ export function GardenAccountMenuItems({
     const { data: accountGroups, isLoading: accountGroupsLoading } =
         useGardenAccountGroups();
     const switchGardenAccount = useSwitchGardenAccount();
+    const setDefaultGarden = useSetDefaultGarden();
     const createGarden = useCreateGarden();
     const deleteSandboxGarden = useDeleteSandboxGarden();
     const fallbackGroups =
@@ -67,7 +70,10 @@ export function GardenAccountMenuItems({
                       accountId: 'current',
                       name: 'Trenutni račun',
                       isCurrent: true,
-                      gardens: currentAccountGardens,
+                      gardens: currentAccountGardens.map((garden) => ({
+                          ...garden,
+                          isDefault: false,
+                      })),
                   },
               ]
             : [];
@@ -81,6 +87,11 @@ export function GardenAccountMenuItems({
             gardens: group.gardens.filter((garden) => !garden.isSandbox),
         }))
         .filter((group) => group.gardens.length > 0);
+    const normalGardenCount = normalGardenGroups.reduce(
+        (count, group) => count + group.gardens.length,
+        0,
+    );
+    const showDefaultGardenControls = normalGardenCount > 1;
     const sandboxGardenGroups = gardenGroups
         .map((group) => ({
             ...group,
@@ -142,16 +153,55 @@ export function GardenAccountMenuItems({
                                 group.accountId === accountGroup.accountId,
                         })) ?? groups,
                 );
-                await setSelectedGardenId(garden.id);
+                await setSelectedGardenId(garden.isDefault ? null : garden.id);
                 void queryClient.invalidateQueries();
                 return;
             }
 
-            const isDefault = accountGroup.gardens[0]?.id === garden.id;
-            await setSelectedGardenId(isDefault ? null : garden.id);
+            await setSelectedGardenId(garden.isDefault ? null : garden.id);
         } catch (error) {
             console.error('Failed to switch garden account:', error);
         }
+    }
+
+    async function handleDefaultGardenSelect(
+        garden: (typeof normalGardenGroups)[number]['gardens'][number],
+    ) {
+        if (garden.isDefault || setDefaultGarden.isPending) {
+            return;
+        }
+
+        if (selectedGardenId === null) {
+            if (!currentGarden) {
+                return;
+            }
+            try {
+                await setSelectedGardenId(currentGarden.id);
+            } catch (error) {
+                console.error(
+                    'Failed to preserve the current garden selection:',
+                    error,
+                );
+                return;
+            }
+        }
+
+        track('game_default_garden_updated', {
+            garden_id: garden.id,
+            garden_name: garden.name,
+            source: 'garden_switcher',
+        });
+
+        setDefaultGarden.mutate(
+            { gardenId: garden.id },
+            {
+                onSuccess: () => {
+                    if (currentGarden?.id === garden.id) {
+                        void setSelectedGardenId(null);
+                    }
+                },
+            },
+        );
     }
 
     async function handleCreateSandboxGarden() {
@@ -344,23 +394,67 @@ export function GardenAccountMenuItems({
                         </DropdownMenuLabel>
                     )}
                     {accountGroup.gardens.map((garden) => (
-                        <DropdownMenuItem
+                        <div
                             key={`${accountGroup.accountId}:${garden.id}`}
-                            className="gap-3"
-                            onClick={() =>
-                                handleGardenSelect(accountGroup, garden)
-                            }
+                            className="flex items-center gap-1"
                         >
-                            <Check
-                                aria-hidden={garden.id !== currentGarden?.id}
-                                className={cx(
-                                    'size-4 shrink-0 opacity-0',
-                                    garden.id === currentGarden?.id &&
-                                        'opacity-100',
-                                )}
-                            />
-                            <Typography noWrap>{garden.name}</Typography>
-                        </DropdownMenuItem>
+                            <DropdownMenuItem
+                                className="min-w-0 flex-1 gap-3"
+                                onClick={() =>
+                                    handleGardenSelect(accountGroup, garden)
+                                }
+                            >
+                                <Check
+                                    aria-hidden={
+                                        garden.id !== currentGarden?.id
+                                    }
+                                    className={cx(
+                                        'size-4 shrink-0 opacity-0',
+                                        garden.id === currentGarden?.id &&
+                                            'opacity-100',
+                                    )}
+                                />
+                                <Typography noWrap>{garden.name}</Typography>
+                            </DropdownMenuItem>
+                            {showDefaultGardenControls && (
+                                <DropdownMenuItem
+                                    aria-label={
+                                        garden.isDefault
+                                            ? `${garden.name} je zadani vrt`
+                                            : `Postavi ${garden.name} kao zadani vrt`
+                                    }
+                                    className={cx(
+                                        'size-7 shrink-0 justify-center rounded-full p-0',
+                                        garden.isDefault &&
+                                            'text-amber-600 dark:text-amber-300',
+                                    )}
+                                    disabled={
+                                        setDefaultGarden.isPending ||
+                                        garden.isDefault ||
+                                        (selectedGardenId === null &&
+                                            !currentGarden)
+                                    }
+                                    onSelect={(event) => {
+                                        event.preventDefault();
+                                        void handleDefaultGardenSelect(garden);
+                                    }}
+                                    title={
+                                        garden.isDefault
+                                            ? `${garden.name} je zadani vrt`
+                                            : `Postavi ${garden.name} kao zadani vrt`
+                                    }
+                                    data-default-garden={garden.isDefault}
+                                >
+                                    <Bookmark
+                                        aria-hidden
+                                        className={cx(
+                                            'size-4',
+                                            garden.isDefault && 'fill-current',
+                                        )}
+                                    />
+                                </DropdownMenuItem>
+                            )}
+                        </div>
                     ))}
                 </Fragment>
             ))}

--- a/packages/game/src/modals/components/GardenTab.tsx
+++ b/packages/game/src/modals/components/GardenTab.tsx
@@ -70,7 +70,7 @@ function GardensSelector() {
     const selectedGarden =
         gardens?.find((g) => g.id === selectedGardenId) ??
         currentGarden ??
-        gardens?.[0];
+        gardens?.find((garden) => !garden.isSandbox);
 
     return (
         <>
@@ -122,9 +122,10 @@ export function GardenTab() {
     } = useGardens();
     const { data: accountGroups, isLoading: accountGroupsLoading } =
         useGardenAccountGroups();
-    const [selectedGardenId] = useCurrentGardenIdParam();
-    const selectedGarden =
-        gardens?.find((g) => g.id === selectedGardenId) ?? gardens?.[0];
+    const { data: currentGarden } = useCurrentGarden();
+    const selectedGarden = gardens?.find(
+        (garden) => garden.id === currentGarden?.id,
+    );
     const hasAnyGarden =
         (gardens?.length ?? 0) > 0 ||
         (accountGroups?.some((group) => group.gardens.length > 0) ?? false);

--- a/packages/storage/src/migrations/0077_certain_serpent_society.sql
+++ b/packages/storage/src/migrations/0077_certain_serpent_society.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "users" ADD COLUMN "default_garden_id" integer;--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_default_garden_id_gardens_id_fk" FOREIGN KEY ("default_garden_id") REFERENCES "public"."gardens"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "users_u_default_garden_id_idx" ON "users" USING btree ("default_garden_id");

--- a/packages/storage/src/migrations/meta/0077_snapshot.json
+++ b/packages/storage/src/migrations/meta/0077_snapshot.json
@@ -1,0 +1,18552 @@
+{
+  "id": "6158a572-6857-43d5-96e2-78ff8ed4481f",
+  "prevId": "35e19597-5ab7-4e76-859e-51bb4d141568",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_achievements": {
+      "name": "account_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_key": {
+          "name": "achievement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "achievement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reward_sunflowers": {
+          "name": "reward_sunflowers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress_value": {
+          "name": "progress_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_granted_at": {
+          "name": "reward_granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_by_user_id": {
+          "name": "denied_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_achievements_account_id_idx": {
+          "name": "account_achievements_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_achievements_status_idx": {
+          "name": "account_achievements_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_achievements_account_key_uq": {
+          "name": "account_achievements_account_key_uq",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "achievement_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_achievements_account_id_accounts_id_fk": {
+          "name": "account_achievements_account_id_accounts_id_fk",
+          "tableFrom": "account_achievements",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_achievements_approved_by_user_id_users_id_fk": {
+          "name": "account_achievements_approved_by_user_id_users_id_fk",
+          "tableFrom": "account_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_achievements_denied_by_user_id_users_id_fk": {
+          "name": "account_achievements_denied_by_user_id_users_id_fk",
+          "tableFrom": "account_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "denied_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_account_limit_overrides": {
+      "name": "ai_account_limit_overrides",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active_daily_limit_micro_usd": {
+          "name": "active_daily_limit_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_daily_limit_micro_usd": {
+          "name": "trial_daily_limit_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_chat_days": {
+          "name": "trial_chat_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ai_account_limit_overrides_disabled_idx": {
+          "name": "ai_account_limit_overrides_disabled_idx",
+          "columns": [
+            {
+              "expression": "disabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_account_limit_overrides_account_id_accounts_id_fk": {
+          "name": "ai_account_limit_overrides_account_id_accounts_id_fk",
+          "tableFrom": "ai_account_limit_overrides",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_account_limit_overrides_updated_by_user_id_users_id_fk": {
+          "name": "ai_account_limit_overrides_updated_by_user_id_users_id_fk",
+          "tableFrom": "ai_account_limit_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_conversations": {
+      "name": "ai_chat_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_chat_conversations_account_idx": {
+          "name": "ai_chat_conversations_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_conversations_user_idx": {
+          "name": "ai_chat_conversations_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_conversations_last_message_idx": {
+          "name": "ai_chat_conversations_last_message_idx",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_conversations_account_id_accounts_id_fk": {
+          "name": "ai_chat_conversations_account_id_accounts_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_chat_conversations_user_id_users_id_fk": {
+          "name": "ai_chat_conversations_user_id_users_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_chat_conversations_garden_id_gardens_id_fk": {
+          "name": "ai_chat_conversations_garden_id_gardens_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_chat_conversations_raised_bed_id_raised_beds_id_fk": {
+          "name": "ai_chat_conversations_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_messages": {
+      "name": "ai_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_chat_messages_conversation_idx": {
+          "name": "ai_chat_messages_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_messages_created_at_idx": {
+          "name": "ai_chat_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_messages_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_chat_messages_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_chat_messages",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_tool_calls": {
+      "name": "ai_chat_tool_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_approval": {
+          "name": "needs_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_correlation_id": {
+          "name": "mcp_correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ai_chat_tool_calls_conversation_idx": {
+          "name": "ai_chat_tool_calls_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_tool_calls_tool_name_idx": {
+          "name": "ai_chat_tool_calls_tool_name_idx",
+          "columns": [
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_tool_calls_created_at_idx": {
+          "name": "ai_chat_tool_calls_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_tool_calls_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_chat_tool_calls_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_chat_tool_calls",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_chat_tool_calls_message_id_ai_chat_messages_id_fk": {
+          "name": "ai_chat_tool_calls_message_id_ai_chat_messages_id_fk",
+          "tableFrom": "ai_chat_tool_calls",
+          "tableTo": "ai_chat_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_chat_tool_calls_approved_by_user_id_users_id_fk": {
+          "name": "ai_chat_tool_calls_approved_by_user_id_users_id_fk",
+          "tableFrom": "ai_chat_tool_calls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_usage_ledger": {
+      "name": "ai_usage_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'suncokret-chat'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_date": {
+          "name": "usage_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reserved_micro_usd": {
+          "name": "reserved_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_micro_usd": {
+          "name": "input_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_micro_usd": {
+          "name": "output_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_micro_usd": {
+          "name": "total_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_usage_ledger_request_unique": {
+          "name": "ai_usage_ledger_request_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_ledger_account_date_idx": {
+          "name": "ai_usage_ledger_account_date_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usage_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_ledger_conversation_idx": {
+          "name": "ai_usage_ledger_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_ledger_status_idx": {
+          "name": "ai_usage_ledger_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_ledger_created_at_idx": {
+          "name": "ai_usage_ledger_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_usage_ledger_account_id_accounts_id_fk": {
+          "name": "ai_usage_ledger_account_id_accounts_id_fk",
+          "tableFrom": "ai_usage_ledger",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_usage_ledger_user_id_users_id_fk": {
+          "name": "ai_usage_ledger_user_id_users_id_fk",
+          "tableFrom": "ai_usage_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_usage_ledger_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_usage_ledger_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_usage_ledger",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_definitions": {
+      "name": "automation_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_definition_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "max_concurrent_runs": {
+          "name": "max_concurrent_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "trigger_module_key": {
+          "name": "trigger_module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_event_type": {
+          "name": "trigger_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":[],\"edges\":[]}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_definitions_key_idx": {
+          "name": "automation_definitions_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_definitions_status_idx": {
+          "name": "automation_definitions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_definitions_trigger_event_type_idx": {
+          "name": "automation_definitions_trigger_event_type_idx",
+          "columns": [
+            {
+              "expression": "trigger_event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_definitions_updated_at_idx": {
+          "name": "automation_definitions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_definitions_created_by_user_id_users_id_fk": {
+          "name": "automation_definitions_created_by_user_id_users_id_fk",
+          "tableFrom": "automation_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "automation_definitions_updated_by_user_id_users_id_fk": {
+          "name": "automation_definitions_updated_by_user_id_users_id_fk",
+          "tableFrom": "automation_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_event_cursors": {
+      "name": "automation_event_cursors",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_run_steps": {
+      "name": "automation_run_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_key": {
+          "name": "module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_kind": {
+          "name": "module_kind",
+          "type": "automation_module_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_run_steps_run_node_idx": {
+          "name": "automation_run_steps_run_node_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_run_steps_run_id_idx": {
+          "name": "automation_run_steps_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_run_steps_status_idx": {
+          "name": "automation_run_steps_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_run_steps_run_id_automation_runs_id_fk": {
+          "name": "automation_run_steps_run_id_automation_runs_id_fk",
+          "tableFrom": "automation_run_steps",
+          "tableTo": "automation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_runs": {
+      "name": "automation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "automation_definition_id": {
+          "name": "automation_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_definition_key": {
+          "name": "automation_definition_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_definition_name": {
+          "name": "automation_definition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "automation_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_type": {
+          "name": "source_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_aggregate_id": {
+          "name": "source_aggregate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_run_id": {
+          "name": "parent_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_requested_by_user_id": {
+          "name": "manual_requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph_snapshot": {
+          "name": "graph_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":[],\"edges\":[]}'::jsonb"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_runs_definition_source_event_idx": {
+          "name": "automation_runs_definition_source_event_idx",
+          "columns": [
+            {
+              "expression": "automation_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"automation_runs\".\"source\" = 'event'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_definition_source_schedule_idx": {
+          "name": "automation_runs_definition_source_schedule_idx",
+          "columns": [
+            {
+              "expression": "automation_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_aggregate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"automation_runs\".\"source_event_type\" in ('automation.schedule', 'automation.schedule.monthly')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_definition_id_idx": {
+          "name": "automation_runs_definition_id_idx",
+          "columns": [
+            {
+              "expression": "automation_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_status_next_run_at_idx": {
+          "name": "automation_runs_status_next_run_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_source_event_type_idx": {
+          "name": "automation_runs_source_event_type_idx",
+          "columns": [
+            {
+              "expression": "source_event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_source_event_id_idx": {
+          "name": "automation_runs_source_event_id_idx",
+          "columns": [
+            {
+              "expression": "source_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_created_at_idx": {
+          "name": "automation_runs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_runs_automation_definition_id_automation_definitions_id_fk": {
+          "name": "automation_runs_automation_definition_id_automation_definitions_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "automation_definitions",
+          "columnsFrom": [
+            "automation_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "automation_runs_source_event_id_events_id_fk": {
+          "name": "automation_runs_source_event_id_events_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "automation_runs_manual_requested_by_user_id_users_id_fk": {
+          "name": "automation_runs_manual_requested_by_user_id_users_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "manual_requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_definition_categories": {
+      "name": "attribute_definition_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_adc_entity_type_name_idx": {
+          "name": "cms_adc_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_adc_order_idx": {
+          "name": "cms_adc_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_adc_is_deleted_idx": {
+          "name": "cms_adc_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_definitions": {
+      "name": "attribute_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multiple": {
+          "name": "multiple",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display": {
+          "name": "display",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_ad_category_idx": {
+          "name": "cms_ad_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_entity_type_name_idx": {
+          "name": "cms_ad_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_order_idx": {
+          "name": "cms_ad_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_is_deleted_idx": {
+          "name": "cms_ad_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_values": {
+      "name": "attribute_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attribute_definition_id": {
+          "name": "attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_av_attribute_definition_id_idx": {
+          "name": "cms_av_attribute_definition_id_idx",
+          "columns": [
+            {
+              "expression": "attribute_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_entity_type_name_idx": {
+          "name": "cms_av_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_entity_id_idx": {
+          "name": "cms_av_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_order_idx": {
+          "name": "cms_av_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_is_deleted_idx": {
+          "name": "cms_av_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attribute_values_attribute_definition_id_attribute_definitions_id_fk": {
+          "name": "attribute_values_attribute_definition_id_attribute_definitions_id_fk",
+          "tableFrom": "attribute_values",
+          "tableTo": "attribute_definitions",
+          "columnsFrom": [
+            "attribute_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attribute_values_entity_id_entities_id_fk": {
+          "name": "attribute_values_entity_id_entities_id_fk",
+          "tableFrom": "attribute_values",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cms_page_revisions": {
+      "name": "cms_page_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cms_page_id": {
+          "name": "cms_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_slug": {
+          "name": "previous_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_slug": {
+          "name": "next_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_title": {
+          "name": "previous_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_title": {
+          "name": "next_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_content": {
+          "name": "previous_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_content": {
+          "name": "next_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_content_kind": {
+          "name": "previous_content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_content_kind": {
+          "name": "next_content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category": {
+          "name": "previous_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_category": {
+          "name": "next_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_tags": {
+          "name": "previous_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_tags": {
+          "name": "next_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_state": {
+          "name": "next_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_title": {
+          "name": "previous_meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_title": {
+          "name": "next_meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_description": {
+          "name": "previous_meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_description": {
+          "name": "next_meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_image_url": {
+          "name": "previous_meta_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_image_url": {
+          "name": "next_meta_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_image_poi_x": {
+          "name": "previous_meta_image_poi_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_image_poi_x": {
+          "name": "next_meta_image_poi_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_image_poi_y": {
+          "name": "previous_meta_image_poi_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_image_poi_y": {
+          "name": "next_meta_image_poi_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_seo_image_url": {
+          "name": "previous_seo_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_seo_image_url": {
+          "name": "next_seo_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_canonical_path": {
+          "name": "previous_canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_canonical_path": {
+          "name": "next_canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_no_index": {
+          "name": "previous_no_index",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_no_index": {
+          "name": "next_no_index",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_published_at": {
+          "name": "previous_published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_published_at": {
+          "name": "next_published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cms_page_revisions_page_id_idx": {
+          "name": "cms_page_revisions_page_id_idx",
+          "columns": [
+            {
+              "expression": "cms_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_page_revisions_action_idx": {
+          "name": "cms_page_revisions_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_page_revisions_created_at_idx": {
+          "name": "cms_page_revisions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cms_page_revisions_cms_page_id_cms_pages_id_fk": {
+          "name": "cms_page_revisions_cms_page_id_cms_pages_id_fk",
+          "tableFrom": "cms_page_revisions",
+          "tableTo": "cms_pages",
+          "columnsFrom": [
+            "cms_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cms_pages": {
+      "name": "cms_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_kind": {
+          "name": "content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_image_url": {
+          "name": "meta_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_image_poi_x": {
+          "name": "meta_image_poi_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_image_poi_y": {
+          "name": "meta_image_poi_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_image_url": {
+          "name": "seo_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_path": {
+          "name": "canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_index": {
+          "name": "no_index",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_pages_slug_active_uq": {
+          "name": "cms_pages_slug_active_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cms_pages\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_state_idx": {
+          "name": "cms_pages_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_content_kind_idx": {
+          "name": "cms_pages_content_kind_idx",
+          "columns": [
+            {
+              "expression": "content_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_category_idx": {
+          "name": "cms_pages_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_published_at_idx": {
+          "name": "cms_pages_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_is_deleted_idx": {
+          "name": "cms_pages_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchy_order": {
+          "name": "hierarchy_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_e_entity_type_name_idx": {
+          "name": "cms_e_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_parent_id_idx": {
+          "name": "cms_e_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_hierarchy_order_idx": {
+          "name": "cms_e_hierarchy_order_idx",
+          "columns": [
+            {
+              "expression": "hierarchy_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_state_idx": {
+          "name": "cms_e_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_is_deleted_idx": {
+          "name": "cms_e_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_parent_id_entities_id_fk": {
+          "name": "entities_parent_id_entities_id_fk",
+          "tableFrom": "entities",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_revisions": {
+      "name": "entity_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_value_id": {
+          "name": "attribute_value_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_definition_id": {
+          "name": "attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_value": {
+          "name": "next_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_state": {
+          "name": "next_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cms_er_entity_id_idx": {
+          "name": "cms_er_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_er_entity_type_name_idx": {
+          "name": "cms_er_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_er_action_idx": {
+          "name": "cms_er_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_revisions_entity_id_entities_id_fk": {
+          "name": "entity_revisions_entity_id_entities_id_fk",
+          "tableFrom": "entity_revisions",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_search_documents": {
+      "name": "entity_search_documents",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_category": {
+          "name": "public_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_category_label": {
+          "name": "public_category_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cms_esd_entity_type_idx": {
+          "name": "cms_esd_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_public_category_idx": {
+          "name": "cms_esd_public_category_idx",
+          "columns": [
+            {
+              "expression": "public_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_state_idx": {
+          "name": "cms_esd_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_published_at_idx": {
+          "name": "cms_esd_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_search_vector_idx": {
+          "name": "cms_esd_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_search_documents_entity_id_entities_id_fk": {
+          "name": "entity_search_documents_entity_id_entities_id_fk",
+          "tableFrom": "entity_search_documents",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_type_categories": {
+      "name": "entity_type_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_etc_order_idx": {
+          "name": "cms_etc_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_etc_is_deleted_idx": {
+          "name": "cms_etc_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_types": {
+      "name": "entity_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchy_order": {
+          "name": "hierarchy_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_root": {
+          "name": "is_root",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "inventory_source_attribute_definition_id": {
+          "name": "inventory_source_attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_et_category_id_idx": {
+          "name": "cms_et_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_order_idx": {
+          "name": "cms_et_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_parent_id_idx": {
+          "name": "cms_et_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_hierarchy_order_idx": {
+          "name": "cms_et_hierarchy_order_idx",
+          "columns": [
+            {
+              "expression": "hierarchy_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_is_deleted_idx": {
+          "name": "cms_et_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_is_root_idx": {
+          "name": "cms_et_is_root_idx",
+          "columns": [
+            {
+              "expression": "is_root",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_inventory_source_attr_def_idx": {
+          "name": "cms_et_inventory_source_attr_def_idx",
+          "columns": [
+            {
+              "expression": "inventory_source_attribute_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_types_category_id_entity_type_categories_id_fk": {
+          "name": "entity_types_category_id_entity_type_categories_id_fk",
+          "tableFrom": "entity_types",
+          "tableTo": "entity_type_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_types_parent_id_entity_types_id_fk": {
+          "name": "entity_types_parent_id_entity_types_id_fk",
+          "tableFrom": "entity_types",
+          "tableTo": "entity_types",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_types_inventory_source_attribute_definition_id_attribute_definitions_id_fk": {
+          "name": "entity_types_inventory_source_attribute_definition_id_attribute_definitions_id_fk",
+          "tableFrom": "entity_types",
+          "tableTo": "attribute_definitions",
+          "columnsFrom": [
+            "inventory_source_attribute_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_edit_request_changes": {
+      "name": "community_edit_request_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_key": {
+          "name": "section_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_definition_id": {
+          "name": "attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribute_value_id": {
+          "name": "attribute_value_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_path": {
+          "name": "attribute_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_value": {
+          "name": "proposed_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_value_hash": {
+          "name": "base_value_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_patch": {
+          "name": "value_patch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_diff": {
+          "name": "review_diff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_edit_changes_request_id_idx": {
+          "name": "community_edit_changes_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_changes_field_key_idx": {
+          "name": "community_edit_changes_field_key_idx",
+          "columns": [
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_changes_attribute_definition_idx": {
+          "name": "community_edit_changes_attribute_definition_idx",
+          "columns": [
+            {
+              "expression": "attribute_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_edit_request_changes_request_id_community_edit_requests_id_fk": {
+          "name": "community_edit_request_changes_request_id_community_edit_requests_id_fk",
+          "tableFrom": "community_edit_request_changes",
+          "tableTo": "community_edit_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_edit_request_changes_attribute_definition_id_attribute_definitions_id_fk": {
+          "name": "community_edit_request_changes_attribute_definition_id_attribute_definitions_id_fk",
+          "tableFrom": "community_edit_request_changes",
+          "tableTo": "attribute_definitions",
+          "columnsFrom": [
+            "attribute_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_edit_request_changes_attribute_value_id_attribute_values_id_fk": {
+          "name": "community_edit_request_changes_attribute_value_id_attribute_values_id_fk",
+          "tableFrom": "community_edit_request_changes",
+          "tableTo": "attribute_values",
+          "columnsFrom": [
+            "attribute_value_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_edit_requests": {
+      "name": "community_edit_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_path": {
+          "name": "public_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_key": {
+          "name": "section_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_user_id": {
+          "name": "submitter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitter_name": {
+          "name": "submitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_email": {
+          "name": "submitter_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_note": {
+          "name": "submitter_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_user_id": {
+          "name": "reviewer_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_name": {
+          "name": "reviewer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_note": {
+          "name": "reviewer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_failure_reason": {
+          "name": "application_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "community_edit_requests_status_idx": {
+          "name": "community_edit_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_requests_entity_type_idx": {
+          "name": "community_edit_requests_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_requests_entity_id_idx": {
+          "name": "community_edit_requests_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_requests_submitter_idx": {
+          "name": "community_edit_requests_submitter_idx",
+          "columns": [
+            {
+              "expression": "submitter_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_requests_created_at_idx": {
+          "name": "community_edit_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_edit_requests_entity_id_entities_id_fk": {
+          "name": "community_edit_requests_entity_id_entities_id_fk",
+          "tableFrom": "community_edit_requests",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_edit_requests_submitter_user_id_users_id_fk": {
+          "name": "community_edit_requests_submitter_user_id_users_id_fk",
+          "tableFrom": "community_edit_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_edit_requests_reviewer_user_id_users_id_fk": {
+          "name": "community_edit_requests_reviewer_user_id_users_id_fk",
+          "tableFrom": "community_edit_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_addresses": {
+      "name": "delivery_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street1": {
+          "name": "street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street2": {
+          "name": "street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'HR'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_addresses_account_id_idx": {
+          "name": "delivery_addresses_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_addresses_is_default_idx": {
+          "name": "delivery_addresses_is_default_idx",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_addresses_deleted_at_idx": {
+          "name": "delivery_addresses_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_addresses_account_id_accounts_id_fk": {
+          "name": "delivery_addresses_account_id_accounts_id_fk",
+          "tableFrom": "delivery_addresses",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_requests": {
+      "name": "delivery_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_requests_operation_id_idx": {
+          "name": "delivery_requests_operation_id_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_requests_created_at_idx": {
+          "name": "delivery_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_requests_operation_id_operations_id_fk": {
+          "name": "delivery_requests_operation_id_operations_id_fk",
+          "tableFrom": "delivery_requests",
+          "tableTo": "operations",
+          "columnsFrom": [
+            "operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_exception_operations": {
+      "name": "delivery_run_exception_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_operation_id": {
+          "name": "client_operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_run_exception_operations_run_client_unique": {
+          "name": "delivery_run_exception_operations_run_client_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_exception_operations_run_id_idx": {
+          "name": "delivery_run_exception_operations_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_exception_operations_driver_user_id_idx": {
+          "name": "delivery_run_exception_operations_driver_user_id_idx",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_exception_operations_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_exception_operations_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_exception_operations",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_exception_operations_driver_user_id_users_id_fk": {
+          "name": "delivery_run_exception_operations_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_run_exception_operations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_handoff_operations": {
+      "name": "delivery_run_handoff_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_stop_id": {
+          "name": "target_stop_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retry_attempt": {
+          "name": "retry_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_operation_id": {
+          "name": "client_operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_run_handoff_operations_run_client_unique": {
+          "name": "delivery_run_handoff_operations_run_client_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_handoff_operations_run_id_idx": {
+          "name": "delivery_run_handoff_operations_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_handoff_operations_target_stop_id_idx": {
+          "name": "delivery_run_handoff_operations_target_stop_id_idx",
+          "columns": [
+            {
+              "expression": "target_stop_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_handoff_operations_driver_user_id_idx": {
+          "name": "delivery_run_handoff_operations_driver_user_id_idx",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_handoff_operations_applied_at_idx": {
+          "name": "delivery_run_handoff_operations_applied_at_idx",
+          "columns": [
+            {
+              "expression": "applied_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_handoff_operations_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_handoff_operations_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_handoff_operations",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_handoff_operations_driver_user_id_users_id_fk": {
+          "name": "delivery_run_handoff_operations_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_run_handoff_operations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_handoff_operations_run_target_stop_fk": {
+          "name": "delivery_run_handoff_operations_run_target_stop_fk",
+          "tableFrom": "delivery_run_handoff_operations",
+          "tableTo": "delivery_run_stops",
+          "columnsFrom": [
+            "run_id",
+            "target_stop_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_handoff_operations_kind_check": {
+          "name": "delivery_run_handoff_operations_kind_check",
+          "value": "\"delivery_run_handoff_operations\".\"kind\" in ('scan', 'mark-item')"
+        },
+        "delivery_run_handoff_operations_retry_attempt_check": {
+          "name": "delivery_run_handoff_operations_retry_attempt_check",
+          "value": "\"delivery_run_handoff_operations\".\"retry_attempt\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_pickup_nodes": {
+      "name": "delivery_run_pickup_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_location_id": {
+          "name": "pickup_location_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "itinerary_sequence": {
+          "name": "itinerary_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_arrival_at": {
+          "name": "estimated_arrival_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_travel_seconds": {
+          "name": "incoming_travel_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_distance_meters": {
+          "name": "incoming_distance_meters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_duration_seconds": {
+          "name": "service_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street1": {
+          "name": "street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street2": {
+          "name": "street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_run_pickup_nodes_run_sequence_unique": {
+          "name": "delivery_run_pickup_nodes_run_sequence_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_nodes_run_location_unique": {
+          "name": "delivery_run_pickup_nodes_run_location_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pickup_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_nodes_run_id_id_unique": {
+          "name": "delivery_run_pickup_nodes_run_id_id_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_nodes_run_itinerary_sequence_unique": {
+          "name": "delivery_run_pickup_nodes_run_itinerary_sequence_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "itinerary_sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"delivery_run_pickup_nodes\".\"itinerary_sequence\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_nodes_run_id_idx": {
+          "name": "delivery_run_pickup_nodes_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_pickup_nodes_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_pickup_nodes_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_pickup_nodes",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_pickup_nodes_pickup_location_id_pickup_locations_id_fk": {
+          "name": "delivery_run_pickup_nodes_pickup_location_id_pickup_locations_id_fk",
+          "tableFrom": "delivery_run_pickup_nodes",
+          "tableTo": "pickup_locations",
+          "columnsFrom": [
+            "pickup_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_pickup_nodes_itinerary_shape_check": {
+          "name": "delivery_run_pickup_nodes_itinerary_shape_check",
+          "value": "(\n                \"delivery_run_pickup_nodes\".\"itinerary_sequence\" is null\n                and \"delivery_run_pickup_nodes\".\"estimated_arrival_at\" is null\n                and \"delivery_run_pickup_nodes\".\"incoming_travel_seconds\" is null\n                and \"delivery_run_pickup_nodes\".\"incoming_distance_meters\" is null\n                and \"delivery_run_pickup_nodes\".\"service_duration_seconds\" is null\n            ) or (\n                \"delivery_run_pickup_nodes\".\"itinerary_sequence\" is not null\n                and \"delivery_run_pickup_nodes\".\"itinerary_sequence\" > 0\n                and \"delivery_run_pickup_nodes\".\"estimated_arrival_at\" is not null\n                and \"delivery_run_pickup_nodes\".\"incoming_travel_seconds\" is not null\n                and \"delivery_run_pickup_nodes\".\"incoming_travel_seconds\" >= 0\n                and \"delivery_run_pickup_nodes\".\"incoming_distance_meters\" is not null\n                and \"delivery_run_pickup_nodes\".\"incoming_distance_meters\" >= 0\n                and \"delivery_run_pickup_nodes\".\"service_duration_seconds\" is not null\n                and \"delivery_run_pickup_nodes\".\"service_duration_seconds\" >= 0\n            )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_pickup_operations": {
+      "name": "delivery_run_pickup_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_node_id": {
+          "name": "pickup_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_operation_id": {
+          "name": "client_operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_run_pickup_operations_run_client_unique": {
+          "name": "delivery_run_pickup_operations_run_client_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_operations_run_id_idx": {
+          "name": "delivery_run_pickup_operations_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_operations_pickup_node_id_idx": {
+          "name": "delivery_run_pickup_operations_pickup_node_id_idx",
+          "columns": [
+            {
+              "expression": "pickup_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_pickup_operations_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_pickup_operations_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_pickup_operations",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_pickup_operations_driver_user_id_users_id_fk": {
+          "name": "delivery_run_pickup_operations_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_run_pickup_operations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_pickup_operations_run_pickup_node_fk": {
+          "name": "delivery_run_pickup_operations_run_pickup_node_fk",
+          "tableFrom": "delivery_run_pickup_operations",
+          "tableTo": "delivery_run_pickup_nodes",
+          "columnsFrom": [
+            "run_id",
+            "pickup_node_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_pickup_operations_kind_check": {
+          "name": "delivery_run_pickup_operations_kind_check",
+          "value": "\"delivery_run_pickup_operations\".\"kind\" in ('scan', 'mark-item', 'confirm-manifest')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_preparations": {
+      "name": "delivery_run_preparations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selection_hash": {
+          "name": "selection_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_run_id": {
+          "name": "delivery_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_run_preparations_driver_user_id_idx": {
+          "name": "delivery_run_preparations_driver_user_id_idx",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_preparations_expires_at_idx": {
+          "name": "delivery_run_preparations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_preparations_consumed_at_idx": {
+          "name": "delivery_run_preparations_consumed_at_idx",
+          "columns": [
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_preparations_delivery_run_id_unique": {
+          "name": "delivery_run_preparations_delivery_run_id_unique",
+          "columns": [
+            {
+              "expression": "delivery_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_preparations_driver_user_id_users_id_fk": {
+          "name": "delivery_run_preparations_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_run_preparations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_preparations_delivery_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_preparations_delivery_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_preparations",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "delivery_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_preparations_consumption_shape_check": {
+          "name": "delivery_run_preparations_consumption_shape_check",
+          "value": "(\"delivery_run_preparations\".\"consumed_at\" is null and \"delivery_run_preparations\".\"delivery_run_id\" is null) or (\"delivery_run_preparations\".\"consumed_at\" is not null and \"delivery_run_preparations\".\"delivery_run_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_slots": {
+      "name": "delivery_run_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_node_id": {
+          "name": "pickup_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot_id": {
+          "name": "time_slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_id": {
+          "name": "manifest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_state": {
+          "name": "manifest_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'confirmed'"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by_user_id": {
+          "name": "confirmed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_run_slots_manifest_id_unique": {
+          "name": "delivery_run_slots_manifest_id_unique",
+          "columns": [
+            {
+              "expression": "manifest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_run_sequence_unique": {
+          "name": "delivery_run_slots_run_sequence_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_run_time_slot_unique": {
+          "name": "delivery_run_slots_run_time_slot_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_run_id_id_unique": {
+          "name": "delivery_run_slots_run_id_id_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_run_id_idx": {
+          "name": "delivery_run_slots_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_pickup_node_id_idx": {
+          "name": "delivery_run_slots_pickup_node_id_idx",
+          "columns": [
+            {
+              "expression": "pickup_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_slots_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_slots_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_slots",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_slots_time_slot_id_time_slots_id_fk": {
+          "name": "delivery_run_slots_time_slot_id_time_slots_id_fk",
+          "tableFrom": "delivery_run_slots",
+          "tableTo": "time_slots",
+          "columnsFrom": [
+            "time_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "delivery_run_slots_confirmed_by_user_id_users_id_fk": {
+          "name": "delivery_run_slots_confirmed_by_user_id_users_id_fk",
+          "tableFrom": "delivery_run_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "delivery_run_slots_run_pickup_node_fk": {
+          "name": "delivery_run_slots_run_pickup_node_fk",
+          "tableFrom": "delivery_run_slots",
+          "tableTo": "delivery_run_pickup_nodes",
+          "columnsFrom": [
+            "run_id",
+            "pickup_node_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_slots_manifest_state_check": {
+          "name": "delivery_run_slots_manifest_state_check",
+          "value": "\"delivery_run_slots\".\"manifest_state\" in ('pending', 'confirmed')"
+        },
+        "delivery_run_slots_manifest_confirmation_shape_check": {
+          "name": "delivery_run_slots_manifest_confirmation_shape_check",
+          "value": "\"delivery_run_slots\".\"manifest_state\" = 'confirmed' or (\"delivery_run_slots\".\"confirmed_at\" is null and \"delivery_run_slots\".\"confirmed_by_user_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_stop_operations": {
+      "name": "delivery_run_stop_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_stop_id": {
+          "name": "target_stop_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_operation_id": {
+          "name": "client_operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_run_stop_operations_run_client_unique": {
+          "name": "delivery_run_stop_operations_run_client_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stop_operations_run_id_idx": {
+          "name": "delivery_run_stop_operations_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stop_operations_target_stop_id_idx": {
+          "name": "delivery_run_stop_operations_target_stop_id_idx",
+          "columns": [
+            {
+              "expression": "target_stop_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stop_operations_driver_user_id_idx": {
+          "name": "delivery_run_stop_operations_driver_user_id_idx",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_stop_operations_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_stop_operations_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_stop_operations",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stop_operations_driver_user_id_users_id_fk": {
+          "name": "delivery_run_stop_operations_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_run_stop_operations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stop_operations_run_target_stop_fk": {
+          "name": "delivery_run_stop_operations_run_target_stop_fk",
+          "tableFrom": "delivery_run_stop_operations",
+          "tableTo": "delivery_run_stops",
+          "columnsFrom": [
+            "run_id",
+            "target_stop_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_stop_operations_kind_check": {
+          "name": "delivery_run_stop_operations_kind_check",
+          "value": "\"delivery_run_stop_operations\".\"kind\" in ('arrive', 'deliver')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_stops": {
+      "name": "delivery_run_stops",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_request_id": {
+          "name": "delivery_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_slot_id": {
+          "name": "run_slot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "itinerary_sequence": {
+          "name": "itinerary_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_duration_seconds": {
+          "name": "service_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_lane_rank": {
+          "name": "retry_lane_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_attempt": {
+          "name": "retry_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stop_key": {
+          "name": "stop_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_dispatch_event_id": {
+          "name": "request_dispatch_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address_id": {
+          "name": "delivery_address_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address_updated_at": {
+          "name": "delivery_address_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address_label": {
+          "name": "delivery_address_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_contact_name": {
+          "name": "delivery_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_phone": {
+          "name": "delivery_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street1": {
+          "name": "delivery_street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street2": {
+          "name": "delivery_street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_city": {
+          "name": "delivery_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_postal_code": {
+          "name": "delivery_postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_country_code": {
+          "name": "delivery_country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_item_state": {
+          "name": "pickup_item_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_trace_link_id": {
+          "name": "pickup_trace_link_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_trace_token": {
+          "name": "pickup_trace_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_resolved_at": {
+          "name": "pickup_resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_resolved_by_user_id": {
+          "name": "pickup_resolved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_verification_state": {
+          "name": "handoff_verification_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_verification_reason": {
+          "name": "handoff_verification_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_verified_at": {
+          "name": "handoff_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_verified_by_user_id": {
+          "name": "handoff_verified_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_arrival_at": {
+          "name": "estimated_arrival_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_travel_seconds": {
+          "name": "estimated_travel_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_distance_meters": {
+          "name": "estimated_distance_meters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_reason": {
+          "name": "exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_note": {
+          "name": "exception_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_occurred_at": {
+          "name": "exception_occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_recorded_by_user_id": {
+          "name": "exception_recorded_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_run_stops_delivery_request_active_unique": {
+          "name": "delivery_run_stops_delivery_request_active_unique",
+          "columns": [
+            {
+              "expression": "delivery_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"delivery_run_stops\".\"released_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_sequence_unique": {
+          "name": "delivery_run_stops_run_sequence_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_id_id_unique": {
+          "name": "delivery_run_stops_run_id_id_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_id_idx": {
+          "name": "delivery_run_stops_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_itinerary_sequence_idx": {
+          "name": "delivery_run_stops_run_itinerary_sequence_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "itinerary_sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_slot_id_idx": {
+          "name": "delivery_run_stops_run_slot_id_idx",
+          "columns": [
+            {
+              "expression": "run_slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_state_idx": {
+          "name": "delivery_run_stops_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_retry_lane_rank_idx": {
+          "name": "delivery_run_stops_run_retry_lane_rank_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retry_lane_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_released_at_idx": {
+          "name": "delivery_run_stops_released_at_idx",
+          "columns": [
+            {
+              "expression": "released_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_pickup_trace_token_idx": {
+          "name": "delivery_run_stops_pickup_trace_token_idx",
+          "columns": [
+            {
+              "expression": "pickup_trace_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_pickup_item_state_idx": {
+          "name": "delivery_run_stops_pickup_item_state_idx",
+          "columns": [
+            {
+              "expression": "pickup_item_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_handoff_verification_state_idx": {
+          "name": "delivery_run_stops_handoff_verification_state_idx",
+          "columns": [
+            {
+              "expression": "handoff_verification_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_stops_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_stops_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_delivery_request_id_delivery_requests_id_fk": {
+          "name": "delivery_run_stops_delivery_request_id_delivery_requests_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "delivery_requests",
+          "columnsFrom": [
+            "delivery_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_pickup_trace_link_id_harvest_trace_links_id_fk": {
+          "name": "delivery_run_stops_pickup_trace_link_id_harvest_trace_links_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "harvest_trace_links",
+          "columnsFrom": [
+            "pickup_trace_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_pickup_resolved_by_user_id_users_id_fk": {
+          "name": "delivery_run_stops_pickup_resolved_by_user_id_users_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "users",
+          "columnsFrom": [
+            "pickup_resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_handoff_verified_by_user_id_users_id_fk": {
+          "name": "delivery_run_stops_handoff_verified_by_user_id_users_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "users",
+          "columnsFrom": [
+            "handoff_verified_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_exception_recorded_by_user_id_users_id_fk": {
+          "name": "delivery_run_stops_exception_recorded_by_user_id_users_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "users",
+          "columnsFrom": [
+            "exception_recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_run_slot_fk": {
+          "name": "delivery_run_stops_run_slot_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "delivery_run_slots",
+          "columnsFrom": [
+            "run_id",
+            "run_slot_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_stops_snapshot_shape_check": {
+          "name": "delivery_run_stops_snapshot_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"run_slot_id\" is null\n                and \"delivery_run_stops\".\"stop_key\" is null\n                and \"delivery_run_stops\".\"request_dispatch_event_id\" is null\n                and \"delivery_run_stops\".\"delivery_address_id\" is null\n                and \"delivery_run_stops\".\"delivery_address_updated_at\" is null\n                and \"delivery_run_stops\".\"delivery_address_label\" is null\n                and \"delivery_run_stops\".\"delivery_contact_name\" is null\n                and \"delivery_run_stops\".\"delivery_phone\" is null\n                and \"delivery_run_stops\".\"delivery_street1\" is null\n                and \"delivery_run_stops\".\"delivery_street2\" is null\n                and \"delivery_run_stops\".\"delivery_city\" is null\n                and \"delivery_run_stops\".\"delivery_postal_code\" is null\n                and \"delivery_run_stops\".\"delivery_country_code\" is null\n            ) or (\n                \"delivery_run_stops\".\"run_slot_id\" is not null\n                and \"delivery_run_stops\".\"stop_key\" is not null\n                and \"delivery_run_stops\".\"request_dispatch_event_id\" is not null\n                and \"delivery_run_stops\".\"delivery_address_id\" is not null\n                and \"delivery_run_stops\".\"delivery_address_updated_at\" is not null\n                and \"delivery_run_stops\".\"delivery_address_label\" is not null\n                and \"delivery_run_stops\".\"delivery_contact_name\" is not null\n                and \"delivery_run_stops\".\"delivery_phone\" is not null\n                and \"delivery_run_stops\".\"delivery_street1\" is not null\n                and \"delivery_run_stops\".\"delivery_city\" is not null\n                and \"delivery_run_stops\".\"delivery_postal_code\" is not null\n                and \"delivery_run_stops\".\"delivery_country_code\" is not null\n            )"
+        },
+        "delivery_run_stops_itinerary_shape_check": {
+          "name": "delivery_run_stops_itinerary_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"itinerary_sequence\" is null\n                and \"delivery_run_stops\".\"service_duration_seconds\" is null\n            ) or (\n                \"delivery_run_stops\".\"itinerary_sequence\" is not null\n                and \"delivery_run_stops\".\"itinerary_sequence\" > 0\n                and \"delivery_run_stops\".\"service_duration_seconds\" is not null\n                and \"delivery_run_stops\".\"service_duration_seconds\" >= 0\n            )"
+        },
+        "delivery_run_stops_retry_shape_check": {
+          "name": "delivery_run_stops_retry_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"retry_lane_rank\" is null\n                and \"delivery_run_stops\".\"retry_attempt\" = 0\n            ) or (\n                \"delivery_run_stops\".\"retry_lane_rank\" is not null\n                and \"delivery_run_stops\".\"retry_lane_rank\" > 0\n                and \"delivery_run_stops\".\"retry_attempt\" > 0\n            )"
+        },
+        "delivery_run_stops_pickup_item_state_check": {
+          "name": "delivery_run_stops_pickup_item_state_check",
+          "value": "\"delivery_run_stops\".\"pickup_item_state\" is null or \"delivery_run_stops\".\"pickup_item_state\" in ('ready', 'scanned', 'missing-label', 'not-ready')"
+        },
+        "delivery_run_stops_pickup_item_resolution_shape_check": {
+          "name": "delivery_run_stops_pickup_item_resolution_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"pickup_item_state\" is null\n                and \"delivery_run_stops\".\"pickup_trace_link_id\" is null\n                and \"delivery_run_stops\".\"pickup_trace_token\" is null\n                and \"delivery_run_stops\".\"pickup_resolved_at\" is null\n                and \"delivery_run_stops\".\"pickup_resolved_by_user_id\" is null\n            ) or (\n                \"delivery_run_stops\".\"pickup_item_state\" = 'ready'\n                and \"delivery_run_stops\".\"pickup_resolved_at\" is null\n                and \"delivery_run_stops\".\"pickup_resolved_by_user_id\" is null\n            ) or (\n                \"delivery_run_stops\".\"pickup_item_state\" in ('scanned', 'missing-label', 'not-ready')\n                and \"delivery_run_stops\".\"pickup_resolved_at\" is not null\n            )"
+        },
+        "delivery_run_stops_handoff_verification_state_check": {
+          "name": "delivery_run_stops_handoff_verification_state_check",
+          "value": "\"delivery_run_stops\".\"handoff_verification_state\" is null or \"delivery_run_stops\".\"handoff_verification_state\" in ('unverified', 'scanned', 'no-label', 'missing', 'skipped')"
+        },
+        "delivery_run_stops_handoff_verification_reason_check": {
+          "name": "delivery_run_stops_handoff_verification_reason_check",
+          "value": "\"delivery_run_stops\".\"handoff_verification_reason\" is null or \"delivery_run_stops\".\"handoff_verification_reason\" in ('scanner-unavailable', 'label-unreadable', 'manual-verification', 'other-operational')"
+        },
+        "delivery_run_stops_handoff_verification_shape_check": {
+          "name": "delivery_run_stops_handoff_verification_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"handoff_verification_state\" is null\n                and \"delivery_run_stops\".\"handoff_verification_reason\" is null\n                and \"delivery_run_stops\".\"handoff_verified_at\" is null\n                and \"delivery_run_stops\".\"handoff_verified_by_user_id\" is null\n            ) or (\n                \"delivery_run_stops\".\"handoff_verification_state\" = 'unverified'\n                and \"delivery_run_stops\".\"handoff_verification_reason\" is null\n                and \"delivery_run_stops\".\"handoff_verified_at\" is null\n                and \"delivery_run_stops\".\"handoff_verified_by_user_id\" is null\n            ) or (\n                \"delivery_run_stops\".\"handoff_verification_state\" in ('scanned', 'no-label', 'missing')\n                and \"delivery_run_stops\".\"handoff_verification_reason\" is null\n                and \"delivery_run_stops\".\"handoff_verified_at\" is not null\n            ) or (\n                \"delivery_run_stops\".\"handoff_verification_state\" = 'skipped'\n                and \"delivery_run_stops\".\"handoff_verification_reason\" is not null\n                and \"delivery_run_stops\".\"handoff_verified_at\" is not null\n            )"
+        },
+        "delivery_run_stops_state_check": {
+          "name": "delivery_run_stops_state_check",
+          "value": "\"delivery_run_stops\".\"state\" in ('pending', 'arrived', 'delivered', 'deferred', 'failed', 'cancelled')"
+        },
+        "delivery_run_stops_exception_reason_check": {
+          "name": "delivery_run_stops_exception_reason_check",
+          "value": "\"delivery_run_stops\".\"exception_reason\" is null or \"delivery_run_stops\".\"exception_reason\" in ('customer-unavailable', 'address-inaccessible', 'address-wrong', 'harvest-damaged', 'harvest-missing', 'cancellation', 'operational-other')"
+        },
+        "delivery_run_stops_cancellation_pair_check": {
+          "name": "delivery_run_stops_cancellation_pair_check",
+          "value": "(\"delivery_run_stops\".\"state\" = 'cancelled') = coalesce(\"delivery_run_stops\".\"exception_reason\" = 'cancellation', false)"
+        },
+        "delivery_run_stops_outcome_shape_check": {
+          "name": "delivery_run_stops_outcome_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"state\" in ('pending', 'arrived')\n                and \"delivery_run_stops\".\"delivered_at\" is null\n                and \"delivery_run_stops\".\"exception_reason\" is null\n                and \"delivery_run_stops\".\"exception_note\" is null\n                and \"delivery_run_stops\".\"exception_occurred_at\" is null\n                and \"delivery_run_stops\".\"exception_recorded_by_user_id\" is null\n            ) or (\n                \"delivery_run_stops\".\"state\" = 'delivered'\n                and \"delivery_run_stops\".\"delivered_at\" is not null\n                and \"delivery_run_stops\".\"exception_reason\" is null\n                and \"delivery_run_stops\".\"exception_note\" is null\n                and \"delivery_run_stops\".\"exception_occurred_at\" is null\n                and \"delivery_run_stops\".\"exception_recorded_by_user_id\" is null\n            ) or (\n                \"delivery_run_stops\".\"state\" in ('deferred', 'failed')\n                and \"delivery_run_stops\".\"delivered_at\" is null\n                and \"delivery_run_stops\".\"exception_reason\" is not null\n                and \"delivery_run_stops\".\"exception_occurred_at\" is not null\n                and \"delivery_run_stops\".\"exception_recorded_by_user_id\" is not null\n            ) or (\n                \"delivery_run_stops\".\"state\" = 'cancelled'\n                and \"delivery_run_stops\".\"delivered_at\" is null\n                and \"delivery_run_stops\".\"exception_reason\" = 'cancellation'\n                and \"delivery_run_stops\".\"exception_occurred_at\" is not null\n            )"
+        },
+        "delivery_run_stops_release_shape_check": {
+          "name": "delivery_run_stops_release_shape_check",
+          "value": "\"delivery_run_stops\".\"released_at\" is null or \"delivery_run_stops\".\"state\" in ('delivered', 'failed', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_runs": {
+      "name": "delivery_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot_id": {
+          "name": "time_slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "encoded_polyline": {
+          "name": "encoded_polyline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_distance_meters": {
+          "name": "total_distance_meters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_seconds": {
+          "name": "total_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_plan_version": {
+          "name": "route_plan_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "route_revision": {
+          "name": "route_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reroute_required_at": {
+          "name": "reroute_required_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reroute_attempted_at": {
+          "name": "reroute_attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimate_source": {
+          "name": "estimate_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy'"
+        },
+        "current_latitude": {
+          "name": "current_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_longitude": {
+          "name": "current_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_accuracy": {
+          "name": "current_location_accuracy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_heading": {
+          "name": "current_location_heading",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_speed": {
+          "name": "current_location_speed",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_recorded_at": {
+          "name": "current_location_recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_received_at": {
+          "name": "current_location_received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimates_updated_at": {
+          "name": "estimates_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_runs_driver_user_id_idx": {
+          "name": "delivery_runs_driver_user_id_idx",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_time_slot_id_idx": {
+          "name": "delivery_runs_time_slot_id_idx",
+          "columns": [
+            {
+              "expression": "time_slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_state_idx": {
+          "name": "delivery_runs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_driver_active_unique": {
+          "name": "delivery_runs_driver_active_unique",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"delivery_runs\".\"state\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_location_recorded_at_idx": {
+          "name": "delivery_runs_location_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "current_location_recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_completed_at_idx": {
+          "name": "delivery_runs_completed_at_idx",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_runs_driver_user_id_users_id_fk": {
+          "name": "delivery_runs_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_runs_time_slot_id_time_slots_id_fk": {
+          "name": "delivery_runs_time_slot_id_time_slots_id_fk",
+          "tableFrom": "delivery_runs",
+          "tableTo": "time_slots",
+          "columnsFrom": [
+            "time_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_runs_route_plan_provenance_check": {
+          "name": "delivery_runs_route_plan_provenance_check",
+          "value": "(\n                \"delivery_runs\".\"route_plan_version\" = 1\n                and \"delivery_runs\".\"estimate_source\" = 'legacy'\n            ) or (\n                \"delivery_runs\".\"route_plan_version\" >= 2\n                and \"delivery_runs\".\"estimate_source\" in ('google', 'local')\n            )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pickup_locations": {
+      "name": "pickup_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street1": {
+          "name": "street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street2": {
+          "name": "street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'HR'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pickup_locations_is_active_idx": {
+          "name": "pickup_locations_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_slots": {
+      "name": "time_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "time_slots_location_id_idx": {
+          "name": "time_slots_location_id_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_type_idx": {
+          "name": "time_slots_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_start_at_idx": {
+          "name": "time_slots_start_at_idx",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_closes_at_idx": {
+          "name": "time_slots_closes_at_idx",
+          "columns": [
+            {
+              "expression": "closes_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_status_idx": {
+          "name": "time_slots_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_unique_slot_idx": {
+          "name": "time_slots_unique_slot_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_slots_location_id_pickup_locations_id_fk": {
+          "name": "time_slots_location_id_pickup_locations_id_fk",
+          "tableFrom": "time_slots",
+          "tableTo": "pickup_locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_messages": {
+      "name": "email_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'acs'"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "email_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_name": {
+          "name": "template_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounced_at": {
+          "name": "bounced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_messages_status_idx": {
+          "name": "email_messages_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_messages_created_idx": {
+          "name": "email_messages_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_messages_provider_message_idx": {
+          "name": "email_messages_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_e_type_idx": {
+          "name": "events_e_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_e_aggregate_id_idx": {
+          "name": "events_e_aggregate_id_idx",
+          "columns": [
+            {
+              "expression": "aggregate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_e_created_at_idx": {
+          "name": "events_e_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farms": {
+      "name": "farms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snow_accumulation": {
+          "name": "snow_accumulation",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "farms_f_is_deleted_idx": {
+          "name": "farms_f_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedbacks": {
+      "name": "feedbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fiscalization_pos_settings": {
+      "name": "fiscalization_pos_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos_id": {
+          "name": "pos_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "premise_id": {
+          "name": "premise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "fiscalization_pos_settings_pos_id_idx": {
+          "name": "fiscalization_pos_settings_pos_id_idx",
+          "columns": [
+            {
+              "expression": "pos_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_pos_settings_is_active_idx": {
+          "name": "fiscalization_pos_settings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_pos_settings_is_deleted_idx": {
+          "name": "fiscalization_pos_settings_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fiscalization_user_settings": {
+      "name": "fiscalization_user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pin": {
+          "name": "pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "use_vat": {
+          "name": "use_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "receipt_number_on_device": {
+          "name": "receipt_number_on_device",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'educ'"
+        },
+        "cert_base64": {
+          "name": "cert_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cert_password": {
+          "name": "cert_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "fiscalization_user_settings_is_active_idx": {
+          "name": "fiscalization_user_settings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_user_settings_is_deleted_idx": {
+          "name": "fiscalization_user_settings_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_blocks": {
+      "name": "garden_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_gb_garden_id_idx": {
+          "name": "garden_gb_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_gb_is_deleted_idx": {
+          "name": "garden_gb_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_blocks_garden_id_gardens_id_fk": {
+          "name": "garden_blocks_garden_id_gardens_id_fk",
+          "tableFrom": "garden_blocks",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_likes": {
+      "name": "garden_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "garden_likes_user_garden_uq": {
+          "name": "garden_likes_user_garden_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_likes_user_id_idx": {
+          "name": "garden_likes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_likes_garden_id_idx": {
+          "name": "garden_likes_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_likes_user_id_users_id_fk": {
+          "name": "garden_likes_user_id_users_id_fk",
+          "tableFrom": "garden_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "garden_likes_garden_id_gardens_id_fk": {
+          "name": "garden_likes_garden_id_gardens_id_fk",
+          "tableFrom": "garden_likes",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_preview_blob_deletions": {
+      "name": "garden_preview_blob_deletions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pathname": {
+          "name": "pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "garden_preview_blob_deletions_pathname_uq": {
+          "name": "garden_preview_blob_deletions_pathname_uq",
+          "columns": [
+            {
+              "expression": "pathname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_preview_blob_deletions_next_attempt_at_idx": {
+          "name": "garden_preview_blob_deletions_next_attempt_at_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_preview_blob_deletions_claim_expires_at_idx": {
+          "name": "garden_preview_blob_deletions_claim_expires_at_idx",
+          "columns": [
+            {
+              "expression": "claim_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_preview_blob_scan_states": {
+      "name": "garden_preview_blob_scan_states",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_preview_capture_leases": {
+      "name": "garden_preview_capture_leases",
+      "schema": "",
+      "columns": {
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "garden_preview_capture_leases_expires_at_idx": {
+          "name": "garden_preview_capture_leases_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_preview_capture_leases_garden_id_gardens_id_fk": {
+          "name": "garden_preview_capture_leases_garden_id_gardens_id_fk",
+          "tableFrom": "garden_preview_capture_leases",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_previews": {
+      "name": "garden_previews",
+      "schema": "",
+      "columns": {
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "capture_request_id": {
+          "name": "capture_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pathname": {
+          "name": "pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renderer_version": {
+          "name": "renderer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_requested_at": {
+          "name": "capture_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "garden_previews_capture_request_id_uq": {
+          "name": "garden_previews_capture_request_id_uq",
+          "columns": [
+            {
+              "expression": "capture_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_previews_pathname_uq": {
+          "name": "garden_previews_pathname_uq",
+          "columns": [
+            {
+              "expression": "pathname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_previews_captured_at_idx": {
+          "name": "garden_previews_captured_at_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_previews_garden_id_gardens_id_fk": {
+          "name": "garden_previews_garden_id_gardens_id_fk",
+          "tableFrom": "garden_previews",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_stacks": {
+      "name": "garden_stacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_x": {
+          "name": "position_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_y": {
+          "name": "position_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocks": {
+          "name": "blocks",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_gs_garden_id_idx": {
+          "name": "garden_gs_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_gs_is_deleted_idx": {
+          "name": "garden_gs_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_stacks_garden_id_gardens_id_fk": {
+          "name": "garden_stacks_garden_id_gardens_id_fk",
+          "tableFrom": "garden_stacks",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_visit_states": {
+      "name": "garden_visit_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_summary_seen_at": {
+          "name": "last_summary_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_summary_facts_hash": {
+          "name": "last_summary_facts_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "garden_visit_states_user_account_garden_unique": {
+          "name": "garden_visit_states_user_account_garden_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_visit_states_account_garden_idx": {
+          "name": "garden_visit_states_account_garden_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_visit_states_garden_id_idx": {
+          "name": "garden_visit_states_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_visit_states_user_id_users_id_fk": {
+          "name": "garden_visit_states_user_id_users_id_fk",
+          "tableFrom": "garden_visit_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "garden_visit_states_account_id_accounts_id_fk": {
+          "name": "garden_visit_states_account_id_accounts_id_fk",
+          "tableFrom": "garden_visit_states",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "garden_visit_states_garden_id_gardens_id_fk": {
+          "name": "garden_visit_states_garden_id_gardens_id_fk",
+          "tableFrom": "garden_visit_states",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gardens": {
+      "name": "gardens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background_palette": {
+          "name": "background_palette",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'current'"
+        },
+        "home_camera": {
+          "name": "home_camera",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_sandbox": {
+          "name": "is_sandbox",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_g_account_id_idx": {
+          "name": "garden_g_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_farm_id_idx": {
+          "name": "garden_g_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_is_deleted_idx": {
+          "name": "garden_g_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_is_public_idx": {
+          "name": "garden_g_is_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_is_sandbox_idx": {
+          "name": "garden_g_is_sandbox_idx",
+          "columns": [
+            {
+              "expression": "is_sandbox",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gardens_account_id_accounts_id_fk": {
+          "name": "gardens_account_id_accounts_id_fk",
+          "tableFrom": "gardens",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gardens_farm_id_farms_id_fk": {
+          "name": "gardens_farm_id_farms_id_fk",
+          "tableFrom": "gardens",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_bed_fields": {
+      "name": "raised_bed_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_bed_fields_raised_bed_id_idx": {
+          "name": "raised_bed_fields_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_bed_fields_is_deleted_idx": {
+          "name": "raised_bed_fields_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_bed_fields_raised_bed_id_raised_beds_id_fk": {
+          "name": "raised_bed_fields_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "raised_bed_fields",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_bed_sensors": {
+      "name": "raised_bed_sensors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "sensor_signalco_id": {
+          "name": "sensor_signalco_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_bed_sensors_raised_bed_id_idx": {
+          "name": "raised_bed_sensors_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_bed_sensors_is_deleted_idx": {
+          "name": "raised_bed_sensors_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_bed_sensors_raised_bed_id_raised_beds_id_fk": {
+          "name": "raised_bed_sensors_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "raised_bed_sensors",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_beds": {
+      "name": "raised_beds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orientation": {
+          "name": "orientation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vertical'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "physical_id": {
+          "name": "physical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_beds_account_id_idx": {
+          "name": "raised_beds_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_garden_id_idx": {
+          "name": "raised_beds_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_block_id_idx": {
+          "name": "raised_beds_block_id_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_is_deleted_idx": {
+          "name": "raised_beds_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_beds_account_id_accounts_id_fk": {
+          "name": "raised_beds_account_id_accounts_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "raised_beds_garden_id_gardens_id_fk": {
+          "name": "raised_beds_garden_id_gardens_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "raised_beds_block_id_garden_blocks_id_fk": {
+          "name": "raised_beds_block_id_garden_blocks_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "garden_blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harvest_trace_links": {
+      "name": "harvest_trace_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_token": {
+          "name": "public_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raised_bed_field_id": {
+          "name": "raised_bed_field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_position_index": {
+          "name": "field_position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_label": {
+          "name": "field_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plant_place_event_id": {
+          "name": "plant_place_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plant_sort_id": {
+          "name": "plant_sort_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harvest_operation_id": {
+          "name": "harvest_operation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_path": {
+          "name": "trace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "printed_at": {
+          "name": "printed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harvest_trace_links_public_token_unique": {
+          "name": "harvest_trace_links_public_token_unique",
+          "columns": [
+            {
+              "expression": "public_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_target_unique": {
+          "name": "harvest_trace_links_target_unique",
+          "columns": [
+            {
+              "expression": "harvest_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raised_bed_field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plant_place_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_status_idx": {
+          "name": "harvest_trace_links_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_target_idx": {
+          "name": "harvest_trace_links_target_idx",
+          "columns": [
+            {
+              "expression": "harvest_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raised_bed_field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plant_place_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_raised_bed_idx": {
+          "name": "harvest_trace_links_raised_bed_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_plant_sort_idx": {
+          "name": "harvest_trace_links_plant_sort_idx",
+          "columns": [
+            {
+              "expression": "plant_sort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_created_at_idx": {
+          "name": "harvest_trace_links_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harvest_trace_links_account_id_accounts_id_fk": {
+          "name": "harvest_trace_links_account_id_accounts_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_garden_id_gardens_id_fk": {
+          "name": "harvest_trace_links_garden_id_gardens_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_raised_bed_id_raised_beds_id_fk": {
+          "name": "harvest_trace_links_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_raised_bed_field_id_raised_bed_fields_id_fk": {
+          "name": "harvest_trace_links_raised_bed_field_id_raised_bed_fields_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "raised_bed_fields",
+          "columnsFrom": [
+            "raised_bed_field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_plant_place_event_id_events_id_fk": {
+          "name": "harvest_trace_links_plant_place_event_id_events_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "events",
+          "columnsFrom": [
+            "plant_place_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_plant_sort_id_entities_id_fk": {
+          "name": "harvest_trace_links_plant_sort_id_entities_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "plant_sort_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_harvest_operation_id_operations_id_fk": {
+          "name": "harvest_trace_links_harvest_operation_id_operations_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "operations",
+          "columnsFrom": [
+            "harvest_operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harvest_trace_scans": {
+      "name": "harvest_trace_scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "harvest_trace_link_id": {
+          "name": "harvest_trace_link_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_agent_family": {
+          "name": "user_agent_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harvest_trace_scans_link_id_idx": {
+          "name": "harvest_trace_scans_link_id_idx",
+          "columns": [
+            {
+              "expression": "harvest_trace_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_scans_scanned_at_idx": {
+          "name": "harvest_trace_scans_scanned_at_idx",
+          "columns": [
+            {
+              "expression": "scanned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harvest_trace_scans_harvest_trace_link_id_harvest_trace_links_id_fk": {
+          "name": "harvest_trace_scans_harvest_trace_link_id_harvest_trace_links_id_fk",
+          "tableFrom": "harvest_trace_scans",
+          "tableTo": "harvest_trace_links",
+          "columnsFrom": [
+            "harvest_trace_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_configs": {
+      "name": "inventory_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_tracking_type": {
+          "name": "default_tracking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pieces'"
+        },
+        "status_attribute_name": {
+          "name": "status_attribute_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "empty_status_value": {
+          "name": "empty_status_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_attribute_name": {
+          "name": "amount_attribute_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "low_count_threshold": {
+          "name": "low_count_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_configs_entity_type_name_idx": {
+          "name": "inv_configs_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_configs_is_deleted_idx": {
+          "name": "inv_configs_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_item_events": {
+      "name": "inventory_item_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_item_id": {
+          "name": "inventory_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_quantity": {
+          "name": "previous_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_quantity": {
+          "name": "new_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_state": {
+          "name": "new_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_item_events_inventory_item_id_idx": {
+          "name": "inv_item_events_inventory_item_id_idx",
+          "columns": [
+            {
+              "expression": "inventory_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_item_events_is_deleted_idx": {
+          "name": "inv_item_events_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_item_events_inventory_item_id_inventory_items_id_fk": {
+          "name": "inventory_item_events_inventory_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_item_events",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "inventory_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_item_field_definitions": {
+      "name": "inventory_item_field_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_config_id": {
+          "name": "inventory_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_field_defs_inventory_config_id_idx": {
+          "name": "inv_field_defs_inventory_config_id_idx",
+          "columns": [
+            {
+              "expression": "inventory_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_field_defs_is_deleted_idx": {
+          "name": "inv_field_defs_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_item_field_definitions_inventory_config_id_inventory_configs_id_fk": {
+          "name": "inventory_item_field_definitions_inventory_config_id_inventory_configs_id_fk",
+          "tableFrom": "inventory_item_field_definitions",
+          "tableTo": "inventory_configs",
+          "columnsFrom": [
+            "inventory_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_items": {
+      "name": "inventory_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_config_id": {
+          "name": "inventory_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_type": {
+          "name": "tracking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pieces'"
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "low_count_threshold": {
+          "name": "low_count_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_fields": {
+          "name": "additional_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_items_inventory_config_id_idx": {
+          "name": "inv_items_inventory_config_id_idx",
+          "columns": [
+            {
+              "expression": "inventory_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_items_entity_id_idx": {
+          "name": "inv_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_items_is_deleted_idx": {
+          "name": "inv_items_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_items_tracking_type_idx": {
+          "name": "inv_items_tracking_type_idx",
+          "columns": [
+            {
+              "expression": "tracking_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_items_inventory_config_id_inventory_configs_id_fk": {
+          "name": "inventory_items_inventory_config_id_inventory_configs_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "inventory_configs",
+          "columnsFrom": [
+            "inventory_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_items_entity_id_entities_id_fk": {
+          "name": "inventory_items_entity_id_entities_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.00'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_id_idx": {
+          "name": "invoice_items_invoice_id_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_entity_id_idx": {
+          "name": "invoice_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_entity_type_idx": {
+          "name": "invoice_items_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_date": {
+          "name": "paid_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_name": {
+          "name": "bill_to_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_email": {
+          "name": "bill_to_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bill_to_address": {
+          "name": "bill_to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_city": {
+          "name": "bill_to_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_state": {
+          "name": "bill_to_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_zip": {
+          "name": "bill_to_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_country": {
+          "name": "bill_to_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_invoice_number_idx": {
+          "name": "invoices_invoice_number_idx",
+          "columns": [
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_account_id_idx": {
+          "name": "invoices_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_transaction_id_idx": {
+          "name": "invoices_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_status_idx": {
+          "name": "invoices_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_issue_date_idx": {
+          "name": "invoices_issue_date_idx",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_due_date_idx": {
+          "name": "invoices_due_date_idx",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_is_deleted_idx": {
+          "name": "invoices_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_account_id_accounts_id_fk": {
+          "name": "invoices_account_id_accounts_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_transaction_id_transactions_id_fk": {
+          "name": "invoices_transaction_id_transactions_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_invoice_number_unique": {
+          "name": "invoices_invoice_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receipts": {
+      "name": "receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_number": {
+          "name": "receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_receipt_number": {
+          "name": "year_receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_reference": {
+          "name": "payment_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jir": {
+          "name": "jir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zki": {
+          "name": "zki",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_status": {
+          "name": "cis_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "cis_reference": {
+          "name": "cis_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_error_message": {
+          "name": "cis_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_timestamp": {
+          "name": "cis_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_response": {
+          "name": "cis_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "business_pin": {
+          "name": "business_pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_name": {
+          "name": "business_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_address": {
+          "name": "business_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_pin": {
+          "name": "customer_pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_address": {
+          "name": "customer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "receipts_invoice_id_idx": {
+          "name": "receipts_invoice_id_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_receipt_number_idx": {
+          "name": "receipts_receipt_number_idx",
+          "columns": [
+            {
+              "expression": "receipt_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_jir_idx": {
+          "name": "receipts_jir_idx",
+          "columns": [
+            {
+              "expression": "jir",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_zki_idx": {
+          "name": "receipts_zki_idx",
+          "columns": [
+            {
+              "expression": "zki",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_cis_status_idx": {
+          "name": "receipts_cis_status_idx",
+          "columns": [
+            {
+              "expression": "cis_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_issued_at_idx": {
+          "name": "receipts_issued_at_idx",
+          "columns": [
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_business_pin_idx": {
+          "name": "receipts_business_pin_idx",
+          "columns": [
+            {
+              "expression": "business_pin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_is_deleted_idx": {
+          "name": "receipts_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "receipts_invoice_id_invoices_id_fk": {
+          "name": "receipts_invoice_id_invoices_id_fk",
+          "tableFrom": "receipts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "receipts_year_receipt_number_unique": {
+          "name": "receipts_year_receipt_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "year_receipt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "newsletter_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscribed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_subscribers_email_idx": {
+          "name": "newsletter_subscribers_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_subscribers_status_idx": {
+          "name": "newsletter_subscribers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_type": {
+          "name": "integration_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'true'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_campaigns": {
+      "name": "notification_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_campaign_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_policy": {
+          "name": "channel_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_label": {
+          "name": "action_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_image_url": {
+          "name": "safe_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_link_url": {
+          "name": "safe_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_action_url": {
+          "name": "safe_action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_channel": {
+          "name": "primary_channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_app'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "notification_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "collapse_key": {
+          "name": "collapse_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "delivery_metadata": {
+          "name": "delivery_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "failures": {
+          "name": "failures",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "target_count": {
+          "name": "target_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "queued_count": {
+          "name": "queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_count": {
+          "name": "sent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "suppressed_count": {
+          "name": "suppressed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enqueued_at": {
+          "name": "enqueued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_from_account_id": {
+          "name": "created_from_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_user_id": {
+          "name": "cancelled_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_campaigns_status_idx": {
+          "name": "notification_campaigns_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_scheduled_at_idx": {
+          "name": "notification_campaigns_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_created_by_user_id_idx": {
+          "name": "notification_campaigns_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_category_idx": {
+          "name": "notification_campaigns_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_event_type_idx": {
+          "name": "notification_campaigns_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_campaigns_created_by_user_id_users_id_fk": {
+          "name": "notification_campaigns_created_by_user_id_users_id_fk",
+          "tableFrom": "notification_campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "notification_campaigns_created_from_account_id_accounts_id_fk": {
+          "name": "notification_campaigns_created_from_account_id_accounts_id_fk",
+          "tableFrom": "notification_campaigns",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "created_from_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_campaigns_cancelled_by_user_id_users_id_fk": {
+          "name": "notification_campaigns_cancelled_by_user_id_users_id_fk",
+          "tableFrom": "notification_campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "cancelled_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery_attempts": {
+      "name": "notification_delivery_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_response_code": {
+          "name": "provider_response_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_response_body": {
+          "name": "provider_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bulk_id": {
+          "name": "bulk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_subscription_id": {
+          "name": "push_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_attempts_notification_id_idx": {
+          "name": "notification_delivery_attempts_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_delivery_attempts_status_idx": {
+          "name": "notification_delivery_attempts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_attempts_notification_id_notifications_id_fk": {
+          "name": "notification_delivery_attempts_notification_id_notifications_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_attempts_user_id_users_id_fk": {
+          "name": "notification_delivery_attempts_user_id_users_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_attempts_account_id_accounts_id_fk": {
+          "name": "notification_delivery_attempts_account_id_accounts_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_attempts_push_subscription_id_web_push_subscriptions_id_fk": {
+          "name": "notification_delivery_attempts_push_subscription_id_web_push_subscriptions_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "web_push_subscriptions",
+          "columnsFrom": [
+            "push_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery_events": {
+      "name": "notification_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "delivery_attempt_id": {
+          "name": "delivery_attempt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_delivery_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_events_attempt_id_idx": {
+          "name": "notification_delivery_events_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "delivery_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_events_delivery_attempt_id_notification_delivery_attempts_id_fk": {
+          "name": "notification_delivery_events_delivery_attempt_id_notification_delivery_attempts_id_fk",
+          "tableFrom": "notification_delivery_events",
+          "tableTo": "notification_delivery_attempts",
+          "columnsFrom": [
+            "delivery_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_events_notification_id_notifications_id_fk": {
+          "name": "notification_delivery_events_notification_id_notifications_id_fk",
+          "tableFrom": "notification_delivery_events",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_email_log": {
+      "name": "notification_email_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailed_at": {
+          "name": "emailed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_email_log_user_id_users_id_fk": {
+          "name": "notification_email_log_user_id_users_id_fk",
+          "tableFrom": "notification_email_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_email_log_notification_id_notifications_id_fk": {
+          "name": "notification_email_log_notification_id_notifications_id_fk",
+          "tableFrom": "notification_email_log",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_user_channel_preferences": {
+      "name": "notification_user_channel_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "notification_preference_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "quiet_hours_start_minute": {
+          "name": "quiet_hours_start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end_minute": {
+          "name": "quiet_hours_end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_window_start_minute": {
+          "name": "delivery_window_start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_window_end_minute": {
+          "name": "delivery_window_end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_frequency": {
+          "name": "digest_frequency",
+          "type": "notification_digest_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_channel_preferences_global_unique_idx": {
+          "name": "notification_user_channel_preferences_global_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification_user_channel_preferences\".\"scope\" = 'global'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_channel_preferences_account_unique_idx": {
+          "name": "notification_user_channel_preferences_account_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification_user_channel_preferences\".\"scope\" = 'account'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_channel_preferences_user_id_users_id_fk": {
+          "name": "notification_user_channel_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_user_channel_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_user_channel_preferences_account_id_accounts_id_fk": {
+          "name": "notification_user_channel_preferences_account_id_accounts_id_fk",
+          "tableFrom": "notification_user_channel_preferences",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_user_channel_preferences_scope_account_id_check": {
+          "name": "notification_user_channel_preferences_scope_account_id_check",
+          "value": "(scope = 'global' and account_id is null) or (scope = 'account' and account_id is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "primary_channel": {
+          "name": "primary_channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_app'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "notification_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bulk_id": {
+          "name": "bulk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collapse_key": {
+          "name": "collapse_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_label": {
+          "name": "action_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_image_url": {
+          "name": "safe_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_link_url": {
+          "name": "safe_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_where": {
+          "name": "read_where",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_account_id_idx": {
+          "name": "notifications_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_readAt_idx": {
+          "name": "notifications_readAt_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_category_idx": {
+          "name": "notifications_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_campaign_id_idx": {
+          "name": "notifications_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_account_id_accounts_id_fk": {
+          "name": "notifications_account_id_accounts_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_garden_id_gardens_id_fk": {
+          "name": "notifications_garden_id_gardens_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_raised_bed_id_raised_beds_id_fk": {
+          "name": "notifications_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_block_id_garden_blocks_id_fk": {
+          "name": "notifications_block_id_garden_blocks_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "garden_blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_digest": {
+          "name": "daily_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.web_push_subscriptions": {
+      "name": "web_push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_label": {
+          "name": "device_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_name": {
+          "name": "browser_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_version": {
+          "name": "browser_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission_state": {
+          "name": "permission_state",
+          "type": "push_permission_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "fail_count": {
+          "name": "fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_at": {
+          "name": "last_failure_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_code": {
+          "name": "last_failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "web_push_subscriptions_endpoint_unique_idx": {
+          "name": "web_push_subscriptions_endpoint_unique_idx",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "web_push_subscriptions_user_id_idx": {
+          "name": "web_push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "web_push_subscriptions_account_id_idx": {
+          "name": "web_push_subscriptions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "web_push_subscriptions_device_id_idx": {
+          "name": "web_push_subscriptions_device_id_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "web_push_subscriptions_account_id_accounts_id_fk": {
+          "name": "web_push_subscriptions_account_id_accounts_id_fk",
+          "tableFrom": "web_push_subscriptions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "web_push_subscriptions_user_id_users_id_fk": {
+          "name": "web_push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "web_push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operations": {
+      "name": "operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_field_id": {
+          "name": "raised_bed_field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_accepted": {
+          "name": "is_accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "operations_entity_id_idx": {
+          "name": "operations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_entity_type_name_idx": {
+          "name": "operations_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_account_id_idx": {
+          "name": "operations_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_farm_id_idx": {
+          "name": "operations_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_garden_id_idx": {
+          "name": "operations_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_raised_bed_id_idx": {
+          "name": "operations_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_raised_bed_field_id_idx": {
+          "name": "operations_raised_bed_field_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_timestamp_idx": {
+          "name": "operations_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_is_deleted_idx": {
+          "name": "operations_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_is_accepted_idx": {
+          "name": "operations_is_accepted_idx",
+          "columns": [
+            {
+              "expression": "is_accepted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outlet_offer_reservations": {
+      "name": "outlet_offer_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "outlet_offer_id": {
+          "name": "outlet_offer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cart_id": {
+          "name": "cart_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cart_item_id": {
+          "name": "cart_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_expires_at": {
+          "name": "hold_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'held'"
+        },
+        "held_outlet_price_cents": {
+          "name": "held_outlet_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_compare_price_cents": {
+          "name": "held_compare_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "held_sowing_date": {
+          "name": "held_sowing_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_initial_plant_status": {
+          "name": "held_initial_plant_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sprouted'"
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "converted_at": {
+          "name": "converted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "outlet_reservations_offer_id_idx": {
+          "name": "outlet_reservations_offer_id_idx",
+          "columns": [
+            {
+              "expression": "outlet_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_account_id_idx": {
+          "name": "outlet_reservations_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_cart_id_idx": {
+          "name": "outlet_reservations_cart_id_idx",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_cart_item_id_idx": {
+          "name": "outlet_reservations_cart_item_id_idx",
+          "columns": [
+            {
+              "expression": "cart_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_status_idx": {
+          "name": "outlet_reservations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_hold_expires_at_idx": {
+          "name": "outlet_reservations_hold_expires_at_idx",
+          "columns": [
+            {
+              "expression": "hold_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outlet_offer_reservations_outlet_offer_id_outlet_offers_id_fk": {
+          "name": "outlet_offer_reservations_outlet_offer_id_outlet_offers_id_fk",
+          "tableFrom": "outlet_offer_reservations",
+          "tableTo": "outlet_offers",
+          "columnsFrom": [
+            "outlet_offer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "outlet_offer_reservations_account_id_accounts_id_fk": {
+          "name": "outlet_offer_reservations_account_id_accounts_id_fk",
+          "tableFrom": "outlet_offer_reservations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "outlet_offer_reservations_cart_id_shopping_carts_id_fk": {
+          "name": "outlet_offer_reservations_cart_id_shopping_carts_id_fk",
+          "tableFrom": "outlet_offer_reservations",
+          "tableTo": "shopping_carts",
+          "columnsFrom": [
+            "cart_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "outlet_offer_reservations_cart_item_id_shopping_cart_items_id_fk": {
+          "name": "outlet_offer_reservations_cart_item_id_shopping_cart_items_id_fk",
+          "tableFrom": "outlet_offer_reservations",
+          "tableTo": "shopping_cart_items",
+          "columnsFrom": [
+            "cart_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outlet_offers": {
+      "name": "outlet_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plant_sort_id": {
+          "name": "plant_sort_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sowing_date": {
+          "name": "sowing_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_plant_status": {
+          "name": "initial_plant_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sprouted'"
+        },
+        "image_urls": {
+          "name": "image_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "outlet_price_cents": {
+          "name": "outlet_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compare_price_cents": {
+          "name": "compare_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "admin_notes": {
+          "name": "admin_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "outlet_offers_plant_sort_id_idx": {
+          "name": "outlet_offers_plant_sort_id_idx",
+          "columns": [
+            {
+              "expression": "plant_sort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_offers_status_idx": {
+          "name": "outlet_offers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_offers_start_at_idx": {
+          "name": "outlet_offers_start_at_idx",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_offers_end_at_idx": {
+          "name": "outlet_offers_end_at_idx",
+          "columns": [
+            {
+              "expression": "end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_offers_is_deleted_idx": {
+          "name": "outlet_offers_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outlet_offers_plant_sort_id_entities_id_fk": {
+          "name": "outlet_offers_plant_sort_id_entities_id_fk",
+          "tableFrom": "outlet_offers",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "plant_sort_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farmer_payout_request_adjustments": {
+      "name": "farmer_payout_request_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payout_request_id": {
+          "name": "payout_request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "farmer_payout_adjustments_request_id_idx": {
+          "name": "farmer_payout_adjustments_request_id_idx",
+          "columns": [
+            {
+              "expression": "payout_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farmer_payout_request_adjustments_payout_request_id_farmer_payout_requests_id_fk": {
+          "name": "farmer_payout_request_adjustments_payout_request_id_farmer_payout_requests_id_fk",
+          "tableFrom": "farmer_payout_request_adjustments",
+          "tableTo": "farmer_payout_requests",
+          "columnsFrom": [
+            "payout_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_request_adjustments_created_by_user_id_users_id_fk": {
+          "name": "farmer_payout_request_adjustments_created_by_user_id_users_id_fk",
+          "tableFrom": "farmer_payout_request_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farmer_payout_request_items": {
+      "name": "farmer_payout_request_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payout_request_id": {
+          "name": "payout_request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_count": {
+          "name": "operation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration_minutes": {
+          "name": "total_duration_minutes",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_per_unit": {
+          "name": "price_per_unit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "farmer_payout_items_request_id_idx": {
+          "name": "farmer_payout_items_request_id_idx",
+          "columns": [
+            {
+              "expression": "payout_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farmer_payout_request_items_payout_request_id_farmer_payout_requests_id_fk": {
+          "name": "farmer_payout_request_items_payout_request_id_farmer_payout_requests_id_fk",
+          "tableFrom": "farmer_payout_request_items",
+          "tableTo": "farmer_payout_requests",
+          "columnsFrom": [
+            "payout_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farmer_payout_requests": {
+      "name": "farmer_payout_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_amount": {
+          "name": "requested_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "farmer_note": {
+          "name": "farmer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_reference": {
+          "name": "bank_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_id": {
+          "name": "receipt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "farmer_payout_requests_farm_id_idx": {
+          "name": "farmer_payout_requests_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farmer_payout_requests_user_id_idx": {
+          "name": "farmer_payout_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farmer_payout_requests_status_idx": {
+          "name": "farmer_payout_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farmer_payout_requests_farm_id_farms_id_fk": {
+          "name": "farmer_payout_requests_farm_id_farms_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_requests_user_id_users_id_fk": {
+          "name": "farmer_payout_requests_user_id_users_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_requests_receipt_id_receipts_id_fk": {
+          "name": "farmer_payout_requests_receipt_id_receipts_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "receipts",
+          "columnsFrom": [
+            "receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_requests_approved_by_user_id_users_id_fk": {
+          "name": "farmer_payout_requests_approved_by_user_id_users_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operation_prices": {
+      "name": "operation_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_per_unit": {
+          "name": "price_per_unit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "operation_prices_farm_type_null_unique": {
+          "name": "operation_prices_farm_type_null_unique",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"operation_prices\".\"entity_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operation_prices_farm_type_entity_unique": {
+          "name": "operation_prices_farm_type_entity_unique",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"operation_prices\".\"entity_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operation_prices_farm_id_idx": {
+          "name": "operation_prices_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operation_prices_farm_id_farms_id_fk": {
+          "name": "operation_prices_farm_id_farms_id_fk",
+          "tableFrom": "operation_prices",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_id_idx": {
+          "name": "refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_at_idx": {
+          "name": "refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_token_hash_idx": {
+          "name": "refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopping_cart_items": {
+      "name": "shopping_cart_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cart_id": {
+          "name": "cart_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": null
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        }
+      },
+      "indexes": {
+        "shopping_cart_items_cart_id_idx": {
+          "name": "shopping_cart_items_cart_id_idx",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_entity_id_idx": {
+          "name": "shopping_cart_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_garden_id_idx": {
+          "name": "shopping_cart_items_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_raised_bed_id_idx": {
+          "name": "shopping_cart_items_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_is_deleted_idx": {
+          "name": "shopping_cart_items_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_status_idx": {
+          "name": "shopping_cart_items_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopping_cart_items_cart_id_shopping_carts_id_fk": {
+          "name": "shopping_cart_items_cart_id_shopping_carts_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "shopping_carts",
+          "columnsFrom": [
+            "cart_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shopping_cart_items_garden_id_gardens_id_fk": {
+          "name": "shopping_cart_items_garden_id_gardens_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shopping_cart_items_raised_bed_id_raised_beds_id_fk": {
+          "name": "shopping_cart_items_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopping_carts": {
+      "name": "shopping_carts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        }
+      },
+      "indexes": {
+        "shopping_carts_account_id_idx": {
+          "name": "shopping_carts_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_carts_is_deleted_idx": {
+          "name": "shopping_carts_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_carts_status_idx": {
+          "name": "shopping_carts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopping_carts_account_id_accounts_id_fk": {
+          "name": "shopping_carts_account_id_accounts_id_fk",
+          "tableFrom": "shopping_carts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_accounts": {
+      "name": "social_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "social_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_key": {
+          "name": "provider_account_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "social_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "default_destination": {
+          "name": "default_destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_destinations": {
+          "name": "allowed_destinations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_reference": {
+          "name": "credential_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_accounts_provider_account_key_idx": {
+          "name": "social_accounts_provider_account_key_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_accounts_provider_idx": {
+          "name": "social_accounts_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_accounts_status_idx": {
+          "name": "social_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_posts": {
+      "name": "social_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "social_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_key": {
+          "name": "provider_account_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "social_post_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "post_type": {
+          "name": "post_type",
+          "type": "social_post_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_urls": {
+          "name": "media_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_submission_id": {
+          "name": "provider_submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_permalink": {
+          "name": "provider_permalink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_metadata": {
+          "name": "failure_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_posts_provider_idx": {
+          "name": "social_posts_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_status_idx": {
+          "name": "social_posts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_scheduled_at_idx": {
+          "name": "social_posts_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_queued_at_idx": {
+          "name": "social_posts_queued_at_idx",
+          "columns": [
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_created_at_idx": {
+          "name": "social_posts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_provider_destination_idx": {
+          "name": "social_posts_provider_destination_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sunflower_ledger_entries": {
+      "name": "sunflower_ledger_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_delta": {
+          "name": "available_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reserved_delta": {
+          "name": "reserved_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_balance_after": {
+          "name": "available_balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reserved_balance_after": {
+          "name": "reserved_balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_balance_after": {
+          "name": "total_balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_eur": {
+          "name": "amount_eur",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sunflower'"
+        },
+        "package_code": {
+          "name": "package_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_entity_id": {
+          "name": "package_entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_id": {
+          "name": "receipt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reservation_key": {
+          "name": "reservation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sunflower_ledger_account_id_idx": {
+          "name": "sunflower_ledger_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_entry_type_idx": {
+          "name": "sunflower_ledger_entry_type_idx",
+          "columns": [
+            {
+              "expression": "entry_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_package_code_idx": {
+          "name": "sunflower_ledger_package_code_idx",
+          "columns": [
+            {
+              "expression": "package_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_package_entity_id_idx": {
+          "name": "sunflower_ledger_package_entity_id_idx",
+          "columns": [
+            {
+              "expression": "package_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_operation_id_idx": {
+          "name": "sunflower_ledger_operation_id_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_transaction_id_idx": {
+          "name": "sunflower_ledger_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_invoice_id_idx": {
+          "name": "sunflower_ledger_invoice_id_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_receipt_id_idx": {
+          "name": "sunflower_ledger_receipt_id_idx",
+          "columns": [
+            {
+              "expression": "receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_reservation_key_idx": {
+          "name": "sunflower_ledger_reservation_key_idx",
+          "columns": [
+            {
+              "expression": "reservation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_source_idx": {
+          "name": "sunflower_ledger_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_created_at_idx": {
+          "name": "sunflower_ledger_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_is_deleted_idx": {
+          "name": "sunflower_ledger_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_account_idempotency_unique": {
+          "name": "sunflower_ledger_account_idempotency_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sunflower_ledger_entries_account_id_accounts_id_fk": {
+          "name": "sunflower_ledger_entries_account_id_accounts_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_package_entity_id_entities_id_fk": {
+          "name": "sunflower_ledger_entries_package_entity_id_entities_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "package_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_operation_id_operations_id_fk": {
+          "name": "sunflower_ledger_entries_operation_id_operations_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "operations",
+          "columnsFrom": [
+            "operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_transaction_id_transactions_id_fk": {
+          "name": "sunflower_ledger_entries_transaction_id_transactions_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_invoice_id_invoices_id_fk": {
+          "name": "sunflower_ledger_entries_invoice_id_invoices_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_receipt_id_receipts_id_fk": {
+          "name": "sunflower_ledger_entries_receipt_id_receipts_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "receipts",
+          "columnsFrom": [
+            "receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_answers": {
+      "name": "survey_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_key": {
+          "name": "question_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "survey_question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "numeric_value": {
+          "name": "numeric_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_value": {
+          "name": "text_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_value": {
+          "name": "contact_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_answers_response_question_unique": {
+          "name": "survey_answers_response_question_unique",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answers_response_idx": {
+          "name": "survey_answers_response_idx",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answers_question_idx": {
+          "name": "survey_answers_question_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answers_question_key_idx": {
+          "name": "survey_answers_question_key_idx",
+          "columns": [
+            {
+              "expression": "question_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_answers_response_id_survey_responses_id_fk": {
+          "name": "survey_answers_response_id_survey_responses_id_fk",
+          "tableFrom": "survey_answers",
+          "tableTo": "survey_responses",
+          "columnsFrom": [
+            "response_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "survey_answers_question_id_survey_questions_id_fk": {
+          "name": "survey_answers_question_id_survey_questions_id_fk",
+          "tableFrom": "survey_answers",
+          "tableTo": "survey_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_assignments": {
+      "name": "survey_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "send_id": {
+          "name": "send_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_assignments_version_target_context_unique": {
+          "name": "survey_assignments_version_target_context_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_survey_idx": {
+          "name": "survey_assignments_survey_idx",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_version_idx": {
+          "name": "survey_assignments_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_account_idx": {
+          "name": "survey_assignments_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_user_idx": {
+          "name": "survey_assignments_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_status_idx": {
+          "name": "survey_assignments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_send_idx": {
+          "name": "survey_assignments_send_idx",
+          "columns": [
+            {
+              "expression": "send_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_assignments_survey_id_surveys_id_fk": {
+          "name": "survey_assignments_survey_id_surveys_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_assignments_version_id_survey_versions_id_fk": {
+          "name": "survey_assignments_version_id_survey_versions_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "survey_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_assignments_send_id_survey_sends_id_fk": {
+          "name": "survey_assignments_send_id_survey_sends_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "survey_sends",
+          "columnsFrom": [
+            "send_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_assignments_account_id_accounts_id_fk": {
+          "name": "survey_assignments_account_id_accounts_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_assignments_user_id_users_id_fk": {
+          "name": "survey_assignments_user_id_users_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_questions": {
+      "name": "survey_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "survey_question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_metadata": {
+          "name": "score_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_questions_version_key_unique": {
+          "name": "survey_questions_version_key_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_questions_version_order_unique": {
+          "name": "survey_questions_version_order_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_questions_version_idx": {
+          "name": "survey_questions_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_questions_version_id_survey_versions_id_fk": {
+          "name": "survey_questions_version_id_survey_versions_id_fk",
+          "tableFrom": "survey_questions",
+          "tableTo": "survey_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_responses": {
+      "name": "survey_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "survey_response_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_app'"
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "imported_external_id": {
+          "name": "imported_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_responses_assignment_unique": {
+          "name": "survey_responses_assignment_unique",
+          "columns": [
+            {
+              "expression": "assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_imported_external_unique": {
+          "name": "survey_responses_imported_external_unique",
+          "columns": [
+            {
+              "expression": "imported_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_survey_idx": {
+          "name": "survey_responses_survey_idx",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_version_idx": {
+          "name": "survey_responses_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_account_idx": {
+          "name": "survey_responses_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_user_idx": {
+          "name": "survey_responses_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_source_idx": {
+          "name": "survey_responses_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_submitted_at_idx": {
+          "name": "survey_responses_submitted_at_idx",
+          "columns": [
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_responses_assignment_id_survey_assignments_id_fk": {
+          "name": "survey_responses_assignment_id_survey_assignments_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "survey_assignments",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_responses_survey_id_surveys_id_fk": {
+          "name": "survey_responses_survey_id_surveys_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_responses_version_id_survey_versions_id_fk": {
+          "name": "survey_responses_version_id_survey_versions_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "survey_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_responses_account_id_accounts_id_fk": {
+          "name": "survey_responses_account_id_accounts_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_responses_user_id_users_id_fk": {
+          "name": "survey_responses_user_id_users_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_send_deliveries": {
+      "name": "survey_send_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "send_id": {
+          "name": "send_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "survey_send_delivery_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_send_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_send_deliveries_send_idx": {
+          "name": "survey_send_deliveries_send_idx",
+          "columns": [
+            {
+              "expression": "send_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_send_deliveries_assignment_idx": {
+          "name": "survey_send_deliveries_assignment_idx",
+          "columns": [
+            {
+              "expression": "assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_send_deliveries_status_idx": {
+          "name": "survey_send_deliveries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_send_deliveries_notification_idx": {
+          "name": "survey_send_deliveries_notification_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_send_deliveries_send_id_survey_sends_id_fk": {
+          "name": "survey_send_deliveries_send_id_survey_sends_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "survey_sends",
+          "columnsFrom": [
+            "send_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "survey_send_deliveries_assignment_id_survey_assignments_id_fk": {
+          "name": "survey_send_deliveries_assignment_id_survey_assignments_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "survey_assignments",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_send_deliveries_account_id_accounts_id_fk": {
+          "name": "survey_send_deliveries_account_id_accounts_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_send_deliveries_user_id_users_id_fk": {
+          "name": "survey_send_deliveries_user_id_users_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_send_deliveries_notification_id_notifications_id_fk": {
+          "name": "survey_send_deliveries_notification_id_notifications_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_sends": {
+      "name": "survey_sends",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_policy": {
+          "name": "channel_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "target_count": {
+          "name": "target_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "assigned_count": {
+          "name": "assigned_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_duplicate_count": {
+          "name": "skipped_duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from_account_id": {
+          "name": "created_from_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_sends_survey_idx": {
+          "name": "survey_sends_survey_idx",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_sends_version_idx": {
+          "name": "survey_sends_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_sends_status_idx": {
+          "name": "survey_sends_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_sends_context_key_idx": {
+          "name": "survey_sends_context_key_idx",
+          "columns": [
+            {
+              "expression": "context_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_sends_survey_id_surveys_id_fk": {
+          "name": "survey_sends_survey_id_surveys_id_fk",
+          "tableFrom": "survey_sends",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_sends_version_id_survey_versions_id_fk": {
+          "name": "survey_sends_version_id_survey_versions_id_fk",
+          "tableFrom": "survey_sends",
+          "tableTo": "survey_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_sends_created_by_user_id_users_id_fk": {
+          "name": "survey_sends_created_by_user_id_users_id_fk",
+          "tableFrom": "survey_sends",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_sends_created_from_account_id_accounts_id_fk": {
+          "name": "survey_sends_created_from_account_id_accounts_id_fk",
+          "tableFrom": "survey_sends",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "created_from_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_versions": {
+      "name": "survey_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_title": {
+          "name": "intro_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_description": {
+          "name": "intro_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thank_you_title": {
+          "name": "thank_you_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thank_you_description": {
+          "name": "thank_you_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_versions_survey_number_unique": {
+          "name": "survey_versions_survey_number_unique",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_versions_survey_status_idx": {
+          "name": "survey_versions_survey_status_idx",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_versions_survey_id_surveys_id_fk": {
+          "name": "survey_versions_survey_id_surveys_id_fk",
+          "tableFrom": "survey_versions",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.surveys": {
+      "name": "surveys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "surveys_key_unique": {
+          "name": "surveys_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "surveys_status_idx": {
+          "name": "surveys_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "surveys_category_idx": {
+          "name": "surveys_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "surveys_created_by_user_id_users_id_fk": {
+          "name": "surveys_created_by_user_id_users_id_fk",
+          "tableFrom": "surveys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "transactions_account_id_idx": {
+          "name": "transactions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_garden_id_idx": {
+          "name": "transactions_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_stripe_payment_id_idx": {
+          "name": "transactions_stripe_payment_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_is_deleted_idx": {
+          "name": "transactions_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_garden_id_gardens_id_fk": {
+          "name": "transactions_garden_id_gardens_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tutorial_checklist_task_claims": {
+      "name": "tutorial_checklist_task_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_key": {
+          "name": "task_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_sunflowers": {
+          "name": "reward_sunflowers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tutorial_checklist_claims_account_id_idx": {
+          "name": "tutorial_checklist_claims_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tutorial_checklist_claims_task_key_idx": {
+          "name": "tutorial_checklist_claims_task_key_idx",
+          "columns": [
+            {
+              "expression": "task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tutorial_checklist_claims_account_task_uq": {
+          "name": "tutorial_checklist_claims_account_task_uq",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tutorial_checklist_task_claims_account_id_accounts_id_fk": {
+          "name": "tutorial_checklist_task_claims_account_id_accounts_id_fk",
+          "tableFrom": "tutorial_checklist_task_claims",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "user_favorite_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_favorites_user_entity_uq": {
+          "name": "user_favorites_user_entity_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_user_id_idx": {
+          "name": "user_favorites_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_entity_type_idx": {
+          "name": "user_favorites_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_entity_id_idx": {
+          "name": "user_favorites_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_favorites_entity_id_entities_id_fk": {
+          "name": "user_favorites_entity_id_entities_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_invitations": {
+      "name": "account_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "account_invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_invitations_account_id_idx": {
+          "name": "account_invitations_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_invitations_email_idx": {
+          "name": "account_invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_invitations_token_idx": {
+          "name": "account_invitations_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_invitations_account_id_accounts_id_fk": {
+          "name": "account_invitations_account_id_accounts_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_invitations_invited_by_user_id_users_id_fk": {
+          "name": "account_invitations_invited_by_user_id_users_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_users": {
+      "name": "account_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_au_account_id_idx": {
+          "name": "users_au_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_au_user_id_idx": {
+          "name": "users_au_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_users_account_id_accounts_id_fk": {
+          "name": "account_users_account_id_accounts_id_fk",
+          "tableFrom": "account_users",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_users_user_id_users_id_fk": {
+          "name": "account_users_user_id_users_id_fk",
+          "tableFrom": "account_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_street1": {
+          "name": "address_street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_street2": {
+          "name": "address_street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_city": {
+          "name": "address_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_zip": {
+          "name": "address_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Europe/Paris'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farm_users": {
+      "name": "farm_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "farm_users_farm_id_idx": {
+          "name": "farm_users_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farm_users_user_id_idx": {
+          "name": "farm_users_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farm_users_farm_user_unique": {
+          "name": "farm_users_farm_user_unique",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farm_users_farm_id_farms_id_fk": {
+          "name": "farm_users_farm_id_farms_id_fk",
+          "tableFrom": "farm_users",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farm_users_user_id_users_id_fk": {
+          "name": "farm_users_user_id_users_id_fk",
+          "tableFrom": "farm_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_logins": {
+      "name": "user_logins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_type": {
+          "name": "login_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_id": {
+          "name": "login_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_data": {
+          "name": "login_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_attempts": {
+          "name": "failed_attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failed_attempt": {
+          "name": "last_failed_attempt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_until": {
+          "name": "blocked_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_ul_user_id_idx": {
+          "name": "users_ul_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_ul_login_type_idx": {
+          "name": "users_ul_login_type_idx",
+          "columns": [
+            {
+              "expression": "login_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_ul_login_id_idx": {
+          "name": "users_ul_login_id_idx",
+          "columns": [
+            {
+              "expression": "login_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_logins_user_id_users_id_fk": {
+          "name": "user_logins_user_id_users_id_fk",
+          "tableFrom": "user_logins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday_day": {
+          "name": "birthday_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday_month": {
+          "name": "birthday_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday_year": {
+          "name": "birthday_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday_last_updated_at": {
+          "name": "birthday_last_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whats_new_last_seen_at": {
+          "name": "whats_new_last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whats_new_popup_disabled": {
+          "name": "whats_new_popup_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "farm_schedule_grouped_watering_enabled": {
+          "name": "farm_schedule_grouped_watering_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_garden_id": {
+          "name": "default_garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_u_username_idx": {
+          "name": "users_u_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_u_default_garden_id_idx": {
+          "name": "users_u_default_garden_id_idx",
+          "columns": [
+            {
+              "expression": "default_garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_default_garden_id_gardens_id_fk": {
+          "name": "users_default_garden_id_gardens_id_fk",
+          "tableFrom": "users",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "default_garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_history": {
+      "name": "weather_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rain": {
+          "name": "rain",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wind_direction": {
+          "name": "wind_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wind_speed": {
+          "name": "wind_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rainy": {
+          "name": "rainy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "snowy": {
+          "name": "snowy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cloudy": {
+          "name": "cloudy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "foggy": {
+          "name": "foggy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "thundery": {
+          "name": "thundery",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "weather_history_recorded_at_idx": {
+          "name": "weather_history_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_status": {
+      "name": "achievement_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.automation_definition_status": {
+      "name": "automation_definition_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "enabled",
+        "disabled",
+        "archived"
+      ]
+    },
+    "public.automation_module_kind": {
+      "name": "automation_module_kind",
+      "schema": "public",
+      "values": [
+        "trigger",
+        "filter",
+        "condition",
+        "action"
+      ]
+    },
+    "public.automation_run_source": {
+      "name": "automation_run_source",
+      "schema": "public",
+      "values": [
+        "event",
+        "manual",
+        "schedule",
+        "test",
+        "replay"
+      ]
+    },
+    "public.automation_run_status": {
+      "name": "automation_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "skipped",
+        "failed",
+        "retrying",
+        "canceled"
+      ]
+    },
+    "public.automation_step_status": {
+      "name": "automation_step_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "succeeded",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.email_status": {
+      "name": "email_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sending",
+        "sent",
+        "failed",
+        "bounced"
+      ]
+    },
+    "public.newsletter_status": {
+      "name": "newsletter_status",
+      "schema": "public",
+      "values": [
+        "subscribed",
+        "unsubscribed",
+        "pending"
+      ]
+    },
+    "public.notification_delivery_status": {
+      "name": "notification_delivery_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "accepted",
+        "sent",
+        "failed",
+        "dropped"
+      ]
+    },
+    "public.notification_delivery_event_type": {
+      "name": "notification_delivery_event_type",
+      "schema": "public",
+      "values": [
+        "queued",
+        "accepted",
+        "sent",
+        "failed",
+        "opened",
+        "clicked",
+        "dismissed",
+        "unsubscribed"
+      ]
+    },
+    "public.notification_digest_frequency": {
+      "name": "notification_digest_frequency",
+      "schema": "public",
+      "values": [
+        "off",
+        "hourly",
+        "daily",
+        "weekly"
+      ]
+    },
+    "public.notification_campaign_status": {
+      "name": "notification_campaign_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "scheduled",
+        "queued",
+        "sending",
+        "sent",
+        "cancelled",
+        "failed"
+      ]
+    },
+    "public.notification_channel": {
+      "name": "notification_channel",
+      "schema": "public",
+      "values": [
+        "in_app",
+        "email",
+        "push",
+        "sms"
+      ]
+    },
+    "public.notification_preference_scope": {
+      "name": "notification_preference_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "account"
+      ]
+    },
+    "public.notification_priority": {
+      "name": "notification_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "critical"
+      ]
+    },
+    "public.push_permission_state": {
+      "name": "push_permission_state",
+      "schema": "public",
+      "values": [
+        "default",
+        "granted",
+        "denied"
+      ]
+    },
+    "public.social_account_status": {
+      "name": "social_account_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "disabled",
+        "needs_reauth"
+      ]
+    },
+    "public.social_post_status": {
+      "name": "social_post_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "queued",
+        "scheduled",
+        "submitting",
+        "submitted",
+        "published",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.social_post_type": {
+      "name": "social_post_type",
+      "schema": "public",
+      "values": [
+        "text",
+        "link",
+        "image",
+        "video",
+        "reel",
+        "story",
+        "carousel",
+        "other"
+      ]
+    },
+    "public.social_provider": {
+      "name": "social_provider",
+      "schema": "public",
+      "values": [
+        "reddit",
+        "instagram",
+        "facebook",
+        "google_business",
+        "x",
+        "tiktok",
+        "threads",
+        "linkedin",
+        "whatsapp"
+      ]
+    },
+    "public.survey_assignment_status": {
+      "name": "survey_assignment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "started",
+        "submitted",
+        "expired",
+        "canceled"
+      ]
+    },
+    "public.survey_question_type": {
+      "name": "survey_question_type",
+      "schema": "public",
+      "values": [
+        "opinion_scale",
+        "long_text",
+        "contact_info"
+      ]
+    },
+    "public.survey_response_source": {
+      "name": "survey_response_source",
+      "schema": "public",
+      "values": [
+        "in_app",
+        "typeform",
+        "admin_import"
+      ]
+    },
+    "public.survey_send_delivery_channel": {
+      "name": "survey_send_delivery_channel",
+      "schema": "public",
+      "values": [
+        "in_app",
+        "email"
+      ]
+    },
+    "public.survey_send_delivery_status": {
+      "name": "survey_send_delivery_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.survey_send_status": {
+      "name": "survey_send_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "scheduled",
+        "sent",
+        "canceled",
+        "failed"
+      ]
+    },
+    "public.survey_status": {
+      "name": "survey_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.survey_version_status": {
+      "name": "survey_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.user_favorite_entity_type": {
+      "name": "user_favorite_entity_type",
+      "schema": "public",
+      "values": [
+        "plant",
+        "plantSort",
+        "operation"
+      ]
+    },
+    "public.account_invitation_status": {
+      "name": "account_invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage/src/migrations/meta/_journal.json
+++ b/packages/storage/src/migrations/meta/_journal.json
@@ -540,6 +540,13 @@
       "when": 1784294413079,
       "tag": "0076_open_morgan_stark",
       "breakpoints": true
+    },
+    {
+      "idx": 77,
+      "version": "7",
+      "when": 1784915842968,
+      "tag": "0077_certain_serpent_society",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage/src/repositories/usersRepo.ts
+++ b/packages/storage/src/repositories/usersRepo.ts
@@ -8,6 +8,8 @@ import { and, desc, eq, sql } from 'drizzle-orm';
 import { createAccount, storage } from '..';
 import {
     accountUsers,
+    gardens,
+    type SelectGarden,
     type UpdateUserInfo,
     userLogins,
     users,
@@ -20,6 +22,26 @@ export interface OAuthUserData {
     email: string;
     providerUserId: string;
     provider: 'google' | 'facebook';
+}
+
+export class UserDefaultGardenNotAccessibleError extends Error {
+    override name = 'UserDefaultGardenNotAccessibleError';
+
+    constructor(readonly gardenId: number) {
+        super(
+            `Garden ${gardenId.toString()} is not accessible to the user or is deleted`,
+        );
+    }
+}
+
+export class UserDefaultGardenSandboxError extends Error {
+    override name = 'UserDefaultGardenSandboxError';
+
+    constructor(readonly gardenId: number) {
+        super(
+            `Sandbox garden ${gardenId.toString()} cannot be used as the default garden`,
+        );
+    }
 }
 
 export function getUsers() {
@@ -61,6 +83,74 @@ export function updateUser(user: { id: string } & Partial<UpdateUserInfo>) {
             ...user,
         })
         .where(eq(users.id, user.id));
+}
+
+export async function getUserDefaultGarden(
+    userId: string,
+): Promise<SelectGarden | null> {
+    const [result] = await storage()
+        .select({ garden: gardens })
+        .from(users)
+        .innerJoin(gardens, eq(users.defaultGardenId, gardens.id))
+        .innerJoin(
+            accountUsers,
+            and(
+                eq(accountUsers.userId, users.id),
+                eq(accountUsers.accountId, gardens.accountId),
+            ),
+        )
+        .where(
+            and(
+                eq(users.id, userId),
+                eq(gardens.isDeleted, false),
+                eq(gardens.isSandbox, false),
+            ),
+        )
+        .limit(1);
+
+    return result?.garden ?? null;
+}
+
+export async function setUserDefaultGarden({
+    gardenId,
+    userId,
+}: {
+    gardenId: number;
+    userId: string;
+}): Promise<SelectGarden> {
+    return storage().transaction(async (tx) => {
+        const [result] = await tx
+            .select({ garden: gardens })
+            .from(gardens)
+            .innerJoin(
+                accountUsers,
+                and(
+                    eq(accountUsers.accountId, gardens.accountId),
+                    eq(accountUsers.userId, userId),
+                ),
+            )
+            .where(eq(gardens.id, gardenId))
+            .limit(1);
+        const garden = result?.garden;
+
+        if (!garden || garden.isDeleted) {
+            throw new UserDefaultGardenNotAccessibleError(gardenId);
+        }
+        if (garden.isSandbox) {
+            throw new UserDefaultGardenSandboxError(gardenId);
+        }
+
+        const [updatedUser] = await tx
+            .update(users)
+            .set({ defaultGardenId: garden.id })
+            .where(eq(users.id, userId))
+            .returning({ id: users.id });
+        if (!updatedUser) {
+            throw new UserDefaultGardenNotAccessibleError(gardenId);
+        }
+
+        return garden;
+    });
 }
 
 export function getUserWithLogins(userName: string) {

--- a/packages/storage/src/schema/usersSchema.ts
+++ b/packages/storage/src/schema/usersSchema.ts
@@ -1,5 +1,6 @@
 import { relations } from 'drizzle-orm';
 import {
+    type AnyPgColumn,
     boolean,
     index,
     integer,
@@ -12,7 +13,7 @@ import {
     uniqueIndex,
 } from 'drizzle-orm/pg-core';
 import { farms } from './farmsSchema';
-import { raisedBeds } from './gardenSchema';
+import { gardens, raisedBeds } from './gardenSchema';
 
 export const accounts = pgTable('accounts', {
     id: text('id').primaryKey(),
@@ -131,12 +132,19 @@ export const users = pgTable(
         )
             .notNull()
             .default(true),
+        defaultGardenId: integer('default_garden_id').references(
+            (): AnyPgColumn => gardens.id,
+            { onDelete: 'set null' },
+        ),
         createdAt: timestamp('created_at').notNull().defaultNow(),
         updatedAt: timestamp('updated_at')
             .notNull()
             .$onUpdate(() => new Date()),
     },
-    (table) => [index('users_u_username_idx').on(table.userName)],
+    (table) => [
+        index('users_u_username_idx').on(table.userName),
+        index('users_u_default_garden_id_idx').on(table.defaultGardenId),
+    ],
 );
 
 export const usersRelations = relations(users, ({ many }) => ({
@@ -154,7 +162,7 @@ export const usersRelations = relations(users, ({ many }) => ({
 export type InsertUser = typeof users.$inferInsert;
 export type UpdateUserInfo = Omit<
     typeof users.$inferInsert,
-    'id' | 'createdAt' | 'updatedAt' | 'role'
+    'id' | 'createdAt' | 'updatedAt' | 'role' | 'defaultGardenId'
 >;
 export type SelectUser = typeof users.$inferSelect;
 

--- a/packages/storage/tests/userDefaultGardenRepo.node.spec.ts
+++ b/packages/storage/tests/userDefaultGardenRepo.node.spec.ts
@@ -1,0 +1,260 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    accountUsers,
+    createAccount,
+    createGarden,
+    gardens,
+    getUserDefaultGarden,
+    setUserDefaultGarden,
+    UserDefaultGardenNotAccessibleError,
+    UserDefaultGardenSandboxError,
+    users,
+} from '@gredice/storage';
+import { and, eq } from 'drizzle-orm';
+import { ensureFarmId } from './helpers/testHelpers';
+import { createTestDb } from './testDb';
+
+async function createUserFixture(accountCount = 1) {
+    const db = createTestDb();
+    const userId = randomUUID();
+    const now = new Date();
+
+    await db.insert(users).values({
+        id: userId,
+        userName: `default-garden-${userId}@example.test`,
+        role: 'user',
+        createdAt: now,
+        updatedAt: now,
+    });
+
+    const accountIds: string[] = [];
+    for (let index = 0; index < accountCount; index += 1) {
+        const accountId = await createAccount();
+        accountIds.push(accountId);
+        await db.insert(accountUsers).values({
+            accountId,
+            userId,
+            createdAt: now,
+            updatedAt: now,
+        });
+    }
+
+    return {
+        accountIds,
+        db,
+        farmId: await ensureFarmId(),
+        userId,
+    };
+}
+
+test('stores an accessible real garden from another user account as the default', async () => {
+    const fixture = await createUserFixture(2);
+    const targetAccountId = fixture.accountIds[1];
+    assert.ok(targetAccountId);
+    const gardenId = await createGarden({
+        accountId: targetAccountId,
+        farmId: fixture.farmId,
+        name: 'Secondary account garden',
+    });
+
+    const selected = await setUserDefaultGarden({
+        gardenId,
+        userId: fixture.userId,
+    });
+
+    assert.equal(selected.id, gardenId);
+    assert.equal(selected.accountId, targetAccountId);
+    assert.equal((await getUserDefaultGarden(fixture.userId))?.id, gardenId);
+    assert.equal(
+        (
+            await fixture.db.query.users.findFirst({
+                where: eq(users.id, fixture.userId),
+            })
+        )?.defaultGardenId,
+        gardenId,
+    );
+});
+
+test('keeps the default garden isolated per user on a shared account', async () => {
+    const fixture = await createUserFixture();
+    const accountId = fixture.accountIds[0];
+    assert.ok(accountId);
+    const secondUserId = randomUUID();
+    const now = new Date();
+    await fixture.db.insert(users).values({
+        id: secondUserId,
+        userName: `default-garden-${secondUserId}@example.test`,
+        role: 'user',
+        createdAt: now,
+        updatedAt: now,
+    });
+    await fixture.db.insert(accountUsers).values({
+        accountId,
+        userId: secondUserId,
+        createdAt: now,
+        updatedAt: now,
+    });
+    const gardenId = await createGarden({
+        accountId,
+        farmId: fixture.farmId,
+        name: 'Shared account garden',
+    });
+
+    await setUserDefaultGarden({ gardenId, userId: fixture.userId });
+
+    assert.equal((await getUserDefaultGarden(fixture.userId))?.id, gardenId);
+    assert.equal(await getUserDefaultGarden(secondUserId), null);
+});
+
+test('rejects a garden from an account the user cannot access', async () => {
+    const fixture = await createUserFixture();
+    const inaccessibleAccountId = await createAccount();
+    const gardenId = await createGarden({
+        accountId: inaccessibleAccountId,
+        farmId: fixture.farmId,
+        name: 'Inaccessible garden',
+    });
+
+    await assert.rejects(
+        () =>
+            setUserDefaultGarden({
+                gardenId,
+                userId: fixture.userId,
+            }),
+        (error: unknown) => {
+            assert.ok(error instanceof UserDefaultGardenNotAccessibleError);
+            assert.equal(error.gardenId, gardenId);
+            return true;
+        },
+    );
+    assert.equal(await getUserDefaultGarden(fixture.userId), null);
+});
+
+test('rejects an accessible sandbox garden', async () => {
+    const fixture = await createUserFixture();
+    const accountId = fixture.accountIds[0];
+    assert.ok(accountId);
+    const gardenId = await createGarden({
+        accountId,
+        farmId: fixture.farmId,
+        isSandbox: true,
+        name: 'Sandbox garden',
+    });
+
+    await assert.rejects(
+        () =>
+            setUserDefaultGarden({
+                gardenId,
+                userId: fixture.userId,
+            }),
+        (error: unknown) => {
+            assert.ok(error instanceof UserDefaultGardenSandboxError);
+            assert.equal(error.gardenId, gardenId);
+            return true;
+        },
+    );
+    assert.equal(await getUserDefaultGarden(fixture.userId), null);
+});
+
+test('rejects a soft-deleted garden', async () => {
+    const fixture = await createUserFixture();
+    const accountId = fixture.accountIds[0];
+    assert.ok(accountId);
+    const gardenId = await createGarden({
+        accountId,
+        farmId: fixture.farmId,
+        name: 'Deleted garden',
+    });
+    await fixture.db
+        .update(gardens)
+        .set({ isDeleted: true })
+        .where(eq(gardens.id, gardenId));
+
+    await assert.rejects(
+        () =>
+            setUserDefaultGarden({
+                gardenId,
+                userId: fixture.userId,
+            }),
+        (error: unknown) => {
+            assert.ok(error instanceof UserDefaultGardenNotAccessibleError);
+            assert.equal(error.gardenId, gardenId);
+            return true;
+        },
+    );
+});
+
+test('does not return a stored default after the user loses account access', async () => {
+    const fixture = await createUserFixture();
+    const accountId = fixture.accountIds[0];
+    assert.ok(accountId);
+    const gardenId = await createGarden({
+        accountId,
+        farmId: fixture.farmId,
+        name: 'Formerly accessible garden',
+    });
+    await setUserDefaultGarden({ gardenId, userId: fixture.userId });
+
+    await fixture.db
+        .delete(accountUsers)
+        .where(
+            and(
+                eq(accountUsers.accountId, accountId),
+                eq(accountUsers.userId, fixture.userId),
+            ),
+        );
+
+    assert.equal(await getUserDefaultGarden(fixture.userId), null);
+    assert.equal(
+        (
+            await fixture.db.query.users.findFirst({
+                where: eq(users.id, fixture.userId),
+            })
+        )?.defaultGardenId,
+        gardenId,
+    );
+});
+
+test('does not return a stored default after the garden is soft-deleted', async () => {
+    const fixture = await createUserFixture();
+    const accountId = fixture.accountIds[0];
+    assert.ok(accountId);
+    const gardenId = await createGarden({
+        accountId,
+        farmId: fixture.farmId,
+        name: 'Soft-deleted default garden',
+    });
+    await setUserDefaultGarden({ gardenId, userId: fixture.userId });
+
+    await fixture.db
+        .update(gardens)
+        .set({ isDeleted: true })
+        .where(eq(gardens.id, gardenId));
+
+    assert.equal(await getUserDefaultGarden(fixture.userId), null);
+});
+
+test('clears the stored default when the garden is hard-deleted', async () => {
+    const fixture = await createUserFixture();
+    const accountId = fixture.accountIds[0];
+    assert.ok(accountId);
+    const gardenId = await createGarden({
+        accountId,
+        farmId: fixture.farmId,
+        name: 'Hard-deleted default garden',
+    });
+    await setUserDefaultGarden({ gardenId, userId: fixture.userId });
+
+    await fixture.db.delete(gardens).where(eq(gardens.id, gardenId));
+
+    assert.equal(
+        (
+            await fixture.db.query.users.findFirst({
+                where: eq(users.id, fixture.userId),
+            })
+        )?.defaultGardenId,
+        null,
+    );
+});


### PR DESCRIPTION
## Summary

- persist a per-user default real garden, including gardens on another accessible account
- switch the active account before loading an initial or later cross-account garden, and stop treating a raw-first sandbox as the implicit default
- add keyboard-accessible default controls to the garden switcher, shown only when the user can access more than one real garden
- keep the currently open garden stable when changing the preference

## Data and migration

- adds nullable `users.default_garden_id` with `ON DELETE SET NULL`
- validates live account membership, rejects sandbox and soft-deleted gardens, and safely falls back after access loss
- includes generated migration `0077_certain_serpent_society`

## Validation

- `pnpm typecheck --filter @gredice/storage --filter api --filter @gredice/game --filter garden`
- `pnpm --filter garden build`
- `pnpm --filter garden exec playwright test` — 264 passed
- `pnpm --filter @gredice/game exec tsx --test src/hooks/gardenSelection.unit.ts` — 5 passed
- `pnpm --filter @gredice/storage test:node userDefaultGardenRepo.node.spec.ts` — 8 passed with migrations
- `git diff --check`