### PR TITLE
fix(skills): restore changelog cover style

### DIFF
--- a/.agents/skills/gredice-changelog-publishing/SKILL.md
+++ b/.agents/skills/gredice-changelog-publishing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gredice-changelog-publishing
-description: "Use for Gredice changelog publishing: auditing merged GitHub PRs, selecting user and farmer facing changes, drafting CMS changelog pages, validating metadata/content, and publishing through apps/app CMS and news surfaces."
+description: "Use for Gredice changelog publishing: auditing merged GitHub PRs, selecting user and farmer facing changes, drafting CMS changelog pages, creating and reviewing on-brand covers, validating metadata/content, and publishing through apps/app CMS and news surfaces."
 ---
 
 # Gredice Changelog Publishing
@@ -10,6 +10,11 @@ description: "Use for Gredice changelog publishing: auditing merged GitHub PRs, 
 Create and publish Gredice changelog entries from merged work while keeping public copy accurate, user-facing, and compatible with the CMS/news pipeline.
 
 Use this together with `github:github` when inspecting pull requests and `gredice-cms-page-authoring` when the CMS shape or section registry may have changed.
+
+Whenever the task creates, replaces, reviews, or attaches a cover, first read
+`.agents/skills/gredice-review-changelog-post/SKILL.md` in full and follow its
+cover workflow. That skill's visual contract is authoritative over automation
+memory, recent generated covers, or inferred changes in style.
 
 ## Scope
 
@@ -84,6 +89,46 @@ Use supported CMS sections from `packages/storage/src/cmsPageSections.ts`. The c
 
 Public changelog APIs and news pages order by `publishedAt`, so historical batches must preserve the release date there before publishing. Do not duplicate the release date in tags or visible content sections.
 
+## Cover Workflow
+
+Apply this workflow whenever a changelog entry needs a new or replacement
+cover:
+
+1. Open at least three accepted published covers that follow the canonical
+   Gredice editorial template, including one from the same product area when
+   possible. Do not treat recency or repeated automation output as evidence
+   that the template changed.
+2. Preserve the template's non-negotiable elements:
+   - a full-bleed warm ivory-to-pale-sage or pale-blue background with a
+     restrained oversized low-contrast arc;
+   - a left editorial column with a short green rule, uppercase Croatian
+     eyebrow, exact dark-forest Croatian headline, and a short muted-green
+     benefit sentence;
+   - one dominant white rounded product panel on the right with a soft shadow,
+     grounded in verified product components, supported UI states, or exact
+     assets;
+   - the same landscape split, hierarchy, spacing, radius, and shadow language
+     across the batch.
+3. Reject text-free editorial art, photography, miniature scenes,
+   free-floating objects, decorative garden scenery, standalone illustrations,
+   and fictional UI as default covers. They remain out of contract even when
+   several recent covers use them. The documented feature-specific full-frame
+   screenshot exception in `gredice-review-changelog-post` is the only default
+   exception unless the user explicitly requests another direction.
+4. Verify all product states and labels against the implementation. Use neutral
+   privacy-safe data. If generated text is not exact, compose the Croatian
+   eyebrow, headline, benefit sentence, and product labels deterministically;
+   never remove required copy to avoid fixing it.
+5. Compare every finished cover side by side with the three accepted
+   references and with the rest of the batch. Reject a cover that loses the
+   canonical series identity, exact Croatian text, product grounding,
+   full-bleed opaque bounds, or balanced left-right composition.
+
+Upload covers below `cms/pages/<pageId>/cover/`, set `metaImageUrl` through
+`updateCmsPage`, and preserve every other CMS field. Re-read the page and
+download the public image to verify the stored URL, dimensions, opacity, and
+checksum.
+
 ## Database Workflow
 
 Use storage repository helpers instead of raw SQL for writes:
@@ -120,15 +165,20 @@ Before applying:
 - Check `metaDescription.length <= 160`.
 - Confirm changelog tags contain only audience/topic labels, not date strings.
 - Confirm Markdown is free-form user/farmer-facing copy with no `Sto je novo`, `Kome je namijenjeno`, or `Datum izdanja` sections.
