### PR TITLE
perf(game): batch moving actor shadows

### DIFF
--- a/apps/garden/scripts/profile-game-scene.mjs
+++ b/apps/garden/scripts/profile-game-scene.mjs
@@ -2066,6 +2066,23 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                     ? globalThis.__grediceGameProfile
                           .instancedInteractionResolvedTargetCount
                     : null;
+            const actorGroundingShadowUpdateCountAtStart =
+                typeof globalThis.__grediceGameProfile
+                    ?.actorGroundingShadowUpdateCount === 'number'
+                    ? globalThis.__grediceGameProfile
+                          .actorGroundingShadowUpdateCount
+                    : null;
+            const animatedCasterShadowRefreshCountAtStart =
+                typeof globalThis.__grediceGameProfile
+                    ?.animatedCasterShadowRefreshCount === 'number'
+                    ? globalThis.__grediceGameProfile
+                          .animatedCasterShadowRefreshCount
+                    : null;
+            const primaryShadowRefreshCountAtStart =
+                typeof globalThis.__grediceGameProfile
+                    ?.primaryShadowRefreshCount === 'number'
+                    ? globalThis.__grediceGameProfile.primaryShadowRefreshCount
+                    : null;
             const rainParticleCountAtStart =
                 typeof globalThis.__grediceGameProfile?.rainParticleCount ===
                 'number'
@@ -2140,7 +2157,36 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                     ? globalThis.__grediceGameProfile
                           .instancedInteractionResolvedTargetCount
                     : null;
