### PR TITLE
perf(game): share instanced block interactions

### DIFF
--- a/apps/garden/scripts/profile-game-scene.mjs
+++ b/apps/garden/scripts/profile-game-scene.mjs
@@ -1957,6 +1957,27 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 typeof metadata.generatedLSystemCacheWriteCount === 'number'
                     ? metadata.generatedLSystemCacheWriteCount
                     : null,
+            instancedInteractionControllerCount:
+                typeof metadata.instancedInteractionControllerCount === 'number'
+                    ? metadata.instancedInteractionControllerCount
+                    : null,
+            instancedInteractionResolutionCount:
+                typeof metadata.instancedInteractionResolutionCount === 'number'
+                    ? metadata.instancedInteractionResolutionCount
+                    : null,
+            instancedInteractionResolutionMaxMs:
+                typeof metadata.instancedInteractionResolutionMaxMs === 'number'
+                    ? metadata.instancedInteractionResolutionMaxMs
+                    : null,
+            instancedInteractionResolutionTotalMs:
+                typeof metadata.instancedInteractionResolutionTotalMs ===
+                'number'
+                    ? metadata.instancedInteractionResolutionTotalMs
+                    : null,
+            instancedInteractionTargetCount:
+                typeof metadata.instancedInteractionTargetCount === 'number'
+                    ? metadata.instancedInteractionTargetCount
+                    : null,
             instancedSnowOverlayCount:
                 typeof metadata.instancedSnowOverlayCount === 'number'
                     ? metadata.instancedSnowOverlayCount

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -2,7 +2,6 @@
 
 import { cx } from '@gredice/ui/utils';
 import {
-    Fragment,
     type HTMLAttributes,
     Suspense,
     useEffect,
@@ -157,28 +156,6 @@ function useAutoQualityProfileMetrics(enabled: boolean) {
     return metrics;
 }
 
-function shouldRenderEntityFactoryForBlock({
-    blockName,
-    blockIndex,
-    noControls,
-    stackLength,
-}: {
-    blockName: string;
-    blockIndex: number;
-    noControls: boolean | undefined;
-    stackLength: number;
-}) {
-    if (!instancedBlockNames.includes(blockName)) {
-        return true;
-    }
-
-    if (noControls) {
-        return false;
-    }
-
-    return blockIndex >= 0 && blockIndex < stackLength;
-}
-
 function GameSceneEntitySlot({
     block,
     noControls,
@@ -219,7 +196,6 @@ function GameSceneEntitySlot({
         </Suspense>
     );
 }
-
 export function GameScene({
     cameraPosition = defaultGameCameraPosition,
     zoom = 'normal',
@@ -378,41 +354,11 @@ export function GameScene({
                                 {garden?.stacks.map((stack) =>
                                     stack.blocks?.map((block, i) => {
                                         if (
-                                            !shouldRenderEntityFactoryForBlock({
-                                                blockName: block.name,
-                                                blockIndex: i,
-                                                noControls,
-                                                stackLength:
-                                                    stack.blocks.length,
-                                            })
-                                        ) {
-                                            return null;
-                                        }
-
-                                        if (
                                             instancedBlockNames.includes(
                                                 block.name,
                                             )
                                         ) {
-                                            const key = `${stack.position.x}|${stack.position.y}|${stack.position.z}|${block.id}-${block.name}-${i}`;
-                                            return (
-                                                <Fragment key={key}>
-                                                    <EntityFactory
-                                                        name={block.name}
-                                                        stack={stack}
-                                                        block={block}
-                                                        stacks={garden.stacks}
-                                                        rotation={
-                                                            block.rotation
-                                                        }
-                                                        variant={block.variant}
-                                                        noRenderInView={
-                                                            instancedBlockNames
-                                                        }
-                                                        noControl={noControls}
-                                                    />
-                                                </Fragment>
-                                            );
+                                            return null;
                                         }
 
                                         const slotKey = `${stack.position.x}|${stack.position.y}|${stack.position.z}|${block.name}-${i}`;
@@ -459,6 +405,7 @@ export function GameScene({
                                 )}
                                 <BlockInteractionLayer
                                     controlsEnabled={!noControls}
+                                    sharedControllerEnabled
                                     stacks={garden?.stacks}
                                 />
                                 {renderDetails && zoom !== 'far' && (

--- a/packages/game/src/controls/BlockInteractionLayer.tsx
+++ b/packages/game/src/controls/BlockInteractionLayer.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import type { ThreeEvent } from '@react-three/fiber';
-import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { type Mesh, MeshBasicMaterial, type Vector3 } from 'three';
 import { instancedBlockNames } from '../entities/EntityInstances';
 import { useBlockData } from '../hooks/useBlockData';
+import { updateGameProfileMetadata } from '../scene/gameProfileMetadata';
 import type { Stack } from '../types/Stack';
 import { useGameState } from '../useGameState';
 import { getBlockHitboxSize } from '../utils/blockHitbox';
@@ -19,6 +20,11 @@ import {
     hasCloserNonLayerIntersection,
     resolveBlockInteractionLayerTarget,
 } from './BlockInteractionResolver';
+import {
+    InstancedBlockInteractionController,
+    type InstancedBlockInteractionControllerApi,
+} from './InstancedBlockInteractionController';
+import { InstancedEntityRenderModeDebugOverlays } from './InstancedEntityRenderModeDebugOverlays';
 
 type LayerEvent<TEvent extends PointerEvent | MouseEvent> =
     ThreeEvent<TEvent> & {
@@ -87,15 +93,23 @@ function hasStopped<TEvent extends PointerEvent | MouseEvent>(
 
 export function BlockInteractionLayer({
     controlsEnabled,
+    sharedControllerEnabled = false,
     stacks,
 }: {
     controlsEnabled: boolean;
+    sharedControllerEnabled?: boolean;
     stacks: Stack[] | undefined;
 }) {
     const { data: blockData } = useBlockData();
     const registry = useBlockInteractionRegistry();
     const hoveredTargetKeyRef = useRef<string | null>(null);
     const layerRef = useRef<Mesh>(null);
+    const resolutionProfileRef = useRef({
+        count: 0,
+        maxMs: 0,
+        totalMs: 0,
+    });
+    const resolutionProfileFlushTimerRef = useRef<number | null>(null);
     const view = useGameState((state) => state.view);
     const editHitboxDebugVisible = useGameState(
         (state) => state.editHitboxDebugVisible,
@@ -106,6 +120,10 @@ export function BlockInteractionLayer({
     );
     const interactionBounds = useMemo(
         () => getBlockInteractionLayerBounds(targets),
+        [targets],
+    );
+    const targetsByKey = useMemo(
+        () => new Map(targets.map((target) => [target.key, target])),
         [targets],
     );
     const material = useMemo(
@@ -132,17 +150,67 @@ export function BlockInteractionLayer({
         };
     }, [material]);
 
-    if (!controlsEnabled || view === 'closeup' || targets.length === 0) {
-        return null;
+    useEffect(() => {
+        if (!sharedControllerEnabled) {
+            return;
+        }
+
+        resolutionProfileRef.current = {
+            count: 0,
+            maxMs: 0,
+            totalMs: 0,
+        };
+        updateGameProfileMetadata({
+            instancedInteractionResolutionCount: 0,
+            instancedInteractionResolutionMaxMs: 0,
+            instancedInteractionResolutionTotalMs: 0,
+        });
+
+        return () => {
+            if (resolutionProfileFlushTimerRef.current !== null) {
+                window.clearTimeout(resolutionProfileFlushTimerRef.current);
+                resolutionProfileFlushTimerRef.current = null;
+            }
+        };
+    }, [sharedControllerEnabled]);
+
+    function flushResolutionProfile() {
+        resolutionProfileFlushTimerRef.current = null;
+        const profile = resolutionProfileRef.current;
+        updateGameProfileMetadata({
+            instancedInteractionResolutionCount: profile.count,
+            instancedInteractionResolutionMaxMs: profile.maxMs,
+            instancedInteractionResolutionTotalMs: profile.totalMs,
+        });
     }
 
-    function getRegisteredTarget<TEvent extends PointerEvent | MouseEvent>(
+    function recordResolutionDuration(durationMs: number) {
+        const profile = resolutionProfileRef.current;
+        profile.count += 1;
+        profile.maxMs = Math.max(profile.maxMs, durationMs);
+        profile.totalMs += durationMs;
+
+        if (
+            sharedControllerEnabled &&
+            resolutionProfileFlushTimerRef.current === null
+        ) {
+            resolutionProfileFlushTimerRef.current = window.setTimeout(
+                flushResolutionProfile,
+                250,
+            );
+        }
+    }
+
+    function getResolvedTarget<TEvent extends PointerEvent | MouseEvent>(
         event: ThreeEvent<TEvent>,
+        controller: InstancedBlockInteractionControllerApi | null,
     ) {
+        const resolutionStart = performance.now();
         const resolvedLayerTarget = resolveBlockInteractionLayerTarget(
             targets,
             event.ray,
         );
+        recordResolutionDuration(performance.now() - resolutionStart);
         if (!resolvedLayerTarget) {
             return null;
         }
@@ -159,22 +227,24 @@ export function BlockInteractionLayer({
             return null;
         }
 
-        const registeredTarget = registry?.getTarget(
-            resolvedLayerTarget.target.key,
-        );
-        if (!registeredTarget) {
+        const registeredTarget = controller
+            ? undefined
+            : registry?.getTarget(resolvedLayerTarget.target.key);
+        if (!controller && !registeredTarget) {
             return null;
         }
 
         return {
             event: createLayerEvent(event, resolvedLayerTarget.hitPoint),
             key: resolvedLayerTarget.target.key,
-            target: registeredTarget,
+            registeredTarget,
+            target: resolvedLayerTarget.target,
         };
     }
 
     function clearHoveredTarget(
         event: ThreeEvent<PointerEvent>,
+        controller: InstancedBlockInteractionControllerApi | null,
         layerEvent?: LayerEvent<PointerEvent>,
     ) {
         const hoveredTargetKey = hoveredTargetKeyRef.current;
@@ -183,6 +253,14 @@ export function BlockInteractionLayer({
         }
 
         hoveredTargetKeyRef.current = null;
+
+        if (controller) {
+            controller.onPointerLeave(
+                targetsByKey.get(hoveredTargetKey) ?? null,
+                layerEvent ?? createLayerEvent(event, event.point),
+            );
+            return;
+        }
 
         const registeredTarget = registry?.getTarget(hoveredTargetKey);
         if (!registeredTarget) {
@@ -194,85 +272,160 @@ export function BlockInteractionLayer({
         );
     }
 
-    function handlePointerMove(event: ThreeEvent<PointerEvent>) {
-        const resolved = getRegisteredTarget(event);
-        const nextTargetKey = resolved?.key ?? null;
+    function renderLayer(
+        controller: InstancedBlockInteractionControllerApi | null,
+    ) {
+        function handlePointerMove(event: ThreeEvent<PointerEvent>) {
+            const resolved = getResolvedTarget(event, controller);
+            const nextTargetKey = resolved?.key ?? null;
 
-        if (hoveredTargetKeyRef.current === nextTargetKey) {
-            return;
+            if (hoveredTargetKeyRef.current === nextTargetKey) {
+                return;
+            }
+
+            clearHoveredTarget(event, controller, resolved?.event);
+            hoveredTargetKeyRef.current = nextTargetKey;
+            if (!resolved) {
+                return;
+            }
+
+            if (controller) {
+                controller.onPickupPointerEnter(
+                    resolved.target,
+                    resolved.event,
+                );
+                if (!hasStopped(resolved.event)) {
+                    controller.onPointerEnter(resolved.target, resolved.event);
+                }
+                return;
+            }
+
+            resolved.registeredTarget?.handlers.onPickupPointerEnter?.(
+                resolved.event,
+            );
+            if (!hasStopped(resolved.event)) {
+                resolved.registeredTarget?.handlers.onPointerEnter?.(
+                    resolved.event,
+                );
+            }
         }
 
-        clearHoveredTarget(event, resolved?.event);
-        hoveredTargetKeyRef.current = nextTargetKey;
-        resolved?.target.handlers.onPickupPointerEnter?.(resolved.event);
-        if (resolved && hasStopped(resolved.event)) {
-            return;
-        }
-        resolved?.target.handlers.onPointerEnter?.(resolved.event);
-    }
+        function handlePointerDown(event: ThreeEvent<PointerEvent>) {
+            const resolved = getResolvedTarget(event, controller);
+            if (!resolved) {
+                return;
+            }
 
-    function handlePointerDown(event: ThreeEvent<PointerEvent>) {
-        const resolved = getRegisteredTarget(event);
-        if (!resolved) {
-            return;
-        }
+            if (controller) {
+                controller.onPointerDown(resolved.target, resolved.event);
+                return;
+            }
 
-        resolved.target.handlers.onRotatePointerDown?.(resolved.event);
-        if (!hasStopped(resolved.event)) {
-            resolved.target.handlers.onPointerDown?.(resolved.event);
-        }
-    }
-
-    function handlePointerLeave(event: ThreeEvent<PointerEvent>) {
-        const resolved = getRegisteredTarget(event);
-        resolved?.target.handlers.onRotatePointerLeave?.(resolved.event);
-        clearHoveredTarget(event, resolved?.event);
-    }
-
-    function handlePointerUp(event: ThreeEvent<PointerEvent>) {
-        const resolved = getRegisteredTarget(event);
-        resolved?.target.handlers.onRotatePointerUp?.(resolved.event);
-    }
-
-    function handleClick(event: ThreeEvent<MouseEvent>) {
-        const resolved = getRegisteredTarget(event);
-        if (!resolved) {
-            return;
+            resolved.registeredTarget?.handlers.onRotatePointerDown?.(
+                resolved.event,
+            );
+            if (!hasStopped(resolved.event)) {
+                resolved.registeredTarget?.handlers.onPointerDown?.(
+                    resolved.event,
+                );
+            }
         }
 
-        resolved.target.handlers.onClick?.(resolved.event);
-        if (!hasStopped(resolved.event)) {
-            resolved.target.handlers.onSelectClick?.(resolved.event);
+        function handlePointerLeave(event: ThreeEvent<PointerEvent>) {
+            const resolved = getResolvedTarget(event, controller);
+            if (!controller) {
+                resolved?.registeredTarget?.handlers.onRotatePointerLeave?.(
+                    resolved.event,
+                );
+            }
+            clearHoveredTarget(event, controller, resolved?.event);
         }
-    }
 
-    return (
-        // biome-ignore lint/a11y/noStaticElementInteractions: Three.js mesh is the single block interaction plane.
-        <mesh
-            ref={layerRef}
-            name={`Interaction:BlockLayer:targets:${targets.length}`}
-            frustumCulled={false}
-            onClick={handleClick}
-            onPointerDown={handlePointerDown}
-            onPointerLeave={handlePointerLeave}
-            onPointerMove={handlePointerMove}
-            onPointerOver={handlePointerMove}
-            onPointerUp={handlePointerUp}
-            position={[
-                interactionBounds.centerX,
-                interactionBounds.centerY,
-                interactionBounds.centerZ,
-            ]}
-            renderOrder={10_000}
-        >
-            <boxGeometry
-                args={[
-                    interactionBounds.width,
-                    interactionBounds.height,
-                    interactionBounds.depth,
+        function handlePointerUp(event: ThreeEvent<PointerEvent>) {
+            const resolved = getResolvedTarget(event, controller);
+            if (!resolved) {
+                return;
+            }
+            if (controller) {
+                controller.onPointerUp(resolved.target, resolved.event);
+                return;
+            }
+            resolved.registeredTarget?.handlers.onRotatePointerUp?.(
+                resolved.event,
+            );
+        }
+
+        function handleClick(event: ThreeEvent<MouseEvent>) {
+            const resolved = getResolvedTarget(event, controller);
+            if (!resolved) {
+                return;
+            }
+
+            if (controller) {
+                controller.onClick(resolved.target, resolved.event);
+                if (!hasStopped(resolved.event)) {
+                    controller.onSelectClick(resolved.target, resolved.event);
+                }
+                return;
+            }
+
+            resolved.registeredTarget?.handlers.onClick?.(resolved.event);
+            if (!hasStopped(resolved.event)) {
+                resolved.registeredTarget?.handlers.onSelectClick?.(
+                    resolved.event,
+                );
+            }
+        }
+
+        return (
+            // biome-ignore lint/a11y/noStaticElementInteractions: Three.js mesh is the single block interaction plane.
+            <mesh
+                ref={layerRef}
+                name={`Interaction:BlockLayer:targets:${targets.length}`}
+                frustumCulled={false}
+                onClick={handleClick}
+                onPointerDown={handlePointerDown}
+                onPointerLeave={handlePointerLeave}
+                onPointerMove={handlePointerMove}
+                onPointerOver={handlePointerMove}
+                onPointerUp={handlePointerUp}
+                position={[
+                    interactionBounds.centerX,
+                    interactionBounds.centerY,
+                    interactionBounds.centerZ,
                 ]}
-            />
-            <primitive attach="material" object={material} />
-        </mesh>
+                renderOrder={10_000}
+            >
+                <boxGeometry
+                    args={[
+                        interactionBounds.width,
+                        interactionBounds.height,
+                        interactionBounds.depth,
+                    ]}
+                />
+                <primitive attach="material" object={material} />
+            </mesh>
+        );
+    }
+
+    if (!controlsEnabled || targets.length === 0) {
+        return null;
+    }
+
+    if (view === 'closeup') {
+        return sharedControllerEnabled ? (
+            <InstancedEntityRenderModeDebugOverlays targets={targets} />
+        ) : null;
+    }
+
+    return sharedControllerEnabled ? (
+        <>
+            <InstancedEntityRenderModeDebugOverlays targets={targets} />
+            <InstancedBlockInteractionController targets={targets}>
+                {(controller) => renderLayer(controller)}
+            </InstancedBlockInteractionController>
+        </>
+    ) : (
+        renderLayer(null)
     );
 }

--- a/packages/game/src/controls/InstancedBlockInteractionController.tsx
+++ b/packages/game/src/controls/InstancedBlockInteractionController.tsx
@@ -1,0 +1,1810 @@
+'use client';
+
+import { animated, useSpring } from '@react-spring/three';
+import { Shadow } from '@react-three/drei';
+import { type ThreeEvent, useThree } from '@react-three/fiber';
+import {
+    type ReactNode,
+    Suspense,
+    useCallback,
+    useContext,
+    useEffect,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
+import { Plane, Raycaster, Vector2, Vector3 } from 'three';
+import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
+import {
+    type ActiveDragPreviewTarget,
+    activeDragPreviewTargetMatches,
+    createActiveDragPreviewTarget,
+    findActiveDragPreviewTargetOffset,
+} from '../dragPreviewIdentity';
+import { useBlockData } from '../hooks/useBlockData';
+import { useBlockDelete } from '../hooks/useBlockDelete';
+import { useBlockMove } from '../hooks/useBlockMove';
+import { useBlockRecycle } from '../hooks/useBlockRecycle';
+import { useBlockRotate } from '../hooks/useBlockRotate';
+import {
+    type CurrentGarden,
+    useCurrentGardenCache,
+} from '../hooks/useCurrentGarden';
+import { useGardenBoxStoreBlock } from '../hooks/useGardenBoxStoreBlock';
+import { isPointOverItemsHudDropTarget } from '../itemsHudDropTarget';
+import {
+    resolveBlockParticleType,
+    useParticles,
+} from '../particles/ParticleSystem';
+import { updateGameProfileMetadata } from '../scene/gameProfileMetadata';
+import {
+    type ActiveDragPreview,
+    GameStateContext,
+    useGameState,
+} from '../useGameState';
+import { useSetRaisedBedCloseupParam } from '../useRaisedBedCloseup';
+import { useGiftBoxParam } from '../useUrlState';
+import { getBlockDataByName, getStackHeight } from '../utils/getStackHeight';
+import {
+    triggerPickHaptic,
+    triggerPlaceHaptic,
+    triggerSelectionHaptic,
+} from '../utils/haptics';
+import {
+    findAttachedRaisedBedBlockId,
+    findRaisedBedByBlockId,
+} from '../utils/raisedBedBlocks';
+import {
+    type BlockInteractionTarget,
+    createBlockInteractionTargetKey,
+} from './BlockInteractionRegistry';
+import type { BlockInteractionLayerTarget } from './BlockInteractionResolver';
+import {
+    areBlockInteractionsSuppressed,
+    suppressBlockInteractions,
+} from './blockInteractionSuppression';
+import {
+    getInstancedInteractionMountProfileMetadata,
+    getPickupPointerMoveCancelDistance,
+    type InstancedInteractionFirstTap,
+    resolveInstancedInteractionTargetReconciliation,
+    resolveInstancedRotationTap,
+} from './instancedBlockInteractionCore';
+import { RecycleIndicator } from './PickableGroup';
+import {
+    createPickupPlacementPreviewResolver,
+    type MovingSegment,
+    type PickupPlacementPreviewResolver,
+    type ResolvedPlacementPreview,
+} from './PickupPlacementResolver';
+import { resolvePickupHudDropAction } from './pickupRemovalDropAction';
+import {
+    createPickupSelectionMoveRequests,
+    createPickupSelectionMovingSegments,
+} from './pickupSelection';
+import { useDeferredSingleClickByTarget } from './useDeferredSingleClick';
+import { useHoveredBlockStore } from './useHoveredBlockStore';
+
+const groundPlane = new Plane(new Vector3(0, 1, 0), 0);
+const pickupHintDelayMs = 120;
+const pickupHoldDelayMs = 320;
+const pickupHintLift = 0.04;
+const pickupLift = 0.1;
+const suppressClickAfterDragMs = 450;
+const placementSnapSearchRadius = 5;
+const animalPickupDisturbanceRadius = 1.8;
+const rotateDragThreshold = 0.1;
+const doubleTapThresholdMs = 320;
+
+type PickupAnchorOffset = {
+    x: number;
+    y: number;
+    z: number;
+};
+
+type PointerSession = {
+    target: BlockInteractionLayerTarget;
+    activePreviewTarget: ActiveDragPreviewTarget;
+    pointerId: number;
+    pointerType: string;
+    startClientX: number;
+    startClientY: number;
+    lastClientX: number;
+    lastClientY: number;
+    pickupClientX: number | null;
+    pickupClientY: number | null;
+    pickupAnchorOffset: PickupAnchorOffset;
+    hasDraggedAfterPickup: boolean;
+    activated: boolean;
+    cancelled: boolean;
+    hintVisible: boolean;
+    hintTimer: number | null;
+    holdTimer: number | null;
+    dragAutopanFrame: number | null;
+    dragAutopanPreviousTime: number | null;
+    latestPreview: ResolvedPlacementPreview | null;
+};
+
+type RotationPointerSession = {
+    point: Vector3;
+    targetKey: string;
+};
+
+export type InstancedBlockInteractionControllerApi = {
+    onClick: (
+        target: BlockInteractionLayerTarget,
+        event: ThreeEvent<MouseEvent>,
+    ) => void;
+    onPickupPointerEnter: (
+        target: BlockInteractionLayerTarget,
+        event: ThreeEvent<PointerEvent>,
+    ) => void;
+    onPointerDown: (
+        target: BlockInteractionLayerTarget,
+        event: ThreeEvent<PointerEvent>,
+    ) => void;
+    onPointerEnter: (
+        target: BlockInteractionLayerTarget,
+        event: ThreeEvent<PointerEvent>,
+    ) => void;
+    onPointerLeave: (
+        target: BlockInteractionLayerTarget | null,
+        event: ThreeEvent<PointerEvent>,
+    ) => void;
+    onPointerUp: (
+        target: BlockInteractionLayerTarget,
+        event: ThreeEvent<PointerEvent>,
+    ) => void;
+    onSelectClick: (
+        target: BlockInteractionLayerTarget,
+        event: ThreeEvent<MouseEvent>,
+    ) => void;
+};
+
+function pointerDistance(session: PointerSession, x: number, y: number) {
+    return Math.hypot(x - session.startClientX, y - session.startClientY);
+}
+
+function clearPointerSessionTimers(session: PointerSession) {
+    if (session.hintTimer) {
+        window.clearTimeout(session.hintTimer);
+        session.hintTimer = null;
+    }
+    if (session.holdTimer) {
+        window.clearTimeout(session.holdTimer);
+        session.holdTimer = null;
+    }
+}
+
+function activeDragPreviewAffectsTarget(
+    preview: ActiveDragPreview | null | undefined,
+    target: ActiveDragPreviewTarget,
+) {
+    return (
+        activeDragPreviewTargetMatches(preview?.source, target) ||
+        Boolean(findActiveDragPreviewTargetOffset(preview?.targets, target))
+    );
+}
+
+const placementPreviewEpsilon = 0.0001;
+
+function placementPreviewNumbersEqual(left: number, right: number) {
+    return Math.abs(left - right) <= placementPreviewEpsilon;
+}
+
+function placementPreviewTargetsEqual(
+    left: ResolvedPlacementPreview['targetOffsets'],
+    right: ResolvedPlacementPreview['targetOffsets'],
+) {
+    if (left.length !== right.length) {
+        return false;
+    }
+
+    return left.every((leftTarget, index) => {
+        const rightTarget = right[index];
+        return (
+            Boolean(rightTarget) &&
+            activeDragPreviewTargetMatches(leftTarget, rightTarget) &&
+            placementPreviewNumbersEqual(
+                leftTarget.hoverHeight,
+                rightTarget?.hoverHeight ?? Number.NaN,
+            )
+        );
+    });
+}
+
+function resolvedPlacementPreviewsEqual(
+    left: ResolvedPlacementPreview | null | undefined,
+    right: ResolvedPlacementPreview | null | undefined,
+) {
+    if (left === right) {
+        return true;
+    }
+    if (!left || !right) {
+        return false;
+    }
+
+    return (
+        placementPreviewNumbersEqual(left.relative.x, right.relative.x) &&
+        placementPreviewNumbersEqual(left.relative.z, right.relative.z) &&
+        placementPreviewNumbersEqual(
+            left.previewHoverHeight,
+            right.previewHoverHeight,
+        ) &&
+        left.hoveredGardenBoxBlockId === right.hoveredGardenBoxBlockId &&
+        left.canStoreInGardenBox === right.canStoreInGardenBox &&
+        left.nextIsOverRecycler === right.nextIsOverRecycler &&
+        left.nextIsBlocked === right.nextIsBlocked &&
+        placementPreviewTargetsEqual(left.targetOffsets, right.targetOffsets)
+    );
+}
+
+function createPreviewTarget(target: BlockInteractionTarget) {
+    return createActiveDragPreviewTarget({
+        blockId: target.block.id,
+        blockIndex: target.blockIndex,
+        stackPosition: {
+            x: target.stack.position.x,
+            z: target.stack.position.z,
+        },
+    });
+}
+
+function isSelectableTarget(target: BlockInteractionLayerTarget) {
+    return (
+        target.block.name === 'GardenBox' ||
+        target.block.name.startsWith('GiftBox_') ||
+        target.block.name === 'Raised_Bed'
+    );
+}
+
+function targetKeyFromPreviewTarget(target: ActiveDragPreviewTarget) {
+    return createBlockInteractionTargetKey({
+        blockId: target.blockId,
+        blockIndex: target.blockIndex,
+        stackPosition: target.stackPosition,
+    });
+}
+
+export function InstancedBlockInteractionController({
+    children,
+    targets,
+}: {
+    children: (controller: InstancedBlockInteractionControllerApi) => ReactNode;
+    targets: BlockInteractionLayerTarget[];
+}) {
+    const [dragSprings, dragSpringsApi] = useSpring(() => ({
+        from: { internalPosition: [0, 0, 0], scale: 1 },
+        config: {
+            mass: 0.1,
+            tension: 200,
+            friction: 10,
+        },
+    }));
+    const { spawn } = useParticles();
+    const getCurrentGarden = useCurrentGardenCache();
+    const { data: blocksData } = useBlockData();
+    const gameStateStore = useContext(GameStateContext);
+    const camera = useThree((state) => state.camera);
+    const gl = useThree((state) => state.gl);
+    const { domElement } = gl;
+    const dragState = useRef({
+        pt: new Vector3(),
+        dest: new Vector3(),
+        relative: new Vector3(),
+        projected: new Vector3(),
+    });
+    const raycaster = useRef(new Raycaster());
+    const pointerVector = useRef(new Vector2());
+
+    const effectsAudioMixer = useGameState((state) => state.audio.effects);
+    const gameCamera = useGameState((state) => state.gameCamera);
+    const setIsDragging = useGameState((state) => state.setIsDragging);
+    const pickupSound = effectsAudioMixer.useSoundEffect(
+        'https://cdn.gredice.com/sounds/effects/Pick Grass 01.mp3',
+    );
+    const dropSound = effectsAudioMixer.useSoundEffect(
+        'https://cdn.gredice.com/sounds/effects/Drop Grass 01.mp3',
+    );
+    const swipeSound = effectsAudioMixer.useSoundEffect(
+        'https://cdn.gredice.com/sounds/effects/Swipe Generic 01.mp3',
+    );
+
+    const setPickupBlock = useGameState((state) => state.setPickupBlock);
+    const pickupSelectionTargets = useGameState(
+        (state) => state.pickupSelectionTargets,
+    );
+    const setPickupSelectionTargets = useGameState(
+        (state) => state.setPickupSelectionTargets,
+    );
+    const clearPickupSelectionTargets = useGameState(
+        (state) => state.clearPickupSelectionTargets,
+    );
+    const disturbAnimals = useGameState((state) => state.disturbAnimals);
+    const activeDragPreview = useGameState((state) => state.activeDragPreview);
+    const setActiveDragPreview = useGameState(
+        (state) => state.setActiveDragPreview,
+    );
+    const setStationaryPickupOutlineTarget = useGameState(
+        (state) => state.setStationaryPickupOutlineTarget,
+    );
+    const setItemsHudDropTargetActive = useGameState(
+        (state) => state.setItemsHudDropTargetActive,
+    );
+    const setOpenGardenBoxBlockId = useGameState(
+        (state) => state.setOpenGardenBoxBlockId,
+    );
+    const localSandboxStorageKey = useGameState(
+        (state) => state.localSandboxStorageKey,
+    );
+
+    const [isBlocked, setIsBlocked] = useState(false);
+    const [isOverRecycler, setIsOverRecycler] = useState(false);
+    const [pickupOutlineVisible, setPickupOutlineVisible] = useState(false);
+    const [visualTarget, setVisualTarget] =
+        useState<BlockInteractionLayerTarget | null>(null);
+    const deleteBlocks = useBlockDelete();
+    const moveBlock = useBlockMove();
+    const recycleBlock = useBlockRecycle();
+    const storeBlockInGardenBox = useGardenBoxStoreBlock();
+    const blockRotate = useBlockRotate();
+    const { track } = useGameAnalytics();
+    const { mutate: setRaisedBedCloseupParam } = useSetRaisedBedCloseupParam();
+    const [, setGiftBoxParam] = useGiftBoxParam();
+
+    const pointerSession = useRef<PointerSession | null>(null);
+    const pointerSessionCleanup = useRef<(() => void) | null>(null);
+    const rotationPointerSession = useRef<RotationPointerSession | null>(null);
+    const firstTap = useRef<InstancedInteractionFirstTap | null>(null);
+    const hoveredTarget = useRef<BlockInteractionLayerTarget | null>(null);
+    const refreshPlacementPreviewFromSessionRef = useRef<
+        ((session: PointerSession) => void) | null
+    >(null);
+    const controllerHandlersRef =
+        useRef<InstancedBlockInteractionControllerApi>({
+            onClick: () => undefined,
+            onPickupPointerEnter: () => undefined,
+            onPointerDown: () => undefined,
+            onPointerEnter: () => undefined,
+            onPointerLeave: () => undefined,
+            onPointerUp: () => undefined,
+            onSelectClick: () => undefined,
+        });
+
+    const targetsByKey = useMemo(
+        () => new Map(targets.map((target) => [target.key, target])),
+        [targets],
+    );
+    const targetsByKeyRef = useRef(targetsByKey);
+
+    useEffect(() => {
+        updateGameProfileMetadata(
+            getInstancedInteractionMountProfileMetadata({
+                mounted: true,
+                targetCount: targets.length,
+            }),
+        );
+        return () => {
+            updateGameProfileMetadata(
+                getInstancedInteractionMountProfileMetadata({
+                    mounted: false,
+                    targetCount: targets.length,
+                }),
+            );
+        };
+    }, [targets.length]);
+
+    useEffect(() => {
+        updateGameProfileMetadata({
+            instancedInteractionTargetCount: targets.length,
+        });
+    }, [targets.length]);
+
+    const stopDragAutopan = useCallback((session: PointerSession) => {
+        if (session.dragAutopanFrame !== null) {
+            window.cancelAnimationFrame(session.dragAutopanFrame);
+            session.dragAutopanFrame = null;
+        }
+        session.dragAutopanPreviousTime = null;
+    }, []);
+
+    const cleanupPointerSessionListeners = useCallback(() => {
+        pointerSessionCleanup.current?.();
+        pointerSessionCleanup.current = null;
+    }, []);
+
+    const clearPickupInteractionState = useCallback(() => {
+        setIsBlocked(false);
+        setIsOverRecycler(false);
+        setPickupOutlineVisible(false);
+        setPickupBlock(null);
+        clearPickupSelectionTargets();
+        setItemsHudDropTargetActive(false);
+    }, [
+        clearPickupSelectionTargets,
+        setItemsHudDropTargetActive,
+        setPickupBlock,
+    ]);
+
+    const resetPickupVisualState = useCallback(() => {
+        setActiveDragPreview(null);
+        clearPickupInteractionState();
+    }, [clearPickupInteractionState, setActiveDragPreview]);
+
+    const cancelPointerSession = useCallback(
+        (resetSpring: boolean) => {
+            const session = pointerSession.current;
+            if (!session) {
+                return;
+            }
+
+            session.cancelled = true;
+            clearPointerSessionTimers(session);
+            stopDragAutopan(session);
+            pointerSession.current = null;
+            cleanupPointerSessionListeners();
+            setPickupOutlineVisible(false);
+            setItemsHudDropTargetActive(false);
+            setStationaryPickupOutlineTarget(null);
+            if (resetSpring) {
+                dragSpringsApi.start({ internalPosition: [0, 0, 0], scale: 1 });
+            }
+        },
+        [
+            cleanupPointerSessionListeners,
+            dragSpringsApi,
+            setItemsHudDropTargetActive,
+            setStationaryPickupOutlineTarget,
+            stopDragAutopan,
+        ],
+    );
+
+    useLayoutEffect(() => {
+        targetsByKeyRef.current = targetsByKey;
+
+        const session = pointerSession.current;
+        const sessionReconciliation =
+            resolveInstancedInteractionTargetReconciliation(
+                session?.target ?? null,
+                targetsByKey,
+            );
+        if (session && sessionReconciliation.type === 'refresh') {
+            session.target = sessionReconciliation.target;
+            setVisualTarget(sessionReconciliation.target);
+        } else if (session && sessionReconciliation.type === 'cancel') {
+            if (session.activated) {
+                suppressBlockInteractions(suppressClickAfterDragMs);
+            }
+            resetPickupVisualState();
+            cancelPointerSession(true);
+            setVisualTarget(null);
+        }
+
+        const currentVisualTarget = visualTarget;
+        const visualTargetReconciliation =
+            resolveInstancedInteractionTargetReconciliation(
+                currentVisualTarget,
+                targetsByKey,
+            );
+        if (
+            visualTargetReconciliation.type === 'refresh' &&
+            visualTargetReconciliation.target !== currentVisualTarget
+        ) {
+            setVisualTarget(visualTargetReconciliation.target);
+        } else if (visualTargetReconciliation.type === 'cancel') {
+            setVisualTarget(null);
+        }
+
+        const currentHoveredTarget = hoveredTarget.current;
+        const hoveredTargetReconciliation =
+            resolveInstancedInteractionTargetReconciliation(
+                currentHoveredTarget,
+                targetsByKey,
+            );
+        if (hoveredTargetReconciliation.type === 'refresh') {
+            hoveredTarget.current = hoveredTargetReconciliation.target;
+        } else if (hoveredTargetReconciliation.type === 'cancel') {
+            if (
+                useHoveredBlockStore.getState().hoveredBlock ===
+                currentHoveredTarget?.block
+            ) {
+                useHoveredBlockStore.getState().setHoveredBlock(null);
+            }
+            hoveredTarget.current = null;
+        }
+
+        if (
+            rotationPointerSession.current &&
+            !targetsByKey.has(rotationPointerSession.current.targetKey)
+        ) {
+            rotationPointerSession.current = null;
+        }
+        if (firstTap.current && !targetsByKey.has(firstTap.current.targetKey)) {
+            firstTap.current = null;
+        }
+    }, [
+        cancelPointerSession,
+        resetPickupVisualState,
+        targetsByKey,
+        visualTarget,
+    ]);
+
+    useEffect(() => {
+        return () => {
+            const session = pointerSession.current;
+            if (session) {
+                session.cancelled = true;
+                if (session.hintTimer) {
+                    window.clearTimeout(session.hintTimer);
+                }
+                if (session.holdTimer) {
+                    window.clearTimeout(session.holdTimer);
+                }
+                stopDragAutopan(session);
+            }
+            pointerSession.current = null;
+            pointerSessionCleanup.current?.();
+            pointerSessionCleanup.current = null;
+            const gameState = gameStateStore?.getState();
+            gameState?.setActiveDragPreview(null);
+            gameState?.setPickupBlock(null);
+            gameState?.clearPickupSelectionTargets();
+            gameState?.setStationaryPickupOutlineTarget(null);
+            gameState?.setItemsHudDropTargetActive(false);
+        };
+    }, [gameStateStore, stopDragAutopan]);
+
+    const visualPreviewTarget = useMemo(
+        () => (visualTarget ? createPreviewTarget(visualTarget) : null),
+        [visualTarget],
+    );
+
+    useLayoutEffect(() => {
+        if (!pickupOutlineVisible || !visualPreviewTarget) {
+            setStationaryPickupOutlineTarget(null);
+            return;
+        }
+
+        setStationaryPickupOutlineTarget(visualPreviewTarget);
+        return () => setStationaryPickupOutlineTarget(null);
+    }, [
+        pickupOutlineVisible,
+        setStationaryPickupOutlineTarget,
+        visualPreviewTarget,
+    ]);
+
+    function getAttachedPlacement(
+        target: BlockInteractionLayerTarget,
+        garden: CurrentGarden | null | undefined,
+    ) {
+        if (target.block.name !== 'Raised_Bed' || !garden) {
+            return null;
+        }
+
+        const attachedRaisedBedBlockId = findAttachedRaisedBedBlockId(
+            garden.stacks,
+            target.block.id,
+        );
+
+        return attachedRaisedBedBlockId
+            ? (garden.stacks
+                  .flatMap((candidateStack) =>
+                      candidateStack.blocks.map(
+                          (candidateBlock, candidateBlockIndex) => ({
+                              candidateStack,
+                              candidateBlock,
+                              candidateBlockIndex,
+                          }),
+                      ),
+                  )
+                  .find(
+                      (candidate) =>
+                          candidate.candidateBlock.id ===
+                          attachedRaisedBedBlockId,
+                  ) ?? null)
+            : null;
+    }
+
+    function getMovingSegments(
+        target: BlockInteractionLayerTarget,
+        activePreviewTarget: ActiveDragPreviewTarget,
+        garden: CurrentGarden | null | undefined = getCurrentGarden(),
+    ): MovingSegment[] {
+        if (!garden || target.blockIndex < 0) {
+            return [];
+        }
+
+        const sourceBlocks = target.stack.blocks.slice(target.blockIndex);
+        if (sourceBlocks.length === 0) {
+            return [];
+        }
+
+        const raisedBed = findRaisedBedByBlockId(garden, target.block.id);
+        const canRecycle = (raisedBed?.status ?? 'new') === 'new';
+        const attachedPlacement = getAttachedPlacement(target, garden);
+        const attachedCurrentStackHeight = attachedPlacement
+            ? getStackHeight(
+                  blocksData,
+                  attachedPlacement.candidateStack,
+                  attachedPlacement.candidateBlock,
+              )
+            : 0;
+        const attachedBlocks = attachedPlacement
+            ? attachedPlacement.candidateStack.blocks.slice(
+                  attachedPlacement.candidateBlockIndex,
+              )
+            : [];
+        const canRecycleSelection =
+            canRecycle &&
+            sourceBlocks.length === 1 &&
+            (!attachedPlacement || attachedBlocks.length === 1);
+
+        return createPickupSelectionMovingSegments({
+            attachedSegment:
+                attachedPlacement && attachedBlocks.length > 0
+                    ? {
+                          sourceStack: attachedPlacement.candidateStack,
+                          sourceStartIndex:
+                              attachedPlacement.candidateBlockIndex,
+                          blocks: attachedBlocks,
+                          baseHeight: attachedCurrentStackHeight,
+                      }
+                    : null,
+            blockData: blocksData,
+            canRecyclePrimarySegment: canRecycleSelection,
+            primaryTarget: activePreviewTarget,
+            selectedTargets:
+                gameStateStore?.getState().pickupSelectionTargets ?? [],
+            stacks: garden.stacks,
+        });
+    }
+
+    function createPlacementPreviewResolver(
+        session: PointerSession,
+        garden: CurrentGarden | null | undefined = getCurrentGarden(),
+    ) {
+        if (!garden || !blocksData || session.target.blockIndex < 0) {
+            return null;
+        }
+
+        const movingSegments = getMovingSegments(
+            session.target,
+            session.activePreviewTarget,
+            garden,
+        );
+        if (movingSegments.length === 0) {
+            return null;
+        }
+
+        return createPickupPlacementPreviewResolver({
+            blockData: blocksData,
+            gardenIsSandbox: garden.isSandbox,
+            localSandboxStorageKey,
+            movingSegments,
+            stacks: garden.stacks,
+        });
+    }
+
+    function getPlacementCandidateDestinations(
+        target: BlockInteractionLayerTarget,
+        seedDestination: {
+            x: number;
+            z: number;
+        },
+    ) {
+        const candidates = new Map<string, { x: number; z: number }>();
+        const addCandidate = (x: number, z: number) => {
+            candidates.set(`${x}|${z}`, { x, z });
+        };
+
+        for (
+            let x = seedDestination.x - placementSnapSearchRadius;
+            x <= seedDestination.x + placementSnapSearchRadius;
+            x++
+        ) {
+            for (
+                let z = seedDestination.z - placementSnapSearchRadius;
+                z <= seedDestination.z + placementSnapSearchRadius;
+                z++
+            ) {
+                addCandidate(x, z);
+            }
+        }
+
+        addCandidate(target.stack.position.x, target.stack.position.z);
+
+        return candidates.values();
+    }
+
+    function getProjectedPointerDistanceSquared({
+        x,
+        y,
+        z,
+        clientX,
+        clientY,
+        rect,
+    }: {
+        x: number;
+        y: number;
+        z: number;
+        clientX: number;
+        clientY: number;
+        rect: DOMRect;
+    }) {
+        const projected = dragState.current.projected
+            .set(x, y, z)
+            .project(camera);
+        if (projected.z < -1 || projected.z > 1) {
+            return Number.POSITIVE_INFINITY;
+        }
+
+        const screenX = rect.left + ((projected.x + 1) / 2) * rect.width;
+        const screenY = rect.top + ((1 - projected.y) / 2) * rect.height;
+        return (screenX - clientX) ** 2 + (screenY - clientY) ** 2;
+    }
+
+    function resolvePlacementPreviewAtDestination(
+        session: PointerSession,
+        destination: {
+            x: number;
+            z: number;
+        },
+        resolver?: PickupPlacementPreviewResolver | null,
+    ) {
+        const { relative } = dragState.current;
+        relative.set(
+            destination.x - session.target.stack.position.x,
+            0,
+            destination.z - session.target.stack.position.z,
+        );
+        return (
+            (
+                resolver ?? createPlacementPreviewResolver(session)
+            )?.resolveForRelative(relative) ?? null
+        );
+    }
+
+    function resolvePlacementPreview(
+        session: PointerSession,
+        clientX: number,
+        clientY: number,
+    ): ResolvedPlacementPreview | null {
+        const garden = getCurrentGarden();
+        if (!garden || !blocksData || session.target.blockIndex < 0) {
+            return null;
+        }
+
+        const rect = domElement.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) {
+            return null;
+        }
+        const resolver = createPlacementPreviewResolver(session, garden);
+        if (!resolver) {
+            return null;
+        }
+
+        const { pt, dest } = dragState.current;
+        pt.set(
+            ((clientX - rect.left) / rect.width) * 2 - 1,
+            ((rect.top - clientY) / rect.height) * 2 + 1,
+            0,
+        );
+
+        pointerVector.current.set(pt.x, pt.y);
+        raycaster.current.setFromCamera(pointerVector.current, camera);
+        const isIntersecting = raycaster.current.ray.intersectPlane(
+            groundPlane,
+            pt,
+        );
+        if (!isIntersecting) {
+            return null;
+        }
+
+        dest.set(
+            pt.x - session.pickupAnchorOffset.x,
+            0,
+            pt.z - session.pickupAnchorOffset.z,
+        ).round();
+
+        let closestPreview: ResolvedPlacementPreview | null = null;
+        let closestDistanceSquared = Number.POSITIVE_INFINITY;
+
+        for (const candidateDestination of getPlacementCandidateDestinations(
+            session.target,
+            {
+                x: dest.x,
+                z: dest.z,
+            },
+        )) {
+            const preview = resolvePlacementPreviewAtDestination(
+                session,
+                candidateDestination,
+                resolver,
+            );
+            if (!preview) {
+                continue;
+            }
+
+            const distanceSquared = getProjectedPointerDistanceSquared({
+                x: candidateDestination.x + session.pickupAnchorOffset.x,
+                y:
+                    session.target.stackHeight +
+                    preview.previewHoverHeight +
+                    pickupLift +
+                    session.pickupAnchorOffset.y,
+                z: candidateDestination.z + session.pickupAnchorOffset.z,
+                clientX,
+                clientY,
+                rect,
+            });
+
+            if (distanceSquared < closestDistanceSquared) {
+                closestDistanceSquared = distanceSquared;
+                closestPreview = preview;
+            }
+        }
+
+        return closestPreview;
+    }
+
+    function createActivePreviewResetQueue() {
+        let resetQueued = false;
+
+        const clearAfterSceneCommit = () => {
+            const previewToClear =
+                gameStateStore?.getState().activeDragPreview ?? null;
+
+            window.requestAnimationFrame(() => {
+                window.requestAnimationFrame(() => {
+                    if (
+                        previewToClear &&
+                        gameStateStore?.getState().activeDragPreview !==
+                            previewToClear
+                    ) {
+                        return;
+                    }
+
+                    setActiveDragPreview(null);
+                });
+            });
+        };
+
+        return {
+            queue: () => {
+                if (resetQueued) {
+                    return;
+                }
+
+                resetQueued = true;
+                clearAfterSceneCommit();
+            },
+            resetIfUnqueued: () => {
+                if (!resetQueued) {
+                    setActiveDragPreview(null);
+                }
+            },
+        };
+    }
+
+    function applyActivePreview(
+        session: PointerSession,
+        preview: ResolvedPlacementPreview,
+    ) {
+        setIsOverRecycler((current) =>
+            current === preview.nextIsOverRecycler
+                ? current
+                : preview.nextIsOverRecycler,
+        );
+        setIsBlocked((current) =>
+            current === preview.nextIsBlocked ? current : preview.nextIsBlocked,
+        );
+        setActiveDragPreview({
+            source: session.activePreviewTarget,
+            targets: preview.targetOffsets,
+            hoveredGardenBoxBlockId: preview.hoveredGardenBoxBlockId,
+            relative: {
+                x: preview.relative.x,
+                z: preview.relative.z,
+            },
+            isBlocked: preview.nextIsBlocked,
+            isOverRecycler: preview.nextIsOverRecycler,
+        });
+        dragSpringsApi.start({
+            internalPosition: [
+                preview.relative.x,
+                preview.previewHoverHeight + pickupLift,
+                preview.relative.z,
+            ],
+            scale: 1.02,
+        });
+    }
+
+    function refreshPlacementPreviewFromSession(session: PointerSession) {
+        const preview = resolvePlacementPreview(
+            session,
+            session.lastClientX,
+            session.lastClientY,
+        );
+        if (
+            !preview ||
+            resolvedPlacementPreviewsEqual(session.latestPreview, preview)
+        ) {
+            return;
+        }
+
+        session.latestPreview = preview;
+        applyActivePreview(session, preview);
+    }
+    refreshPlacementPreviewFromSessionRef.current =
+        refreshPlacementPreviewFromSession;
+
+    useEffect(() => {
+        const session = pointerSession.current;
+        if (
+            !session?.activated ||
+            pickupSelectionTargets.length === 0 ||
+            !activeDragPreviewTargetMatches(
+                activeDragPreview?.source,
+                session.activePreviewTarget,
+            )
+        ) {
+            return;
+        }
+
+        refreshPlacementPreviewFromSessionRef.current?.(session);
+    }, [activeDragPreview?.source, pickupSelectionTargets]);
+
+    function startDragAutopan(session: PointerSession) {
+        if (session.dragAutopanFrame !== null || !gameCamera) {
+            return;
+        }
+
+        const tick = (timestamp: number) => {
+            const activeSession = pointerSession.current;
+            if (
+                activeSession !== session ||
+                activeSession.cancelled ||
+                !activeSession.activated
+            ) {
+                stopDragAutopan(session);
+                return;
+            }
+
+            const pointer = {
+                clientX: activeSession.lastClientX,
+                clientY: activeSession.lastClientY,
+            };
+            if (
+                isPointOverItemsHudDropTarget(pointer.clientX, pointer.clientY)
+            ) {
+                activeSession.dragAutopanPreviousTime = timestamp;
+                activeSession.dragAutopanFrame =
+                    window.requestAnimationFrame(tick);
+                return;
+            }
+
+            const previousTime =
+                activeSession.dragAutopanPreviousTime ?? timestamp;
+            activeSession.dragAutopanPreviousTime = timestamp;
+            const frameDeltaSeconds = Math.max(
+                0,
+                (timestamp - previousTime) / 1000,
+            );
+            const didPan = gameCamera.panByDragEdge(pointer, frameDeltaSeconds);
+
+            if (didPan) {
+                refreshPlacementPreviewFromSession(activeSession);
+            }
+
+            activeSession.dragAutopanFrame = window.requestAnimationFrame(tick);
+        };
+
+        session.dragAutopanFrame = window.requestAnimationFrame(tick);
+    }
+
+    function activatePickup() {
+        const session = pointerSession.current;
+        if (!session || session.cancelled || session.activated) {
+            return;
+        }
+
+        const preview = resolvePlacementPreviewAtDestination(session, {
+            x: session.target.stack.position.x,
+            z: session.target.stack.position.z,
+        });
+        if (!preview) {
+            cancelPointerSession(true);
+            return;
+        }
+
+        session.activated = true;
+        session.pickupClientX = session.lastClientX;
+        session.pickupClientY = session.lastClientY;
+        session.hasDraggedAfterPickup = false;
+        session.latestPreview = preview;
+        setIsDragging(false);
+        setPickupOutlineVisible(true);
+        setPickupBlock(session.target.block);
+        setPickupSelectionTargets([session.activePreviewTarget]);
+        useHoveredBlockStore.getState().setHoveredBlock(null);
+        disturbAnimals({
+            sourceBlockId: session.target.block.id,
+            sourceBlockName: session.target.block.name,
+            position: {
+                x: session.target.stack.position.x,
+                y: session.target.stackHeight,
+                z: session.target.stack.position.z,
+            },
+            radius: animalPickupDisturbanceRadius,
+        });
+        pickupSound.play();
+        triggerPickHaptic();
+        spawn(
+            resolveBlockParticleType(session.target.block.name),
+            session.target.stack.position
+                .clone()
+                .setY(session.target.stackHeight),
+            4,
+        );
+        applyActivePreview(session, preview);
+    }
+
+    async function finishPickup(
+        session: PointerSession,
+        preview: ResolvedPlacementPreview | null,
+        {
+            hudDropRequested,
+        }: {
+            hudDropRequested: boolean;
+        },
+    ) {
+        const target = session.target;
+        const garden = getCurrentGarden();
+        const attachedPlacement = getAttachedPlacement(target, garden);
+        const raisedBed = findRaisedBedByBlockId(garden, target.block.id);
+        const movingSegments = getMovingSegments(
+            target,
+            session.activePreviewTarget,
+            garden,
+        );
+        const hudDropAction = hudDropRequested
+            ? resolvePickupHudDropAction({
+                  forceDelete: Boolean(garden?.isSandbox),
+                  movingSegments,
+              })
+            : null;
+        const blockIdsToDelete =
+            hudDropAction?.type === 'delete' ? hudDropAction.blockIds : [];
+
+        if (blockIdsToDelete.length > 0) {
+            resetPickupVisualState();
+            dragSpringsApi.start({
+                internalPosition: preview
+                    ? [
+                          preview.relative.x,
+                          preview.previewHoverHeight + 0.2,
+                          preview.relative.z,
+                      ]
+                    : [0, pickupLift, 0],
+                scale: 0.1,
+            });
+            dropSound.play();
+            triggerPlaceHaptic();
+            try {
+                await deleteBlocks.mutateAsync({
+                    blockIds: blockIdsToDelete,
+                });
+            } finally {
+                dragSpringsApi.start({
+                    internalPosition: [0, 0, 0],
+                    scale: 1,
+                });
+            }
+            return;
+        }
+
+        if (hudDropAction?.type === 'recycle') {
+            clearPickupInteractionState();
+            const activePreviewReset = createActivePreviewResetQueue();
+            dragSpringsApi.start({
+                internalPosition: preview
+                    ? [preview.relative.x, -1.5, preview.relative.z]
+                    : [0, -1.5, 0],
+                scale: 0.1,
+            });
+            triggerPlaceHaptic();
+            await recycleBlock
+                .mutateAsync({
+                    position: target.stack.position,
+                    blockIndex: target.blockIndex,
+                    raisedBedId: raisedBed?.id,
+                    attached: attachedPlacement
+                        ? {
+                              position: {
+                                  x: attachedPlacement.candidateStack.position
+                                      .x,
+                                  z: attachedPlacement.candidateStack.position
+                                      .z,
+                              },
+                              blockIndex: attachedPlacement.candidateBlockIndex,
+                          }
+                        : undefined,
+                    onOptimisticUpdate: activePreviewReset.queue,
+                })
+                .finally(activePreviewReset.resetIfUnqueued);
+            return;
+        }
+
+        if (hudDropRequested) {
+            resetPickupVisualState();
+            dragSpringsApi.start({ internalPosition: [0, 0, 0], scale: 1 });
+            return;
+        }
+
+        if (!preview || preview.nextIsBlocked) {
+            resetPickupVisualState();
+            dragSpringsApi.start({ internalPosition: [0, 0, 0], scale: 1 });
+            return;
+        }
+
+        const relative = preview.relative;
+        const hasMoved =
+            Math.abs(relative.x) > 0.0001 || Math.abs(relative.z) > 0.0001;
+
+        if (
+            !hasMoved &&
+            !preview.canStoreInGardenBox &&
+            !preview.nextIsOverRecycler
+        ) {
+            resetPickupVisualState();
+            dragSpringsApi.start({ internalPosition: [0, 0, 0], scale: 1 });
+            return;
+        }
+
+        const previewDropPosition = target.stack.position
+            .clone()
+            .add(relative)
+            .setY(preview.previewHoverHeight + target.stackHeight);
+
+        if (preview.canStoreInGardenBox && preview.hoveredGardenBoxBlockId) {
+            clearPickupInteractionState();
+            const activePreviewReset = createActivePreviewResetQueue();
+            dragSpringsApi.start({
+                internalPosition: [
+                    relative.x,
+                    preview.previewHoverHeight + 0.2,
+                    relative.z,
+                ],
+                scale: 0.1,
+            });
+            dropSound.play();
+            triggerPlaceHaptic();
+            spawn(
+                resolveBlockParticleType(target.block.name),
+                previewDropPosition,
+                8,
+            );
+            const blockDataForInventory = getBlockDataByName(
+                blocksData,
+                target.block.name,
+            );
+
+            await storeBlockInGardenBox
+                .mutateAsync({
+                    sourcePosition: {
+                        x: target.stack.position.x,
+                        z: target.stack.position.z,
+                    },
+                    blockIndex: target.blockIndex,
+                    sourceBlockId: target.block.id,
+                    blockName: target.block.name,
+                    blockEntityId: blockDataForInventory?.id.toString(),
+                    blockLabel:
+                        blockDataForInventory?.information?.label ??
+                        target.block.name,
+                    gardenBoxBlockId: preview.hoveredGardenBoxBlockId,
+                    onOptimisticUpdate: activePreviewReset.queue,
+                })
+                .finally(activePreviewReset.resetIfUnqueued);
+            return;
+        }
+
+        if (preview.nextIsOverRecycler) {
+            clearPickupInteractionState();
+            const activePreviewReset = createActivePreviewResetQueue();
+            dragSpringsApi.start({
+                internalPosition: [relative.x, -1.5, relative.z],
+                scale: 0.1,
+            });
+            triggerPlaceHaptic();
+            await recycleBlock
+                .mutateAsync({
+                    position: target.stack.position,
+                    blockIndex: target.blockIndex,
+                    raisedBedId: raisedBed?.id,
+                    attached: attachedPlacement
+                        ? {
+                              position: {
+                                  x: attachedPlacement.candidateStack.position
+                                      .x,
+                                  z: attachedPlacement.candidateStack.position
+                                      .z,
+                              },
+                              blockIndex: attachedPlacement.candidateBlockIndex,
+                          }
+                        : undefined,
+                    onOptimisticUpdate: activePreviewReset.queue,
+                })
+                .finally(activePreviewReset.resetIfUnqueued);
+            return;
+        }
+
+        const moveRequests = createPickupSelectionMoveRequests(
+            movingSegments,
+            relative,
+        );
+        const [primaryMoveRequest, ...additionalBlockMoves] = moveRequests;
+        if (!primaryMoveRequest) {
+            resetPickupVisualState();
+            dragSpringsApi.start({ internalPosition: [0, 0, 0], scale: 1 });
+            return;
+        }
+
+        clearPickupInteractionState();
+        const activePreviewReset = createActivePreviewResetQueue();
+        dragSpringsApi.start({
+            internalPosition: [
+                relative.x,
+                preview.previewHoverHeight,
+                relative.z,
+            ],
+            scale: 1,
+        });
+        dropSound.play();
+        triggerPlaceHaptic();
+        spawn(
+            resolveBlockParticleType(target.block.name),
+            previewDropPosition,
+            8,
+        );
+
+        await moveBlock
+            .mutateAsync({
+                ...primaryMoveRequest,
+                additionalBlocks: additionalBlockMoves,
+                onOptimisticUpdate: activePreviewReset.queue,
+            })
+            .finally(activePreviewReset.resetIfUnqueued);
+    }
+
+    function handleWindowPointerMove(event: PointerEvent) {
+        const session = pointerSession.current;
+        if (!session || event.pointerId !== session.pointerId) {
+            return;
+        }
+
+        session.lastClientX = event.clientX;
+        session.lastClientY = event.clientY;
+
+        if (!session.activated) {
+            if (
+                pointerDistance(session, event.clientX, event.clientY) >
+                getPickupPointerMoveCancelDistance(session.pointerType)
+            ) {
+                cancelPointerSession(session.hintVisible);
+            }
+            return;
+        }
+
+        event.preventDefault();
+        if (!session.hasDraggedAfterPickup) {
+            const pickupClientX = session.pickupClientX ?? session.startClientX;
+            const pickupClientY = session.pickupClientY ?? session.startClientY;
+
+            if (
+                Math.hypot(
+                    event.clientX - pickupClientX,
+                    event.clientY - pickupClientY,
+                ) <= getPickupPointerMoveCancelDistance(session.pointerType)
+            ) {
+                return;
+            }
+
+            session.hasDraggedAfterPickup = true;
+            startDragAutopan(session);
+        }
+
+        setItemsHudDropTargetActive(
+            isPointOverItemsHudDropTarget(event.clientX, event.clientY),
+        );
+
+        refreshPlacementPreviewFromSession(session);
+    }
+
+    function handleWindowPointerUp(event: PointerEvent) {
+        const session = pointerSession.current;
+        if (!session || event.pointerId !== session.pointerId) {
+            return;
+        }
+
+        clearPointerSessionTimers(session);
+        stopDragAutopan(session);
+        cleanupPointerSessionListeners();
+        pointerSession.current = null;
+
+        if (!session.activated) {
+            if (session.hintVisible) {
+                dragSpringsApi.start({
+                    internalPosition: [0, 0, 0],
+                    scale: 1,
+                });
+            }
+            setPickupOutlineVisible(false);
+            setStationaryPickupOutlineTarget(null);
+            return;
+        }
+
+        event.preventDefault();
+        suppressBlockInteractions(suppressClickAfterDragMs);
+        const preview =
+            resolvePlacementPreview(
+                session,
+                session.lastClientX,
+                session.lastClientY,
+            ) ?? session.latestPreview;
+        void finishPickup(session, preview, {
+            hudDropRequested: isPointOverItemsHudDropTarget(
+                session.lastClientX,
+                session.lastClientY,
+            ),
+        });
+    }
+
+    function handleWindowPointerCancel(event: PointerEvent) {
+        const session = pointerSession.current;
+        if (!session || event.pointerId !== session.pointerId) {
+            return;
+        }
+
+        suppressBlockInteractions(suppressClickAfterDragMs);
+        resetPickupVisualState();
+        cancelPointerSession(true);
+    }
+
+    function handlePickupPointerEnter(
+        target: BlockInteractionLayerTarget,
+        event: ThreeEvent<PointerEvent>,
+    ) {
+        if (
+            target.blockIndex < 0 ||
+            !event.nativeEvent.shiftKey ||
+            !gameStateStore
+        ) {
+            return false;
+        }
+
+        const gameState = gameStateStore.getState();
+        const preview = gameState.activeDragPreview;
+        const activePreviewTarget = createPreviewTarget(target);
+        if (
+            !preview ||
+            activeDragPreviewAffectsTarget(preview, activePreviewTarget)
+        ) {
+            return false;
+        }
+
+        const added = gameState.addPickupSelectionTarget(activePreviewTarget);
+        if (!added) {
+            return false;
+        }
+
+        event.stopPropagation();
+        triggerSelectionHaptic();
+        return true;
+    }
+
+    function handlePointerDown(
+        target: BlockInteractionLayerTarget,
+        event: ThreeEvent<PointerEvent>,
+    ) {
+        if (event.button === 0 && handlePickupPointerEnter(target, event)) {
+            return;
+        }
+
+        if (
+            event.button !== 0 ||
+            pointerSession.current ||
+            areBlockInteractionsSuppressed() ||
+            !getCurrentGarden() ||
+            !blocksData ||
+            target.blockIndex < 0
+        ) {
+            return;
+        }
+
+        event.stopPropagation();
+        setVisualTarget(target);
+        setIsBlocked(false);
+        setIsOverRecycler(false);
+        dragSpringsApi.set({ internalPosition: [0, 0, 0], scale: 1 });
+
+        const nativeEvent = event.nativeEvent;
+        const session: PointerSession = {
+            target,
+            activePreviewTarget: createPreviewTarget(target),
+            pointerId: nativeEvent.pointerId,
+            pointerType: nativeEvent.pointerType,
+            startClientX: nativeEvent.clientX,
+            startClientY: nativeEvent.clientY,
+            lastClientX: nativeEvent.clientX,
+            lastClientY: nativeEvent.clientY,
+            pickupClientX: null,
+            pickupClientY: null,
+            pickupAnchorOffset: {
+                x: event.point.x - target.stack.position.x,
+                y: event.point.y - target.stackHeight,
+                z: event.point.z - target.stack.position.z,
+            },
+            hasDraggedAfterPickup: false,
+            activated: false,
+            cancelled: false,
+            hintVisible: false,
+            hintTimer: null,
+            holdTimer: null,
+            dragAutopanFrame: null,
+            dragAutopanPreviousTime: null,
+            latestPreview: null,
+        };
+        pointerSession.current = session;
+
+        session.hintTimer = window.setTimeout(() => {
+            const activeSession = pointerSession.current;
+            if (
+                activeSession !== session ||
+                activeSession.cancelled ||
+                activeSession.activated
+            ) {
+                return;
+            }
+
+            activeSession.hintVisible = true;
+            setPickupOutlineVisible(true);
+            dragSpringsApi.start({
+                internalPosition: [0, pickupHintLift, 0],
+                scale: 1.01,
+            });
+        }, pickupHintDelayMs);
+
+        session.holdTimer = window.setTimeout(
+            activatePickup,
+            pickupHoldDelayMs,
+        );
+
+        window.addEventListener('pointermove', handleWindowPointerMove, {
+            passive: false,
+        });
+        window.addEventListener('pointerup', handleWindowPointerUp);
+        window.addEventListener('pointercancel', handleWindowPointerCancel);
+        pointerSessionCleanup.current = () => {
+            window.removeEventListener('pointermove', handleWindowPointerMove);
+            window.removeEventListener('pointerup', handleWindowPointerUp);
+            window.removeEventListener(
+                'pointercancel',
+                handleWindowPointerCancel,
+            );
+        };
+    }
+
+    function handleClick(event: ThreeEvent<MouseEvent>) {
+        if (areBlockInteractionsSuppressed()) {
+            event.stopPropagation();
+        }
+    }
+
+    function handlePointerEnter(
+        target: BlockInteractionLayerTarget,
+        event: ThreeEvent<PointerEvent>,
+    ) {
+        if (
+            !isSelectableTarget(target) ||
+            gameStateStore?.getState().activeDragPreview
+        ) {
+            return;
+        }
+
+        hoveredTarget.current = target;
+        event.stopPropagation();
+        useHoveredBlockStore.getState().setHoveredBlock(target.block);
+    }
+
+    function handlePointerLeave(
+        target: BlockInteractionLayerTarget | null,
+        event: ThreeEvent<PointerEvent>,
+    ) {
+        rotationPointerSession.current = null;
+        const currentHoveredTarget = hoveredTarget.current;
+        const targetKey = target?.key ?? currentHoveredTarget?.key;
+        if (!targetKey) {
+            return;
+        }
+
+        const hoveredBlock = useHoveredBlockStore.getState().hoveredBlock;
+        const targetBlock =
+            targetsByKey.get(targetKey)?.block ??
+            target?.block ??
+            currentHoveredTarget?.block;
+        if (targetBlock && hoveredBlock === targetBlock) {
+            event.stopPropagation();
+            useHoveredBlockStore.getState().setHoveredBlock(null);
+        }
+        if (hoveredTarget.current?.key === targetKey) {
+            hoveredTarget.current = null;
+        }
+    }
+
+    function handleDeferredSelection(targetKey: string) {
+        const target = targetsByKeyRef.current.get(targetKey);
+        if (!target || gameStateStore?.getState().activeDragPreview) {
+            return;
+        }
+
+        if (target.block.name === 'GardenBox') {
+            if (!getCurrentGarden()?.isSandbox) {
+                setOpenGardenBoxBlockId(target.block.id);
+            }
+            return;
+        }
+
+        const garden = getCurrentGarden();
+        const raisedBed =
+            target.block.name === 'Raised_Bed'
+                ? findRaisedBedByBlockId(garden, target.block.id)
+                : null;
+        if (target.block.name === 'Raised_Bed' && raisedBed) {
+            track('game_raised_bed_opened', {
+                block_id: target.block.id,
+                raised_bed_name: raisedBed.name,
+            });
+            setRaisedBedCloseupParam(raisedBed.name);
+            useHoveredBlockStore.getState().setHoveredBlock(null);
+            return;
+        }
+
+        if (target.block.name.startsWith('GiftBox_')) {
+            setGiftBoxParam(target.block.id);
+        }
+    }
+
+    const handleDeferredSelectionClick = useDeferredSingleClickByTarget(
+        handleDeferredSelection,
+        targetsByKey,
+    );
+
+    function handleSelectClick(
+        target: BlockInteractionLayerTarget,
+        event: ThreeEvent<MouseEvent>,
+    ) {
+        if (!isSelectableTarget(target)) {
+            event.stopPropagation();
+            return;
+        }
+
+        handleDeferredSelectionClick(target.key, event);
+    }
+
+    function doRotate(target: BlockInteractionLayerTarget) {
+        const gameState = gameStateStore?.getState();
+        if (
+            gameState?.isDragging ||
+            gameState?.pickupBlock ||
+            gameState?.hudPlacementDrag
+        ) {
+            return false;
+        }
+
+        const garden = getCurrentGarden();
+        const attachedRaisedBedBlockId =
+            target.block.name === 'Raised_Bed' && garden
+                ? findAttachedRaisedBedBlockId(garden.stacks, target.block.id)
+                : null;
+        const blockIds = attachedRaisedBedBlockId
+            ? [target.block.id, attachedRaisedBedBlockId]
+            : [target.block.id];
+
+        blockRotate.mutate({
+            blockId: target.block.id,
+            rotation: target.block.rotation + 1,
+            blockIds,
+        });
+
+        swipeSound.play();
+        return true;
+    }
+
+    function handleRotatePointerDown(
+        target: BlockInteractionLayerTarget,
+        event: ThreeEvent<PointerEvent>,
+    ) {
+        if (event.button !== 0) {
+            return;
+        }
+
+        rotationPointerSession.current = {
+            point: event.point.clone(),
+            targetKey: target.key,
+        };
+    }
+
+    function handleRotatePointerUp(
+        target: BlockInteractionLayerTarget,
+        event: ThreeEvent<PointerEvent>,
+    ) {
+        if (event.button !== 0) {
+            return;
+        }
+
+        const pointerDown = rotationPointerSession.current;
+        rotationPointerSession.current = null;
+        if (!pointerDown || pointerDown.targetKey !== target.key) {
+            firstTap.current = null;
+            return;
+        }
+
+        const tap = resolveInstancedRotationTap({
+            distance: event.point.distanceTo(pointerDown.point),
+            doubleTapThresholdMs,
+            now: Date.now(),
+            previousTap: firstTap.current,
+            targetKey: target.key,
+            dragThreshold: rotateDragThreshold,
+        });
+        firstTap.current = tap.nextTap;
+        if (!tap.shouldRotate) {
+            return;
+        }
+
+        if (doRotate(target)) {
+            event.stopPropagation();
+        }
+    }
+
+    controllerHandlersRef.current = {
+        onClick: (_target, event) => handleClick(event),
+        onPickupPointerEnter: handlePickupPointerEnter,
+        onPointerDown: (target, event) => {
+            handleRotatePointerDown(target, event);
+            handlePointerDown(target, event);
+        },
+        onPointerEnter: handlePointerEnter,
+        onPointerLeave: handlePointerLeave,
+        onPointerUp: handleRotatePointerUp,
+        onSelectClick: handleSelectClick,
+    };
+
+    const controller = useMemo<InstancedBlockInteractionControllerApi>(
+        () => ({
+            onClick: (target, event) =>
+                controllerHandlersRef.current.onClick(target, event),
+            onPickupPointerEnter: (target, event) =>
+                controllerHandlersRef.current.onPickupPointerEnter(
+                    target,
+                    event,
+                ),
+            onPointerDown: (target, event) =>
+                controllerHandlersRef.current.onPointerDown(target, event),
+            onPointerEnter: (target, event) =>
+                controllerHandlersRef.current.onPointerEnter(target, event),
+            onPointerLeave: (target, event) =>
+                controllerHandlersRef.current.onPointerLeave(target, event),
+            onPointerUp: (target, event) =>
+                controllerHandlersRef.current.onPointerUp(target, event),
+            onSelectClick: (target, event) =>
+                controllerHandlersRef.current.onSelectClick(target, event),
+        }),
+        [],
+    );
+
+    const blockedTargets =
+        activeDragPreview?.isBlocked === true
+            ? activeDragPreview.targets
+                  .map((previewTarget) => {
+                      const target = targetsByKey.get(
+                          targetKeyFromPreviewTarget(previewTarget),
+                      );
+                      return target
+                          ? {
+                                key: target.key,
+                                position: [
+                                    target.stack.position.x +
+                                        activeDragPreview.relative.x,
+                                    target.stackHeight +
+                                        previewTarget.hoverHeight +
+                                        pickupLift,
+                                    target.stack.position.z +
+                                        activeDragPreview.relative.z,
+                                ] as [number, number, number],
+                            }
+                          : null;
+                  })
+                  .filter((target) => target !== null)
+            : [];
+    const showBlockedIndicator = isBlocked || blockedTargets.length > 0;
+    const blockedScaleSprings = useSpring({
+        scale: showBlockedIndicator ? 1 : 0,
+        opacity: showBlockedIndicator ? 1 : 0,
+        config: {
+            tension: 350,
+        },
+    });
+    const dragPosition = dragSprings.internalPosition as unknown as [
+        number,
+        number,
+        number,
+    ];
+    const fallbackBlockedPosition: [number, number, number] | null =
+        isBlocked && visualTarget
+            ? [
+                  visualTarget.stack.position.x,
+                  visualTarget.stackHeight,
+                  visualTarget.stack.position.z,
+              ]
+            : null;
+    const recyclePosition: [number, number, number] | null = visualTarget
+        ? [
+              visualTarget.stack.position.x,
+              visualTarget.stackHeight + 0.2,
+              visualTarget.stack.position.z,
+          ]
+        : null;
+
+    return (
+        <>
+            {children(controller)}
+            {blockedTargets.map((target) => (
+                <animated.group
+                    key={`blocked-${target.key}`}
+                    scale={blockedScaleSprings.scale}
+                    position={target.position}
+                >
+                    <Shadow
+                        color={0xff0000}
+                        opacity={1}
+                        colorStop={0.5}
+                        scale={2}
+                    />
+                </animated.group>
+            ))}
+            {blockedTargets.length === 0 && fallbackBlockedPosition ? (
+                <animated.group
+                    position={dragPosition}
+                    scale={dragSprings.scale}
+                >
+                    <animated.group
+                        scale={blockedScaleSprings.scale}
+                        position={fallbackBlockedPosition}
+                    >
+                        <Shadow
+                            color={0xff0000}
+                            opacity={1}
+                            colorStop={0.5}
+                            scale={2}
+                        />
+                    </animated.group>
+                </animated.group>
+            ) : null}
+            {isOverRecycler && recyclePosition ? (
+                <animated.group
+                    position={dragPosition}
+                    scale={dragSprings.scale}
+                >
+                    <Suspense>
+                        <animated.group position={recyclePosition}>
+                            <RecycleIndicator />
+                        </animated.group>
+                    </Suspense>
+                </animated.group>
+            ) : null}
+        </>
+    );
+}

--- a/packages/game/src/controls/InstancedEntityRenderModeDebugOverlays.tsx
+++ b/packages/game/src/controls/InstancedEntityRenderModeDebugOverlays.tsx
@@ -1,0 +1,50 @@
+import { Edges } from '@react-three/drei';
+import { useBlockData } from '../hooks/useBlockData';
+import { useGameState } from '../useGameState';
+import type { BlockInteractionLayerTarget } from './BlockInteractionResolver';
+
+const instancedRenderModeDebugColor = '#22c55e';
+
+export function InstancedEntityRenderModeDebugOverlays({
+    targets,
+}: {
+    targets: BlockInteractionLayerTarget[];
+}) {
+    const { data: blockData } = useBlockData();
+    const visible = useGameState((state) => state.entityRenderModeDebugVisible);
+
+    if (!visible) {
+        return null;
+    }
+
+    return targets.map((target) => {
+        const blockHeight =
+            blockData?.find(
+                (entity) => entity.information.name === target.block.name,
+            )?.attributes.height ?? 1;
+        const overlayHeight = Math.max(blockHeight, 0.35);
+
+        return (
+            <mesh
+                key={target.key}
+                name={`Debug:EntityRenderMode:instanced:${target.block.name}:${target.block.id}`}
+                position={[
+                    target.stack.position.x,
+                    target.stackHeight + overlayHeight / 2,
+                    target.stack.position.z,
+                ]}
+                scale={[1.05, 1.02, 1.05]}
+                renderOrder={10_001}
+                raycast={() => null}
+            >
+                <boxGeometry args={[1, overlayHeight, 1]} />
+                <meshBasicMaterial visible={false} />
+                <Edges
+                    color={instancedRenderModeDebugColor}
+                    renderOrder={10_001}
+                    threshold={1}
+                />
+            </mesh>
+        );
+    });
+}

--- a/packages/game/src/controls/instancedBlockInteractionCore.ts
+++ b/packages/game/src/controls/instancedBlockInteractionCore.ts
@@ -1,0 +1,116 @@
+const mouseMoveCancelDistance = 6;
+const touchMoveCancelDistance = 12;
+
+export type InstancedInteractionFirstTap = {
+    targetKey: string;
+    timeStamp: number;
+};
+
+export type InstancedInteractionTargetReconciliation<TTarget> =
+    | {
+          type: 'none';
+      }
+    | {
+          type: 'cancel';
+      }
+    | {
+          target: TTarget;
+          type: 'refresh';
+      };
+
+export function resolveInstancedInteractionTargetReconciliation<
+    TTarget extends { key: string },
+>(
+    currentTarget: TTarget | null,
+    targetsByKey: ReadonlyMap<string, TTarget>,
+): InstancedInteractionTargetReconciliation<TTarget> {
+    if (!currentTarget) {
+        return { type: 'none' };
+    }
+
+    const nextTarget = targetsByKey.get(currentTarget.key);
+    return nextTarget
+        ? {
+              target: nextTarget,
+              type: 'refresh',
+          }
+        : { type: 'cancel' };
+}
+
+export function resolveInstancedDeferredSelectionClick({
+    clickCount,
+    pendingTargetKeys,
+    suppressed,
+    targetKey,
+}: {
+    clickCount: number;
+    pendingTargetKeys: ReadonlySet<string>;
+    suppressed: boolean;
+    targetKey: string;
+}) {
+    return {
+        cancelPendingTarget: pendingTargetKeys.has(targetKey),
+        shouldSchedule: clickCount <= 1 && !suppressed,
+    };
+}
+
+export function getPickupPointerMoveCancelDistance(pointerType: string) {
+    return pointerType === 'touch'
+        ? touchMoveCancelDistance
+        : mouseMoveCancelDistance;
+}
+
+export function resolveInstancedRotationTap({
+    distance,
+    doubleTapThresholdMs,
+    now,
+    previousTap,
+    targetKey,
+    dragThreshold,
+}: {
+    distance: number;
+    doubleTapThresholdMs: number;
+    now: number;
+    previousTap: InstancedInteractionFirstTap | null;
+    targetKey: string;
+    dragThreshold: number;
+}) {
+    if (distance > dragThreshold) {
+        return {
+            nextTap: null,
+            shouldRotate: false,
+        };
+    }
+
+    if (
+        !previousTap ||
+        previousTap.targetKey !== targetKey ||
+        now - previousTap.timeStamp >= doubleTapThresholdMs
+    ) {
+        return {
+            nextTap: {
+                targetKey,
+                timeStamp: now,
+            },
+            shouldRotate: false,
+        };
+    }
+
+    return {
+        nextTap: null,
+        shouldRotate: true,
+    };
+}
+
+export function getInstancedInteractionMountProfileMetadata({
+    mounted,
+    targetCount,
+}: {
+    mounted: boolean;
+    targetCount: number;
+}) {
+    return {
+        instancedInteractionControllerCount: mounted ? 1 : 0,
+        instancedInteractionTargetCount: mounted ? targetCount : 0,
+    };
+}

--- a/packages/game/src/controls/instancedBlockInteractionCore.unit.ts
+++ b/packages/game/src/controls/instancedBlockInteractionCore.unit.ts
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    getInstancedInteractionMountProfileMetadata,
+    getPickupPointerMoveCancelDistance,
+    resolveInstancedDeferredSelectionClick,
+    resolveInstancedInteractionTargetReconciliation,
+    resolveInstancedRotationTap,
+} from './instancedBlockInteractionCore';
+
+describe('instanced block interaction pointer policy', () => {
+    it('keeps the existing desktop and touch pickup movement thresholds', () => {
+        assert.equal(getPickupPointerMoveCancelDistance('mouse'), 6);
+        assert.equal(getPickupPointerMoveCancelDistance('pen'), 6);
+        assert.equal(getPickupPointerMoveCancelDistance('touch'), 12);
+    });
+
+    it('rotates only after two stationary taps on the same resolved target', () => {
+        const firstTap = resolveInstancedRotationTap({
+            distance: 0,
+            doubleTapThresholdMs: 320,
+            now: 1_000,
+            previousTap: null,
+            targetKey: 'first',
+            dragThreshold: 0.1,
+        });
+        const changedTarget = resolveInstancedRotationTap({
+            distance: 0,
+            doubleTapThresholdMs: 320,
+            now: 1_100,
+            previousTap: firstTap.nextTap,
+            targetKey: 'second',
+            dragThreshold: 0.1,
+        });
+        const secondTap = resolveInstancedRotationTap({
+            distance: 0,
+            doubleTapThresholdMs: 320,
+            now: 1_200,
+            previousTap: changedTarget.nextTap,
+            targetKey: 'second',
+            dragThreshold: 0.1,
+        });
+
+        assert.equal(firstTap.shouldRotate, false);
+        assert.equal(changedTarget.shouldRotate, false);
+        assert.equal(secondTap.shouldRotate, true);
+        assert.equal(secondTap.nextTap, null);
+    });
+
+    it('cancels a rotation tap after pointer travel', () => {
+        const result = resolveInstancedRotationTap({
+            distance: 0.11,
+            doubleTapThresholdMs: 320,
+            now: 1_000,
+            previousTap: {
+                targetKey: 'target',
+                timeStamp: 900,
+            },
+            targetKey: 'target',
+            dragThreshold: 0.1,
+        });
+
+        assert.deepEqual(result, {
+            nextTap: null,
+            shouldRotate: false,
+        });
+    });
+});
+
+describe('instanced block interaction target reconciliation', () => {
+    it('refreshes a captured target when the same key survives a stack update', () => {
+        const currentTarget = { key: 'target', version: 1 };
+        const refreshedTarget = { key: 'target', version: 2 };
+
+        assert.deepEqual(
+            resolveInstancedInteractionTargetReconciliation(
+                currentTarget,
+                new Map([[refreshedTarget.key, refreshedTarget]]),
+            ),
+            {
+                target: refreshedTarget,
+                type: 'refresh',
+            },
+        );
+    });
+
+    it('cancels a captured target removed by a stack update', () => {
+        assert.deepEqual(
+            resolveInstancedInteractionTargetReconciliation(
+                { key: 'removed' },
+                new Map(),
+            ),
+            {
+                type: 'cancel',
+            },
+        );
+    });
+
+    it('does nothing when there is no captured target', () => {
+        assert.deepEqual(
+            resolveInstancedInteractionTargetReconciliation(null, new Map()),
+            {
+                type: 'none',
+            },
+        );
+    });
+});
+
+describe('instanced deferred selection click policy', () => {
+    it('does not cancel another target pending selection', () => {
+        assert.deepEqual(
+            resolveInstancedDeferredSelectionClick({
+                clickCount: 1,
+                pendingTargetKeys: new Set(['raised-bed']),
+                suppressed: false,
+                targetKey: 'garden-box',
+            }),
+            {
+                cancelPendingTarget: false,
+                shouldSchedule: true,
+            },
+        );
+    });
+
+    it('cancels only the same target pending selection on a double click', () => {
+        assert.deepEqual(
+            resolveInstancedDeferredSelectionClick({
+                clickCount: 2,
+                pendingTargetKeys: new Set(['raised-bed', 'garden-box']),
+                suppressed: false,
+                targetKey: 'raised-bed',
+            }),
+            {
+                cancelPendingTarget: true,
+                shouldSchedule: false,
+            },
+        );
+    });
+
+    it('does not schedule suppressed interactions', () => {
+        assert.deepEqual(
+            resolveInstancedDeferredSelectionClick({
+                clickCount: 1,
+                pendingTargetKeys: new Set<string>(),
+                suppressed: true,
+                targetKey: 'raised-bed',
+            }),
+            {
+                cancelPendingTarget: false,
+                shouldSchedule: false,
+            },
+        );
+    });
+});
+
+describe('instanced block interaction mount profile', () => {
+    it('reports one shared controller for a dense target set', () => {
+        assert.deepEqual(
+            getInstancedInteractionMountProfileMetadata({
+                mounted: true,
+                targetCount: 625,
+            }),
+            {
+                instancedInteractionControllerCount: 1,
+                instancedInteractionTargetCount: 625,
+            },
+        );
+    });
+
+    it('clears controller and target counts on unmount', () => {
+        assert.deepEqual(
+            getInstancedInteractionMountProfileMetadata({
+                mounted: false,
+                targetCount: 625,
+            }),
+            {
+                instancedInteractionControllerCount: 0,
+                instancedInteractionTargetCount: 0,
+            },
+        );
+    });
+});

--- a/packages/game/src/controls/useDeferredSingleClick.ts
+++ b/packages/game/src/controls/useDeferredSingleClick.ts
@@ -1,6 +1,7 @@
 import type { ThreeEvent } from '@react-three/fiber';
 import { useEffect, useRef } from 'react';
 import { areBlockInteractionsSuppressed } from './blockInteractionSuppression';
+import { resolveInstancedDeferredSelectionClick } from './instancedBlockInteractionCore';
 
 const defaultDelayMs = 340;
 
@@ -39,5 +40,80 @@ export function useDeferredSingleClick(
                 callbackRef.current();
             }
         }, delayMs);
+    };
+}
+
+type DeferredSingleClickTargetLookup = {
+    has: (targetKey: string) => boolean;
+};
+
+export function useDeferredSingleClickByTarget(
+    callback: (targetKey: string) => void,
+    validTargets: DeferredSingleClickTargetLookup,
+    delayMs = defaultDelayMs,
+) {
+    const callbackRef = useRef(callback);
+    const timeoutByTargetKeyRef = useRef(new Map<string, number>());
+    const validTargetsRef = useRef(validTargets);
+
+    callbackRef.current = callback;
+    validTargetsRef.current = validTargets;
+
+    useEffect(() => {
+        const timeoutByTargetKey = timeoutByTargetKeyRef.current;
+        for (const [targetKey, timeout] of timeoutByTargetKey) {
+            if (validTargets.has(targetKey)) {
+                continue;
+            }
+
+            window.clearTimeout(timeout);
+            timeoutByTargetKey.delete(targetKey);
+        }
+    }, [validTargets]);
+
+    useEffect(() => {
+        const timeoutByTargetKey = timeoutByTargetKeyRef.current;
+        return () => {
+            for (const timeout of timeoutByTargetKey.values()) {
+                window.clearTimeout(timeout);
+            }
+            timeoutByTargetKey.clear();
+        };
+    }, []);
+
+    return (targetKey: string, event: ThreeEvent<MouseEvent>) => {
+        event.stopPropagation();
+
+        const timeoutByTargetKey = timeoutByTargetKeyRef.current;
+        const suppressed = areBlockInteractionsSuppressed();
+        const action = resolveInstancedDeferredSelectionClick({
+            clickCount: event.nativeEvent.detail,
+            pendingTargetKeys: new Set(timeoutByTargetKey.keys()),
+            suppressed,
+            targetKey,
+        });
+
+        if (action.cancelPendingTarget) {
+            const timeout = timeoutByTargetKey.get(targetKey);
+            if (timeout !== undefined) {
+                window.clearTimeout(timeout);
+            }
+            timeoutByTargetKey.delete(targetKey);
+        }
+
+        if (!action.shouldSchedule) {
+            return;
+        }
+
+        const timeout = window.setTimeout(() => {
+            timeoutByTargetKey.delete(targetKey);
+            if (
+                !areBlockInteractionsSuppressed() &&
+                validTargetsRef.current.has(targetKey)
+            ) {
+                callbackRef.current(targetKey);
+            }
+        }, delayMs);
+        timeoutByTargetKey.set(targetKey, timeout);
     };
 }

--- a/packages/game/src/entities/EntityFactory.tsx
+++ b/packages/game/src/entities/EntityFactory.tsx
@@ -1,29 +1,12 @@
 import { Edges } from '@react-three/drei';
-import type { ThreeEvent } from '@react-three/fiber';
-import {
-    type ComponentType,
-    memo,
-    type PropsWithChildren,
-    useContext,
-} from 'react';
-import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
-import {
-    createBlockInteractionTargetKey,
-    useBlockInteractionTargetRegistration,
-} from '../controls/BlockInteractionRegistry';
+import { type ComponentType, memo, type PropsWithChildren } from 'react';
 import { PickableGroup } from '../controls/PickableGroup';
 import { RotatableGroup } from '../controls/RotatableGroup';
 import { SelectableGroup } from '../controls/SelectableGroup';
-import { useDeferredSingleClick } from '../controls/useDeferredSingleClick';
-import { useHoveredBlockStore } from '../controls/useHoveredBlockStore';
 import { useBlockData } from '../hooks/useBlockData';
-import { useCurrentGardenCache } from '../hooks/useCurrentGarden';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
-import { GameStateContext, useGameState } from '../useGameState';
-import { useSetRaisedBedCloseupParam } from '../useRaisedBedCloseup';
-import { useGiftBoxParam } from '../useUrlState';
+import { useGameState } from '../useGameState';
 import { useStackHeight } from '../utils/getStackHeight';
-import { findRaisedBedByBlockId } from '../utils/raisedBedBlocks';
 import { areEntityFactoryPropsEqual } from './entityFactoryMemo';
 import { entityNameMap } from './entityNameMap';
 import { QueuedPlacementDropAnimation } from './helpers/PlacementDropAnimation';
@@ -111,105 +94,6 @@ function EntityPlacementDropAnimation({
     );
 }
 
-function InstancedEntitySelectionRegistration({
-    block,
-    blockIndex,
-    interactionTargetKey,
-    stack,
-}: Pick<EntityInstanceProps, 'stack' | 'block'> & {
-    blockIndex: number;
-    interactionTargetKey: string | undefined;
-}) {
-    const getCurrentGarden = useCurrentGardenCache();
-    const gameStateStore = useContext(GameStateContext);
-    const { track } = useGameAnalytics();
-    const setHoveredBlock = useHoveredBlockStore(
-        (state) => state.setHoveredBlock,
-    );
-    const setOpenGardenBoxBlockId = useGameState(
-        (state) => state.setOpenGardenBoxBlockId,
-    );
-    const { mutate: setRaisedBedCloseupParam } = useSetRaisedBedCloseupParam();
-    const [, setGiftBoxParam] = useGiftBoxParam();
-    const selectable =
-        block.name === 'GardenBox' ||
-        block.name.startsWith('GiftBox_') ||
-        block.name === 'Raised_Bed';
-    const hasActiveDragPreview = () =>
-        Boolean(gameStateStore?.getState().activeDragPreview);
-
-    const handleSelected = useDeferredSingleClick(() => {
-        if (hasActiveDragPreview()) {
-            return;
-        }
-
-        if (block.name === 'GardenBox') {
-            if (!getCurrentGarden()?.isSandbox) {
-                setOpenGardenBoxBlockId(block.id);
-            }
-            return;
-        }
-
-        const garden = getCurrentGarden();
-        const raisedBed =
-            block.name === 'Raised_Bed'
-                ? findRaisedBedByBlockId(garden, block.id)
-                : null;
-        if (block.name === 'Raised_Bed' && raisedBed) {
-            track('game_raised_bed_opened', {
-                block_id: block.id,
-                raised_bed_name: raisedBed.name,
-            });
-            setRaisedBedCloseupParam(raisedBed.name);
-            setHoveredBlock(null);
-            return;
-        }
-
-        if (block.name.startsWith('GiftBox_')) {
-            setGiftBoxParam(block.id);
-        }
-    });
-
-    useBlockInteractionTargetRegistration(
-        interactionTargetKey,
-        interactionTargetKey
-            ? {
-                  block,
-                  blockIndex,
-                  stack,
-              }
-            : undefined,
-        {
-            onSelectClick: (event: ThreeEvent<MouseEvent>) => {
-                handleSelected(event);
-            },
-            ...(selectable
-                ? {
-                      onPointerEnter: (event: ThreeEvent<PointerEvent>) => {
-                          if (hasActiveDragPreview()) {
-                              return;
-                          }
-
-                          event.stopPropagation();
-                          setHoveredBlock(block);
-                      },
-                      onPointerLeave: (event: ThreeEvent<PointerEvent>) => {
-                          if (
-                              useHoveredBlockStore.getState().hoveredBlock ===
-                              block
-                          ) {
-                              event.stopPropagation();
-                              setHoveredBlock(null);
-                          }
-                      },
-                  }
-                : {}),
-        },
-    );
-
-    return null;
-}
-
 function EntityFactoryComponent({
     name,
     stack,
@@ -221,55 +105,14 @@ function EntityFactoryComponent({
     const EntityComponent = entityComponents[name];
     const view = useGameState((state) => state.view);
     const isInstancedInView = noRenderInView?.includes(name) ?? false;
-    const blockIndex = stack.blocks.indexOf(block);
-    const interactionTargetKey = isInstancedInView
-        ? createBlockInteractionTargetKey({
-              blockId: block.id,
-              blockIndex,
-              stackPosition: stack.position,
-          })
-        : undefined;
 
     if (isInstancedInView) {
-        if (noControl || view === 'closeup') {
-            return (
-                <EntityRenderModeDebugOverlay
-                    stack={stack}
-                    block={block}
-                    instanced
-                />
-            );
-        }
-
         return (
-            <>
-                <InstancedEntitySelectionRegistration
-                    block={block}
-                    blockIndex={blockIndex}
-                    interactionTargetKey={interactionTargetKey}
-                    stack={stack}
-                />
-                <PickableGroup
-                    stack={stack}
-                    block={block}
-                    interactionTargetKey={interactionTargetKey}
-                    noControl={noControl}
-                    renderPickupOutline={false}
-                >
-                    <RotatableGroup
-                        block={block}
-                        blockIndex={blockIndex}
-                        interactionTargetKey={interactionTargetKey}
-                        stack={stack}
-                    >
-                        <EntityRenderModeDebugOverlay
-                            stack={stack}
-                            block={block}
-                            instanced
-                        />
-                    </RotatableGroup>
-                </PickableGroup>
-            </>
+            <EntityRenderModeDebugOverlay
+                stack={stack}
+                block={block}
+                instanced
+            />
         );
     }
 

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -742,6 +742,13 @@ export function DebugHud() {
             : 'n/a';
     const shadowMapMode =
         profileSnapshot?.shadowMapAutoUpdate === false ? 'cached' : 'auto';
+    const interactionResolutionCount =
+        profileSnapshot?.instancedInteractionResolutionCount ?? 0;
+    const interactionResolutionAverageMs =
+        interactionResolutionCount > 0
+            ? (profileSnapshot?.instancedInteractionResolutionTotalMs ?? 0) /
+              interactionResolutionCount
+            : undefined;
 
     return (
         <div
@@ -863,6 +870,11 @@ export function DebugHud() {
                                     icon={Layers}
                                     label="Overlays"
                                     value={`snow ${profileSnapshot?.instancedSnowOverlayCount ?? 0} · mulch ${profileSnapshot?.raisedBedMulchOverlayCount ?? 0} · decor ${profileSnapshot?.groundDecorationCount ?? 0}`}
+                                />
+                                <InfoRow
+                                    icon={Settings}
+                                    label="Block interactions"
+                                    value={`${profileSnapshot?.instancedInteractionControllerCount ?? 0} controller · ${profileSnapshot?.instancedInteractionTargetCount ?? 0} targets · ${interactionResolutionCount} resolves · avg ${formatMetric(interactionResolutionAverageMs)} ms · max ${formatMetric(profileSnapshot?.instancedInteractionResolutionMaxMs)} ms`}
                                 />
                                 <InfoRow
                                     icon={Settings}

--- a/packages/game/src/scene/gameProfileMetadata.ts
+++ b/packages/game/src/scene/gameProfileMetadata.ts
@@ -194,6 +194,11 @@ export type GameProfileMetadata = {
     generatedLSystemCachePeakEstimatedBytes?: number;
     generatedLSystemCacheWriteCount?: number;
     generatedPlantProfile?: GeneratedPlantProfileSnapshot | null;
+    instancedInteractionControllerCount?: number;
+    instancedInteractionResolutionCount?: number;
+    instancedInteractionResolutionMaxMs?: number;
+    instancedInteractionResolutionTotalMs?: number;
+    instancedInteractionTargetCount?: number;
     instancedSnowOverlayCount?: number;
     placementChunkLogicalTouchedCount?: number;
     placementChunkLogicalUpdateCount?: number;


### PR DESCRIPTION
## What

- replace per-instanced-block interaction control trees with one scene-level controller
- resolve pointer hits through the existing shared interaction layer and retain stable target handlers
- preserve selection, closeup, double-tap rotation, hold/drag/touch, multi-select, move, store, recycle, delete, sandbox, audio, haptics, particles, autopan, and cleanup behavior
- reconcile active pointer, hover, rotation, first-tap, and deferred-click state when targets change
- keep non-instanced entities and public-garden interaction paths unchanged
- add controller/target/resolution profiling metadata and debug visibility

## Why

Dense gardens previously mounted a full React interaction tree for every instanced block. The dense fixture contains 661 interaction targets; this change keeps exactly one shared controller for all of them.

Matched production profiles showed substantially lower controller heap and scripting cost without a task-time or frame-rate regression:

- controls scenario: heap -84.9%, scripting time -86.6%
- camera scenario: heap -78.6%, scripting time -67.2%
- async game chunk: +4,438 bytes gzip (+0.88%)

## Validation

- `pnpm --filter @gredice/game test` — 611/611 pass
- `pnpm lint --filter @gredice/game` — 804 files, no fixes
- `pnpm --filter @gredice/game typecheck`
- Garden and WWW typechecks
- `pnpm --filter garden test:profile` — 8/8 pass
- clean production Garden build — 35 routes, 5.1s compile, 3.1s TypeScript
- dense production profile — one controller / 661 targets; 19 camera resolutions; max 0.30ms and 0.60ms total; no page errors
- independent final audit found no interaction ownership, input parity, cleanup, or production-instrumentation blockers
- `git diff --check`

Absolute software-headless GPU budgets remain environment-limited; matched before/after controller costs and the single-controller counters are the acceptance evidence.

Closes #4293