+- For every cover, confirm the canonical headline-and-product-panel template,
+  exact Croatian text, privacy-safe verified product state, opaque landscape
+  bounds, and side-by-side comparison against at least three accepted covers.
 - Dry-run the create/update script and review counts.
 
 After applying:
 
 - Query `cms_pages` by `contentKind`, `state`, and `slug` prefix to confirm expected rows.
 - Spot-check one content payload parses and uses supported section names.
+- Download every uploaded cover and confirm its natural dimensions, opacity,
+  and checksum match the reviewed local file.
 - For published entries, check `/novosti/sto-je-novo`, one detail page, and `/api/news/changelog` when a dev or deployed target is available.
 - For skill/docs-only edits, run `git diff --check`.
 
 ## Reporting
 
-Summarize what changed with counts and exact CMS IDs/slugs when pages were created or updated. If entries remain drafts, state that explicitly and point to the admin CMS edit pages when useful.
+Summarize what changed with counts and exact CMS IDs/slugs when pages were created or updated. Report replacement-cover dimensions and verification results. If entries remain drafts, state that explicitly and point to the admin CMS edit pages when useful.

--- a/.agents/skills/gredice-review-changelog-post/SKILL.md
+++ b/.agents/skills/gredice-review-changelog-post/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: gredice-review-changelog-post
-description: "Review and prepare individual Gredice CMS changelog posts through the admin UI: simplify Croatian public copy, add relevant inline links, create and attach sharp privacy-safe component-grounded screenshots or visuals, validate metadata and cover rendering, and move drafts to review without publishing. Use when given a Gredice /admin/cms/pages/PAGE_ID/edit URL or asked to polish, illustrate, link, or mark a changelog post ready for review."
+description: "Review and prepare individual or batched Gredice CMS changelog posts through the admin UI or storage workflow: simplify Croatian public copy, add relevant inline links, create and attach sharp privacy-safe component-grounded covers, validate metadata and rendering, and move drafts to review without publishing. Use when given Gredice /admin/cms/pages/PAGE_ID/edit URLs or asked to polish, illustrate, link, batch-review, or mark changelog posts ready for review."
 ---
 
 # Gredice Changelog Post Review
 
 ## Overview
 
-Prepare one existing changelog post for editorial review. Work from the exact CMS page and the real user-facing feature, keep the copy public and non-technical, attach a meaningful sharp cover, and stop before publication.
+Prepare one or more existing changelog posts for editorial review. Work from
+the exact CMS pages and real user-facing features, keep the copy public and
+non-technical, attach meaningful sharp covers, and stop before publication.
 
 Use this together with `gredice-changelog-publishing` for general changelog conventions and an authenticated browser-control skill for CMS and live-page interactions.
 
