### PR TITLE
Refresh shopping cart when modal opens

### DIFF
--- a/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
+++ b/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
@@ -613,6 +613,46 @@ test.describe('shopping cart item presence', () => {
         ).toContainText('Košara je prazna');
     });
 
+    test('keeps cached cart items visible when the modal refresh fails', async ({
+        mount,
+        page,
+    }) => {
+        let shoppingCartGetCount = 0;
+
+        await page.route('**/api/gredice/**/shopping-cart', async (route) => {
+            if (route.request().method() !== 'GET') {
+                await route.fallback();
+                return;
+            }
+
+            shoppingCartGetCount += 1;
+            await route.fulfill({
+                body: JSON.stringify({ error: 'Temporary failure' }),
+                contentType: 'application/json',
+                status: 500,
+            });
+        });
+
+        await mount(<ShoppingCartHudItemsPresenceStory />);
+
+        await page.getByTitle('Košara').click();
+
+        await expect.poll(() => shoppingCartGetCount).toBe(1);
+        await expect(
+            page.getByText('Greška prilikom učitavanja košare'),
+        ).toBeVisible();
+        await expect(
+            page.locator('[data-shopping-cart-item-id="1"]'),
+        ).toBeVisible();
+        await expect(
+            page.locator('[data-shopping-cart-summary]'),
+        ).toContainText('2.50 €');
+        await expect(
+            page.getByRole('button', { name: 'Očisti košaru' }),
+        ).toBeEnabled();
+        await expect(page.getByRole('button', { name: 'Plati' })).toBeEnabled();
+    });
+
     test('reuses an exiting row when an optimistic removal rolls back', async ({
         mount,
         page,

--- a/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
+++ b/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
@@ -9,6 +9,53 @@ import {
     ShoppingCartPlantSortStory,
 } from './ShoppingCartOptimisticToggleStory';
 
+const shoppingCartServerItem = {
+    id: 1,
+    cartId: 1,
+    entityId: 'operation-1',
+    entityTypeName: 'operation',
+    gardenId: null,
+    raisedBedId: null,
+    positionIndex: null,
+    additionalData: null,
+    amount: 1,
+    currency: 'eur',
+    status: 'new',
+    isDeleted: false,
+    createdAt: '2026-05-21T00:00:00.000Z',
+    updatedAt: '2026-05-21T00:00:00.000Z',
+    shopData: {
+        name: 'Zalijevanje',
+        description: 'Mock operation.',
+        image: '',
+        price: 2.5,
+    },
+    entityData: {
+        id: 1,
+        entityType: { id: 10, name: 'operation', label: 'Radnje' },
+        slug: 'mock-watering',
+        information: {
+            name: 'watering',
+            label: 'Zalijevanje',
+            shortDescription: 'Mock operation.',
+        },
+    },
+};
+
+function createShoppingCartServerData(
+    items: (typeof shoppingCartServerItem)[] = [shoppingCartServerItem],
+) {
+    return {
+        allowPurchase: true,
+        hasDeliverableItems: false,
+        id: 1,
+        items,
+        notes: [],
+        total: items.reduce((total, item) => total + item.shopData.price, 0),
+        totalSunflowers: 0,
+    };
+}
+
 async function getPresenceAnimation(locator: Locator) {
     return locator.evaluate((node) => {
         const style = window.getComputedStyle(node);
@@ -468,6 +515,19 @@ test.describe('shopping cart item presence', () => {
         mount,
         page,
     }) => {
+        await page.route('**/api/gredice/**/shopping-cart', async (route) => {
+            if (route.request().method() !== 'GET') {
+                await route.fallback();
+                return;
+            }
+
+            await route.fulfill({
+                body: JSON.stringify(createShoppingCartServerData()),
+                contentType: 'application/json',
+                status: 200,
+            });
+        });
+
         await mount(<ShoppingCartHudItemsPresenceStory />);
 
         const cartTrigger = page.getByTitle('Košara');
@@ -515,6 +575,42 @@ test.describe('shopping cart item presence', () => {
 
         await expect(cartDialog).toHaveCount(0);
         await expect(cartTrigger).toHaveCount(0);
+    });
+
+    test('refreshes the shopping cart when the production modal opens', async ({
+        mount,
+        page,
+    }) => {
+        let shoppingCartGetCount = 0;
+
+        await page.route('**/api/gredice/**/shopping-cart', async (route) => {
+            if (route.request().method() !== 'GET') {
+                await route.fallback();
+                return;
+            }
+
+            shoppingCartGetCount += 1;
+            await route.fulfill({
+                body: JSON.stringify(createShoppingCartServerData([])),
+                contentType: 'application/json',
+                status: 200,
+            });
+        });
+
+        await mount(<ShoppingCartHudItemsPresenceStory />);
+
+        await expect(page.getByTestId('cart-source-item-ids')).toHaveText('1');
+        expect(shoppingCartGetCount).toBe(0);
+
+        await page.getByTitle('Košara').click();
+
+        await expect.poll(() => shoppingCartGetCount).toBe(1);
+        await expect(page.getByTestId('cart-source-item-ids')).toHaveText(
+            'empty',
+        );
+        await expect(
+            page.getByRole('dialog', { name: 'Košara' }),
+        ).toContainText('Košara je prazna');
     });
 
     test('reuses an exiting row when an optimistic removal rolls back', async ({

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -14,7 +14,7 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
-import { useLayoutEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { isCompleteDeliverySelection, useCheckout } from '../hooks/useCheckout';
 import { useCurrentAccount } from '../hooks/useCurrentAccount';
@@ -478,12 +478,18 @@ export function ShoppingCart({
 }
 
 export function ShoppingCartHud() {
-    const { data: cart } = useShoppingCart();
+    const { data: cart, refetch: refetchCart } = useShoppingCart();
     const { track } = useGameAnalytics();
     const [isOpen, setIsOpen] = useShoppingCartOpenParam();
     const [checkoutStep, setCheckoutStep] =
         useState<ShoppingCartCheckoutStep>('cart');
     const showTransientHub = useShoppingCartTransientHub(isOpen);
+
+    useEffect(() => {
+        if (isOpen) {
+            void refetchCart();
+        }
+    }, [isOpen, refetchCart]);
 
     if (!cart?.items.length && !showTransientHub && !isOpen) {
         return null;

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -86,6 +86,7 @@ export function ShoppingCart({
     const { track } = useGameAnalytics();
     const deleteCart = useShoppingCartDelete();
     const checkout = useCheckout();
+    const shouldRenderCartItems = !isLoading && (!isError || Boolean(cart));
 
     // State for delivery flow
     const [deliverySelection, setDeliverySelection] =
@@ -357,7 +358,7 @@ export function ShoppingCart({
                                 Greška prilikom učitavanja košare
                             </Typography>
                         )}
-                        {!isLoading && !isError ? (
+                        {shouldRenderCartItems ? (
                             <ShoppingCartItemsPresence
                                 items={cart?.items ?? []}
                             />


### PR DESCRIPTION
## What changed

- refetch the shared shopping-cart query whenever the URL-backed cart modal transitions to open
- keep the existing cached cart visible while the request is in flight or a background refresh fails
- add production-HUD component coverage proving opening the modal starts a GET and applies the returned cart state
- cover failed refreshes so cached items remain reviewable alongside cached totals and actions
- update the existing modal lifecycle test with deterministic server state now that opening performs a request

## Why

The cart query remains fresh for five minutes. When multiple users work in the same garden/account, one user's app can therefore keep showing another user's older cart state until a manual app refresh. Opening the cart is the point where the latest shared state is needed.

## User impact

Users now see the latest shopping cart state after opening the cart modal without refreshing the Garden app. URL-, tutorial-, and trigger-driven modal opens all use the same open-state transition. If the refresh fails, users can still review the cached items before using cached cart actions.

## Validation

- `pnpm --filter garden exec playwright test tests/shopping-cart-optimistic-toggle.spec.tsx --project=chromium` (15 passed)
- `pnpm --filter @gredice/game test` (616 passed)
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter garden exec biome check tests/shopping-cart-optimistic-toggle.spec.tsx ../../packages/game/src/hud/ShoppingCartHud.tsx`
- `pnpm --filter garden test:prepare`
- `git diff --check`