### PR TITLE
fix(game): fit five delivery days on mobile

### DIFF
--- a/apps/garden/tests/delivery-slot-picker.spec.tsx
+++ b/apps/garden/tests/delivery-slot-picker.spec.tsx
@@ -125,3 +125,42 @@ test('keeps time slots within a mobile-width container', async ({
         )
         .toBe(true);
 });
+
+test('shows five delivery days within a mobile-width container', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <DeliverySlotPickerStory
+            autoSelectFirstDeliverySlot={false}
+            containerClassName="w-[21rem]"
+            referenceDate="2026-07-13T10:00:00.000Z"
+            slots={Array.from({ length: 7 }, (_, index) => ({
+                endAt: `2026-07-${(13 + index).toString()}T12:00:00.000Z`,
+                fulfillment: 'delivery',
+                id: index + 1,
+                startAt: `2026-07-${(13 + index).toString()}T10:00:00.000Z`,
+            }))}
+        />,
+    );
+
+    const deliveryDays = page.getByRole('group', { name: 'Odaberi dan' });
+    const dayButtons = deliveryDays.getByRole('button');
+    await expect(dayButtons).toHaveCount(7);
+
+    const [deliveryDaysBox, fifthDayBox] = await Promise.all([
+        deliveryDays.boundingBox(),
+        dayButtons.nth(4).boundingBox(),
+    ]);
+
+    expect(deliveryDaysBox).not.toBeNull();
+    expect(fifthDayBox).not.toBeNull();
+
+    if (!deliveryDaysBox || !fifthDayBox) {
+        throw new Error('Delivery day layout is not visible');
+    }
+
+    expect(fifthDayBox.x + fifthDayBox.width).toBeLessThanOrEqual(
+        deliveryDaysBox.x + deliveryDaysBox.width + 1,
+    );
+});

--- a/packages/game/src/shared-ui/delivery/DeliverySlotPicker.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliverySlotPicker.tsx
@@ -431,7 +431,7 @@ export function DeliverySlotPicker({
 
                     {selectedWeek && selectedWeek.days.length > 0 ? (
                         <fieldset
-                            className="m-0 flex min-w-0 gap-2 overflow-x-auto border-0 p-0 pb-1"
+                            className="m-0 grid min-w-0 auto-cols-[minmax(3.2rem,1fr)] grid-flow-col gap-2 overflow-x-auto border-0 p-0 pb-1"
                             disabled={disabled}
                         >
                             <legend className="sr-only">Odaberi dan</legend>
@@ -448,7 +448,7 @@ export function DeliverySlotPicker({
                                         aria-label={`${formatters.fullDate.format(day.date)}, ${slotCountLabel(day.slots.length)}${isToday ? ', danas' : ''}`}
                                         aria-pressed={isSelected}
                                         className={cx(
-                                            'relative flex min-h-[5.5rem] min-w-[5rem] flex-1 flex-col items-center justify-center rounded-lg border px-2.5 py-2 text-center transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-not-allowed',
+                                            'relative flex min-h-[5.5rem] min-w-0 flex-col items-center justify-center rounded-lg border px-2.5 py-2 text-center transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-not-allowed',
                                             isSelected
                                                 ? 'border-primary bg-primary/10 text-primary ring-1 ring-inset ring-primary/40'
                                                 : 'border-border bg-background text-foreground hover:border-primary/50 hover:bg-muted/50',
@@ -472,21 +472,26 @@ export function DeliverySlotPicker({
                                         type="button"
                                     >
                                         {isToday && (
-                                            <span className="absolute left-1.5 top-1.5 rounded-full bg-primary px-1.5 py-0.5 text-[0.5rem] font-bold uppercase tracking-wide text-primary-foreground">
+                                            <span className="absolute left-1 top-1 rounded-full bg-primary px-1 py-0.5 text-[0.45rem] font-bold uppercase leading-none tracking-wide text-primary-foreground">
                                                 Danas
                                             </span>
                                         )}
                                         <span
                                             aria-hidden
                                             className={cx(
-                                                'absolute right-1.5 top-1.5 flex size-5 items-center justify-center rounded-full bg-muted text-[0.6rem] font-bold text-foreground/70',
+                                                'absolute right-1 top-1 flex size-4 items-center justify-center rounded-full bg-muted text-[0.5rem] font-bold text-foreground/70',
                                                 isSelected &&
                                                     'bg-primary text-primary-foreground',
                                             )}
                                         >
                                             {day.slots.length}
                                         </span>
-                                        <span className="text-[0.65rem] font-bold uppercase tracking-wide">
+                                        <span
+                                            className={cx(
+                                                'text-[0.65rem] font-bold uppercase tracking-wide',
+                                                isToday && 'mt-3',
+                                            )}
+                                        >
                                             {formatters.weekday.format(
                                                 day.date,
                                             )}


### PR DESCRIPTION
## What changed

- size delivery-day cards with a responsive grid so at least five dates fit in the mobile picker without scrolling
- keep additional days horizontally accessible and let wider layouts expand to show the full week
- compact the `Danas` and slot-count badges so narrow cards remain legible
- add a Playwright component regression that verifies the fifth day stays inside a 336 px mobile-width container

## Why

The picker reserved at least 80 px for every date card. Five cards plus their gaps therefore required 432 px, so typical mobile delivery modals only showed four complete dates.

## Validation

- `pnpm lint --filter @gredice/game --filter garden`
- `pnpm typecheck --filter @gredice/game --filter garden`
- `GREDICE_PLAYWRIGHT_REUSE_SERVER=true pnpm --filter garden exec playwright test tests/delivery-slot-picker.spec.tsx --project=chromium` (4 passed)
- visually inspected the focused 336 px component rendering