@@ -51,6 +53,10 @@ Na stranici [Dostava](https://www.gredice.com/dostava) moÅ¾ete pregledati podruÄ
   - a left editorial column with a short green rule and uppercase eyebrow, a bold dark-forest Croatian headline, and one short muted-green benefit statement;
   - one dominant white rounded product panel on the right with a soft diffused shadow, containing the exact component, asset, or supported state that explains the change;
   - a consistent landscape split, typographic hierarchy, outer margins, internal spacing, corner radius, and shadow language across every cover in the batch.
+- This template is mandatory unless the documented feature-specific full-frame
+  screenshot exception is stronger or the user explicitly requests another
+  direction. Recency, repetition, or automation memory cannot redefine the
+  template. Text-free editorial images are not the established default series.
 - Use the accepted covers as visual references when generating a new cover. The subject may change, but the editorial grid and art direction must remain recognizably from the same series.
 - Do not default to photography, photorealistic scenes, free-floating objects, stock-style illustrations, collages, or decorative garden scenery. Do not use a device mockup unless the post specifically concerns device or edge-to-edge behavior. A conceptually relevant image still fails review when it does not match the established cover system.
 - Inspect the implemented feature before designing its cover. Check the live page and, when useful, the responsible app components, stories, fixtures, and checked-in assets to identify the real controls, states, labels, and visual language.
@@ -72,7 +78,7 @@ Na stranici [Dostava](https://www.gredice.com/dostava) moÅ¾ete pregledati podruÄ
 - Prefer PNG for crisp UI. If transfer size is unreliable, use JPEG quality 90-92 while retaining the high pixel dimensions.
 - Reuse an existing accurate component or asset when it is stronger than a screenshot. Do not invent a generic scene or substitute a loosely related product page.
 - Search the app components, Storybook stories, and checked-in product assets first, including `apps/www/public/assets/blocks`. Compose only verified components and exact mentioned renders on a temporary, privacy-safe artboard with a fixed 16:9 frame, balanced internal spacing, and the visual group centered within the frame.
-- Keep generated Croatian text short enough to render reliably. Verify every diacritic, amount, date, label, and line break at natural size. Regenerate or compose exact text deterministically when any word is misspelled, malformed, clipped, or visually ambiguous.
+- Keep generated Croatian text short enough to render reliably. Verify every diacritic, amount, date, label, and line break at natural size. Regenerate or compose the eyebrow, headline, benefit sentence, and product labels deterministically when any word is misspelled, malformed, clipped, or visually ambiguous. Never omit required copy merely to avoid correcting generated text.
 - Make the outer artboard a full-bleed, opaque rectangle. Do not give the artboard itself rounded corners or include page/body padding around it. Inner cards may be rounded, but every output corner must be painted by the artboard background; JPEG output must not contain differently colored corner wedges, and PNG output must not rely on transparent outer corners.
 - Capture the artboard element's exact bounds rather than the surrounding page. Confirm all four edges and corners belong to the intended background before upload.
 - For a release centered on one entity, use its exact render as the dominant hero. Capture the artboard element at high density so the uploaded cover is at least 1920 x 1080 when the source assets support it.

--- a/.agents/skills/gredice-review-changelog-post/agents/openai.yaml
+++ b/.agents/skills/gredice-review-changelog-post/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Gredice Changelog Post Review"
-  short_description: "Review posts with accurate component-grounded visuals"
-  default_prompt: "Use $gredice-review-changelog-post to review a Gredice changelog post, add relevant links, create a sharp privacy-safe cover grounded in real app components when applicable, and mark it ready for review."
+  short_description: "Review changelog posts with on-brand product covers"
+  default_prompt: "Use $gredice-review-changelog-post to review one or more Gredice changelog posts, add relevant links, create privacy-safe covers in the established editorial style from verified product states, and prepare them for review."


### PR DESCRIPTION
## What changed

- Make the changelog publishing skill load the dedicated cover-review skill whenever a cover is created, replaced, reviewed, or attached.
- Lock the established Gredice cover contract: Croatian editorial copy on the left and a grounded product panel on the right.
- Reject recent text-free, photorealistic, decorative, and fictional-UI drift as precedent.
- Add deterministic text, three-reference comparison, immutable upload, checksum, opacity, and CMS readback requirements.
- Make the review skill explicitly support batches and regenerate its agent metadata.

## Why

The July 22–25 draft changelogs were generated through workflows that did not consistently load the authoritative cover-review guidance. Repeated recent outputs were then treated as a style change, producing text-free and photorealistic covers that no longer matched the established series.

## Impact

Future changelog jobs now have one authoritative visual contract and explicit rejection criteria. The ten affected draft covers (CMS pages 144–153) were separately regenerated in the established style and updated URL-only after public checksum verification; they remain drafts.

## Validation

- Official `quick_validate.py` passed for both changed skills.
- `git diff --check`
- Ten replacement covers verified as opaque 1672×941 RGB PNGs.
- Public Blob bytes matched local SHA-256 checksums for all ten covers.
- CMS post-write readback confirmed only `metaImageUrl`/`updatedAt` changed and all pages remain `draft`.