### PR TITLE
perf(game): localize placement animation chunk updates

### DIFF
--- a/apps/garden/app/debug/profile/game/page.tsx
+++ b/apps/garden/app/debug/profile/game/page.tsx
@@ -259,6 +259,7 @@ export default async function GameProfilePage({
     const closeupRaisedBedId = resolvePositiveInteger(
         firstValue(params.closeupRaisedBedId),
     );
+    const placementProfile = firstValue(params.placement) === '1';
     const isOperationRewardDebug =
         isOperationVisualRewardDebugProfile(mockGardenProfile);
     const quality = resolveQuality(firstValue(params.quality));
@@ -278,6 +279,7 @@ export default async function GameProfilePage({
             data-game-profile-closeup-raised-bed-id={
                 closeupRaisedBedId ?? undefined
             }
+            data-game-profile-placement={placementProfile ? '1' : '0'}
         >
             <ProfileGameScene
                 key={mode}
@@ -288,7 +290,9 @@ export default async function GameProfilePage({
                 debugHud={showDebugHud}
                 hideHud={!showHud}
                 initialQualitySetting={quality}
-                enableGameProfileController={closeupRaisedBedId !== null}
+                enableGameProfileController={
+                    closeupRaisedBedId !== null || placementProfile
+                }
                 mockGarden
                 mockGardenProfile={mockGardenProfile}
                 noControls={!enableControls}

--- a/apps/garden/scripts/profile-game-scene.mjs
+++ b/apps/garden/scripts/profile-game-scene.mjs
@@ -12,6 +12,8 @@ const gameProfileWeatherTransitionEventName =
     'gredice:game-profile-weather-transition';
 const gameProfileCloseupCommandEventName =
     'gredice:game-profile-closeup-command';
+const gameProfilePlacementCommandEventName =
+    'gredice:game-profile-placement-command';
 
 const coreScenarios = [
     {
@@ -208,6 +210,21 @@ const denseMobileScenarios = [
     },
 ];
 
+const placementScenarios = [
+    {
+        name: 'game-dense-25x25-placement-desktop',
+        path: '/debug/profile/game?mode=details&profile=dense&quality=medium&placement=1',
+        viewport: { width: 1280, height: 720 },
+        dpr: 1,
+        isMobile: false,
+        budget: 'gameDenseMotion',
+        placementProfile: {
+            action: 'run',
+            staggerMs: 120,
+        },
+    },
+];
+
 const constrainedAutoQualityDevice = {
     autoQualityDeviceClass: 'constrained',
     navigatorMetrics: {
@@ -382,6 +399,7 @@ const scenarioSets = {
     core: coreScenarios,
     dense: denseScenarios,
     'dense-mobile': denseMobileScenarios,
+    placement: placementScenarios,
     'plant-closeup': plantCloseupScenarios,
     rewards: rewardScenarios,
     'weather-transitions': weatherTransitionScenarios,
@@ -648,7 +666,7 @@ function printHelp(options) {
             '  --warmup-ms <ms>       Warmup wait after canvas appears. Default: 5000',
             '  --soak-ms <ms>         Run the scene before sampling. Default: 0',
             '  --sample-ms <ms>       requestAnimationFrame sample window. Default: 5000',
-            `  --scenario-set <set>    core, dense, dense-mobile, plant-closeup, auto-quality, rewards, weather-transitions, all, or comma-separated names. Current: ${options.scenarioSet}`,
+            `  --scenario-set <set>    core, dense, dense-mobile, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or comma-separated names. Current: ${options.scenarioSet}`,
             '  --scenario <name>       Profile exact scenario name(s). Repeat or use commas.',
             '  --screenshots           Save a PNG screenshot for each scenario.',
             '  --fail-on-budget       Exit non-zero when a budget check fails.',
@@ -673,6 +691,7 @@ function allScenarios() {
         ...coreScenarios,
         ...denseScenarios,
         ...denseMobileScenarios,
+        ...placementScenarios,
         ...plantCloseupScenarios,
         ...autoQualityScenarios,
         ...rewardScenarios,
@@ -704,7 +723,7 @@ function resolveScenarios(scenarioSet, scenarioNames = []) {
 
         if (!candidates.length) {
             throw new Error(
-                `Unknown scenario set or scenario: ${token}. Use core, dense, dense-mobile, plant-closeup, auto-quality, rewards, weather-transitions, all, or one of: ${knownScenarios.map((scenario) => scenario.name).join(', ')}.`,
+                `Unknown scenario set or scenario: ${token}. Use core, dense, dense-mobile, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or one of: ${knownScenarios.map((scenario) => scenario.name).join(', ')}.`,
             );
         }
 
@@ -733,6 +752,7 @@ function getScenarioRequest(path) {
         gardenProfile: url.searchParams.get('profile') ?? 'default',
         hud: url.searchParams.get('hud') ?? '0',
         mode: url.searchParams.get('mode') ?? 'baseline',
+        placement: url.searchParams.get('placement') ?? '0',
         quality: url.searchParams.get('quality') ?? 'auto',
     };
 }
@@ -1671,9 +1691,12 @@ async function measureScenario(browser, baseUrl, scenario, options) {
     );
 
     const weatherTransitionRequest = scenario.weatherTransition ?? null;
+    const placementProfileRequest = scenario.placementProfile ?? null;
     const samplePromise = page.evaluate(
         async (sampleOptions) => {
             const {
+                placementProfileEventName,
+                placementProfileRequest,
                 sampleMs,
                 weatherTransitionEventName,
                 weatherTransitionRequest,
@@ -1703,6 +1726,13 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 ? globalThis.dispatchEvent(
                       new CustomEvent(weatherTransitionEventName, {
                           detail: { request: weatherTransitionRequest },
+                      }),
+                  )
+                : false;
+            const placementProfileDispatched = placementProfileRequest
+                ? globalThis.dispatchEvent(
+                      new CustomEvent(placementProfileEventName, {
+                          detail: placementProfileRequest,
                       }),
                   )
                 : false;
@@ -1782,6 +1812,7 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 p50FrameMs: percentile(0.5),
                 p95FrameMs: percentile(0.95),
                 p99FrameMs: percentile(0.99),
+                placementProfileDispatched,
                 rainMountedAtStart,
                 rainParticleCountAtEnd:
                     typeof globalThis.__grediceGameProfile
@@ -1805,6 +1836,8 @@ async function measureScenario(browser, baseUrl, scenario, options) {
             };
         },
         {
+            placementProfileEventName: gameProfilePlacementCommandEventName,
+            placementProfileRequest,
             sampleMs: options.sampleMs,
             weatherTransitionEventName: gameProfileWeatherTransitionEventName,
             weatherTransitionRequest,
@@ -1927,6 +1960,33 @@ async function measureScenario(browser, baseUrl, scenario, options) {
             instancedSnowOverlayCount:
                 typeof metadata.instancedSnowOverlayCount === 'number'
                     ? metadata.instancedSnowOverlayCount
+                    : null,
+            placementChunkLogicalTouchedCount:
+                typeof metadata.placementChunkLogicalTouchedCount === 'number'
+                    ? metadata.placementChunkLogicalTouchedCount
+                    : null,
+            placementChunkLogicalUpdateCount:
+                typeof metadata.placementChunkLogicalUpdateCount === 'number'
+                    ? metadata.placementChunkLogicalUpdateCount
+                    : null,
+            placementChunkPhysicalRebuildCount:
+                typeof metadata.placementChunkPhysicalRebuildCount === 'number'
+                    ? metadata.placementChunkPhysicalRebuildCount
+                    : null,
+            placementChunkPhysicalRebuildDurationMaxMs:
+                typeof metadata.placementChunkPhysicalRebuildDurationMaxMs ===
+                'number'
+                    ? metadata.placementChunkPhysicalRebuildDurationMaxMs
+                    : null,
+            placementChunkPhysicalRebuildDurationP95Ms:
+                typeof metadata.placementChunkPhysicalRebuildDurationP95Ms ===
+                'number'
+                    ? metadata.placementChunkPhysicalRebuildDurationP95Ms
+                    : null,
+            placementChunkPhysicalTransformedInstanceCount:
+                typeof metadata.placementChunkPhysicalTransformedInstanceCount ===
+                'number'
+                    ? metadata.placementChunkPhysicalTransformedInstanceCount
                     : null,
             qualityTier:
                 typeof metadata.qualityTier === 'string'
@@ -2054,6 +2114,8 @@ async function measureScenario(browser, baseUrl, scenario, options) {
             isMobile: scenario.isMobile,
             mode: profileMetadata?.mode ?? request.mode,
             motion: scenario.motion ?? 'none',
+            placementProfile:
+                placementProfileRequest === null ? 'none' : 'placement-drop',
             quality: profileMetadata?.quality ?? request.quality,
             viewport: scenario.viewport,
             weatherTransition: weatherTransitionRequest ?? 'none',
@@ -2867,6 +2929,39 @@ function buildMarkdown(report) {
             ),
     );
     lines.push(...(failures.length ? failures : ['- None']));
+
+    const placementProfiles = report.scenarios.filter(
+        (scenario) => scenario.requested.placementProfile === 'placement-drop',
+    );
+    if (placementProfiles.length > 0) {
+        lines.push('', '## Placement Animation Evidence', '');
+        lines.push(
+            '| Scenario | Command | Logical updates/touched | Physical rebuilds/transformed | Rebuild p95/max | Frame p95/max | Draw/render | Triangles/render | Evidence |',
+            '| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
+        );
+        for (const scenario of placementProfiles) {
+            const dispatched =
+                scenario.sample.placementProfileDispatched === true;
+            const logicalUpdateCount =
+                scenario.runtime?.placementChunkLogicalUpdateCount;
+            const logicalTouchedCount =
+                scenario.runtime?.placementChunkLogicalTouchedCount;
+            const physicalRebuildCount =
+                scenario.runtime?.placementChunkPhysicalRebuildCount;
+            const transformedInstanceCount =
+                scenario.runtime
+                    ?.placementChunkPhysicalTransformedInstanceCount;
+            const evidenceCaptured =
+                dispatched &&
+                typeof logicalUpdateCount === 'number' &&
+                logicalUpdateCount > 0 &&
+                typeof physicalRebuildCount === 'number' &&
+                physicalRebuildCount > 0;
+            lines.push(
+                `| ${scenario.name} | ${dispatched ? 'dispatched' : 'missing'} | ${logicalUpdateCount ?? 'n/a'}/${logicalTouchedCount ?? 'n/a'} | ${physicalRebuildCount ?? 'n/a'}/${transformedInstanceCount ?? 'n/a'} | ${round(scenario.runtime?.placementChunkPhysicalRebuildDurationP95Ms) ?? 'n/a'}/${round(scenario.runtime?.placementChunkPhysicalRebuildDurationMaxMs) ?? 'n/a'} ms | ${scenario.sample.p95FrameMs}/${scenario.sample.maxFrameMs} ms | ${scenario.sample.drawCallsPerRenderedFrame} | ${scenario.sample.trianglesPerRenderedFrame} | ${evidenceCaptured ? 'captured' : 'missing'} |`,
+            );
+        }
+    }
 
     if (Object.keys(report.plantCloseupMedians).length > 0) {
         lines.push('', '## Raised-bed Close-up Medians', '');

--- a/apps/garden/scripts/profile-game-scene.unit.mjs
+++ b/apps/garden/scripts/profile-game-scene.unit.mjs
@@ -115,6 +115,29 @@ test('profile request reads the deterministic closeup target', () => {
     assert.equal(request.quality, 'medium');
 });
 
+test('placement scenario resolves a deterministic staggered two-chunk run', () => {
+    const scenarios = resolveScenarios('placement');
+
+    assert.equal(scenarios.length, 1);
+    assert.equal(scenarios[0].name, 'game-dense-25x25-placement-desktop');
+    assert.deepEqual(scenarios[0].placementProfile, {
+        action: 'run',
+        staggerMs: 120,
+    });
+    assert.match(scenarios[0].path, /placement=1/);
+    assert.match(scenarios[0].path, /profile=dense/);
+});
+
+test('profile request exposes placement profiling mode', () => {
+    const request = getScenarioRequest(
+        '/debug/profile/game?profile=dense&quality=medium&placement=1',
+    );
+
+    assert.equal(request.gardenProfile, 'dense');
+    assert.equal(request.placement, '1');
+    assert.equal(request.quality, 'medium');
+});
+
 function closeupPhase(value) {
     const sample = {
         drawCallsPerRenderedFrame: value * 10,

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -61,9 +61,12 @@ import {
     resolveGameQualityProfile,
 } from './scene/gameQuality';
 import { Scene } from './scene/Scene';
+import type { Block } from './types/Block';
 import type { Stack } from './types/Stack';
 import {
+    formatBlockPlacementDropAnimationRenderIdentity,
     type GameState,
+    getBlockPlacementDropAnimationRenderIdForBlockId,
     type MockGardenProfile,
     useGameState,
     type WinterMode,
@@ -174,6 +177,47 @@ function shouldRenderEntityFactoryForBlock({
     }
 
     return blockIndex >= 0 && blockIndex < stackLength;
+}
+
+function GameSceneEntitySlot({
+    block,
+    noControls,
+    stack,
+    stacks,
+}: {
+    block: Block;
+    noControls: boolean | undefined;
+    stack: Stack;
+    stacks: Stack[];
+}) {
+    const placementDropAnimationRenderId = useGameState((state) =>
+        getBlockPlacementDropAnimationRenderIdForBlockId(
+            state.blockPlacementDropAnimations,
+            block.id,
+        ),
+    );
+    const renderIdentity = formatBlockPlacementDropAnimationRenderIdentity(
+        block.id,
+        placementDropAnimationRenderId,
+    );
+    const entityFactory = (
+        <EntityFactory
+            name={block.name}
+            stack={stack}
+            block={block}
+            stacks={stacks}
+            rotation={block.rotation}
+            variant={block.variant}
+            noRenderInView={instancedBlockNames}
+            noControl={noControls}
+        />
+    );
+
+    return (
+        <Suspense key={renderIdentity} fallback={null}>
+            {entityFactory}
+        </Suspense>
+    );
 }
 
 export function GameScene({
@@ -345,38 +389,41 @@ export function GameScene({
                                             return null;
                                         }
 
-                                        const entityFactory = (
-                                            <EntityFactory
-                                                name={block.name}
-                                                stack={stack}
-                                                block={block}
-                                                stacks={garden.stacks}
-                                                rotation={block.rotation}
-                                                variant={block.variant}
-                                                noRenderInView={
-                                                    instancedBlockNames
-                                                }
-                                                noControl={noControls}
-                                            />
-                                        );
-                                        const key = `${stack.position.x}|${stack.position.y}|${stack.position.z}|${block.id}-${block.name}-${i}`;
-
                                         if (
                                             instancedBlockNames.includes(
                                                 block.name,
                                             )
                                         ) {
+                                            const key = `${stack.position.x}|${stack.position.y}|${stack.position.z}|${block.id}-${block.name}-${i}`;
                                             return (
                                                 <Fragment key={key}>
-                                                    {entityFactory}
+                                                    <EntityFactory
+                                                        name={block.name}
+                                                        stack={stack}
+                                                        block={block}
+                                                        stacks={garden.stacks}
+                                                        rotation={
+                                                            block.rotation
+                                                        }
+                                                        variant={block.variant}
+                                                        noRenderInView={
+                                                            instancedBlockNames
+                                                        }
+                                                        noControl={noControls}
+                                                    />
                                                 </Fragment>
                                             );
                                         }
 
+                                        const slotKey = `${stack.position.x}|${stack.position.y}|${stack.position.z}|${block.name}-${i}`;
                                         return (
-                                            <Suspense key={key} fallback={null}>
-                                                {entityFactory}
-                                            </Suspense>
+                                            <GameSceneEntitySlot
+                                                key={slotKey}
+                                                block={block}
+                                                noControls={noControls}
+                                                stack={stack}
+                                                stacks={garden.stacks}
+                                            />
                                         );
                                     }),
                                 )}

--- a/packages/game/src/GameSceneWrapper.tsx
+++ b/packages/game/src/GameSceneWrapper.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { groundGameAssetNames, primaryGameAssetNames } from './data/models';
+import { resetPlacementAnimationProfileMetrics } from './entities/placementAnimationProfileMetrics';
 import { GameFlagsContext } from './GameFlagsContext';
 import { GameScene, type GameSceneProps } from './GameScene';
 import { GameProfileController } from './scene/GameProfileController';
@@ -44,6 +45,10 @@ export function GameSceneWrapper({
         });
     }
     useDisposeGameStateStore(storeRef.current);
+
+    useEffect(() => {
+        resetPlacementAnimationProfileMetrics();
+    }, []);
 
     // Sync winterMode prop changes to the store
     useEffect(() => {

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -1,6 +1,7 @@
 import {
     cloneElement,
     isValidElement,
+    memo,
     type ReactNode,
     useEffect,
     useLayoutEffect,
@@ -33,7 +34,6 @@ import type { Stack } from '../types/Stack';
 import { type ActiveDragPreview, useGameState } from '../useGameState';
 import { getStackHeight } from '../utils/getStackHeight';
 import {
-    chunkMeshInstances,
     createMergedChunkGeometry,
     createMeshInstanceMatrix,
     type MeshInstanceChunk,
@@ -45,7 +45,19 @@ import {
 } from './entityBlockInstanceIndex';
 import { blockPickupOutlineStyle } from './helpers/blockPickupOutlineStyle';
 import { HoverOutline } from './helpers/HoverOutline';
-import { PlacementDropAnimation } from './helpers/PlacementDropAnimation';
+import { QueuedPlacementDropAnimation } from './helpers/PlacementDropAnimation';
+import {
+    addressPlacementAnimationChunks,
+    createPlacementAnimationChunkCache,
+    createPlacementDropAnimationRenderIdsSelector,
+    localizePlacementDropAnimationChunks,
+} from './placementAnimationChunks';
+import {
+    placementAnimationProfileNow,
+    recordPlacementAnimationChunkRebuild,
+    recordPlacementAnimationChunkUpdate,
+    shouldRecordPlacementAnimationChunkRebuild,
+} from './placementAnimationProfileMetrics';
 
 const defaultLocalPosition: [number, number, number] = [0, 0, 0];
 const defaultLocalRotation: [number, number, number] = [0, 0, 0];
@@ -397,7 +409,7 @@ export function EntityInstancesGeometry(
 ) {
     const {
         instanceKey,
-        instances,
+        instances: incomingInstances,
         renderSnow = true,
         localPosition,
         localRotation,
@@ -412,10 +424,7 @@ export function EntityInstancesGeometry(
         receiveShadow = true,
         renderOrder,
     } = props;
-    const placementDropAnimations = useGameState(
-        (state) => state.blockPlacementDropAnimations,
-    );
-
+    const instances = useStableEntityBlockInstances(incomingInstances);
     const stableLocalPosition = useStableTuple(
         localPosition ?? defaultLocalPosition,
     );
@@ -430,28 +439,75 @@ export function EntityInstancesGeometry(
         }),
         [stableLocalPosition, stableLocalRotation],
     );
-    const animatedBlockIds = useMemo(
-        () => new Set(Object.keys(placementDropAnimations)),
-        [placementDropAnimations],
+    const addressedChunks = useMemo(
+        () => addressPlacementAnimationChunks(instances ?? []),
+        [instances],
     );
-    const stableInstances = useMemo(
+    const selectAnimatedRenderIds = useMemo(
         () =>
-            (instances ?? []).filter(
-                (data) => !animatedBlockIds.has(data.block.id),
-            ),
-        [animatedBlockIds, instances],
+            createPlacementDropAnimationRenderIdsSelector([
+                ...addressedChunks.addressByBlockId.keys(),
+            ]),
+        [addressedChunks.addressByBlockId],
     );
-    const animatedInstances = useMemo(
+    const animatedRenderIds = useGameState(selectAnimatedRenderIds);
+    const placementAnimationChunkCache = useMemo(
+        () => createPlacementAnimationChunkCache<EntityBlockInstance>(),
+        [],
+    );
+    const localizedChunks = useMemo(
         () =>
-            (instances ?? []).filter((data) =>
-                animatedBlockIds.has(data.block.id),
+            localizePlacementDropAnimationChunks(
+                addressedChunks,
+                animatedRenderIds,
+                placementAnimationChunkCache,
             ),
-        [animatedBlockIds, instances],
+        [addressedChunks, animatedRenderIds, placementAnimationChunkCache],
     );
-    const stableChunks = useMemo(
-        () => chunkMeshInstances(stableInstances),
-        [stableInstances],
-    );
+    const {
+        animatedInstances,
+        chunks: stableChunks,
+        placementSignatureByChunkKey,
+    } = localizedChunks;
+    const previousPlacementProjection = useRef<
+        | {
+              addressedChunks: typeof addressedChunks;
+              placementSignatureByChunkKey: ReadonlyMap<string, string>;
+          }
+        | undefined
+    >(undefined);
+
+    useEffect(() => {
+        const previousProjection = previousPlacementProjection.current;
+        previousPlacementProjection.current = {
+            addressedChunks,
+            placementSignatureByChunkKey,
+        };
+        if (
+            !previousProjection ||
+            previousProjection.addressedChunks !== addressedChunks
+        ) {
+            return;
+        }
+
+        const candidateChunkKeys = new Set([
+            ...previousProjection.placementSignatureByChunkKey.keys(),
+            ...placementSignatureByChunkKey.keys(),
+        ]);
+        let touchedChunkCount = 0;
+        for (const chunkKey of candidateChunkKeys) {
+            if (
+                previousProjection.placementSignatureByChunkKey.get(
+                    chunkKey,
+                ) !== placementSignatureByChunkKey.get(chunkKey)
+            ) {
+                touchedChunkCount += 1;
+            }
+        }
+        if (touchedChunkCount > 0) {
+            recordPlacementAnimationChunkUpdate({ touchedChunkCount });
+        }
+    }, [addressedChunks, placementSignatureByChunkKey]);
 
     const material = 'material' in props ? props.material : undefined;
     const materialNode = 'materialNode' in props ? props.materialNode : null;
@@ -461,10 +517,10 @@ export function EntityInstancesGeometry(
     }
 
     const renderAnimatedInstances = (suffix: string) =>
-        animatedInstances.map((data) => (
-            <PlacementDropAnimation
-                key={`block-${instanceKey}-${suffix}-${data.id}`}
-                animation={placementDropAnimations[data.block.id]}
+        animatedInstances.map(({ instance: data, renderId }) => (
+            <QueuedPlacementDropAnimation
+                key={`block-${instanceKey}-${suffix}-placement:${renderId}`}
+                animationRenderId={renderId}
                 block={data.block}
                 particlePosition={[
                     data.position[0],
@@ -487,16 +543,16 @@ export function EntityInstancesGeometry(
                         {cloneMaterialNode(materialNode)}
                     </mesh>
                 </group>
-            </PlacementDropAnimation>
+            </QueuedPlacementDropAnimation>
         ));
 
     const renderAnimatedSnowOverlays = () =>
         !snow || !renderSnow
             ? null
-            : animatedInstances.map((data) => (
-                  <PlacementDropAnimation
-                      key={`block-${instanceKey}-snow-${data.id}`}
-                      animation={placementDropAnimations[data.block.id]}
+            : animatedInstances.map(({ instance: data, renderId }) => (
+                  <QueuedPlacementDropAnimation
+                      key={`block-${instanceKey}-snow-placement:${renderId}`}
+                      animationRenderId={renderId}
                       block={data.block}
                       particlePosition={[
                           data.position[0],
@@ -522,16 +578,16 @@ export function EntityInstancesGeometry(
                               />
                           </group>
                       </group>
-                  </PlacementDropAnimation>
+                  </QueuedPlacementDropAnimation>
               ));
 
     const renderAnimatedRainOverlays = () =>
         !renderRainWetOverlay
             ? null
-            : animatedInstances.map((data) => (
-                  <PlacementDropAnimation
-                      key={`block-${instanceKey}-rain-${data.id}`}
-                      animation={placementDropAnimations[data.block.id]}
+            : animatedInstances.map(({ instance: data, renderId }) => (
+                  <QueuedPlacementDropAnimation
+                      key={`block-${instanceKey}-rain-placement:${renderId}`}
+                      animationRenderId={renderId}
                       block={data.block}
                       particlePosition={[
                           data.position[0],
@@ -549,13 +605,16 @@ export function EntityInstancesGeometry(
                               <RainWetOverlay geometry={geometry} />
                           </group>
                       </group>
-                  </PlacementDropAnimation>
+                  </QueuedPlacementDropAnimation>
               ));
 
     return (
         <>
-            {stableChunks.map((chunk) =>
-                renderStableChunksAsMergedGeometry ? (
+            {stableChunks.map((chunk) => {
+                const placementSignature =
+                    placementSignatureByChunkKey.get(chunk.key) ?? '';
+
+                return renderStableChunksAsMergedGeometry ? (
                     <ChunkedMergedMesh
                         key={`${instanceKey}:${chunk.key}`}
                         castShadow={castShadow}
@@ -565,6 +624,7 @@ export function EntityInstancesGeometry(
                         localTransform={localTransform}
                         material={material}
                         materialNode={materialNode}
+                        placementSignature={placementSignature}
                         receiveShadow={receiveShadow}
                         renderOrder={renderOrder}
                         scale={stableScale}
@@ -579,12 +639,13 @@ export function EntityInstancesGeometry(
                         localTransform={localTransform}
                         material={material}
                         materialNode={materialNode}
+                        placementSignature={placementSignature}
                         receiveShadow={receiveShadow}
                         renderOrder={renderOrder}
                         scale={stableScale}
                     />
-                ),
-            )}
+                );
+            })}
             {renderAnimatedInstances('base')}
             {(instances ?? []).map((data) =>
                 data.pickupOutlineVisible ? (
@@ -615,6 +676,7 @@ export function EntityInstancesGeometry(
                     chunks={stableChunks}
                     geometry={geometry}
                     localTransform={localTransform}
+                    placementSignatureByChunkKey={placementSignatureByChunkKey}
                     scale={stableScale}
                 />
             )}
@@ -623,6 +685,7 @@ export function EntityInstancesGeometry(
                     chunks={stableChunks}
                     geometry={geometry}
                     localTransform={localTransform}
+                    placementSignatureByChunkKey={placementSignatureByChunkKey}
                     scale={stableScale}
                     snow={snow}
                     snowLift={snowLift}
@@ -635,7 +698,7 @@ export function EntityInstancesGeometry(
     );
 }
 
-function ChunkedInstancedMesh({
+const ChunkedInstancedMesh = memo(function ChunkedInstancedMesh({
     castShadow,
     chunk,
     debugName,
@@ -643,6 +706,7 @@ function ChunkedInstancedMesh({
     localTransform,
     material,
     materialNode,
+    placementSignature,
     receiveShadow,
     renderOrder,
     scale,
@@ -654,29 +718,55 @@ function ChunkedInstancedMesh({
     localTransform: MeshInstanceLocalTransform;
     material: Material | Material[] | undefined;
     materialNode: ReactNode;
+    placementSignature: string;
     receiveShadow: boolean;
     renderOrder?: number;
     scale: EntityInstancesBlockBaseProps['scale'];
 }) {
     const meshRef = useRef<InstancedMesh | null>(null);
+    const previousChunkInstances = useRef<EntityBlockInstance[] | undefined>(
+        undefined,
+    );
+    const previousPlacementSignature = useRef<string | undefined>(undefined);
 
     useLayoutEffect(() => {
+        const startedAt = placementAnimationProfileNow();
         const mesh = meshRef.current;
-        if (!mesh) {
-            return;
+        if (mesh) {
+            chunk.instances.forEach((instance, index) => {
+                mesh.setMatrixAt(
+                    index,
+                    createMeshInstanceMatrix(instance, localTransform, scale),
+                );
+            });
+            mesh.count = chunk.instances.length;
+            mesh.instanceMatrix.needsUpdate = true;
+            mesh.computeBoundingBox();
+            mesh.computeBoundingSphere();
         }
 
-        chunk.instances.forEach((instance, index) => {
-            mesh.setMatrixAt(
-                index,
-                createMeshInstanceMatrix(instance, localTransform, scale),
-            );
-        });
-        mesh.count = chunk.instances.length;
-        mesh.instanceMatrix.needsUpdate = true;
-        mesh.computeBoundingBox();
-        mesh.computeBoundingSphere();
-    }, [chunk.instances, localTransform, scale]);
+        const previousInstances = previousChunkInstances.current;
+        const previousSignature = previousPlacementSignature.current;
+        previousChunkInstances.current = chunk.instances;
+        previousPlacementSignature.current = placementSignature;
+        if (
+            shouldRecordPlacementAnimationChunkRebuild({
+                currentInstances: chunk.instances,
+                currentPlacementSignature: placementSignature,
+                previousInstances,
+                previousPlacementSignature: previousSignature,
+            })
+        ) {
+            recordPlacementAnimationChunkRebuild({
+                durationMs: placementAnimationProfileNow() - startedAt,
+                transformedInstanceCount: chunk.instances.length,
+            });
+        }
+    }, [chunk.instances, localTransform, placementSignature, scale]);
+
+    if (chunk.instances.length === 0) {
+        return null;
+    }
 
     return (
         <instancedMesh
@@ -690,9 +780,9 @@ function ChunkedInstancedMesh({
             {cloneMaterialNode(materialNode)}
         </instancedMesh>
     );
-}
+});
 
-function ChunkedMergedMesh({
+const ChunkedMergedMesh = memo(function ChunkedMergedMesh({
     castShadow,
     chunk,
     debugName,
@@ -700,6 +790,7 @@ function ChunkedMergedMesh({
     localTransform,
     material,
     materialNode,
+    placementSignature,
     receiveShadow,
     renderOrder,
     scale,
@@ -711,22 +802,58 @@ function ChunkedMergedMesh({
     localTransform: MeshInstanceLocalTransform;
     material: Material | Material[] | undefined;
     materialNode: ReactNode;
+    placementSignature: string;
     receiveShadow: boolean;
     renderOrder?: number;
     scale: EntityInstancesBlockBaseProps['scale'];
 }) {
-    const mergedGeometry = useMemo(
-        () =>
-            createMergedChunkGeometry({
-                geometry,
-                instances: chunk.instances,
-                localTransform,
-                scale,
-            }),
-        [chunk.instances, geometry, localTransform, scale],
+    const previousChunkInstances = useRef<EntityBlockInstance[] | undefined>(
+        undefined,
     );
+    const previousPlacementSignature = useRef<string | undefined>(undefined);
+    const mergedGeometryBuild = useMemo(() => {
+        const startedAt = placementAnimationProfileNow();
+        const mergedGeometry = createMergedChunkGeometry({
+            geometry,
+            instances: chunk.instances,
+            localTransform,
+            scale,
+        });
+
+        return {
+            durationMs: placementAnimationProfileNow() - startedAt,
+            geometry: mergedGeometry,
+        };
+    }, [chunk.instances, geometry, localTransform, scale]);
+    const mergedGeometry = mergedGeometryBuild.geometry;
 
     useEffect(() => () => mergedGeometry.dispose(), [mergedGeometry]);
+    useEffect(() => {
+        const previousInstances = previousChunkInstances.current;
+        const previousSignature = previousPlacementSignature.current;
+        previousChunkInstances.current = chunk.instances;
+        previousPlacementSignature.current = placementSignature;
+        if (
+            !shouldRecordPlacementAnimationChunkRebuild({
+                currentInstances: chunk.instances,
+                currentPlacementSignature: placementSignature,
+                previousInstances,
+                previousPlacementSignature: previousSignature,
+            })
+        ) {
+            return;
+        }
+
+        recordPlacementAnimationChunkRebuild({
+            durationMs: mergedGeometryBuild.durationMs,
+            transformedInstanceCount: chunk.instances.length,
+        });
+    }, [
+        chunk.instances,
+        chunk.instances.length,
+        mergedGeometryBuild.durationMs,
+        placementSignature,
+    ]);
 
     if (!mergedGeometry.getAttribute('position')) {
         return null;
@@ -744,12 +871,13 @@ function ChunkedMergedMesh({
             {cloneMaterialNode(materialNode)}
         </mesh>
     );
-}
+});
 
 function InstancedSnowOverlays({
     chunks,
     geometry,
     localTransform,
+    placementSignatureByChunkKey,
     scale,
     snow,
     snowLift,
@@ -758,6 +886,7 @@ function InstancedSnowOverlays({
     chunks: MeshInstanceChunk<EntityBlockInstance>[];
     geometry: BufferGeometry;
     localTransform: MeshInstanceLocalTransform;
+    placementSignatureByChunkKey: ReadonlyMap<string, string>;
     scale: EntityInstancesBlockBaseProps['scale'];
     snow: SnowMaterialOptions;
     snowLift: number;
@@ -815,6 +944,9 @@ function InstancedSnowOverlays({
             localTransform={liftedTransform}
             material={material}
             materialNode={null}
+            placementSignature={
+                placementSignatureByChunkKey.get(chunk.key) ?? ''
+            }
             receiveShadow={false}
             scale={scale}
         />
@@ -825,11 +957,13 @@ function InstancedRainWetOverlays({
     chunks,
     geometry,
     localTransform,
+    placementSignatureByChunkKey,
     scale,
 }: {
     chunks: MeshInstanceChunk<EntityBlockInstance>[];
     geometry: BufferGeometry;
     localTransform: MeshInstanceLocalTransform;
+    placementSignatureByChunkKey: ReadonlyMap<string, string>;
     scale: EntityInstancesBlockBaseProps['scale'];
 }) {
     const visible = useRainWetOverlayVisible();
@@ -843,6 +977,7 @@ function InstancedRainWetOverlays({
             chunks={chunks}
             geometry={geometry}
             localTransform={localTransform}
+            placementSignatureByChunkKey={placementSignatureByChunkKey}
             scale={scale}
         />
     );
@@ -852,11 +987,13 @@ function VisibleInstancedRainWetOverlays({
     chunks,
     geometry,
     localTransform,
+    placementSignatureByChunkKey,
     scale,
 }: {
     chunks: MeshInstanceChunk<EntityBlockInstance>[];
     geometry: BufferGeometry;
     localTransform: MeshInstanceLocalTransform;
+    placementSignatureByChunkKey: ReadonlyMap<string, string>;
     scale: EntityInstancesBlockBaseProps['scale'];
 }) {
     const material = useRainWetOverlayMaterial({ geometry });
@@ -871,6 +1008,9 @@ function VisibleInstancedRainWetOverlays({
             localTransform={localTransform}
             material={material}
             materialNode={null}
+            placementSignature={
+                placementSignatureByChunkKey.get(chunk.key) ?? ''
+            }
             receiveShadow={false}
             scale={scale}
         />

--- a/packages/game/src/entities/helpers/PlacementDropAnimation.tsx
+++ b/packages/game/src/entities/helpers/PlacementDropAnimation.tsx
@@ -8,6 +8,8 @@ import {
 import type { Block } from '../../types/Block';
 import {
     type BlockPlacementDropAnimation,
+    getBlockPlacementDropAnimationByRenderId,
+    getBlockPlacementDropAnimationForBlockId,
     useGameState,
 } from '../../useGameState';
 
@@ -64,8 +66,9 @@ export function PlacementDropAnimation({
         }
 
         startedSequence.current = animation.sequence;
+        const animationRenderId = animation.renderId;
         const spawnLandingParticles = () => {
-            if (!markParticlesSpawned(block.id)) {
+            if (!markParticlesSpawned(animationRenderId)) {
                 return;
             }
 
@@ -77,7 +80,7 @@ export function PlacementDropAnimation({
         };
         const finish = () => {
             spawnLandingParticles();
-            completeAnimation(block.id);
+            completeAnimation(animationRenderId);
         };
 
         if (prefersReducedMotion()) {
@@ -94,7 +97,6 @@ export function PlacementDropAnimation({
     }, [
         animation,
         api,
-        block.id,
         block.name,
         completeAnimation,
         markParticlesSpawned,
@@ -118,17 +120,27 @@ export function PlacementDropAnimation({
 }
 
 export function QueuedPlacementDropAnimation({
+    animationRenderId,
     block,
     children,
     particlePosition,
     position,
 }: PropsWithChildren<{
+    animationRenderId?: number;
     block: Block;
     particlePosition: Vector3 | [number, number, number];
     position?: [number, number, number];
 }>) {
-    const animation = useGameState(
-        (state) => state.blockPlacementDropAnimations[block.id] ?? null,
+    const animation = useGameState((state) =>
+        animationRenderId === undefined
+            ? getBlockPlacementDropAnimationForBlockId(
+                  state.blockPlacementDropAnimations,
+                  block.id,
+              )
+            : getBlockPlacementDropAnimationByRenderId(
+                  state.blockPlacementDropAnimations,
+                  animationRenderId,
+              ),
     );
 
     return (

--- a/packages/game/src/entities/placementAnimationChunks.ts
+++ b/packages/game/src/entities/placementAnimationChunks.ts
@@ -1,0 +1,237 @@
+import type { GameState } from '../useGameState';
+import {
+    type ChunkedMeshInstance,
+    chunkMeshInstances,
+    type MeshInstanceChunk,
+} from './chunkedMeshGeometry';
+
+type PlacementAnimationInstance = ChunkedMeshInstance & {
+    block: {
+        id: string;
+    };
+};
+
+export type PlacementAnimationChunkAddress = {
+    chunkIndex: number;
+    instanceIndex: number;
+    order: number;
+};
+
+export type AddressedPlacementAnimationChunks<
+    T extends PlacementAnimationInstance,
+> = {
+    addressByBlockId: ReadonlyMap<string, PlacementAnimationChunkAddress>;
+    chunks: MeshInstanceChunk<T>[];
+};
+
+type PlacementAnimationChunkCacheEntry<T extends PlacementAnimationInstance> = {
+    chunk: MeshInstanceChunk<T>;
+    signature: string;
+    sourceChunk: MeshInstanceChunk<T>;
+};
+
+export type PlacementAnimationChunkCache<T extends PlacementAnimationInstance> =
+    Map<string, PlacementAnimationChunkCacheEntry<T>>;
+
+type PlacementAnimationState = Pick<GameState, 'blockPlacementDropAnimations'>;
+
+const emptyPlacementSignatures = new Map<string, string>();
+
+function renderIdsEqual(
+    left: ReadonlyMap<string, number>,
+    right: ReadonlyMap<string, number>,
+) {
+    if (left.size !== right.size) {
+        return false;
+    }
+
+    for (const [blockId, renderId] of left) {
+        if (right.get(blockId) !== renderId) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+export function createPlacementDropAnimationRenderIdsSelector(
+    ownedBlockIds: readonly string[],
+) {
+    const ownedBlockIdSet = new Set(ownedBlockIds);
+    let previousAnimations:
+        | PlacementAnimationState['blockPlacementDropAnimations']
+        | undefined;
+    let previousSelection: ReadonlyMap<string, number> = new Map();
+
+    return (state: PlacementAnimationState) => {
+        if (state.blockPlacementDropAnimations === previousAnimations) {
+            return previousSelection;
+        }
+        previousAnimations = state.blockPlacementDropAnimations;
+
+        const nextSelection = new Map<string, number>();
+
+        for (const [blockId, animation] of Object.entries(
+            state.blockPlacementDropAnimations,
+        )) {
+            if (ownedBlockIdSet.has(blockId)) {
+                nextSelection.set(blockId, animation.renderId);
+            } else if (ownedBlockIdSet.has(animation.sourceBlockId)) {
+                nextSelection.set(animation.sourceBlockId, animation.renderId);
+            }
+        }
+
+        if (renderIdsEqual(previousSelection, nextSelection)) {
+            return previousSelection;
+        }
+
+        previousSelection = nextSelection;
+        return previousSelection;
+    };
+}
+
+export function addressPlacementAnimationChunks<
+    T extends PlacementAnimationInstance,
+>(instances: T[]): AddressedPlacementAnimationChunks<T> {
+    const chunks = chunkMeshInstances(instances);
+    const orderByInstance = new Map<T, number>();
+    const addressByBlockId = new Map<string, PlacementAnimationChunkAddress>();
+
+    instances.forEach((instance, order) => {
+        orderByInstance.set(instance, order);
+    });
+    chunks.forEach((chunk, chunkIndex) => {
+        chunk.instances.forEach((instance, instanceIndex) => {
+            const order = orderByInstance.get(instance);
+            if (order === undefined) {
+                return;
+            }
+
+            addressByBlockId.set(instance.block.id, {
+                chunkIndex,
+                instanceIndex,
+                order,
+            });
+        });
+    });
+
+    return {
+        addressByBlockId,
+        chunks,
+    };
+}
+
+export function createPlacementAnimationChunkCache<
+    T extends PlacementAnimationInstance,
+>(): PlacementAnimationChunkCache<T> {
+    return new Map();
+}
+
+export function localizePlacementDropAnimationChunks<
+    T extends PlacementAnimationInstance,
+>(
+    addressed: AddressedPlacementAnimationChunks<T>,
+    animatedRenderIds: ReadonlyMap<string, number>,
+    chunkCache: PlacementAnimationChunkCache<T>,
+) {
+    const animatedAddresses: Array<
+        PlacementAnimationChunkAddress & { renderId: number }
+    > = [];
+    const animatedBlockIdsByChunkIndex = new Map<number, Set<string>>();
+
+    for (const [blockId, renderId] of animatedRenderIds) {
+        const address = addressed.addressByBlockId.get(blockId);
+        if (!address) {
+            continue;
+        }
+
+        animatedAddresses.push({ ...address, renderId });
+        const chunkBlockIds = animatedBlockIdsByChunkIndex.get(
+            address.chunkIndex,
+        );
+        if (chunkBlockIds) {
+            chunkBlockIds.add(blockId);
+        } else {
+            animatedBlockIdsByChunkIndex.set(
+                address.chunkIndex,
+                new Set([blockId]),
+            );
+        }
+    }
+
+    if (animatedBlockIdsByChunkIndex.size === 0) {
+        return {
+            animatedInstances: [] as Array<{
+                instance: T;
+                renderId: number;
+            }>,
+            chunks: addressed.chunks,
+            placementSignatureByChunkKey: emptyPlacementSignatures,
+            touchedChunkKeys: [] as string[],
+        };
+    }
+
+    const chunks = [...addressed.chunks];
+    const placementSignatureByChunkKey = new Map<string, string>();
+    const touchedChunkKeys: string[] = [];
+    const touchedChunkIndexes = [...animatedBlockIdsByChunkIndex.keys()].sort(
+        (left, right) => left - right,
+    );
+
+    for (const chunkIndex of touchedChunkIndexes) {
+        const chunk = addressed.chunks[chunkIndex];
+        const chunkBlockIds = animatedBlockIdsByChunkIndex.get(chunkIndex);
+        if (!chunk || !chunkBlockIds) {
+            continue;
+        }
+
+        const placementSignature = JSON.stringify([...chunkBlockIds].sort());
+        const cachedChunk = chunkCache.get(chunk.key);
+        if (
+            cachedChunk?.sourceChunk === chunk &&
+            cachedChunk.signature === placementSignature
+        ) {
+            chunks[chunkIndex] = cachedChunk.chunk;
+        } else {
+            const localizedChunk = {
+                key: chunk.key,
+                instances: chunk.instances.filter(
+                    (instance) => !chunkBlockIds.has(instance.block.id),
+                ),
+            };
+            chunks[chunkIndex] = localizedChunk;
+            chunkCache.set(chunk.key, {
+                chunk: localizedChunk,
+                signature: placementSignature,
+                sourceChunk: chunk,
+            });
+        }
+        placementSignatureByChunkKey.set(chunk.key, placementSignature);
+        touchedChunkKeys.push(chunk.key);
+    }
+
+    animatedAddresses.sort((left, right) => left.order - right.order);
+    const animatedInstances: Array<{
+        instance: T;
+        renderId: number;
+    }> = [];
+    for (const address of animatedAddresses) {
+        const instance =
+            addressed.chunks[address.chunkIndex]?.instances[
+                address.instanceIndex
+            ];
+        if (instance) {
+            animatedInstances.push({
+                instance,
+                renderId: address.renderId,
+            });
+        }
+    }
+
+    return {
+        animatedInstances,
+        chunks,
+        placementSignatureByChunkKey,
+        touchedChunkKeys,
+    };
+}

--- a/packages/game/src/entities/placementAnimationChunks.unit.ts
+++ b/packages/game/src/entities/placementAnimationChunks.unit.ts
@@ -1,0 +1,280 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { BlockPlacementDropAnimation } from '../useGameState';
+import {
+    addressPlacementAnimationChunks,
+    createPlacementAnimationChunkCache,
+    createPlacementDropAnimationRenderIdsSelector,
+    localizePlacementDropAnimationChunks,
+} from './placementAnimationChunks';
+
+type TestInstance = {
+    block: { id: string };
+    position: [number, number, number];
+    rotation: number;
+};
+
+function createInstance(id: string, x: number, z = 0): TestInstance {
+    return {
+        block: { id },
+        position: [x, 0, z],
+        rotation: 0,
+    };
+}
+
+function createAnimation(
+    sequence: number,
+    sourceBlockId: string,
+    particlesSpawned = false,
+): BlockPlacementDropAnimation {
+    return {
+        createdAt: sequence,
+        particlesSpawned,
+        renderId: sequence,
+        sequence,
+        sourceBlockId,
+    };
+}
+
+describe('addressPlacementAnimationChunks', () => {
+    it('keeps deterministic block addresses through reorder, add, and remove', () => {
+        const first = addressPlacementAnimationChunks([
+            createInstance('a', 0),
+            createInstance('b', 9),
+            createInstance('c', 1),
+        ]);
+
+        assert.deepEqual(
+            first.chunks.map((chunk) => [
+                chunk.key,
+                chunk.instances.map((instance) => instance.block.id),
+            ]),
+            [
+                ['0:0', ['a', 'c']],
+                ['1:0', ['b']],
+            ],
+        );
+        assert.deepEqual(first.addressByBlockId.get('c'), {
+            chunkIndex: 0,
+            instanceIndex: 1,
+            order: 2,
+        });
+
+        const second = addressPlacementAnimationChunks([
+            createInstance('c', 1),
+            createInstance('d', -1),
+            createInstance('a', 0),
+        ]);
+
+        assert.deepEqual(
+            second.chunks.map((chunk) => [
+                chunk.key,
+                chunk.instances.map((instance) => instance.block.id),
+            ]),
+            [
+                ['-1:0', ['d']],
+                ['0:0', ['c', 'a']],
+            ],
+        );
+        assert.deepEqual(second.addressByBlockId.get('a'), {
+            chunkIndex: 1,
+            instanceIndex: 1,
+            order: 2,
+        });
+        assert.equal(second.addressByBlockId.has('b'), false);
+    });
+});
+
+describe('createPlacementDropAnimationRenderIdsSelector', () => {
+    it('ignores unrelated animation updates and preserves render identity for particles', () => {
+        const select = createPlacementDropAnimationRenderIdsSelector([
+            'a',
+            'b',
+        ]);
+        const empty = select({ blockPlacementDropAnimations: {} });
+        const unrelated = select({
+            blockPlacementDropAnimations: {
+                outside: createAnimation(1, 'outside'),
+            },
+        });
+
+        assert.strictEqual(unrelated, empty);
+
+        const queuedAnimation = createAnimation(2, 'a');
+        const queued = select({
+            blockPlacementDropAnimations: {
+                a: queuedAnimation,
+                outside: createAnimation(1, 'outside'),
+            },
+        });
+        assert.deepEqual([...queued], [['a', 2]]);
+
+        const particles = select({
+            blockPlacementDropAnimations: {
+                a: { ...queuedAnimation, particlesSpawned: true },
+                outside: createAnimation(1, 'outside'),
+            },
+        });
+        assert.strictEqual(particles, queued);
+
+        const anotherUnrelatedUpdate = select({
+            blockPlacementDropAnimations: {
+                a: {
+                    ...queuedAnimation,
+                    particlesSpawned: true,
+                },
+                outside: createAnimation(3, 'outside'),
+            },
+        });
+        assert.strictEqual(anotherUnrelatedUpdate, queued);
+
+        const completed = select({ blockPlacementDropAnimations: {} });
+        assert.deepEqual([...completed], []);
+    });
+
+    it('keeps the optimistic render identity while the store rekeys first', () => {
+        const select = createPlacementDropAnimationRenderIdsSelector([
+            'optimistic',
+        ]);
+        const animation = createAnimation(7, 'optimistic');
+        const queued = select({
+            blockPlacementDropAnimations: { optimistic: animation },
+        });
+        const storeRekeyed = select({
+            blockPlacementDropAnimations: { persisted: animation },
+        });
+
+        assert.deepEqual([...queued], [['optimistic', 7]]);
+        assert.strictEqual(storeRekeyed, queued);
+    });
+});
+
+describe('localizePlacementDropAnimationChunks', () => {
+    it('replaces only the owning chunk while preserving unrelated references', () => {
+        const addressed = addressPlacementAnimationChunks([
+            createInstance('a', 0),
+            createInstance('b', 1),
+            createInstance('c', 9),
+            createInstance('d', 17),
+        ]);
+        const localized = localizePlacementDropAnimationChunks(
+            addressed,
+            new Map([['a', 1]]),
+            createPlacementAnimationChunkCache(),
+        );
+
+        assert.notStrictEqual(localized.chunks, addressed.chunks);
+        assert.notStrictEqual(localized.chunks[0], addressed.chunks[0]);
+        assert.strictEqual(localized.chunks[1], addressed.chunks[1]);
+        assert.strictEqual(localized.chunks[2], addressed.chunks[2]);
+        assert.deepEqual(
+            localized.chunks[0]?.instances.map((instance) => instance.block.id),
+            ['b'],
+        );
+        assert.deepEqual(
+            localized.animatedInstances.map(
+                ({ instance }) => instance.block.id,
+            ),
+            ['a'],
+        );
+        assert.equal(localized.animatedInstances[0]?.renderId, 1);
+        assert.equal(
+            localized.placementSignatureByChunkKey.get('0:0'),
+            '["a"]',
+        );
+        assert.equal(localized.placementSignatureByChunkKey.has('1:0'), false);
+        assert.deepEqual(localized.touchedChunkKeys, ['0:0']);
+    });
+
+    it('keeps an emptied owner chunk addressable for completion', () => {
+        const addressed = addressPlacementAnimationChunks([
+            createInstance('a', 0),
+            createInstance('b', 9),
+        ]);
+        const chunkCache = createPlacementAnimationChunkCache<TestInstance>();
+        const queued = localizePlacementDropAnimationChunks(
+            addressed,
+            new Map([['a', 1]]),
+            chunkCache,
+        );
+        const completed = localizePlacementDropAnimationChunks(
+            addressed,
+            new Map(),
+            chunkCache,
+        );
+
+        assert.equal(queued.chunks[0]?.instances.length, 0);
+        assert.equal(queued.chunks[0]?.key, '0:0');
+        assert.strictEqual(completed.chunks, addressed.chunks);
+        assert.notStrictEqual(completed.chunks[0], queued.chunks[0]);
+        assert.strictEqual(completed.chunks[0], addressed.chunks[0]);
+        assert.strictEqual(completed.chunks[1], queued.chunks[1]);
+        assert.equal(completed.placementSignatureByChunkKey.size, 0);
+    });
+
+    it('does no work for cancelled or missing animation blocks', () => {
+        const addressed = addressPlacementAnimationChunks([
+            createInstance('a', 0),
+            createInstance('b', 9),
+        ]);
+        const chunkCache = createPlacementAnimationChunkCache<TestInstance>();
+
+        for (const animatedRenderIds of [
+            new Map<string, number>(),
+            new Map([['missing', 1]]),
+        ]) {
+            const localized = localizePlacementDropAnimationChunks(
+                addressed,
+                animatedRenderIds,
+                chunkCache,
+            );
+
+            assert.strictEqual(localized.chunks, addressed.chunks);
+            assert.deepEqual(localized.animatedInstances, []);
+            assert.deepEqual(localized.touchedChunkKeys, []);
+        }
+    });
+
+    it('reuses unchanged active chunks across sequential cross-chunk updates', () => {
+        const addressed = addressPlacementAnimationChunks([
+            createInstance('a', 0),
+            createInstance('a-peer', 1),
+            createInstance('b', 9),
+            createInstance('b-peer', 10),
+        ]);
+        const chunkCache = createPlacementAnimationChunkCache<TestInstance>();
+
+        const onlyA = localizePlacementDropAnimationChunks(
+            addressed,
+            new Map([['a', 1]]),
+            chunkCache,
+        );
+        const aAndB = localizePlacementDropAnimationChunks(
+            addressed,
+            new Map([
+                ['a', 1],
+                ['b', 2],
+            ]),
+            chunkCache,
+        );
+        const onlyB = localizePlacementDropAnimationChunks(
+            addressed,
+            new Map([['b', 2]]),
+            chunkCache,
+        );
+
+        assert.strictEqual(aAndB.chunks[0], onlyA.chunks[0]);
+        assert.strictEqual(
+            aAndB.chunks[0]?.instances,
+            onlyA.chunks[0]?.instances,
+        );
+        assert.strictEqual(onlyB.chunks[1], aAndB.chunks[1]);
+        assert.strictEqual(
+            onlyB.chunks[1]?.instances,
+            aAndB.chunks[1]?.instances,
+        );
+        assert.strictEqual(onlyB.chunks[0], addressed.chunks[0]);
+        assert.equal(aAndB.placementSignatureByChunkKey.get('0:0'), '["a"]');
+        assert.equal(aAndB.placementSignatureByChunkKey.get('1:0'), '["b"]');
+    });
+});

--- a/packages/game/src/entities/placementAnimationProfileMetrics.ts
+++ b/packages/game/src/entities/placementAnimationProfileMetrics.ts
@@ -1,0 +1,106 @@
+import { updateGameProfileMetadata } from '../scene/gameProfileMetadata';
+
+const maxDurationSamples = 256;
+const durationSamples: number[] = [];
+let placementChunkLogicalTouchedCount = 0;
+let placementChunkLogicalUpdateCount = 0;
+let placementChunkPhysicalRebuildCount = 0;
+let placementChunkPhysicalRebuildDurationMaxMs = 0;
+let placementChunkPhysicalTransformedInstanceCount = 0;
+
+function durationPercentile95() {
+    if (durationSamples.length === 0) {
+        return 0;
+    }
+
+    const sortedSamples = [...durationSamples].sort(
+        (left, right) => left - right,
+    );
+    const index = Math.max(0, Math.ceil(sortedSamples.length * 0.95) - 1);
+
+    return sortedSamples[index] ?? 0;
+}
+
+export function placementAnimationProfileNow() {
+    return typeof performance === 'undefined' ? Date.now() : performance.now();
+}
+
+export function shouldRecordPlacementAnimationChunkRebuild({
+    currentInstances,
+    currentPlacementSignature,
+    previousInstances,
+    previousPlacementSignature,
+}: {
+    currentInstances: readonly unknown[];
+    currentPlacementSignature: string;
+    previousInstances: readonly unknown[] | undefined;
+    previousPlacementSignature: string | undefined;
+}) {
+    return (
+        previousInstances !== undefined &&
+        previousInstances !== currentInstances &&
+        (previousPlacementSignature !== '' || currentPlacementSignature !== '')
+    );
+}
+
+export function readPlacementAnimationProfileMetrics() {
+    return {
+        placementChunkLogicalTouchedCount,
+        placementChunkLogicalUpdateCount,
+        placementChunkPhysicalRebuildCount,
+        placementChunkPhysicalRebuildDurationMaxMs,
+        placementChunkPhysicalRebuildDurationP95Ms: durationPercentile95(),
+        placementChunkPhysicalTransformedInstanceCount,
+    };
+}
+
+function publishPlacementAnimationProfileMetrics() {
+    updateGameProfileMetadata(readPlacementAnimationProfileMetrics());
+}
+
+export function resetPlacementAnimationProfileMetrics() {
+    durationSamples.length = 0;
+    placementChunkLogicalTouchedCount = 0;
+    placementChunkLogicalUpdateCount = 0;
+    placementChunkPhysicalRebuildCount = 0;
+    placementChunkPhysicalRebuildDurationMaxMs = 0;
+    placementChunkPhysicalTransformedInstanceCount = 0;
+    publishPlacementAnimationProfileMetrics();
+}
+
+export function recordPlacementAnimationChunkUpdate({
+    touchedChunkCount,
+}: {
+    touchedChunkCount: number;
+}) {
+    placementChunkLogicalTouchedCount += Math.max(0, touchedChunkCount);
+    placementChunkLogicalUpdateCount += 1;
+    publishPlacementAnimationProfileMetrics();
+}
+
+export function recordPlacementAnimationChunkRebuild({
+    durationMs,
+    transformedInstanceCount,
+}: {
+    durationMs: number;
+    transformedInstanceCount: number;
+}) {
+    const safeDurationMs =
+        Number.isFinite(durationMs) && durationMs > 0 ? durationMs : 0;
+
+    placementChunkPhysicalRebuildCount += 1;
+    placementChunkPhysicalTransformedInstanceCount += Math.max(
+        0,
+        transformedInstanceCount,
+    );
+    placementChunkPhysicalRebuildDurationMaxMs = Math.max(
+        placementChunkPhysicalRebuildDurationMaxMs,
+        safeDurationMs,
+    );
+    durationSamples.push(safeDurationMs);
+    if (durationSamples.length > maxDurationSamples) {
+        durationSamples.shift();
+    }
+
+    publishPlacementAnimationProfileMetrics();
+}

--- a/packages/game/src/entities/placementAnimationProfileMetrics.unit.ts
+++ b/packages/game/src/entities/placementAnimationProfileMetrics.unit.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    readPlacementAnimationProfileMetrics,
+    recordPlacementAnimationChunkRebuild,
+    recordPlacementAnimationChunkUpdate,
+    resetPlacementAnimationProfileMetrics,
+    shouldRecordPlacementAnimationChunkRebuild,
+} from './placementAnimationProfileMetrics';
+
+describe('placement animation profile metrics', () => {
+    it('separates logical chunk touches from physical overlay rebuilds', () => {
+        resetPlacementAnimationProfileMetrics();
+        recordPlacementAnimationChunkUpdate({ touchedChunkCount: 1 });
+        recordPlacementAnimationChunkRebuild({
+            durationMs: 1,
+            transformedInstanceCount: 7,
+        });
+        recordPlacementAnimationChunkRebuild({
+            durationMs: 2,
+            transformedInstanceCount: 7,
+        });
+        recordPlacementAnimationChunkRebuild({
+            durationMs: 3,
+            transformedInstanceCount: 7,
+        });
+
+        assert.deepEqual(readPlacementAnimationProfileMetrics(), {
+            placementChunkLogicalTouchedCount: 1,
+            placementChunkLogicalUpdateCount: 1,
+            placementChunkPhysicalRebuildCount: 3,
+            placementChunkPhysicalRebuildDurationMaxMs: 3,
+            placementChunkPhysicalRebuildDurationP95Ms: 3,
+            placementChunkPhysicalTransformedInstanceCount: 21,
+        });
+
+        resetPlacementAnimationProfileMetrics();
+        assert.deepEqual(readPlacementAnimationProfileMetrics(), {
+            placementChunkLogicalTouchedCount: 0,
+            placementChunkLogicalUpdateCount: 0,
+            placementChunkPhysicalRebuildCount: 0,
+            placementChunkPhysicalRebuildDurationMaxMs: 0,
+            placementChunkPhysicalRebuildDurationP95Ms: 0,
+            placementChunkPhysicalTransformedInstanceCount: 0,
+        });
+    });
+
+    it('records hidden instance-reference rebuilds only while placement is involved', () => {
+        const previousInstances = [{}];
+        const currentInstances = [{}];
+
+        assert.equal(
+            shouldRecordPlacementAnimationChunkRebuild({
+                currentInstances,
+                currentPlacementSignature: '["a"]',
+                previousInstances,
+                previousPlacementSignature: '["a"]',
+            }),
+            true,
+        );
+        assert.equal(
+            shouldRecordPlacementAnimationChunkRebuild({
+                currentInstances,
+                currentPlacementSignature: '',
+                previousInstances,
+                previousPlacementSignature: '',
+            }),
+            false,
+        );
+        assert.equal(
+            shouldRecordPlacementAnimationChunkRebuild({
+                currentInstances,
+                currentPlacementSignature: '["a"]',
+                previousInstances: currentInstances,
+                previousPlacementSignature: '',
+            }),
+            false,
+        );
+    });
+});

--- a/packages/game/src/hooks/useBlockPlace.ts
+++ b/packages/game/src/hooks/useBlockPlace.ts
@@ -127,6 +127,12 @@ export function useBlockPlace() {
     const queueBlockPlacementDropAnimation = useGameState(
         (state) => state.queueBlockPlacementDropAnimation,
     );
+    const rekeyBlockPlacementDropAnimation = useGameState(
+        (state) => state.rekeyBlockPlacementDropAnimation,
+    );
+    const cancelBlockPlacementDropAnimation = useGameState(
+        (state) => state.cancelBlockPlacementDropAnimation,
+    );
     const gardenQueryKey = currentGardenKeys(
         winterMode,
         garden?.id,
@@ -273,6 +279,10 @@ export function useBlockPlace() {
                 return;
             }
 
+            rekeyBlockPlacementDropAnimation(
+                context.optimisticBlockId,
+                data.id,
+            );
             queryClient.setQueryData<CurrentGardenData | null>(
                 gardenQueryKey,
                 (currentGarden) =>
@@ -288,6 +298,7 @@ export function useBlockPlace() {
         onError: (error, _variables, context) => {
             console.error('Error creating block', error);
             if (context?.optimisticBlockId) {
+                cancelBlockPlacementDropAnimation(context.optimisticBlockId);
                 queryClient.setQueryData<CurrentGardenData | null>(
                     gardenQueryKey,
                     (currentGarden) =>

--- a/packages/game/src/hooks/useGardenBoxPlaceBlock.ts
+++ b/packages/game/src/hooks/useGardenBoxPlaceBlock.ts
@@ -100,6 +100,12 @@ export function useGardenBoxPlaceBlock() {
     const queueBlockPlacementDropAnimation = useGameState(
         (state) => state.queueBlockPlacementDropAnimation,
     );
+    const rekeyBlockPlacementDropAnimation = useGameState(
+        (state) => state.rekeyBlockPlacementDropAnimation,
+    );
+    const cancelBlockPlacementDropAnimation = useGameState(
+        (state) => state.cancelBlockPlacementDropAnimation,
+    );
 
     return useMutation({
         mutationKey,
@@ -184,6 +190,7 @@ export function useGardenBoxPlaceBlock() {
             }
 
             const optimisticBlockId = context.optimisticBlockId;
+            rekeyBlockPlacementDropAnimation(optimisticBlockId, data.id);
             queryClient.setQueryData<CurrentGardenData | null>(
                 context.gardenQueryKey,
                 (garden) =>
@@ -198,6 +205,9 @@ export function useGardenBoxPlaceBlock() {
         },
         onError: (error, _variables, context) => {
             console.error('Error placing block from garden box', error);
+            if (context?.optimisticBlockId) {
+                cancelBlockPlacementDropAnimation(context.optimisticBlockId);
+            }
             if (context?.previousInventory) {
                 queryClient.setQueryData(
                     inventoryQueryKey,

--- a/packages/game/src/scene/GameProfileController.tsx
+++ b/packages/game/src/scene/GameProfileController.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import { useEffect } from 'react';
+import { meshChunkSize } from '../entities/chunkedMeshGeometry';
+import { instancedBlockNames } from '../entities/EntityInstances';
+import { resetPlacementAnimationProfileMetrics } from '../entities/placementAnimationProfileMetrics';
 import { getGeneratedPackedPlantRenderTaskSchedulerSnapshot } from '../generators/plant/hooks/useGeneratedLSystem';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import type { Block } from '../types/Block';
@@ -18,6 +21,8 @@ import {
 
 export const gameProfileCloseupCommandEventName =
     'gredice:game-profile-closeup-command';
+export const gameProfilePlacementCommandEventName =
+    'gredice:game-profile-placement-command';
 
 type ProfileGarden = {
     raisedBeds: Array<{
@@ -27,6 +32,10 @@ type ProfileGarden = {
     }>;
     stacks: Array<{
         blocks: Block[];
+        position?: {
+            x: number;
+            z: number;
+        };
     }>;
 };
 
@@ -40,6 +49,15 @@ export type GameProfileCloseupCommand =
       }
     | {
           action: 'reset';
+      };
+
+export type GameProfilePlacementCommand =
+    | {
+          action: 'reset';
+      }
+    | {
+          action: 'run';
+          staggerMs: number;
       };
 
 export function readGameProfileCloseupCommand(
@@ -64,6 +82,82 @@ export function readGameProfileCloseupCommand(
     }
 
     return null;
+}
+
+export function readGameProfilePlacementCommand(
+    value: unknown,
+): GameProfilePlacementCommand | null {
+    if (!value || typeof value !== 'object') {
+        return null;
+    }
+
+    const action = Reflect.get(value, 'action');
+    if (action === 'reset') {
+        return { action };
+    }
+    if (action !== 'run') {
+        return null;
+    }
+
+    const staggerMs = Reflect.get(value, 'staggerMs');
+    if (staggerMs === undefined) {
+        return { action, staggerMs: 120 };
+    }
+    if (
+        typeof staggerMs !== 'number' ||
+        !Number.isFinite(staggerMs) ||
+        staggerMs < 0 ||
+        staggerMs > 1_000
+    ) {
+        return null;
+    }
+
+    return { action, staggerMs };
+}
+
+const instancedBlockNameSet: ReadonlySet<string> = new Set(instancedBlockNames);
+
+function profilePlacementChunkKey(position: { x: number; z: number }) {
+    return `${Math.floor(position.x / meshChunkSize)}:${Math.floor(
+        position.z / meshChunkSize,
+    )}`;
+}
+
+export function resolveGameProfilePlacementBlockIds(
+    garden: ProfileGarden | null | undefined,
+) {
+    if (!garden) {
+        return [];
+    }
+
+    const firstTargetByBlockName = new Map<
+        string,
+        { blockId: string; chunkKey: string }
+    >();
+    for (const stack of garden.stacks) {
+        if (!stack.position) {
+            continue;
+        }
+        const chunkKey = profilePlacementChunkKey(stack.position);
+        for (const block of stack.blocks) {
+            if (!instancedBlockNameSet.has(block.name)) {
+                continue;
+            }
+            const firstTarget = firstTargetByBlockName.get(block.name);
+            if (!firstTarget) {
+                firstTargetByBlockName.set(block.name, {
+                    blockId: block.id,
+                    chunkKey,
+                });
+                continue;
+            }
+            if (firstTarget.chunkKey !== chunkKey) {
+                return [firstTarget.blockId, block.id];
+            }
+        }
+    }
+
+    return [];
 }
 
 export function resolveGameProfileRaisedBedTarget(
@@ -107,6 +201,12 @@ export function GameProfileController() {
         (current) => current.closeupCameraSettled,
     );
     const gameCamera = useGameState((current) => current.gameCamera);
+    const queueBlockPlacementDropAnimation = useGameState(
+        (current) => current.queueBlockPlacementDropAnimation,
+    );
+    const cancelBlockPlacementDropAnimation = useGameState(
+        (current) => current.cancelBlockPlacementDropAnimation,
+    );
     const { mutate: removeRaisedBedCloseupParam } =
         useRemoveRaisedBedCloseupParam();
     const { mutate: setRaisedBedCloseupParam } = useSetRaisedBedCloseupParam();
@@ -187,6 +287,76 @@ export function GameProfileController() {
             resetGeneratedPlantProfile();
         };
     }, [garden, removeRaisedBedCloseupParam, setRaisedBedCloseupParam]);
+
+    useEffect(() => {
+        const pendingTimeouts = new Set<number>();
+        const clearPendingTimeouts = () => {
+            for (const timeout of pendingTimeouts) {
+                window.clearTimeout(timeout);
+            }
+            pendingTimeouts.clear();
+        };
+        const handleCommand = (event: Event) => {
+            const command =
+                event instanceof CustomEvent
+                    ? readGameProfilePlacementCommand(event.detail)
+                    : null;
+            if (!command) {
+                return;
+            }
+            clearPendingTimeouts();
+            const blockIds = resolveGameProfilePlacementBlockIds(garden);
+            for (const blockId of blockIds) {
+                cancelBlockPlacementDropAnimation(blockId);
+            }
+            if (command.action === 'reset') {
+                resetPlacementAnimationProfileMetrics();
+                return;
+            }
+
+            if (blockIds.length === 0) {
+                resetPlacementAnimationProfileMetrics();
+                return;
+            }
+
+            const startTimeout = window.setTimeout(() => {
+                pendingTimeouts.delete(startTimeout);
+                resetPlacementAnimationProfileMetrics();
+                const [firstBlockId, ...remainingBlockIds] = blockIds;
+                if (!firstBlockId) {
+                    return;
+                }
+                queueBlockPlacementDropAnimation(firstBlockId);
+                remainingBlockIds.forEach((blockId, index) => {
+                    const timeout = window.setTimeout(
+                        () => {
+                            pendingTimeouts.delete(timeout);
+                            queueBlockPlacementDropAnimation(blockId);
+                        },
+                        command.staggerMs * (index + 1),
+                    );
+                    pendingTimeouts.add(timeout);
+                });
+            }, 0);
+            pendingTimeouts.add(startTimeout);
+        };
+
+        window.addEventListener(
+            gameProfilePlacementCommandEventName,
+            handleCommand,
+        );
+        return () => {
+            window.removeEventListener(
+                gameProfilePlacementCommandEventName,
+                handleCommand,
+            );
+            clearPendingTimeouts();
+        };
+    }, [
+        cancelBlockPlacementDropAnimation,
+        garden,
+        queueBlockPlacementDropAnimation,
+    ]);
 
     return null;
 }

--- a/packages/game/src/scene/GameProfileController.unit.ts
+++ b/packages/game/src/scene/GameProfileController.unit.ts
@@ -3,6 +3,8 @@ import test from 'node:test';
 import type { Block } from '../types/Block';
 import {
     readGameProfileCloseupCommand,
+    readGameProfilePlacementCommand,
+    resolveGameProfilePlacementBlockIds,
     resolveGameProfileRaisedBedTarget,
 } from './GameProfileController';
 
@@ -85,5 +87,66 @@ test('profile target resolution uses the raised bed primary block', () => {
             3,
         ),
         null,
+    );
+});
+
+test('profile placement command validates the repeatable stagger', () => {
+    assert.deepEqual(readGameProfilePlacementCommand({ action: 'run' }), {
+        action: 'run',
+        staggerMs: 120,
+    });
+    assert.deepEqual(
+        readGameProfilePlacementCommand({ action: 'run', staggerMs: 80 }),
+        {
+            action: 'run',
+            staggerMs: 80,
+        },
+    );
+    assert.deepEqual(readGameProfilePlacementCommand({ action: 'reset' }), {
+        action: 'reset',
+    });
+    assert.equal(
+        readGameProfilePlacementCommand({ action: 'run', staggerMs: -1 }),
+        null,
+    );
+});
+
+test('profile placement targets use one entity batch across separate chunks', () => {
+    const blockA: Block = {
+        id: 'grass-a',
+        name: 'Block_Grass',
+        rotation: 0,
+    };
+    const blockB: Block = {
+        id: 'grass-b',
+        name: 'Block_Grass',
+        rotation: 0,
+    };
+
+    assert.deepEqual(
+        resolveGameProfilePlacementBlockIds({
+            raisedBeds: [],
+            stacks: [
+                {
+                    blocks: [blockA],
+                    position: { x: 0, z: 0 },
+                },
+                {
+                    blocks: [
+                        {
+                            id: 'non-instanced',
+                            name: 'Unknown',
+                            rotation: 0,
+                        },
+                    ],
+                    position: { x: 8, z: 0 },
+                },
+                {
+                    blocks: [blockB],
+                    position: { x: 9, z: 0 },
+                },
+            ],
+        }),
+        ['grass-a', 'grass-b'],
     );
 });

--- a/packages/game/src/scene/gameProfileMetadata.ts
+++ b/packages/game/src/scene/gameProfileMetadata.ts
@@ -195,6 +195,12 @@ export type GameProfileMetadata = {
     generatedLSystemCacheWriteCount?: number;
     generatedPlantProfile?: GeneratedPlantProfileSnapshot | null;
     instancedSnowOverlayCount?: number;
+    placementChunkLogicalTouchedCount?: number;
+    placementChunkLogicalUpdateCount?: number;
+    placementChunkPhysicalRebuildCount?: number;
+    placementChunkPhysicalRebuildDurationMaxMs?: number;
+    placementChunkPhysicalRebuildDurationP95Ms?: number;
+    placementChunkPhysicalTransformedInstanceCount?: number;
     qualityTier?: GameQualityProfileTier;
     rainParticleCount?: number;
     rainWetOverlayDistinctUniformCount?: number;

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -165,8 +165,77 @@ export type PlacedBlockEffect = {
 export type BlockPlacementDropAnimation = {
     createdAt: number;
     particlesSpawned: boolean;
+    renderId: number;
     sequence: number;
+    sourceBlockId: string;
 };
+
+function findBlockPlacementDropAnimationByRenderId(
+    animations: Readonly<Record<string, BlockPlacementDropAnimation>>,
+    renderId: number,
+) {
+    for (const [blockId, animation] of Object.entries(animations)) {
+        if (animation.renderId === renderId) {
+            return { animation, blockId };
+        }
+    }
+
+    return null;
+}
+
+export function getBlockPlacementDropAnimationByRenderId(
+    animations: Readonly<Record<string, BlockPlacementDropAnimation>>,
+    renderId: number,
+) {
+    return (
+        findBlockPlacementDropAnimationByRenderId(animations, renderId)
+            ?.animation ?? null
+    );
+}
+
+export function getBlockPlacementDropAnimationForBlockId(
+    animations: Readonly<Record<string, BlockPlacementDropAnimation>>,
+    blockId: string,
+) {
+    const current = animations[blockId];
+    if (current) {
+        return current;
+    }
+
+    return (
+        Object.values(animations).find(
+            (animation) => animation.sourceBlockId === blockId,
+        ) ?? null
+    );
+}
+
+export function getBlockPlacementDropAnimationRenderIdForBlockId(
+    animations: Readonly<Record<string, BlockPlacementDropAnimation>>,
+    blockId: string,
+) {
+    return getBlockPlacementDropAnimationForBlockId(animations, blockId)
+        ?.renderId;
+}
+
+export function resolveBlockPlacementDropAnimationRenderIdentity(
+    blockId: string,
+    animations: Readonly<Record<string, BlockPlacementDropAnimation>>,
+) {
+    const renderId = getBlockPlacementDropAnimationRenderIdForBlockId(
+        animations,
+        blockId,
+    );
+    return formatBlockPlacementDropAnimationRenderIdentity(blockId, renderId);
+}
+
+export function formatBlockPlacementDropAnimationRenderIdentity(
+    blockId: string,
+    renderId: number | undefined,
+) {
+    return renderId === undefined
+        ? `block:${blockId}`
+        : `placement:${renderId}`;
+}
 
 export type GardenVisitSummaryHighlight = {
     createdAt: number;
@@ -331,8 +400,13 @@ export type GameState = {
     consumePlacedBlockEffect: (blockId: string) => PlacedBlockEffect | null;
     blockPlacementDropAnimations: Record<string, BlockPlacementDropAnimation>;
     queueBlockPlacementDropAnimation: (blockId: string) => void;
-    markBlockPlacementDropParticlesSpawned: (blockId: string) => boolean;
-    completeBlockPlacementDropAnimation: (blockId: string) => void;
+    rekeyBlockPlacementDropAnimation: (
+        sourceBlockId: string,
+        targetBlockId: string,
+    ) => void;
+    cancelBlockPlacementDropAnimation: (blockId: string) => void;
+    markBlockPlacementDropParticlesSpawned: (renderId: number) => boolean;
+    completeBlockPlacementDropAnimation: (renderId: number) => void;
     gardenVisitSummaryHighlight: GardenVisitSummaryHighlight | null;
     setGardenVisitSummaryHighlight: (
         highlight: Omit<GardenVisitSummaryHighlight, 'createdAt' | 'sequence'>,
@@ -445,6 +519,7 @@ export function createGameState({
         timeLocation,
     );
     const { sunrise, sunset } = getGameSunriseSunset(timeLocation, now);
+    let nextBlockPlacementDropAnimationRenderId = 0;
     return createStore<GameState>((set, get) => ({
         isMock: isMock,
         mockGardenProfile: mockGardenProfile ?? 'default',
@@ -703,35 +778,89 @@ export function createGameState({
         },
         blockPlacementDropAnimations: {},
         queueBlockPlacementDropAnimation: (blockId) =>
-            set((state) => ({
-                blockPlacementDropAnimations: {
-                    ...state.blockPlacementDropAnimations,
-                    [blockId]: {
-                        createdAt: Date.now(),
-                        particlesSpawned: false,
-                        sequence:
-                            (state.blockPlacementDropAnimations[blockId]
-                                ?.sequence ?? 0) + 1,
+            set((state) => {
+                nextBlockPlacementDropAnimationRenderId += 1;
+                return {
+                    blockPlacementDropAnimations: {
+                        ...state.blockPlacementDropAnimations,
+                        [blockId]: {
+                            createdAt: Date.now(),
+                            particlesSpawned: false,
+                            renderId: nextBlockPlacementDropAnimationRenderId,
+                            sequence:
+                                (state.blockPlacementDropAnimations[blockId]
+                                    ?.sequence ?? 0) + 1,
+                            sourceBlockId: blockId,
+                        },
                     },
-                },
-            })),
-        markBlockPlacementDropParticlesSpawned: (blockId) => {
-            const animation = get().blockPlacementDropAnimations[blockId];
-            if (!animation || animation.particlesSpawned) {
+                };
+            }),
+        rekeyBlockPlacementDropAnimation: (sourceBlockId, targetBlockId) =>
+            set((state) => {
+                if (sourceBlockId === targetBlockId) {
+                    return state;
+                }
+                const animation =
+                    state.blockPlacementDropAnimations[sourceBlockId];
+                if (!animation) {
+                    return state;
+                }
+
+                const blockPlacementDropAnimations = {
+                    ...state.blockPlacementDropAnimations,
+                    [targetBlockId]: animation,
+                };
+                delete blockPlacementDropAnimations[sourceBlockId];
+
+                return { blockPlacementDropAnimations };
+            }),
+        cancelBlockPlacementDropAnimation: (blockId) =>
+            set((state) => {
+                const animation = getBlockPlacementDropAnimationForBlockId(
+                    state.blockPlacementDropAnimations,
+                    blockId,
+                );
+                if (!animation) {
+                    return state;
+                }
+                const entry = findBlockPlacementDropAnimationByRenderId(
+                    state.blockPlacementDropAnimations,
+                    animation.renderId,
+                );
+                if (!entry) {
+                    return state;
+                }
+
+                const blockPlacementDropAnimations = {
+                    ...state.blockPlacementDropAnimations,
+                };
+                delete blockPlacementDropAnimations[entry.blockId];
+
+                return { blockPlacementDropAnimations };
+            }),
+        markBlockPlacementDropParticlesSpawned: (renderId) => {
+            const entry = findBlockPlacementDropAnimationByRenderId(
+                get().blockPlacementDropAnimations,
+                renderId,
+            );
+            if (!entry || entry.animation.particlesSpawned) {
                 return false;
             }
 
             set((state) => {
-                const current = state.blockPlacementDropAnimations[blockId];
-                if (!current || current.particlesSpawned) {
+                const currentEntry = findBlockPlacementDropAnimationByRenderId(
+                    state.blockPlacementDropAnimations,
+                    renderId,
+                );
+                if (!currentEntry || currentEntry.animation.particlesSpawned) {
                     return state;
                 }
 
                 return {
                     blockPlacementDropAnimations: {
                         ...state.blockPlacementDropAnimations,
-                        [blockId]: {
-                            ...current,
+                        [currentEntry.blockId]: {
+                            ...currentEntry.animation,
                             particlesSpawned: true,
                         },
                     },
@@ -739,19 +868,15 @@ export function createGameState({
             });
             return true;
         },
-        completeBlockPlacementDropAnimation: (blockId) =>
-            set((state) => {
-                if (!state.blockPlacementDropAnimations[blockId]) {
-                    return state;
-                }
-
-                const blockPlacementDropAnimations = {
-                    ...state.blockPlacementDropAnimations,
-                };
-                delete blockPlacementDropAnimations[blockId];
-
-                return { blockPlacementDropAnimations };
-            }),
+        completeBlockPlacementDropAnimation: (renderId) => {
+            const entry = findBlockPlacementDropAnimationByRenderId(
+                get().blockPlacementDropAnimations,
+                renderId,
+            );
+            if (entry) {
+                get().cancelBlockPlacementDropAnimation(entry.blockId);
+            }
+        },
         gardenVisitSummaryHighlight: null,
         setGardenVisitSummaryHighlight: (highlight) =>
             set((state) => ({

--- a/packages/game/src/useGameState.unit.ts
+++ b/packages/game/src/useGameState.unit.ts
@@ -2,7 +2,12 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { createActiveDragPreviewTarget } from './dragPreviewIdentity';
 import type { ActiveDragPreview } from './useGameState';
-import { activeDragPreviewsEqual, createGameState } from './useGameState';
+import {
+    activeDragPreviewsEqual,
+    createGameState,
+    getBlockPlacementDropAnimationRenderIdForBlockId,
+    resolveBlockPlacementDropAnimationRenderIdentity,
+} from './useGameState';
 import { getGameSunriseSunset, getGameTimeOfDay } from './utils/timeOfDay';
 
 function createPreview(): ActiveDragPreview {
@@ -186,6 +191,122 @@ test('clearPickupSelectionTargets resets every active pickup target', () => {
         store.getState().clearPickupSelectionTargets();
 
         assert.deepEqual(store.getState().pickupSelectionTargets, []);
+    } finally {
+        store.getState().audio.dispose();
+    }
+});
+
+test('placement animation keeps render and completion identity through optimistic rekey', () => {
+    const store = createGameState({
+        appBaseUrl: '',
+        freezeTime: new Date('2026-01-01T12:00:00.000Z'),
+        isMock: true,
+    });
+
+    try {
+        store.getState().queueBlockPlacementDropAnimation('optimistic');
+        const animation =
+            store.getState().blockPlacementDropAnimations.optimistic;
+        assert.ok(animation);
+        const optimisticRenderIdentity =
+            resolveBlockPlacementDropAnimationRenderIdentity(
+                'optimistic',
+                store.getState().blockPlacementDropAnimations,
+            );
+        const optimisticRenderId =
+            getBlockPlacementDropAnimationRenderIdForBlockId(
+                store.getState().blockPlacementDropAnimations,
+                'optimistic',
+            );
+
+        store.getState().queueBlockPlacementDropAnimation('unrelated');
+        assert.equal(
+            getBlockPlacementDropAnimationRenderIdForBlockId(
+                store.getState().blockPlacementDropAnimations,
+                'optimistic',
+            ),
+            optimisticRenderId,
+        );
+        store.getState().cancelBlockPlacementDropAnimation('unrelated');
+
+        store
+            .getState()
+            .rekeyBlockPlacementDropAnimation('optimistic', 'persisted');
+
+        assert.equal(
+            store.getState().blockPlacementDropAnimations.optimistic,
+            undefined,
+        );
+        assert.strictEqual(
+            store.getState().blockPlacementDropAnimations.persisted,
+            animation,
+        );
+        assert.equal(
+            resolveBlockPlacementDropAnimationRenderIdentity(
+                'optimistic',
+                store.getState().blockPlacementDropAnimations,
+            ),
+            optimisticRenderIdentity,
+        );
+        assert.equal(
+            resolveBlockPlacementDropAnimationRenderIdentity(
+                'persisted',
+                store.getState().blockPlacementDropAnimations,
+            ),
+            optimisticRenderIdentity,
+        );
+
+        assert.equal(
+            store
+                .getState()
+                .markBlockPlacementDropParticlesSpawned(animation.renderId),
+            true,
+        );
+        assert.equal(
+            store.getState().blockPlacementDropAnimations.persisted
+                ?.particlesSpawned,
+            true,
+        );
+        assert.equal(
+            store
+                .getState()
+                .markBlockPlacementDropParticlesSpawned(animation.renderId),
+            false,
+        );
+
+        store
+            .getState()
+            .completeBlockPlacementDropAnimation(animation.renderId);
+        assert.deepEqual(store.getState().blockPlacementDropAnimations, {});
+        assert.equal(
+            resolveBlockPlacementDropAnimationRenderIdentity(
+                'persisted',
+                store.getState().blockPlacementDropAnimations,
+            ),
+            'block:persisted',
+        );
+    } finally {
+        store.getState().audio.dispose();
+    }
+});
+
+test('placement animation cancellation resolves the optimistic source after rekey', () => {
+    const store = createGameState({
+        appBaseUrl: '',
+        freezeTime: new Date('2026-01-01T12:00:00.000Z'),
+        isMock: true,
+    });
+
+    try {
+        store.getState().queueBlockPlacementDropAnimation('optimistic');
+        store
+            .getState()
+            .rekeyBlockPlacementDropAnimation('optimistic', 'persisted');
+        store.getState().cancelBlockPlacementDropAnimation('optimistic');
+
+        assert.deepEqual(store.getState().blockPlacementDropAnimations, {});
+        store.getState().cancelBlockPlacementDropAnimation('missing');
+        assert.deepEqual(store.getState().blockPlacementDropAnimations, {});
     } finally {
         store.getState().audio.dispose();
     }


### PR DESCRIPTION
## What

- address placement-drop animations by stable world-space instance chunk
- cache per-chunk render inputs so unchanged chunks preserve object and instance-array identity across animation membership changes
- rebuild only chunks that contain an active placement animation instead of remapping the full instanced entity batch
- transfer optimistic animation records to persisted block IDs on success and cancel them on failure
- preserve the active drop spring through optimistic-to-persisted ID replacement with an immutable render identity
- add window-scoped logical/physical rebuild metrics and a repeatable dense placement profile scenario

## Why

A placement animation previously caused every instance chunk for that entity to rebuild while the animation was active. In the 57-chunk dense fixture, the production profile now dispatches the staggered placement command with four touched chunks, four physical chunk rebuilds, and 56 transformed instances total; unrelated active chunks retain their original references.

Independent review corrected cached active-chunk rebuilds, hidden physical reference churn, per-session metric resets, optimistic animation cleanup, and a fast-response spring remount. Completion now updates only the affected non-instanced slot or instanced chunk; instanced blocks do not gain per-block scene subscriptions.

## Validation

- `pnpm --filter @gredice/game test` — 600/600 pass
- `pnpm lint --filter @gredice/game` — 800 files, no fixes
- `pnpm --filter @gredice/game typecheck`
- `pnpm typecheck --filter garden --filter www` — 6/6 tasks
- `pnpm --filter garden test:profile` — 8/8 pass
- production Garden build plus `placement` profile — four touched chunks / four physical rebuilds / 56 transformed instances; rebuild p95 and max 0.1ms
- focused optimistic-to-persisted animation identity tests — 16/16 pass
- `git diff --check`

The absolute software-headless frame budget remains red because SwiftShader/readback stalls dominate the run; the localized rebuild counters are the acceptance evidence, not those absolute FPS values.

Closes #4292