### PR TITLE
perf(game): decouple cloud shade from the primary shadow map

### DIFF
--- a/apps/garden/scripts/profile-game-scene.mjs
+++ b/apps/garden/scripts/profile-game-scene.mjs
@@ -1822,6 +1822,26 @@ async function measureScenario(browser, baseUrl, scenario, options) {
         }
 
         return {
+            animatedCasterShadowRefreshCount:
+                typeof metadata.animatedCasterShadowRefreshCount === 'number'
+                    ? metadata.animatedCasterShadowRefreshCount
+                    : null,
+            cloudAttenuationMaskResolution:
+                typeof metadata.cloudAttenuationMaskResolution === 'number'
+                    ? metadata.cloudAttenuationMaskResolution
+                    : null,
+            cloudAttenuationMaterialCount:
+                typeof metadata.cloudAttenuationMaterialCount === 'number'
+                    ? metadata.cloudAttenuationMaterialCount
+                    : null,
+            cloudAttenuationUpdateCount:
+                typeof metadata.cloudAttenuationUpdateCount === 'number'
+                    ? metadata.cloudAttenuationUpdateCount
+                    : null,
+            cloudAttenuationUpdateMs:
+                typeof metadata.cloudAttenuationUpdateMs === 'number'
+                    ? metadata.cloudAttenuationUpdateMs
+                    : null,
             cloudProjectedShadowCount:
                 typeof metadata.cloudProjectedShadowCount === 'number'
                     ? metadata.cloudProjectedShadowCount
@@ -1927,6 +1947,10 @@ async function measureScenario(browser, baseUrl, scenario, options) {
             raisedBedMulchOverlayCount:
                 typeof metadata.raisedBedMulchOverlayCount === 'number'
                     ? metadata.raisedBedMulchOverlayCount
+                    : null,
+            primaryShadowRefreshCount:
+                typeof metadata.primaryShadowRefreshCount === 'number'
+                    ? metadata.primaryShadowRefreshCount
                     : null,
             shadowMapAutoUpdate:
                 typeof metadata.shadowMapAutoUpdate === 'boolean'
@@ -2814,7 +2838,7 @@ function buildMarkdown(report) {
         const quality = scenario.runtime?.qualityTier ?? 'n/a';
         const shadow = scenario.runtime
             ? scenario.runtime.shadowsEnabled
-                ? `${scenario.runtime.shadowMapSize}px, ${scenario.runtime.shadowMapAutoUpdate === false ? 'cached' : 'auto'}, invalidations ${scenario.runtime.shadowMapInvalidationCount ?? 'n/a'}, cloud ${scenario.runtime.cloudProjectedShadowCount ?? 'n/a'} projected/${scenario.runtime.cloudRealShadowCasterCount ?? 'n/a'} real`
+                ? `${scenario.runtime.shadowMapSize}px, ${scenario.runtime.shadowMapAutoUpdate === false ? 'cached' : 'auto'}, refreshes ${scenario.runtime.primaryShadowRefreshCount ?? 'n/a'} (${scenario.runtime.animatedCasterShadowRefreshCount ?? 'n/a'} animated), invalidations ${scenario.runtime.shadowMapInvalidationCount ?? 'n/a'}, cloud ${scenario.runtime.cloudProjectedShadowCount ?? 'n/a'} projected/${scenario.runtime.cloudRealShadowCasterCount ?? 'n/a'} real, attenuation ${scenario.runtime.cloudAttenuationMaskResolution ?? 'n/a'}px/${scenario.runtime.cloudAttenuationUpdateMs ?? 'n/a'}ms/${scenario.runtime.cloudAttenuationUpdateCount ?? 'n/a'} updates/${scenario.runtime.cloudAttenuationMaterialCount ?? 'n/a'} materials`
                 : 'off'
             : 'n/a';
         const weather = scenario.runtime

--- a/packages/game/src/entities/birds/Birds.tsx
+++ b/packages/game/src/entities/birds/Birds.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Group, Material, Object3D } from 'three';
 import { MathUtils, Mesh, MeshStandardMaterial, Vector3 } from 'three';
 import { useBlockData } from '../../hooks/useBlockData';
+import { useAnimatedCasterShadowMapRefresh } from '../../scene/SceneTime';
 import type { Block } from '../../types/Block';
 import type { Stack } from '../../types/Stack';
 import {
@@ -2055,6 +2056,7 @@ export function Birds({ stacks }: { stacks: Stack[] | undefined }) {
         () => createBirdHabitats(stacks, blockData),
         [blockData, stacks],
     );
+    useAnimatedCasterShadowMapRefresh(habitats.length > 0);
 
     if (habitats.length <= 0) {
         return null;

--- a/packages/game/src/entities/dogs/Dogs.tsx
+++ b/packages/game/src/entities/dogs/Dogs.tsx
@@ -7,6 +7,7 @@ import { MathUtils, Mesh, MeshStandardMaterial, Vector3 } from 'three';
 import { useGameFlags } from '../../GameFlagsContext';
 import { useBlockData } from '../../hooks/useBlockData';
 import { useWeatherNow } from '../../hooks/useWeatherNow';
+import { useAnimatedCasterShadowMapRefresh } from '../../scene/SceneTime';
 import type { Block } from '../../types/Block';
 import type { Stack } from '../../types/Stack';
 import {
@@ -2002,6 +2003,7 @@ export function Dogs({
         () => createDogHabitats(stacks, blockData),
         [blockData, stacks],
     );
+    useAnimatedCasterShadowMapRefresh(habitats.length > 0);
 
     if (habitats.length <= 0) {
         return null;

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -741,11 +741,7 @@ export function DebugHud() {
             ? `${profileSnapshot.canvasWidth}×${profileSnapshot.canvasHeight}`
             : 'n/a';
     const shadowMapMode =
-        profileSnapshot?.shadowMapAutoUpdate === false
-            ? profileSnapshot.shadowMapDynamicRefreshMs
-                ? `cached · ${profileSnapshot.shadowMapDynamicRefreshMs}ms dynamic`
-                : 'cached'
-            : 'auto';
+        profileSnapshot?.shadowMapAutoUpdate === false ? 'cached' : 'auto';
 
     return (
         <div
@@ -849,14 +845,14 @@ export function DebugHud() {
                                     label="Shadows"
                                     value={
                                         profileSnapshot?.shadowsEnabled
-                                            ? `${profileSnapshot.shadowMapSize}px · ${shadowMapMode} · ${profileSnapshot.shadowMapInvalidationCount ?? 0} invalidations`
+                                            ? `${profileSnapshot.shadowMapSize}px · ${shadowMapMode} · ${profileSnapshot.primaryShadowRefreshCount ?? 0} refreshes (${profileSnapshot.animatedCasterShadowRefreshCount ?? 0} animated) · ${profileSnapshot.shadowMapInvalidationCount ?? 0} invalidations`
                                             : 'off'
                                     }
                                 />
                                 <InfoRow
                                     icon={Cloud}
                                     label="Cloud shadows"
-                                    value={`${profileSnapshot?.cloudProjectedShadowCount ?? 0} projected · ${profileSnapshot?.cloudRealShadowCasterCount ?? 0} real`}
+                                    value={`${profileSnapshot?.cloudProjectedShadowCount ?? 0} projected · ${profileSnapshot?.cloudRealShadowCasterCount ?? 0} real · ${profileSnapshot?.cloudAttenuationMaskResolution ?? 0}px/${profileSnapshot?.cloudAttenuationUpdateMs ?? 0}ms · ${profileSnapshot?.cloudAttenuationUpdateCount ?? 0} updates · ${profileSnapshot?.cloudAttenuationMaterialCount ?? 0} materials`}
                                 />
                                 <InfoRow
                                     icon={Droplets}

--- a/packages/game/src/scene/CloudLayer.tsx
+++ b/packages/game/src/scene/CloudLayer.tsx
@@ -18,11 +18,18 @@ import {
     type Mesh,
     type MeshBasicMaterial,
     type OrthographicCamera,
+    type Vector3,
 } from 'three';
 import type { Stack } from '../types/Stack';
 import { useGameState } from '../useGameState';
+import { CloudShadowAttenuation } from './CloudShadowAttenuationLayer';
+import {
+    type CloudShadowSample,
+    resolveCloudShadowAttenuationConfig,
+    resolveCloudShadowProjection,
+} from './cloudShadowAttenuation';
 import { updateGameProfileMetadata } from './gameProfileMetadata';
-import type { GameCloudShadowMode } from './gameQuality';
+import type { GameQualityProfile } from './gameQuality';
 import { useSceneTimeInvalidation } from './SceneTime';
 import { getVisualDaylightAmount, smoothstep } from './visualDayNight';
 
@@ -44,9 +51,7 @@ const CLOUD_MAX_COVERAGE_SCALE = 1.14;
 const CLOUD_BASE_DRIFT_SPEED = 0.35;
 const CLOUD_WIND_DRIFT_SPEED = 0.5;
 const CLOUD_RENDER_ORDER = 30;
-const CLOUD_SHADOW_CASTER_BASE_ALPHA_TEST = 0.2;
-const CLOUD_SHADOW_CASTER_HARD_ALPHA_TEST = 0.08;
-const CLOUD_SHADOW_CASTER_SOFT_ALPHA_TEST = 0.02;
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
 
 function seededRandom(seed: number) {
     const value = Math.sin(seed * 12.9898) * 43758.5453;
@@ -58,7 +63,12 @@ function wrapValue(value: number, min: number, max: number) {
     return MathUtils.euclideanModulo(value - min, range) + min;
 }
 
-function createCloudAlphaTexture() {
+type CloudAlphaAsset = {
+    canvas: HTMLCanvasElement;
+    texture: CanvasTexture;
+};
+
+function createCloudAlphaAsset(): CloudAlphaAsset | null {
     const canvas = document.createElement('canvas');
     canvas.width = 256;
     canvas.height = 256;
@@ -103,7 +113,7 @@ function createCloudAlphaTexture() {
     texture.wrapS = ClampToEdgeWrapping;
     texture.wrapT = ClampToEdgeWrapping;
     texture.needsUpdate = true;
-    return texture;
+    return { canvas, texture };
 }
 
 function getCloudBounds(stacks: Stack[] | undefined) {
@@ -142,9 +152,10 @@ function getCloudBounds(stacks: Stack[] | undefined) {
 type CloudLayerProps = {
     cloudy: number;
     foggy: number;
-    shadowMode: GameCloudShadowMode;
+    quality: GameQualityProfile;
     shadowStrength: number;
     stacks: Stack[] | undefined;
+    sunPosition: Vector3;
     timeOfDay: number;
     windDirection: number;
     windSpeed: number;
@@ -194,6 +205,49 @@ function createCloudSlot(index: number): CloudSlot {
     };
 }
 
+function createCloudShadowSample(): CloudShadowSample {
+    return {
+        altitude: 0,
+        height: 0,
+        opacity: 0,
+        rotation: 0,
+        width: 0,
+        x: 0,
+        z: 0,
+    };
+}
+
+function getPrefersReducedMotion() {
+    return (
+        typeof window !== 'undefined' &&
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia(REDUCED_MOTION_QUERY).matches
+    );
+}
+
+function usePrefersReducedMotion() {
+    const [prefersReducedMotion, setPrefersReducedMotion] = useState(
+        getPrefersReducedMotion,
+    );
+
+    useEffect(() => {
+        if (
+            typeof window === 'undefined' ||
+            typeof window.matchMedia !== 'function'
+        ) {
+            return;
+        }
+
+        const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+        const handleChange = () => setPrefersReducedMotion(mediaQuery.matches);
+        handleChange();
+        mediaQuery.addEventListener('change', handleChange);
+        return () => mediaQuery.removeEventListener('change', handleChange);
+    }, []);
+
+    return prefersReducedMotion;
+}
+
 function spawnCloud(
     slot: CloudSlot,
     cloud: CloudDefinition,
@@ -230,18 +284,20 @@ function spawnCloud(
 export function CloudLayer({
     cloudy,
     foggy,
-    shadowMode,
+    quality,
     shadowStrength,
     stacks,
+    sunPosition,
     timeOfDay,
     windDirection,
     windSpeed,
 }: CloudLayerProps) {
     const cloudRefs = useRef<Array<Mesh | null>>([]);
-    const cloudShadowRefs = useRef<Array<Mesh | null>>([]);
     const materialRefs = useRef<Array<MeshBasicMaterial | null>>([]);
-    const shadowMaterialRefs = useRef<Array<MeshBasicMaterial | null>>([]);
     const cloudSlotsRef = useRef<Array<CloudSlot>>([]);
+    const cloudShadowSamplesRef = useRef<Array<CloudShadowSample>>(
+        Array.from({ length: MAX_CLOUDS }, createCloudShadowSample),
+    );
     const cloudSlotsActiveRef = useRef(false);
     const [hasActiveCloudSlots, setHasActiveCloudSlots] = useState(false);
     const camera = useThree((state) => state.camera);
@@ -249,17 +305,30 @@ export function CloudLayer({
         (state) => state.size,
     );
     const gameCamera = useGameState((state) => state.gameCamera);
-    const cloudAlphaTexture = useMemo(
+    const cloudAlphaAsset = useMemo(
         () =>
-            typeof document === 'undefined' ? null : createCloudAlphaTexture(),
+            typeof document === 'undefined' ? null : createCloudAlphaAsset(),
         [],
+    );
+    const prefersReducedMotion = usePrefersReducedMotion();
+    const attenuationConfig = useMemo(
+        () =>
+            resolveCloudShadowAttenuationConfig({
+                prefersReducedMotion,
+                quality,
+            }),
+        [prefersReducedMotion, quality],
+    );
+    const shadowProjection = useMemo(
+        () => resolveCloudShadowProjection(sunPosition),
+        [sunPosition],
     );
 
     useEffect(() => {
         return () => {
-            cloudAlphaTexture?.dispose();
+            cloudAlphaAsset?.texture.dispose();
         };
-    }, [cloudAlphaTexture]);
+    }, [cloudAlphaAsset]);
 
     const bounds = useMemo(() => getCloudBounds(stacks), [stacks]);
     const cameraFrameRef = useRef<CloudCameraFrame>({
@@ -293,7 +362,6 @@ export function CloudLayer({
         CLOUD_MAX_COVERAGE_SCALE,
         smoothstep(0.08, 0.78, visibleCloudiness),
     );
-    const realShadowCasterCount = shadowStrength > 0 ? visibleCloudCount : 0;
     const visibleOpacity =
         daylightVisibility * (0.2 + effectiveCloudiness * 0.26 + foggy * 0.035);
     const windStrength = Math.min(1.4, Math.max(0, windSpeed / 12));
@@ -303,11 +371,14 @@ export function CloudLayer({
 
     useEffect(() => {
         updateGameProfileMetadata({
-            cloudProjectedShadowCount: 0,
-            cloudRealShadowCasterCount: realShadowCasterCount,
+            cloudProjectedShadowCount:
+                attenuationConfig.enabled && shadowStrength > 0
+                    ? visibleCloudCount
+                    : 0,
+            cloudRealShadowCasterCount: 0,
             cloudVisualCount: visibleCloudCount,
         });
-    }, [realShadowCasterCount, visibleCloudCount]);
+    }, [attenuationConfig.enabled, shadowStrength, visibleCloudCount]);
 
     useEffect(
         () => () => {
@@ -431,16 +502,6 @@ export function CloudLayer({
         const driftSpeed =
             (CLOUD_BASE_DRIFT_SPEED + windStrength * CLOUD_WIND_DRIFT_SPEED) *
             0.5;
-        const targetShadowAlphaTest =
-            shadowMode === 'hard'
-                ? CLOUD_SHADOW_CASTER_HARD_ALPHA_TEST
-                : CLOUD_SHADOW_CASTER_SOFT_ALPHA_TEST;
-        const shadowCoverage = smoothstep(0.08, 0.75, shadowStrength);
-        const shadowAlphaTest = MathUtils.lerp(
-            CLOUD_SHADOW_CASTER_BASE_ALPHA_TEST,
-            targetShadowAlphaTest,
-            shadowCoverage,
-        );
         const travelRangeX = Math.max(
             28,
             bounds.spanX + CLOUD_TRAVEL_MARGIN * 2,
@@ -455,11 +516,10 @@ export function CloudLayer({
         const wrapMaxZ = bounds.centerZ + travelRangeZ;
         for (let index = 0; index < MAX_CLOUDS; index += 1) {
             const mesh = cloudRefs.current[index];
-            const shadowMesh = cloudShadowRefs.current[index];
             const material = materialRefs.current[index];
-            const shadowMaterial = shadowMaterialRefs.current[index];
             const cloud = cloudDefinitions[index];
             const slot = cloudSlotsRef.current[index];
+            const shadowSample = cloudShadowSamplesRef.current[index];
             const shouldBeVisible = index < visibleCloudCount;
             if (
                 shouldBeVisible &&
@@ -484,12 +544,10 @@ export function CloudLayer({
                 if (mesh) {
                     mesh.visible = false;
                 }
-                if (shadowMesh) {
-                    shadowMesh.visible = false;
-                }
                 if (material) {
                     material.opacity = 0;
                 }
+                shadowSample.opacity = 0;
                 continue;
             }
 
@@ -516,12 +574,10 @@ export function CloudLayer({
                 if (mesh) {
                     mesh.visible = false;
                 }
-                if (shadowMesh) {
-                    shadowMesh.visible = false;
-                }
                 if (material) {
                     material.opacity = 0;
                 }
+                shadowSample.opacity = 0;
                 continue;
             }
 
@@ -576,34 +632,17 @@ export function CloudLayer({
                 material.opacity =
                     visibleOpacity * cloud.opacityScale * slot.visibility;
             }
-            const shouldRenderShadow =
-                index < realShadowCasterCount && slot.visibility > 0.001;
-            if (shadowMesh) {
-                if (!shouldRenderShadow) {
-                    shadowMesh.visible = false;
-                } else {
-                    const shadowScale =
-                        (CLOUD_BASE_SCALE +
-                            slot.visibility * CLOUD_SCALE_RANGE) *
-                        cloud.sizeScale *
-                        coverageScale;
-                    shadowMesh.visible = true;
-                    shadowMesh.position.set(x, y, z);
-                    shadowMesh.rotation.set(
-                        -Math.PI / 2,
-                        0,
-                        cloud.phase * 0.08,
-                    );
-                    shadowMesh.scale.set(
-                        shadowScale * 1.12,
-                        shadowScale * 1.05,
-                        1,
-                    );
-                }
-            }
-            if (shadowMaterial) {
-                shadowMaterial.alphaTest = shadowAlphaTest;
-            }
+            const shadowScale =
+                (CLOUD_BASE_SCALE + slot.visibility * CLOUD_SCALE_RANGE) *
+                cloud.sizeScale *
+                coverageScale;
+            shadowSample.altitude = y;
+            shadowSample.height = cloud.height * shadowScale * 1.05;
+            shadowSample.opacity = slot.visibility;
+            shadowSample.rotation = cloud.phase * 0.08;
+            shadowSample.width = cloud.width * shadowScale * 1.12;
+            shadowSample.x = x;
+            shadowSample.z = z;
         }
 
         const hasActiveSlots = cloudSlotsRef.current.some(
@@ -615,66 +654,55 @@ export function CloudLayer({
         }
     });
 
-    if (!cloudAlphaTexture || !shouldAnimateCloudSlots) {
+    if (!cloudAlphaAsset) {
         return null;
     }
 
     return (
         <>
-            {cloudDefinitions.map((cloud, index) => (
-                <group key={cloud.id} name={`Environment:CloudSlot:${index}`}>
-                    <mesh
-                        castShadow
-                        frustumCulled={false}
-                        name={`Environment:CloudShadowCaster:${index}`}
-                        receiveShadow={false}
-                        ref={(mesh) => {
-                            cloudShadowRefs.current[index] = mesh;
-                        }}
-                        visible={false}
+            <CloudShadowAttenuation
+                bounds={bounds}
+                cloudAlphaCanvas={cloudAlphaAsset.canvas}
+                config={attenuationConfig}
+                mode={quality.cloudShadowMode}
+                projection={shadowProjection}
+                samplesRef={cloudShadowSamplesRef}
+                strength={shadowStrength}
+            />
+            {shouldAnimateCloudSlots &&
+                cloudDefinitions.map((cloud, index) => (
+                    <group
+                        key={cloud.id}
+                        name={`Environment:CloudSlot:${index}`}
                     >
-                        <planeGeometry args={[cloud.width, cloud.height]} />
-                        <meshBasicMaterial
-                            alphaMap={cloudAlphaTexture}
-                            alphaTest={CLOUD_SHADOW_CASTER_HARD_ALPHA_TEST}
-                            colorWrite={false}
-                            depthWrite={false}
-                            fog={false}
-                            ref={(material) => {
-                                shadowMaterialRefs.current[index] = material;
+                        <mesh
+                            castShadow={false}
+                            frustumCulled={false}
+                            name={`Environment:CloudBillboard:${index}`}
+                            renderOrder={CLOUD_RENDER_ORDER}
+                            ref={(mesh) => {
+                                cloudRefs.current[index] = mesh;
+                                mesh?.quaternion.copy(camera.quaternion);
                             }}
-                            side={DoubleSide}
-                            toneMapped={false}
-                        />
-                    </mesh>
-                    <mesh
-                        castShadow={false}
-                        frustumCulled={false}
-                        name={`Environment:CloudBillboard:${index}`}
-                        renderOrder={CLOUD_RENDER_ORDER}
-                        ref={(mesh) => {
-                            cloudRefs.current[index] = mesh;
-                            mesh?.quaternion.copy(camera.quaternion);
-                        }}
-                    >
-                        <planeGeometry args={[cloud.width, cloud.height]} />
-                        <meshBasicMaterial
-                            alphaMap={cloudAlphaTexture}
-                            alphaTest={CLOUD_ALPHA_TEST}
-                            color={cloud.tint}
-                            depthWrite={false}
-                            fog={false}
-                            opacity={0}
-                            ref={(material) => {
-                                materialRefs.current[index] = material;
-                            }}
-                            side={DoubleSide}
-                            toneMapped={false}
-                            transparent
-                        />
-                    </mesh>
-                </group>
-            ))}
+                        >
+                            <planeGeometry args={[cloud.width, cloud.height]} />
+                            <meshBasicMaterial
+                                alphaMap={cloudAlphaAsset.texture}
+                                alphaTest={CLOUD_ALPHA_TEST}
+                                color={cloud.tint}
+                                depthWrite={false}
+                                fog={false}
+                                opacity={0}
+                                ref={(material) => {
+                                    materialRefs.current[index] = material;
+                                }}
+                                side={DoubleSide}
+                                toneMapped={false}
+                                transparent
+                            />
+                        </mesh>
+                    </group>
+                ))}
         </>
     );
 }

--- a/packages/game/src/scene/CloudShadowAttenuationLayer.tsx
+++ b/packages/game/src/scene/CloudShadowAttenuationLayer.tsx
@@ -1,0 +1,303 @@
+'use client';
+
+import { useFrame, useThree } from '@react-three/fiber';
+import {
+    type MutableRefObject,
+    useEffect,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
+import { CanvasTexture, ClampToEdgeWrapping, LinearFilter } from 'three';
+import {
+    type CloudShadowAttenuationConfig,
+    type CloudShadowBounds,
+    type CloudShadowMaterialLeaseMap,
+    type CloudShadowProjection,
+    type CloudShadowSample,
+    getCloudShadowAttenuationMaterialUniforms,
+    releaseCloudShadowAttenuationMaterials,
+    resolveCloudShadowAttenuationActivation,
+    resolveCloudShadowAttenuationUpdateTick,
+    resolveCloudShadowMaskPlacement,
+    syncCloudShadowAttenuationMaterials,
+} from './cloudShadowAttenuation';
+import { updateGameProfileMetadata } from './gameProfileMetadata';
+import type { GameCloudShadowMode } from './gameQuality';
+
+const materialScanMs = 1_000;
+
+type CloudShadowMaskSurface = {
+    canvas: HTMLCanvasElement;
+    context: CanvasRenderingContext2D;
+    texture: CanvasTexture;
+};
+
+function createCloudShadowMaskSurface(resolution: number) {
+    if (typeof document === 'undefined' || resolution <= 0) {
+        return null;
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = resolution;
+    canvas.height = resolution;
+    const context = canvas.getContext('2d');
+    if (!context) {
+        return null;
+    }
+
+    context.fillStyle = '#000000';
+    context.fillRect(0, 0, resolution, resolution);
+
+    const texture = new CanvasTexture(canvas);
+    texture.generateMipmaps = false;
+    texture.magFilter = LinearFilter;
+    texture.minFilter = LinearFilter;
+    texture.wrapS = ClampToEdgeWrapping;
+    texture.wrapT = ClampToEdgeWrapping;
+    texture.needsUpdate = true;
+
+    return { canvas, context, texture };
+}
+
+function drawCloudShadowMask({
+    bounds,
+    cloudAlphaCanvas,
+    projection,
+    samples,
+    surface,
+}: {
+    bounds: CloudShadowBounds;
+    cloudAlphaCanvas: HTMLCanvasElement;
+    projection: CloudShadowProjection;
+    samples: readonly CloudShadowSample[];
+    surface: CloudShadowMaskSurface;
+}) {
+    const { canvas, context } = surface;
+    context.save();
+    context.globalCompositeOperation = 'copy';
+    context.globalAlpha = 1;
+    context.fillStyle = '#000000';
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.restore();
+
+    context.save();
+    context.globalCompositeOperation = 'lighter';
+    for (const sample of samples) {
+        if (sample.opacity <= 0.001) {
+            continue;
+        }
+
+        const placement = resolveCloudShadowMaskPlacement({
+            bounds,
+            projection,
+            resolution: canvas.width,
+            sample,
+        });
+        context.save();
+        context.globalAlpha = placement.alpha;
+        context.translate(placement.x, placement.y);
+        context.rotate(placement.rotation);
+        context.drawImage(
+            cloudAlphaCanvas,
+            -placement.width / 2,
+            -placement.height / 2,
+            placement.width,
+            placement.height,
+        );
+        context.restore();
+    }
+    context.restore();
+    surface.texture.needsUpdate = true;
+}
+
+export function CloudShadowAttenuation({
+    bounds,
+    cloudAlphaCanvas,
+    config,
+    mode,
+    projection,
+    samplesRef,
+    strength,
+}: {
+    bounds: CloudShadowBounds;
+    cloudAlphaCanvas: HTMLCanvasElement;
+    config: CloudShadowAttenuationConfig;
+    mode: GameCloudShadowMode;
+    projection: CloudShadowProjection;
+    samplesRef: MutableRefObject<CloudShadowSample[]>;
+    strength: number;
+}) {
+    const scene = useThree((state) => state.scene);
+    const [activated, setActivated] = useState(() =>
+        resolveCloudShadowAttenuationActivation({
+            activated: false,
+            strength,
+        }),
+    );
+    const surfaceResolution =
+        activated && config.enabled ? config.maskResolution : 0;
+    const surface = useMemo(
+        () => createCloudShadowMaskSurface(surfaceResolution),
+        [surfaceResolution],
+    );
+    const leasesRef = useRef<CloudShadowMaterialLeaseMap>(new Map());
+    const attenuationActiveRef = useRef(false);
+    const nextMaterialScanAtRef = useRef(0);
+    const nextUpdateAtRef = useRef(0);
+    const forceUpdateRef = useRef(true);
+    const updateCountRef = useRef(0);
+    const uniforms = getCloudShadowAttenuationMaterialUniforms();
+    const materialIntegrationEnabled =
+        activated && config.enabled && surface !== null;
+    const maskInvalidationKey = [
+        bounds.maxX,
+        bounds.maxZ,
+        bounds.minX,
+        bounds.minZ,
+        cloudAlphaCanvas.width,
+        cloudAlphaCanvas.height,
+        projection.x,
+        projection.z,
+        surface?.texture.uuid ?? 'none',
+    ].join('|');
+
+    useEffect(() => {
+        if (
+            resolveCloudShadowAttenuationActivation({
+                activated,
+                strength,
+            }) !== activated
+        ) {
+            setActivated(true);
+        }
+    }, [activated, strength]);
+
+    useEffect(() => {
+        void maskInvalidationKey;
+        forceUpdateRef.current = true;
+        nextUpdateAtRef.current = 0;
+    }, [maskInvalidationKey]);
+
+    useEffect(() => {
+        return () => {
+            surface?.texture.dispose();
+        };
+    }, [surface]);
+
+    useEffect(() => {
+        updateGameProfileMetadata({
+            cloudAttenuationMaskResolution: materialIntegrationEnabled
+                ? config.maskResolution
+                : 0,
+            cloudAttenuationUpdateCount: updateCountRef.current,
+            cloudAttenuationUpdateMs: materialIntegrationEnabled
+                ? config.updateMs
+                : 0,
+        });
+    }, [config.maskResolution, config.updateMs, materialIntegrationEnabled]);
+
+    useLayoutEffect(() => {
+        const leases = leasesRef.current;
+        const materialCount = syncCloudShadowAttenuationMaterials({
+            enabled: materialIntegrationEnabled,
+            leases,
+            root: scene,
+            uniforms,
+        });
+        updateGameProfileMetadata({
+            cloudAttenuationMaterialCount: materialCount,
+        });
+
+        return () => {
+            releaseCloudShadowAttenuationMaterials(leases);
+            updateGameProfileMetadata({
+                cloudAttenuationMaterialCount: 0,
+            });
+        };
+    }, [materialIntegrationEnabled, scene, uniforms]);
+
+    useEffect(
+        () => () => {
+            updateGameProfileMetadata({
+                cloudAttenuationMaskResolution: 0,
+                cloudAttenuationUpdateCount: 0,
+                cloudAttenuationUpdateMs: 0,
+            });
+        },
+        [],
+    );
+
+    useFrame(() => {
+        if (!activated) {
+            return;
+        }
+
+        const attenuationActive =
+            materialIntegrationEnabled &&
+            strength > 0.001 &&
+            samplesRef.current.some((sample) => sample.opacity > 0.001);
+        if (attenuationActive && !attenuationActiveRef.current) {
+            forceUpdateRef.current = true;
+            nextUpdateAtRef.current = 0;
+        }
+        attenuationActiveRef.current = attenuationActive;
+
+        uniforms.bounds.value.set(
+            bounds.minX,
+            bounds.minZ,
+            1 / Math.max(0.001, bounds.maxX - bounds.minX),
+            1 / Math.max(0.001, bounds.maxZ - bounds.minZ),
+        );
+        uniforms.hardness.value = mode === 'hard' ? 1 : 0;
+        uniforms.map.value = surface?.texture ?? null;
+        uniforms.projection.value.set(projection.x, projection.z);
+        uniforms.strength.value = attenuationActive ? strength : 0;
+
+        const now = performance.now();
+        if (now >= nextMaterialScanAtRef.current) {
+            nextMaterialScanAtRef.current = now + materialScanMs;
+            const materialCount = syncCloudShadowAttenuationMaterials({
+                enabled: materialIntegrationEnabled,
+                leases: leasesRef.current,
+                root: scene,
+                uniforms,
+            });
+            updateGameProfileMetadata({
+                cloudAttenuationMaterialCount: materialCount,
+            });
+        }
+
+        if (!surface) {
+            return;
+        }
+
+        const tick = resolveCloudShadowAttenuationUpdateTick({
+            enabled: attenuationActive,
+            force: forceUpdateRef.current,
+            nextUpdateAt: nextUpdateAtRef.current,
+            now,
+            updateMs: config.updateMs,
+        });
+        nextUpdateAtRef.current = tick.nextUpdateAt;
+        if (!tick.shouldUpdate) {
+            return;
+        }
+
+        forceUpdateRef.current = false;
+        drawCloudShadowMask({
+            bounds,
+            cloudAlphaCanvas,
+            projection,
+            samples: samplesRef.current,
+            surface,
+        });
+        updateCountRef.current += 1;
+        updateGameProfileMetadata({
+            cloudAttenuationUpdateCount: updateCountRef.current,
+        });
+    });
+
+    return null;
+}

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -37,10 +37,7 @@ import Snow from './Snow/Snow';
 import { resolveSnowParticleCounts } from './Snow/snowParticles';
 import { Stars } from './Stars';
 import { SunMoon } from './SunMoon';
-import {
-    buildDirectionalShadowDepthSignature,
-    cloudShadowRefreshMsByMode,
-} from './shadowMapScheduling';
+import { buildDirectionalShadowDepthSignature } from './shadowMapScheduling';
 import {
     resolveEnvironmentSkyBackgroundColors,
     resolveSkyBackgroundColor,
@@ -898,10 +895,6 @@ export function Environment({
         : daylightVisibility *
           smoothstep(0.08, 0.22, cloudCover) *
           (1 - smoothstep(0.5, 0.9, effectiveCloudCover));
-    const cloudShadowDynamicRefreshMs =
-        qualityProfile.shadows && cloudShadowStrength > 0
-            ? cloudShadowRefreshMsByMode[qualityProfile.cloudShadowMode]
-            : undefined;
     const gardenShadowSignature = useMemo(
         () => buildStackShadowSignature(garden?.stacks),
         [garden?.stacks],
@@ -1030,7 +1023,6 @@ export function Environment({
                 }
             />
             <ShadowMapController
-                dynamicRefreshMs={cloudShadowDynamicRefreshMs}
                 enabled={qualityProfile.shadows}
                 invalidationKey={shadowInvalidationKey}
                 settleKey={shadowSettleKey}
@@ -1109,11 +1101,12 @@ export function Environment({
                 <CloudLayer
                     cloudy={blendedWeather.cloudy ?? 0}
                     foggy={blendedWeather.foggy ?? 0}
-                    shadowMode={qualityProfile.cloudShadowMode}
+                    quality={qualityProfile}
                     shadowStrength={
                         qualityProfile.shadows ? cloudShadowStrength : 0
                     }
                     stacks={garden?.stacks}
+                    sunPosition={directionalLight.position}
                     timeOfDay={timeOfDay}
                     windDirection={windDirection}
                     windSpeed={windSpeed}

--- a/packages/game/src/scene/SceneTime.tsx
+++ b/packages/game/src/scene/SceneTime.tsx
@@ -25,6 +25,10 @@ export const sceneFrameRates = {
 
 type SceneTimeContextValue = {
     acquireContinuousRender: (framesPerSecond?: number) => () => void;
+    requestAnimatedCasterShadowRefresh: (now: number) => void;
+    subscribeAnimatedCasterShadowRefresh: (
+        listener: (now: number) => void,
+    ) => () => void;
     subscribeSceneResume: (listener: () => void) => () => void;
     timeUniform: IUniform<number>;
 };
@@ -54,6 +58,9 @@ export function SceneTimeProvider({
     const animationFrameRef = useRef<number | null>(null);
     const baseFramesPerSecondRef = useRef(
         normalizeSceneFramesPerSecond(baseFramesPerSecond),
+    );
+    const animatedCasterShadowRefreshListenersRef = useRef(
+        new Set<(now: number) => void>(),
     );
     const canvasVisibleRef = useRef(true);
     const continuousRenderLeasesRef = useRef(new Map<symbol, number>());
@@ -91,6 +98,24 @@ export function SceneTimeProvider({
             sceneResumeListenersRef.current.delete(listener);
         };
     }, []);
+
+    const requestAnimatedCasterShadowRefresh = useCallback((now: number) => {
+        for (const listener of animatedCasterShadowRefreshListenersRef.current) {
+            listener(now);
+        }
+    }, []);
+
+    const subscribeAnimatedCasterShadowRefresh = useCallback(
+        (listener: (now: number) => void) => {
+            animatedCasterShadowRefreshListenersRef.current.add(listener);
+            return () => {
+                animatedCasterShadowRefreshListenersRef.current.delete(
+                    listener,
+                );
+            };
+        },
+        [],
+    );
 
     const startContinuousRenderLoop = useCallback(() => {
         if (
@@ -214,6 +239,7 @@ export function SceneTimeProvider({
         return () => {
             disposedRef.current = true;
             stopContinuousRenderLoop();
+            animatedCasterShadowRefreshListenersRef.current.clear();
             continuousRenderLeasesRef.current.clear();
             sceneResumeListenersRef.current.clear();
         };
@@ -293,10 +319,18 @@ export function SceneTimeProvider({
     const contextValue = useMemo(
         () => ({
             acquireContinuousRender,
+            requestAnimatedCasterShadowRefresh,
+            subscribeAnimatedCasterShadowRefresh,
             subscribeSceneResume,
             timeUniform,
         }),
-        [acquireContinuousRender, subscribeSceneResume, timeUniform],
+        [
+            acquireContinuousRender,
+            requestAnimatedCasterShadowRefresh,
+            subscribeAnimatedCasterShadowRefresh,
+            subscribeSceneResume,
+            timeUniform,
+        ],
     );
 
     return (
@@ -341,6 +375,35 @@ export function useSceneResume(listener: () => void) {
 
     useEffect(
         () => sceneTime.subscribeSceneResume(listener),
+        [listener, sceneTime],
+    );
+}
+
+// Actual moving cast-shadow owners opt into this contract. Secondary effects
+// such as moving cloud shade intentionally never request primary-map refreshes.
+export function useAnimatedCasterShadowMapRefresh(enabled = true) {
+    const sceneTime = useContext(SceneTimeContext);
+    if (!sceneTime) {
+        throw new Error('Missing SceneTimeProvider in the scene tree');
+    }
+
+    useFrame(() => {
+        if (enabled) {
+            sceneTime.requestAnimatedCasterShadowRefresh(performance.now());
+        }
+    });
+}
+
+export function useAnimatedCasterShadowMapRefreshSubscription(
+    listener: (now: number) => void,
+) {
+    const sceneTime = useContext(SceneTimeContext);
+    if (!sceneTime) {
+        throw new Error('Missing SceneTimeProvider in the scene tree');
+    }
+
+    useEffect(
+        () => sceneTime.subscribeAnimatedCasterShadowRefresh(listener),
         [listener, sceneTime],
     );
 }

--- a/packages/game/src/scene/ShadowMapController.tsx
+++ b/packages/game/src/scene/ShadowMapController.tsx
@@ -9,51 +9,101 @@ import {
     useState,
 } from 'react';
 import { updateGameProfileMetadata } from './gameProfileMetadata';
-import { useSceneResume, useSceneTimeInvalidation } from './SceneTime';
 import {
-    hasShadowDynamicCadenceChanged,
-    resolveShadowMapRefreshTick,
+    useAnimatedCasterShadowMapRefreshSubscription,
+    useSceneResume,
+    useSceneTimeInvalidation,
+} from './SceneTime';
+import {
+    animatedCasterShadowRefreshMs,
+    requestPrimaryShadowMapRefresh,
+    resolveAnimatedCasterShadowRefreshTick,
 } from './shadowMapScheduling';
 
 const shadowSettleMs = 900;
 
 export function ShadowMapController({
-    dynamicRefreshMs,
     enabled,
     invalidationKey,
     settleKey,
 }: {
-    dynamicRefreshMs?: number;
     enabled: boolean;
     invalidationKey: string;
     settleKey?: string;
 }) {
     const gl = useThree((state) => state.gl);
     const invalidate = useThree((state) => state.invalidate);
+    const animatedRefreshCountRef = useRef(0);
     const invalidationCountRef = useRef(0);
-    const nextDynamicRefreshRef = useRef(0);
-    const previousDynamicRefreshMsRef = useRef<number | undefined>(undefined);
+    const nextAnimatedRefreshAtRef = useRef(0);
+    const refreshCountRef = useRef(0);
     const settleUntilRef = useRef(0);
     const [shadowSettleGeneration, setShadowSettleGeneration] = useState(0);
     const [shadowSettling, setShadowSettling] = useState(false);
-    const normalizedDynamicRefreshMs =
-        enabled && typeof dynamicRefreshMs === 'number' && dynamicRefreshMs > 0
-            ? dynamicRefreshMs
-            : undefined;
     useSceneTimeInvalidation(enabled && shadowSettling);
+
+    const reportShadowMapState = useCallback(() => {
+        updateGameProfileMetadata({
+            animatedCasterShadowRefreshCount: animatedRefreshCountRef.current,
+            primaryShadowRefreshCount: refreshCountRef.current,
+            shadowMapAutoUpdate: gl.shadowMap.autoUpdate,
+            shadowMapDynamicRefreshMs: 0,
+            shadowMapInvalidationCount: invalidationCountRef.current,
+        });
+    }, [gl]);
+
+    const requestShadowRefresh = useCallback(
+        (invalidateFrame: boolean) => {
+            if (!enabled) {
+                return;
+            }
+
+            refreshCountRef.current = requestPrimaryShadowMapRefresh(
+                gl.shadowMap,
+                enabled,
+                refreshCountRef.current,
+            );
+            if (invalidateFrame) {
+                invalidate();
+            }
+            reportShadowMapState();
+        },
+        [enabled, gl, invalidate, reportShadowMapState],
+    );
+
+    const requestAnimatedCasterShadowRefresh = useCallback(
+        (now: number) => {
+            const tick = resolveAnimatedCasterShadowRefreshTick({
+                enabled,
+                nextRefreshAt: nextAnimatedRefreshAtRef.current,
+                now,
+                refreshMs: animatedCasterShadowRefreshMs,
+                settleUntil: settleUntilRef.current,
+            });
+            nextAnimatedRefreshAtRef.current = tick.nextRefreshAt;
+            if (!tick.shouldRefresh) {
+                return;
+            }
+
+            animatedRefreshCountRef.current += 1;
+            requestShadowRefresh(false);
+        },
+        [enabled, requestShadowRefresh],
+    );
+    useAnimatedCasterShadowMapRefreshSubscription(
+        requestAnimatedCasterShadowRefresh,
+    );
 
     const settleShadows = useCallback(() => {
         if (!enabled) {
             return;
         }
 
-        gl.shadowMap.enabled = true;
-        gl.shadowMap.needsUpdate = true;
+        requestShadowRefresh(true);
         settleUntilRef.current = performance.now() + shadowSettleMs;
         setShadowSettling(true);
         setShadowSettleGeneration((generation) => generation + 1);
-        invalidate();
-    }, [enabled, gl, invalidate]);
+    }, [enabled, requestShadowRefresh]);
 
     useSceneResume(settleShadows);
 
@@ -63,24 +113,24 @@ export function ShadowMapController({
 
         gl.shadowMap.enabled = enabled;
         gl.shadowMap.autoUpdate = !enabled;
-        gl.shadowMap.needsUpdate = true;
+        if (enabled) {
+            requestShadowRefresh(true);
+        } else {
+            gl.shadowMap.needsUpdate = true;
+        }
         if (!enabled) {
-            nextDynamicRefreshRef.current = 0;
+            nextAnimatedRefreshAtRef.current = 0;
             settleUntilRef.current = 0;
             setShadowSettling(false);
         }
-        invalidate();
-        updateGameProfileMetadata({
-            shadowMapAutoUpdate: gl.shadowMap.autoUpdate,
-            shadowMapInvalidationCount: invalidationCountRef.current,
-        });
+        reportShadowMapState();
 
         return () => {
             gl.shadowMap.autoUpdate = previousAutoUpdate;
             gl.shadowMap.enabled = previousEnabled;
             gl.shadowMap.needsUpdate = true;
         };
-    }, [enabled, gl, invalidate]);
+    }, [enabled, gl, reportShadowMapState, requestShadowRefresh]);
 
     useLayoutEffect(() => {
         void invalidationKey;
@@ -89,48 +139,14 @@ export function ShadowMapController({
             return;
         }
 
-        gl.shadowMap.enabled = true;
-        gl.shadowMap.needsUpdate = true;
         invalidationCountRef.current += 1;
-        invalidate();
-        updateGameProfileMetadata({
-            shadowMapAutoUpdate: gl.shadowMap.autoUpdate,
-            shadowMapInvalidationCount: invalidationCountRef.current,
-        });
-    }, [enabled, gl, invalidate, invalidationKey]);
+        requestShadowRefresh(true);
+    }, [enabled, invalidationKey, requestShadowRefresh]);
 
     useLayoutEffect(() => {
         void settleKey;
         settleShadows();
     }, [settleKey, settleShadows]);
-
-    useLayoutEffect(() => {
-        const previousDynamicRefreshMs = previousDynamicRefreshMsRef.current;
-        previousDynamicRefreshMsRef.current = normalizedDynamicRefreshMs;
-        updateGameProfileMetadata({
-            shadowMapAutoUpdate: gl.shadowMap.autoUpdate,
-            shadowMapDynamicRefreshMs: normalizedDynamicRefreshMs,
-            shadowMapInvalidationCount: invalidationCountRef.current,
-        });
-
-        if (
-            !hasShadowDynamicCadenceChanged(
-                previousDynamicRefreshMs,
-                normalizedDynamicRefreshMs,
-            )
-        ) {
-            return;
-        }
-
-        nextDynamicRefreshRef.current = 0;
-        if (!enabled) {
-            return;
-        }
-
-        gl.shadowMap.enabled = true;
-        gl.shadowMap.needsUpdate = true;
-        invalidate();
-    }, [enabled, gl, invalidate, normalizedDynamicRefreshMs]);
 
     useEffect(() => {
         void shadowSettleGeneration;
@@ -154,20 +170,11 @@ export function ShadowMapController({
             return;
         }
 
-        const now = performance.now();
-        const refreshTick = resolveShadowMapRefreshTick({
-            dynamicRefreshMs: normalizedDynamicRefreshMs,
-            nextDynamicRefreshAt: nextDynamicRefreshRef.current,
-            now,
-            settleUntil: settleUntilRef.current,
-        });
-        nextDynamicRefreshRef.current = refreshTick.nextDynamicRefreshAt;
-        if (!refreshTick.shouldRefresh) {
+        if (performance.now() > settleUntilRef.current) {
             return;
         }
 
-        gl.shadowMap.enabled = true;
-        gl.shadowMap.needsUpdate = true;
+        requestShadowRefresh(false);
     });
 
     return null;

--- a/packages/game/src/scene/cloudShadowAttenuation.ts
+++ b/packages/game/src/scene/cloudShadowAttenuation.ts
@@ -1,0 +1,503 @@
+import {
+    type IUniform,
+    type Material,
+    type Object3D,
+    type Texture,
+    Vector2,
+    Vector4,
+} from 'three';
+import type { GameQualityProfile } from './gameQuality';
+
+const CLOUD_SHADOW_SHADER_CACHE_KEY = 'gredice-cloud-shadow-attenuation-v1';
+const CLOUD_SHADOW_MAX_PROJECTION_SLOPE = 1.5;
+
+const cloudShadowVertexPars = /* glsl */ `
+varying vec3 vGrediceCloudShadowWorldPosition;
+`;
+
+const cloudShadowVertex = /* glsl */ `
+#include <worldpos_vertex>
+
+#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined( USE_SHADOWMAP ) || defined( USE_TRANSMISSION ) || NUM_SPOT_LIGHT_COORDS > 0
+    vGrediceCloudShadowWorldPosition = worldPosition.xyz;
+#else
+    vec4 grediceCloudShadowWorldPosition = vec4( transformed, 1.0 );
+
+    #ifdef USE_BATCHING
+        grediceCloudShadowWorldPosition = batchingMatrix * grediceCloudShadowWorldPosition;
+    #endif
+
+    #ifdef USE_INSTANCING
+        grediceCloudShadowWorldPosition = instanceMatrix * grediceCloudShadowWorldPosition;
+    #endif
+
+    vGrediceCloudShadowWorldPosition = ( modelMatrix * grediceCloudShadowWorldPosition ).xyz;
+#endif
+`;
+
+const cloudShadowFragmentPars = /* glsl */ `
+uniform sampler2D grediceCloudShadowMap;
+uniform vec4 grediceCloudShadowBounds;
+uniform vec2 grediceCloudShadowProjection;
+uniform float grediceCloudShadowStrength;
+uniform float grediceCloudShadowHardness;
+varying vec3 vGrediceCloudShadowWorldPosition;
+`;
+
+export const cloudShadowFragmentShaderChunk = /* glsl */ `
+#include <aomap_fragment>
+
+float grediceCloudShadowAttenuation = 1.0;
+if ( grediceCloudShadowStrength > 0.001 ) {
+    vec2 grediceCloudShadowGroundPosition =
+        vGrediceCloudShadowWorldPosition.xz -
+        grediceCloudShadowProjection * vGrediceCloudShadowWorldPosition.y;
+    vec2 grediceCloudShadowUv =
+        ( grediceCloudShadowGroundPosition - grediceCloudShadowBounds.xy ) *
+        grediceCloudShadowBounds.zw;
+    float grediceCloudShadowInBounds =
+        step( 0.0, grediceCloudShadowUv.x ) *
+        step( 0.0, grediceCloudShadowUv.y ) *
+        step( grediceCloudShadowUv.x, 1.0 ) *
+        step( grediceCloudShadowUv.y, 1.0 );
+    float grediceCloudShadowMask =
+        texture2D( grediceCloudShadowMap, grediceCloudShadowUv ).r *
+        grediceCloudShadowInBounds;
+    float grediceCloudShadowHardMask =
+        smoothstep( 0.08, 0.52, grediceCloudShadowMask );
+    grediceCloudShadowAttenuation =
+        1.0 -
+        mix(
+            grediceCloudShadowMask,
+            grediceCloudShadowHardMask,
+            grediceCloudShadowHardness
+        ) *
+        grediceCloudShadowStrength;
+}
+
+reflectedLight.directDiffuse *= grediceCloudShadowAttenuation;
+reflectedLight.directSpecular *= grediceCloudShadowAttenuation;
+`;
+
+export type CloudShadowBounds = {
+    maxX: number;
+    maxZ: number;
+    minX: number;
+    minZ: number;
+};
+
+export type CloudShadowProjection = {
+    x: number;
+    z: number;
+};
+
+export type CloudShadowSample = {
+    altitude: number;
+    height: number;
+    opacity: number;
+    rotation: number;
+    width: number;
+    x: number;
+    z: number;
+};
+
+export type CloudShadowAttenuationConfig = {
+    enabled: boolean;
+    maskResolution: number;
+    updateMs: number;
+};
+
+export type CloudShadowMaskPlacement = {
+    alpha: number;
+    height: number;
+    rotation: number;
+    width: number;
+    x: number;
+    y: number;
+};
+
+export type CloudShadowMaterialUniforms = {
+    bounds: IUniform<Vector4>;
+    hardness: IUniform<number>;
+    map: IUniform<Texture | null>;
+    projection: IUniform<Vector2>;
+    strength: IUniform<number>;
+};
+
+type CloudShadowMaterialPatchState = {
+    consumerCount: number;
+    originalCustomProgramCacheKey: Material['customProgramCacheKey'];
+    originalOnBeforeCompile: Material['onBeforeCompile'];
+    patchedCustomProgramCacheKey: Material['customProgramCacheKey'];
+    patchedOnBeforeCompile: Material['onBeforeCompile'];
+};
+
+export type CloudShadowMaterialLease = {
+    material: Material;
+    release: () => void;
+};
+
+export type CloudShadowMaterialLeaseMap = Map<string, CloudShadowMaterialLease>;
+
+const materialPatchStates = new WeakMap<
+    Material,
+    CloudShadowMaterialPatchState
+>();
+// The production garden owns one active weather scene, so one stable uniform
+// set lets shared materials keep a single compiled program across transitions.
+// Concurrent weather scenes with different masks would contend for these
+// values and would need renderer- or scene-scoped uniforms.
+const sharedCloudShadowMaterialUniforms: CloudShadowMaterialUniforms = {
+    bounds: { value: new Vector4(0, 0, 1, 1) },
+    hardness: { value: 0 },
+    map: { value: null },
+    projection: { value: new Vector2() },
+    strength: { value: 0 },
+};
+
+function clamp(value: number, min: number, max: number) {
+    return Math.min(max, Math.max(min, value));
+}
+
+function resolveBaseCloudShadowAttenuationConfig(quality: GameQualityProfile) {
+    if (quality.tier === 'auto-constrained' || quality.shadowMapSize <= 1024) {
+        return { maskResolution: 64, updateMs: 240 };
+    }
+
+    if (
+        quality.tier === 'high' ||
+        quality.cloudShadowMode === 'soft' ||
+        quality.shadowMapSize >= 4096
+    ) {
+        return { maskResolution: 192, updateMs: 96 };
+    }
+
+    return { maskResolution: 128, updateMs: 160 };
+}
+
+export function resolveCloudShadowAttenuationConfig({
+    prefersReducedMotion,
+    quality,
+}: {
+    prefersReducedMotion: boolean;
+    quality: GameQualityProfile;
+}): CloudShadowAttenuationConfig {
+    if (!quality.shadows) {
+        return {
+            enabled: false,
+            maskResolution: 0,
+            updateMs: 0,
+        };
+    }
+
+    const base = resolveBaseCloudShadowAttenuationConfig(quality);
+    return {
+        enabled: true,
+        maskResolution: prefersReducedMotion
+            ? Math.min(base.maskResolution, 128)
+            : base.maskResolution,
+        updateMs: prefersReducedMotion
+            ? Math.max(base.updateMs, 320)
+            : base.updateMs,
+    };
+}
+
+export function getCloudShadowAttenuationMaterialUniforms() {
+    return sharedCloudShadowMaterialUniforms;
+}
+
+export function resolveCloudShadowAttenuationActivation({
+    activated,
+    strength,
+}: {
+    activated: boolean;
+    strength: number;
+}) {
+    return activated || (Number.isFinite(strength) && strength > 0.001);
+}
+
+export function resolveCloudShadowAttenuationUpdateTick({
+    enabled,
+    force,
+    nextUpdateAt,
+    now,
+    updateMs,
+}: {
+    enabled: boolean;
+    force: boolean;
+    nextUpdateAt: number;
+    now: number;
+    updateMs: number;
+}) {
+    const shouldUpdate =
+        enabled &&
+        Number.isFinite(updateMs) &&
+        updateMs > 0 &&
+        (force || now >= nextUpdateAt);
+
+    return {
+        nextUpdateAt: shouldUpdate ? now + updateMs : nextUpdateAt,
+        shouldUpdate,
+    };
+}
+
+export function resolveCloudShadowProjection({
+    x,
+    y,
+    z,
+}: {
+    x: number;
+    y: number;
+    z: number;
+}): CloudShadowProjection {
+    if (!Number.isFinite(y) || y <= 0.001) {
+        return { x: 0, z: 0 };
+    }
+
+    return {
+        x: clamp(
+            x / y,
+            -CLOUD_SHADOW_MAX_PROJECTION_SLOPE,
+            CLOUD_SHADOW_MAX_PROJECTION_SLOPE,
+        ),
+        z: clamp(
+            z / y,
+            -CLOUD_SHADOW_MAX_PROJECTION_SLOPE,
+            CLOUD_SHADOW_MAX_PROJECTION_SLOPE,
+        ),
+    };
+}
+
+export function projectCloudShadowReceiverToGround(
+    position: { x: number; y: number; z: number },
+    projection: CloudShadowProjection,
+) {
+    return {
+        x: position.x - projection.x * position.y,
+        z: position.z - projection.z * position.y,
+    };
+}
+
+export function resolveCloudShadowMaskPlacement({
+    bounds,
+    projection,
+    resolution,
+    sample,
+}: {
+    bounds: CloudShadowBounds;
+    projection: CloudShadowProjection;
+    resolution: number;
+    sample: CloudShadowSample;
+}): CloudShadowMaskPlacement {
+    const spanX = Math.max(0.001, bounds.maxX - bounds.minX);
+    const spanZ = Math.max(0.001, bounds.maxZ - bounds.minZ);
+    const groundPosition = projectCloudShadowReceiverToGround(
+        {
+            x: sample.x,
+            y: sample.altitude,
+            z: sample.z,
+        },
+        projection,
+    );
+
+    return {
+        alpha: clamp(sample.opacity, 0, 1),
+        height: (sample.height / spanZ) * resolution,
+        // Canvas Y points down while world/texture Z-V points up.
+        rotation: -sample.rotation,
+        width: (sample.width / spanX) * resolution,
+        x: ((groundPosition.x - bounds.minX) / spanX) * resolution,
+        y: ((bounds.maxZ - groundPosition.z) / spanZ) * resolution,
+    };
+}
+
+function hasMaterialFlag(material: Material, flag: string) {
+    return Reflect.get(material, flag) === true;
+}
+
+export function supportsCloudShadowAttenuation(material: Material) {
+    // Built-in lit materials share the reflected-light shader contract above.
+    // ShaderMaterial receivers need an explicit output integration and are
+    // intentionally left unchanged instead of guessing at their uniforms.
+    return (
+        hasMaterialFlag(material, 'isMeshStandardMaterial') ||
+        hasMaterialFlag(material, 'isMeshPhysicalMaterial') ||
+        hasMaterialFlag(material, 'isMeshLambertMaterial') ||
+        hasMaterialFlag(material, 'isMeshPhongMaterial') ||
+        hasMaterialFlag(material, 'isMeshToonMaterial')
+    );
+}
+
+function isMaterial(value: unknown): value is Material {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        Reflect.get(value, 'isMaterial') === true
+    );
+}
+
+function getObjectMaterials(object: Object3D) {
+    const value = Reflect.get(object, 'material');
+    if (Array.isArray(value)) {
+        return value.filter(isMaterial);
+    }
+
+    return isMaterial(value) ? [value] : [];
+}
+
+function injectCloudShadowAttenuationShader(
+    shader: Parameters<Material['onBeforeCompile']>[0],
+    uniforms: CloudShadowMaterialUniforms,
+) {
+    shader.uniforms.grediceCloudShadowMap = uniforms.map;
+    shader.uniforms.grediceCloudShadowBounds = uniforms.bounds;
+    shader.uniforms.grediceCloudShadowProjection = uniforms.projection;
+    shader.uniforms.grediceCloudShadowStrength = uniforms.strength;
+    shader.uniforms.grediceCloudShadowHardness = uniforms.hardness;
+
+    shader.vertexShader = shader.vertexShader
+        .replace(
+            '#include <common>',
+            `#include <common>\n${cloudShadowVertexPars}`,
+        )
+        .replace('#include <worldpos_vertex>', cloudShadowVertex);
+    shader.fragmentShader = shader.fragmentShader
+        .replace(
+            '#include <common>',
+            `#include <common>\n${cloudShadowFragmentPars}`,
+        )
+        .replace('#include <aomap_fragment>', cloudShadowFragmentShaderChunk);
+}
+
+export function retainCloudShadowAttenuationMaterial(
+    material: Material,
+    uniforms: CloudShadowMaterialUniforms,
+): CloudShadowMaterialLease {
+    const existingState = materialPatchStates.get(material);
+    if (existingState) {
+        existingState.consumerCount += 1;
+        let released = false;
+        return {
+            material,
+            release: () => {
+                if (released) {
+                    return;
+                }
+                released = true;
+                releaseCloudShadowAttenuationMaterial(material);
+            },
+        };
+    }
+
+    const originalOnBeforeCompile = material.onBeforeCompile;
+    const originalCustomProgramCacheKey = material.customProgramCacheKey;
+    const patchedOnBeforeCompile: Material['onBeforeCompile'] = (
+        shader,
+        renderer,
+    ) => {
+        originalOnBeforeCompile.call(material, shader, renderer);
+        injectCloudShadowAttenuationShader(shader, uniforms);
+    };
+    const patchedCustomProgramCacheKey: Material['customProgramCacheKey'] =
+        () =>
+            `${originalCustomProgramCacheKey.call(material)}|${CLOUD_SHADOW_SHADER_CACHE_KEY}`;
+    const state = {
+        consumerCount: 1,
+        originalCustomProgramCacheKey,
+        originalOnBeforeCompile,
+        patchedCustomProgramCacheKey,
+        patchedOnBeforeCompile,
+    };
+    materialPatchStates.set(material, state);
+    material.onBeforeCompile = patchedOnBeforeCompile;
+    material.customProgramCacheKey = patchedCustomProgramCacheKey;
+    material.needsUpdate = true;
+
+    let released = false;
+    return {
+        material,
+        release: () => {
+            if (released) {
+                return;
+            }
+            released = true;
+            releaseCloudShadowAttenuationMaterial(material);
+        },
+    };
+}
+
+function releaseCloudShadowAttenuationMaterial(material: Material) {
+    const state = materialPatchStates.get(material);
+    if (!state) {
+        return;
+    }
+
+    state.consumerCount = Math.max(0, state.consumerCount - 1);
+    if (state.consumerCount > 0) {
+        return;
+    }
+
+    if (material.onBeforeCompile === state.patchedOnBeforeCompile) {
+        material.onBeforeCompile = state.originalOnBeforeCompile;
+    }
+    if (material.customProgramCacheKey === state.patchedCustomProgramCacheKey) {
+        material.customProgramCacheKey = state.originalCustomProgramCacheKey;
+    }
+    material.needsUpdate = true;
+    materialPatchStates.delete(material);
+}
+
+export function syncCloudShadowAttenuationMaterials({
+    enabled,
+    leases,
+    root,
+    uniforms,
+}: {
+    enabled: boolean;
+    leases: CloudShadowMaterialLeaseMap;
+    root: Object3D;
+    uniforms: CloudShadowMaterialUniforms;
+}) {
+    const activeMaterialIds = new Set<string>();
+
+    if (enabled) {
+        root.traverse((object) => {
+            for (const material of getObjectMaterials(object)) {
+                if (!supportsCloudShadowAttenuation(material)) {
+                    continue;
+                }
+
+                activeMaterialIds.add(material.uuid);
+                if (!leases.has(material.uuid)) {
+                    leases.set(
+                        material.uuid,
+                        retainCloudShadowAttenuationMaterial(
+                            material,
+                            uniforms,
+                        ),
+                    );
+                }
+            }
+        });
+    }
+
+    for (const [materialId, lease] of leases) {
+        if (activeMaterialIds.has(materialId)) {
+            continue;
+        }
+
+        lease.release();
+        leases.delete(materialId);
+    }
+
+    return leases.size;
+}
+
+export function releaseCloudShadowAttenuationMaterials(
+    leases: CloudShadowMaterialLeaseMap,
+) {
+    for (const lease of leases.values()) {
+        lease.release();
+    }
+    leases.clear();
+}

--- a/packages/game/src/scene/cloudShadowAttenuation.unit.ts
+++ b/packages/game/src/scene/cloudShadowAttenuation.unit.ts
@@ -1,0 +1,370 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    MeshBasicMaterial,
+    MeshStandardMaterial,
+    Object3D,
+    ShaderMaterial,
+    Texture,
+    Vector2,
+    Vector4,
+} from 'three';
+import CustomShaderMaterial from 'three-custom-shader-material/vanilla';
+import {
+    type CloudShadowMaterialLeaseMap,
+    cloudShadowFragmentShaderChunk,
+    projectCloudShadowReceiverToGround,
+    releaseCloudShadowAttenuationMaterials,
+    resolveCloudShadowAttenuationActivation,
+    resolveCloudShadowAttenuationConfig,
+    resolveCloudShadowAttenuationUpdateTick,
+    resolveCloudShadowMaskPlacement,
+    retainCloudShadowAttenuationMaterial,
+    supportsCloudShadowAttenuation,
+    syncCloudShadowAttenuationMaterials,
+} from './cloudShadowAttenuation';
+import { gameQualityProfiles, resolveGameQualityProfile } from './gameQuality';
+
+const uniforms = {
+    bounds: { value: new Vector4(-10, -10, 0.05, 0.05) },
+    hardness: { value: 0 },
+    map: { value: new Texture() },
+    projection: { value: new Vector2(0.5, -0.25) },
+    strength: { value: 0.8 },
+};
+
+describe('cloud shadow attenuation quality', () => {
+    it('scales mask resolution and cadence with quality', () => {
+        const constrained = resolveGameQualityProfile('auto', undefined, {
+            coarsePointer: true,
+            coreCount: 4,
+            dpr: 3,
+            memoryGb: 4,
+            narrowViewport: true,
+        });
+
+        assert.deepEqual(
+            resolveCloudShadowAttenuationConfig({
+                prefersReducedMotion: false,
+                quality: constrained,
+            }),
+            {
+                enabled: true,
+                maskResolution: 64,
+                updateMs: 240,
+            },
+        );
+        assert.deepEqual(
+            resolveCloudShadowAttenuationConfig({
+                prefersReducedMotion: false,
+                quality: gameQualityProfiles.medium,
+            }),
+            {
+                enabled: true,
+                maskResolution: 128,
+                updateMs: 160,
+            },
+        );
+        assert.deepEqual(
+            resolveCloudShadowAttenuationConfig({
+                prefersReducedMotion: false,
+                quality: gameQualityProfiles.high,
+            }),
+            {
+                enabled: true,
+                maskResolution: 192,
+                updateMs: 96,
+            },
+        );
+    });
+
+    it('slows and caps the mask for reduced motion', () => {
+        assert.deepEqual(
+            resolveCloudShadowAttenuationConfig({
+                prefersReducedMotion: true,
+                quality: gameQualityProfiles.high,
+            }),
+            {
+                enabled: true,
+                maskResolution: 128,
+                updateMs: 320,
+            },
+        );
+    });
+
+    it('disables attenuation with user shadows', () => {
+        assert.deepEqual(
+            resolveCloudShadowAttenuationConfig({
+                prefersReducedMotion: false,
+                quality: gameQualityProfiles.low,
+            }),
+            {
+                enabled: false,
+                maskResolution: 0,
+                updateMs: 0,
+            },
+        );
+    });
+});
+
+describe('cloud shadow attenuation scheduling', () => {
+    it('activates lazily and remains active after weather clears', () => {
+        assert.equal(
+            resolveCloudShadowAttenuationActivation({
+                activated: false,
+                strength: 0,
+            }),
+            false,
+        );
+        assert.equal(
+            resolveCloudShadowAttenuationActivation({
+                activated: false,
+                strength: Number.NaN,
+            }),
+            false,
+        );
+        assert.equal(
+            resolveCloudShadowAttenuationActivation({
+                activated: false,
+                strength: 0.2,
+            }),
+            true,
+        );
+        assert.equal(
+            resolveCloudShadowAttenuationActivation({
+                activated: true,
+                strength: 0,
+            }),
+            true,
+        );
+    });
+
+    it('updates only when due and schedules from now without catch-up', () => {
+        assert.deepEqual(
+            resolveCloudShadowAttenuationUpdateTick({
+                enabled: true,
+                force: false,
+                nextUpdateAt: 1_000,
+                now: 999,
+                updateMs: 160,
+            }),
+            {
+                nextUpdateAt: 1_000,
+                shouldUpdate: false,
+            },
+        );
+        assert.deepEqual(
+            resolveCloudShadowAttenuationUpdateTick({
+                enabled: true,
+                force: false,
+                nextUpdateAt: 1_000,
+                now: 1_400,
+                updateMs: 160,
+            }),
+            {
+                nextUpdateAt: 1_560,
+                shouldUpdate: true,
+            },
+        );
+    });
+
+    it('supports forced updates and remains idle while disabled', () => {
+        assert.equal(
+            resolveCloudShadowAttenuationUpdateTick({
+                enabled: true,
+                force: true,
+                nextUpdateAt: 10_000,
+                now: 500,
+                updateMs: 240,
+            }).shouldUpdate,
+            true,
+        );
+        assert.deepEqual(
+            resolveCloudShadowAttenuationUpdateTick({
+                enabled: false,
+                force: true,
+                nextUpdateAt: 10_000,
+                now: 500,
+                updateMs: 240,
+            }),
+            {
+                nextUpdateAt: 10_000,
+                shouldUpdate: false,
+            },
+        );
+    });
+});
+
+describe('cloud shadow world projection', () => {
+    it('maps raised receivers onto the same sun ray as the ground footprint', () => {
+        const projection = { x: 0.5, z: -0.25 };
+        const ground = projectCloudShadowReceiverToGround(
+            { x: 7, y: 0, z: 4.5 },
+            projection,
+        );
+        const raised = projectCloudShadowReceiverToGround(
+            { x: 8, y: 2, z: 4 },
+            projection,
+        );
+
+        assert.deepEqual(raised, ground);
+    });
+
+    it('projects cloud altitude before mapping to mask pixels', () => {
+        const placement = resolveCloudShadowMaskPlacement({
+            bounds: { maxX: 10, maxZ: 10, minX: -10, minZ: -10 },
+            projection: { x: 0.5, z: -0.25 },
+            resolution: 100,
+            sample: {
+                altitude: 10,
+                height: 4,
+                opacity: 0.75,
+                rotation: 0.2,
+                width: 8,
+                x: 12,
+                z: 2,
+            },
+        });
+
+        assert.deepEqual(
+            {
+                alpha: placement.alpha,
+                height: placement.height,
+                rotation: placement.rotation,
+                width: placement.width,
+                x: placement.x,
+            },
+            {
+                alpha: 0.75,
+                height: 20,
+                rotation: -0.2,
+                width: 40,
+                x: 85,
+            },
+        );
+        assert.ok(Math.abs(placement.y - 27.5) < Number.EPSILON * 32);
+    });
+});
+
+describe('cloud shadow material integration', () => {
+    it('skips the texture lookup when cloud strength is zero', () => {
+        assert.match(
+            cloudShadowFragmentShaderChunk,
+            /if \( grediceCloudShadowStrength > 0\.001 \)/,
+        );
+        assert.ok(
+            cloudShadowFragmentShaderChunk.indexOf(
+                'grediceCloudShadowStrength > 0.001',
+            ) <
+                cloudShadowFragmentShaderChunk.indexOf(
+                    'texture2D( grediceCloudShadowMap',
+                ),
+        );
+    });
+
+    it('composes and restores exact material shader hooks', () => {
+        const material = new MeshStandardMaterial();
+        let originalHookCallCount = 0;
+        material.onBeforeCompile = (shader) => {
+            originalHookCallCount += 1;
+            shader.fragmentShader = shader.fragmentShader.replace(
+                'void main()',
+                '// existing material hook\nvoid main()',
+            );
+        };
+        material.customProgramCacheKey = () => 'existing-cache-key';
+        const originalOnBeforeCompile = material.onBeforeCompile;
+        const originalCustomProgramCacheKey = material.customProgramCacheKey;
+        const leaseA = retainCloudShadowAttenuationMaterial(material, uniforms);
+        const patchedOnBeforeCompile = material.onBeforeCompile;
+        const patchedCustomProgramCacheKey = material.customProgramCacheKey;
+        const leaseB = retainCloudShadowAttenuationMaterial(material, uniforms);
+
+        assert.notEqual(patchedOnBeforeCompile, originalOnBeforeCompile);
+        assert.notEqual(
+            patchedCustomProgramCacheKey,
+            originalCustomProgramCacheKey,
+        );
+        assert.match(
+            material.customProgramCacheKey(),
+            /^existing-cache-key\|gredice-cloud-shadow-attenuation-v1$/,
+        );
+        const shader = {
+            fragmentShader:
+                '#include <common>\nvoid main() {\n#include <aomap_fragment>\n}',
+            uniforms: {},
+            vertexShader:
+                '#include <common>\nvoid main() {\n#include <worldpos_vertex>\n}',
+        };
+        Reflect.apply(material.onBeforeCompile, material, [shader, undefined]);
+        assert.equal(originalHookCallCount, 1);
+        assert.match(shader.fragmentShader, /existing material hook/);
+        assert.match(shader.fragmentShader, /grediceCloudShadowAttenuation/);
+
+        leaseA.release();
+        assert.equal(material.onBeforeCompile, patchedOnBeforeCompile);
+        leaseB.release();
+        assert.equal(material.onBeforeCompile, originalOnBeforeCompile);
+        assert.equal(
+            material.customProgramCacheKey,
+            originalCustomProgramCacheKey,
+        );
+    });
+
+    it('patches lit materials and excludes unlit materials', () => {
+        const generatedPlantMaterial = new CustomShaderMaterial({
+            baseMaterial: MeshStandardMaterial,
+        });
+
+        assert.equal(
+            supportsCloudShadowAttenuation(new MeshStandardMaterial()),
+            true,
+        );
+        assert.equal(
+            supportsCloudShadowAttenuation(generatedPlantMaterial),
+            true,
+        );
+        assert.equal(
+            supportsCloudShadowAttenuation(new MeshBasicMaterial()),
+            false,
+        );
+        assert.equal(
+            supportsCloudShadowAttenuation(new ShaderMaterial()),
+            false,
+        );
+        generatedPlantMaterial.dispose();
+    });
+
+    it('releases scene material hooks when attenuation is disabled', () => {
+        const root = new Object3D();
+        const material = new MeshStandardMaterial();
+        const object = new Object3D();
+        Reflect.set(object, 'material', material);
+        root.add(object);
+        const leases: CloudShadowMaterialLeaseMap = new Map();
+        const originalOnBeforeCompile = material.onBeforeCompile;
+
+        assert.equal(
+            syncCloudShadowAttenuationMaterials({
+                enabled: true,
+                leases,
+                root,
+                uniforms,
+            }),
+            1,
+        );
+        assert.notEqual(material.onBeforeCompile, originalOnBeforeCompile);
+        assert.equal(
+            syncCloudShadowAttenuationMaterials({
+                enabled: false,
+                leases,
+                root,
+                uniforms,
+            }),
+            0,
+        );
+        assert.equal(material.onBeforeCompile, originalOnBeforeCompile);
+
+        releaseCloudShadowAttenuationMaterials(leases);
+    });
+});

--- a/packages/game/src/scene/gameProfileMetadata.ts
+++ b/packages/game/src/scene/gameProfileMetadata.ts
@@ -168,6 +168,11 @@ export type GeneratedPlantProfileSnapshot = {
 };
 
 export type GameProfileMetadata = {
+    animatedCasterShadowRefreshCount?: number;
+    cloudAttenuationMaskResolution?: number;
+    cloudAttenuationMaterialCount?: number;
+    cloudAttenuationUpdateCount?: number;
+    cloudAttenuationUpdateMs?: number;
     cloudProjectedShadowCount?: number;
     cloudRealShadowCasterCount?: number;
     cloudVisualCount?: number;
@@ -195,6 +200,7 @@ export type GameProfileMetadata = {
     rainWetOverlayDistinctUniformCount?: number;
     rainWetOverlayMaterialConsumerCount?: number;
     raisedBedMulchOverlayCount?: number;
+    primaryShadowRefreshCount?: number;
     rendererGeometries?: number;
     rendererLines?: number;
     rendererMatrices?: number;

--- a/packages/game/src/scene/shadowMapScheduling.ts
+++ b/packages/game/src/scene/shadowMapScheduling.ts
@@ -4,10 +4,52 @@ type ShadowLightPosition = {
     z: number;
 };
 
-export const cloudShadowRefreshMsByMode = {
-    hard: 160,
-    soft: 96,
-} as const;
+type ShadowMapRefreshTarget = {
+    enabled: boolean;
+    needsUpdate: boolean;
+};
+
+export const animatedCasterShadowRefreshMs = 160;
+
+export function requestPrimaryShadowMapRefresh(
+    shadowMap: ShadowMapRefreshTarget,
+    enabled: boolean,
+    refreshCount: number,
+) {
+    if (!enabled) {
+        return refreshCount;
+    }
+
+    shadowMap.enabled = true;
+    shadowMap.needsUpdate = true;
+    return refreshCount + 1;
+}
+
+export function resolveAnimatedCasterShadowRefreshTick({
+    enabled,
+    nextRefreshAt,
+    now,
+    refreshMs,
+    settleUntil,
+}: {
+    enabled: boolean;
+    nextRefreshAt: number;
+    now: number;
+    refreshMs: number;
+    settleUntil: number;
+}) {
+    const shouldRefresh =
+        enabled &&
+        Number.isFinite(refreshMs) &&
+        refreshMs > 0 &&
+        now > settleUntil &&
+        now >= nextRefreshAt;
+
+    return {
+        nextRefreshAt: shouldRefresh ? now + refreshMs : nextRefreshAt,
+        shouldRefresh,
+    };
+}
 
 function formatShadowSignatureValue(value: number) {
     return Number.isFinite(value) ? value.toFixed(4) : '0';
@@ -32,42 +74,4 @@ export function buildDirectionalShadowDepthSignature({
         formatShadowSignatureValue(lightPosition.y),
         formatShadowSignatureValue(lightPosition.z),
     ].join('|');
-}
-
-export function hasShadowDynamicCadenceChanged(
-    previousRefreshMs: number | undefined,
-    refreshMs: number | undefined,
-) {
-    return previousRefreshMs !== refreshMs;
-}
-
-export function resolveShadowMapRefreshTick({
-    dynamicRefreshMs,
-    nextDynamicRefreshAt,
-    now,
-    settleUntil,
-}: {
-    dynamicRefreshMs: number | undefined;
-    nextDynamicRefreshAt: number;
-    now: number;
-    settleUntil: number;
-}) {
-    const hasDynamicRefresh =
-        typeof dynamicRefreshMs === 'number' &&
-        Number.isFinite(dynamicRefreshMs) &&
-        dynamicRefreshMs > 0;
-    const shouldRefreshDynamic =
-        hasDynamicRefresh && now >= nextDynamicRefreshAt;
-    const shouldRefreshSettling = now <= settleUntil;
-
-    return {
-        nextDynamicRefreshAt: shouldRefreshDynamic
-            ? now + dynamicRefreshMs
-            : hasDynamicRefresh
-              ? nextDynamicRefreshAt
-              : 0,
-        shouldRefresh: shouldRefreshSettling || shouldRefreshDynamic,
-        shouldRefreshDynamic,
-        shouldRefreshSettling,
-    };
 }

--- a/packages/game/src/scene/shadowMapScheduling.unit.ts
+++ b/packages/game/src/scene/shadowMapScheduling.unit.ts
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+    animatedCasterShadowRefreshMs,
     buildDirectionalShadowDepthSignature,
-    cloudShadowRefreshMsByMode,
-    hasShadowDynamicCadenceChanged,
-    resolveShadowMapRefreshTick,
+    requestPrimaryShadowMapRefresh,
+    resolveAnimatedCasterShadowRefreshTick,
 } from './shadowMapScheduling';
 
 const baseShadowDepth = {
@@ -60,79 +60,95 @@ describe('buildDirectionalShadowDepthSignature', () => {
     });
 });
 
-describe('shadow map scheduling', () => {
-    it('uses reduced hard and soft cloud-shadow refresh rates', () => {
-        assert.deepEqual(cloudShadowRefreshMsByMode, {
-            hard: 160,
-            soft: 96,
+describe('primary shadow refresh accounting', () => {
+    it('marks and counts an enabled primary shadow refresh', () => {
+        const shadowMap = { enabled: false, needsUpdate: false };
+
+        assert.equal(requestPrimaryShadowMapRefresh(shadowMap, true, 4), 5);
+        assert.deepEqual(shadowMap, {
+            enabled: true,
+            needsUpdate: true,
         });
     });
 
-    it('detects dynamic cadence start, change, and removal', () => {
-        assert.equal(hasShadowDynamicCadenceChanged(undefined, 96), true);
-        assert.equal(hasShadowDynamicCadenceChanged(96, 96), false);
-        assert.equal(hasShadowDynamicCadenceChanged(96, 64), true);
-        assert.equal(hasShadowDynamicCadenceChanged(64, undefined), true);
-    });
+    it('does not touch or count the primary map while shadows are disabled', () => {
+        const shadowMap = { enabled: false, needsUpdate: false };
 
-    it('refreshes throughout settlement and stops after its deadline', () => {
+        assert.equal(requestPrimaryShadowMapRefresh(shadowMap, false, 4), 4);
+        assert.deepEqual(shadowMap, {
+            enabled: false,
+            needsUpdate: false,
+        });
+    });
+});
+
+describe('animated caster shadow refresh scheduling', () => {
+    it('waits for settlement and refreshes animated casters at a bounded cadence', () => {
+        const settling = resolveAnimatedCasterShadowRefreshTick({
+            enabled: true,
+            nextRefreshAt: 0,
+            now: 900,
+            refreshMs: animatedCasterShadowRefreshMs,
+            settleUntil: 900,
+        });
+        assert.deepEqual(settling, {
+            nextRefreshAt: 0,
+            shouldRefresh: false,
+        });
+
+        const due = resolveAnimatedCasterShadowRefreshTick({
+            enabled: true,
+            nextRefreshAt: settling.nextRefreshAt,
+            now: 901,
+            refreshMs: animatedCasterShadowRefreshMs,
+            settleUntil: 900,
+        });
+        assert.deepEqual(due, {
+            nextRefreshAt: 1_061,
+            shouldRefresh: true,
+        });
+
         assert.deepEqual(
-            resolveShadowMapRefreshTick({
-                dynamicRefreshMs: undefined,
-                nextDynamicRefreshAt: 0,
-                now: 800,
+            resolveAnimatedCasterShadowRefreshTick({
+                enabled: true,
+                nextRefreshAt: due.nextRefreshAt,
+                now: 1_000,
+                refreshMs: animatedCasterShadowRefreshMs,
                 settleUntil: 900,
             }),
             {
-                nextDynamicRefreshAt: 0,
-                shouldRefresh: true,
-                shouldRefreshDynamic: false,
-                shouldRefreshSettling: true,
+                nextRefreshAt: 1_061,
+                shouldRefresh: false,
             },
         );
-        assert.equal(
-            resolveShadowMapRefreshTick({
-                dynamicRefreshMs: undefined,
-                nextDynamicRefreshAt: 0,
-                now: 901,
-                settleUntil: 900,
-            }).shouldRefresh,
-            false,
+    });
+
+    it('does not catch up after stalls or refresh while shadows are disabled', () => {
+        assert.deepEqual(
+            resolveAnimatedCasterShadowRefreshTick({
+                enabled: true,
+                nextRefreshAt: 1_000,
+                now: 2_000,
+                refreshMs: animatedCasterShadowRefreshMs,
+                settleUntil: 0,
+            }),
+            {
+                nextRefreshAt: 2_160,
+                shouldRefresh: true,
+            },
         );
-    });
-
-    it('refreshes dynamic shadows only when due without catch-up bursts', () => {
-        const earlyTick = resolveShadowMapRefreshTick({
-            dynamicRefreshMs: 96,
-            nextDynamicRefreshAt: 1_000,
-            now: 999,
-            settleUntil: 0,
-        });
-        assert.equal(earlyTick.shouldRefresh, false);
-        assert.equal(earlyTick.nextDynamicRefreshAt, 1_000);
-
-        const dueTick = resolveShadowMapRefreshTick({
-            dynamicRefreshMs: 96,
-            nextDynamicRefreshAt: 1_000,
-            now: 1_400,
-            settleUntil: 0,
-        });
-        assert.equal(dueTick.shouldRefresh, true);
-        assert.equal(dueTick.shouldRefreshDynamic, true);
-        assert.equal(dueTick.nextDynamicRefreshAt, 1_496);
-    });
-
-    it('requests one update when dynamic and settlement refresh overlap', () => {
-        const tick = resolveShadowMapRefreshTick({
-            dynamicRefreshMs: 64,
-            nextDynamicRefreshAt: 500,
-            now: 500,
-            settleUntil: 900,
-        });
-
-        assert.equal(tick.shouldRefresh, true);
-        assert.equal(tick.shouldRefreshDynamic, true);
-        assert.equal(tick.shouldRefreshSettling, true);
-        assert.equal(tick.nextDynamicRefreshAt, 564);
+        assert.deepEqual(
+            resolveAnimatedCasterShadowRefreshTick({
+                enabled: false,
+                nextRefreshAt: 1_000,
+                now: 2_000,
+                refreshMs: animatedCasterShadowRefreshMs,
+                settleUntil: 0,
+            }),
+            {
+                nextRefreshAt: 1_000,
+                shouldRefresh: false,
+            },
+        );
     });
 });


### PR DESCRIPTION
## What

- replace moving cloud shadow-caster meshes with one bounded, low-resolution world-space attenuation mask
- stop cloud motion from refreshing the primary 2K/4K directional shadow map
- patch supported lit materials once, preserve existing shader hooks/cache keys, and restore them on release
- scale mask resolution/cadence by quality and reduced-motion settings
- lazily initialize the mask/material integration so fresh clear-weather sessions pay no cloud-shadow setup cost
- preserve moving bird/dog shadows through an explicit scene-scoped animated-caster refresh contract, globally capped at 160ms and inactive when no habitats exist
- add shader/projection/lifecycle/scheduling tests and profile metadata

## Why

Moving clouds previously forced the full primary shadow map to rerender at the cloud cadence. The dense cloudy diagnostic now uses a 128px mask at 160ms, reports 8 projected / 0 real cloud casters, and reduced the earlier cloudy submission spike from roughly 320 to about 99 draw calls per rendered frame in the same profiling surface. Fresh clear weather reports 0px / 0ms / 0 updates / 0 patched materials.

Animated bird and dog habitats now request bounded primary-shadow refreshes directly. Profiling confirms those refreshes continue after the 900ms settlement window while cloud motion remains unable to trigger them.

## Validation

- `pnpm --filter @gredice/game test` — 587/587 pass
- `pnpm lint --filter @gredice/game`
- `pnpm --filter @gredice/game typecheck`
- `pnpm typecheck --filter garden --filter www` — 6/6 tasks
- `pnpm --filter garden test:profile` — 6/6 pass
- production Garden build plus clear/cloudy runtime profile — no shader/WebGLProgram errors; clear animal scene recorded post-settlement animated refreshes with cloud setup still lazy
- `git diff --check`

Short software/headless frame budgets remain noisy/red, so those runs are shader/submission evidence rather than a device thermal acceptance claim. Generic `ShaderMaterial`/`RawShaderMaterial` receivers such as bespoke water/effects remain intentionally unpatched; standard lit materials and generated-plant Standard-based materials are covered.

Closes #4291