### PR TITLE
Polish harvest scheduling checkout step

### DIFF
--- a/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
+++ b/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
@@ -359,7 +359,9 @@ function ShoppingCartItemsPresencePanel({
             ) : (
                 <ShoppingCart
                     checkoutStep="cart"
+                    deliverySummary={null}
                     onCheckoutStepChange={() => undefined}
+                    onDeliverySummaryChange={() => undefined}
                 />
             )}
         </div>

--- a/apps/garden/tests/harvest-schedule-step.spec.tsx
+++ b/apps/garden/tests/harvest-schedule-step.spec.tsx
@@ -1,58 +1,116 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import { HarvestScheduleStepStory } from './HarvestScheduleStepStory';
 
-test('shows only the summary when every date is already valid', async ({
+test('shows the summary and lets a valid flexible date be changed again', async ({
     mount,
     page,
 }) => {
     await mount(<HarvestScheduleStepStory />);
+
+    const carrotDate = page.getByLabel('Datum branja za Berba mrkve');
+    const editDates = page.getByRole('button', { name: 'Uredi datume' });
 
     await expect(
         page.getByText(
             'Svi datumi branja usklađeni su s odabranim terminom dostave.',
         ),
     ).toBeVisible();
-    await expect(page.getByLabel('Datum branja za Berba mrkve')).toHaveCount(0);
+    await expect(carrotDate).toHaveCount(0);
+    await expect(editDates).toBeVisible();
+
+    await editDates.click();
+
+    await expect(carrotDate).toHaveValue('2026-07-22');
+    await expect(page.getByLabel('Datum branja za Berba salate')).toHaveCount(
+        0,
+    );
+    await carrotDate.fill('2026-07-23');
+    await page.getByRole('button', { name: 'Završi uređivanje' }).click();
+
+    await expect(carrotDate).toHaveCount(0);
     await expect(
-        page.getByRole('button', { name: 'Uredi datume' }),
-    ).toHaveCount(0);
+        page.getByText('Planirano branje: 23. srpnja 2026.'),
+    ).toBeVisible();
+    await expect(editDates).toBeVisible();
 });
 
-test('collects invalid flexible dates, keeps same-day crops fixed, and returns to summary', async ({
+test('applies a suggested date and keeps it available for another manual edit', async ({
     mount,
     page,
 }) => {
+    await page.setViewportSize({ height: 844, width: 390 });
     await mount(<HarvestScheduleStepStory invalid />);
+
+    const carrotDate = page.getByLabel('Datum branja za Berba mrkve');
+    const confirm = page.getByRole('button', { name: 'Potvrdi i plati' });
+    const output = page.getByLabel('Odabrani datumi branja');
 
     await expect(
         page.getByText('Provjeri označene datume prije plaćanja.', {
             exact: false,
         }),
     ).toBeVisible();
-    await expect(page.getByLabel('Datum branja za Berba mrkve')).toHaveValue(
-        '2026-07-20',
-    );
+    await expect(carrotDate).toHaveValue('2026-07-20');
+    await expect(
+        page.getByText('Predloženi datum branja: 21. srpnja 2026.'),
+    ).toBeVisible();
+    await expect(
+        page.getByText('Ispravi datume branja kako bi mogao nastaviti.'),
+    ).toHaveCount(0);
+    await expect(confirm).toBeDisabled();
+    await expect(
+        page.getByRole('button', { name: 'Uredi datume' }),
+    ).toHaveCount(0);
     await expect(page.getByLabel('Datum branja za Berba salate')).toHaveCount(
         0,
     );
-    await expect(
-        page.getByRole('button', { name: 'Uredi datume' }),
-    ).toBeVisible();
-    await expect(page.getByLabel('Odabrani datumi branja')).toContainText(
+    await expect(output).toContainText(
         '"cartItemId":71,"scheduledDate":"2026-07-24"',
     );
 
-    await page.getByLabel('Datum branja za Berba mrkve').fill('2026-07-22');
+    await page
+        .getByRole('button', {
+            name: 'Primijeni predloženi datum za Berba mrkve',
+        })
+        .click();
 
     await expect(
         page.getByText(
             'Svi datumi branja usklađeni su s odabranim terminom dostave.',
         ),
     ).toBeVisible();
-    await expect(page.getByLabel('Datum branja za Berba mrkve')).toHaveCount(0);
-    await expect(page.getByLabel('Odabrani datumi branja')).toContainText(
-        '"cartItemId":72,"scheduledDate":"2026-07-22"',
+    await expect(carrotDate).toHaveCount(0);
+    await expect(confirm).toBeEnabled();
+    await expect(output).toContainText(
+        '"cartItemId":72,"scheduledDate":"2026-07-21"',
     );
+
+    await page.getByRole('button', { name: 'Uredi datume' }).click();
+
+    await expect(carrotDate).toHaveValue('2026-07-21');
+    await carrotDate.fill('2026-07-20');
+    await expect(
+        page.getByRole('button', { name: 'Završi uređivanje' }),
+    ).toBeDisabled();
+    await page
+        .getByRole('button', {
+            name: 'Primijeni predloženi datum za Berba mrkve',
+        })
+        .click();
+    await expect(carrotDate).toHaveValue('2026-07-21');
+    await carrotDate.fill('2026-07-23');
+    await expect(output).toContainText(
+        '"cartItemId":72,"scheduledDate":"2026-07-23"',
+    );
+    await page.getByRole('button', { name: 'Završi uređivanje' }).click();
+
+    await expect(carrotDate).toHaveCount(0);
+    await expect(
+        page.getByText('Planirano branje: 23. srpnja 2026.'),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Uredi datume' }),
+    ).toBeVisible();
 });
 
 test('renders the existing checkout action when provided', async ({

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -74,12 +74,16 @@ export type ShoppingCartCheckoutStep = 'cart' | 'delivery' | 'harvest';
 
 interface ShoppingCartProps {
     checkoutStep: ShoppingCartCheckoutStep;
+    deliverySummary: DeliveryStepSummary | null;
     onCheckoutStepChange: (step: ShoppingCartCheckoutStep) => void;
+    onDeliverySummaryChange: (summary: DeliveryStepSummary) => void;
 }
 
 export function ShoppingCart({
     checkoutStep,
+    deliverySummary,
     onCheckoutStepChange,
+    onDeliverySummaryChange,
 }: ShoppingCartProps) {
     const { data: account } = useCurrentAccount();
     const { data: cart, isLoading, isError } = useShoppingCart();
@@ -91,8 +95,6 @@ export function ShoppingCart({
     // State for delivery flow
     const [deliverySelection, setDeliverySelection] =
         useState<DeliverySelectionData | null>(null);
-    const [deliverySummary, setDeliverySummary] =
-        useState<DeliveryStepSummary | null>(null);
     const [harvestDates, setHarvestDates] = useState<
         readonly HarvestScheduleDateSelection[]
     >([]);
@@ -180,7 +182,7 @@ export function ShoppingCart({
 
     function handleDeliveryProceed(summary: DeliveryStepSummary) {
         if (isCompleteDeliverySelection(deliverySelection)) {
-            setDeliverySummary(summary);
+            onDeliverySummaryChange(summary);
             setHarvestDates([]);
             setTransitionDirection('forward');
             onCheckoutStepChange('harvest');
@@ -484,6 +486,8 @@ export function ShoppingCartHud() {
     const [isOpen, setIsOpen] = useShoppingCartOpenParam();
     const [checkoutStep, setCheckoutStep] =
         useState<ShoppingCartCheckoutStep>('cart');
+    const [deliverySummary, setDeliverySummary] =
+        useState<DeliveryStepSummary | null>(null);
     const showTransientHub = useShoppingCartTransientHub(isOpen);
 
     useEffect(() => {
@@ -515,7 +519,9 @@ export function ShoppingCartHud() {
                             ? 'Košara'
                             : checkoutStep === 'delivery'
                               ? 'Dostava'
-                              : 'Branje'
+                              : deliverySummary?.mode === 'pickup'
+                                ? 'Sažetak preuzimanja'
+                                : 'Sažetak dostave'
                     }
                     className="md:max-w-2xl"
                     headerIcon={
@@ -561,7 +567,9 @@ export function ShoppingCartHud() {
                 >
                     <ShoppingCart
                         checkoutStep={checkoutStep}
+                        deliverySummary={deliverySummary}
                         onCheckoutStepChange={setCheckoutStep}
+                        onDeliverySummaryChange={setDeliverySummary}
                     />
                 </GameModal>
             </Row>

--- a/packages/game/src/shared-ui/delivery/DeliveryStep.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliveryStep.tsx
@@ -315,7 +315,7 @@ export function DeliveryStep({
                         />
                     ) : (
                         <NoDataPlaceholder className="min-w-0 flex-1">
-                            Dodaj adresu za dostavu kako bi mogao nastaviti.
+                            Dodaj adresu za dostavu kako bi mogao/la nastaviti.
                         </NoDataPlaceholder>
                     )}
                     <Button

--- a/packages/game/src/shared-ui/delivery/HarvestScheduleStep.tsx
+++ b/packages/game/src/shared-ui/delivery/HarvestScheduleStep.tsx
@@ -4,13 +4,14 @@ import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { Chip } from '@gredice/ui/Chip';
 import { Input } from '@gredice/ui/Input';
-import { Calendar, Check, Edit, Info, Navigate } from '@gredice/ui/icons';
+import { Check, Edit, Info, Navigate } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import {
     createHarvestScheduleDateSelections,
+    getSuggestedHarvestDate,
     type HarvestScheduleDateSelection,
     type HarvestScheduleItem,
     harvestCalendarDateKey,
@@ -197,46 +198,26 @@ export function HarvestScheduleStep({
 
     return (
         <Stack spacing={6}>
-            <section aria-labelledby="harvest-delivery-summary-title">
-                <Stack spacing={3}>
-                    <Row spacing={2}>
-                        <Calendar
-                            aria-hidden="true"
-                            className="size-5 shrink-0"
-                        />
-                        <Typography
-                            component="h3"
-                            id="harvest-delivery-summary-title"
-                            level="h6"
-                            semiBold
-                        >
-                            Sažetak{' '}
-                            {delivery.mode === 'pickup'
-                                ? 'preuzimanja'
-                                : 'dostave'}
-                        </Typography>
-                    </Row>
-                    <div className="grid gap-3 rounded-lg border bg-card/60 p-3 sm:grid-cols-2">
+            <section
+                aria-label={
+                    delivery.mode === 'pickup'
+                        ? 'Detalji preuzimanja'
+                        : 'Detalji dostave'
+                }
+            >
+                <div className="rounded-lg border bg-card/60 px-3 py-2.5">
+                    <Stack spacing={2}>
                         <div>
                             <Typography level="body3" tertiary>
-                                Datum
+                                {deliveryWindow ? 'Datum i vrijeme' : 'Datum'}
                             </Typography>
                             <Typography level="body2" semiBold>
                                 {formatCalendarDate(delivery.deliveryDate)}
+                                {deliveryWindow ? ` · ${deliveryWindow}` : null}
                             </Typography>
                         </div>
-                        {deliveryWindow ? (
-                            <div>
-                                <Typography level="body3" tertiary>
-                                    Vrijeme
-                                </Typography>
-                                <Typography level="body2" semiBold>
-                                    {deliveryWindow}
-                                </Typography>
-                            </div>
-                        ) : null}
                         {delivery.destinationLabel ? (
-                            <div className="sm:col-span-2">
+                            <div>
                                 <Typography level="body3" tertiary>
                                     {delivery.mode === 'pickup'
                                         ? 'Mjesto preuzimanja'
@@ -247,8 +228,8 @@ export function HarvestScheduleStep({
                                 </Typography>
                             </div>
                         ) : null}
-                    </div>
-                </Stack>
+                    </Stack>
+                </div>
             </section>
 
             <section aria-labelledby="harvest-schedule-title">
@@ -271,10 +252,14 @@ export function HarvestScheduleStep({
                                 Branje se planira prema svježini svake biljke.
                             </Typography>
                         </div>
-                        {hasDatesToAdjust && hasFlexibleDates ? (
+                        {hasFlexibleDates &&
+                        (allDatesValid || editFlexibleDates) ? (
                             <Button
                                 aria-pressed={editFlexibleDates}
-                                disabled={isConfirming}
+                                disabled={
+                                    isConfirming ||
+                                    (editFlexibleDates && !allDatesValid)
+                                }
                                 size="sm"
                                 startDecorator={
                                     <Edit
@@ -303,7 +288,11 @@ export function HarvestScheduleStep({
                         >
                             Provjeri označene datume prije plaćanja. Za biljke
                             koje se moraju brati isti dan datum je već
-                            postavljen na dan dostave.
+                            postavljen na dan{' '}
+                            {delivery.mode === 'pickup'
+                                ? 'preuzimanja'
+                                : 'dostave'}
+                            .
                         </Alert>
                     ) : (
                         <Alert
@@ -334,6 +323,10 @@ export function HarvestScheduleStep({
                                 allowedFrom !== null &&
                                 allowedFrom === allowedTo;
                             const selectedDateValid = isHarvestDateWithinRange(
+                                selectedDate,
+                                item,
+                            );
+                            const suggestedDate = getSuggestedHarvestDate(
                                 selectedDate,
                                 item,
                             );
@@ -407,6 +400,42 @@ export function HarvestScheduleStep({
 
                                         {showDateControl ? (
                                             <div>
+                                                {!selectedDateValid &&
+                                                suggestedDate ? (
+                                                    <Row
+                                                        className="mb-2 min-w-0 flex-wrap"
+                                                        justifyContent="space-between"
+                                                        spacing={2}
+                                                    >
+                                                        <Typography
+                                                            level="body3"
+                                                            semiBold
+                                                        >
+                                                            Predloženi datum
+                                                            branja:{' '}
+                                                            {formatCalendarDate(
+                                                                suggestedDate,
+                                                            )}
+                                                        </Typography>
+                                                        <Button
+                                                            aria-label={`Primijeni predloženi datum za ${item.operationLabel}`}
+                                                            color="warning"
+                                                            disabled={
+                                                                isConfirming
+                                                            }
+                                                            size="sm"
+                                                            variant="soft"
+                                                            onClick={() =>
+                                                                handleDateChange(
+                                                                    item,
+                                                                    suggestedDate,
+                                                                )
+                                                            }
+                                                        >
+                                                            Primijeni prijedlog
+                                                        </Button>
+                                                    </Row>
+                                                ) : null}
                                                 <Input
                                                     aria-describedby={helpId}
                                                     aria-invalid={
@@ -479,17 +508,6 @@ export function HarvestScheduleStep({
                 </Stack>
             </section>
 
-            {!allDatesValid ? (
-                <Typography
-                    aria-live="polite"
-                    color="danger"
-                    level="body3"
-                    role="status"
-                >
-                    Ispravi datume branja kako bi mogao nastaviti.
-                </Typography>
-            ) : null}
-
             <Row className="flex-wrap" justifyContent="end" spacing={4}>
                 <Button
                     disabled={isConfirming}
@@ -509,7 +527,9 @@ export function HarvestScheduleStep({
                     </fieldset>
                 ) : (
                     <Button
-                        disabled={confirmDisabled || !allDatesValid}
+                        disabled={
+                            confirmDisabled || !allDatesValid || isConfirming
+                        }
                         endDecorator={
                             <Navigate
                                 aria-hidden="true"

--- a/packages/game/src/shared-ui/delivery/harvestSchedule.ts
+++ b/packages/game/src/shared-ui/delivery/harvestSchedule.ts
@@ -67,6 +67,33 @@ export function isHarvestDateWithinRange(
     );
 }
 
+export function getSuggestedHarvestDate(
+    scheduledDate: string | null | undefined,
+    item: Pick<HarvestScheduleItem, 'allowedFrom' | 'allowedTo'>,
+) {
+    const dateKey = harvestCalendarDateKey(scheduledDate);
+    const allowedFrom = harvestCalendarDateKey(item.allowedFrom);
+    const allowedTo = harvestCalendarDateKey(item.allowedTo);
+
+    if (!allowedFrom || !allowedTo || allowedFrom > allowedTo) {
+        return null;
+    }
+
+    if (!dateKey) {
+        return allowedTo;
+    }
+
+    if (dateKey < allowedFrom) {
+        return allowedFrom;
+    }
+
+    if (dateKey > allowedTo) {
+        return allowedTo;
+    }
+
+    return dateKey;
+}
+
 export function createHarvestScheduleDateSelections(
     items: readonly HarvestScheduleItem[],
 ): HarvestScheduleDateSelection[] {

--- a/packages/game/src/shared-ui/delivery/harvestSchedule.unit.ts
+++ b/packages/game/src/shared-ui/delivery/harvestSchedule.unit.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
     createHarvestScheduleDateSelections,
+    getSuggestedHarvestDate,
     type HarvestScheduleItem,
     harvestCalendarDateKey,
     isHarvestDateWithinRange,
@@ -42,6 +43,36 @@ test('accepts both inclusive harvest range boundaries', () => {
     );
     assert.equal(isHarvestDateWithinRange('2026-07-20', flexibleItem), false);
     assert.equal(isHarvestDateWithinRange('2026-07-25', flexibleItem), false);
+});
+
+test('suggests the nearest allowed date without changing valid selections', () => {
+    assert.equal(
+        getSuggestedHarvestDate('2026-07-20', flexibleItem),
+        flexibleItem.allowedFrom,
+    );
+    assert.equal(
+        getSuggestedHarvestDate('2026-07-25', flexibleItem),
+        flexibleItem.allowedTo,
+    );
+    assert.equal(
+        getSuggestedHarvestDate('2026-07-22', flexibleItem),
+        '2026-07-22',
+    );
+    assert.equal(
+        getSuggestedHarvestDate(null, flexibleItem),
+        flexibleItem.allowedTo,
+    );
+    assert.equal(
+        getSuggestedHarvestDate('not-a-date', flexibleItem),
+        flexibleItem.allowedTo,
+    );
+    assert.equal(
+        getSuggestedHarvestDate('2026-07-22', {
+            allowedFrom: '2026-07-24',
+            allowedTo: '2026-07-21',
+        }),
+        null,
+    );
 });
 
 test('keeps valid dates, preserves flexible corrections, and fixes same-day crops', () => {


### PR DESCRIPTION
## Summary

- use a single mode-aware modal title for delivery or pickup and compact the selected date/time into one row
- add a deterministic suggested harvest date with one-click application while preserving manual date entry
- keep flexible harvest dates editable after the first valid selection, including recovery from an invalid re-edit
- remove the redundant bottom error message and use the established inclusive Croatian `/la` wording
- add mobile-width component coverage for suggestion, validation, re-opening, and changing a date again

## Root cause

The edit affordance was gated by an invalid schedule, so it disappeared as soon as a user selected a valid date. The harvest step also repeated the modal title and required invalid dates to be corrected manually.

## User impact

Users can apply a valid suggested date immediately, reopen the editor later, and choose another valid date without leaving the checkout flow. Same-day crops remain fixed to the delivery or pickup date.

## Validation

- `pnpm --filter @gredice/game test` — 617 passed
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter garden test:prepare`
- targeted Garden Chromium component tests — 18 passed, including the harvest flow at 390px width
- package-local Biome checks
- `git diff --check`