### PR TITLE
Fix CMS OG cover image border

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,6 +12,7 @@
         "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
+        "test": "node --import tsx --test src/cms/CmsOgImage.unit.ts",
         "typecheck": "tsc --noEmit --pretty false"
     },
     "devDependencies": {
@@ -25,6 +26,7 @@
         "@types/suncalc": "1.9.2",
         "tailwindcss": "4.3.2",
         "tailwindcss-animate": "1.0.7",
+        "tsx": "4.23.0",
         "typescript": "7.0.2"
     },
     "dependencies": {

--- a/packages/ui/src/cms/CmsOgImage.tsx
+++ b/packages/ui/src/cms/CmsOgImage.tsx
@@ -227,6 +227,7 @@ export function CmsOgImage({
                         alt=""
                         src={normalizedImageUrl ?? undefined}
                         style={{
+                            borderRadius: 30,
                             height: '100%',
                             objectFit: 'cover',
                             objectPosition: cmsImageObjectPosition(
@@ -234,20 +235,6 @@ export function CmsOgImage({
                                 pointOfInterestY,
                             ),
                             width: '100%',
-                        }}
-                    />
-                    <div
-                        style={{
-                            borderColor: '#FFFFFFA6',
-                            borderRadius: 30,
-                            borderStyle: 'solid',
-                            borderWidth: 10,
-                            bottom: 0,
-                            display: 'flex',
-                            left: 0,
-                            position: 'absolute',
-                            right: 0,
-                            top: 0,
                         }}
                     />
                 </div>

--- a/packages/ui/src/cms/CmsOgImage.unit.ts
+++ b/packages/ui/src/cms/CmsOgImage.unit.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    Children,
+    type CSSProperties,
+    isValidElement,
+    type ReactNode,
+} from 'react';
+import { CmsOgImage } from './CmsOgImage';
+
+function collectCoverStyles(root: ReactNode) {
+    const borderWidths: CSSProperties['borderWidth'][] = [];
+    const imageBorderRadii: CSSProperties['borderRadius'][] = [];
+
+    function visit(node: ReactNode) {
+        if (
+            !isValidElement<{
+                children?: ReactNode;
+                style?: CSSProperties;
+            }>(node)
+        ) {
+            return;
+        }
+
+        if (node.props.style?.borderWidth !== undefined) {
+            borderWidths.push(node.props.style.borderWidth);
+        }
+        if (node.type === 'img') {
+            imageBorderRadii.push(node.props.style?.borderRadius);
+        }
+
+        Children.forEach(node.props.children, visit);
+    }
+
+    visit(root);
+    return { borderWidths, imageBorderRadii };
+}
+
+describe('CmsOgImage cover', () => {
+    it('rounds the image without drawing an inset overlay border', () => {
+        const styles = collectCoverStyles(
+            CmsOgImage({
+                imageUrl: 'https://www.gredice.com/cover.jpg',
+                title: 'Naslov',
+            }),
+        );
+
+        assert.deepEqual(styles.imageBorderRadii, [30]);
+        assert.equal(styles.borderWidths.includes(10), false);
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1715,6 +1715,9 @@ importers:
       tailwindcss-animate:
         specifier: 1.0.7
         version: 1.0.7(tailwindcss@4.3.2)
+      tsx:
+        specifier: 4.23.0
+        version: 4.23.0
       typescript:
         specifier: 7.0.2
         version: 7.0.2


### PR DESCRIPTION
## What changed

- removed the 10 px semi-transparent overlay drawn over CMS OG cover images
- applied the existing 30 px radius directly to the image so `next/og` reliably renders one clean rounded crop
- added a focused shared-UI regression test and test script

## Why

The overlay composited the same cover photo beneath a translucent white stroke, which looked like a duplicate inset border. Parent overflow clipping was not reliable in the OG renderer, so the image now owns its radius directly.

This shared renderer covers generated CMS page, Novosti, changelog, and admin preview OG images.

## Validation

- `pnpm lint --filter @gredice/ui`
- `pnpm test --filter @gredice/ui`
- `pnpm typecheck --filter @gredice/ui`
- `pnpm typecheck --filter app --filter news --filter www`
- `git diff --check`
- direct `next/og` 1200×630 render, visually inspected with a cover image