### PR TITLE
feat(checkout): schedule harvest dates before delivery

### DIFF
--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -1,10 +1,17 @@
 import {
     assignStripeCustomerId,
+    cartContainsDeliverableItems,
     consumeInventoryItem,
     getAccount,
+    getDeliveryAddress,
+    getHarvestScheduleForCart,
+    getPickupLocation,
     getShoppingCart,
     getSunflowerPackageEligibilityForAccount,
+    getTimeSlot,
+    getTimeSlotEffectiveClosesAt,
     getUser,
+    HarvestScheduleConflictError,
     markCartPaidIfAllItemsPaid,
     normalizeShoppingCartInventoryUsage,
     normalizeShoppingCartScheduledDates,
@@ -16,6 +23,7 @@ import {
     setCartItemPaid,
     spendSunflowers,
     sunflowerPackageEntityTypeName,
+    validateHarvestDateSelections,
 } from '@gredice/storage';
 import {
     type CheckoutItem,
@@ -27,6 +35,14 @@ import { Hono } from 'hono';
 import { describeRoute, resolver, validator as zValidator } from 'hono-openapi';
 import { z } from 'zod';
 import { getCartInfo } from '../../../lib/checkout/cartInfo';
+import {
+    CheckoutDeliverySelectionError,
+    validateCheckoutDeliverySelection,
+} from '../../../lib/checkout/deliverySelection';
+import {
+    buildCheckoutAdditionalData,
+    encodeHarvestDatesMetadata,
+} from '../../../lib/checkout/harvestCheckout';
 import {
     buildOrderConfirmationItems,
     notifyOrderConfirmationEmail,
@@ -111,11 +127,23 @@ const app = new Hono<{ Variables: AuthVariables }>()
                         notes: z.string().max(500).optional(),
                     })
                     .optional(),
+                harvestDates: z
+                    .array(
+                        z.object({
+                            cartItemId: z.number().int().positive(),
+                            scheduledDate: z
+                                .string()
+                                .regex(/^\d{4}-\d{2}-\d{2}$/),
+                        }),
+                    )
+                    .max(100)
+                    .optional(),
             }),
         ),
         async (context) => {
             const { accountId, userId } = context.get('authContext');
-            const { cartId, deliveryInfo } = context.req.valid('json');
+            const { cartId, deliveryInfo, harvestDates } =
+                context.req.valid('json');
 
             // Retrieve data
             const [account, user, initialCart] = await Promise.all([
@@ -132,6 +160,17 @@ const app = new Hono<{ Variables: AuthVariables }>()
             if (!initialCart) {
                 return context.json({ error: 'Cart not found' }, 404);
             }
+            if (initialCart.accountId !== accountId) {
+                console.warn('Account ID mismatch', {
+                    accountId,
+                    cartAccountId: initialCart.accountId,
+                });
+                return context.json({ error: 'Cart not found' }, 404);
+            }
+            if (initialCart.status === 'paid') {
+                return context.json({ error: 'Cart already paid' }, 400);
+            }
+
             const inventoryNormalizedCart =
                 (await normalizeShoppingCartInventoryUsage(cartId)) ??
                 initialCart;
@@ -142,19 +181,88 @@ const app = new Hono<{ Variables: AuthVariables }>()
                         defaultMissingScheduledDates: true,
                     },
                 )) ?? inventoryNormalizedCart;
-            if (cart.accountId !== accountId) {
-                console.warn('Account ID mismatch', {
-                    accountId,
-                    cartAccountId: cart.accountId,
+            const requiresDelivery = await cartContainsDeliverableItems(
+                cart.id,
+            );
+            const [slot, address, location] = await Promise.all([
+                deliveryInfo
+                    ? getTimeSlot(deliveryInfo.slotId)
+                    : Promise.resolve(undefined),
+                deliveryInfo?.mode === 'delivery' && deliveryInfo.addressId
+                    ? getDeliveryAddress(deliveryInfo.addressId, accountId)
+                    : Promise.resolve(undefined),
+                deliveryInfo?.mode === 'pickup' && deliveryInfo.locationId
+                    ? getPickupLocation(deliveryInfo.locationId)
+                    : Promise.resolve(undefined),
+            ]);
+            let canonicalHarvestDates: Array<{
+                cartItemId: number;
+                scheduledDate: string;
+            }> = [];
+
+            try {
+                validateCheckoutDeliverySelection({
+                    address,
+                    location,
+                    requiresDelivery,
+                    selection: deliveryInfo,
+                    slot: slot
+                        ? {
+                              ...slot,
+                              effectiveClosesAt:
+                                  getTimeSlotEffectiveClosesAt(slot),
+                          }
+                        : undefined,
                 });
-                return context.json({ error: 'Cart not found' }, 404);
+
+                if (deliveryInfo) {
+                    const schedule = await getHarvestScheduleForCart({
+                        accountId,
+                        cartId: cart.id,
+                        deliverySlotId: deliveryInfo.slotId,
+                    });
+                    canonicalHarvestDates = validateHarvestDateSelections(
+                        schedule,
+                        harvestDates ?? [],
+                    );
+                } else if (harvestDates?.length) {
+                    return context.json(
+                        {
+                            error: 'Delivery selection is required for harvest dates',
+                        },
+                        400,
+                    );
+                }
+            } catch (error) {
+                if (error instanceof CheckoutDeliverySelectionError) {
+                    return context.json(
+                        {
+                            error: error.message,
+                            code: error.code,
+                        },
+                        error.status,
+                    );
+                }
+                if (error instanceof HarvestScheduleConflictError) {
+                    return context.json(
+                        {
+                            error: error.message,
+                            code: error.code,
+                            details: error.details,
+                        },
+                        error.statusCode,
+                    );
+                }
+
+                throw error;
             }
 
-            // Validate cart status
-            if (cart.status === 'paid') {
-                return context.json({ error: 'Cart already paid' }, 400);
-            }
-
+            const harvestDateByCartItemId = new Map(
+                canonicalHarvestDates.map((selection) => [
+                    selection.cartItemId,
+                    selection.scheduledDate,
+                ]),
+            );
             // Retrieve entities data
             const cartInfo = await getCartInfo(cart.items, accountId);
             if (!cartInfo.allowPurchase) {
@@ -204,6 +312,15 @@ const app = new Hono<{ Variables: AuthVariables }>()
             const requiresStripePayment = cartInfo.items.some(
                 (item) => item.status !== 'paid' && item.currency === 'eur',
             );
+            const expectedNonStripeCartItemIds = cartInfo.items.flatMap(
+                (item) =>
+                    item.status !== 'paid' &&
+                    (item.currency === 'sunflower' ||
+                        item.currency === 'inventory' ||
+                        item.usesInventory)
+                        ? [item.id]
+                        : [],
+            );
 
             // Handle sunflower items
             if (!requiresStripePayment) {
@@ -215,6 +332,8 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 if (sunflowerCartItemsWithShopData.length > 0) {
                     // Check if there are enough sunflowers in the account
                     for (const item of sunflowerCartItemsWithShopData) {
+                        const scheduledHarvestDate =
+                            harvestDateByCartItemId.get(item.id);
                         const sunflowerAmount = calculateSunflowerAmount(item);
                         let didPaySunflowers = false;
                         try {
@@ -242,14 +361,13 @@ const app = new Hono<{ Variables: AuthVariables }>()
                                     ...item,
                                     amount_total: sunflowerAmount,
                                     scheduledDeliveryEmailKeys,
-                                    additionalData: {
-                                        ...(item.additionalData
-                                            ? JSON.parse(item.additionalData)
-                                            : {}),
-                                        ...(deliveryInfo
-                                            ? { delivery: deliveryInfo }
-                                            : {}),
-                                    },
+                                    additionalData: buildCheckoutAdditionalData(
+                                        {
+                                            additionalData: item.additionalData,
+                                            deliveryInfo,
+                                            scheduledHarvestDate,
+                                        },
+                                    ),
                                 }),
                             ]);
                         }
@@ -268,6 +386,8 @@ const app = new Hono<{ Variables: AuthVariables }>()
 
                 if (inventoryCartItems.length > 0) {
                     for (const item of inventoryCartItems) {
+                        const scheduledHarvestDate =
+                            harvestDateByCartItemId.get(item.id);
                         if ((item.inventoryAvailable ?? 0) < item.amount) {
                             return context.json(
                                 { error: 'Nema dovoljno predmeta u ruksaku' },
@@ -289,14 +409,11 @@ const app = new Hono<{ Variables: AuthVariables }>()
                                 ...item,
                                 amount_total: 0,
                                 scheduledDeliveryEmailKeys,
-                                additionalData: {
-                                    ...(item.additionalData
-                                        ? JSON.parse(item.additionalData)
-                                        : {}),
-                                    ...(deliveryInfo
-                                        ? { delivery: deliveryInfo }
-                                        : {}),
-                                },
+                                additionalData: buildCheckoutAdditionalData({
+                                    additionalData: item.additionalData,
+                                    deliveryInfo,
+                                    scheduledHarvestDate,
+                                }),
                             }),
                         ]);
                     }
@@ -327,6 +444,9 @@ const app = new Hono<{ Variables: AuthVariables }>()
             for (const item of stripeCartItemsWithShopData) {
                 // TODO: Apply discounted price if available
 
+                const scheduledHarvestDate = harvestDateByCartItemId.get(
+                    item.id,
+                );
                 const name = item.shopData?.name;
                 const description = item.shopData?.description || undefined;
                 const finalPrice =
@@ -381,14 +501,13 @@ const app = new Hono<{ Variables: AuthVariables }>()
                             raisedBedId: item.raisedBedId,
                             positionIndex:
                                 item.positionIndex?.toString() ?? null,
-                            additionalData: JSON.stringify({
-                                ...(item.additionalData
-                                    ? JSON.parse(item.additionalData)
-                                    : {}),
-                                ...(deliveryInfo
-                                    ? { delivery: deliveryInfo }
-                                    : {}),
-                            }),
+                            additionalData: JSON.stringify(
+                                buildCheckoutAdditionalData({
+                                    additionalData: item.additionalData,
+                                    deliveryInfo,
+                                    scheduledHarvestDate,
+                                }),
+                            ),
                             outletOfferId: item.outlet?.offerId ?? null,
                             outletReservationId:
                                 item.outlet?.reservationId ?? null,
@@ -427,6 +546,10 @@ const app = new Hono<{ Variables: AuthVariables }>()
                         expiresAt: hasOutletStripeItems
                             ? outletCheckoutExpiresAt
                             : undefined,
+                        metadata: encodeHarvestDatesMetadata(
+                            canonicalHarvestDates,
+                            expectedNonStripeCartItemIds,
+                        ),
                     },
                 );
 

--- a/apps/api/app/api/[...route]/shoppingCartRoutes.ts
+++ b/apps/api/app/api/[...route]/shoppingCartRoutes.ts
@@ -6,11 +6,13 @@ import {
 import {
     cartContainsDeliverableItems,
     deleteShoppingCart,
+    getHarvestScheduleForCart,
     getOrCreateShoppingCart,
     getOutletOffer,
     getRaisedBed,
     getShoppingCart,
     getSunflowers,
+    HarvestScheduleConflictError,
     normalizeShoppingCartInventoryUsage,
     normalizeShoppingCartScheduledDates,
     OutletOfferUnavailableError,
@@ -30,6 +32,50 @@ import {
 import { getPostHogClient } from '../../../lib/posthog-server';
 
 const app = new Hono<{ Variables: AuthVariables }>()
+    .get(
+        '/harvest-schedule',
+        describeRoute({
+            description:
+                'Preview allowed harvest dates for the current cart and delivery slot',
+        }),
+        authValidator(['user', 'admin']),
+        zValidator(
+            'query',
+            z.object({
+                slotId: z.coerce.number().int().positive(),
+            }),
+        ),
+        async (context) => {
+            const { accountId } = context.get('authContext');
+            const { slotId } = context.req.valid('query');
+            const cart = await getOrCreateShoppingCart(accountId, 'new');
+            if (!cart) {
+                return context.json({ error: 'Cart not found' }, 404);
+            }
+
+            try {
+                const schedule = await getHarvestScheduleForCart({
+                    accountId,
+                    cartId: cart.id,
+                    deliverySlotId: slotId,
+                });
+                return context.json(schedule);
+            } catch (error) {
+                if (error instanceof HarvestScheduleConflictError) {
+                    return context.json(
+                        {
+                            error: error.message,
+                            code: error.code,
+                            details: error.details,
+                        },
+                        error.statusCode,
+                    );
+                }
+
+                throw error;
+            }
+        },
+    )
     .get(
         '/',
         describeRoute({

--- a/apps/api/lib/checkout/deliverySelection.node.spec.ts
+++ b/apps/api/lib/checkout/deliverySelection.node.spec.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    CheckoutDeliverySelectionError,
+    checkoutDeliverySelectionErrorCodes,
+    validateCheckoutDeliverySelection,
+} from './deliverySelection';
+
+const now = new Date('2026-07-24T08:00:00.000Z');
+const deliverySlot = {
+    id: 7,
+    type: 'delivery',
+    status: 'scheduled',
+    startAt: new Date('2026-07-28T08:00:00.000Z'),
+    effectiveClosesAt: new Date('2026-07-26T08:00:00.000Z'),
+    locationId: 3,
+};
+
+describe('validateCheckoutDeliverySelection', () => {
+    it('requires a selection for a cart with deliverable items', () => {
+        assert.throws(
+            () =>
+                validateCheckoutDeliverySelection({
+                    requiresDelivery: true,
+                    now,
+                }),
+            (error) =>
+                error instanceof CheckoutDeliverySelectionError &&
+                error.code === checkoutDeliverySelectionErrorCodes.REQUIRED,
+        );
+    });
+
+    it('accepts an owned address for an available delivery slot', () => {
+        const selection = {
+            slotId: 7,
+            mode: 'delivery' as const,
+            addressId: 11,
+        };
+
+        assert.deepEqual(
+            validateCheckoutDeliverySelection({
+                address: { id: 11 },
+                requiresDelivery: true,
+                now,
+                selection,
+                slot: deliverySlot,
+            }),
+            selection,
+        );
+    });
+
+    it('rejects a pickup location that does not belong to the slot', () => {
+        assert.throws(
+            () =>
+                validateCheckoutDeliverySelection({
+                    location: { id: 9, isActive: true },
+                    requiresDelivery: true,
+                    now,
+                    selection: {
+                        slotId: 8,
+                        mode: 'pickup',
+                        locationId: 9,
+                    },
+                    slot: {
+                        ...deliverySlot,
+                        id: 8,
+                        type: 'pickup',
+                        locationId: 3,
+                    },
+                }),
+            (error) =>
+                error instanceof CheckoutDeliverySelectionError &&
+                error.code ===
+                    checkoutDeliverySelectionErrorCodes.LOCATION_INVALID,
+        );
+    });
+
+    it('rejects a slot after its effective close deadline', () => {
+        assert.throws(
+            () =>
+                validateCheckoutDeliverySelection({
+                    address: { id: 11 },
+                    requiresDelivery: true,
+                    now,
+                    selection: {
+                        slotId: 7,
+                        mode: 'delivery',
+                        addressId: 11,
+                    },
+                    slot: {
+                        ...deliverySlot,
+                        effectiveClosesAt: now,
+                    },
+                }),
+            (error) =>
+                error instanceof CheckoutDeliverySelectionError &&
+                error.code ===
+                    checkoutDeliverySelectionErrorCodes.SLOT_UNAVAILABLE,
+        );
+    });
+});

--- a/apps/api/lib/checkout/deliverySelection.ts
+++ b/apps/api/lib/checkout/deliverySelection.ts
@@ -1,0 +1,124 @@
+export interface CheckoutDeliverySelection {
+    slotId: number;
+    mode: 'delivery' | 'pickup';
+    addressId?: number;
+    locationId?: number;
+    notes?: string;
+}
+
+interface CheckoutDeliverySlot {
+    id: number;
+    type: string;
+    status: string;
+    startAt: Date;
+    effectiveClosesAt: Date;
+    locationId: number;
+}
+
+interface CheckoutDeliveryAddress {
+    id: number;
+}
+
+interface CheckoutPickupLocation {
+    id: number;
+    isActive: boolean;
+}
+
+export const checkoutDeliverySelectionErrorCodes = {
+    REQUIRED: 'delivery-selection-required',
+    SLOT_UNAVAILABLE: 'delivery-slot-unavailable',
+    MODE_MISMATCH: 'delivery-mode-mismatch',
+    ADDRESS_INVALID: 'delivery-address-invalid',
+    LOCATION_INVALID: 'pickup-location-invalid',
+} as const;
+
+type CheckoutDeliverySelectionErrorCode =
+    (typeof checkoutDeliverySelectionErrorCodes)[keyof typeof checkoutDeliverySelectionErrorCodes];
+
+export class CheckoutDeliverySelectionError extends Error {
+    override name = 'CheckoutDeliverySelectionError';
+
+    constructor(
+        readonly code: CheckoutDeliverySelectionErrorCode,
+        readonly status: 400 | 409,
+        message: string,
+    ) {
+        super(message);
+    }
+}
+
+export function validateCheckoutDeliverySelection({
+    address,
+    location,
+    now = new Date(),
+    requiresDelivery,
+    selection,
+    slot,
+}: {
+    address?: CheckoutDeliveryAddress;
+    location?: CheckoutPickupLocation;
+    now?: Date;
+    requiresDelivery: boolean;
+    selection?: CheckoutDeliverySelection;
+    slot?: CheckoutDeliverySlot;
+}) {
+    if (!selection) {
+        if (!requiresDelivery) {
+            return;
+        }
+
+        throw new CheckoutDeliverySelectionError(
+            checkoutDeliverySelectionErrorCodes.REQUIRED,
+            400,
+            'Odabir dostave ili preuzimanja je obavezan.',
+        );
+    }
+
+    if (
+        !slot ||
+        slot.id !== selection.slotId ||
+        slot.status !== 'scheduled' ||
+        slot.startAt.getTime() <= now.getTime() ||
+        slot.effectiveClosesAt.getTime() <= now.getTime()
+    ) {
+        throw new CheckoutDeliverySelectionError(
+            checkoutDeliverySelectionErrorCodes.SLOT_UNAVAILABLE,
+            409,
+            'Odabrani termin više nije dostupan.',
+        );
+    }
+
+    if (slot.type !== selection.mode) {
+        throw new CheckoutDeliverySelectionError(
+            checkoutDeliverySelectionErrorCodes.MODE_MISMATCH,
+            400,
+            'Način preuzimanja ne odgovara odabranom terminu.',
+        );
+    }
+
+    if (selection.mode === 'delivery') {
+        if (!address || address.id !== selection.addressId) {
+            throw new CheckoutDeliverySelectionError(
+                checkoutDeliverySelectionErrorCodes.ADDRESS_INVALID,
+                400,
+                'Odaberi važeću adresu za dostavu.',
+            );
+        }
+
+        return selection;
+    }
+
+    if (
+        !location?.isActive ||
+        location.id !== slot.locationId ||
+        location.id !== selection.locationId
+    ) {
+        throw new CheckoutDeliverySelectionError(
+            checkoutDeliverySelectionErrorCodes.LOCATION_INVALID,
+            400,
+            'Lokacija preuzimanja ne odgovara odabranom terminu.',
+        );
+    }
+
+    return selection;
+}

--- a/apps/api/lib/checkout/harvestCheckout.node.spec.ts
+++ b/apps/api/lib/checkout/harvestCheckout.node.spec.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    buildCheckoutAdditionalData,
+    decodeExpectedNonStripeCartItemIdsMetadata,
+    decodeHarvestDatesMetadata,
+    encodeHarvestDatesMetadata,
+} from './harvestCheckout';
+
+test('harvest checkout preserves metadata and applies the canonical date', () => {
+    assert.deepEqual(
+        buildCheckoutAdditionalData({
+            additionalData: JSON.stringify({
+                scheduledDate: '2026-07-20T00:00:00.000Z',
+                sowingLocation: 'outdoor',
+            }),
+            deliveryInfo: {
+                slotId: 8,
+                mode: 'pickup',
+                locationId: 3,
+            },
+            scheduledHarvestDate: '2026-07-24T00:00:00.000Z',
+        }),
+        {
+            scheduledDate: '2026-07-24T00:00:00.000Z',
+            sowingLocation: 'outdoor',
+            delivery: {
+                slotId: 8,
+                mode: 'pickup',
+                locationId: 3,
+            },
+        },
+    );
+});
+
+test('non-harvest checkout leaves an existing scheduled date unchanged', () => {
+    assert.deepEqual(
+        buildCheckoutAdditionalData({
+            additionalData: JSON.stringify({
+                scheduledDate: '2026-07-27T00:00:00.000Z',
+            }),
+        }),
+        {
+            scheduledDate: '2026-07-27T00:00:00.000Z',
+        },
+    );
+});
+
+test('round-trips a chunked canonical harvest date map for Stripe fulfillment', () => {
+    const selections = Array.from({ length: 100 }, (_, index) => ({
+        cartItemId: index + 1,
+        scheduledDate: '2026-07-24T00:00:00.000Z',
+    }));
+
+    const metadata = encodeHarvestDatesMetadata(selections, [104, 102]);
+    assert.ok(Number(metadata.harvestDatesChunkCount) > 1);
+    assert.deepEqual(
+        [...decodeHarvestDatesMetadata(metadata).entries()],
+        selections.map(
+            ({ cartItemId, scheduledDate }) =>
+                [cartItemId, scheduledDate] as const,
+        ),
+    );
+    assert.deepEqual(
+        [...(decodeExpectedNonStripeCartItemIdsMetadata(metadata) ?? [])],
+        [102, 104],
+    );
+});
+
+test('rejects incomplete canonical harvest date metadata', () => {
+    assert.throws(
+        () =>
+            decodeHarvestDatesMetadata({
+                harvestDatesVersion: '1',
+                harvestDatesChunkCount: '2',
+                harvestDates0: '[[1,"2026-07-24T00:00:00.000Z"]]',
+            }),
+        /Incomplete harvest date checkout metadata/,
+    );
+});
+
+test('distinguishes a legacy session from a new empty non-Stripe snapshot', () => {
+    assert.equal(decodeExpectedNonStripeCartItemIdsMetadata(undefined), null);
+
+    const metadata = encodeHarvestDatesMetadata([], []);
+    assert.deepEqual(
+        [...(decodeExpectedNonStripeCartItemIdsMetadata(metadata) ?? [])],
+        [],
+    );
+});

--- a/apps/api/lib/checkout/harvestCheckout.ts
+++ b/apps/api/lib/checkout/harvestCheckout.ts
@@ -1,0 +1,234 @@
+import type { CheckoutDeliverySelection } from './deliverySelection';
+
+const harvestDatesMetadataVersion = '1';
+const harvestDatesMetadataChunkSize = 450;
+const harvestDatePattern = /^\d{4}-\d{2}-\d{2}T00:00:00\.000Z$/u;
+
+export interface CanonicalHarvestDateSelection {
+    cartItemId: number;
+    scheduledDate: string;
+}
+
+function parseAdditionalData(value: string | null | undefined) {
+    if (!value) {
+        return {};
+    }
+
+    const parsed: unknown = JSON.parse(value);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('Shopping cart item additional data must be an object');
+    }
+
+    return parsed;
+}
+
+export function buildCheckoutAdditionalData({
+    additionalData,
+    deliveryInfo,
+    scheduledHarvestDate,
+}: {
+    additionalData: string | null | undefined;
+    deliveryInfo?: CheckoutDeliverySelection;
+    scheduledHarvestDate?: string;
+}) {
+    return {
+        ...parseAdditionalData(additionalData),
+        ...(scheduledHarvestDate
+            ? { scheduledDate: scheduledHarvestDate }
+            : {}),
+        ...(deliveryInfo ? { delivery: deliveryInfo } : {}),
+    };
+}
+
+function isCanonicalHarvestDate(value: unknown): value is string {
+    if (typeof value !== 'string' || !harvestDatePattern.test(value)) {
+        return false;
+    }
+
+    const date = new Date(value);
+    return !Number.isNaN(date.getTime()) && date.toISOString() === value;
+}
+
+export function encodeHarvestDatesMetadata(
+    selections: readonly CanonicalHarvestDateSelection[],
+    expectedNonStripeCartItemIds: readonly number[] = [],
+) {
+    const entries: Array<readonly [number, string]> = [];
+    const seenCartItemIds = new Set<number>();
+    for (const selection of [...selections].sort(
+        (first, second) => first.cartItemId - second.cartItemId,
+    )) {
+        if (
+            !Number.isInteger(selection.cartItemId) ||
+            selection.cartItemId <= 0 ||
+            seenCartItemIds.has(selection.cartItemId) ||
+            !isCanonicalHarvestDate(selection.scheduledDate)
+        ) {
+            throw new Error('Invalid canonical harvest date metadata');
+        }
+
+        seenCartItemIds.add(selection.cartItemId);
+        entries.push([selection.cartItemId, selection.scheduledDate]);
+    }
+
+    const chunks: string[] = [];
+    let currentChunk: Array<readonly [number, string]> = [];
+    for (const entry of entries) {
+        const candidate = [...currentChunk, entry];
+        const serializedCandidate = JSON.stringify(candidate);
+
+        if (
+            currentChunk.length > 0 &&
+            serializedCandidate.length > harvestDatesMetadataChunkSize
+        ) {
+            chunks.push(JSON.stringify(currentChunk));
+            currentChunk = [entry];
+        } else {
+            currentChunk = candidate;
+        }
+    }
+    if (currentChunk.length > 0) {
+        chunks.push(JSON.stringify(currentChunk));
+    }
+
+    const expectedIds = [
+        ...new Set(
+            [...expectedNonStripeCartItemIds].sort(
+                (first, second) => first - second,
+            ),
+        ),
+    ];
+    if (
+        expectedIds.length !== expectedNonStripeCartItemIds.length ||
+        expectedIds.some((id) => !Number.isInteger(id) || id <= 0)
+    ) {
+        throw new Error('Invalid non-Stripe cart item metadata');
+    }
+    const expectedIdChunks: string[] = [];
+    let currentExpectedIdChunk: number[] = [];
+    for (const id of expectedIds) {
+        const candidate = [...currentExpectedIdChunk, id];
+        if (
+            currentExpectedIdChunk.length > 0 &&
+            JSON.stringify(candidate).length > harvestDatesMetadataChunkSize
+        ) {
+            expectedIdChunks.push(JSON.stringify(currentExpectedIdChunk));
+            currentExpectedIdChunk = [id];
+        } else {
+            currentExpectedIdChunk = candidate;
+        }
+    }
+    if (currentExpectedIdChunk.length > 0) {
+        expectedIdChunks.push(JSON.stringify(currentExpectedIdChunk));
+    }
+
+    return Object.fromEntries([
+        ['harvestDatesVersion', harvestDatesMetadataVersion],
+        ['harvestDatesChunkCount', chunks.length.toString()],
+        ['nonStripeCartItemIdsChunkCount', expectedIdChunks.length.toString()],
+        ...chunks.map(
+            (chunk, index) =>
+                [`harvestDates${index.toString()}`, chunk] as const,
+        ),
+        ...expectedIdChunks.map(
+            (chunk, index) =>
+                [`nonStripeCartItemIds${index.toString()}`, chunk] as const,
+        ),
+    ]);
+}
+
+export function decodeHarvestDatesMetadata(
+    metadata: Record<string, unknown> | null | undefined,
+) {
+    const version = metadata?.harvestDatesVersion;
+    const chunkCountValue = metadata?.harvestDatesChunkCount;
+    if (version === undefined && chunkCountValue === undefined) {
+        return new Map<number, string>();
+    }
+    if (
+        version !== harvestDatesMetadataVersion ||
+        typeof chunkCountValue !== 'string' ||
+        !/^(?:0|[1-9]\d?)$/u.test(chunkCountValue)
+    ) {
+        throw new Error('Invalid harvest date checkout metadata');
+    }
+
+    const chunkCount = Number.parseInt(chunkCountValue, 10);
+    const selections = new Map<number, string>();
+    for (let index = 0; index < chunkCount; index += 1) {
+        const chunk = metadata?.[`harvestDates${index.toString()}`];
+        if (typeof chunk !== 'string') {
+            throw new Error('Incomplete harvest date checkout metadata');
+        }
+
+        const entries: unknown = JSON.parse(chunk);
+        if (!Array.isArray(entries)) {
+            throw new Error('Invalid harvest date checkout metadata chunk');
+        }
+
+        for (const entry of entries) {
+            if (
+                !Array.isArray(entry) ||
+                entry.length !== 2 ||
+                !Number.isInteger(entry[0]) ||
+                entry[0] <= 0 ||
+                !isCanonicalHarvestDate(entry[1]) ||
+                selections.has(entry[0])
+            ) {
+                throw new Error('Invalid harvest date checkout metadata entry');
+            }
+            selections.set(entry[0], entry[1]);
+        }
+    }
+
+    return selections;
+}
+
+export function decodeExpectedNonStripeCartItemIdsMetadata(
+    metadata: Record<string, unknown> | null | undefined,
+) {
+    const version = metadata?.harvestDatesVersion;
+    const chunkCountValue = metadata?.nonStripeCartItemIdsChunkCount;
+    if (version === undefined && chunkCountValue === undefined) {
+        return null;
+    }
+    if (
+        version !== harvestDatesMetadataVersion ||
+        typeof chunkCountValue !== 'string' ||
+        !/^(?:0|[1-9]\d?)$/u.test(chunkCountValue)
+    ) {
+        throw new Error('Invalid non-Stripe cart item checkout metadata');
+    }
+
+    const chunkCount = Number.parseInt(chunkCountValue, 10);
+    const cartItemIds = new Set<number>();
+    for (let index = 0; index < chunkCount; index += 1) {
+        const chunk = metadata?.[`nonStripeCartItemIds${index.toString()}`];
+        if (typeof chunk !== 'string') {
+            throw new Error(
+                'Incomplete non-Stripe cart item checkout metadata',
+            );
+        }
+
+        const entries: unknown = JSON.parse(chunk);
+        if (!Array.isArray(entries)) {
+            throw new Error(
+                'Invalid non-Stripe cart item checkout metadata chunk',
+            );
+        }
+        for (const entry of entries) {
+            if (
+                !Number.isInteger(entry) ||
+                entry <= 0 ||
+                cartItemIds.has(entry)
+            ) {
+                throw new Error(
+                    'Invalid non-Stripe cart item checkout metadata entry',
+                );
+            }
+            cartItemIds.add(entry);
+        }
+    }
+
+    return cartItemIds;
+}

--- a/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
@@ -5,6 +5,7 @@ import {
     buildCheckoutInvoiceBillingSnapshot,
     buildCheckoutInvoiceLineItem,
 } from '../billing/checkoutInvoiceDraft';
+import { encodeHarvestDatesMetadata } from '../checkout/harvestCheckout';
 import {
     __testUtils,
     type ProcessCheckoutSessionDependencies,
@@ -2134,6 +2135,125 @@ describe('processCheckoutSession', () => {
             [1],
         );
         assert.equal(callsNamed(calls, 'createTransaction').length, 1);
+    });
+
+    it('uses the canonical harvest date for a mixed checkout and ignores a later non-Stripe cart item', async () => {
+        const calls: RecordedCall[] = [];
+        const canonicalHarvestDate = '2026-07-24T00:00:00.000Z';
+        const harvestEntityData = {
+            attributes: {
+                deliverable: true,
+                stage: {
+                    information: {
+                        name: 'harvest',
+                    },
+                },
+            },
+        };
+        const expectedSunflowerItem = {
+            ...makeSunflowerCartItem(),
+            additionalData: JSON.stringify({
+                scheduledDate: '2026-07-25T00:00:00.000Z',
+            }),
+            entityData: harvestEntityData,
+        };
+        const laterSunflowerItem = {
+            ...makeSunflowerCartItem(),
+            id: 3,
+            entityId: '100',
+            positionIndex: 4,
+            entityData: harvestEntityData,
+        };
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return {
+                    ...makeSession(),
+                    metadata: encodeHarvestDatesMetadata(
+                        [
+                            {
+                                cartItemId: expectedSunflowerItem.id,
+                                scheduledDate: canonicalHarvestDate,
+                            },
+                        ],
+                        [expectedSunflowerItem.id],
+                    ),
+                };
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                return makeCart();
+            },
+            getRaisedBedFieldsWithEvents: async (...args: unknown[]) => {
+                record(calls, 'getRaisedBedFieldsWithEvents', args);
+                return [
+                    { id: 88, positionIndex: 2, active: true },
+                    { id: 89, positionIndex: 3, active: true },
+                    { id: 90, positionIndex: 4, active: true },
+                ];
+            },
+            normalizeShoppingCartInventoryUsage: async (...args: unknown[]) => {
+                record(calls, 'normalizeShoppingCartInventoryUsage', args);
+                return {
+                    id: 100,
+                    items: [expectedSunflowerItem, laterSunflowerItem],
+                };
+            },
+            getCartInfo: async (...args: unknown[]) => {
+                record(calls, 'getCartInfo', args);
+                return {
+                    allowPurchase: true,
+                    notes: [],
+                    items: [expectedSunflowerItem, laterSunflowerItem],
+                };
+            },
+        });
+
+        await processCheckoutSession('cs_paid', dependencies);
+
+        assert.deepStrictEqual(callsNamed(calls, 'spendSunflowers')[0]?.args, [
+            'account-1',
+            5000,
+            'shoppingCart:100',
+        ]);
+        assert.deepStrictEqual(
+            callsNamed(calls, 'setCartItemPaid').map((call) => call.args[0]),
+            [1, 2],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'createOperation').map((call) =>
+                isRecord(call.args[0]) ? call.args[0].entityId : undefined,
+            ),
+            [42, 99],
+        );
+
+        const scheduledEvents = callsNamed(calls, 'createEvent')
+            .map((call) => call.args[0])
+            .filter(isRecordedEvent)
+            .filter((event) => event.type === 'operations.scheduled');
+        assert.equal(scheduledEvents.length, 2);
+        assert.ok(
+            scheduledEvents.some(
+                (event) =>
+                    isRecord(event.data) &&
+                    event.data.scheduledDate === canonicalHarvestDate,
+            ),
+        );
+        assert.equal(
+            callsNamed(calls, 'setCartItemPaid').some(
+                (call) => call.args[0] === laterSunflowerItem.id,
+            ),
+            false,
+        );
+        assert.equal(
+            callsNamed(calls, 'createOperation').some(
+                (call) =>
+                    isRecord(call.args[0]) &&
+                    call.args[0].entityId ===
+                        Number(laterSunflowerItem.entityId),
+            ),
+            false,
+        );
     });
 });
 

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -63,6 +63,10 @@ import {
     type ShoppingCartItemWithShopData,
 } from '../checkout/cartInfo';
 import {
+    decodeExpectedNonStripeCartItemIdsMetadata,
+    decodeHarvestDatesMetadata,
+} from '../checkout/harvestCheckout';
+import {
     buildOrderConfirmationItems,
     notifyOrderConfirmationEmail,
 } from '../checkout/orderConfirmationEmail';