+            const actorGroundingShadowUpdateCountAtEnd =
+                typeof globalThis.__grediceGameProfile
+                    ?.actorGroundingShadowUpdateCount === 'number'
+                    ? globalThis.__grediceGameProfile
+                          .actorGroundingShadowUpdateCount
+                    : null;
+            const animatedCasterShadowRefreshCountAtEnd =
+                typeof globalThis.__grediceGameProfile
+                    ?.animatedCasterShadowRefreshCount === 'number'
+                    ? globalThis.__grediceGameProfile
+                          .animatedCasterShadowRefreshCount
+                    : null;
+            const primaryShadowRefreshCountAtEnd =
+                typeof globalThis.__grediceGameProfile
+                    ?.primaryShadowRefreshCount === 'number'
+                    ? globalThis.__grediceGameProfile.primaryShadowRefreshCount
+                    : null;
             const nonGpuSample = {
+                actorGroundingShadowUpdateCountDelta:
+                    actorGroundingShadowUpdateCountAtStart === null ||
+                    actorGroundingShadowUpdateCountAtEnd === null
+                        ? null
+                        : actorGroundingShadowUpdateCountAtEnd -
+                          actorGroundingShadowUpdateCountAtStart,
+                animatedCasterShadowRefreshCountDelta:
+                    animatedCasterShadowRefreshCountAtStart === null ||
+                    animatedCasterShadowRefreshCountAtEnd === null
+                        ? null
+                        : animatedCasterShadowRefreshCountAtEnd -
+                          animatedCasterShadowRefreshCountAtStart,
                 averageFrameMs,
                 canvas: canvas
                     ? {
@@ -2177,6 +2223,13 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 p95FrameMs: percentile(0.95),
                 p99FrameMs: percentile(0.99),
                 placementProfileDispatched,
+                primaryShadowRefreshCountAtStart,
+                primaryShadowRefreshCountDelta:
+                    primaryShadowRefreshCountAtStart === null ||
+                    primaryShadowRefreshCountAtEnd === null
+                        ? null
+                        : primaryShadowRefreshCountAtEnd -
+                          primaryShadowRefreshCountAtStart,
                 rainMountedAtStart,
                 rainParticleCountAtEnd:
                     typeof globalThis.__grediceGameProfile
@@ -2247,6 +2300,35 @@ async function measureScenario(browser, baseUrl, scenario, options) {
         }
 
         return {
+            actorGroundingShadowBatchCount:
+                typeof metadata.actorGroundingShadowBatchCount === 'number'
+                    ? metadata.actorGroundingShadowBatchCount
+                    : null,
+            actorGroundingShadowCapacity:
+                typeof metadata.actorGroundingShadowCapacity === 'number'
+                    ? metadata.actorGroundingShadowCapacity
+                    : null,
+            actorGroundingShadowCount:
+                typeof metadata.actorGroundingShadowCount === 'number'
+                    ? metadata.actorGroundingShadowCount
+                    : null,
+            actorGroundingShadowDroppedCount:
+                typeof metadata.actorGroundingShadowDroppedCount === 'number'
+                    ? metadata.actorGroundingShadowDroppedCount
+                    : null,
+            actorGroundingShadowPrimaryCasterCount:
+                typeof metadata.actorGroundingShadowPrimaryCasterCount ===
+                'number'
+                    ? metadata.actorGroundingShadowPrimaryCasterCount
+                    : null,
+            actorGroundingShadowUpdateCount:
+                typeof metadata.actorGroundingShadowUpdateCount === 'number'
+                    ? metadata.actorGroundingShadowUpdateCount
+                    : null,
+            actorGroundingShadowVisibleCount:
+                typeof metadata.actorGroundingShadowVisibleCount === 'number'
+                    ? metadata.actorGroundingShadowVisibleCount
+                    : null,
             animatedCasterShadowRefreshCount:
                 typeof metadata.animatedCasterShadowRefreshCount === 'number'
                     ? metadata.animatedCasterShadowRefreshCount
@@ -2532,6 +2614,7 @@ async function measureScenario(browser, baseUrl, scenario, options) {
         isMobile: scenario.isMobile,
         mode: profileMetadata?.mode ?? request.mode,
         motion: scenario.motion ?? scenario.interaction ?? 'none',
+        scenarioName: scenario.name,
         placementProfile:
             placementProfileRequest === null ? 'none' : 'placement-drop',
         quality: profileMetadata?.quality ?? request.quality,
@@ -2723,6 +2806,8 @@ function evaluateHighTargetAcceptance({
         1,
         Math.floor((sample.elapsedMs ?? 0) / 1_000),
     );
+    const expectedActorGroundingShadowCount =
+        requested.mode === 'rain' || requested.mode === 'snow' ? 4 : 5;
     const checks = [
         exact('highTargetQualityRequest', requested.quality, 'high'),
         exact('highTargetQualityTier', runtime?.qualityTier, 'high'),
@@ -2757,10 +2842,45 @@ function evaluateHighTargetAcceptance({
             runtime?.generatedPlantVisibleInstanceCount,
             highTargetExpectedGeneratedPlantInstanceCount,
         ),
+        exact(
+            'highTargetActorGroundingShadowCount',
+            runtime?.actorGroundingShadowCount,
+            expectedActorGroundingShadowCount,
+        ),
+        exact(
+            'highTargetActorGroundingShadowBatchCount',
+            runtime?.actorGroundingShadowBatchCount,
+            1,
+        ),
+        exact(
+            'highTargetActorGroundingShadowDroppedCount',
+            runtime?.actorGroundingShadowDroppedCount,
+            0,
+        ),
+        exact(
+            'highTargetActorGroundingShadowPrimaryCasters',
+            runtime?.actorGroundingShadowPrimaryCasterCount,
+            0,
+        ),
         minimum(
+            'highTargetActorGroundingShadowVisibleCount',
+            runtime?.actorGroundingShadowVisibleCount,
+            4,
+        ),
+        minimum(
+            'highTargetActorGroundingShadowUpdates',
+            sample.actorGroundingShadowUpdateCountDelta,
+            1,
+        ),
+        exact(
             'highTargetAnimatedCasterShadowRefreshes',
             runtime?.animatedCasterShadowRefreshCount,
-            1,
+            0,
+        ),
+        exact(
+            'highTargetAnimatedCasterShadowRefreshesDuringSample',
+            sample.animatedCasterShadowRefreshCountDelta,
+            0,
         ),
         minimum('highTargetRenderedFps', sample.renderedFps, 1),
         minimum(
@@ -2773,6 +2893,24 @@ function evaluateHighTargetAcceptance({
         exact('highTargetApiErrors', apiErrors.length, 0),
         exact('highTargetPageErrors', pageErrors.length, 0),
     ];
+    if (
+        requested.scenarioName?.startsWith(
+            'game-high-target-clear-idle-desktop',
+        )
+    ) {
+        checks.push(
+            minimum(
+                'highTargetPrimaryShadowRefreshesBeforeSample',
+                sample.primaryShadowRefreshCountAtStart,
+                1,
+            ),
+            exact(
+                'highTargetPrimaryShadowRefreshesDuringClearIdle',
+                sample.primaryShadowRefreshCountDelta,
+                0,
+            ),
+        );
+    }
     if (requested.motion === 'hover-scan') {
         checks.push(
             minimum(

--- a/apps/garden/scripts/profile-game-scene.unit.mjs
+++ b/apps/garden/scripts/profile-game-scene.unit.mjs
@@ -564,7 +564,7 @@ test('render budgets skip incomplete or disjoint GPU timer results', () => {
 });
 
 test('high target acceptance proves the intended workload rendered', () => {
-    const result = evaluateHighTargetAcceptance({
+    const input = {
         apiErrors: [],
         pageErrors: [],
         requested: {
@@ -575,7 +575,12 @@ test('high target acceptance proves the intended workload rendered', () => {
             quality: 'high',
         },
         runtime: {
-            animatedCasterShadowRefreshCount: 1,
+            actorGroundingShadowBatchCount: 1,
+            actorGroundingShadowCount: 4,
+            actorGroundingShadowDroppedCount: 0,
+            actorGroundingShadowPrimaryCasterCount: 0,
+            actorGroundingShadowVisibleCount: 4,
+            animatedCasterShadowRefreshCount: 0,
             generatedPlantFieldCount: 54,
             generatedPlantExpectedInstanceCount: 537,
             generatedPlantInstanceCount: 537,
@@ -587,6 +592,8 @@ test('high target acceptance proves the intended workload rendered', () => {
             rainParticleCount: 1_000,
         },
         sample: {
+            actorGroundingShadowUpdateCountDelta: 60,
+            animatedCasterShadowRefreshCountDelta: 0,
             canvas: {
                 clientHeight: 720,
                 clientWidth: 1280,
@@ -601,7 +608,8 @@ test('high target acceptance proves the intended workload rendered', () => {
             reportedDpr: 2,
             submittedTriangles: 1_000_000,
         },
-    });
+    };
+    const result = evaluateHighTargetAcceptance(input);
 
     assert.equal(result.pass, true);
     assert.equal(
@@ -616,6 +624,90 @@ test('high target acceptance proves the intended workload rendered', () => {
         )?.pass,
         true,
     );
+
+    const casterResult = evaluateHighTargetAcceptance({
+        ...input,
+        runtime: {
+            ...input.runtime,
+            actorGroundingShadowPrimaryCasterCount: 1,
+        },
+    });
+    assert.equal(casterResult.pass, false);
+    assert.equal(
+        casterResult.checks.find(
+            (check) =>
+                check.name === 'highTargetActorGroundingShadowPrimaryCasters',
+        )?.pass,
+        false,
+    );
+});
+
+test('high target acceptance distinguishes a cached map from refreshes and resets', () => {
+    for (const [primaryShadowRefreshCountDelta, expectedPass] of [
+        [0, true],
+        [1, false],
+        [-1, false],
+    ]) {
+        const result = evaluateHighTargetAcceptance({
+            apiErrors: [],
+            pageErrors: [],
+            requested: {
+                blockGeometryMerging: '1',
+                gardenProfile: 'high-target',
+                mode: 'details',
+                quality: 'high',
+                scenarioName: 'game-high-target-clear-idle-desktop-run-1',
+            },
+            runtime: {
+                actorGroundingShadowBatchCount: 1,
+                actorGroundingShadowCount: 5,
+                actorGroundingShadowDroppedCount: 0,
+                actorGroundingShadowPrimaryCasterCount: 0,
+                actorGroundingShadowVisibleCount: 4,
+                animatedCasterShadowRefreshCount: 0,
+                generatedPlantExpectedInstanceCount: 537,
+                generatedPlantFieldCount: 54,
+                generatedPlantInstanceCount: 537,
+                generatedPlantVisibleFieldCount: 54,
+                generatedPlantVisibleInstanceCount: 537,
+                qualityTier: 'high',
+            },
+            sample: {
+                actorGroundingShadowUpdateCountDelta: 60,
+                animatedCasterShadowRefreshCountDelta: 0,
+                canvas: {
+                    clientHeight: 720,
+                    clientWidth: 1280,
+                    height: 1440,
+                    width: 2560,
+                },
+                drawCalls: 100,
+                elapsedMs: 5_000,
+                primaryShadowRefreshCountAtStart: 2,
+                primaryShadowRefreshCountDelta,
+                renderedFps: 12,
+                renderedFrames: 60,
+                reportedDpr: 2,
+                submittedTriangles: 1_000_000,
+            },
+        });
+
+        assert.equal(result.pass, expectedPass);
+        assert.deepEqual(
+            result.checks.find(
+                (check) =>
+                    check.name ===
+                    'highTargetPrimaryShadowRefreshesDuringClearIdle',
+            ),
+            {
+                actual: primaryShadowRefreshCountDelta,
+                comparison: 'equal',
+                limit: 0,
+                name: 'highTargetPrimaryShadowRefreshesDuringClearIdle',
+                pass: expectedPass,
+            },
+        );
+    }
 });
 
 test('high target acceptance requires the full workload to remain visible', () => {

--- a/docs/game-performance-optimization-results.md
+++ b/docs/game-performance-optimization-results.md
@@ -523,6 +523,50 @@ because the software renderer reports repeated `ReadPixels` stalls. Draw-call,
 triangle, and heap gates pass. GPU elapsed-time gating is skipped because the
 runner does not expose a valid timer-query result.
 
+### Moving-actor shadow separation
+
+Issue `#4323` removes cats, dogs, birds, and bees from the cached 4096px
+directional shadow map. High and other shadow-enabled configurations now use
+one scene-level instanced analytic ellipse batch for actor grounding. It has no
+texture, render target, or secondary shadow pass. Shadow-disabled quality
+profiles skip registration, state construction, and the draw entirely.
+
+The complete 18-run High target matrix passed structural acceptance in every
+repeat:
+
+- clear, camera, hover, and placement runs registered all five target actors;
+- rain and snow registered four actors because bees correctly remained
+  inactive;
+- every run used one batch, retained at least four visible grounding shadows,
+  and reported zero dropped registrations and zero actor primary casters;
+- animated-caster refreshes fell from a clear-idle median of `17` per run to
+  zero; and
+- the clear-idle primary-map request count fell from a median of `21` during
+  startup and sampling to four startup/static requests, followed by exactly
+  zero refreshes in every measured five-second idle window.
+
+The same Chromium 149 and ANGLE SwiftShader runner produced these median
+render-submission comparisons:
+
+| Phase | Draws/render before | After | Reduction | Triangles/render before | After | Reduction |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Clear idle | 313.9 | 152.0 | 51.6% | 39,402 | 21,526 | 45.4% |
+| Camera motion | 306.7 | 153.7 | 49.9% | 38,874 | 21,576 | 44.5% |
+| Hover/selection | 305.0 | 152.0 | 50.2% | 38,824 | 21,526 | 44.6% |
+| Placement | 306.3 | 170.9 | 44.2% | 38,811 | 25,959 | 33.1% |
+| Rain | 272.0 | 142.0 | 47.8% | 39,668 | 23,954 | 39.6% |
+| Snow | 367.0 | 204.4 | 44.3% | 98,540 | 67,123 | 31.9% |
+
+The roughly 44–52% call reduction in ordinary phases is direct evidence that
+moving actors no longer trigger full-scene primary shadow submissions.
+SwiftShader p95 frame time remains dominated by the previously documented
+`ReadPixels` stalls and is not treated as physical-GPU evidence; snow was
+especially noisy across its three runs.
+
+Placement still requested `7`, `7`, and `11` primary refreshes while its
+drop-settling window was active. That separate lifecycle is intentionally
+tracked by issue `#4331` rather than folded into actor shadow scheduling.
+
 ## Raised-bed close-up profiling foundation
 
 Added 2026-07-23 for the L-system close-up optimization series.

--- a/packages/game/src/entities/animals/ActorGroundingShadows.tsx
+++ b/packages/game/src/entities/animals/ActorGroundingShadows.tsx
@@ -1,0 +1,391 @@
+'use client';
+
+import { useFrame } from '@react-three/fiber';
+import {
+    createContext,
+    type PropsWithChildren,
+    useCallback,
+    useContext,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+} from 'react';
+import {
+    DoubleSide,
+    DynamicDrawUsage,
+    type InstancedMesh,
+    Matrix4,
+    PlaneGeometry,
+    Quaternion,
+    ShaderMaterial,
+    Vector3,
+} from 'three';
+import { updateGameProfileMetadata } from '../../scene/gameProfileMetadata';
+import { useOptionalGameState } from '../../useGameState';
+import {
+    type ActorGroundingShadowRegistration,
+    ActorGroundingShadowRegistry,
+    type ActorGroundingShadowState,
+    actorGroundingShadowCapacity,
+    resolveActorGroundingShadow,
+} from './actorGroundingShadowRegistry';
+
+const actorGroundingShadowGeometry = new PlaneGeometry(2, 2);
+actorGroundingShadowGeometry.rotateX(-Math.PI / 2);
+actorGroundingShadowGeometry.name = 'ActorGroundingShadowGeometry';
+const actorGroundingShadowProfileReportIntervalSeconds = 0.25;
+
+const actorGroundingShadowMaterial = new ShaderMaterial({
+    depthTest: true,
+    depthWrite: false,
+    fragmentShader: `
+        varying float vActorShadowOpacity;
+        varying vec2 vActorShadowUv;
+
+        void main() {
+            float radiusSquared = dot(vActorShadowUv, vActorShadowUv);
+            if (radiusSquared >= 1.0 || vActorShadowOpacity <= 0.0) {
+                discard;
+            }
+
+            float radialFade = 1.0 - smoothstep(0.08, 1.0, radiusSquared);
+            float alpha = vActorShadowOpacity * radialFade * radialFade;
+            if (alpha <= 0.001) {
+                discard;
+            }
+
+            gl_FragColor = vec4(0.0, 0.0, 0.0, alpha);
+        }
+    `,
+    side: DoubleSide,
+    transparent: true,
+    vertexShader: `
+        varying float vActorShadowOpacity;
+        varying vec2 vActorShadowUv;
+
+        void main() {
+            vActorShadowUv = uv * 2.0 - 1.0;
+
+            #ifdef USE_INSTANCING
+                vActorShadowOpacity = clamp(
+                    length(instanceMatrix[1].xyz),
+                    0.0,
+                    1.0
+                );
+                vec4 worldPosition =
+                    modelMatrix * instanceMatrix * vec4(position, 1.0);
+            #else
+                vActorShadowOpacity = 0.0;
+                vec4 worldPosition = modelMatrix * vec4(position, 1.0);
+            #endif
+
+            gl_Position =
+                projectionMatrix * viewMatrix * worldPosition;
+        }
+    `,
+});
+actorGroundingShadowMaterial.name = 'ActorGroundingShadowMaterial';
+actorGroundingShadowMaterial.toneMapped = false;
+
+type ActorGroundingShadowContextValue = {
+    enabled: boolean;
+    registry: ActorGroundingShadowRegistry;
+};
+
+type ActorGroundingShadowProfileSnapshot = {
+    batchCount: number;
+    capacity: number;
+    count: number;
+    droppedCount: number;
+    primaryCasterCount: number;
+    updateCount: number;
+    visibleCount: number;
+};
+
+const ActorGroundingShadowContext =
+    createContext<ActorGroundingShadowContextValue | null>(null);
+const actorGroundingShadowProfileSnapshots = new Map<
+    symbol,
+    ActorGroundingShadowProfileSnapshot
+>();
+
+const hiddenMatrix = new Matrix4().makeScale(0, 0, 0);
+const upAxis = new Vector3(0, 1, 0);
+
+function disableRaycast() {
+    return undefined;
+}
+
+function publishActorGroundingShadowProfile() {
+    const aggregate = {
+        batchCount: 0,
+        capacity: 0,
+        count: 0,
+        droppedCount: 0,
+        primaryCasterCount: 0,
+        updateCount: 0,
+        visibleCount: 0,
+    };
+    for (const snapshot of actorGroundingShadowProfileSnapshots.values()) {
+        aggregate.batchCount += snapshot.batchCount;
+        aggregate.capacity += snapshot.capacity;
+        aggregate.count += snapshot.count;
+        aggregate.droppedCount += snapshot.droppedCount;
+        aggregate.primaryCasterCount += snapshot.primaryCasterCount;
+        aggregate.updateCount += snapshot.updateCount;
+        aggregate.visibleCount += snapshot.visibleCount;
+    }
+
+    updateGameProfileMetadata({
+        actorGroundingShadowBatchCount: aggregate.batchCount,
+        actorGroundingShadowCapacity: aggregate.capacity,
+        actorGroundingShadowCount: aggregate.count,
+        actorGroundingShadowDroppedCount: aggregate.droppedCount,
+        actorGroundingShadowPrimaryCasterCount: aggregate.primaryCasterCount,
+        actorGroundingShadowUpdateCount: aggregate.updateCount,
+        actorGroundingShadowVisibleCount: aggregate.visibleCount,
+    });
+}
+
+function clearActorGroundingShadowProfile(owner: symbol) {
+    if (actorGroundingShadowProfileSnapshots.delete(owner)) {
+        publishActorGroundingShadowProfile();
+    }
+}
+
+function reportActorGroundingShadowProfile({
+    batchCount,
+    owner,
+    registry,
+    visibleCount,
+}: {
+    batchCount: number;
+    owner: symbol;
+    registry: ActorGroundingShadowRegistry;
+    visibleCount: number;
+}) {
+    const stats = registry.getStats();
+    actorGroundingShadowProfileSnapshots.set(owner, {
+        batchCount,
+        capacity: stats.capacity,
+        count: stats.registeredCount,
+        droppedCount: stats.droppedCount,
+        primaryCasterCount: stats.primaryCasterCount,
+        updateCount: stats.updateCount,
+        visibleCount,
+    });
+    publishActorGroundingShadowProfile();
+}
+
+function ActorGroundingShadowBatch({
+    owner,
+    registry,
+}: {
+    owner: symbol;
+    registry: ActorGroundingShadowRegistry;
+}) {
+    const meshRef = useRef<InstancedMesh | null>(null);
+    const snowCoverage = useOptionalGameState((state) => state.snowCoverage, 0);
+    const batchCountRef = useRef(0);
+    const lastSnowCoverageRef = useRef(Number.NaN);
+    const lastProfileReportAtRef = useRef(Number.NEGATIVE_INFINITY);
+    const lastVersionRef = useRef(-1);
+    const previousDrawCountRef = useRef(0);
+    const profileReportPendingRef = useRef(false);
+    const visibleCountRef = useRef(0);
+    const scratch = useMemo(
+        () => ({
+            matrix: new Matrix4(),
+            position: new Vector3(),
+            quaternion: new Quaternion(),
+            scale: new Vector3(),
+        }),
+        [],
+    );
+
+    useLayoutEffect(() => {
+        const mesh = meshRef.current;
+        if (!mesh) {
+            return;
+        }
+
+        mesh.count = 0;
+        mesh.instanceMatrix.setUsage(DynamicDrawUsage);
+        reportActorGroundingShadowProfile({
+            batchCount: 0,
+            owner,
+            registry,
+            visibleCount: 0,
+        });
+
+        return () => {
+            clearActorGroundingShadowProfile(owner);
+        };
+    }, [owner, registry]);
+
+    useFrame(({ clock }) => {
+        const mesh = meshRef.current;
+        if (!mesh) {
+            return;
+        }
+
+        const version = registry.getVersion();
+        const matricesChanged =
+            lastVersionRef.current !== version ||
+            !Object.is(lastSnowCoverageRef.current, snowCoverage);
+        if (matricesChanged) {
+            const entries = registry.getEntries();
+            const drawCount =
+                entries.length === 0
+                    ? 0
+                    : Math.max(...entries.map((entry) => entry.slot)) + 1;
+            const clearCount = Math.max(
+                previousDrawCountRef.current,
+                drawCount,
+            );
+            for (let slot = 0; slot < clearCount; slot += 1) {
+                mesh.setMatrixAt(slot, hiddenMatrix);
+            }
+
+            let visibleCount = 0;
+            for (const entry of entries) {
+                const resolved = resolveActorGroundingShadow({
+                    snowCoverage,
+                    species: entry.species,
+                    state: entry.state,
+                });
+                if (!resolved.visible) {
+                    continue;
+                }
+
+                visibleCount += 1;
+                scratch.position.set(resolved.x, resolved.y, resolved.z);
+                scratch.quaternion.setFromAxisAngle(upAxis, resolved.yaw);
+                scratch.scale.set(
+                    resolved.halfWidth,
+                    resolved.opacity,
+                    resolved.halfLength,
+                );
+                scratch.matrix.compose(
+                    scratch.position,
+                    scratch.quaternion,
+                    scratch.scale,
+                );
+                mesh.setMatrixAt(entry.slot, scratch.matrix);
+            }
+
+            mesh.count = drawCount;
+            mesh.instanceMatrix.clearUpdateRanges();
+            if (drawCount > 0) {
+                mesh.instanceMatrix.addUpdateRange(0, drawCount * 16);
+                mesh.instanceMatrix.needsUpdate = true;
+            }
+
+            batchCountRef.current = entries.length > 0 ? 1 : 0;
+            previousDrawCountRef.current = drawCount;
+            visibleCountRef.current = visibleCount;
+            lastSnowCoverageRef.current = snowCoverage;
+            lastVersionRef.current = version;
+            profileReportPendingRef.current = true;
+        }
+
+        if (
+            profileReportPendingRef.current &&
+            clock.elapsedTime - lastProfileReportAtRef.current >=
+                actorGroundingShadowProfileReportIntervalSeconds
+        ) {
+            lastProfileReportAtRef.current = clock.elapsedTime;
+            profileReportPendingRef.current = false;
+            reportActorGroundingShadowProfile({
+                batchCount: batchCountRef.current,
+                owner,
+                registry,
+                visibleCount: visibleCountRef.current,
+            });
+        }
+    });
+
+    return (
+        <instancedMesh
+            ref={meshRef}
+            args={[
+                actorGroundingShadowGeometry,
+                actorGroundingShadowMaterial,
+                actorGroundingShadowCapacity,
+            ]}
+            castShadow={false}
+            dispose={null}
+            frustumCulled={false}
+            name="ActorGroundingShadows"
+            raycast={disableRaycast}
+            receiveShadow={false}
+            renderOrder={1}
+        />
+    );
+}
+
+export function ActorGroundingShadowProvider({
+    children,
+    enabled,
+}: PropsWithChildren<{ enabled: boolean }>) {
+    const registry = useMemo(() => new ActorGroundingShadowRegistry(), []);
+    const profileOwner = useMemo(
+        () => Symbol('actor-grounding-shadow-profile-owner'),
+        [],
+    );
+    const context = useMemo(() => ({ enabled, registry }), [enabled, registry]);
+
+    useLayoutEffect(() => {
+        if (!enabled) {
+            clearActorGroundingShadowProfile(profileOwner);
+        }
+    }, [enabled, profileOwner]);
+
+    return (
+        <ActorGroundingShadowContext.Provider value={context}>
+            {children}
+            {enabled && (
+                <ActorGroundingShadowBatch
+                    owner={profileOwner}
+                    registry={registry}
+                />
+            )}
+        </ActorGroundingShadowContext.Provider>
+    );
+}
+
+export function useActorGroundingShadow({
+    id,
+    primaryCasterCount,
+    species,
+}: ActorGroundingShadowRegistration) {
+    const context = useContext(ActorGroundingShadowContext);
+    if (!context) {
+        throw new Error('Missing ActorGroundingShadowProvider in scene tree');
+    }
+    const { enabled, registry } = context;
+
+    useLayoutEffect(() => {
+        if (!enabled) {
+            return;
+        }
+
+        const registration = registry.register({
+            id,
+            primaryCasterCount,
+            species,
+        });
+        return registration.unregister;
+    }, [enabled, id, primaryCasterCount, registry, species]);
+
+    const update = useCallback(
+        (state: ActorGroundingShadowState) => {
+            if (enabled) {
+                registry.update(id, state);
+            }
+        },
+        [enabled, id, registry],
+    );
+
+    return enabled ? update : null;
+}

--- a/packages/game/src/entities/animals/actorGroundingShadowRegistry.ts
+++ b/packages/game/src/entities/animals/actorGroundingShadowRegistry.ts
@@ -1,0 +1,299 @@
+export type ActorGroundingShadowSpecies = 'bee' | 'bird' | 'cat' | 'dog';
+
+export type ActorGroundingShadowState = {
+    actorY: number;
+    receiverY: number;
+    visible: boolean;
+    x: number;
+    yaw: number;
+    z: number;
+};
+
+export type ActorGroundingShadowRegistration = {
+    id: string;
+    primaryCasterCount: number;
+    species: ActorGroundingShadowSpecies;
+};
+
+export type ResolvedActorGroundingShadow = {
+    halfLength: number;
+    halfWidth: number;
+    opacity: number;
+    visible: boolean;
+    x: number;
+    y: number;
+    yaw: number;
+    z: number;
+};
+
+export type ActorGroundingShadowRegistryEntry =
+    ActorGroundingShadowRegistration & {
+        slot: number;
+        state: ActorGroundingShadowState;
+    };
+
+export type ActorGroundingShadowRegistryStats = {
+    capacity: number;
+    droppedCount: number;
+    primaryCasterCount: number;
+    registeredCount: number;
+    updateCount: number;
+};
+
+type ActorGroundingShadowProfile = {
+    baseHalfLength: number;
+    baseHalfWidth: number;
+    baseOpacity: number;
+    cutoffHeight: number;
+    maxFootprintScale: number;
+};
+
+export const actorGroundingShadowCapacity = 128;
+export const actorGroundingShadowSurfaceLift = 0.006;
+export const actorGroundingShadowSnowLift = 0.012;
+
+export const actorGroundingShadowProfiles = {
+    bee: {
+        baseHalfLength: 0.055,
+        baseHalfWidth: 0.035,
+        baseOpacity: 0.16,
+        cutoffHeight: 1.4,
+        maxFootprintScale: 1.8,
+    },
+    bird: {
+        baseHalfLength: 0.2,
+        baseHalfWidth: 0.14,
+        baseOpacity: 0.26,
+        cutoffHeight: 2.6,
+        maxFootprintScale: 2.1,
+    },
+    cat: {
+        baseHalfLength: 0.38,
+        baseHalfWidth: 0.23,
+        baseOpacity: 0.34,
+        cutoffHeight: 1.2,
+        maxFootprintScale: 1.65,
+    },
+    dog: {
+        baseHalfLength: 0.52,
+        baseHalfWidth: 0.31,
+        baseOpacity: 0.36,
+        cutoffHeight: 1.6,
+        maxFootprintScale: 1.7,
+    },
+} satisfies Record<ActorGroundingShadowSpecies, ActorGroundingShadowProfile>;
+
+const hiddenActorGroundingShadowState: ActorGroundingShadowState = {
+    actorY: 0,
+    receiverY: 0,
+    visible: false,
+    x: 0,
+    yaw: 0,
+    z: 0,
+};
+
+function clampUnit(value: number) {
+    return Math.min(1, Math.max(0, value));
+}
+
+function hasFiniteTransform(state: ActorGroundingShadowState) {
+    return (
+        Number.isFinite(state.actorY) &&
+        Number.isFinite(state.receiverY) &&
+        Number.isFinite(state.x) &&
+        Number.isFinite(state.yaw) &&
+        Number.isFinite(state.z)
+    );
+}
+
+function isSameState(
+    left: ActorGroundingShadowState,
+    right: ActorGroundingShadowState,
+) {
+    return (
+        Object.is(left.actorY, right.actorY) &&
+        Object.is(left.receiverY, right.receiverY) &&
+        left.visible === right.visible &&
+        Object.is(left.x, right.x) &&
+        Object.is(left.yaw, right.yaw) &&
+        Object.is(left.z, right.z)
+    );
+}
+
+export function resolveActorGroundingShadow({
+    snowCoverage,
+    species,
+    state,
+}: {
+    snowCoverage: number;
+    species: ActorGroundingShadowSpecies;
+    state: ActorGroundingShadowState;
+}): ResolvedActorGroundingShadow {
+    const profile = actorGroundingShadowProfiles[species];
+    const finiteTransform = hasFiniteTransform(state);
+    const actorY = finiteTransform ? state.actorY : 0;
+    const receiverY = finiteTransform ? state.receiverY : 0;
+    const height = Math.max(0, actorY - receiverY);
+    const heightRatio = clampUnit(height / profile.cutoffHeight);
+    const remainingOpacity = 1 - heightRatio;
+    const footprintScale = 1 + (profile.maxFootprintScale - 1) * heightRatio;
+    const finiteSnowCoverage = Number.isFinite(snowCoverage)
+        ? clampUnit(snowCoverage)
+        : 0;
+    const visible =
+        state.visible &&
+        finiteTransform &&
+        height < profile.cutoffHeight &&
+        remainingOpacity > 0;
+
+    return {
+        halfLength: profile.baseHalfLength * footprintScale,
+        halfWidth: profile.baseHalfWidth * footprintScale,
+        opacity: visible
+            ? profile.baseOpacity * remainingOpacity * remainingOpacity
+            : 0,
+        visible,
+        x: finiteTransform ? state.x : 0,
+        y:
+            receiverY +
+            actorGroundingShadowSurfaceLift +
+            finiteSnowCoverage * actorGroundingShadowSnowLift,
+        yaw: finiteTransform ? state.yaw : 0,
+        z: finiteTransform ? state.z : 0,
+    };
+}
+
+export class ActorGroundingShadowRegistry {
+    private readonly entries = new Map<
+        string,
+        ActorGroundingShadowRegistryEntry
+    >();
+    private readonly droppedIds = new Set<string>();
+    private readonly freeSlots: number[] = [];
+    private nextSlot = 0;
+    private updateCount = 0;
+    private version = 0;
+
+    constructor(readonly capacity = actorGroundingShadowCapacity) {
+        if (!Number.isInteger(capacity) || capacity < 1) {
+            throw new Error(
+                'Actor grounding-shadow capacity must be a positive integer',
+            );
+        }
+    }
+
+    getEntries() {
+        return [...this.entries.values()].sort(
+            (left, right) => left.slot - right.slot,
+        );
+    }
+
+    getStats(): ActorGroundingShadowRegistryStats {
+        let primaryCasterCount = 0;
+        for (const entry of this.entries.values()) {
+            primaryCasterCount += entry.primaryCasterCount;
+        }
+
+        return {
+            capacity: this.capacity,
+            droppedCount: this.droppedIds.size,
+            primaryCasterCount,
+            registeredCount: this.entries.size,
+            updateCount: this.updateCount,
+        };
+    }
+
+    getVersion() {
+        return this.version;
+    }
+
+    register({
+        id,
+        primaryCasterCount,
+        species,
+    }: ActorGroundingShadowRegistration) {
+        if (id.length === 0) {
+            throw new Error('Actor grounding-shadow registration needs an id');
+        }
+        if (this.entries.has(id) || this.droppedIds.has(id)) {
+            throw new Error(
+                `Actor grounding-shadow id "${id}" is already registered`,
+            );
+        }
+        if (!Number.isInteger(primaryCasterCount) || primaryCasterCount < 0) {
+            throw new Error(
+                'Actor grounding-shadow primary caster count must be a non-negative integer',
+            );
+        }
+
+        const reusedSlot = this.freeSlots.shift();
+        const slot = reusedSlot ?? this.nextSlot;
+        if (slot >= this.capacity) {
+            if (reusedSlot !== undefined) {
+                this.freeSlots.unshift(reusedSlot);
+            }
+
+            this.droppedIds.add(id);
+            this.publishChange();
+
+            let registered = true;
+            return {
+                slot: null,
+                unregister: () => {
+                    if (!registered) {
+                        return;
+                    }
+
+                    registered = false;
+                    this.droppedIds.delete(id);
+                    this.publishChange();
+                },
+            };
+        }
+        if (reusedSlot === undefined) {
+            this.nextSlot += 1;
+        }
+
+        const entry: ActorGroundingShadowRegistryEntry = {
+            id,
+            primaryCasterCount,
+            slot,
+            species,
+            state: hiddenActorGroundingShadowState,
+        };
+        this.entries.set(id, entry);
+        this.publishChange();
+
+        let registered = true;
+        return {
+            slot,
+            unregister: () => {
+                if (!registered || this.entries.get(id) !== entry) {
+                    return;
+                }
+
+                registered = false;
+                this.entries.delete(id);
+                this.freeSlots.push(slot);
+                this.freeSlots.sort((left, right) => left - right);
+                this.publishChange();
+            },
+        };
+    }
+
+    update(id: string, state: ActorGroundingShadowState) {
+        const entry = this.entries.get(id);
+        if (!entry || isSameState(entry.state, state)) {
+            return false;
+        }
+
+        entry.state = { ...state };
+        this.updateCount += 1;
+        this.publishChange();
+        return true;
+    }
+
+    private publishChange() {
+        this.version += 1;
+    }
+}

--- a/packages/game/src/entities/animals/actorGroundingShadowRegistry.unit.ts
+++ b/packages/game/src/entities/animals/actorGroundingShadowRegistry.unit.ts
@@ -1,0 +1,208 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    ActorGroundingShadowRegistry,
+    type ActorGroundingShadowState,
+    actorGroundingShadowProfiles,
+    actorGroundingShadowSnowLift,
+    resolveActorGroundingShadow,
+} from './actorGroundingShadowRegistry';
+
+const groundedState: ActorGroundingShadowState = {
+    actorY: 0.2,
+    receiverY: 0.2,
+    visible: true,
+    x: 3,
+    yaw: 0.4,
+    z: -2,
+};
+
+describe('actor grounding-shadow projection', () => {
+    it('keeps grounded actors at their species footprint and opacity', () => {
+        const resolved = resolveActorGroundingShadow({
+            snowCoverage: 0,
+            species: 'cat',
+            state: groundedState,
+        });
+        const profile = actorGroundingShadowProfiles.cat;
+
+        assert.equal(resolved.visible, true);
+        assert.equal(resolved.halfLength, profile.baseHalfLength);
+        assert.equal(resolved.halfWidth, profile.baseHalfWidth);
+        assert.equal(resolved.opacity, profile.baseOpacity);
+        assert.equal(resolved.x, groundedState.x);
+        assert.equal(resolved.z, groundedState.z);
+    });
+
+    it('grows and quadratically fades a flying actor footprint', () => {
+        const profile = actorGroundingShadowProfiles.bird;
+        const resolved = resolveActorGroundingShadow({
+            snowCoverage: 0,
+            species: 'bird',
+            state: {
+                ...groundedState,
+                actorY: groundedState.receiverY + profile.cutoffHeight / 2,
+            },
+        });
+        const expectedScale = 1 + (profile.maxFootprintScale - 1) / 2;
+
+        assert.equal(resolved.visible, true);
+        assert.equal(
+            resolved.halfLength,
+            profile.baseHalfLength * expectedScale,
+        );
+        assert.equal(resolved.halfWidth, profile.baseHalfWidth * expectedScale);
+        assert.equal(resolved.opacity, profile.baseOpacity * 0.25);
+    });
+
+    it('cuts the projection off at the species flight height', () => {
+        const profile = actorGroundingShadowProfiles.bee;
+        const resolved = resolveActorGroundingShadow({
+            snowCoverage: 0,
+            species: 'bee',
+            state: {
+                ...groundedState,
+                actorY: groundedState.receiverY + profile.cutoffHeight,
+            },
+        });
+
+        assert.equal(resolved.visible, false);
+        assert.equal(resolved.opacity, 0);
+    });
+
+    it('lifts the receiver plane slightly as snow accumulates', () => {
+        const clear = resolveActorGroundingShadow({
+            snowCoverage: 0,
+            species: 'dog',
+            state: groundedState,
+        });
+        const snow = resolveActorGroundingShadow({
+            snowCoverage: 1,
+            species: 'dog',
+            state: groundedState,
+        });
+
+        assert.ok(
+            Math.abs(snow.y - clear.y - actorGroundingShadowSnowLift) <
+                Number.EPSILON,
+        );
+    });
+
+    it('returns finite hidden values for invalid transforms and snow', () => {
+        const resolved = resolveActorGroundingShadow({
+            snowCoverage: Number.POSITIVE_INFINITY,
+            species: 'cat',
+            state: {
+                actorY: Number.NaN,
+                receiverY: Number.NEGATIVE_INFINITY,
+                visible: true,
+                x: Number.POSITIVE_INFINITY,
+                yaw: Number.NaN,
+                z: Number.NEGATIVE_INFINITY,
+            },
+        });
+
+        assert.equal(resolved.visible, false);
+        for (const value of Object.values(resolved)) {
+            if (typeof value === 'number') {
+                assert.equal(Number.isFinite(value), true);
+            }
+        }
+    });
+});
+
+describe('ActorGroundingShadowRegistry', () => {
+    it('keeps live slots stable and reuses a released slot', () => {
+        const registry = new ActorGroundingShadowRegistry(3);
+        const cat = registry.register({
+            id: 'cat:a',
+            primaryCasterCount: 7,
+            species: 'cat',
+        });
+        const dog = registry.register({
+            id: 'dog:b',
+            primaryCasterCount: 9,
+            species: 'dog',
+        });
+
+        assert.equal(cat.slot, 0);
+        assert.equal(dog.slot, 1);
+        registry.update('dog:b', groundedState);
+        assert.equal(
+            registry.getEntries().find((entry) => entry.id === 'dog:b')?.slot,
+            1,
+        );
+
+        cat.unregister();
+        const bird = registry.register({
+            id: 'bird:c',
+            primaryCasterCount: 4,
+            species: 'bird',
+        });
+
+        assert.equal(bird.slot, 0);
+        assert.equal(
+            registry.getEntries().find((entry) => entry.id === 'dog:b')?.slot,
+            1,
+        );
+        assert.deepEqual(registry.getStats(), {
+            capacity: 3,
+            droppedCount: 0,
+            primaryCasterCount: 13,
+            registeredCount: 2,
+            updateCount: 1,
+        });
+    });
+
+    it('does not dirty the batch for equivalent or unknown updates', () => {
+        const registry = new ActorGroundingShadowRegistry(1);
+        registry.register({
+            id: 'cat:a',
+            primaryCasterCount: 0,
+            species: 'cat',
+        });
+        const registeredVersion = registry.getVersion();
+
+        assert.equal(registry.update('cat:a', groundedState), true);
+        assert.equal(registry.getVersion(), registeredVersion + 1);
+        assert.equal(registry.update('cat:a', { ...groundedState }), false);
+        assert.equal(registry.update('missing', groundedState), false);
+        assert.equal(registry.getVersion(), registeredVersion + 1);
+        assert.equal(registry.getStats().updateCount, 1);
+    });
+
+    it('drops overflow registrations without crashing the scene', () => {
+        const registry = new ActorGroundingShadowRegistry(1);
+        const cat = registry.register({
+            id: 'cat:a',
+            primaryCasterCount: 0,
+            species: 'cat',
+        });
+        const dog = registry.register({
+            id: 'dog:b',
+            primaryCasterCount: 0,
+            species: 'dog',
+        });
+
+        assert.equal(cat.slot, 0);
+        assert.equal(dog.slot, null);
+        assert.equal(registry.update('dog:b', groundedState), false);
+        assert.deepEqual(registry.getStats(), {
+            capacity: 1,
+            droppedCount: 1,
+            primaryCasterCount: 0,
+            registeredCount: 1,
+            updateCount: 0,
+        });
+
+        dog.unregister();
+        cat.unregister();
+        assert.deepEqual(registry.getStats(), {
+            capacity: 1,
+            droppedCount: 0,
+            primaryCasterCount: 0,
+            registeredCount: 0,
+            updateCount: 0,
+        });
+    });
+});

--- a/packages/game/src/entities/animals/actorMeshShadows.ts
+++ b/packages/game/src/entities/animals/actorMeshShadows.ts
@@ -1,0 +1,22 @@
+import { Mesh, type Object3D } from 'three';
+
+export function configureActorMeshShadows(
+    root: Object3D,
+    prepareMesh: (mesh: Mesh) => void,
+) {
+    let primaryCasterCount = 0;
+
+    root.traverse((object) => {
+        if (!(object instanceof Mesh)) {
+            return;
+        }
+
+        prepareMesh(object);
+        object.castShadow = false;
+        if (object.castShadow) {
+            primaryCasterCount += 1;
+        }
+    });
+
+    return { primaryCasterCount };
+}

--- a/packages/game/src/entities/animals/actorMeshShadows.unit.ts
+++ b/packages/game/src/entities/animals/actorMeshShadows.unit.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { BoxGeometry, Group, Mesh, MeshBasicMaterial } from 'three';
+import { configureActorMeshShadows } from './actorMeshShadows';
+
+test('actor meshes leave the primary map while preserving receiver policy', () => {
+    const root = new Group();
+    const nested = new Group();
+    const body = new Mesh(new BoxGeometry(), new MeshBasicMaterial());
+    const wing = new Mesh(new BoxGeometry(), new MeshBasicMaterial());
+    body.name = 'body';
+    body.castShadow = true;
+    wing.name = 'wing';
+    wing.castShadow = true;
+    nested.add(wing);
+    root.add(body, nested);
+
+    const result = configureActorMeshShadows(root, (mesh) => {
+        mesh.receiveShadow = mesh.name !== 'wing';
+    });
+
+    assert.deepEqual(result, { primaryCasterCount: 0 });
+    assert.equal(body.castShadow, false);
+    assert.equal(body.receiveShadow, true);
+    assert.equal(wing.castShadow, false);
+    assert.equal(wing.receiveShadow, false);
+});

--- a/packages/game/src/entities/bees/Bees.tsx
+++ b/packages/game/src/entities/bees/Bees.tsx
@@ -5,7 +5,7 @@ import type { Group, Material, Object3D } from 'three';
 import {
     DoubleSide,
     MathUtils,
-    Mesh,
+    type Mesh,
     MeshStandardMaterial,
     Vector3,
 } from 'three';
@@ -27,7 +27,9 @@ import {
     type RaisedBedOrientation,
 } from '../../utils/raisedBedOrientation';
 import { useGameGLTF } from '../../utils/useGameGLTF';
+import { useActorGroundingShadow } from '../animals/ActorGroundingShadows';
 import { AnimalTargetDebugMarker } from '../animals/AnimalDebugIndicators';
+import { configureActorMeshShadows } from '../animals/actorMeshShadows';
 import { getCactusVariantConfig } from '../Cactus';
 import { getBlockSurfaceDecorations } from '../groundDecorations/getBlockSurfaceDecorations';
 import { resolveGroundDecorationSurface } from '../groundDecorations/groundDecorationConfig';
@@ -1003,13 +1005,8 @@ function cloneBeeMaterial(material: Material, objectName: string) {
     return clone;
 }
 
-function isMesh(object: Object3D): object is Mesh {
-    return object instanceof Mesh;
-}
-
 function prepareBeeMesh(object: Mesh) {
     const isWing = object.name.includes('Bee_Wing');
-    object.castShadow = !isWing;
     object.receiveShadow = !isWing;
     object.material = Array.isArray(object.material)
         ? object.material.map((material) =>
@@ -1177,12 +1174,12 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
 
     const beeModel = useMemo(() => {
         const clone = gltf.scene.clone(true);
-        clone.traverse((object) => {
-            if (isMesh(object)) {
-                prepareBeeMesh(object);
-            }
-        });
+        const { primaryCasterCount } = configureActorMeshShadows(
+            clone,
+            prepareBeeMesh,
+        );
         return {
+            primaryCasterCount,
             rig: {
                 bodyPivot: getBeeRigNode(clone, 'Bee_BodyPivot'),
                 headPivot: getBeeRigNode(clone, 'Bee_HeadPivot'),
@@ -1192,6 +1189,11 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
             scene: clone,
         };
     }, [gltf.scene]);
+    const updateGroundingShadow = useActorGroundingShadow({
+        id: `bee:${habitat.id}`,
+        primaryCasterCount: beeModel.primaryCasterCount,
+        species: 'bee',
+    });
 
     useEffect(() => {
         randomRef.current = createRandom(habitat.seed);
@@ -1424,6 +1426,18 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
             runtime,
             seed: habitat.seed,
         });
+        if (runtime && updateGroundingShadow) {
+            updateGroundingShadow({
+                actorY: group.position.y,
+                receiverY: runtime.target.position.y,
+                visible:
+                    runtime.phase === 'foraging' &&
+                    runtime.target.kind !== 'wander',
+                x: group.position.x,
+                yaw: group.rotation.y,
+                z: group.position.z,
+            });
+        }
 
         if (
             enableDebugHudFlag &&

--- a/packages/game/src/entities/birds/Birds.tsx
+++ b/packages/game/src/entities/birds/Birds.tsx
@@ -3,9 +3,8 @@ import { useAnimations } from '@react-three/drei';
 import { type ThreeEvent, useFrame, useThree } from '@react-three/fiber';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Group, Material, Object3D } from 'three';
-import { MathUtils, Mesh, MeshStandardMaterial, Vector3 } from 'three';
+import { MathUtils, type Mesh, MeshStandardMaterial, Vector3 } from 'three';
 import { useBlockData } from '../../hooks/useBlockData';
-import { useAnimatedCasterShadowMapRefresh } from '../../scene/SceneTime';
 import type { Block } from '../../types/Block';
 import type { Stack } from '../../types/Stack';
 import {
@@ -15,7 +14,9 @@ import {
 } from '../../useGameState';
 import { getStackHeight } from '../../utils/getStackHeight';
 import { useGameGLTF } from '../../utils/useGameGLTF';
+import { useActorGroundingShadow } from '../animals/ActorGroundingShadows';
 import { AnimalTargetDebugMarker } from '../animals/AnimalDebugIndicators';
+import { configureActorMeshShadows } from '../animals/actorMeshShadows';
 import { waterBlockName } from '../waterBlockFoam';
 import {
     type BirdBehavior,
@@ -31,6 +32,7 @@ type BirdTarget = {
     blockId?: string;
     circle?: BirdCircleMotion;
     facingYaw?: number;
+    groundY: number;
     position: Vector3;
 };
 
@@ -43,6 +45,7 @@ type BirdCircleMotion = {
 };
 
 type BirdCircleAnchor = {
+    groundY: number;
     id: string;
     position: Vector3;
 };
@@ -303,12 +306,12 @@ function targetForBlock({
     blockData: BlockData[] | null | undefined;
     stack: Stack;
 }) {
-    const y =
-        getStackHeight(blockData, stack, block) +
-        getVisualPerchYOffset(blockData, block.name);
+    const groundY = getStackHeight(blockData, stack, block);
+    const y = groundY + getVisualPerchYOffset(blockData, block.name);
     return {
         behavior,
         blockId: block.id,
+        groundY,
         id: `${behavior}-${block.id}`,
         position: new Vector3(stack.position.x, y, stack.position.z),
     } satisfies BirdTarget;
@@ -323,10 +326,10 @@ function circleAnchorForBlock({
     blockData: BlockData[] | null | undefined;
     stack: Stack;
 }) {
-    const y =
-        getStackHeight(blockData, stack, block) +
-        getVisualPerchYOffset(blockData, block.name);
+    const groundY = getStackHeight(blockData, stack, block);
+    const y = groundY + getVisualPerchYOffset(blockData, block.name);
     return {
+        groundY,
         id: `circle-${block.id}`,
         position: new Vector3(stack.position.x, y, stack.position.z),
     } satisfies BirdCircleAnchor;
@@ -339,6 +342,7 @@ function targetForGroundStack(
     const topY = getStackHeight(blockData, stack) + birdGroundLift;
     return {
         behavior: 'ground',
+        groundY: topY - birdGroundLift,
         id: `ground-${stack.position.x}-${stack.position.z}`,
         position: new Vector3(stack.position.x, topY, stack.position.z),
     } satisfies BirdTarget;
@@ -428,6 +432,7 @@ function createAirTarget({
     const jitterAngle = random() * fullTurn;
     return {
         behavior: 'air',
+        groundY: home.groundY,
         id: `air-${home.id}-${index}`,
         position: new Vector3(
             anchor.x + Math.cos(jitterAngle) * jitterRadius,
@@ -464,6 +469,7 @@ function createCircleTarget({
             radius,
             startAngle,
         },
+        groundY: anchor.groundY,
         id: `circle-${home.id}-${anchor.id}`,
         position: new Vector3(
             center.x + Math.cos(startAngle) * radius,
@@ -1335,10 +1341,6 @@ function tintBirdPartMaterial(object: Mesh) {
         : cloneBirdPartMaterial(object.material, tintColor);
 }
 
-function isMesh(object: Object3D): object is Mesh {
-    return object instanceof Mesh;
-}
-
 function getBirdRigNode(scene: Object3D, name: string): BirdRigNode {
     const object = scene.getObjectByName(name) ?? null;
     return {
@@ -1513,6 +1515,14 @@ function createBirdDebugEntry({
     };
 }
 
+function getBirdShadowReceiverY(runtime: BirdRuntimeState) {
+    if (runtime.phase === 'settled' && runtime.target.behavior !== 'ground') {
+        return runtime.target.position.y;
+    }
+
+    return runtime.target.groundY;
+}
+
 function Bird({ habitat }: { habitat: BirdHabitat }) {
     const gltf = useGameGLTF('BirdSmall');
     const clock = useThree((state) => state.clock);
@@ -1542,14 +1552,15 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
 
     const birdModel = useMemo(() => {
         const clone = gltf.scene.clone(true);
-        clone.traverse((object) => {
-            if (isMesh(object)) {
-                object.castShadow = true;
+        const { primaryCasterCount } = configureActorMeshShadows(
+            clone,
+            (object) => {
                 object.receiveShadow = true;
                 tintBirdPartMaterial(object);
-            }
-        });
+            },
+        );
         return {
+            primaryCasterCount,
             rig: {
                 flightLegPoseAmount: 0,
                 footLeft: getBirdRigNode(clone, 'BirdSmall_Foot_L'),
@@ -1566,6 +1577,11 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
         };
     }, [gltf.scene]);
     const { actions } = useAnimations(gltf.animations, birdModel.scene);
+    const updateGroundingShadow = useActorGroundingShadow({
+        id: `bird:${habitat.id}`,
+        primaryCasterCount: birdModel.primaryCasterCount,
+        species: 'bird',
+    });
 
     useEffect(() => {
         const idleAction = actions.BirdSmall_Idle;
@@ -2026,6 +2042,17 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
         });
         updateGroundPeckPose({ delta, rig: birdModel.rig });
 
+        if (runtime && group && updateGroundingShadow) {
+            updateGroundingShadow({
+                actorY: group.position.y,
+                receiverY: getBirdShadowReceiverY(runtime),
+                visible: true,
+                x: group.position.x,
+                yaw: group.rotation.y,
+                z: group.position.z,
+            });
+        }
+
         if (runtime && group && now - lastAnimalDebugUpdateRef.current >= 0.5) {
             lastAnimalDebugUpdateRef.current = now;
             setAnimalDebugEntry(
@@ -2056,7 +2083,6 @@ export function Birds({ stacks }: { stacks: Stack[] | undefined }) {
         () => createBirdHabitats(stacks, blockData),
         [blockData, stacks],
     );
-    useAnimatedCasterShadowMapRefresh(habitats.length > 0);
 
     if (habitats.length <= 0) {
         return null;

--- a/packages/game/src/entities/cats/Cats.tsx
+++ b/packages/game/src/entities/cats/Cats.tsx
@@ -2,8 +2,8 @@ import type { BlockData } from '@gredice/client';
 import { useAnimations } from '@react-three/drei';
 import { type ThreeEvent, useFrame, useThree } from '@react-three/fiber';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { AnimationAction, Group, Material, Object3D } from 'three';
-import { MathUtils, Mesh, MeshStandardMaterial, Vector3 } from 'three';
+import type { AnimationAction, Group, Material } from 'three';
+import { MathUtils, type Mesh, MeshStandardMaterial, Vector3 } from 'three';
 import { useGameFlags } from '../../GameFlagsContext';
 import { useBlockData } from '../../hooks/useBlockData';
 import { useWeatherNow } from '../../hooks/useWeatherNow';
@@ -17,11 +17,13 @@ import {
 } from '../../useGameState';
 import { getStackHeight } from '../../utils/getStackHeight';
 import { useGameGLTF } from '../../utils/useGameGLTF';
+import { useActorGroundingShadow } from '../animals/ActorGroundingShadows';
 import {
     type AnimalDebugPathPoint,
     AnimalPathDebugIndicator,
     AnimalTargetDebugMarker,
 } from '../animals/AnimalDebugIndicators';
+import { configureActorMeshShadows } from '../animals/actorMeshShadows';
 import {
     animalPresencePosition,
     animalPresenceUpdateIntervalSeconds,
@@ -1161,10 +1163,6 @@ function getCatAnimationName(runtime: CatRuntimeState): CatAnimationName {
     return 'Cat_Idle';
 }
 
-function isMesh(object: Object3D): object is Mesh {
-    return object instanceof Mesh;
-}
-
 function getCatDebugActivity(runtime: CatRuntimeState) {
     if (runtime.phase === 'moving') {
         return `walking to ${runtime.target.behavior}`;
@@ -1290,7 +1288,6 @@ function cloneCatMaterial(material: Material) {
 }
 
 function prepareCatMesh(object: Mesh) {
-    object.castShadow = true;
     object.frustumCulled = false;
     object.receiveShadow = true;
     object.material = Array.isArray(object.material)
@@ -1351,14 +1348,21 @@ function Cat({
 
     const catModel = useMemo(() => {
         const clone = gltf.scene.clone(true);
-        clone.traverse((object) => {
-            if (isMesh(object)) {
-                prepareCatMesh(object);
-            }
-        });
-        return clone;
+        const { primaryCasterCount } = configureActorMeshShadows(
+            clone,
+            prepareCatMesh,
+        );
+        return {
+            primaryCasterCount,
+            scene: clone,
+        };
     }, [gltf.scene]);
-    const { actions } = useAnimations(gltf.animations, catModel);
+    const { actions } = useAnimations(gltf.animations, catModel.scene);
+    const updateActorGroundingShadow = useActorGroundingShadow({
+        id: `cat:${habitat.id}`,
+        primaryCasterCount: catModel.primaryCasterCount,
+        species: 'cat',
+    });
 
     useEffect(() => {
         const action = actions[activeAnimation];
@@ -1686,6 +1690,20 @@ function Cat({
         const group = groupRef.current;
         const now = clock.elapsedTime;
 
+        if (group && updateActorGroundingShadow) {
+            updateActorGroundingShadow({
+                actorY: group.position.y,
+                receiverY: getCatWalkYAt(
+                    group.position,
+                    habitat.groundSurfaces,
+                ),
+                visible: group.visible && catModel.scene.visible,
+                x: group.position.x,
+                yaw: group.rotation.y,
+                z: group.position.z,
+            });
+        }
+
         if (
             runtime &&
             group &&
@@ -1724,7 +1742,7 @@ function Cat({
                 onPointerDown={handlePointerDown}
                 onClick={handleClick}
             >
-                <primitive object={catModel} />
+                <primitive object={catModel.scene} />
             </group>
             <AnimalTargetDebugMarker ref={targetDebugRef} color="#38bdf8" />
             <AnimalPathDebugIndicator

--- a/packages/game/src/entities/dogs/Dogs.tsx
+++ b/packages/game/src/entities/dogs/Dogs.tsx
@@ -3,11 +3,10 @@ import { useAnimations } from '@react-three/drei';
 import { type ThreeEvent, useFrame, useThree } from '@react-three/fiber';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { AnimationAction, Group, Material, Object3D } from 'three';
-import { MathUtils, Mesh, MeshStandardMaterial, Vector3 } from 'three';
+import { MathUtils, type Mesh, MeshStandardMaterial, Vector3 } from 'three';
 import { useGameFlags } from '../../GameFlagsContext';
 import { useBlockData } from '../../hooks/useBlockData';
 import { useWeatherNow } from '../../hooks/useWeatherNow';
-import { useAnimatedCasterShadowMapRefresh } from '../../scene/SceneTime';
 import type { Block } from '../../types/Block';
 import type { Stack } from '../../types/Stack';
 import {
@@ -18,11 +17,13 @@ import {
 } from '../../useGameState';
 import { getStackHeight } from '../../utils/getStackHeight';
 import { useGameGLTF } from '../../utils/useGameGLTF';
+import { useActorGroundingShadow } from '../animals/ActorGroundingShadows';
 import {
     type AnimalDebugPathPoint,
     AnimalPathDebugIndicator,
     AnimalTargetDebugMarker,
 } from '../animals/AnimalDebugIndicators';
+import { configureActorMeshShadows } from '../animals/actorMeshShadows';
 import {
     animalPresencePosition,
     animalPresenceUpdateIntervalSeconds,
@@ -1228,10 +1229,6 @@ function getDogAnimationName(runtime: DogRuntimeState): DogAnimationName {
     return 'Dog_Idle';
 }
 
-function isMesh(object: Object3D): object is Mesh {
-    return object instanceof Mesh;
-}
-
 function getDogDebugActivity(runtime: DogRuntimeState) {
     if (runtime.phase === 'moving') {
         return `walking to ${runtime.target.behavior}`;
@@ -1357,7 +1354,6 @@ function cloneDogMaterial(material: Material) {
 }
 
 function prepareDogMesh(object: Mesh) {
-    object.castShadow = true;
     object.frustumCulled = false;
     object.receiveShadow = true;
     object.material = Array.isArray(object.material)
@@ -1524,17 +1520,22 @@ function Dog({
 
     const dogModel = useMemo(() => {
         const clone = gltf.scene.clone(true);
-        clone.traverse((object) => {
-            if (isMesh(object)) {
-                prepareDogMesh(object);
-            }
-        });
+        const { primaryCasterCount } = configureActorMeshShadows(
+            clone,
+            prepareDogMesh,
+        );
         return {
+            primaryCasterCount,
             rig: createDogRig(clone),
             scene: clone,
         };
     }, [gltf.scene]);
     const { actions } = useAnimations(gltf.animations, dogModel.scene);
+    const updateActorGroundingShadow = useActorGroundingShadow({
+        id: `dog:${habitat.id}`,
+        primaryCasterCount: dogModel.primaryCasterCount,
+        species: 'dog',
+    });
 
     useEffect(() => {
         const action = actions[activeAnimation];
@@ -1880,6 +1881,20 @@ function Dog({
         const group = groupRef.current;
         const now = clock.elapsedTime;
 
+        if (group && updateActorGroundingShadow) {
+            updateActorGroundingShadow({
+                actorY: group.position.y,
+                receiverY: getDogWalkYAt(
+                    group.position,
+                    habitat.groundSurfaces,
+                ),
+                visible: group.visible && dogModel.scene.visible,
+                x: group.position.x,
+                yaw: group.rotation.y,
+                z: group.position.z,
+            });
+        }
+
         if (
             runtime &&
             group &&
@@ -2003,7 +2018,6 @@ export function Dogs({
         () => createDogHabitats(stacks, blockData),
         [blockData, stacks],
     );
-    useAnimatedCasterShadowMapRefresh(habitats.length > 0);
 
     if (habitats.length <= 0) {
         return null;

--- a/packages/game/src/scene/Scene.tsx
+++ b/packages/game/src/scene/Scene.tsx
@@ -19,6 +19,7 @@ import {
     PCFShadowMap,
     type WebGLRendererParameters,
 } from 'three';
+import { ActorGroundingShadowProvider } from '../entities/animals/ActorGroundingShadows';
 import {
     HoverOutlineEffect,
     HoverOutlineProvider,
@@ -271,18 +272,22 @@ export function Scene({
                 suspendWhenOffscreen={suspendWhenOffscreen}
             >
                 <WeatherSurfaceUniformProvider>
-                    <HoverOutlineProvider>
-                        <SceneDebugName />
-                        <GeneratedLSystemCacheStatsReporter />
-                        {debugStats && <RendererStatsReporter />}
-                        <SceneWireframeMode
-                            enabled={Boolean(
-                                debugStats && wireframeDebugVisible,
-                            )}
-                        />
-                        {children}
-                        <HoverOutlineEffect />
-                    </HoverOutlineProvider>
+                    <ActorGroundingShadowProvider
+                        enabled={qualityProfile.shadows}
+                    >
+                        <HoverOutlineProvider>
+                            <SceneDebugName />
+                            <GeneratedLSystemCacheStatsReporter />
+                            {debugStats && <RendererStatsReporter />}
+                            <SceneWireframeMode
+                                enabled={Boolean(
+                                    debugStats && wireframeDebugVisible,
+                                )}
+                            />
+                            {children}
+                            <HoverOutlineEffect />
+                        </HoverOutlineProvider>
+                    </ActorGroundingShadowProvider>
                 </WeatherSurfaceUniformProvider>
             </SceneTimeProvider>
         </Canvas>

--- a/packages/game/src/scene/SceneTime.tsx
+++ b/packages/game/src/scene/SceneTime.tsx
@@ -25,10 +25,6 @@ export const sceneFrameRates = {
 
 type SceneTimeContextValue = {
     acquireContinuousRender: (framesPerSecond?: number) => () => void;
-    requestAnimatedCasterShadowRefresh: (now: number) => void;
-    subscribeAnimatedCasterShadowRefresh: (
-        listener: (now: number) => void,
-    ) => () => void;
     subscribeSceneResume: (listener: () => void) => () => void;
     timeUniform: IUniform<number>;
 };
@@ -58,9 +54,6 @@ export function SceneTimeProvider({
     const animationFrameRef = useRef<number | null>(null);
     const baseFramesPerSecondRef = useRef(
         normalizeSceneFramesPerSecond(baseFramesPerSecond),
-    );
-    const animatedCasterShadowRefreshListenersRef = useRef(
-        new Set<(now: number) => void>(),
     );
     const canvasVisibleRef = useRef(true);
     const continuousRenderLeasesRef = useRef(new Map<symbol, number>());
@@ -98,24 +91,6 @@ export function SceneTimeProvider({
             sceneResumeListenersRef.current.delete(listener);
         };
     }, []);
-
-    const requestAnimatedCasterShadowRefresh = useCallback((now: number) => {
-        for (const listener of animatedCasterShadowRefreshListenersRef.current) {
-            listener(now);
-        }
-    }, []);
-
-    const subscribeAnimatedCasterShadowRefresh = useCallback(
-        (listener: (now: number) => void) => {
-            animatedCasterShadowRefreshListenersRef.current.add(listener);
-            return () => {
-                animatedCasterShadowRefreshListenersRef.current.delete(
-                    listener,
-                );
-            };
-        },
-        [],
-    );
 
     const startContinuousRenderLoop = useCallback(() => {
         if (
@@ -239,7 +214,6 @@ export function SceneTimeProvider({
         return () => {
             disposedRef.current = true;
             stopContinuousRenderLoop();
-            animatedCasterShadowRefreshListenersRef.current.clear();
             continuousRenderLeasesRef.current.clear();
             sceneResumeListenersRef.current.clear();
         };
@@ -319,18 +293,10 @@ export function SceneTimeProvider({
     const contextValue = useMemo(
         () => ({
             acquireContinuousRender,
-            requestAnimatedCasterShadowRefresh,
-            subscribeAnimatedCasterShadowRefresh,
             subscribeSceneResume,
             timeUniform,
         }),
-        [
-            acquireContinuousRender,
-            requestAnimatedCasterShadowRefresh,
-            subscribeAnimatedCasterShadowRefresh,
-            subscribeSceneResume,
-            timeUniform,
-        ],
+        [acquireContinuousRender, subscribeSceneResume, timeUniform],
     );
 
     return (
@@ -375,35 +341,6 @@ export function useSceneResume(listener: () => void) {
 
     useEffect(
         () => sceneTime.subscribeSceneResume(listener),
-        [listener, sceneTime],
-    );
-}
-
-// Actual moving cast-shadow owners opt into this contract. Secondary effects
-// such as moving cloud shade intentionally never request primary-map refreshes.
-export function useAnimatedCasterShadowMapRefresh(enabled = true) {
-    const sceneTime = useContext(SceneTimeContext);
-    if (!sceneTime) {
-        throw new Error('Missing SceneTimeProvider in the scene tree');
-    }
-
-    useFrame(() => {
-        if (enabled) {
-            sceneTime.requestAnimatedCasterShadowRefresh(performance.now());
-        }
-    });
-}
-
-export function useAnimatedCasterShadowMapRefreshSubscription(
-    listener: (now: number) => void,
-) {
-    const sceneTime = useContext(SceneTimeContext);
-    if (!sceneTime) {
-        throw new Error('Missing SceneTimeProvider in the scene tree');
-    }
-
-    useEffect(
-        () => sceneTime.subscribeAnimatedCasterShadowRefresh(listener),
         [listener, sceneTime],
     );
 }

--- a/packages/game/src/scene/ShadowMapController.tsx
+++ b/packages/game/src/scene/ShadowMapController.tsx
@@ -9,16 +9,8 @@ import {
     useState,
 } from 'react';
 import { updateGameProfileMetadata } from './gameProfileMetadata';
-import {
-    useAnimatedCasterShadowMapRefreshSubscription,
-    useSceneResume,
-    useSceneTimeInvalidation,
-} from './SceneTime';
-import {
-    animatedCasterShadowRefreshMs,
-    requestPrimaryShadowMapRefresh,
-    resolveAnimatedCasterShadowRefreshTick,
-} from './shadowMapScheduling';
+import { useSceneResume, useSceneTimeInvalidation } from './SceneTime';
+import { requestPrimaryShadowMapRefresh } from './shadowMapScheduling';
 
 const shadowSettleMs = 900;
 
@@ -33,9 +25,7 @@ export function ShadowMapController({
 }) {
     const gl = useThree((state) => state.gl);
     const invalidate = useThree((state) => state.invalidate);
-    const animatedRefreshCountRef = useRef(0);
     const invalidationCountRef = useRef(0);
-    const nextAnimatedRefreshAtRef = useRef(0);
     const refreshCountRef = useRef(0);
     const settleUntilRef = useRef(0);
     const [shadowSettleGeneration, setShadowSettleGeneration] = useState(0);
@@ -44,7 +34,7 @@ export function ShadowMapController({
 
     const reportShadowMapState = useCallback(() => {
         updateGameProfileMetadata({
-            animatedCasterShadowRefreshCount: animatedRefreshCountRef.current,
+            animatedCasterShadowRefreshCount: 0,
             primaryShadowRefreshCount: refreshCountRef.current,
             shadowMapAutoUpdate: gl.shadowMap.autoUpdate,
             shadowMapDynamicRefreshMs: 0,
@@ -69,29 +59,6 @@ export function ShadowMapController({
             reportShadowMapState();
         },
         [enabled, gl, invalidate, reportShadowMapState],
-    );
-
-    const requestAnimatedCasterShadowRefresh = useCallback(
-        (now: number) => {
-            const tick = resolveAnimatedCasterShadowRefreshTick({
-                enabled,
-                nextRefreshAt: nextAnimatedRefreshAtRef.current,
-                now,
-                refreshMs: animatedCasterShadowRefreshMs,
-                settleUntil: settleUntilRef.current,
-            });
-            nextAnimatedRefreshAtRef.current = tick.nextRefreshAt;
-            if (!tick.shouldRefresh) {
-                return;
-            }
-
-            animatedRefreshCountRef.current += 1;
-            requestShadowRefresh(false);
-        },
-        [enabled, requestShadowRefresh],
-    );
-    useAnimatedCasterShadowMapRefreshSubscription(
-        requestAnimatedCasterShadowRefresh,
     );
 
     const settleShadows = useCallback(() => {
@@ -119,7 +86,6 @@ export function ShadowMapController({
             gl.shadowMap.needsUpdate = true;
         }
         if (!enabled) {
-            nextAnimatedRefreshAtRef.current = 0;
             settleUntilRef.current = 0;
             setShadowSettling(false);
         }

--- a/packages/game/src/scene/gameProfileMetadata.ts
+++ b/packages/game/src/scene/gameProfileMetadata.ts
@@ -168,6 +168,13 @@ export type GeneratedPlantProfileSnapshot = {
 };
 
 export type GameProfileMetadata = {
+    actorGroundingShadowBatchCount?: number;
+    actorGroundingShadowCapacity?: number;
+    actorGroundingShadowCount?: number;
+    actorGroundingShadowDroppedCount?: number;
+    actorGroundingShadowPrimaryCasterCount?: number;
+    actorGroundingShadowUpdateCount?: number;
+    actorGroundingShadowVisibleCount?: number;
     animatedCasterShadowRefreshCount?: number;
     cloudAttenuationMaskResolution?: number;
     cloudAttenuationMaterialCount?: number;

--- a/packages/game/src/scene/gameQuality.unit.ts
+++ b/packages/game/src/scene/gameQuality.unit.ts
@@ -65,6 +65,19 @@ test('manual quality profiles ignore constrained device metrics', () => {
     }
 });
 
+test('low quality disables both primary and analytic actor shadows', () => {
+    assert.deepEqual(
+        {
+            shadowMapSize: gameQualityProfiles.low.shadowMapSize,
+            shadows: gameQualityProfiles.low.shadows,
+        },
+        {
+            shadowMapSize: 0,
+            shadows: false,
+        },
+    );
+});
+
 test('auto quality profile resolves medium for a standard device', () => {
     assert.equal(
         resolveGameQualityProfile('auto', undefined, standardDeviceMetrics),

--- a/packages/game/src/scene/shadowMapScheduling.ts
+++ b/packages/game/src/scene/shadowMapScheduling.ts
@@ -9,8 +9,6 @@ type ShadowMapRefreshTarget = {
     needsUpdate: boolean;
 };
 
-export const animatedCasterShadowRefreshMs = 160;
-
 export function requestPrimaryShadowMapRefresh(
     shadowMap: ShadowMapRefreshTarget,
     enabled: boolean,
@@ -23,32 +21,6 @@ export function requestPrimaryShadowMapRefresh(
     shadowMap.enabled = true;
     shadowMap.needsUpdate = true;
     return refreshCount + 1;
-}
-
-export function resolveAnimatedCasterShadowRefreshTick({
-    enabled,
-    nextRefreshAt,
-    now,
-    refreshMs,
-    settleUntil,
-}: {
-    enabled: boolean;
-    nextRefreshAt: number;
-    now: number;
-    refreshMs: number;
-    settleUntil: number;
-}) {
-    const shouldRefresh =
-        enabled &&
-        Number.isFinite(refreshMs) &&
-        refreshMs > 0 &&
-        now > settleUntil &&
-        now >= nextRefreshAt;
-
-    return {
-        nextRefreshAt: shouldRefresh ? now + refreshMs : nextRefreshAt,
-        shouldRefresh,
-    };
 }
 
 function formatShadowSignatureValue(value: number) {

--- a/packages/game/src/scene/shadowMapScheduling.unit.ts
+++ b/packages/game/src/scene/shadowMapScheduling.unit.ts
@@ -1,10 +1,8 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
-    animatedCasterShadowRefreshMs,
     buildDirectionalShadowDepthSignature,
     requestPrimaryShadowMapRefresh,
-    resolveAnimatedCasterShadowRefreshTick,
 } from './shadowMapScheduling';
 
 const baseShadowDepth = {
@@ -79,76 +77,5 @@ describe('primary shadow refresh accounting', () => {
             enabled: false,
             needsUpdate: false,
         });
-    });
-});
-
-describe('animated caster shadow refresh scheduling', () => {
-    it('waits for settlement and refreshes animated casters at a bounded cadence', () => {
-        const settling = resolveAnimatedCasterShadowRefreshTick({
-            enabled: true,
-            nextRefreshAt: 0,
-            now: 900,
-            refreshMs: animatedCasterShadowRefreshMs,
-            settleUntil: 900,
-        });
-        assert.deepEqual(settling, {
-            nextRefreshAt: 0,
-            shouldRefresh: false,
-        });
-
-        const due = resolveAnimatedCasterShadowRefreshTick({
-            enabled: true,
-            nextRefreshAt: settling.nextRefreshAt,
-            now: 901,
-            refreshMs: animatedCasterShadowRefreshMs,
-            settleUntil: 900,
-        });
-        assert.deepEqual(due, {
-            nextRefreshAt: 1_061,
-            shouldRefresh: true,
-        });
-
-        assert.deepEqual(
-            resolveAnimatedCasterShadowRefreshTick({
-                enabled: true,
-                nextRefreshAt: due.nextRefreshAt,
-                now: 1_000,
-                refreshMs: animatedCasterShadowRefreshMs,
-                settleUntil: 900,
-            }),
-            {
-                nextRefreshAt: 1_061,
-                shouldRefresh: false,
-            },
-        );
-    });
-
-    it('does not catch up after stalls or refresh while shadows are disabled', () => {
-        assert.deepEqual(
-            resolveAnimatedCasterShadowRefreshTick({
-                enabled: true,
-                nextRefreshAt: 1_000,
-                now: 2_000,
-                refreshMs: animatedCasterShadowRefreshMs,
-                settleUntil: 0,
-            }),
-            {
-                nextRefreshAt: 2_160,
-                shouldRefresh: true,
-            },
-        );
-        assert.deepEqual(
-            resolveAnimatedCasterShadowRefreshTick({
-                enabled: false,
-                nextRefreshAt: 1_000,
-                now: 2_000,
-                refreshMs: animatedCasterShadowRefreshMs,
-                settleUntil: 0,
-            }),
-            {
-                nextRefreshAt: 1_000,
-                shouldRefresh: false,
-            },
-        );
     });
 });


### PR DESCRIPTION
## Summary

- remove cats, dogs, birds, and bees from the cached 4096px primary shadow map
- replace their moving silhouettes with one High-gated instanced analytic grounding-shadow batch
- remove the 160ms animated-caster primary-map scheduler and add strict profile counters for caster leakage, dropped slots, visibility, and ambient refreshes
- preserve shadow-disabled tiers with no batch registration or per-frame receiver lookup

## Verification

- `pnpm --filter @gredice/game test` — 636/636 passed
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter garden test:profile` — 30/30 passed
- targeted Biome checks and `git diff --check`
- `pnpm --filter garden build`
- production High target matrix — structural acceptance passed 18/18 runs

## Measured result

On the same Chromium 149 / ANGLE SwiftShader runner:

- clear-idle draws/render: 313.9 → 152.0 (-51.6%)
- clear-idle triangles/render: 39,402 → 21,526 (-45.4%)
- across all six phases, draws/render fell 44.2–51.6% and triangles/render fell 31.9–45.4%
- clear-idle animated refreshes fell from median 17 to 0
- clear-idle primary requests fell from median 21 to four startup/static requests, then exactly 0 during every five-second sample

SwiftShader p95 remains dominated by the documented `ReadPixels` stalls and is not used as physical-GPU evidence. Placement still issues 7–11 settling refreshes and is tracked separately by #4331.

Closes #4323