### PR TITLE
fix(ai): schedule user-facing raised-bed suggestions

### DIFF
--- a/apps/api/lib/garden/raisedBedAiAnalysisService.node.spec.ts
+++ b/apps/api/lib/garden/raisedBedAiAnalysisService.node.spec.ts
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    buildAvailableOperationsContext,
     buildPastPlantFieldsContext,
+    getOperationSchedulingDateOptions,
     getRaisedBedImageAnalysisWeeklyLimit,
     getWeatherHistoryDayRange,
     normalizeAnalysisReferenceDate,
@@ -29,6 +31,66 @@ test('getWeatherHistoryDayRange resolves the Zagreb local weather day', () => {
     assert.strictEqual(range.date, '2026-05-12');
     assert.strictEqual(range.from.toISOString(), '2026-05-11T22:00:00.000Z');
     assert.strictEqual(range.to.toISOString(), '2026-05-12T21:59:59.999Z');
+});
+
+test('getOperationSchedulingDateOptions returns the next three Zagreb dates', () => {
+    assert.deepStrictEqual(
+        getOperationSchedulingDateOptions(new Date('2026-07-25T22:30:00.000Z')),
+        ['2026-07-27', '2026-07-28', '2026-07-29'],
+    );
+});
+
+test('buildAvailableOperationsContext excludes internal operations and embeds date placeholders', () => {
+    const operations = buildAvailableOperationsContext(
+        [
+            {
+                id: '11',
+                slug: 'malciranje-gredice',
+                attributes: {
+                    application: 'raisedBedFull',
+                    internal: false,
+                },
+                information: { label: 'Malčiranje gredice' },
+            },
+            {
+                id: '12',
+                slug: 'zalijevanje-biljke',
+                attributes: { application: 'plant' },
+                information: { label: 'Zalijevanje biljke' },
+            },
+            {
+                id: '13',
+                slug: 'interna-kontrola',
+                attributes: {
+                    application: 'raisedBedFull',
+                    internal: true,
+                },
+                information: { label: 'Interna kontrola' },
+            },
+        ],
+        101,
+    );
+
+    assert.deepStrictEqual(operations, [
+        {
+            id: '11',
+            name: 'Malčiranje gredice',
+            slug: 'malciranje-gredice',
+            application: 'raisedBedFull',
+            raisedBedOperationUrl:
+                'https://www.gredice.com/radnje/malciranje-gredice#raisedBedId=101&scheduledDate={scheduledDate}',
+            plantFieldOperationUrlTemplate: null,
+        },
+        {
+            id: '12',
+            name: 'Zalijevanje biljke',
+            slug: 'zalijevanje-biljke',
+            application: 'plant',
+            raisedBedOperationUrl: null,
+            plantFieldOperationUrlTemplate:
+                'https://www.gredice.com/radnje/zalijevanje-biljke#raisedBedId=101&positionIndex={positionIndex}&scheduledDate={scheduledDate}',
+        },
+    ]);
 });
 
 test('buildPastPlantFieldsContext summarizes only previous plant names', () => {

--- a/apps/api/lib/garden/raisedBedAiAnalysisService.ts
+++ b/apps/api/lib/garden/raisedBedAiAnalysisService.ts
@@ -470,6 +470,71 @@ type AnalysisParams = {
     referenceDate?: Date | string | null;
 };
 
+type AnalysisOperationEntity = {
+    id: string;
+    slug?: string;
+    attributes?: {
+        application?: string | null;
+        internal?: boolean | null;
+    };
+    information?: { label?: string; name?: string };
+};
+
+export function buildAvailableOperationsContext(
+    operations: AnalysisOperationEntity[],
+    raisedBedId: number,
+) {
+    return operations
+        .filter((operation) => operation.attributes?.internal !== true)
+        .map((operation) => {
+            const application = operation.attributes?.application ?? null;
+            const isRaisedBedOperation =
+                application === 'raisedBedFull' ||
+                application === 'raisedBed1m';
+            const isPlantFieldOperation = application === 'plant';
+            const publicOperationUrl = operation.slug
+                ? `https://www.gredice.com/radnje/${operation.slug}`
+                : null;
+
+            return {
+                id: operation.id,
+                name:
+                    operation.information?.label ??
+                    operation.information?.name ??
+                    operation.id,
+                slug: operation.slug ?? null,
+                application,
+                raisedBedOperationUrl:
+                    isRaisedBedOperation && publicOperationUrl
+                        ? `${publicOperationUrl}#raisedBedId=${raisedBedId}&scheduledDate={scheduledDate}`
+                        : null,
+                plantFieldOperationUrlTemplate:
+                    isPlantFieldOperation && publicOperationUrl
+                        ? `${publicOperationUrl}#raisedBedId=${raisedBedId}&positionIndex={positionIndex}&scheduledDate={scheduledDate}`
+                        : null,
+            };
+        });
+}
+
+export function getOperationSchedulingDateOptions(now = new Date()) {
+    const localNow = tz(WEATHER_CONTEXT_TIME_ZONE)(now);
+
+    return Array.from({ length: 3 }, (_, index) =>
+        formatLocalDateKey(
+            new TZDate(
+                localNow.getFullYear(),
+                localNow.getMonth(),
+                localNow.getDate() + index + 1,
+                0,
+                0,
+                0,
+                0,
+                WEATHER_CONTEXT_TIME_ZONE,
+            ),
+        ),
+    );
+}
+
 async function buildAnalysisPrompt({
     accountId,
     gardenId,
@@ -488,12 +553,7 @@ async function buildAnalysisPrompt({
                 information?: { name?: string };
             }>('plantSort'),
             getOperations(accountId, gardenId, raisedBed.id),
-            getEntitiesFormatted<{
-                id: string;
-                slug?: string;
-                attributes?: { application?: string | null };
-                information?: { label?: string; name?: string };
-            }>('operation'),
+            getEntitiesFormatted<AnalysisOperationEntity>('operation'),
             buildWeatherContext(referenceDate),
         ],
     );
@@ -510,33 +570,10 @@ async function buildAnalysisPrompt({
             entity.information?.label ?? entity.information?.name ?? entity.id,
         ]),
     );
-    const availableOperations = operationsData.map((entity) => {
-        const application = entity.attributes?.application ?? null;
-        const isRaisedBedOperation =
-            application === 'raisedBedFull' || application === 'raisedBed1m';
-        const isPlantFieldOperation = application === 'plant';
-        const publicOperationUrl = entity.slug
-            ? `https://www.gredice.com/radnje/${entity.slug}`
-            : null;
-
-        return {
-            id: entity.id,
-            name:
-                entity.information?.label ??
-                entity.information?.name ??
-                entity.id,
-            slug: entity.slug ?? null,
-            application,
-            raisedBedOperationUrl:
-                isRaisedBedOperation && publicOperationUrl
-                    ? `${publicOperationUrl}#raisedBedId=${raisedBed.id}`
-                    : null,
-            plantFieldOperationUrlTemplate:
-                isPlantFieldOperation && publicOperationUrl
-                    ? `${publicOperationUrl}#raisedBedId=${raisedBed.id}&positionIndex={positionIndex}`
-                    : null,
-        };
-    });
+    const availableOperations = buildAvailableOperationsContext(
+        operationsData,
+        raisedBed.id,
+    );
 
     const plantedFields = raisedBed.fields
         .filter((field) => field.active && field.plantSortId)
@@ -592,7 +629,8 @@ async function buildAnalysisPrompt({
         raisedBed.fields.length || RAISED_BED_FIELDS_PER_BLOCK * 2;
     const rows = Math.max(1, Math.ceil(totalFields / RAISED_BED_COLUMNS));
     const orientation = raisedBed.orientation ?? 'vertical';
-    const nowIso = new Date().toISOString();
+    const analysisNow = new Date();
+    const nowIso = analysisNow.toISOString();
     const referenceDateIso = referenceDate.toISOString();
     const imageDateSource = inputReferenceDateValue
         ? 'requestReferenceDate'
@@ -601,10 +639,13 @@ async function buildAnalysisPrompt({
         typeof positionIndex === 'number'
             ? toPositionLabel(positionIndex)
             : null;
+    const operationSchedulingDates =
+        getOperationSchedulingDateOptions(analysisNow);
 
     return {
         system: [
             'Ti si stručni agronom za urbane vrtove. Piši ISKLJUČIVO na hrvatskom jeziku i vrati odgovor kao uredno formatiran markdown. Korisnik nema fizički pristup gredici; kada preporuka traži rad na gredici, predloži naručivanje najbliže odgovarajuće operacije iz dostupnog popisa umjesto da korisniku kažeš da to sam ručno napravi.',
+            'Internu radnju nikada ne predlaži kao korisnikov sljedeći korak. Radnju smiješ preporučiti samo ako postoji u `availableOperations`; `executedOperations` je isključivo povijesni kontekst i nije izvor novih preporuka.',
             'Nikada u vidljivom odgovoru ne spominji interne nazive ili JSON ključeve poput `positionIndex`, `positionLabel`, `needsRemoval`, `removalRecommendation`, `plantStatus`, `plantSortId`, `currentLocation`, `sowingLocation`, `availableOperations`, `raisedBedOperationUrl` ili `plantFieldOperationUrlTemplate`. Ne citiraj `key: value` parove iz JSON-a.',
             'Kad trebaš identificirati lokaciju, napiši samo "polje N" koristeći korisniku vidljivu oznaku polja. Nikada ne dodaj 0-bazirani indeks polja u tekst odgovora.',
             'Statuse, bool vrijednosti i interne oznake pretvori u normalan hrvatski tekst, npr. "označeno za uklanjanje", "spremno za berbu" ili "u stakleniku".',
@@ -619,8 +660,9 @@ async function buildAnalysisPrompt({
             '- Polja s `currentLocation: "greenhouse"` su presadnice koje trenutno rastu u stakleniku i još nisu presađene u gredicu; polja s `currentLocation: "raisedBed"` su u gredici. `sowingLocation` opisuje gdje je biljka započela.',
             '- `pastPlantFields` navodi samo nazive biljaka koje su ranije bile u polju; ne sadrži povijest događaja ni datume.',
             '- `imageDate` je datum fotografija/dnevničkog unosa. Koristi `imageDate`, `analysisReferenceDate` i `weather.historical` za procjenu stanja na fotografijama. `currentDate`, `weather.now` i `weather.forecast` koristi samo za današnje i buduće preporuke za zalijevanje, zaštitu od mraza, sjetvu i berbu.',
-            '- Kada preporučiš konkretnu radnju, napiši je kao markdown poveznicu s apsolutnim URL-om iz konteksta, npr. `[Naziv radnje](https://www.gredice.com/radnje/{slug}#raisedBedId={raisedBedId})`.',
+            '- Kada preporučiš konkretnu radnju, napiši je kao markdown poveznicu s apsolutnim URL-om iz konteksta, npr. `[Naziv radnje](https://www.gredice.com/radnje/{slug}#raisedBedId={raisedBedId}&scheduledDate=YYYY-MM-DD)`.',
             '- Za radnje nad pojedinom biljkom/poljem koristi točan URL predložak iz konteksta. Interna vrijednost polja smije postojati samo u URL-u markdown poveznice, nikada u vidljivom tekstu.',
+            '- Svakoj preporučenoj radnji odaberi konkretan datum iz `operationSchedulingDates` koji odgovara tekstu preporuke. U URL-u zamijeni `{scheduledDate}` tim datumom u formatu `YYYY-MM-DD`; ne ostavljaj placeholder i ne koristi drugi datum.',
             '- Koristi samo apsolutne `https://www.gredice.com/radnje/...` URL predloške iz `availableOperations`; ne izmišljaj slugove, ne piši sirovi URL bez markdown oznake i ne dodaj link ako za radnju ne postoji odgovarajući URL predložak.',
         ].join('\n'),
         messages: [
@@ -669,6 +711,7 @@ async function buildAnalysisPrompt({
                                         pastPlantFields.length > 0
                                             ? pastPlantFields
                                             : undefined,
+                                    operationSchedulingDates,
                                     availableOperations,
                                     executedOperations,
                                 },

--- a/apps/garden/tests/RaisedBedDiaryStory.tsx
+++ b/apps/garden/tests/RaisedBedDiaryStory.tsx
@@ -75,6 +75,19 @@ function todayUtcIso() {
     ).toISOString();
 }
 
+function futureLocalDateInput(daysFromToday: number) {
+    const today = new Date();
+    const date = new Date(
+        today.getFullYear(),
+        today.getMonth(),
+        today.getDate() + daysFromToday,
+    );
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+
+    return `${date.getFullYear()}-${month}-${day}`;
+}
+
 const diaryEntries: DiaryEntry[] = [
     {
         id: 1,
@@ -94,8 +107,7 @@ const diaryEntries: DiaryEntry[] = [
     {
         id: 2,
         name: 'AI analysis with operation links',
-        description:
-            '## Analysis\n\nSchedule [Malčiranje gredice](https://www.gredice.com/radnje/mock-raised-bed-mulching#raisedBedId=101) for the full bed and [Zalijevanje biljke](https://www.gredice.com/radnje/mock-plant-watering#raisedBedId=101&positionIndex=5) for the stressed plant.',
+        description: `## Analysis\n\nSchedule [Malčiranje gredice](https://www.gredice.com/radnje/mock-raised-bed-mulching#raisedBedId=101&scheduledDate=${futureLocalDateInput(2)}) for the full bed and [Zalijevanje biljke](https://www.gredice.com/radnje/mock-plant-watering#raisedBedId=101&positionIndex=5&scheduledDate=${futureLocalDateInput(3)}) for the stressed plant.`,
         status: null,
         timestamp: new Date('2026-05-12T12:00:00.000Z'),
         imageUrls,

--- a/apps/garden/tests/raised-bed-diary.spec.tsx
+++ b/apps/garden/tests/raised-bed-diary.spec.tsx
@@ -387,7 +387,8 @@ test('saved AI operation scheduling failures stay recoverable', async ({
     const scheduleDialog = page.getByRole('dialog', {
         name: 'Zakaži radnju: Malčiranje gredice',
     });
-    const selectedDate = await expectCalendarDatePicker(scheduleDialog);
+    await expectCalendarDatePicker(scheduleDialog);
+    const selectedDate = futureScheduleDateInput(2);
     await scheduleDialog.getByRole('button', { name: 'Potvrdi' }).click();
 
     expectBaseSchedulingPayload(await scheduledPayload, {

--- a/apps/garden/tests/raised-bed-diary.spec.tsx
+++ b/apps/garden/tests/raised-bed-diary.spec.tsx
@@ -132,6 +132,17 @@ function defaultScheduleDateInput() {
     );
 }
 
+function futureScheduleDateInput(daysFromToday: number) {
+    const today = new Date();
+    return formatDateInput(
+        new Date(
+            today.getFullYear(),
+            today.getMonth(),
+            today.getDate() + daysFromToday,
+        ),
+    );
+}
+
 async function expectCalendarDatePicker(scheduleDialog: Locator) {
     await expect(scheduleDialog.locator('[data-event-calendar]')).toBeVisible();
     await expect(scheduleDialog.getByLabel('Željeni datum radnje')).toHaveCount(
@@ -314,7 +325,8 @@ test('saved AI operation links render as scheduling chips', async ({
         scheduleDialog.getByText('Malčiranje gredice', { exact: true }),
     ).toBeVisible();
 
-    const selectedDate = await expectCalendarDatePicker(scheduleDialog);
+    await expectCalendarDatePicker(scheduleDialog);
+    const selectedDate = futureScheduleDateInput(2);
     await scheduleDialog.getByRole('button', { name: 'Potvrdi' }).click();
 
     expectBaseSchedulingPayload(await scheduledPayload, {
@@ -342,7 +354,8 @@ test('saved AI plant operation chip schedules the targeted field', async ({
     const scheduleDialog = page.getByRole('dialog', {
         name: 'Zakaži radnju: Zalijevanje biljke',
     });
-    const selectedDate = await expectCalendarDatePicker(scheduleDialog);
+    await expectCalendarDatePicker(scheduleDialog);
+    const selectedDate = futureScheduleDateInput(3);
     await scheduleDialog.getByRole('button', { name: 'Potvrdi' }).click();
 
     expectBaseSchedulingPayload(await scheduledPayload, {

--- a/packages/game/src/hud/raisedBed/RaisedBedAiOperationMarkdown.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedAiOperationMarkdown.tsx
@@ -170,6 +170,7 @@ function RaisedBedAiOperationChip({
     return (
         <OperationScheduleModal
             gardenId={gardenId}
+            initialScheduledDate={target.scheduledDate}
             operation={operation}
             onConfirm={async (scheduledDate) => {
                 await setShoppingCartItem.mutateAsync({

--- a/packages/game/src/hud/raisedBed/raisedBedAiOperationLinks.ts
+++ b/packages/game/src/hud/raisedBed/raisedBedAiOperationLinks.ts
@@ -7,6 +7,7 @@ export type RaisedBedAiOperationLinkTarget = {
     operationSlug?: string;
     raisedBedId: number;
     positionIndex?: number;
+    scheduledDate?: string;
 };
 
 function parsePositiveInteger(value: string | null) {
@@ -27,10 +28,26 @@ function parseNonNegativeInteger(value: string | null) {
     return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
 }
 
+function parseCalendarDate(value: string | null) {
+    if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        return null;
+    }
+
+    const [year, month, day] = value.split('-').map(Number);
+    const date = new Date(Date.UTC(year, month - 1, day));
+
+    return date.getUTCFullYear() === year &&
+        date.getUTCMonth() === month - 1 &&
+        date.getUTCDate() === day
+        ? value
+        : null;
+}
+
 export function buildRaisedBedAiOperationHref({
     operationSlug,
     raisedBedId,
     positionIndex,
+    scheduledDate,
 }: RaisedBedAiOperationLinkTarget) {
     if (!operationSlug) {
         return null;
@@ -42,6 +59,11 @@ export function buildRaisedBedAiOperationHref({
 
     if (typeof positionIndex === 'number') {
         hash.set('positionIndex', String(positionIndex));
+    }
+
+    const validScheduledDate = parseCalendarDate(scheduledDate ?? null);
+    if (validScheduledDate) {
+        hash.set('scheduledDate', validScheduledDate);
     }
 
     return `https://${PUBLIC_OPERATION_HOST}${PUBLIC_OPERATION_PATH_PREFIX}${operationSlug}#${hash.toString()}`;
@@ -81,6 +103,12 @@ export function parseRaisedBedAiOperationHref(
         return null;
     }
 
+    const rawScheduledDate = hash.get('scheduledDate') ?? hash.get('date');
+    const scheduledDate =
+        rawScheduledDate === null
+            ? undefined
+            : (parseCalendarDate(rawScheduledDate) ?? undefined);
+
     if (
         url.hostname === PUBLIC_OPERATION_HOST &&
         url.pathname.startsWith(PUBLIC_OPERATION_PATH_PREFIX)
@@ -95,9 +123,12 @@ export function parseRaisedBedAiOperationHref(
             return null;
         }
 
-        return typeof positionIndex === 'number'
-            ? { operationSlug, raisedBedId, positionIndex }
-            : { operationSlug, raisedBedId };
+        return {
+            operationSlug,
+            raisedBedId,
+            ...(typeof positionIndex === 'number' ? { positionIndex } : {}),
+            ...(scheduledDate ? { scheduledDate } : {}),
+        };
     }
 
     if (url.pathname.startsWith(LEGACY_AI_OPERATION_LINK_PATH_PREFIX)) {
@@ -109,9 +140,12 @@ export function parseRaisedBedAiOperationHref(
             return null;
         }
 
-        return typeof positionIndex === 'number'
-            ? { operationId, raisedBedId, positionIndex }
-            : { operationId, raisedBedId };
+        return {
+            operationId,
+            raisedBedId,
+            ...(typeof positionIndex === 'number' ? { positionIndex } : {}),
+            ...(scheduledDate ? { scheduledDate } : {}),
+        };
     }
 
     return null;

--- a/packages/game/src/hud/raisedBed/raisedBedAiOperationLinks.unit.ts
+++ b/packages/game/src/hud/raisedBed/raisedBedAiOperationLinks.unit.ts
@@ -10,15 +10,17 @@ describe('raised bed AI operation links', () => {
         const href = buildRaisedBedAiOperationHref({
             operationSlug: 'malciranje-gredice',
             raisedBedId: 101,
+            scheduledDate: '2026-07-28',
         });
 
         assert.strictEqual(
             href,
-            'https://www.gredice.com/radnje/malciranje-gredice#raisedBedId=101',
+            'https://www.gredice.com/radnje/malciranje-gredice#raisedBedId=101&scheduledDate=2026-07-28',
         );
         assert.deepStrictEqual(parseRaisedBedAiOperationHref(href), {
             operationSlug: 'malciranje-gredice',
             raisedBedId: 101,
+            scheduledDate: '2026-07-28',
         });
     });
 
@@ -27,16 +29,18 @@ describe('raised bed AI operation links', () => {
             operationSlug: 'zalijevanje-biljke',
             raisedBedId: 101,
             positionIndex: 5,
+            scheduledDate: '2026-07-29',
         });
 
         assert.strictEqual(
             href,
-            'https://www.gredice.com/radnje/zalijevanje-biljke#raisedBedId=101&positionIndex=5',
+            'https://www.gredice.com/radnje/zalijevanje-biljke#raisedBedId=101&positionIndex=5&scheduledDate=2026-07-29',
         );
         assert.deepStrictEqual(parseRaisedBedAiOperationHref(href), {
             operationSlug: 'zalijevanje-biljke',
             raisedBedId: 101,
             positionIndex: 5,
+            scheduledDate: '2026-07-29',
         });
     });
 
@@ -62,6 +66,31 @@ describe('raised bed AI operation links', () => {
                 operationId: 42,
                 raisedBedId: 101,
                 positionIndex: 5,
+            },
+        );
+    });
+
+    it('accepts date as a scheduling-date compatibility alias', () => {
+        assert.deepStrictEqual(
+            parseRaisedBedAiOperationHref(
+                'https://www.gredice.com/radnje/zalijevanje-biljke#raisedBedId=101&date=2026-07-30',
+            ),
+            {
+                operationSlug: 'zalijevanje-biljke',
+                raisedBedId: 101,
+                scheduledDate: '2026-07-30',
+            },
+        );
+    });
+
+    it('ignores invalid scheduled dates without discarding the operation link', () => {
+        assert.deepStrictEqual(
+            parseRaisedBedAiOperationHref(
+                'https://www.gredice.com/radnje/zalijevanje-biljke#raisedBedId=101&scheduledDate=2026-02-31',
+            ),
+            {
+                operationSlug: 'zalijevanje-biljke',
+                raisedBedId: 101,
             },
         );
     });

--- a/packages/game/src/hud/raisedBed/shared/OperationScheduleModal.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationScheduleModal.tsx
@@ -32,6 +32,7 @@ function parseLocalDateInput(value: string) {
 
 export function OperationScheduleModal({
     gardenId,
+    initialScheduledDate,
     operation,
     onConfirm,
     positionIndex,
@@ -40,6 +41,7 @@ export function OperationScheduleModal({
     trigger,
 }: {
     gardenId: number;
+    initialScheduledDate?: string;
     operation: OperationData;
     onConfirm: (date: Date) => Promise<void>;
     positionIndex?: number;
@@ -65,7 +67,15 @@ export function OperationScheduleModal({
         tomorrow.getMonth() + 3,
         tomorrow.getDate(),
     );
-    const operationDefaultDate = formatLocalDate(tomorrow);
+    const parsedInitialScheduledDate = initialScheduledDate
+        ? parseLocalDateInput(initialScheduledDate)
+        : null;
+    const operationDefaultDate =
+        parsedInitialScheduledDate &&
+        parsedInitialScheduledDate >= tomorrow &&
+        parsedInitialScheduledDate <= threeMonthsFromTomorrow
+            ? formatLocalDate(parsedInitialScheduledDate)
+            : formatLocalDate(tomorrow);
     const selectedDateInput = scheduledDateInput ?? operationDefaultDate;
     const selectedDate = parseLocalDateInput(selectedDateInput);
     const showWateringCalendar =


### PR DESCRIPTION
## Summary

- exclude internal operations from the raised-bed image analysis recommendation catalog and instruct the model to treat executed operations as history only
- add concrete Zagreb scheduling dates to suggested operation URL templates
- parse and validate embedded `scheduledDate` values, then preselect them in the scheduling modal with a safe fallback for stale dates
- cover catalog filtering, date-link parsing, and whole-bed/plant-field scheduling flows

## Why

Raised-bed AI analysis could suggest an internal farm operation as a user action. Suggested operation links also lost the date implied by the recommendation, forcing the user to pick it again.

## Validation

- `pnpm --filter api exec node --import tsx --test --conditions=react-server lib/garden/raisedBedAiAnalysisService.node.spec.ts` (6 passed)
- `pnpm --filter @gredice/game test` (624 passed)
- `pnpm typecheck --filter api --filter @gredice/game --filter garden`
- `pnpm --filter api exec tsc --noEmit --pretty false`
- targeted Biome checks for all changed files
- focused Garden Playwright component tests (3 passed)
- `git diff --check`

`pnpm --filter garden build` was attempted but the local Next/Turbopack process stalled in optimized compilation; the focused component tests were run against the local Garden dev server instead.