@@ -336,6 +340,8 @@ async function processNonStripeCartItems(
     cartId: number,
     accountId: string,
     deliveryInfo?: unknown,
+    harvestDateByCartItemId = new Map<number, string>(),
+    expectedNonStripeCartItemIds: ReadonlySet<number> | null = null,
     scheduledDeliveryEmailKeys?: Set<string>,
     checkoutSessionId?: string | null,
     dependencies: ProcessCheckoutSessionDependencies = realDependencies,
@@ -364,9 +370,29 @@ async function processNonStripeCartItems(
         );
         return [];
     }
+    const isExpectedNonStripeItem = (item: { id: number }) =>
+        expectedNonStripeCartItemIds === null ||
+        expectedNonStripeCartItemIds.has(item.id);
+    for (const item of cartInfo.items) {
+        if (
+            expectedNonStripeCartItemIds?.has(item.id) &&
+            item.status !== 'paid' &&
+            item.entityTypeName === 'operation' &&
+            item.entityData.attributes?.deliverable === true &&
+            item.entityData.attributes.stage?.information.name === 'harvest' &&
+            !harvestDateByCartItemId.has(item.id)
+        ) {
+            throw new Error(
+                `Missing canonical harvest date for non-Stripe cart item ${item.id.toString()}`,
+            );
+        }
+    }
 
     const sunflowerCartItemsWithShopData = cartInfo.items.filter(
-        (item) => item.status !== 'paid' && item.currency === 'sunflower',
+        (item) =>
+            item.status !== 'paid' &&
+            item.currency === 'sunflower' &&
+            isExpectedNonStripeItem(item),
     );
 
     // Precompute sunflower amounts and total required, so we can spend in a single operation
@@ -410,6 +436,11 @@ async function processNonStripeCartItems(
             const additionalData = {
                 ...baseAdditionalData,
                 ...(deliveryInfo ? { delivery: deliveryInfo } : {}),
+                ...(harvestDateByCartItemId.has(item.id)
+                    ? {
+                          scheduledDate: harvestDateByCartItemId.get(item.id),
+                      }
+                    : {}),
             };
 
             await Promise.all([
@@ -440,7 +471,8 @@ async function processNonStripeCartItems(
     const inventoryCartItems = cartInfo.items.filter(
         (item) =>
             item.status !== 'paid' &&
-            (item.currency === 'inventory' || item.usesInventory),
+            (item.currency === 'inventory' || item.usesInventory) &&
+            isExpectedNonStripeItem(item),
     );
 
     // Helper function to generate inventory key
@@ -491,6 +523,11 @@ async function processNonStripeCartItems(
             const additionalData = {
                 ...baseAdditionalData,
                 ...(deliveryInfo ? { delivery: deliveryInfo } : {}),
+                ...(harvestDateByCartItemId.has(item.id)
+                    ? {
+                          scheduledDate: harvestDateByCartItemId.get(item.id),
+                      }
+                    : {}),
             };
 
             await Promise.all([
@@ -1287,12 +1324,19 @@ async function processPaidCheckoutSession(
     }
 
     const uniqueAffectedCartIds = Array.from(new Set(affectedCartIds));
+    const harvestDateByCartItemId = decodeHarvestDatesMetadata(
+        session.metadata,
+    );
+    const expectedNonStripeCartItemIds =
+        decodeExpectedNonStripeCartItemIdsMetadata(session.metadata);
     if (accountId && uniqueAffectedCartIds.length > 0) {
         for (const cartId of uniqueAffectedCartIds) {
             const nonStripeItems = await processNonStripeCartItems(
                 cartId,
                 accountId,
                 deliveryInfo,
+                harvestDateByCartItemId,
+                expectedNonStripeCartItemIds,
                 scheduledDeliveryEmailKeys,
                 session.id,
                 dependencies,

--- a/apps/garden/tests/DeliveryStepPickupStory.tsx
+++ b/apps/garden/tests/DeliveryStepPickupStory.tsx
@@ -1,0 +1,46 @@
+import * as ReactQuery from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+import {
+    DeliveryStep,
+    type DeliveryStepSummary,
+} from '../../../packages/game/src/shared-ui/delivery/DeliveryStep';
+
+export function DeliveryStepPickupStory() {
+    const queryClient = useMemo(
+        () =>
+            new ReactQuery.QueryClient({
+                defaultOptions: {
+                    queries: {
+                        refetchOnReconnect: false,
+                        refetchOnWindowFocus: false,
+                        retry: false,
+                        retryOnMount: false,
+                        staleTime: Infinity,
+                    },
+                },
+            }),
+        [],
+    );
+    const [summary, setSummary] = useState<DeliveryStepSummary | null>(null);
+
+    return (
+        <ReactQuery.QueryClientProvider client={queryClient}>
+            <div className="w-[40rem] max-w-full p-5">
+                <DeliveryStep
+                    initialSelection={{
+                        mode: 'pickup',
+                        locationId: 7,
+                        slotId: 41,
+                    }}
+                    isValid
+                    onBack={() => undefined}
+                    onProceed={setSummary}
+                    onSelectionChange={() => undefined}
+                />
+                <output aria-label="Sažetak osobnog preuzimanja">
+                    {summary?.destinationLabel ?? ''}
+                </output>
+            </div>
+        </ReactQuery.QueryClientProvider>
+    );
+}

--- a/apps/garden/tests/HarvestScheduleStepStory.tsx
+++ b/apps/garden/tests/HarvestScheduleStepStory.tsx
@@ -1,0 +1,88 @@
+import { Button } from '@gredice/ui/Button';
+import { useState } from 'react';
+import {
+    type HarvestScheduleDateSelection,
+    type HarvestScheduleItem,
+    HarvestScheduleStep,
+} from '../../../packages/game/src/shared-ui/delivery/HarvestScheduleStep';
+
+const items = [
+    {
+        cartItemId: 71,
+        operationLabel: 'Berba salate',
+        raisedBedLabel: 'Gredica 3',
+        plants: [
+            {
+                id: 901,
+                label: 'Salata',
+                maxHarvestDaysBeforeDelivery: 0,
+            },
+        ],
+        scheduledDate: '2026-07-24',
+        allowedFrom: '2026-07-24',
+        allowedTo: '2026-07-24',
+        valid: true,
+    },
+    {
+        cartItemId: 72,
+        operationLabel: 'Berba mrkve',
+        raisedBedLabel: 'Gredica 4',
+        plants: [
+            {
+                id: 902,
+                label: 'Mrkva',
+                maxHarvestDaysBeforeDelivery: 3,
+            },
+        ],
+        scheduledDate: '2026-07-22',
+        allowedFrom: '2026-07-21',
+        allowedTo: '2026-07-24',
+        valid: true,
+    },
+] satisfies HarvestScheduleItem[];
+
+export function HarvestScheduleStepStory({
+    invalid = false,
+    withConfirmAction = false,
+}: {
+    invalid?: boolean;
+    withConfirmAction?: boolean;
+}) {
+    const [selections, setSelections] = useState<
+        readonly HarvestScheduleDateSelection[]
+    >([]);
+    const scenarioItems = invalid
+        ? items.map((item) => ({
+              ...item,
+              scheduledDate: '2026-07-20',
+              valid: false,
+              validationReason: 'before_allowed_range',
+          }))
+        : items;
+
+    return (
+        <div className="w-[40rem] max-w-full p-5">
+            <HarvestScheduleStep
+                confirmAction={
+                    withConfirmAction ? (
+                        <Button>Postojeće plaćanje</Button>
+                    ) : undefined
+                }
+                delivery={{
+                    deliveryDate: '2026-07-24',
+                    mode: 'delivery',
+                    slotStartAt: '2026-07-24T15:00:00.000Z',
+                    slotEndAt: '2026-07-24T17:00:00.000Z',
+                    destinationLabel: 'Dom — Ilica 1, Zagreb',
+                }}
+                items={scenarioItems}
+                onBack={() => {}}
+                onConfirm={setSelections}
+                onSelectedDatesChange={setSelections}
+            />
+            <output aria-label="Odabrani datumi branja">
+                {JSON.stringify(selections)}
+            </output>
+        </div>
+    );
+}

--- a/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
+++ b/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
@@ -358,8 +358,8 @@ function ShoppingCartItemsPresencePanel({
                 <ShoppingCartHud />
             ) : (
                 <ShoppingCart
-                    showDeliveryStep={false}
-                    onShowDeliveryStepChange={() => undefined}
+                    checkoutStep="cart"
+                    onCheckoutStepChange={() => undefined}
                 />
             )}
         </div>

--- a/apps/garden/tests/ShoppingCartStepTransitionStory.tsx
+++ b/apps/garden/tests/ShoppingCartStepTransitionStory.tsx
@@ -2,13 +2,16 @@ import { useState } from 'react';
 import { ShoppingCartStepTransition } from '../../../packages/game/src/hud/components/shopping-cart/ShoppingCartStepTransition';
 
 export function ShoppingCartStepTransitionStory() {
-    const [step, setStep] = useState<'cart' | 'delivery'>('cart');
+    const [step, setStep] = useState<'cart' | 'delivery' | 'harvest'>('cart');
+    const [direction, setDirection] = useState<'forward' | 'backward'>(
+        'forward',
+    );
     const [cartUpdateCount, setCartUpdateCount] = useState(0);
     const [proceedCount, setProceedCount] = useState(0);
 
     return (
         <div className="w-80 p-8">
-            <ShoppingCartStepTransition step={step}>
+            <ShoppingCartStepTransition direction={direction} step={step}>
                 {step === 'cart' ? (
                     <div>
                         <button
@@ -24,15 +27,45 @@ export function ShoppingCartStepTransitionStory() {
                         </output>
                         <button
                             type="button"
-                            onClick={() => setStep('delivery')}
+                            onClick={() => {
+                                setDirection('forward');
+                                setStep('delivery');
+                            }}
                         >
                             Dostava
                         </button>
                     </div>
+                ) : step === 'delivery' ? (
+                    <div>
+                        <button
+                            type="button"
+                            onClick={() => {
+                                setDirection('backward');
+                                setStep('cart');
+                            }}
+                        >
+                            Natrag
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => {
+                                setDirection('forward');
+                                setStep('harvest');
+                            }}
+                        >
+                            Nastavi
+                        </button>
+                    </div>
                 ) : (
                     <div>
-                        <button type="button" onClick={() => setStep('cart')}>
-                            Natrag
+                        <button
+                            type="button"
+                            onClick={() => {
+                                setDirection('backward');
+                                setStep('delivery');
+                            }}
+                        >
+                            Natrag na dostavu
                         </button>
                         <button
                             type="button"
@@ -40,7 +73,7 @@ export function ShoppingCartStepTransitionStory() {
                                 setProceedCount((count) => count + 1)
                             }
                         >
-                            Nastavi
+                            Potvrdi datume
                         </button>
                         <output aria-label="Broj nastavaka">
                             {proceedCount}

--- a/apps/garden/tests/delivery-step-pickup.spec.tsx
+++ b/apps/garden/tests/delivery-step-pickup.spec.tsx
@@ -1,0 +1,111 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { DeliveryStepPickupStory } from './DeliveryStepPickupStory';
+
+test('explains a pickup-location failure and recovers through retry', async ({
+    mount,
+    page,
+}) => {
+    const startAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    const endAt = new Date(startAt.getTime() + 2 * 60 * 60 * 1000);
+    const effectiveClosesAt = new Date(startAt.getTime() - 24 * 60 * 60 * 1000);
+    let pickupLocationRequestCount = 0;
+    let releaseFirstPickupRequest: () => void = () => undefined;
+    const firstPickupRequest = new Promise<void>((resolve) => {
+        releaseFirstPickupRequest = resolve;
+    });
+
+    await page.route(
+        '**/api/gredice/api/delivery/pickup-locations**',
+        async (route) => {
+            pickupLocationRequestCount += 1;
+
+            if (pickupLocationRequestCount === 1) {
+                await firstPickupRequest;
+                await route.fulfill({
+                    body: JSON.stringify({ error: 'Unavailable' }),
+                    contentType: 'application/json',
+                    status: 503,
+                });
+                return;
+            }
+
+            await route.fulfill({
+                body: JSON.stringify([
+                    {
+                        id: 7,
+                        name: 'Gredice Maksimir',
+                        street1: 'Maksimirska 1',
+                        street2: null,
+                        city: 'Zagreb',
+                        postalCode: '10000',
+                        countryCode: 'HR',
+                        isActive: true,
+                        createdAt: startAt.toISOString(),
+                        updatedAt: startAt.toISOString(),
+                    },
+                ]),
+                contentType: 'application/json',
+                status: 200,
+            });
+        },
+    );
+    await page.route('**/api/gredice/api/delivery/slots**', async (route) => {
+        await route.fulfill({
+            body: JSON.stringify([
+                {
+                    id: 41,
+                    locationId: 7,
+                    type: 'pickup',
+                    startAt: startAt.toISOString(),
+                    endAt: endAt.toISOString(),
+                    closesAt: null,
+                    effectiveClosesAt: effectiveClosesAt.toISOString(),
+                    status: 'scheduled',
+                    createdAt: startAt.toISOString(),
+                    updatedAt: startAt.toISOString(),
+                    location: null,
+                },
+            ]),
+            contentType: 'application/json',
+            status: 200,
+        });
+    });
+    await page.route(
+        '**/api/gredice/api/delivery/addresses**',
+        async (route) => {
+            await route.fulfill({
+                body: '[]',
+                contentType: 'application/json',
+                status: 200,
+            });
+        },
+    );
+
+    await mount(<DeliveryStepPickupStory />);
+
+    await expect(
+        page.getByRole('status', {
+            name: 'Učitavanje lokacije za osobno preuzimanje',
+        }),
+    ).toBeVisible();
+    releaseFirstPickupRequest();
+
+    await expect(
+        page.getByText('Nije moguće učitati lokaciju', { exact: false }),
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Nastavi' })).toBeDisabled();
+
+    await page.getByRole('button', { name: 'Pokušaj ponovno' }).click();
+
+    await expect(
+        page.getByText('Gredice Maksimir — Maksimirska 1, 10000 Zagreb', {
+            exact: false,
+        }),
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Nastavi' })).toBeEnabled();
+
+    await page.getByRole('button', { name: 'Nastavi' }).click();
+    await expect(page.getByLabel('Sažetak osobnog preuzimanja')).toHaveText(
+        'Gredice Maksimir — Maksimirska 1, 10000 Zagreb',
+    );
+});

--- a/apps/garden/tests/harvest-schedule-step.spec.tsx
+++ b/apps/garden/tests/harvest-schedule-step.spec.tsx
@@ -1,0 +1,70 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { HarvestScheduleStepStory } from './HarvestScheduleStepStory';
+
+test('shows only the summary when every date is already valid', async ({
+    mount,
+    page,
+}) => {
+    await mount(<HarvestScheduleStepStory />);
+
+    await expect(
+        page.getByText(
+            'Svi datumi branja usklađeni su s odabranim terminom dostave.',
+        ),
+    ).toBeVisible();
+    await expect(page.getByLabel('Datum branja za Berba mrkve')).toHaveCount(0);
+    await expect(
+        page.getByRole('button', { name: 'Uredi datume' }),
+    ).toHaveCount(0);
+});
+
+test('collects invalid flexible dates, keeps same-day crops fixed, and returns to summary', async ({
+    mount,
+    page,
+}) => {
+    await mount(<HarvestScheduleStepStory invalid />);
+
+    await expect(
+        page.getByText('Provjeri označene datume prije plaćanja.', {
+            exact: false,
+        }),
+    ).toBeVisible();
+    await expect(page.getByLabel('Datum branja za Berba mrkve')).toHaveValue(
+        '2026-07-20',
+    );
+    await expect(page.getByLabel('Datum branja za Berba salate')).toHaveCount(
+        0,
+    );
+    await expect(
+        page.getByRole('button', { name: 'Uredi datume' }),
+    ).toBeVisible();
+    await expect(page.getByLabel('Odabrani datumi branja')).toContainText(
+        '"cartItemId":71,"scheduledDate":"2026-07-24"',
+    );
+
+    await page.getByLabel('Datum branja za Berba mrkve').fill('2026-07-22');
+
+    await expect(
+        page.getByText(
+            'Svi datumi branja usklađeni su s odabranim terminom dostave.',
+        ),
+    ).toBeVisible();
+    await expect(page.getByLabel('Datum branja za Berba mrkve')).toHaveCount(0);
+    await expect(page.getByLabel('Odabrani datumi branja')).toContainText(
+        '"cartItemId":72,"scheduledDate":"2026-07-22"',
+    );
+});
+
+test('renders the existing checkout action when provided', async ({
+    mount,
+    page,
+}) => {
+    await mount(<HarvestScheduleStepStory withConfirmAction />);
+
+    await expect(
+        page.getByRole('button', { name: 'Postojeće plaćanje' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Potvrdi i plati' }),
+    ).toHaveCount(0);
+});

--- a/apps/garden/tests/shopping-cart-step-transition.spec.tsx
+++ b/apps/garden/tests/shopping-cart-step-transition.spec.tsx
@@ -99,7 +99,18 @@ test.describe('shopping cart step transition', () => {
         const proceed = page.getByRole('button', { name: 'Nastavi' });
         await proceed.focus();
         await expect(proceed).toBeFocused();
-        await proceed.dispatchEvent('click');
+        await proceed.click();
+
+        const harvestTransition = page.locator(
+            '[data-shopping-cart-step="harvest"]',
+        );
+        await expect(harvestTransition).toHaveAttribute(
+            'data-step-direction',
+            'forward',
+        );
+        await page
+            .getByRole('button', { name: 'Potvrdi datume' })
+            .dispatchEvent('click');
         await expect(page.getByLabel('Broj nastavaka')).toHaveText('1');
     });
 
@@ -154,5 +165,19 @@ test.describe('shopping cart step transition', () => {
                 { opacity: '1', transform: undefined },
             ],
         });
+    });
+
+    test('uses the reverse motion when returning from harvest to delivery', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<ShoppingCartStepTransitionStory />);
+        await page.getByRole('button', { name: 'Dostava' }).click();
+        await page.getByRole('button', { name: 'Nastavi' }).click();
+        await page.getByRole('button', { name: 'Natrag na dostavu' }).click();
+
+        await expect(
+            page.locator('[data-shopping-cart-step="delivery"]'),
+        ).toHaveAttribute('data-step-direction', 'backward');
     });
 });

--- a/apps/storybook/stories/packages/game/shared-ui/HarvestScheduleStep.stories.tsx
+++ b/apps/storybook/stories/packages/game/shared-ui/HarvestScheduleStep.stories.tsx
@@ -1,0 +1,151 @@
+import {
+    type HarvestScheduleDateSelection,
+    HarvestScheduleStep,
+    type HarvestScheduleStepProps,
+} from '@packages/game/shared-ui/delivery/HarvestScheduleStep';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useState } from 'react';
+
+const validItems: HarvestScheduleStepProps['items'] = [
+    {
+        cartItemId: 41,
+        operationLabel: 'Berba salate',
+        raisedBedLabel: 'Gredica 12',
+        plants: [
+            {
+                id: 101,
+                label: 'Salata',
+                maxHarvestDaysBeforeDelivery: 0,
+            },
+        ],
+        scheduledDate: '2026-07-24',
+        allowedFrom: '2026-07-24',
+        allowedTo: '2026-07-24',
+        valid: true,
+    },
+    {
+        cartItemId: 42,
+        operationLabel: 'Berba mrkve',
+        raisedBedLabel: 'Gredica 8',
+        plants: [
+            {
+                id: 102,
+                label: 'Mrkva',
+                maxHarvestDaysBeforeDelivery: 3,
+            },
+        ],
+        scheduledDate: '2026-07-22',
+        allowedFrom: '2026-07-21',
+        allowedTo: '2026-07-24',
+        valid: true,
+    },
+];
+
+const meta = {
+    title: 'packages/game/shared-ui/delivery/HarvestScheduleStep',
+    component: HarvestScheduleStep,
+    tags: ['autodocs'],
+    args: {
+        delivery: {
+            deliveryDate: '2026-07-24',
+            mode: 'delivery',
+            startAt: '2026-07-24T15:00:00.000Z',
+            endAt: '2026-07-24T17:00:00.000Z',
+            destinationLabel: 'Dom — Ilica 1, Zagreb',
+        },
+        items: validItems,
+        onSelectedDatesChange: () => {},
+        onBack: () => {},
+        onConfirm: () => {},
+    },
+    argTypes: {
+        confirmAction: { control: false },
+        onBack: { control: false },
+        onConfirm: { control: false },
+        onSelectedDatesChange: { control: false },
+    },
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Final checkout step that summarizes delivery and keeps every harvest date inside the freshness window of its plants.',
+            },
+        },
+    },
+    render: (args) => <HarvestScheduleStepStory {...args} />,
+} satisfies Meta<typeof HarvestScheduleStep>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const AllDatesValid: Story = {};
+
+export const NeedsAdjustment: Story = {
+    args: {
+        items: [
+            {
+                ...validItems[0],
+                scheduledDate: '2026-07-22',
+                valid: false,
+                validationReason: 'before_allowed_range',
+            },
+            {
+                ...validItems[1],
+                scheduledDate: '2026-07-20',
+                valid: false,
+                validationReason: 'before_allowed_range',
+            },
+        ],
+    },
+};
+
+export const Pickup: Story = {
+    args: {
+        delivery: {
+            deliveryDate: '2026-07-24',
+            mode: 'pickup',
+            startAt: '2026-07-24T15:00:00.000Z',
+            endAt: '2026-07-24T17:00:00.000Z',
+            destinationLabel: 'Gredice HQ',
+        },
+    },
+};
+
+export const Confirming: Story = {
+    args: {
+        isConfirming: true,
+    },
+};
+
+export const MobileWidth: Story = {
+    parameters: {
+        layout: 'fullscreen',
+    },
+    render: (args) => (
+        <div className="min-h-screen w-full bg-background p-4">
+            <div className="mx-auto w-full max-w-[22rem] rounded-xl border border-border bg-card p-4 shadow-sm">
+                <HarvestScheduleStepStory {...args} />
+            </div>
+        </div>
+    ),
+};
+
+function HarvestScheduleStepStory(args: HarvestScheduleStepProps) {
+    const [selections, setSelections] = useState<
+        readonly HarvestScheduleDateSelection[]
+    >([]);
+
+    return (
+        <div className="w-[40rem] max-w-full rounded-xl border border-border bg-background p-5 shadow-sm">
+            <HarvestScheduleStep
+                {...args}
+                onSelectedDatesChange={setSelections}
+                onConfirm={setSelections}
+            />
+            <output aria-label="Odabrani datumi branja" className="sr-only">
+                {JSON.stringify(selections)}
+            </output>
+        </div>
+    );
+}

--- a/packages/game/src/hooks/useCheckout.ts
+++ b/packages/game/src/hooks/useCheckout.ts
@@ -10,12 +10,18 @@ export interface CheckoutData {
         locationId?: number;
         notes?: string;
     };
+    harvestDates?: Array<{
+        cartItemId: number;
+        scheduledDate: string;
+    }>;
 }
 
 // Type guard to check if delivery selection is complete
 export function isCompleteDeliverySelection(
-    // biome-ignore lint/suspicious/noExplicitAny: Valid for validation
-    selection: any,
+    selection:
+        | Partial<NonNullable<CheckoutData['deliveryInfo']>>
+        | null
+        | undefined,
 ): selection is CheckoutData['deliveryInfo'] {
     return (
         Boolean(selection) &&
@@ -37,18 +43,17 @@ export function useCheckout() {
                     json: data,
                 });
             if (!response.ok) {
-                console.error(
-                    'Failed to create checkout session:',
-                    response.statusText,
+                throw new Error(
+                    response.statusText ||
+                        'Nije moguće pokrenuti plaćanje. Provjeri odabrane datume.',
                 );
-                // TODO: Show notification to user
-                return;
             }
 
             const responseData = await response.json();
             if (!responseData) {
-                console.error('Failed to create checkout session');
-                return;
+                throw new Error(
+                    'Poslužitelj nije vratio podatke za pokretanje plaćanja.',
+                );
             }
 
             if ('success' in responseData) {
@@ -58,9 +63,9 @@ export function useCheckout() {
 
             const { url } = responseData;
             if (!url) {
-                console.error('No URL returned from checkout session');
-                // TODO: Show notification to user
-                return;
+                throw new Error(
+                    'Poslužitelj nije vratio poveznicu za plaćanje.',
+                );
             }
 
             // If a URL is provided, redirect the user to that URL

--- a/packages/game/src/hooks/useHarvestSchedule.ts
+++ b/packages/game/src/hooks/useHarvestSchedule.ts
@@ -1,0 +1,41 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useQuery } from '@tanstack/react-query';
+
+export const harvestScheduleQueryKey = ['shopping-cart', 'harvest-schedule'];
+
+export function useHarvestSchedule(
+    deliverySlotId: number | undefined,
+    enabled = true,
+) {
+    return useQuery({
+        queryKey: [...harvestScheduleQueryKey, deliverySlotId],
+        queryFn: async () => {
+            if (deliverySlotId === undefined) {
+                throw new Error('Delivery slot is required');
+            }
+
+            const response = await clientAuthenticated().api['shopping-cart'][
+                'harvest-schedule'
+            ].$get({
+                query: {
+                    slotId: deliverySlotId.toString(),
+                },
+            });
+
+            if (!response.ok) {
+                throw new Error(
+                    'Nije moguće provjeriti raspored branja za odabrani termin.',
+                );
+            }
+
+            return response.json();
+        },
+        enabled: enabled && deliverySlotId !== undefined,
+        retry: false,
+        staleTime: 0,
+    });
+}
+
+export type HarvestScheduleData = NonNullable<
+    Awaited<ReturnType<typeof useHarvestSchedule>['data']>
+>;

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -2,6 +2,7 @@ import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { DotIndicator } from '@gredice/ui/DotIndicator';
 import {
+    Calendar,
     Delete,
     Info,
     Navigate,
@@ -17,13 +18,20 @@ import { useLayoutEffect, useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { isCompleteDeliverySelection, useCheckout } from '../hooks/useCheckout';
 import { useCurrentAccount } from '../hooks/useCurrentAccount';
+import { useHarvestSchedule } from '../hooks/useHarvestSchedule';
 import { useShoppingCart } from '../hooks/useShoppingCart';
 import { useShoppingCartDelete } from '../hooks/useShoppingCartDelete';
 import { useShoppingCartTransientHub } from '../hooks/useShoppingCartTransientHub';
 import {
     type DeliverySelectionData,
     DeliveryStep,
+    type DeliveryStepSummary,
 } from '../shared-ui/delivery/DeliveryStep';
+import {
+    type HarvestScheduleDateSelection,
+    HarvestScheduleStep,
+} from '../shared-ui/delivery/HarvestScheduleStep';
+import { isHarvestDateWithinRange } from '../shared-ui/delivery/harvestSchedule';
 import { GameModal } from '../shared-ui/game-modal';
 import { useShoppingCartOpenParam } from '../useUrlState';
 import {
@@ -62,14 +70,16 @@ function useSunflowerSuggestionLayout(showSuggestion: boolean) {
     return reserveLayout;
 }
 
+export type ShoppingCartCheckoutStep = 'cart' | 'delivery' | 'harvest';
+
 interface ShoppingCartProps {
-    showDeliveryStep: boolean;
-    onShowDeliveryStepChange: (showDeliveryStep: boolean) => void;
+    checkoutStep: ShoppingCartCheckoutStep;
+    onCheckoutStepChange: (step: ShoppingCartCheckoutStep) => void;
 }
 
 export function ShoppingCart({
-    showDeliveryStep,
-    onShowDeliveryStepChange,
+    checkoutStep,
+    onCheckoutStepChange,
 }: ShoppingCartProps) {
     const { data: account } = useCurrentAccount();
     const { data: cart, isLoading, isError } = useShoppingCart();
@@ -80,6 +90,18 @@ export function ShoppingCart({
     // State for delivery flow
     const [deliverySelection, setDeliverySelection] =
         useState<DeliverySelectionData | null>(null);
+    const [deliverySummary, setDeliverySummary] =
+        useState<DeliveryStepSummary | null>(null);
+    const [harvestDates, setHarvestDates] = useState<
+        readonly HarvestScheduleDateSelection[]
+    >([]);
+    const [transitionDirection, setTransitionDirection] = useState<
+        'forward' | 'backward'
+    >('forward');
+    const harvestSchedule = useHarvestSchedule(
+        deliverySelection?.slotId,
+        checkoutStep === 'harvest',
+    );
 
     const showSunflowersSuggestion = Boolean(
         !cart?.items.some((item) => item.currency === 'sunflower') &&
@@ -96,33 +118,36 @@ export function ShoppingCart({
         showSunflowersSuggestion,
     );
 
-    function handleCheckout() {
+    function submitCheckout(
+        selectedHarvestDates?: readonly HarvestScheduleDateSelection[],
+    ) {
         if (!cart?.id) {
             console.error('No cart available for checkout');
             return;
         }
 
-        // If cart contains deliverable items and user hasn't gone through delivery step yet
-        if (cart.hasDeliverableItems && !deliverySelection) {
-            track('game_cart_delivery_opened', {
-                item_count: cart.items.length,
-                total: cart.total,
-            });
-            onShowDeliveryStepChange(true);
+        if (
+            cart.hasDeliverableItems &&
+            !isCompleteDeliverySelection(deliverySelection)
+        ) {
+            handleDelivery();
             return;
         }
 
-        // Prepare checkout data with delivery information if available
         const checkoutData = {
             cartId: cart.id,
             ...(isCompleteDeliverySelection(deliverySelection) && {
                 deliveryInfo: deliverySelection,
+            }),
+            ...(selectedHarvestDates && {
+                harvestDates: [...selectedHarvestDates],
             }),
         };
 
         track('game_cart_checkout_clicked', {
             has_delivery_selection:
                 isCompleteDeliverySelection(deliverySelection),
+            harvest_date_count: selectedHarvestDates?.length ?? 0,
             item_count: cart.items.length,
             total: cart.total,
             total_sunflowers: cart.totalSunflowers,
@@ -139,7 +164,8 @@ export function ShoppingCart({
     }
 
     function handleBackToCart() {
-        onShowDeliveryStepChange(false);
+        setTransitionDirection('backward');
+        onCheckoutStepChange('cart');
     }
 
     function handleDelivery() {
@@ -147,27 +173,152 @@ export function ShoppingCart({
             item_count: cart?.items.length,
             total: cart?.total,
         });
-        onShowDeliveryStepChange(true);
+        setTransitionDirection('forward');
+        onCheckoutStepChange('delivery');
     }
 
-    function handleDeliveryProceed() {
+    function handleDeliveryProceed(summary: DeliveryStepSummary) {
         if (isCompleteDeliverySelection(deliverySelection)) {
-            // Proceed with checkout including delivery information
-            handleCheckout();
+            setDeliverySummary(summary);
+            setHarvestDates([]);
+            setTransitionDirection('forward');
+            onCheckoutStepChange('harvest');
+            track('game_cart_harvest_schedule_opened', {
+                item_count: cart?.items.length,
+                slot_id: deliverySelection.slotId,
+            });
         }
     }
 
-    // Show delivery step if user clicked on checkout with deliverable items
-    if (showDeliveryStep) {
+    function handleBackToDelivery() {
+        setTransitionDirection('backward');
+        onCheckoutStepChange('delivery');
+    }
+
+    if (checkoutStep === 'delivery') {
         return (
-            <ShoppingCartStepTransition step="delivery">
+            <ShoppingCartStepTransition
+                direction={transitionDirection}
+                step="delivery"
+            >
                 <DeliveryStep
+                    initialSelection={deliverySelection}
                     onSelectionChange={setDeliverySelection}
                     onBack={handleBackToCart}
                     onProceed={handleDeliveryProceed}
-                    checkout={checkout}
                     isValid={isCompleteDeliverySelection(deliverySelection)}
                 />
+            </ShoppingCartStepTransition>
+        );
+    }
+
+    if (checkoutStep === 'harvest') {
+        const scheduleItems =
+            harvestSchedule.data?.items.map((item) => ({
+                ...item,
+                plants: item.plants.map((plant) => ({
+                    id: plant.plantId,
+                    label: plant.label,
+                    maxHarvestDaysBeforeDelivery:
+                        plant.maxHarvestDaysBeforeDelivery,
+                })),
+                reason: item.validationReason,
+                scheduledDate: item.scheduledDate ?? '',
+            })) ?? [];
+        const selectedDateByItemId = new Map(
+            harvestDates.map((selection) => [
+                selection.cartItemId,
+                selection.scheduledDate,
+            ]),
+        );
+        const canSubmitHarvestSchedule =
+            Boolean(harvestSchedule.data && deliverySummary) &&
+            harvestDates.length === scheduleItems.length &&
+            scheduleItems.every((item) =>
+                isHarvestDateWithinRange(
+                    selectedDateByItemId.get(item.cartItemId) ?? '',
+                    item,
+                ),
+            );
+
+        return (
+            <ShoppingCartStepTransition
+                direction={transitionDirection}
+                step="harvest"
+            >
+                {harvestSchedule.isLoading ? (
+                    <Stack spacing={4}>
+                        <Typography
+                            aria-live="polite"
+                            component="h3"
+                            level="body1"
+                            role="status"
+                        >
+                            Provjeravam datume branja...
+                        </Typography>
+                        <Row justifyContent="end">
+                            <Button
+                                disabled={checkout.isPending}
+                                variant="outlined"
+                                onClick={handleBackToDelivery}
+                            >
+                                Natrag
+                            </Button>
+                        </Row>
+                    </Stack>
+                ) : null}
+                {harvestSchedule.isError ? (
+                    <Stack spacing={4}>
+                        <Alert color="danger">
+                            Nije moguće provjeriti datume branja. Pokušaj
+                            ponovno ili odaberi drugi termin.
+                        </Alert>
+                        <Row justifyContent="end" spacing={4}>
+                            <Button
+                                variant="outlined"
+                                onClick={handleBackToDelivery}
+                            >
+                                Natrag
+                            </Button>
+                            <Button
+                                loading={harvestSchedule.isFetching}
+                                onClick={() => harvestSchedule.refetch()}
+                            >
+                                Pokušaj ponovno
+                            </Button>
+                        </Row>
+                    </Stack>
+                ) : null}
+                {harvestSchedule.data && deliverySummary ? (
+                    <HarvestScheduleStep
+                        confirmAction={
+                            <ButtonConfirmPayment
+                                cart={cart}
+                                checkout={checkout}
+                                disabled={!canSubmitHarvestSchedule}
+                                onConfirm={() => submitCheckout(harvestDates)}
+                            />
+                        }
+                        delivery={{
+                            deliveryDate: harvestSchedule.data.deliveryDate,
+                            mode: deliverySummary.mode,
+                            slotStartAt: deliverySummary.startAt,
+                            slotEndAt: deliverySummary.endAt,
+                            destinationLabel: deliverySummary.destinationLabel,
+                        }}
+                        items={scheduleItems}
+                        isConfirming={checkout.isPending}
+                        onBack={handleBackToDelivery}
+                        onConfirm={submitCheckout}
+                        onSelectedDatesChange={setHarvestDates}
+                    />
+                ) : null}
+                {checkout.isError ? (
+                    <Alert color="danger">
+                        Plaćanje nije pokrenuto. Provjeri termin i datume branja
+                        pa pokušaj ponovno.
+                    </Alert>
+                ) : null}
             </ShoppingCartStepTransition>
         );
     }
@@ -308,7 +459,7 @@ export function ShoppingCart({
                                     <ButtonConfirmPayment
                                         cart={cart}
                                         checkout={checkout}
-                                        onConfirm={handleCheckout}
+                                        onConfirm={() => submitCheckout()}
                                     />
                                 )}
                             </div>
@@ -320,7 +471,7 @@ export function ShoppingCart({
     );
 
     return (
-        <ShoppingCartStepTransition step="cart">
+        <ShoppingCartStepTransition direction={transitionDirection} step="cart">
             {cartStep}
         </ShoppingCartStepTransition>
     );
@@ -330,7 +481,8 @@ export function ShoppingCartHud() {
     const { data: cart } = useShoppingCart();
     const { track } = useGameAnalytics();
     const [isOpen, setIsOpen] = useShoppingCartOpenParam();
-    const [showDeliveryStep, setShowDeliveryStep] = useState(false);
+    const [checkoutStep, setCheckoutStep] =
+        useState<ShoppingCartCheckoutStep>('cart');
     const showTransientHub = useShoppingCartTransientHub(isOpen);
 
     if (!cart?.items.length && !showTransientHub && !isOpen) {
@@ -351,11 +503,19 @@ export function ShoppingCartHud() {
                         }
                         setIsOpen(open);
                     }}
-                    title={showDeliveryStep ? 'Dostava' : 'Košara'}
+                    title={
+                        checkoutStep === 'cart'
+                            ? 'Košara'
+                            : checkoutStep === 'delivery'
+                              ? 'Dostava'
+                              : 'Branje'
+                    }
                     className="md:max-w-2xl"
                     headerIcon={
-                        showDeliveryStep ? (
+                        checkoutStep === 'delivery' ? (
                             <Truck className="size-7 shrink-0" />
+                        ) : checkoutStep === 'harvest' ? (
+                            <Calendar className="size-7 shrink-0" />
                         ) : (
                             <ShoppingCartIcon className="size-7 shrink-0" />
                         )
@@ -393,8 +553,8 @@ export function ShoppingCartHud() {
                     }
                 >
                     <ShoppingCart
-                        showDeliveryStep={showDeliveryStep}
-                        onShowDeliveryStepChange={setShowDeliveryStep}
+                        checkoutStep={checkoutStep}
+                        onCheckoutStepChange={setCheckoutStep}
                     />
                 </GameModal>
             </Row>

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartStepTransition.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartStepTransition.tsx
@@ -1,9 +1,10 @@
-import { type ReactNode, useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
 import styles from './ShoppingCartStepTransition.module.css';
 
 interface ShoppingCartStepTransitionProps {
     children: ReactNode;
-    step: 'cart' | 'delivery';
+    direction?: 'forward' | 'backward';
+    step: 'cart' | 'delivery' | 'harvest';
 }
 
 interface ShoppingCartStepContentProps extends ShoppingCartStepTransitionProps {
@@ -13,24 +14,43 @@ interface ShoppingCartStepContentProps extends ShoppingCartStepTransitionProps {
 function ShoppingCartStepContent({
     animate,
     children,
+    direction,
     step,
 }: ShoppingCartStepContentProps) {
     const [shouldAnimate] = useState(animate);
-    const direction = step === 'delivery' ? 'forward' : 'backward';
+    const contentRef = useRef<HTMLElement>(null);
+    const resolvedDirection =
+        direction ?? (step === 'cart' ? 'backward' : 'forward');
+    const accessibleStepLabel =
+        step === 'cart'
+            ? 'Košarica'
+            : step === 'delivery'
+              ? 'Dostava'
+              : 'Branje';
+
+    useEffect(() => {
+        if (step === 'harvest') {
+            contentRef.current?.focus();
+        }
+    }, [step]);
 
     return (
-        <div
+        <section
+            aria-label={accessibleStepLabel}
             className={shouldAnimate ? styles.step : undefined}
             data-shopping-cart-step={step}
-            data-step-direction={direction}
+            data-step-direction={resolvedDirection}
+            ref={contentRef}
+            tabIndex={step === 'harvest' ? -1 : undefined}
         >
             {children}
-        </div>
+        </section>
     );
 }
 
 export function ShoppingCartStepTransition({
     children,
+    direction,
     step,
 }: ShoppingCartStepTransitionProps) {
     const [hasMounted, setHasMounted] = useState(false);
@@ -40,7 +60,12 @@ export function ShoppingCartStepTransition({
     }, []);
 
     return (
-        <ShoppingCartStepContent animate={hasMounted} key={step} step={step}>
+        <ShoppingCartStepContent
+            animate={hasMounted}
+            direction={direction}
+            key={step}
+            step={step}
+        >
             {children}
         </ShoppingCartStepContent>
     );

--- a/packages/game/src/shared-ui/delivery/DeliveryStep.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliveryStep.tsx
@@ -73,7 +73,13 @@ export function DeliveryStep({
     });
     const { data: addresses, isLoading: isLoadingAddresses } =
         useDeliveryAddresses();
-    const { data: pickupLocations } = usePickupLocations();
+    const {
+        data: pickupLocations,
+        isError: pickupLocationsError,
+        isFetching: pickupLocationsFetching,
+        isPending: pickupLocationsPending,
+        refetch: refetchPickupLocations,
+    } = usePickupLocations();
     const { data: timeSlots, isLoading: slotsLoading } = useTimeSlots({
         from: slotRange.from,
         includeArchived: true,
@@ -237,7 +243,7 @@ export function DeliveryStep({
                 onValueChange={handleSlotChange}
             />
 
-            {selectedTimeSlot?.type === 'pickup' && (
+            {selectedTimeSlot?.type === 'pickup' && selectedPickupLocation ? (
                 <Alert
                     color="warning"
                     startDecorator={<Info className="size-5 shrink-0" />}
@@ -246,7 +252,48 @@ export function DeliveryStep({
                     preuzimaš na {pickupDestinationLabel}; neće biti dostavljena
                     na tvoju adresu.
                 </Alert>
-            )}
+            ) : null}
+
+            {selectedTimeSlot?.type === 'pickup' &&
+            !selectedPickupLocation &&
+            pickupLocationsPending ? (
+                <div
+                    aria-label="Učitavanje lokacije za osobno preuzimanje"
+                    role="status"
+                >
+                    <Skeleton className="h-16 w-full rounded-md" />
+                </div>
+            ) : null}
+
+            {selectedTimeSlot?.type === 'pickup' &&
+            !selectedPickupLocation &&
+            pickupLocationsError ? (
+                <Stack spacing={3}>
+                    <Alert color="danger">
+                        Nije moguće učitati lokaciju za osobno preuzimanje.
+                        Pokušaj ponovno ili odaberi drugi termin.
+                    </Alert>
+                    <Row justifyContent="end">
+                        <Button
+                            loading={pickupLocationsFetching}
+                            variant="outlined"
+                            onClick={() => refetchPickupLocations()}
+                        >
+                            Pokušaj ponovno
+                        </Button>
+                    </Row>
+                </Stack>
+            ) : null}
+
+            {selectedTimeSlot?.type === 'pickup' &&
+            !selectedPickupLocation &&
+            !pickupLocationsPending &&
+            !pickupLocationsError ? (
+                <Alert color="danger">
+                    Lokacija za odabrani termin osobnog preuzimanja više nije
+                    dostupna. Odaberi drugi termin.
+                </Alert>
+            ) : null}
 
             {selectedTimeSlot?.type === 'delivery' && (
                 <Row alignItems="end" className="min-w-0" spacing={2}>

--- a/packages/game/src/shared-ui/delivery/DeliveryStep.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliveryStep.tsx
@@ -9,11 +9,9 @@ import { Skeleton } from '@gredice/ui/Skeleton';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useEffect, useMemo, useState } from 'react';
-import type { useCheckout } from '../../hooks/useCheckout';
 import { useDeliveryAddresses } from '../../hooks/useDeliveryAddresses';
-import { useShoppingCart } from '../../hooks/useShoppingCart';
+import { usePickupLocations } from '../../hooks/usePickupLocations';
 import { useTimeSlots } from '../../hooks/useTimeSlots';
-import { ButtonConfirmPayment } from '../../hud/components/shopping-cart/ButtonConfirmPayment';
 import { DeliveryAddressesSection } from './DeliveryAddressesSection';
 import {
     DeliverySlotPicker,
@@ -29,24 +27,33 @@ export interface DeliverySelectionData {
     notes?: string;
 }
 
+export interface DeliveryStepSummary {
+    mode: 'delivery' | 'pickup';
+    startAt: string;
+    endAt: string;
+    destinationLabel: string;
+}
+
 interface DeliveryStepProps {
+    initialSelection?: DeliverySelectionData | null;
     onSelectionChange: (selection: DeliverySelectionData | null) => void;
     onBack: () => void;
-    onProceed: () => void;
-    checkout: ReturnType<typeof useCheckout>;
+    onProceed: (summary: DeliveryStepSummary) => void;
     isValid: boolean;
 }
 
 export function DeliveryStep({
+    initialSelection,
     onSelectionChange,
     onBack,
-    checkout,
     onProceed,
     isValid,
 }: DeliveryStepProps) {
-    const [selection, setSelection] = useState<DeliverySelectionData>({
-        mode: 'delivery',
-    });
+    const [selection, setSelection] = useState<DeliverySelectionData>(
+        initialSelection ?? {
+            mode: 'delivery',
+        },
+    );
     const [manageAddresses, setManageAddresses] = useState(false);
     const [slotRange] = useState(() => {
         const referenceDate = new Date();
@@ -64,9 +71,9 @@ export function DeliveryStep({
             to: to.toISOString(),
         };
     });
-    const { data: cart } = useShoppingCart();
     const { data: addresses, isLoading: isLoadingAddresses } =
         useDeliveryAddresses();
+    const { data: pickupLocations } = usePickupLocations();
     const { data: timeSlots, isLoading: slotsLoading } = useTimeSlots({
         from: slotRange.from,
         includeArchived: true,
@@ -98,6 +105,29 @@ export function DeliveryStep({
     const selectedTimeSlot = timeSlots?.find(
         (slot) => slot.id === selection.slotId,
     );
+    const selectedAddress = addresses?.find(
+        (address) => address.id === selection.addressId,
+    );
+    const selectedPickupLocation = pickupLocations?.find(
+        (location) =>
+            location.id === selection.locationId &&
+            location.id === selectedTimeSlot?.locationId,
+    );
+    const selectedSlotAvailable =
+        selectedTimeSlot !== undefined &&
+        (selectedTimeSlot.type === 'delivery' ||
+            selectedTimeSlot.type === 'pickup') &&
+        isDeliverySlotAvailable(selectedTimeSlot, slotRange.referenceDate);
+    const canProceed =
+        isValid &&
+        selectedSlotAvailable &&
+        selection.mode === selectedTimeSlot.type &&
+        (selectedTimeSlot.type === 'delivery'
+            ? selectedAddress !== undefined
+            : selectedPickupLocation !== undefined);
+    const pickupDestinationLabel = selectedPickupLocation
+        ? `${selectedPickupLocation.name} — ${selectedPickupLocation.street1}, ${selectedPickupLocation.postalCode} ${selectedPickupLocation.city}`
+        : 'odabranoj lokaciji';
 
     useEffect(() => {
         if (
@@ -213,8 +243,8 @@ export function DeliveryStep({
                     startDecorator={<Info className="size-5 shrink-0" />}
                 >
                     <strong>Odabrano je osobno preuzimanje.</strong> Narudžbu
-                    preuzimaš na lokaciji Gredice HQ; neće biti dostavljena na
-                    tvoju adresu.
+                    preuzimaš na {pickupDestinationLabel}; neće biti dostavljena
+                    na tvoju adresu.
                 </Alert>
             )}
 
@@ -256,12 +286,39 @@ export function DeliveryStep({
                 <Button variant="outlined" onClick={onBack}>
                     Natrag
                 </Button>
-                <ButtonConfirmPayment
-                    cart={cart}
-                    checkout={checkout}
-                    disabled={!isValid}
-                    onConfirm={onProceed}
-                />
+                <Button
+                    variant="solid"
+                    disabled={!canProceed}
+                    endDecorator={<Navigate className="size-5 shrink-0" />}
+                    onClick={() => {
+                        if (
+                            !canProceed ||
+                            !selectedTimeSlot ||
+                            (selectedTimeSlot.type !== 'delivery' &&
+                                selectedTimeSlot.type !== 'pickup')
+                        ) {
+                            return;
+                        }
+
+                        onProceed({
+                            mode: selectedTimeSlot.type,
+                            startAt: new Date(
+                                selectedTimeSlot.startAt,
+                            ).toISOString(),
+                            endAt: new Date(
+                                selectedTimeSlot.endAt,
+                            ).toISOString(),
+                            destinationLabel:
+                                selectedTimeSlot.type === 'pickup'
+                                    ? pickupDestinationLabel
+                                    : selectedAddress
+                                      ? `${selectedAddress.label} — ${selectedAddress.street1}, ${selectedAddress.city}`
+                                      : 'Adresa za dostavu',
+                        });
+                    }}
+                >
+                    Nastavi
+                </Button>
             </Row>
         </Stack>
     );

--- a/packages/game/src/shared-ui/delivery/HarvestScheduleStep.tsx
+++ b/packages/game/src/shared-ui/delivery/HarvestScheduleStep.tsx
@@ -1,0 +1,528 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Chip } from '@gredice/ui/Chip';
+import { Input } from '@gredice/ui/Input';
+import { Calendar, Check, Edit, Info, Navigate } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import {
+    createHarvestScheduleDateSelections,
+    type HarvestScheduleDateSelection,
+    type HarvestScheduleItem,
+    harvestCalendarDateKey,
+    isHarvestDateWithinRange,
+} from './harvestSchedule';
+
+export type {
+    HarvestScheduleDateSelection,
+    HarvestScheduleItem,
+    HarvestSchedulePlant,
+} from './harvestSchedule';
+
+export interface HarvestScheduleDeliverySummary {
+    deliveryDate: string;
+    mode: 'delivery' | 'pickup';
+    startAt?: string;
+    endAt?: string;
+    slotStartAt?: string;
+    slotEndAt?: string;
+    destinationLabel?: string | null;
+}
+
+export interface HarvestScheduleStepProps {
+    delivery: HarvestScheduleDeliverySummary;
+    items: readonly HarvestScheduleItem[];
+    onSelectedDatesChange: (
+        selections: readonly HarvestScheduleDateSelection[],
+    ) => void;
+    onBack: () => void;
+    onConfirm: (selections: readonly HarvestScheduleDateSelection[]) => void;
+    confirmAction?: ReactNode;
+    confirmDisabled?: boolean;
+    confirmLabel?: string;
+    isConfirming?: boolean;
+}
+
+const dateFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'Europe/Zagreb',
+});
+
+const timeFormatter = new Intl.DateTimeFormat('hr-HR', {
+    hour: '2-digit',
+    hour12: false,
+    minute: '2-digit',
+    timeZone: 'Europe/Zagreb',
+});
+
+function formatCalendarDate(value: string | null) {
+    const dateKey = harvestCalendarDateKey(value);
+    if (!dateKey) {
+        return 'Nepoznat datum';
+    }
+
+    return dateFormatter.format(new Date(`${dateKey}T12:00:00.000Z`));
+}
+
+function formatDeliveryWindow(startAt?: string, endAt?: string) {
+    if (!startAt || !endAt) {
+        return null;
+    }
+
+    const startDate = new Date(startAt);
+    const endDate = new Date(endAt);
+    if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+        return null;
+    }
+
+    return `${timeFormatter.format(startDate)} – ${timeFormatter.format(endDate)}`;
+}
+
+function plantRuleLabel(maxDays: number) {
+    if (maxDays <= 0) {
+        return 'isti dan';
+    }
+
+    return maxDays === 1
+        ? 'do 1 dan ranije'
+        : `do ${maxDays.toString()} dana ranije`;
+}
+
+function validationReasonLabel(item: HarvestScheduleItem) {
+    const reason = item.validationReason ?? item.reason;
+    switch (reason) {
+        case 'missing_date':
+            return 'Datum branja nije bio postavljen.';
+        case 'invalid_date':
+            return 'Postavljeni datum branja nije ispravan.';
+        case 'before_allowed_range':
+            return 'Postavljeni datum branja je prerano.';
+        case 'after_delivery_date':
+            return 'Branje ne može biti nakon dostave.';
+        default:
+            return item.reason ?? null;
+    }
+}
+
+function scheduleSelectionKey(items: readonly HarvestScheduleItem[]) {
+    return JSON.stringify(
+        items.map((item) => [
+            item.cartItemId,
+            item.scheduledDate,
+            item.allowedFrom,
+            item.allowedTo,
+            item.valid,
+        ]),
+    );
+}
+
+export function HarvestScheduleStep({
+    delivery,
+    items,
+    onSelectedDatesChange,
+    onBack,
+    onConfirm,
+    confirmAction,
+    confirmDisabled = false,
+    confirmLabel = 'Potvrdi i plati',
+    isConfirming = false,
+}: HarvestScheduleStepProps) {
+    const selectedDatesChangeRef = useRef(onSelectedDatesChange);
+    const lastScheduleKeyRef = useRef<string | null>(null);
+    const currentScheduleKey = scheduleSelectionKey(items);
+    const [selectedDates, setSelectedDates] = useState(() =>
+        createHarvestScheduleDateSelections(items),
+    );
+    const [editFlexibleDates, setEditFlexibleDates] = useState(false);
+
+    useEffect(() => {
+        selectedDatesChangeRef.current = onSelectedDatesChange;
+    }, [onSelectedDatesChange]);
+
+    useEffect(() => {
+        if (lastScheduleKeyRef.current === currentScheduleKey) {
+            return;
+        }
+
+        lastScheduleKeyRef.current = currentScheduleKey;
+        const nextSelections = createHarvestScheduleDateSelections(items);
+        setSelectedDates(nextSelections);
+        setEditFlexibleDates(false);
+        selectedDatesChangeRef.current(nextSelections);
+    }, [currentScheduleKey, items]);
+
+    const selectedDateByItemId = useMemo(
+        () =>
+            new Map(
+                selectedDates.map((selection) => [
+                    selection.cartItemId,
+                    selection.scheduledDate,
+                ]),
+            ),
+        [selectedDates],
+    );
+    const allDatesValid = items.every((item) =>
+        isHarvestDateWithinRange(
+            selectedDateByItemId.get(item.cartItemId) ?? '',
+            item,
+        ),
+    );
+    const hasFlexibleDates = items.some(
+        (item) =>
+            harvestCalendarDateKey(item.allowedFrom) !==
+            harvestCalendarDateKey(item.allowedTo),
+    );
+    const hasDatesToAdjust = !allDatesValid;
+    const deliveryWindow = formatDeliveryWindow(
+        delivery.slotStartAt ?? delivery.startAt,
+        delivery.slotEndAt ?? delivery.endAt,
+    );
+
+    function handleDateChange(item: HarvestScheduleItem, date: string) {
+        const nextSelections = selectedDates.map((selection) =>
+            selection.cartItemId === item.cartItemId
+                ? { ...selection, scheduledDate: date }
+                : selection,
+        );
+
+        setSelectedDates(nextSelections);
+        onSelectedDatesChange(nextSelections);
+    }
+
+    return (
+        <Stack spacing={6}>
+            <section aria-labelledby="harvest-delivery-summary-title">
+                <Stack spacing={3}>
+                    <Row spacing={2}>
+                        <Calendar
+                            aria-hidden="true"
+                            className="size-5 shrink-0"
+                        />
+                        <Typography
+                            component="h3"
+                            id="harvest-delivery-summary-title"
+                            level="h6"
+                            semiBold
+                        >
+                            Sažetak{' '}
+                            {delivery.mode === 'pickup'
+                                ? 'preuzimanja'
+                                : 'dostave'}
+                        </Typography>
+                    </Row>
+                    <div className="grid gap-3 rounded-lg border bg-card/60 p-3 sm:grid-cols-2">
+                        <div>
+                            <Typography level="body3" tertiary>
+                                Datum
+                            </Typography>
+                            <Typography level="body2" semiBold>
+                                {formatCalendarDate(delivery.deliveryDate)}
+                            </Typography>
+                        </div>
+                        {deliveryWindow ? (
+                            <div>
+                                <Typography level="body3" tertiary>
+                                    Vrijeme
+                                </Typography>
+                                <Typography level="body2" semiBold>
+                                    {deliveryWindow}
+                                </Typography>
+                            </div>
+                        ) : null}
+                        {delivery.destinationLabel ? (
+                            <div className="sm:col-span-2">
+                                <Typography level="body3" tertiary>
+                                    {delivery.mode === 'pickup'
+                                        ? 'Mjesto preuzimanja'
+                                        : 'Adresa dostave'}
+                                </Typography>
+                                <Typography level="body2" semiBold>
+                                    {delivery.destinationLabel}
+                                </Typography>
+                            </div>
+                        ) : null}
+                    </div>
+                </Stack>
+            </section>
+
+            <section aria-labelledby="harvest-schedule-title">
+                <Stack spacing={4}>
+                    <Row
+                        className="min-w-0 flex-wrap"
+                        justifyContent="space-between"
+                        spacing={2}
+                    >
+                        <div className="min-w-0">
+                            <Typography
+                                component="h3"
+                                id="harvest-schedule-title"
+                                level="h6"
+                                semiBold
+                            >
+                                Datumi branja
+                            </Typography>
+                            <Typography level="body3" tertiary>
+                                Branje se planira prema svježini svake biljke.
+                            </Typography>
+                        </div>
+                        {hasDatesToAdjust && hasFlexibleDates ? (
+                            <Button
+                                aria-pressed={editFlexibleDates}
+                                disabled={isConfirming}
+                                size="sm"
+                                startDecorator={
+                                    <Edit
+                                        aria-hidden="true"
+                                        className="size-4"
+                                    />
+                                }
+                                variant="outlined"
+                                onClick={() =>
+                                    setEditFlexibleDates((editing) => !editing)
+                                }
+                            >
+                                {editFlexibleDates
+                                    ? 'Završi uređivanje'
+                                    : 'Uredi datume'}
+                            </Button>
+                        ) : null}
+                    </Row>
+
+                    {hasDatesToAdjust ? (
+                        <Alert
+                            color="warning"
+                            startDecorator={
+                                <Info aria-hidden="true" className="size-5" />
+                            }
+                        >
+                            Provjeri označene datume prije plaćanja. Za biljke
+                            koje se moraju brati isti dan datum je već
+                            postavljen na dan dostave.
+                        </Alert>
+                    ) : (
+                        <Alert
+                            color="success"
+                            startDecorator={
+                                <Check aria-hidden="true" className="size-5" />
+                            }
+                        >
+                            Svi datumi branja usklađeni su s odabranim terminom{' '}
+                            {delivery.mode === 'pickup'
+                                ? 'preuzimanja'
+                                : 'dostave'}
+                            .
+                        </Alert>
+                    )}
+
+                    <Stack spacing={3}>
+                        {items.map((item) => {
+                            const selectedDate =
+                                selectedDateByItemId.get(item.cartItemId) ?? '';
+                            const allowedFrom = harvestCalendarDateKey(
+                                item.allowedFrom,
+                            );
+                            const allowedTo = harvestCalendarDateKey(
+                                item.allowedTo,
+                            );
+                            const fixedToDeliveryDate =
+                                allowedFrom !== null &&
+                                allowedFrom === allowedTo;
+                            const selectedDateValid = isHarvestDateWithinRange(
+                                selectedDate,
+                                item,
+                            );
+                            const showDateControl =
+                                !fixedToDeliveryDate &&
+                                (!selectedDateValid || editFlexibleDates);
+                            const inputId = `harvest-date-${item.cartItemId.toString()}`;
+                            const helpId = `${inputId}-help`;
+
+                            return (
+                                <article
+                                    className="rounded-lg border bg-card p-3"
+                                    key={item.cartItemId}
+                                >
+                                    <Stack spacing={3}>
+                                        <Row
+                                            className="min-w-0 flex-wrap"
+                                            justifyContent="space-between"
+                                            spacing={2}
+                                        >
+                                            <div className="min-w-0">
+                                                <Typography
+                                                    component="h4"
+                                                    level="body2"
+                                                    semiBold
+                                                >
+                                                    {item.operationLabel}
+                                                </Typography>
+                                                {item.raisedBedLabel ? (
+                                                    <Typography
+                                                        level="body3"
+                                                        tertiary
+                                                    >
+                                                        {item.raisedBedLabel}
+                                                    </Typography>
+                                                ) : null}
+                                            </div>
+                                            <Chip
+                                                color={
+                                                    selectedDateValid
+                                                        ? 'success'
+                                                        : 'warning'
+                                                }
+                                                size="sm"
+                                                variant="soft"
+                                            >
+                                                {formatCalendarDate(
+                                                    selectedDate,
+                                                )}
+                                            </Chip>
+                                        </Row>
+
+                                        <Row className="flex-wrap" spacing={1}>
+                                            {item.plants.map((plant) => (
+                                                <Chip
+                                                    key={
+                                                        plant.id ??
+                                                        `${item.cartItemId.toString()}-${plant.label}`
+                                                    }
+                                                    size="sm"
+                                                    title={`${plant.label}: ${plantRuleLabel(plant.maxHarvestDaysBeforeDelivery)}`}
+                                                    variant="outlined"
+                                                >
+                                                    {plant.label} ·{' '}
+                                                    {plantRuleLabel(
+                                                        plant.maxHarvestDaysBeforeDelivery,
+                                                    )}
+                                                </Chip>
+                                            ))}
+                                        </Row>
+
+                                        {showDateControl ? (
+                                            <div>
+                                                <Input
+                                                    aria-describedby={helpId}
+                                                    aria-invalid={
+                                                        !selectedDateValid
+                                                    }
+                                                    disabled={isConfirming}
+                                                    fullWidth
+                                                    id={inputId}
+                                                    label={`Datum branja za ${item.operationLabel}`}
+                                                    max={allowedTo ?? undefined}
+                                                    min={
+                                                        allowedFrom ?? undefined
+                                                    }
+                                                    type="date"
+                                                    value={selectedDate}
+                                                    onChange={(event) =>
+                                                        handleDateChange(
+                                                            item,
+                                                            event.target.value,
+                                                        )
+                                                    }
+                                                />
+                                                <Typography
+                                                    component="p"
+                                                    color={
+                                                        selectedDateValid
+                                                            ? undefined
+                                                            : 'danger'
+                                                    }
+                                                    id={helpId}
+                                                    level="body3"
+                                                >
+                                                    Odaberi datum od{' '}
+                                                    {formatCalendarDate(
+                                                        item.allowedFrom,
+                                                    )}{' '}
+                                                    do{' '}
+                                                    {formatCalendarDate(
+                                                        item.allowedTo,
+                                                    )}
+                                                    .
+                                                    {!selectedDateValid
+                                                        ? ' Odabrani datum nije dopušten.'
+                                                        : ''}
+                                                </Typography>
+                                                {!selectedDateValid &&
+                                                validationReasonLabel(item) ? (
+                                                    <Typography
+                                                        color="warning"
+                                                        level="body3"
+                                                    >
+                                                        {validationReasonLabel(
+                                                            item,
+                                                        )}
+                                                    </Typography>
+                                                ) : null}
+                                            </div>
+                                        ) : (
+                                            <Typography level="body3" tertiary>
+                                                {fixedToDeliveryDate
+                                                    ? `Branje je obavezno na dan ${delivery.mode === 'pickup' ? 'preuzimanja' : 'dostave'}.`
+                                                    : `Planirano branje: ${formatCalendarDate(selectedDate)}.`}
+                                            </Typography>
+                                        )}
+                                    </Stack>
+                                </article>
+                            );
+                        })}
+                    </Stack>
+                </Stack>
+            </section>
+
+            {!allDatesValid ? (
+                <Typography
+                    aria-live="polite"
+                    color="danger"
+                    level="body3"
+                    role="status"
+                >
+                    Ispravi datume branja kako bi mogao nastaviti.
+                </Typography>
+            ) : null}
+
+            <Row className="flex-wrap" justifyContent="end" spacing={4}>
+                <Button
+                    disabled={isConfirming}
+                    variant="outlined"
+                    onClick={onBack}
+                >
+                    Natrag
+                </Button>
+                {confirmAction ? (
+                    <fieldset
+                        className="contents"
+                        disabled={
+                            confirmDisabled || !allDatesValid || isConfirming
+                        }
+                    >
+                        {confirmAction}
+                    </fieldset>
+                ) : (
+                    <Button
+                        disabled={confirmDisabled || !allDatesValid}
+                        endDecorator={
+                            <Navigate
+                                aria-hidden="true"
+                                className="size-5 shrink-0"
+                            />
+                        }
+                        loading={isConfirming}
+                        onClick={() => onConfirm(selectedDates)}
+                    >
+                        {confirmLabel}
+                    </Button>
+                )}
+            </Row>
+        </Stack>
+    );
+}

--- a/packages/game/src/shared-ui/delivery/harvestSchedule.ts
+++ b/packages/game/src/shared-ui/delivery/harvestSchedule.ts
@@ -1,0 +1,92 @@
+export interface HarvestSchedulePlant {
+    id?: number | string;
+    label: string;
+    maxHarvestDaysBeforeDelivery: number;
+}
+
+export interface HarvestScheduleItem {
+    cartItemId: number;
+    operationLabel: string;
+    raisedBedLabel?: string | null;
+    plants: readonly HarvestSchedulePlant[];
+    scheduledDate: string | null;
+    allowedFrom: string;
+    allowedTo: string;
+    valid: boolean;
+    reason?: string | null;
+    validationReason?: string | null;
+}
+
+export interface HarvestScheduleDateSelection {
+    cartItemId: number;
+    scheduledDate: string;
+}
+
+const calendarDatePattern = /^(\d{4})-(\d{2})-(\d{2})/;
+
+export function harvestCalendarDateKey(value: string | null | undefined) {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const match = calendarDatePattern.exec(value);
+    if (!match) {
+        return null;
+    }
+
+    const [, year, month, day] = match;
+    const date = new Date(`${year}-${month}-${day}T12:00:00.000Z`);
+
+    if (
+        Number.isNaN(date.getTime()) ||
+        date.getUTCFullYear() !== Number(year) ||
+        date.getUTCMonth() + 1 !== Number(month) ||
+        date.getUTCDate() !== Number(day)
+    ) {
+        return null;
+    }
+
+    return `${year}-${month}-${day}`;
+}
+
+export function isHarvestDateWithinRange(
+    scheduledDate: string,
+    item: Pick<HarvestScheduleItem, 'allowedFrom' | 'allowedTo'>,
+) {
+    const dateKey = harvestCalendarDateKey(scheduledDate);
+    const allowedFrom = harvestCalendarDateKey(item.allowedFrom);
+    const allowedTo = harvestCalendarDateKey(item.allowedTo);
+
+    return Boolean(
+        dateKey &&
+            allowedFrom &&
+            allowedTo &&
+            allowedFrom <= allowedTo &&
+            dateKey >= allowedFrom &&
+            dateKey <= allowedTo,
+    );
+}
+
+export function createHarvestScheduleDateSelections(
+    items: readonly HarvestScheduleItem[],
+): HarvestScheduleDateSelection[] {
+    return items.map((item) => {
+        const scheduledDate = harvestCalendarDateKey(item.scheduledDate);
+        const allowedFrom = harvestCalendarDateKey(item.allowedFrom);
+        const allowedTo = harvestCalendarDateKey(item.allowedTo);
+        const fixedToDeliveryDate =
+            allowedFrom !== null && allowedFrom === allowedTo;
+
+        return {
+            cartItemId: item.cartItemId,
+            scheduledDate:
+                item.valid &&
+                scheduledDate &&
+                isHarvestDateWithinRange(scheduledDate, item)
+                    ? scheduledDate
+                    : fixedToDeliveryDate
+                      ? (allowedTo ?? '')
+                      : (scheduledDate ?? ''),
+        };
+    });
+}

--- a/packages/game/src/shared-ui/delivery/harvestSchedule.unit.ts
+++ b/packages/game/src/shared-ui/delivery/harvestSchedule.unit.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    createHarvestScheduleDateSelections,
+    type HarvestScheduleItem,
+    harvestCalendarDateKey,
+    isHarvestDateWithinRange,
+} from './harvestSchedule';
+
+const flexibleItem = {
+    cartItemId: 1,
+    operationLabel: 'Berba mrkve',
+    plants: [
+        {
+            label: 'Mrkva',
+            maxHarvestDaysBeforeDelivery: 3,
+        },
+    ],
+    scheduledDate: '2026-07-22T00:00:00.000Z',
+    allowedFrom: '2026-07-21',
+    allowedTo: '2026-07-24',
+    valid: true,
+} satisfies HarvestScheduleItem;
+
+test('extracts and validates calendar date keys without timezone shifts', () => {
+    assert.equal(
+        harvestCalendarDateKey('2026-07-24T23:00:00.000Z'),
+        '2026-07-24',
+    );
+    assert.equal(harvestCalendarDateKey('2026-02-29'), null);
+    assert.equal(harvestCalendarDateKey('not-a-date'), null);
+});
+
+test('accepts both inclusive harvest range boundaries', () => {
+    assert.equal(
+        isHarvestDateWithinRange(flexibleItem.allowedFrom, flexibleItem),
+        true,
+    );
+    assert.equal(
+        isHarvestDateWithinRange(flexibleItem.allowedTo, flexibleItem),
+        true,
+    );
+    assert.equal(isHarvestDateWithinRange('2026-07-20', flexibleItem), false);
+    assert.equal(isHarvestDateWithinRange('2026-07-25', flexibleItem), false);
+});
+
+test('keeps valid dates, preserves flexible corrections, and fixes same-day crops', () => {
+    assert.deepEqual(
+        createHarvestScheduleDateSelections([
+            flexibleItem,
+            {
+                ...flexibleItem,
+                cartItemId: 2,
+                scheduledDate: '2026-07-20T00:00:00.000Z',
+                valid: false,
+            },
+            {
+                ...flexibleItem,
+                cartItemId: 3,
+                operationLabel: 'Berba salate',
+                scheduledDate: '2026-07-23T00:00:00.000Z',
+                allowedFrom: '2026-07-24',
+                allowedTo: '2026-07-24',
+                valid: false,
+            },
+        ]),
+        [
+            {
+                cartItemId: 1,
+                scheduledDate: '2026-07-22',
+            },
+            {
+                cartItemId: 2,
+                scheduledDate: '2026-07-20',
+            },
+            {
+                cartItemId: 3,
+                scheduledDate: '2026-07-24',
+            },
+        ],
+    );
+});

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -30,6 +30,7 @@
         "sunflower-packages:seed": "tsx --conditions=react-server --env-file=.env ./scripts/seedSunflowerPackageCatalog.ts",
         "plant-relationships:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/backfillPlantRelationships.ts",
         "plant-health:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/backfillPlantHealthDirectory.ts",
+        "plants:max-harvest-days:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/backfillPlantMaxHarvestDaysBeforeDelivery.ts",
         "operations:all-targets:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/backfillOperationAppliesToAllTargets.ts",
         "generated-images:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/upsertGeneratedImageAttributes.ts",
         "blocks:images:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/upsertGeneratedImageAttributes.ts --entity-type block --source information.name --target image.cover --template 'https://www.gredice.com/assets/blocks/{encodedValue}.webp' --label Slika --description 'Public block image generated from the in-game block name and used by admin previews, directory cards, search results, and compact block UI.' --order aa",

--- a/packages/storage/scripts/backfillPlantMaxHarvestDaysBeforeDelivery.ts
+++ b/packages/storage/scripts/backfillPlantMaxHarvestDaysBeforeDelivery.ts
@@ -1,0 +1,24 @@
+import { closeStorage } from '../src';
+import {
+    backfillPlantMaxHarvestDaysBeforeDelivery,
+    parsePlantMaxHarvestDaysBackfillArgs,
+} from './lib/plantMaxHarvestDaysBeforeDelivery';
+
+async function main() {
+    const { apply } = parsePlantMaxHarvestDaysBackfillArgs(
+        process.argv.slice(2),
+    );
+    return backfillPlantMaxHarvestDaysBeforeDelivery({ apply });
+}
+
+main()
+    .then((report) => {
+        console.log(JSON.stringify(report, null, 2));
+    })
+    .catch((error: unknown) => {
+        console.error(error);
+        process.exitCode = 1;
+    })
+    .finally(async () => {
+        await closeStorage();
+    });

--- a/packages/storage/scripts/lib/plantMaxHarvestDaysBeforeDelivery.ts
+++ b/packages/storage/scripts/lib/plantMaxHarvestDaysBeforeDelivery.ts
@@ -1,0 +1,650 @@
+import { slugify } from '@gredice/js/slug';
+import { and, eq, inArray } from 'drizzle-orm';
+import {
+    attributeDefinitionCategories,
+    attributeValues,
+    createAttributeDefinition,
+    createAttributeValueMutationSideEffects,
+    entities,
+    flushAttributeValueMutationSideEffects,
+    getAttributeDefinitions,
+    type SelectAttributeDefinition,
+    storage,
+    updateAttributeDefinition,
+    upsertAttributeValue,
+} from '../../src';
+
+export type PlantMaxHarvestDaysEntry = {
+    name: string;
+    maxHarvestDaysBeforeDelivery: number;
+};
+
+// This is a freshness policy, not the plant's harvest window. Zero means that
+// the plant must be harvested on the delivery or pickup date.
+export const plantMaxHarvestDaysBeforeDelivery = [
+    { name: 'Kelj pupčar', maxHarvestDaysBeforeDelivery: 1 },
+    { name: 'Jagoda', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Bamija', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Tikva', maxHarvestDaysBeforeDelivery: 3 },
+    { name: 'Raštika', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Korijandar', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Kopar', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Dinja', maxHarvestDaysBeforeDelivery: 1 },
+    { name: 'Ljupčac', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Timijan', maxHarvestDaysBeforeDelivery: 1 },
+    { name: 'Kadulja', maxHarvestDaysBeforeDelivery: 1 },
+    { name: 'Matičnjak', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Čili', maxHarvestDaysBeforeDelivery: 1 },
+    { name: 'Artičoka', maxHarvestDaysBeforeDelivery: 1 },
+    { name: 'Kamilica', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Origano', maxHarvestDaysBeforeDelivery: 1 },
+    { name: 'Bosiljak', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Bob', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Repa', maxHarvestDaysBeforeDelivery: 2 },
+    { name: 'Koraba', maxHarvestDaysBeforeDelivery: 2 },
+    { name: 'Matovilac', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Luk vlasac', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Cvjetača', maxHarvestDaysBeforeDelivery: 1 },
+    { name: 'Brokula', maxHarvestDaysBeforeDelivery: 1 },
+    { name: 'Grašak', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Paprika', maxHarvestDaysBeforeDelivery: 1 },
+    { name: 'Poriluk', maxHarvestDaysBeforeDelivery: 2 },
+    { name: 'Celer', maxHarvestDaysBeforeDelivery: 2 },
+    { name: 'Cikla', maxHarvestDaysBeforeDelivery: 2 },
+    { name: 'Špinat', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Komorač', maxHarvestDaysBeforeDelivery: 2 },
+    { name: 'Rotkvica', maxHarvestDaysBeforeDelivery: 2 },
+    { name: 'Rajčica', maxHarvestDaysBeforeDelivery: 1 },
+    { name: 'Rukola', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Salata', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Kelj', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Kupus', maxHarvestDaysBeforeDelivery: 3 },
+    { name: 'Grah', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Mahuna', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Tikvice', maxHarvestDaysBeforeDelivery: 1 },
+    { name: 'Krastavac', maxHarvestDaysBeforeDelivery: 1 },
+    { name: 'Češnjak', maxHarvestDaysBeforeDelivery: 3 },
+    { name: 'Peršin', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Luk', maxHarvestDaysBeforeDelivery: 3 },
+    { name: 'Blitva', maxHarvestDaysBeforeDelivery: 0 },
+    { name: 'Mrkva', maxHarvestDaysBeforeDelivery: 2 },
+    { name: 'Patlidžan', maxHarvestDaysBeforeDelivery: 1 },
+] satisfies PlantMaxHarvestDaysEntry[];
+
+const actor = {
+    id: 'plant-harvest-delivery-backfill',
+    name: 'Plant harvest delivery backfill',
+};
+
+const namePath = 'information.name';
+export const maxHarvestDaysBeforeDeliveryPath =
+    'attributes.maxHarvestDaysBeforeDelivery';
+
+type ExistingAttributeValue = {
+    id: number;
+    value: string | null;
+};
+
+type PlantCandidate = {
+    entityId: number;
+    name: string;
+    normalizedName: string;
+    state: string;
+    maxHarvestDaysBeforeDelivery: number;
+};
+
+type PlannedPlant = PlantCandidate & {
+    action: 'create' | 'update' | 'unchanged';
+    existingValue: ExistingAttributeValue | null;
+};
+
+export function parsePlantMaxHarvestDaysBackfillArgs(argv: string[]) {
+    let apply = false;
+
+    for (const arg of argv) {
+        if (arg === '--') {
+            continue;
+        }
+        if (arg === '--apply') {
+            apply = true;
+            continue;
+        }
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+
+    return { apply };
+}
+
+export function normalizePlantName(value: string) {
+    return slugify(value.trim());
+}
+
+export function plantMaxHarvestDaysByNormalizedName(
+    entries: readonly PlantMaxHarvestDaysEntry[],
+) {
+    const result = new Map<string, PlantMaxHarvestDaysEntry>();
+
+    for (const entry of entries) {
+        const normalizedName = normalizePlantName(entry.name);
+        if (!normalizedName) {
+            throw new Error('Plant freshness policy contains an empty name.');
+        }
+        if (
+            !Number.isInteger(entry.maxHarvestDaysBeforeDelivery) ||
+            entry.maxHarvestDaysBeforeDelivery < 0
+        ) {
+            throw new Error(
+                `Expected a non-negative integer for ${entry.name}, found ${entry.maxHarvestDaysBeforeDelivery}.`,
+            );
+        }
+        if (result.has(normalizedName)) {
+            throw new Error(
+                `Plant freshness policy contains duplicate normalized name ${normalizedName}.`,
+            );
+        }
+        result.set(normalizedName, entry);
+    }
+
+    return result;
+}
+
+export function maxHarvestDaysBeforeDeliveryDefinitionConfig(
+    entityTypeName = 'plant',
+) {
+    return {
+        category: 'attributes',
+        dataType: 'number',
+        defaultValue: '0',
+        description:
+            'Maksimalan broj cijelih dana prije datuma dostave ili preuzimanja kada se biljka smije ubrati. 0 znači da se mora ubrati isti kalendarski dan.',
+        display: false,
+        entityTypeName,
+        label: 'Maksimalno dana prije dostave',
+        multiple: false,
+        name: 'maxHarvestDaysBeforeDelivery',
+        order: null,
+        required: true,
+        unit: 'dana',
+    };
+}
+
+function attributePath(definition: SelectAttributeDefinition) {
+    return `${definition.category}.${definition.name}`;
+}
+
+function definitionsAtPath(
+    definitions: SelectAttributeDefinition[],
+    path: string,
+) {
+    return definitions.filter(
+        (definition) => attributePath(definition) === path,
+    );
+}
+
+function requireExactlyOneDefinition(
+    definitions: SelectAttributeDefinition[],
+    path: string,
+    entityTypeName: string,
+) {
+    const matches = definitionsAtPath(definitions, path);
+    if (matches.length !== 1) {
+        throw new Error(
+            `Expected exactly one active ${entityTypeName} ${path} definition, found ${matches.length}.`,
+        );
+    }
+    const definition = matches[0];
+    if (!definition) {
+        throw new Error(`Missing active ${entityTypeName} ${path} definition.`);
+    }
+    return definition;
+}
+
+async function requireAttributesCategory(entityTypeName: string) {
+    const categories = await storage()
+        .select({ id: attributeDefinitionCategories.id })
+        .from(attributeDefinitionCategories)
+        .where(
+            and(
+                eq(
+                    attributeDefinitionCategories.entityTypeName,
+                    entityTypeName,
+                ),
+                eq(attributeDefinitionCategories.name, 'attributes'),
+                eq(attributeDefinitionCategories.isDeleted, false),
+            ),
+        );
+
+    if (categories.length !== 1) {
+        throw new Error(
+            `Expected exactly one active ${entityTypeName} attributes category, found ${categories.length}.`,
+        );
+    }
+}
+
+async function preflightPlants({
+    entityTypeName,
+    matrix,
+    nameDefinition,
+}: {
+    entityTypeName: string;
+    matrix: readonly PlantMaxHarvestDaysEntry[];
+    nameDefinition: SelectAttributeDefinition;
+}) {
+    const policyByName = plantMaxHarvestDaysByNormalizedName(matrix);
+    const activeEntities = await storage()
+        .select({
+            entityId: entities.id,
+            state: entities.state,
+        })
+        .from(entities)
+        .where(
+            and(
+                eq(entities.entityTypeName, entityTypeName),
+                eq(entities.isDeleted, false),
+            ),
+        )
+        .orderBy(entities.id);
+
+    if (activeEntities.length === 0) {
+        throw new Error(`No active ${entityTypeName} entities found.`);
+    }
+
+    const entityIds = activeEntities.map((entity) => entity.entityId);
+    const nameValues = await storage()
+        .select({
+            entityId: attributeValues.entityId,
+            value: attributeValues.value,
+        })
+        .from(attributeValues)
+        .where(
+            and(
+                eq(attributeValues.entityTypeName, entityTypeName),
+                eq(attributeValues.attributeDefinitionId, nameDefinition.id),
+                eq(attributeValues.isDeleted, false),
+                inArray(attributeValues.entityId, entityIds),
+            ),
+        );
+
+    const namesByEntityId = new Map<number, Array<{ value: string | null }>>();
+    for (const nameValue of nameValues) {
+        const values = namesByEntityId.get(nameValue.entityId) ?? [];
+        values.push({ value: nameValue.value });
+        namesByEntityId.set(nameValue.entityId, values);
+    }
+
+    const candidates: PlantCandidate[] = [];
+    const seenNormalizedNames = new Map<string, number>();
+    for (const entity of activeEntities) {
+        const values = namesByEntityId.get(entity.entityId) ?? [];
+        if (values.length !== 1) {
+            throw new Error(
+                `Expected exactly one active ${namePath} value for ${entityTypeName} #${entity.entityId}, found ${values.length}.`,
+            );
+        }
+        const value = values[0]?.value?.trim();
+        if (!value) {
+            throw new Error(
+                `Expected a non-empty ${namePath} value for ${entityTypeName} #${entity.entityId}.`,
+            );
+        }
+
+        const normalizedName = normalizePlantName(value);
+        const duplicateEntityId = seenNormalizedNames.get(normalizedName);
+        if (duplicateEntityId !== undefined) {
+            throw new Error(
+                `Plant name ${JSON.stringify(value)} resolves to the same normalized name as entity #${duplicateEntityId}.`,
+            );
+        }
+        seenNormalizedNames.set(normalizedName, entity.entityId);
+
+        const policy = policyByName.get(normalizedName);
+        if (!policy) {
+            throw new Error(
+                `Missing maxHarvestDaysBeforeDelivery policy for ${value} (#${entity.entityId}).`,
+            );
+        }
+        candidates.push({
+            entityId: entity.entityId,
+            name: value,
+            normalizedName,
+            state: entity.state,
+            maxHarvestDaysBeforeDelivery: policy.maxHarvestDaysBeforeDelivery,
+        });
+    }
+
+    return {
+        candidates,
+        catalogEntriesWithoutEntity: Array.from(policyByName.entries())
+            .filter(
+                ([normalizedName]) => !seenNormalizedNames.has(normalizedName),
+            )
+            .map(([, entry]) => entry.name),
+    };
+}
+
+function targetDefinitionNeedsUpdate(
+    definition: SelectAttributeDefinition,
+    expected: ReturnType<typeof maxHarvestDaysBeforeDeliveryDefinitionConfig>,
+) {
+    return (
+        definition.category !== expected.category ||
+        definition.dataType !== expected.dataType ||
+        definition.defaultValue !== expected.defaultValue ||
+        definition.description !== expected.description ||
+        definition.display !== expected.display ||
+        definition.entityTypeName !== expected.entityTypeName ||
+        definition.label !== expected.label ||
+        definition.multiple !== expected.multiple ||
+        definition.name !== expected.name ||
+        definition.order !== expected.order ||
+        definition.required !== expected.required ||
+        definition.unit !== expected.unit
+    );
+}
+
+async function ensureTargetDefinition({
+    apply,
+    entityTypeName,
+    existingDefinition,
+}: {
+    apply: boolean;
+    entityTypeName: string;
+    existingDefinition: SelectAttributeDefinition | null;
+}) {
+    const expected =
+        maxHarvestDaysBeforeDeliveryDefinitionConfig(entityTypeName);
+    if (existingDefinition) {
+        const needsUpdate = targetDefinitionNeedsUpdate(
+            existingDefinition,
+            expected,
+        );
+        if (!apply || !needsUpdate) {
+            return {
+                created: false,
+                definition: existingDefinition,
+                updated: false,
+                wouldCreate: false,
+                wouldUpdate: !apply && needsUpdate,
+            };
+        }
+
+        await updateAttributeDefinition({
+            id: existingDefinition.id,
+            ...expected,
+        });
+        const definitions = await getAttributeDefinitions(entityTypeName);
+        const updatedDefinition = requireExactlyOneDefinition(
+            definitions,
+            maxHarvestDaysBeforeDeliveryPath,
+            entityTypeName,
+        );
+        return {
+            created: false,
+            definition: updatedDefinition,
+            updated: true,
+            wouldCreate: false,
+            wouldUpdate: false,
+        };
+    }
+
+    if (!apply) {
+        return {
+            created: false,
+            definition: null,
+            updated: false,
+            wouldCreate: true,
+            wouldUpdate: false,
+        };
+    }
+
+    const id = await createAttributeDefinition(expected);
+    const definitions = await getAttributeDefinitions(entityTypeName);
+    const createdDefinition = requireExactlyOneDefinition(
+        definitions,
+        maxHarvestDaysBeforeDeliveryPath,
+        entityTypeName,
+    );
+    if (createdDefinition.id !== id) {
+        throw new Error(
+            `Failed to create ${entityTypeName} ${maxHarvestDaysBeforeDeliveryPath}.`,
+        );
+    }
+
+    return {
+        created: true,
+        definition: createdDefinition,
+        updated: false,
+        wouldCreate: false,
+        wouldUpdate: false,
+    };
+}
+
+async function getExistingTargetValue({
+    attributeDefinitionId,
+    candidate,
+    entityTypeName,
+}: {
+    attributeDefinitionId: number | null;
+    candidate: PlantCandidate;
+    entityTypeName: string;
+}): Promise<ExistingAttributeValue | null> {
+    if (!attributeDefinitionId) {
+        return null;
+    }
+
+    const values = await storage()
+        .select({
+            id: attributeValues.id,
+            value: attributeValues.value,
+        })
+        .from(attributeValues)
+        .where(
+            and(
+                eq(attributeValues.entityId, candidate.entityId),
+                eq(attributeValues.entityTypeName, entityTypeName),
+                eq(
+                    attributeValues.attributeDefinitionId,
+                    attributeDefinitionId,
+                ),
+                eq(attributeValues.isDeleted, false),
+            ),
+        );
+
+    if (values.length > 1) {
+        throw new Error(
+            `Expected at most one active ${maxHarvestDaysBeforeDeliveryPath} value for ${candidate.name} (#${candidate.entityId}), found ${values.length}.`,
+        );
+    }
+
+    return values[0] ?? null;
+}
+
+async function planPlants({
+    candidates,
+    entityTypeName,
+    targetDefinition,
+}: {
+    candidates: PlantCandidate[];
+    entityTypeName: string;
+    targetDefinition: SelectAttributeDefinition | null;
+}) {
+    const planned: PlannedPlant[] = [];
+
+    for (const candidate of candidates) {
+        const existingValue = await getExistingTargetValue({
+            attributeDefinitionId: targetDefinition?.id ?? null,
+            candidate,
+            entityTypeName,
+        });
+        const nextValue = candidate.maxHarvestDaysBeforeDelivery.toString();
+        planned.push({
+            ...candidate,
+            action:
+                existingValue?.value === nextValue
+                    ? 'unchanged'
+                    : existingValue
+                      ? 'update'
+                      : 'create',
+            existingValue,
+        });
+    }
+
+    return planned;
+}
+
+export async function backfillPlantMaxHarvestDaysBeforeDelivery({
+    apply = false,
+    entityTypeName = 'plant',
+    matrix = plantMaxHarvestDaysBeforeDelivery,
+}: {
+    apply?: boolean;
+    entityTypeName?: string;
+    matrix?: readonly PlantMaxHarvestDaysEntry[];
+} = {}) {
+    const definitions = await getAttributeDefinitions(entityTypeName);
+    const nameDefinition = requireExactlyOneDefinition(
+        definitions,
+        namePath,
+        entityTypeName,
+    );
+    const targetDefinitions = definitionsAtPath(
+        definitions,
+        maxHarvestDaysBeforeDeliveryPath,
+    );
+    if (targetDefinitions.length > 1) {
+        throw new Error(
+            `Expected at most one active ${entityTypeName} ${maxHarvestDaysBeforeDeliveryPath} definition, found ${targetDefinitions.length}.`,
+        );
+    }
+    const existingTargetDefinition = targetDefinitions[0] ?? null;
+
+    // Complete every catalog, definition, and value check before any write.
+    await requireAttributesCategory(entityTypeName);
+    const preflight = await preflightPlants({
+        entityTypeName,
+        matrix,
+        nameDefinition,
+    });
+    const planned = await planPlants({
+        candidates: preflight.candidates,
+        entityTypeName,
+        targetDefinition: existingTargetDefinition,
+    });
+    const definitionResult = await ensureTargetDefinition({
+        apply,
+        entityTypeName,
+        existingDefinition: existingTargetDefinition,
+    });
+
+    const verifiedPlants: Array<{
+        entityId: number;
+        name: string;
+        valueId: number;
+        value: number;
+    }> = [];
+
+    if (apply) {
+        const definition = definitionResult.definition;
+        if (!definition) {
+            throw new Error(
+                `Cannot apply without ${maxHarvestDaysBeforeDeliveryPath} definition.`,
+            );
+        }
+        const expectedDefinition =
+            maxHarvestDaysBeforeDeliveryDefinitionConfig(entityTypeName);
+        if (targetDefinitionNeedsUpdate(definition, expectedDefinition)) {
+            throw new Error(
+                `${maxHarvestDaysBeforeDeliveryPath} does not match the expected definition after applying changes.`,
+            );
+        }
+
+        const sideEffects = createAttributeValueMutationSideEffects();
+        for (const candidate of preflight.candidates) {
+            sideEffects.entityIds.add(candidate.entityId);
+            sideEffects.entityTypeNames.add(entityTypeName);
+            sideEffects.searchEntityIds.add(candidate.entityId);
+            sideEffects.dashboardAdmin = true;
+        }
+        await storage().transaction(async (tx) => {
+            for (const plant of planned) {
+                if (plant.action === 'unchanged') {
+                    continue;
+                }
+                await upsertAttributeValue(
+                    {
+                        id: plant.existingValue?.id,
+                        attributeDefinitionId: definition.id,
+                        entityId: plant.entityId,
+                        entityTypeName,
+                        order: definition.order,
+                        value: plant.maxHarvestDaysBeforeDelivery.toString(),
+                    },
+                    actor,
+                    { db: tx, sideEffects },
+                );
+            }
+        });
+        await flushAttributeValueMutationSideEffects(sideEffects);
+
+        for (const candidate of preflight.candidates) {
+            const persistedValue = await getExistingTargetValue({
+                attributeDefinitionId: definition.id,
+                candidate,
+                entityTypeName,
+            });
+            const expectedValue =
+                candidate.maxHarvestDaysBeforeDelivery.toString();
+            if (persistedValue?.value !== expectedValue) {
+                throw new Error(
+                    `Failed to verify ${maxHarvestDaysBeforeDeliveryPath}=${expectedValue} for ${candidate.name} (#${candidate.entityId}).`,
+                );
+            }
+            verifiedPlants.push({
+                entityId: candidate.entityId,
+                name: candidate.name,
+                valueId: persistedValue.id,
+                value: candidate.maxHarvestDaysBeforeDelivery,
+            });
+        }
+    }
+
+    return {
+        mode: apply ? 'apply' : 'dry-run',
+        attribute: {
+            path: maxHarvestDaysBeforeDeliveryPath,
+            definitionId: definitionResult.definition?.id ?? null,
+            created: definitionResult.created,
+            updated: definitionResult.updated,
+            wouldCreate: definitionResult.wouldCreate,
+            wouldUpdate: definitionResult.wouldUpdate,
+        },
+        preflight: {
+            entityTypeName,
+            namePath,
+            activePlants: preflight.candidates.length,
+            policyEntries: matrix.length,
+            catalogEntriesWithoutEntity: preflight.catalogEntriesWithoutEntity,
+        },
+        verification: apply
+            ? {
+                  plants: verifiedPlants,
+              }
+            : null,
+        totals: {
+            create: planned.filter((plant) => plant.action === 'create').length,
+            update: planned.filter((plant) => plant.action === 'update').length,
+            unchanged: planned.filter((plant) => plant.action === 'unchanged')
+                .length,
+        },
+        plants: planned.map((plant) => ({
+            entityId: plant.entityId,
+            name: plant.name,
+            normalizedName: plant.normalizedName,
+            state: plant.state,
+            existingValueId: plant.existingValue?.id ?? null,
+            previousValue: plant.existingValue?.value ?? null,
+            nextValue: plant.maxHarvestDaysBeforeDelivery,
+            action: plant.action,
+        })),
+    };
+}

--- a/packages/storage/src/@types/EntityStandardized.ts
+++ b/packages/storage/src/@types/EntityStandardized.ts
@@ -14,13 +14,14 @@ export type EntityStandardized = {
         instructions?: string;
 
         // Parent items
-        plant?: EntityStandardized;
+        plant?: EntityStandardized | null;
     };
     attributes?: {
         seedingDistance?: number; // in cm
         frequency?: string;
         application?: string;
         deliverable?: boolean;
+        maxHarvestDaysBeforeDelivery?: number;
         duration?: number;
         relativeDays?: number | null;
         stage?: {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -62,6 +62,7 @@ export * from './repositories/gardenPreviewsRepo';
 export * from './repositories/gardenSandboxRepo';
 export * from './repositories/gardensRepo';
 export * from './repositories/gardenVisitStatesRepo';
+export * from './repositories/harvestScheduleRepo';
 export * from './repositories/harvestTraceLinksRepo';
 export * from './repositories/inventoryManagementRepo';
 export * from './repositories/inventoryRepo';

--- a/packages/storage/src/repositories/deliveryRequestsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRequestsRepo.ts
@@ -1542,6 +1542,10 @@ export async function createDeliveryRequest(data: {
         throw new Error('Time slot is not available for booking');
     }
 
+    if (slot.type !== data.mode) {
+        throw new Error('Delivery mode does not match the selected time slot');
+    }
+
     // Validate mode-specific requirements
     if (data.mode === 'delivery' && !data.addressId) {
         throw new Error('Address ID is required for delivery mode');
@@ -1573,6 +1577,15 @@ export async function createDeliveryRequest(data: {
         );
         if (!address) {
             throw new Error('Delivery address not found or access denied');
+        }
+    }
+
+    if (data.mode === 'pickup' && data.locationId) {
+        const location = await getPickupLocation(data.locationId);
+        if (!location?.isActive || location.id !== slot.locationId) {
+            throw new Error(
+                'Pickup location does not match the selected time slot',
+            );
         }
     }
 

--- a/packages/storage/src/repositories/deliveryUtilsRepo.ts
+++ b/packages/storage/src/repositories/deliveryUtilsRepo.ts
@@ -15,6 +15,7 @@ export async function cartContainsDeliverableItems(
     const items = await storage().query.shoppingCartItems.findMany({
         where: and(
             eq(shoppingCartItems.cartId, cartId),
+            eq(shoppingCartItems.entityTypeName, 'operation'),
             eq(shoppingCartItems.isDeleted, false),
             eq(shoppingCartItems.status, 'new'), // Only check unpaid items
         ),
@@ -83,6 +84,7 @@ export async function getDeliverableCartItems(
     const items = await storage().query.shoppingCartItems.findMany({
         where: and(
             eq(shoppingCartItems.cartId, cartId),
+            eq(shoppingCartItems.entityTypeName, 'operation'),
             eq(shoppingCartItems.isDeleted, false),
             eq(shoppingCartItems.status, 'new'),
         ),
@@ -148,7 +150,11 @@ export async function getDeliverableCartItems(
     );
 
     // Filter items to only include those with deliverable entities
-    return items.filter((item) => deliverableEntityIds.has(item.entityId));
+    return items.filter(
+        (item) =>
+            item.entityTypeName === 'operation' &&
+            deliverableEntityIds.has(item.entityId),
+    );
 }
 
 // Check if specific cart item is deliverable
@@ -183,6 +189,7 @@ export async function isCartItemDeliverable({
                 attributeValues.attributeDefinitionId,
                 deliverableAttributeDef.id,
             ),
+            eq(attributeValues.entityTypeName, 'operation'),
             eq(attributeValues.isDeleted, false),
         ),
     });

--- a/packages/storage/src/repositories/harvestScheduleRepo.ts
+++ b/packages/storage/src/repositories/harvestScheduleRepo.ts
@@ -1,0 +1,649 @@
+import 'server-only';
+import type { EntityStandardized } from '../@types/EntityStandardized';
+import {
+    addCalendarDays,
+    getTimeZoneDateKey,
+    isCalendarDateKey,
+} from '../helpers/timezoneUtils';
+import type { SelectShoppingCartItem } from '../schema';
+import { TimeSlotStatuses } from '../schema';
+import { getEntitiesFormatted } from './entitiesRepo';
+import {
+    getRaisedBedFieldsWithEventsForBeds,
+    type RaisedBedFieldWithEvents,
+} from './raisedBedFieldsRepo';
+import {
+    getRaisedBedIdsByAccount,
+    getRaisedBedMetadataByIds,
+} from './raisedBedsRepo';
+import { getShoppingCart } from './shoppingCartRepo';
+import { getTimeSlot } from './timeSlotsRepo';
+
+const ZAGREB_TIME_ZONE = 'Europe/Zagreb';
+
+export type HarvestScheduleConflictCode =
+    | 'cart_not_found'
+    | 'delivery_slot_not_found'
+    | 'delivery_slot_unavailable'
+    | 'delivery_date_in_past'
+    | 'harvest_target_missing'
+    | 'harvest_plant_mapping_missing'
+    | 'harvest_date_selection_invalid';
+
+export type HarvestScheduleStatusCode = 404 | 409;
+
+export class HarvestScheduleConflictError extends Error {
+    constructor(
+        message: string,
+        public readonly statusCode: HarvestScheduleStatusCode,
+        public readonly code: HarvestScheduleConflictCode,
+        public readonly details?: Record<string, unknown>,
+    ) {
+        super(message);
+        this.name = 'HarvestScheduleConflictError';
+    }
+}
+
+export type HarvestScheduleValidationReason =
+    | 'missing_date'
+    | 'invalid_date'
+    | 'before_allowed_range'
+    | 'after_delivery_date';
+
+export type HarvestSchedulePlant = {
+    plantId: number;
+    plantSortId: number;
+    name: string;
+    label: string;
+    maxHarvestDaysBeforeDelivery: number;
+};
+
+export type HarvestScheduleItem = {
+    cartItemId: number;
+    operationId: number;
+    operationName: string;
+    operationLabel: string;
+    raisedBedId: number;
+    raisedBedName: string | null;
+    raisedBedLabel: string;
+    positionIndex: number | null;
+    targetPositionIndexes: number[];
+    plants: HarvestSchedulePlant[];
+    maxHarvestDaysBeforeDelivery: number;
+    scheduledDate: string | null;
+    allowedFrom: string;
+    allowedTo: string;
+    valid: boolean;
+    validationReason: HarvestScheduleValidationReason | null;
+};
+
+export type HarvestSchedule = {
+    deliverySlotId: number;
+    deliveryDate: string;
+    allValid: boolean;
+    requiresAdjustment: boolean;
+    items: HarvestScheduleItem[];
+};
+
+export type HarvestDateSelection = {
+    cartItemId: number;
+    scheduledDate: string;
+};
+
+export type CanonicalHarvestDateSelection = {
+    cartItemId: number;
+    scheduledDate: string;
+};
+
+type ResolvedHarvestPlant = {
+    plant: EntityStandardized;
+    plantSort: EntityStandardized;
+};
+
+type RaisedBedMetadata = Awaited<
+    ReturnType<typeof getRaisedBedMetadataByIds>
+>[number];
+
+function parseEntityId(entityId: string) {
+    if (!/^\d+$/.test(entityId)) {
+        return null;
+    }
+
+    const parsed = Number(entityId);
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function operationIsDeliverableHarvest(operation: EntityStandardized) {
+    return (
+        operation.attributes?.deliverable === true &&
+        operation.attributes.stage?.information.name === 'harvest'
+    );
+}
+
+export function normalizeMaxHarvestDaysBeforeDelivery(value: unknown) {
+    const parsed =
+        typeof value === 'number'
+            ? value
+            : typeof value === 'string' && value.trim() !== ''
+              ? Number(value)
+              : Number.NaN;
+
+    return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 0;
+}
+
+export function getStrictestHarvestLeadDays(values: unknown[]) {
+    return values.length === 0
+        ? 0
+        : Math.min(
+              ...values.map((value) =>
+                  normalizeMaxHarvestDaysBeforeDelivery(value),
+              ),
+          );
+}
+
+function normalizeDateInputToZagrebDateKey(value: string) {
+    if (isCalendarDateKey(value)) {
+        return value;
+    }
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        return null;
+    }
+
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+        return null;
+    }
+
+    return getTimeZoneDateKey(parsed, ZAGREB_TIME_ZONE);
+}
+
+function dateKeyToUtcIso(dateKey: string) {
+    return `${dateKey}T00:00:00.000Z`;
+}
+
+export function getHarvestDateRange({
+    deliveryDate,
+    maxHarvestDaysBeforeDelivery,
+    now = new Date(),
+}: {
+    deliveryDate: string;
+    maxHarvestDaysBeforeDelivery: number;
+    now?: Date;
+}) {
+    if (!isCalendarDateKey(deliveryDate)) {
+        throw new Error('Invalid delivery calendar date.');
+    }
+
+    const today = getTimeZoneDateKey(now, ZAGREB_TIME_ZONE);
+    const leadDays = normalizeMaxHarvestDaysBeforeDelivery(
+        maxHarvestDaysBeforeDelivery,
+    );
+    const unconstrainedFrom = addCalendarDays(deliveryDate, -leadDays);
+
+    return {
+        allowedFrom: unconstrainedFrom < today ? today : unconstrainedFrom,
+        allowedTo: deliveryDate,
+    };
+}
+
+function getCartItemScheduledDate(item: SelectShoppingCartItem) {
+    if (!item.additionalData) {
+        return {
+            dateKey: null,
+            reason: 'missing_date' as const,
+        };
+    }
+
+    try {
+        const parsed = JSON.parse(item.additionalData) as unknown;
+        if (
+            !parsed ||
+            typeof parsed !== 'object' ||
+            Array.isArray(parsed) ||
+            !('scheduledDate' in parsed) ||
+            typeof parsed.scheduledDate !== 'string'
+        ) {
+            return {
+                dateKey: null,
+                reason: 'missing_date' as const,
+            };
+        }
+
+        const dateKey = normalizeDateInputToZagrebDateKey(parsed.scheduledDate);
+        return dateKey
+            ? { dateKey, reason: null }
+            : { dateKey: null, reason: 'invalid_date' as const };
+    } catch {
+        return {
+            dateKey: null,
+            reason: 'invalid_date' as const,
+        };
+    }
+}
+
+function validateDateKeyAgainstRange({
+    allowedFrom,
+    allowedTo,
+    dateKey,
+    missingReason,
+}: {
+    allowedFrom: string;
+    allowedTo: string;
+    dateKey: string | null;
+    missingReason: 'missing_date' | 'invalid_date' | null;
+}): HarvestScheduleValidationReason | null {
+    if (!dateKey) {
+        return missingReason ?? 'missing_date';
+    }
+    if (dateKey < allowedFrom) {
+        return 'before_allowed_range';
+    }
+    if (dateKey > allowedTo) {
+        return 'after_delivery_date';
+    }
+    return null;
+}
+
+function entityName(entity: EntityStandardized, fallback: string) {
+    return entity.information?.name?.trim() || fallback;
+}
+
+function entityLabel(entity: EntityStandardized, fallback: string) {
+    return (
+        entity.information?.label?.trim() ||
+        entity.information?.name?.trim() ||
+        fallback
+    );
+}
+
+function raisedBedLabel(raisedBed: RaisedBedMetadata) {
+    return (
+        raisedBed.name?.trim() ||
+        (raisedBed.physicalId
+            ? `Gredica ${raisedBed.physicalId}`
+            : `Gredica #${raisedBed.id.toString()}`)
+    );
+}
+
+function uniqueResolvedPlants(plants: ResolvedHarvestPlant[]) {
+    const byPlantSortId = new Map<number, ResolvedHarvestPlant>();
+    for (const resolvedPlant of plants) {
+        byPlantSortId.set(resolvedPlant.plantSort.id, resolvedPlant);
+    }
+    return Array.from(byPlantSortId.values()).sort(
+        (left, right) => left.plantSort.id - right.plantSort.id,
+    );
+}
+
+function buildHarvestScheduleItem({
+    cartItem,
+    deliveryDate,
+    now = new Date(),
+    operation,
+    plants,
+    raisedBed,
+    targetFields,
+}: {
+    cartItem: SelectShoppingCartItem;
+    deliveryDate: string;
+    now?: Date;
+    operation: EntityStandardized;
+    plants: ResolvedHarvestPlant[];
+    raisedBed: RaisedBedMetadata;
+    targetFields: RaisedBedFieldWithEvents[];
+}): HarvestScheduleItem {
+    const summarizedPlants = uniqueResolvedPlants(plants).map(
+        ({ plant, plantSort }) => ({
+            plantId: plant.id,
+            plantSortId: plantSort.id,
+            name: entityName(plant, `plant-${plant.id.toString()}`),
+            label: entityLabel(plant, `Biljka #${plant.id.toString()}`),
+            maxHarvestDaysBeforeDelivery: normalizeMaxHarvestDaysBeforeDelivery(
+                plant.attributes?.maxHarvestDaysBeforeDelivery,
+            ),
+        }),
+    );
+    const maxHarvestDaysBeforeDelivery = getStrictestHarvestLeadDays(
+        summarizedPlants.map((plant) => plant.maxHarvestDaysBeforeDelivery),
+    );
+    const { allowedFrom, allowedTo } = getHarvestDateRange({
+        deliveryDate,
+        maxHarvestDaysBeforeDelivery,
+        now,
+    });
+    const scheduledDate = getCartItemScheduledDate(cartItem);
+    const validationReason = validateDateKeyAgainstRange({
+        allowedFrom,
+        allowedTo,
+        dateKey: scheduledDate.dateKey,
+        missingReason: scheduledDate.reason,
+    });
+
+    return {
+        cartItemId: cartItem.id,
+        operationId: operation.id,
+        operationName: entityName(
+            operation,
+            `operation-${operation.id.toString()}`,
+        ),
+        operationLabel: entityLabel(
+            operation,
+            `Radnja #${operation.id.toString()}`,
+        ),
+        raisedBedId: raisedBed.id,
+        raisedBedName: raisedBed.name,
+        raisedBedLabel: raisedBedLabel(raisedBed),
+        positionIndex: cartItem.positionIndex,
+        targetPositionIndexes: targetFields
+            .map((field) => field.positionIndex)
+            .sort((left, right) => left - right),
+        plants: summarizedPlants,
+        maxHarvestDaysBeforeDelivery,
+        scheduledDate: scheduledDate.dateKey,
+        allowedFrom,
+        allowedTo,
+        valid: validationReason === null,
+        validationReason,
+    };
+}
+
+function targetFieldsForCartItem({
+    cartItem,
+    fields,
+}: {
+    cartItem: SelectShoppingCartItem;
+    fields: RaisedBedFieldWithEvents[];
+}) {
+    if (cartItem.positionIndex !== null) {
+        const field = fields.find(
+            (candidate) =>
+                candidate.positionIndex === cartItem.positionIndex &&
+                candidate.active &&
+                typeof candidate.plantSortId === 'number',
+        );
+        return field ? [field] : [];
+    }
+
+    return fields.filter(
+        (field) => field.active && typeof field.plantSortId === 'number',
+    );
+}
+
+function throwMissingTarget(
+    cartItem: SelectShoppingCartItem,
+    reason: string,
+): never {
+    throw new HarvestScheduleConflictError(
+        'Nije moguće odrediti biljke za planiranu berbu.',
+        409,
+        'harvest_target_missing',
+        {
+            cartItemId: cartItem.id,
+            raisedBedId: cartItem.raisedBedId,
+            positionIndex: cartItem.positionIndex,
+            reason,
+        },
+    );
+}
+
+function resolvePlantsForFields({
+    cartItem,
+    fields,
+    plantSortsById,
+}: {
+    cartItem: SelectShoppingCartItem;
+    fields: RaisedBedFieldWithEvents[];
+    plantSortsById: Map<number, EntityStandardized>;
+}) {
+    return fields.map((field) => {
+        if (typeof field.plantSortId !== 'number') {
+            return throwMissingTarget(cartItem, 'missing_plant_sort');
+        }
+
+        const plantSort = plantSortsById.get(field.plantSortId);
+        const plant = plantSort?.information?.plant;
+        if (!plantSort || !plant) {
+            throw new HarvestScheduleConflictError(
+                'Sorta biljke nema povezanu matičnu biljku.',
+                409,
+                'harvest_plant_mapping_missing',
+                {
+                    cartItemId: cartItem.id,
+                    plantSortId: field.plantSortId,
+                    raisedBedId: cartItem.raisedBedId,
+                    positionIndex: field.positionIndex,
+                },
+            );
+        }
+
+        return { plant, plantSort };
+    });
+}
+
+export async function getHarvestScheduleForCart({
+    accountId,
+    cartId,
+    deliverySlotId,
+    now = new Date(),
+}: {
+    accountId?: string;
+    cartId: number;
+    deliverySlotId: number;
+    now?: Date;
+}): Promise<HarvestSchedule> {
+    const [cart, deliverySlot, operations] = await Promise.all([
+        getShoppingCart(cartId),
+        getTimeSlot(deliverySlotId),
+        getEntitiesFormatted<EntityStandardized>('operation'),
+    ]);
+
+    if (!cart || (accountId !== undefined && cart.accountId !== accountId)) {
+        throw new HarvestScheduleConflictError(
+            'Košarica nije pronađena.',
+            404,
+            'cart_not_found',
+            { cartId },
+        );
+    }
+    if (!deliverySlot) {
+        throw new HarvestScheduleConflictError(
+            'Termin dostave nije pronađen.',
+            404,
+            'delivery_slot_not_found',
+            { deliverySlotId },
+        );
+    }
+    if (deliverySlot.status !== TimeSlotStatuses.SCHEDULED) {
+        throw new HarvestScheduleConflictError(
+            'Termin dostave više nije dostupan.',
+            409,
+            'delivery_slot_unavailable',
+            { deliverySlotId, status: deliverySlot.status },
+        );
+    }
+
+    const deliveryDate = getTimeZoneDateKey(
+        deliverySlot.startAt,
+        ZAGREB_TIME_ZONE,
+    );
+    const today = getTimeZoneDateKey(now, ZAGREB_TIME_ZONE);
+    if (deliveryDate < today) {
+        throw new HarvestScheduleConflictError(
+            'Termin dostave je u prošlosti.',
+            409,
+            'delivery_date_in_past',
+            { deliveryDate, deliverySlotId },
+        );
+    }
+
+    const operationsById = new Map(
+        operations
+            .filter(operationIsDeliverableHarvest)
+            .map((operation) => [operation.id, operation]),
+    );
+    const harvestItems = cart.items.flatMap((item) => {
+        if (item.status !== 'new' || item.entityTypeName !== 'operation') {
+            return [];
+        }
+        const operationId = parseEntityId(item.entityId);
+        const operation = operationId
+            ? operationsById.get(operationId)
+            : undefined;
+        return operation ? [{ cartItem: item, operation }] : [];
+    });
+
+    if (harvestItems.length === 0) {
+        return {
+            deliverySlotId,
+            deliveryDate,
+            allValid: true,
+            requiresAdjustment: false,
+            items: [],
+        };
+    }
+
+    const raisedBedIds = Array.from(
+        new Set(
+            harvestItems.map(({ cartItem }) => {
+                if (cartItem.raisedBedId === null) {
+                    return throwMissingTarget(cartItem, 'missing_raised_bed');
+                }
+                return cartItem.raisedBedId;
+            }),
+        ),
+    );
+    const [fieldsByRaisedBedId, raisedBedMetadata, plantSorts, accountBedIds] =
+        await Promise.all([
+            getRaisedBedFieldsWithEventsForBeds(raisedBedIds),
+            getRaisedBedMetadataByIds(raisedBedIds),
+            getEntitiesFormatted<EntityStandardized>('plantSort'),
+            accountId
+                ? getRaisedBedIdsByAccount(accountId)
+                : Promise.resolve(raisedBedIds),
+        ]);
+    const raisedBedsById = new Map(
+        raisedBedMetadata.map((raisedBed) => [raisedBed.id, raisedBed]),
+    );
+    const accountBedIdSet = new Set(accountBedIds);
+    const plantSortsById = new Map(
+        plantSorts.map((plantSort) => [plantSort.id, plantSort]),
+    );
+
+    const items = harvestItems.map(({ cartItem, operation }) => {
+        if (cartItem.raisedBedId === null) {
+            return throwMissingTarget(cartItem, 'missing_raised_bed');
+        }
+        const raisedBed = raisedBedsById.get(cartItem.raisedBedId);
+        if (!raisedBed || !accountBedIdSet.has(cartItem.raisedBedId)) {
+            return throwMissingTarget(
+                cartItem,
+                accountId ? 'raised_bed_not_owned' : 'raised_bed_not_found',
+            );
+        }
+
+        const targetFields = targetFieldsForCartItem({
+            cartItem,
+            fields: fieldsByRaisedBedId.get(cartItem.raisedBedId) ?? [],
+        });
+        if (targetFields.length === 0) {
+            return throwMissingTarget(cartItem, 'active_plant_not_found');
+        }
+
+        return buildHarvestScheduleItem({
+            cartItem,
+            deliveryDate,
+            now,
+            operation,
+            plants: resolvePlantsForFields({
+                cartItem,
+                fields: targetFields,
+                plantSortsById,
+            }),
+            raisedBed,
+            targetFields,
+        });
+    });
+    const allValid = items.every((item) => item.valid);
+
+    return {
+        deliverySlotId,
+        deliveryDate,
+        allValid,
+        requiresAdjustment: !allValid,
+        items,
+    };
+}
+
+export function validateHarvestDateSelections(
+    schedule: HarvestSchedule,
+    selections: HarvestDateSelection[],
+): CanonicalHarvestDateSelection[] {
+    const expectedItemsById = new Map(
+        schedule.items.map((item) => [item.cartItemId, item]),
+    );
+    const selectionsById = new Map<number, HarvestDateSelection>();
+    const duplicateCartItemIds = new Set<number>();
+    const unexpectedCartItemIds = new Set<number>();
+
+    for (const selection of selections) {
+        if (selectionsById.has(selection.cartItemId)) {
+            duplicateCartItemIds.add(selection.cartItemId);
+        }
+        selectionsById.set(selection.cartItemId, selection);
+        if (!expectedItemsById.has(selection.cartItemId)) {
+            unexpectedCartItemIds.add(selection.cartItemId);
+        }
+    }
+
+    const missingCartItemIds = schedule.items
+        .filter((item) => !selectionsById.has(item.cartItemId))
+        .map((item) => item.cartItemId);
+    if (
+        duplicateCartItemIds.size > 0 ||
+        unexpectedCartItemIds.size > 0 ||
+        missingCartItemIds.length > 0
+    ) {
+        throw new HarvestScheduleConflictError(
+            'Datumi berbe ne odgovaraju sadržaju košarice.',
+            409,
+            'harvest_date_selection_invalid',
+            {
+                duplicateCartItemIds: Array.from(duplicateCartItemIds),
+                missingCartItemIds,
+                unexpectedCartItemIds: Array.from(unexpectedCartItemIds),
+            },
+        );
+    }
+
+    return schedule.items.map((item) => {
+        const selection = selectionsById.get(item.cartItemId);
+        const dateKey = selection
+            ? normalizeDateInputToZagrebDateKey(selection.scheduledDate)
+            : null;
+        const validationReason = validateDateKeyAgainstRange({
+            allowedFrom: item.allowedFrom,
+            allowedTo: item.allowedTo,
+            dateKey,
+            missingReason: dateKey ? null : 'invalid_date',
+        });
+        if (validationReason || !dateKey) {
+            throw new HarvestScheduleConflictError(
+                'Odabrani datum berbe nije dopušten.',
+                409,
+                'harvest_date_selection_invalid',
+                {
+                    allowedFrom: item.allowedFrom,
+                    allowedTo: item.allowedTo,
+                    cartItemId: item.cartItemId,
+                    reason: validationReason,
+                    scheduledDate: selection?.scheduledDate,
+                },
+            );
+        }
+
+        return {
+            cartItemId: item.cartItemId,
+            scheduledDate: dateKeyToUtcIso(dateKey),
+        };
+    });
+}

--- a/packages/storage/tests/deliveryRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRequestsRepo.node.spec.ts
@@ -356,7 +356,34 @@ test('createDeliveryRequest enforces operation and address ownership', async () 
         postalCode: '10000',
         countryCode: 'HR',
     });
+    const otherPickupLocationId = await createPickupLocation({
+        name: `Other pickup location ${randomUUID()}`,
+        street1: 'Druga 1',
+        city: 'Zagreb',
+        postalCode: '10000',
+        countryCode: 'HR',
+    });
 
+    await assert.rejects(
+        createDeliveryRequest({
+            operationId: operation.id,
+            slotId: pickupSlotId,
+            mode: 'delivery',
+            addressId: foreignAddressId,
+            accountId: ownerAccountId,
+        }),
+        /Delivery mode does not match the selected time slot/,
+    );
+    await assert.rejects(
+        createDeliveryRequest({
+            operationId: operation.id,
+            slotId: pickupSlotId,
+            mode: 'pickup',
+            locationId: otherPickupLocationId,
+            accountId: ownerAccountId,
+        }),
+        /Pickup location does not match the selected time slot/,
+    );
     await assert.rejects(
         createDeliveryRequest({
             operationId: operation.id,

--- a/packages/storage/tests/harvestScheduleRepo.node.spec.ts
+++ b/packages/storage/tests/harvestScheduleRepo.node.spec.ts
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    getHarvestDateRange,
+    getStrictestHarvestLeadDays,
+    type HarvestSchedule,
+    HarvestScheduleConflictError,
+    normalizeMaxHarvestDaysBeforeDelivery,
+    validateHarvestDateSelections,
+} from '../src/repositories/harvestScheduleRepo';
+
+function scheduleWithRanges(
+    ranges: Array<{
+        allowedFrom: string;
+        allowedTo: string;
+        cartItemId: number;
+    }>,
+): HarvestSchedule {
+    const items = ranges.map(({ allowedFrom, allowedTo, cartItemId }) => ({
+        allowedFrom,
+        allowedTo,
+        cartItemId,
+        maxHarvestDaysBeforeDelivery: 0,
+        operationId: 10,
+        operationLabel: 'Berba',
+        operationName: 'harvest',
+        plants: [],
+        positionIndex: null,
+        raisedBedId: 20,
+        raisedBedLabel: 'Gredica 1',
+        raisedBedName: 'Gredica 1',
+        scheduledDate: allowedTo,
+        targetPositionIndexes: [],
+        valid: true,
+        validationReason: null,
+    }));
+
+    return {
+        allValid: true,
+        deliveryDate: '2026-08-10',
+        deliverySlotId: 30,
+        items,
+        requiresAdjustment: false,
+    };
+}
+
+test('same-day harvest produces a one-day inclusive range', () => {
+    assert.deepEqual(
+        getHarvestDateRange({
+            deliveryDate: '2026-08-10',
+            maxHarvestDaysBeforeDelivery: 0,
+            now: new Date('2026-08-01T12:00:00.000Z'),
+        }),
+        {
+            allowedFrom: '2026-08-10',
+            allowedTo: '2026-08-10',
+        },
+    );
+});
+
+test('harvest range uses Zagreb calendar days and never starts before today', () => {
+    assert.deepEqual(
+        getHarvestDateRange({
+            deliveryDate: '2026-03-30',
+            maxHarvestDaysBeforeDelivery: 2,
+            now: new Date('2026-03-28T23:30:00.000Z'),
+        }),
+        {
+            allowedFrom: '2026-03-29',
+            allowedTo: '2026-03-30',
+        },
+    );
+    assert.deepEqual(
+        getHarvestDateRange({
+            deliveryDate: '2027-01-02',
+            maxHarvestDaysBeforeDelivery: 3,
+            now: new Date('2026-12-20T12:00:00.000Z'),
+        }),
+        {
+            allowedFrom: '2026-12-30',
+            allowedTo: '2027-01-02',
+        },
+    );
+});
+
+test('invalid lead values default conservatively and mixed plants use the strictest value', () => {
+    assert.equal(normalizeMaxHarvestDaysBeforeDelivery(undefined), 0);
+    assert.equal(normalizeMaxHarvestDaysBeforeDelivery(-2), 0);
+    assert.equal(normalizeMaxHarvestDaysBeforeDelivery(2.9), 2);
+    assert.equal(normalizeMaxHarvestDaysBeforeDelivery('4'), 4);
+    assert.equal(getStrictestHarvestLeadDays([5, 2, 0, 3]), 0);
+    assert.equal(getStrictestHarvestLeadDays([5, 2, 3]), 2);
+    assert.equal(getStrictestHarvestLeadDays([]), 0);
+});
+
+test('validates an exact selection set and returns canonical UTC calendar dates', () => {
+    const schedule = scheduleWithRanges([
+        {
+            cartItemId: 1,
+            allowedFrom: '2026-08-08',
+            allowedTo: '2026-08-10',
+        },
+        {
+            cartItemId: 2,
+            allowedFrom: '2026-08-10',
+            allowedTo: '2026-08-10',
+        },
+    ]);
+
+    assert.deepEqual(
+        validateHarvestDateSelections(schedule, [
+            { cartItemId: 2, scheduledDate: '2026-08-10' },
+            {
+                cartItemId: 1,
+                scheduledDate: '2026-08-08T00:00:00.000Z',
+            },
+        ]),
+        [
+            {
+                cartItemId: 1,
+                scheduledDate: '2026-08-08T00:00:00.000Z',
+            },
+            {
+                cartItemId: 2,
+                scheduledDate: '2026-08-10T00:00:00.000Z',
+            },
+        ],
+    );
+});
+
+test('rejects missing, duplicate, stale, and out-of-range selections', () => {
+    const schedule = scheduleWithRanges([
+        {
+            cartItemId: 1,
+            allowedFrom: '2026-08-08',
+            allowedTo: '2026-08-10',
+        },
+        {
+            cartItemId: 2,
+            allowedFrom: '2026-08-10',
+            allowedTo: '2026-08-10',
+        },
+    ]);
+
+    assert.throws(
+        () =>
+            validateHarvestDateSelections(schedule, [
+                { cartItemId: 1, scheduledDate: '2026-08-08' },
+                { cartItemId: 1, scheduledDate: '2026-08-09' },
+                { cartItemId: 999, scheduledDate: '2026-08-10' },
+            ]),
+        (error) => {
+            assert.ok(error instanceof HarvestScheduleConflictError);
+            assert.equal(error.statusCode, 409);
+            assert.equal(error.code, 'harvest_date_selection_invalid');
+            assert.deepEqual(error.details, {
+                duplicateCartItemIds: [1],
+                missingCartItemIds: [2],
+                unexpectedCartItemIds: [999],
+            });
+            return true;
+        },
+    );
+
+    assert.throws(
+        () =>
+            validateHarvestDateSelections(schedule, [
+                { cartItemId: 1, scheduledDate: '2026-08-07' },
+                { cartItemId: 2, scheduledDate: '2026-08-10' },
+            ]),
+        (error) => {
+            assert.ok(error instanceof HarvestScheduleConflictError);
+            assert.equal(error.details?.reason, 'before_allowed_range');
+            assert.equal(error.details?.cartItemId, 1);
+            return true;
+        },
+    );
+});

--- a/packages/storage/tests/plantMaxHarvestDaysBeforeDeliveryBackfill.node.spec.ts
+++ b/packages/storage/tests/plantMaxHarvestDaysBeforeDeliveryBackfill.node.spec.ts
@@ -1,0 +1,357 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    attributeValues,
+    createAttributeDefinition,
+    createAttributeDefinitionCategory,
+    createEntity,
+    entityRevisions,
+    getAttributeDefinitions,
+    getEntityFormatted,
+    getEntityRaw,
+    storage,
+    updateEntity,
+    upsertAttributeValue,
+    upsertEntityType,
+} from '@gredice/storage';
+import { and, eq, inArray } from 'drizzle-orm';
+import {
+    backfillPlantMaxHarvestDaysBeforeDelivery,
+    maxHarvestDaysBeforeDeliveryDefinitionConfig,
+    maxHarvestDaysBeforeDeliveryPath,
+    normalizePlantName,
+    parsePlantMaxHarvestDaysBackfillArgs,
+    plantMaxHarvestDaysBeforeDelivery,
+    plantMaxHarvestDaysByNormalizedName,
+} from '../scripts/lib/plantMaxHarvestDaysBeforeDelivery';
+import { createTestDb } from './testDb';
+
+test('canonical plant freshness policy covers all 47 current plants', () => {
+    const policy = plantMaxHarvestDaysByNormalizedName(
+        plantMaxHarvestDaysBeforeDelivery,
+    );
+
+    assert.equal(policy.size, 47);
+    assert.equal(
+        policy.get(normalizePlantName('Salata'))?.maxHarvestDaysBeforeDelivery,
+        0,
+    );
+    assert.equal(
+        policy.get(normalizePlantName('Blitva'))?.maxHarvestDaysBeforeDelivery,
+        0,
+    );
+    assert.equal(
+        policy.get(normalizePlantName('Rajčica'))?.maxHarvestDaysBeforeDelivery,
+        1,
+    );
+    assert.equal(
+        policy.get(normalizePlantName('Mrkva'))?.maxHarvestDaysBeforeDelivery,
+        2,
+    );
+    assert.equal(
+        policy.get(normalizePlantName('Luk'))?.maxHarvestDaysBeforeDelivery,
+        3,
+    );
+
+    assert.equal(
+        plantMaxHarvestDaysBeforeDelivery.filter(
+            (plant) => plant.maxHarvestDaysBeforeDelivery === 0,
+        ).length,
+        21,
+    );
+    assert.equal(
+        plantMaxHarvestDaysBeforeDelivery.filter(
+            (plant) => plant.maxHarvestDaysBeforeDelivery === 1,
+        ).length,
+        14,
+    );
+    assert.equal(
+        plantMaxHarvestDaysBeforeDelivery.filter(
+            (plant) => plant.maxHarvestDaysBeforeDelivery === 2,
+        ).length,
+        8,
+    );
+    assert.equal(
+        plantMaxHarvestDaysBeforeDelivery.filter(
+            (plant) => plant.maxHarvestDaysBeforeDelivery === 3,
+        ).length,
+        4,
+    );
+});
+
+test('plant freshness backfill is dry-run by default and rejects unknown arguments', () => {
+    assert.deepEqual(parsePlantMaxHarvestDaysBackfillArgs([]), {
+        apply: false,
+    });
+    assert.deepEqual(parsePlantMaxHarvestDaysBackfillArgs(['--', '--apply']), {
+        apply: true,
+    });
+    assert.throws(
+        () => parsePlantMaxHarvestDaysBackfillArgs(['--force']),
+        /Unknown argument/u,
+    );
+});
+
+test('plant freshness backfill creates explicit values and is idempotent', async () => {
+    createTestDb();
+    const suffix = randomUUID();
+    const entityTypeName = `plant-harvest-policy-${suffix}`;
+    const matrix = [
+        { name: 'Blitva', maxHarvestDaysBeforeDelivery: 0 },
+        { name: 'Luk', maxHarvestDaysBeforeDelivery: 3 },
+    ];
+
+    await upsertEntityType({
+        name: entityTypeName,
+        label: `Plant harvest policy ${suffix}`,
+    });
+    await createAttributeDefinitionCategory({
+        entityTypeName,
+        name: 'information',
+        label: 'Informacije',
+        order: 'a',
+    });
+    await createAttributeDefinitionCategory({
+        entityTypeName,
+        name: 'attributes',
+        label: 'Atributi',
+        order: 'b',
+    });
+    const nameDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        dataType: 'text',
+        display: true,
+        entityTypeName,
+        label: 'Naziv',
+        multiple: false,
+        name: 'name',
+        required: true,
+    });
+    const blitvaId = await createEntity(entityTypeName);
+    const lukId = await createEntity(entityTypeName);
+    await upsertAttributeValue({
+        attributeDefinitionId: nameDefinitionId,
+        entityId: blitvaId,
+        entityTypeName,
+        value: 'Blitva',
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: nameDefinitionId,
+        entityId: lukId,
+        entityTypeName,
+        value: 'Luk ',
+    });
+    await updateEntity({
+        id: blitvaId,
+        entityTypeName,
+        state: 'published',
+    });
+
+    const dryRun = await backfillPlantMaxHarvestDaysBeforeDelivery({
+        entityTypeName,
+        matrix,
+    });
+    assert.equal(dryRun.mode, 'dry-run');
+    assert.equal(dryRun.attribute.wouldCreate, true);
+    assert.deepEqual(dryRun.totals, {
+        create: 2,
+        update: 0,
+        unchanged: 0,
+    });
+    assert.equal(
+        (await getAttributeDefinitions(entityTypeName)).filter(
+            (definition) =>
+                `${definition.category}.${definition.name}` ===
+                maxHarvestDaysBeforeDeliveryPath,
+        ).length,
+        0,
+    );
+
+    const firstApply = await backfillPlantMaxHarvestDaysBeforeDelivery({
+        apply: true,
+        entityTypeName,
+        matrix,
+    });
+    assert.equal(firstApply.attribute.created, true);
+    assert.equal(firstApply.verification?.plants.length, 2);
+    assert.deepEqual(firstApply.totals, {
+        create: 2,
+        update: 0,
+        unchanged: 0,
+    });
+
+    const definitions = await getAttributeDefinitions(entityTypeName);
+    const targetDefinition = definitions.find(
+        (definition) =>
+            `${definition.category}.${definition.name}` ===
+            maxHarvestDaysBeforeDeliveryPath,
+    );
+    assert.ok(targetDefinition);
+    const expectedDefinition =
+        maxHarvestDaysBeforeDeliveryDefinitionConfig(entityTypeName);
+    assert.deepEqual(
+        {
+            category: targetDefinition.category,
+            dataType: targetDefinition.dataType,
+            defaultValue: targetDefinition.defaultValue,
+            description: targetDefinition.description,
+            display: targetDefinition.display,
+            entityTypeName: targetDefinition.entityTypeName,
+            label: targetDefinition.label,
+            multiple: targetDefinition.multiple,
+            name: targetDefinition.name,
+            order: targetDefinition.order,
+            required: targetDefinition.required,
+            unit: targetDefinition.unit,
+        },
+        expectedDefinition,
+    );
+
+    const entityIds = [blitvaId, lukId];
+    let persistedValues = await storage()
+        .select({
+            id: attributeValues.id,
+            entityId: attributeValues.entityId,
+            value: attributeValues.value,
+        })
+        .from(attributeValues)
+        .where(
+            and(
+                eq(attributeValues.attributeDefinitionId, targetDefinition.id),
+                eq(attributeValues.isDeleted, false),
+                inArray(attributeValues.entityId, entityIds),
+            ),
+        );
+    assert.deepEqual(
+        persistedValues
+            .map(({ entityId, value }) => ({ entityId, value }))
+            .sort((left, right) => left.entityId - right.entityId),
+        [
+            { entityId: blitvaId, value: '0' },
+            { entityId: lukId, value: '3' },
+        ],
+    );
+
+    const revisionsBeforeSecondApply = await storage()
+        .select({
+            id: entityRevisions.id,
+            action: entityRevisions.action,
+            actorId: entityRevisions.actorId,
+            actorName: entityRevisions.actorName,
+        })
+        .from(entityRevisions)
+        .where(
+            and(
+                eq(entityRevisions.attributeDefinitionId, targetDefinition.id),
+                inArray(entityRevisions.entityId, entityIds),
+            ),
+        );
+    assert.equal(revisionsBeforeSecondApply.length, 2);
+    assert.ok(
+        revisionsBeforeSecondApply.every(
+            (revision) =>
+                revision.action === 'attribute.created' &&
+                revision.actorId === 'plant-harvest-delivery-backfill' &&
+                revision.actorName === 'Plant harvest delivery backfill',
+        ),
+    );
+
+    const secondApply = await backfillPlantMaxHarvestDaysBeforeDelivery({
+        apply: true,
+        entityTypeName,
+        matrix,
+    });
+    assert.deepEqual(secondApply.totals, {
+        create: 0,
+        update: 0,
+        unchanged: 2,
+    });
+    const revisionsAfterSecondApply = await storage()
+        .select({ id: entityRevisions.id })
+        .from(entityRevisions)
+        .where(
+            and(
+                eq(entityRevisions.attributeDefinitionId, targetDefinition.id),
+                inArray(entityRevisions.entityId, entityIds),
+            ),
+        );
+    assert.equal(
+        revisionsAfterSecondApply.length,
+        revisionsBeforeSecondApply.length,
+    );
+
+    const blitvaValue = persistedValues.find(
+        (value) => value.entityId === blitvaId,
+    );
+    assert.ok(blitvaValue);
+    await upsertAttributeValue({
+        id: blitvaValue.id,
+        attributeDefinitionId: targetDefinition.id,
+        entityId: blitvaId,
+        entityTypeName,
+        value: '2',
+    });
+    const correctiveApply = await backfillPlantMaxHarvestDaysBeforeDelivery({
+        apply: true,
+        entityTypeName,
+        matrix,
+    });
+    assert.deepEqual(correctiveApply.totals, {
+        create: 0,
+        update: 1,
+        unchanged: 1,
+    });
+    persistedValues = await storage()
+        .select({
+            id: attributeValues.id,
+            entityId: attributeValues.entityId,
+            value: attributeValues.value,
+        })
+        .from(attributeValues)
+        .where(
+            and(
+                eq(attributeValues.attributeDefinitionId, targetDefinition.id),
+                eq(attributeValues.isDeleted, false),
+                inArray(attributeValues.entityId, entityIds),
+            ),
+        );
+    assert.deepEqual(
+        persistedValues
+            .map(({ entityId, value }) => ({ entityId, value }))
+            .sort((left, right) => left.entityId - right.entityId),
+        [
+            { entityId: blitvaId, value: '0' },
+            { entityId: lukId, value: '3' },
+        ],
+    );
+
+    const futurePlantId = await createEntity(entityTypeName);
+    await upsertAttributeValue({
+        attributeDefinitionId: nameDefinitionId,
+        entityId: futurePlantId,
+        entityTypeName,
+        value: 'Nova biljka',
+    });
+    await updateEntity({
+        id: futurePlantId,
+        entityTypeName,
+        state: 'published',
+    });
+    const futurePlantRaw = await getEntityRaw(futurePlantId);
+    const virtualDefault = futurePlantRaw?.attributes.find(
+        (attribute) => attribute.attributeDefinitionId === targetDefinition.id,
+    );
+    assert.equal(virtualDefault?.id, 0);
+    assert.equal(virtualDefault?.value, '0');
+
+    const futurePlantFormatted = await getEntityFormatted<{
+        attributes?: {
+            maxHarvestDaysBeforeDelivery?: number;
+        };
+    }>(futurePlantId);
+    assert.equal(
+        futurePlantFormatted.attributes?.maxHarvestDaysBeforeDelivery,
+        0,
+    );
+});

--- a/packages/stripe/src/lib/server/serverStripe.ts
+++ b/packages/stripe/src/lib/server/serverStripe.ts
@@ -123,6 +123,7 @@ export async function getStripeCheckoutSession(sessionId: string) {
             paymentStatus: session.payment_status,
             lineItems: line_items,
             amountTotal: session.amount_total,
+            metadata: session.metadata,
         };
     } catch (error) {
         if (error instanceof Error) {
@@ -172,6 +173,7 @@ export async function stripeCheckout(
         items: CheckoutItem[];
         expiresAt?: Date;
         allowPromotionCodes?: boolean;
+        metadata?: Record<string, string | number | null>;
     },
 ) {
     try {
@@ -199,6 +201,7 @@ export async function stripeCheckout(
             locale: 'hr',
             cancel_url: getReturnUrl({ status: 'cancel' }),
             success_url: getReturnUrl({ status: 'success' }),
+            metadata: data.metadata,
         };
         if (data.expiresAt) {
             params.expires_at = Math.floor(data.expiresAt.getTime() / 1000);


### PR DESCRIPTION
## Summary

- add `plant.attributes.maxHarvestDaysBeforeDelivery` with a same-day default and a guarded, explicit 47-plant policy backfill
- insert a `Branje` step after delivery selection, showing a compact summary for valid schedules and correction controls only when needed
- recompute and validate schedules server-side, then preserve accepted harvest dates across EUR, sunflower, inventory, mixed, Stripe metadata, and webhook checkout paths
- validate delivery/pickup ownership, slot availability, pickup-location loading/retry, exact cart coverage, stale selections, and canonical Zagreb calendar dates

## Data

- leafy plants such as Salata, Blitva, Rukola, Matovilac, Špinat, Kelj, and Raštika remain same-day (`0`)
- the backfill is dry-run by default and rejects unknown, missing, duplicate, or malformed plant data before writing
- after merge, `pnpm bootstrap` supplied the storage database target; the guarded backfill created attribute definition `#212` and values for all 47 active plants
- the final dry-run reported `create: 0`, `update: 0`, `unchanged: 47`, confirming the backfill is complete and idempotent

## Validation

- `pnpm --filter @gredice/storage test` — 678 passed
- `pnpm --filter api test:node` — 292 passed
- `pnpm --filter @gredice/game test` — 576 passed
- focused Garden Playwright component tests — 9 passed, including pickup loading/error/retry
- API, game, Garden, and Storybook typechecks passed
- targeted Biome checks and `git diff --check` passed
- GitHub CI run `#9375`, License Compliance, and all Vercel previews passed