### PR TITLE
perf(game): coalesce placement shadow refreshes

### DIFF
--- a/apps/garden/scripts/profile-game-scene.mjs
+++ b/apps/garden/scripts/profile-game-scene.mjs
@@ -2083,6 +2083,17 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                     ?.primaryShadowRefreshCount === 'number'
                     ? globalThis.__grediceGameProfile.primaryShadowRefreshCount
                     : null;
+            const placementShadowDeferredChangeCountAtStart =
+                typeof globalThis.__grediceGameProfile
+                    ?.placementShadowDeferredChangeCount === 'number'
+                    ? globalThis.__grediceGameProfile
+                          .placementShadowDeferredChangeCount
+                    : null;
+            const placementShadowFlushCountAtStart =
+                typeof globalThis.__grediceGameProfile
+                    ?.placementShadowFlushCount === 'number'
+                    ? globalThis.__grediceGameProfile.placementShadowFlushCount
+                    : null;
             const rainParticleCountAtStart =
                 typeof globalThis.__grediceGameProfile?.rainParticleCount ===
                 'number'
@@ -2174,6 +2185,17 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                     ?.primaryShadowRefreshCount === 'number'
                     ? globalThis.__grediceGameProfile.primaryShadowRefreshCount
                     : null;
+            const placementShadowDeferredChangeCountAtEnd =
+                typeof globalThis.__grediceGameProfile
+                    ?.placementShadowDeferredChangeCount === 'number'
+                    ? globalThis.__grediceGameProfile
+                          .placementShadowDeferredChangeCount
+                    : null;
+            const placementShadowFlushCountAtEnd =
+                typeof globalThis.__grediceGameProfile
+                    ?.placementShadowFlushCount === 'number'
+                    ? globalThis.__grediceGameProfile.placementShadowFlushCount
+                    : null;
             const nonGpuSample = {
                 actorGroundingShadowUpdateCountDelta:
                     actorGroundingShadowUpdateCountAtStart === null ||
@@ -2223,6 +2245,18 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 p95FrameMs: percentile(0.95),
                 p99FrameMs: percentile(0.99),
                 placementProfileDispatched,
+                placementShadowDeferredChangeCountDelta:
+                    placementShadowDeferredChangeCountAtStart === null ||
+                    placementShadowDeferredChangeCountAtEnd === null
+                        ? null
+                        : placementShadowDeferredChangeCountAtEnd -
+                          placementShadowDeferredChangeCountAtStart,
+                placementShadowFlushCountDelta:
+                    placementShadowFlushCountAtStart === null ||
+                    placementShadowFlushCountAtEnd === null
+                        ? null
+                        : placementShadowFlushCountAtEnd -
+                          placementShadowFlushCountAtStart,
                 primaryShadowRefreshCountAtStart,
                 primaryShadowRefreshCountDelta:
                     primaryShadowRefreshCountAtStart === null ||
@@ -2511,6 +2545,31 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 typeof metadata.placementChunkPhysicalTransformedInstanceCount ===
                 'number'
                     ? metadata.placementChunkPhysicalTransformedInstanceCount
+                    : null,
+            placementProjectedShadowCount:
+                typeof metadata.placementProjectedShadowCount === 'number'
+                    ? metadata.placementProjectedShadowCount
+                    : null,
+            placementProjectedShadowDroppedCount:
+                typeof metadata.placementProjectedShadowDroppedCount ===
+                'number'
+                    ? metadata.placementProjectedShadowDroppedCount
+                    : null,
+            placementProjectedShadowPeakCount:
+                typeof metadata.placementProjectedShadowPeakCount === 'number'
+                    ? metadata.placementProjectedShadowPeakCount
+                    : null,
+            placementShadowActiveCount:
+                typeof metadata.placementShadowActiveCount === 'number'
+                    ? metadata.placementShadowActiveCount
+                    : null,
+            placementShadowDeferredChangeCount:
+                typeof metadata.placementShadowDeferredChangeCount === 'number'
+                    ? metadata.placementShadowDeferredChangeCount
+                    : null,
+            placementShadowFlushCount:
+                typeof metadata.placementShadowFlushCount === 'number'
+                    ? metadata.placementShadowFlushCount
                     : null,
             qualityTier:
                 typeof metadata.qualityTier === 'string'
@@ -2935,6 +2994,41 @@ function evaluateHighTargetAcceptance({
             minimum(
                 'highTargetPlacementRebuilds',
                 runtime?.placementChunkPhysicalRebuildCount,
+                1,
+            ),
+            exact(
+                'highTargetPlacementActiveAtEnd',
+                runtime?.placementShadowActiveCount,
+                0,
+            ),
+            exact(
+                'highTargetPlacementProjectedAtEnd',
+                runtime?.placementProjectedShadowCount,
+                0,
+            ),
+            exact(
+                'highTargetPlacementProjectedPeak',
+                runtime?.placementProjectedShadowPeakCount,
+                2,
+            ),
+            exact(
+                'highTargetPlacementProjectedDrops',
+                runtime?.placementProjectedShadowDroppedCount,
+                0,
+            ),
+            minimum(
+                'highTargetPlacementShadowDeferredChanges',
+                sample.placementShadowDeferredChangeCountDelta,
+                1,
+            ),
+            exact(
+                'highTargetPlacementShadowFlushes',
+                sample.placementShadowFlushCountDelta,
+                1,
+            ),
+            exact(
+                'highTargetPlacementPrimaryShadowRefreshes',
+                sample.primaryShadowRefreshCountDelta,
                 1,
             ),
         );
@@ -3871,8 +3965,8 @@ function buildMarkdown(report) {
     if (placementProfiles.length > 0) {
         lines.push('', '## Placement Animation Evidence', '');
         lines.push(
-            '| Scenario | Command | Logical updates/touched | Physical rebuilds/transformed | Rebuild p95/max | Frame p95/max | Draw/render | Triangles/render | Evidence |',
-            '| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
+            '| Scenario | Command | Logical updates/touched | Physical rebuilds/transformed | Projected peak/end/dropped | Deferred/flush/primary | Rebuild p95/max | Frame p95/max | Draw/render | Triangles/render | Evidence |',
+            '| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
         );
         for (const scenario of placementProfiles) {
             const dispatched =
@@ -3893,7 +3987,7 @@ function buildMarkdown(report) {
                 typeof physicalRebuildCount === 'number' &&
                 physicalRebuildCount > 0;
             lines.push(
-                `| ${scenario.name} | ${dispatched ? 'dispatched' : 'missing'} | ${logicalUpdateCount ?? 'n/a'}/${logicalTouchedCount ?? 'n/a'} | ${physicalRebuildCount ?? 'n/a'}/${transformedInstanceCount ?? 'n/a'} | ${round(scenario.runtime?.placementChunkPhysicalRebuildDurationP95Ms) ?? 'n/a'}/${round(scenario.runtime?.placementChunkPhysicalRebuildDurationMaxMs) ?? 'n/a'} ms | ${scenario.sample.p95FrameMs}/${scenario.sample.maxFrameMs} ms | ${scenario.sample.drawCallsPerRenderedFrame} | ${scenario.sample.trianglesPerRenderedFrame} | ${evidenceCaptured ? 'captured' : 'missing'} |`,
+                `| ${scenario.name} | ${dispatched ? 'dispatched' : 'missing'} | ${logicalUpdateCount ?? 'n/a'}/${logicalTouchedCount ?? 'n/a'} | ${physicalRebuildCount ?? 'n/a'}/${transformedInstanceCount ?? 'n/a'} | ${scenario.runtime?.placementProjectedShadowPeakCount ?? 'n/a'}/${scenario.runtime?.placementProjectedShadowCount ?? 'n/a'}/${scenario.runtime?.placementProjectedShadowDroppedCount ?? 'n/a'} | ${scenario.sample.placementShadowDeferredChangeCountDelta ?? 'n/a'}/${scenario.sample.placementShadowFlushCountDelta ?? 'n/a'}/${scenario.sample.primaryShadowRefreshCountDelta ?? 'n/a'} | ${round(scenario.runtime?.placementChunkPhysicalRebuildDurationP95Ms) ?? 'n/a'}/${round(scenario.runtime?.placementChunkPhysicalRebuildDurationMaxMs) ?? 'n/a'} ms | ${scenario.sample.p95FrameMs}/${scenario.sample.maxFrameMs} ms | ${scenario.sample.drawCallsPerRenderedFrame} | ${scenario.sample.trianglesPerRenderedFrame} | ${evidenceCaptured ? 'captured' : 'missing'} |`,
             );
         }
     }

--- a/apps/garden/scripts/profile-game-scene.unit.mjs
+++ b/apps/garden/scripts/profile-game-scene.unit.mjs
@@ -710,6 +710,88 @@ test('high target acceptance distinguishes a cached map from refreshes and reset
     }
 });
 
+test('high target placement acceptance requires one deferred final shadow flush', () => {
+    const createInput = ({
+        activeCount = 0,
+        deferredDelta = 2,
+        flushDelta = 1,
+        primaryDelta = 1,
+        projectedDrops = 0,
+        projectedEnd = 0,
+        projectedPeak = 2,
+    } = {}) => ({
+        apiErrors: [],
+        pageErrors: [],
+        requested: {
+            blockGeometryMerging: '1',
+            gardenProfile: 'high-target',
+            mode: 'details',
+            placementProfile: 'placement-drop',
+            quality: 'high',
+        },
+        runtime: {
+            actorGroundingShadowBatchCount: 1,
+            actorGroundingShadowCount: 5,
+            actorGroundingShadowDroppedCount: 0,
+            actorGroundingShadowPrimaryCasterCount: 0,
+            actorGroundingShadowVisibleCount: 4,
+            animatedCasterShadowRefreshCount: 0,
+            generatedPlantExpectedInstanceCount: 537,
+            generatedPlantFieldCount: 54,
+            generatedPlantInstanceCount: 537,
+            generatedPlantVisibleFieldCount: 54,
+            generatedPlantVisibleInstanceCount: 537,
+            placementChunkPhysicalRebuildCount: 2,
+            placementProjectedShadowCount: projectedEnd,
+            placementProjectedShadowDroppedCount: projectedDrops,
+            placementProjectedShadowPeakCount: projectedPeak,
+            placementShadowActiveCount: activeCount,
+            qualityTier: 'high',
+        },
+        sample: {
+            actorGroundingShadowUpdateCountDelta: 60,
+            animatedCasterShadowRefreshCountDelta: 0,
+            canvas: {
+                clientHeight: 720,
+                clientWidth: 1280,
+                height: 1440,
+                width: 2560,
+            },
+            drawCalls: 100,
+            elapsedMs: 5_000,
+            placementProfileDispatched: true,
+            placementShadowDeferredChangeCountDelta: deferredDelta,
+            placementShadowFlushCountDelta: flushDelta,
+            primaryShadowRefreshCountDelta: primaryDelta,
+            renderedFps: 12,
+            renderedFrames: 60,
+            reportedDpr: 2,
+            submittedTriangles: 1_000_000,
+        },
+    });
+
+    assert.equal(evaluateHighTargetAcceptance(createInput()).pass, true);
+
+    for (const invalid of [
+        { flushDelta: 0 },
+        { flushDelta: 2 },
+        { primaryDelta: 0 },
+        { primaryDelta: 2 },
+        { deferredDelta: 0 },
+        { activeCount: 1 },
+        { projectedEnd: 1 },
+        { projectedDrops: 1 },
+        { projectedPeak: 0 },
+        { projectedPeak: 1 },
+        { projectedPeak: 3 },
+    ]) {
+        assert.equal(
+            evaluateHighTargetAcceptance(createInput(invalid)).pass,
+            false,
+        );
+    }
+});
+
 test('high target acceptance requires the full workload to remain visible', () => {
     const result = evaluateHighTargetAcceptance({
         apiErrors: [],

--- a/docs/game-performance-optimization-results.md
+++ b/docs/game-performance-optimization-results.md
@@ -567,6 +567,43 @@ Placement still requested `7`, `7`, and `11` primary refreshes while its
 drop-settling window was active. That separate lifecycle is intentionally
 tracked by issue `#4331` rather than folded into actor shadow scheduling.
 
+### Placement shadow completion coalescing
+
+Issue `#4331` replaces the placement-specific 900 ms shadow-settling timer
+with an explicit static-dirty scheduler. It defers garden shadow changes while
+one or more placement springs are active and consumes them once, on the first
+render frame after the last completion or cancellation. The static signature
+contains only stack positions and render-affecting block properties, so an
+optimistic-to-persisted block ID replacement no longer invalidates the map.
+
+Transient component and instanced placement geometry is excluded from the
+primary caster set. While it moves, a conservative hitbox-derived ellipse uses
+the same instanced projected-shadow batch as actors, with separate placement
+accounting so the actor acceptance metrics remain exact. Stable geometry is
+restored before the coalesced final refresh.
+
+The focused three-repeat production High placement profile passed all
+structural and lifecycle acceptance checks:
+
+- the scenario's two staggered placements reached a projected-shadow peak of
+  exactly two, returned to zero, and recorded zero dropped proxies in every
+  run;
+- each run recorded one deferred placement cycle, one final placement flush,
+  one primary-map refresh, and zero active placements at the end;
+- the former primary-refresh train of `7`, `7`, and `11` requests became
+  exactly `1`, `1`, and `1`; and
+- the placement median moved from `170.9` to `156.7` draws per rendered frame
+  and from `25,959` to `22,627` triangles per rendered frame on the same
+  Chromium 149 / ANGLE SwiftShader runner, reductions of `8.3%` and `12.8%`.
+
+The production profiler now rejects a placement run with zero or multiple
+final shadow refreshes, a projected peak other than exactly two, any dropped
+or nonzero final proxy, a nonzero active count, or no deferred dirtiness.
+SwiftShader frame-time and long-task
+budgets remain red because of the documented `ReadPixels` stalls; all three
+placement acceptance runs passed independently of those aspirational
+physical-device budgets.
+
 ## Raised-bed close-up profiling foundation
 
 Added 2026-07-23 for the L-system close-up optimization series.
@@ -678,9 +715,10 @@ soaked for 15 seconds, and sampled for 10 seconds in the production build.
 
 - All four completed without page or WebGL/shader errors. The only console
   errors were expected profile-route provider requests returning 401/404.
-- Resuming a hidden or offscreen scene now explicitly re-arms the bounded
-  900 ms shadow-settlement window, preventing stale caster shadows without
-  restoring continuous offscreen rendering.
+- This historical soak used a bounded 900 ms shadow-settlement window after
+  resume. Issue `#4331` supersedes that timer with a one-frame coalesced static
+  refresh, preventing stale caster shadows without restoring continuous
+  offscreen rendering.
 - The repository's `33.3 ms` physical-device floor still fails in this
   headless environment, which reports synchronous `ReadPixels` GPU stalls.
   This is not treated as release clearance; the physical thermal gates below

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -23,6 +23,7 @@ import {
     EntityInstances,
     instancedBlockNames,
 } from './entities/EntityInstances';
+import { PlacementGroundingShadows } from './entities/helpers/PlacementGroundingShadows';
 import { RaisedBedMulchOverlays } from './entities/raisedBed/RaisedBedMulchOverlays';
 import {
     SunflowerDropFlyAnimation,
@@ -349,6 +350,9 @@ export function GameScene({
                                 noSound={noSound}
                                 quality={qualityProfile}
                                 weather={weather}
+                            />
+                            <PlacementGroundingShadows
+                                stacks={garden?.stacks}
                             />
                             <group name="GameScene:Entities">
                                 {garden?.stacks.map((stack) =>

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -537,7 +537,7 @@ export function EntityInstancesGeometry(
                         rotation={localTransform.rotation}
                         scale={stableScale}
                         receiveShadow={receiveShadow}
-                        castShadow={castShadow}
+                        castShadow={false}
                         renderOrder={renderOrder}
                     >
                         {cloneMaterialNode(materialNode)}

--- a/packages/game/src/entities/animals/ActorGroundingShadows.tsx
+++ b/packages/game/src/entities/animals/ActorGroundingShadows.tsx
@@ -27,7 +27,10 @@ import {
     ActorGroundingShadowRegistry,
     type ActorGroundingShadowState,
     actorGroundingShadowCapacity,
-    resolveActorGroundingShadow,
+    actorGroundingShadowProfiles,
+    type GroundingShadowProfile,
+    type PlacementGroundingShadowRegistration,
+    resolveGroundingShadow,
 } from './actorGroundingShadowRegistry';
 
 const actorGroundingShadowGeometry = new PlaneGeometry(2, 2);
@@ -98,6 +101,9 @@ type ActorGroundingShadowProfileSnapshot = {
     count: number;
     droppedCount: number;
     primaryCasterCount: number;
+    placementCount: number;
+    placementDroppedCount: number;
+    placementPeakCount: number;
     updateCount: number;
     visibleCount: number;
 };
@@ -122,6 +128,9 @@ function publishActorGroundingShadowProfile() {
         capacity: 0,
         count: 0,
         droppedCount: 0,
+        placementCount: 0,
+        placementDroppedCount: 0,
+        placementPeakCount: 0,
         primaryCasterCount: 0,
         updateCount: 0,
         visibleCount: 0,
@@ -131,6 +140,9 @@ function publishActorGroundingShadowProfile() {
         aggregate.capacity += snapshot.capacity;
         aggregate.count += snapshot.count;
         aggregate.droppedCount += snapshot.droppedCount;
+        aggregate.placementCount += snapshot.placementCount;
+        aggregate.placementDroppedCount += snapshot.placementDroppedCount;
+        aggregate.placementPeakCount += snapshot.placementPeakCount;
         aggregate.primaryCasterCount += snapshot.primaryCasterCount;
         aggregate.updateCount += snapshot.updateCount;
         aggregate.visibleCount += snapshot.visibleCount;
@@ -144,6 +156,9 @@ function publishActorGroundingShadowProfile() {
         actorGroundingShadowPrimaryCasterCount: aggregate.primaryCasterCount,
         actorGroundingShadowUpdateCount: aggregate.updateCount,
         actorGroundingShadowVisibleCount: aggregate.visibleCount,
+        placementProjectedShadowCount: aggregate.placementCount,
+        placementProjectedShadowDroppedCount: aggregate.placementDroppedCount,
+        placementProjectedShadowPeakCount: aggregate.placementPeakCount,
     });
 }
 
@@ -156,11 +171,13 @@ function clearActorGroundingShadowProfile(owner: symbol) {
 function reportActorGroundingShadowProfile({
     batchCount,
     owner,
+    placementPeakCount,
     registry,
     visibleCount,
 }: {
     batchCount: number;
     owner: symbol;
+    placementPeakCount: number;
     registry: ActorGroundingShadowRegistry;
     visibleCount: number;
 }) {
@@ -170,6 +187,9 @@ function reportActorGroundingShadowProfile({
         capacity: stats.capacity,
         count: stats.registeredCount,
         droppedCount: stats.droppedCount,
+        placementCount: stats.placementRegisteredCount,
+        placementDroppedCount: stats.placementDroppedCount,
+        placementPeakCount,
         primaryCasterCount: stats.primaryCasterCount,
         updateCount: stats.updateCount,
         visibleCount,
@@ -190,6 +210,7 @@ function ActorGroundingShadowBatch({
     const lastSnowCoverageRef = useRef(Number.NaN);
     const lastProfileReportAtRef = useRef(Number.NEGATIVE_INFINITY);
     const lastVersionRef = useRef(-1);
+    const placementPeakCountRef = useRef(0);
     const previousDrawCountRef = useRef(0);
     const profileReportPendingRef = useRef(false);
     const visibleCountRef = useRef(0);
@@ -214,6 +235,7 @@ function ActorGroundingShadowBatch({
         reportActorGroundingShadowProfile({
             batchCount: 0,
             owner,
+            placementPeakCount: 0,
             registry,
             visibleCount: 0,
         });
@@ -249,16 +271,21 @@ function ActorGroundingShadowBatch({
 
             let visibleCount = 0;
             for (const entry of entries) {
-                const resolved = resolveActorGroundingShadow({
+                const resolved = resolveGroundingShadow({
+                    profile:
+                        entry.kind === 'placement'
+                            ? entry.profile
+                            : actorGroundingShadowProfiles[entry.species],
                     snowCoverage,
-                    species: entry.species,
                     state: entry.state,
                 });
                 if (!resolved.visible) {
                     continue;
                 }
 
-                visibleCount += 1;
+                if (entry.kind !== 'placement') {
+                    visibleCount += 1;
+                }
                 scratch.position.set(resolved.x, resolved.y, resolved.z);
                 scratch.quaternion.setFromAxisAngle(upAxis, resolved.yaw);
                 scratch.scale.set(
@@ -281,7 +308,12 @@ function ActorGroundingShadowBatch({
                 mesh.instanceMatrix.needsUpdate = true;
             }
 
-            batchCountRef.current = entries.length > 0 ? 1 : 0;
+            const stats = registry.getStats();
+            batchCountRef.current = stats.registeredCount > 0 ? 1 : 0;
+            placementPeakCountRef.current = Math.max(
+                placementPeakCountRef.current,
+                stats.placementRegisteredCount,
+            );
             previousDrawCountRef.current = drawCount;
             visibleCountRef.current = visibleCount;
             lastSnowCoverageRef.current = snowCoverage;
@@ -299,6 +331,7 @@ function ActorGroundingShadowBatch({
             reportActorGroundingShadowProfile({
                 batchCount: batchCountRef.current,
                 owner,
+                placementPeakCount: placementPeakCountRef.current,
                 registry,
                 visibleCount: visibleCountRef.current,
             });
@@ -388,4 +421,69 @@ export function useActorGroundingShadow({
     );
 
     return enabled ? update : null;
+}
+
+export function usePlacementGroundingShadow({
+    id,
+    profile,
+    state,
+}: Omit<PlacementGroundingShadowRegistration, 'kind'> & {
+    state: ActorGroundingShadowState;
+}) {
+    const context = useContext(ActorGroundingShadowContext);
+    if (!context) {
+        throw new Error('Missing ActorGroundingShadowProvider in scene tree');
+    }
+    const { enabled, registry } = context;
+    const {
+        baseHalfLength,
+        baseHalfWidth,
+        baseOpacity,
+        cutoffHeight,
+        maxFootprintScale,
+    } = profile;
+    const { actorY, receiverY, visible, x, yaw, z } = state;
+
+    useLayoutEffect(() => {
+        if (!enabled) {
+            return;
+        }
+
+        const placementProfile: GroundingShadowProfile = {
+            baseHalfLength,
+            baseHalfWidth,
+            baseOpacity,
+            cutoffHeight,
+            maxFootprintScale,
+        };
+        const registration = registry.register({
+            id,
+            kind: 'placement',
+            profile: placementProfile,
+        });
+        registry.update(id, {
+            actorY,
+            receiverY,
+            visible,
+            x,
+            yaw,
+            z,
+        });
+        return registration.unregister;
+    }, [
+        actorY,
+        baseHalfLength,
+        baseHalfWidth,
+        baseOpacity,
+        cutoffHeight,
+        enabled,
+        id,
+        maxFootprintScale,
+        receiverY,
+        registry,
+        visible,
+        x,
+        yaw,
+        z,
+    ]);
 }

--- a/packages/game/src/entities/animals/actorGroundingShadowRegistry.ts
+++ b/packages/game/src/entities/animals/actorGroundingShadowRegistry.ts
@@ -11,8 +11,23 @@ export type ActorGroundingShadowState = {
 
 export type ActorGroundingShadowRegistration = {
     id: string;
+    kind?: 'actor';
     primaryCasterCount: number;
     species: ActorGroundingShadowSpecies;
+};
+
+export type GroundingShadowProfile = {
+    baseHalfLength: number;
+    baseHalfWidth: number;
+    baseOpacity: number;
+    cutoffHeight: number;
+    maxFootprintScale: number;
+};
+
+export type PlacementGroundingShadowRegistration = {
+    id: string;
+    kind: 'placement';
+    profile: GroundingShadowProfile;
 };
 
 export type ResolvedActorGroundingShadow = {
@@ -26,26 +41,23 @@ export type ResolvedActorGroundingShadow = {
     z: number;
 };
 
-export type ActorGroundingShadowRegistryEntry =
-    ActorGroundingShadowRegistration & {
-        slot: number;
-        state: ActorGroundingShadowState;
-    };
+export type ActorGroundingShadowRegistryEntry = (
+    | ActorGroundingShadowRegistration
+    | PlacementGroundingShadowRegistration
+) & {
+    slot: number;
+    state: ActorGroundingShadowState;
+};
 
 export type ActorGroundingShadowRegistryStats = {
     capacity: number;
     droppedCount: number;
+    placementDroppedCount: number;
+    placementRegisteredCount: number;
+    placementUpdateCount: number;
     primaryCasterCount: number;
     registeredCount: number;
     updateCount: number;
-};
-
-type ActorGroundingShadowProfile = {
-    baseHalfLength: number;
-    baseHalfWidth: number;
-    baseOpacity: number;
-    cutoffHeight: number;
-    maxFootprintScale: number;
 };
 
 export const actorGroundingShadowCapacity = 128;
@@ -81,7 +93,7 @@ export const actorGroundingShadowProfiles = {
         cutoffHeight: 1.6,
         maxFootprintScale: 1.7,
     },
-} satisfies Record<ActorGroundingShadowSpecies, ActorGroundingShadowProfile>;
+} satisfies Record<ActorGroundingShadowSpecies, GroundingShadowProfile>;
 
 const hiddenActorGroundingShadowState: ActorGroundingShadowState = {
     actorY: 0,
@@ -129,7 +141,22 @@ export function resolveActorGroundingShadow({
     species: ActorGroundingShadowSpecies;
     state: ActorGroundingShadowState;
 }): ResolvedActorGroundingShadow {
-    const profile = actorGroundingShadowProfiles[species];
+    return resolveGroundingShadow({
+        profile: actorGroundingShadowProfiles[species],
+        snowCoverage,
+        state,
+    });
+}
+
+export function resolveGroundingShadow({
+    profile,
+    snowCoverage,
+    state,
+}: {
+    profile: GroundingShadowProfile;
+    snowCoverage: number;
+    state: ActorGroundingShadowState;
+}): ResolvedActorGroundingShadow {
     const finiteTransform = hasFiniteTransform(state);
     const actorY = finiteTransform ? state.actorY : 0;
     const receiverY = finiteTransform ? state.receiverY : 0;
@@ -168,9 +195,11 @@ export class ActorGroundingShadowRegistry {
         string,
         ActorGroundingShadowRegistryEntry
     >();
-    private readonly droppedIds = new Set<string>();
+    private readonly droppedIds = new Map<string, 'actor' | 'placement'>();
     private readonly freeSlots: number[] = [];
     private nextSlot = 0;
+    private placementDroppedCount = 0;
+    private placementUpdateCount = 0;
     private updateCount = 0;
     private version = 0;
 
@@ -189,16 +218,32 @@ export class ActorGroundingShadowRegistry {
     }
 
     getStats(): ActorGroundingShadowRegistryStats {
+        let placementRegisteredCount = 0;
         let primaryCasterCount = 0;
+        let registeredCount = 0;
         for (const entry of this.entries.values()) {
-            primaryCasterCount += entry.primaryCasterCount;
+            if (entry.kind === 'placement') {
+                placementRegisteredCount += 1;
+            } else {
+                registeredCount += 1;
+                primaryCasterCount += entry.primaryCasterCount;
+            }
+        }
+        let droppedCount = 0;
+        for (const kind of this.droppedIds.values()) {
+            if (kind === 'actor') {
+                droppedCount += 1;
+            }
         }
 
         return {
             capacity: this.capacity,
-            droppedCount: this.droppedIds.size,
+            droppedCount,
+            placementDroppedCount: this.placementDroppedCount,
+            placementRegisteredCount,
+            placementUpdateCount: this.placementUpdateCount,
             primaryCasterCount,
-            registeredCount: this.entries.size,
+            registeredCount,
             updateCount: this.updateCount,
         };
     }
@@ -207,11 +252,12 @@ export class ActorGroundingShadowRegistry {
         return this.version;
     }
 
-    register({
-        id,
-        primaryCasterCount,
-        species,
-    }: ActorGroundingShadowRegistration) {
+    register(
+        registration:
+            | ActorGroundingShadowRegistration
+            | PlacementGroundingShadowRegistration,
+    ) {
+        const { id } = registration;
         if (id.length === 0) {
             throw new Error('Actor grounding-shadow registration needs an id');
         }
@@ -220,7 +266,11 @@ export class ActorGroundingShadowRegistry {
                 `Actor grounding-shadow id "${id}" is already registered`,
             );
         }
-        if (!Number.isInteger(primaryCasterCount) || primaryCasterCount < 0) {
+        if (
+            registration.kind !== 'placement' &&
+            (!Number.isInteger(registration.primaryCasterCount) ||
+                registration.primaryCasterCount < 0)
+        ) {
             throw new Error(
                 'Actor grounding-shadow primary caster count must be a non-negative integer',
             );
@@ -233,7 +283,13 @@ export class ActorGroundingShadowRegistry {
                 this.freeSlots.unshift(reusedSlot);
             }
 
-            this.droppedIds.add(id);
+            this.droppedIds.set(
+                id,
+                registration.kind === 'placement' ? 'placement' : 'actor',
+            );
+            if (registration.kind === 'placement') {
+                this.placementDroppedCount += 1;
+            }
             this.publishChange();
 
             let registered = true;
@@ -254,13 +310,23 @@ export class ActorGroundingShadowRegistry {
             this.nextSlot += 1;
         }
 
-        const entry: ActorGroundingShadowRegistryEntry = {
-            id,
-            primaryCasterCount,
-            slot,
-            species,
-            state: hiddenActorGroundingShadowState,
-        };
+        const entry: ActorGroundingShadowRegistryEntry =
+            registration.kind === 'placement'
+                ? {
+                      id,
+                      kind: 'placement',
+                      profile: registration.profile,
+                      slot,
+                      state: hiddenActorGroundingShadowState,
+                  }
+                : {
+                      id,
+                      kind: 'actor',
+                      primaryCasterCount: registration.primaryCasterCount,
+                      slot,
+                      species: registration.species,
+                      state: hiddenActorGroundingShadowState,
+                  };
         this.entries.set(id, entry);
         this.publishChange();
 
@@ -288,7 +354,11 @@ export class ActorGroundingShadowRegistry {
         }
 
         entry.state = { ...state };
-        this.updateCount += 1;
+        if (entry.kind === 'placement') {
+            this.placementUpdateCount += 1;
+        } else {
+            this.updateCount += 1;
+        }
         this.publishChange();
         return true;
     }

--- a/packages/game/src/entities/animals/actorGroundingShadowRegistry.unit.ts
+++ b/packages/game/src/entities/animals/actorGroundingShadowRegistry.unit.ts
@@ -148,6 +148,9 @@ describe('ActorGroundingShadowRegistry', () => {
         assert.deepEqual(registry.getStats(), {
             capacity: 3,
             droppedCount: 0,
+            placementDroppedCount: 0,
+            placementRegisteredCount: 0,
+            placementUpdateCount: 0,
             primaryCasterCount: 13,
             registeredCount: 2,
             updateCount: 1,
@@ -190,6 +193,9 @@ describe('ActorGroundingShadowRegistry', () => {
         assert.deepEqual(registry.getStats(), {
             capacity: 1,
             droppedCount: 1,
+            placementDroppedCount: 0,
+            placementRegisteredCount: 0,
+            placementUpdateCount: 0,
             primaryCasterCount: 0,
             registeredCount: 1,
             updateCount: 0,
@@ -200,9 +206,76 @@ describe('ActorGroundingShadowRegistry', () => {
         assert.deepEqual(registry.getStats(), {
             capacity: 1,
             droppedCount: 0,
+            placementDroppedCount: 0,
+            placementRegisteredCount: 0,
+            placementUpdateCount: 0,
             primaryCasterCount: 0,
             registeredCount: 0,
             updateCount: 0,
         });
+    });
+
+    it('shares slots with placements while keeping actor stats isolated', () => {
+        const registry = new ActorGroundingShadowRegistry(3);
+        registry.register({
+            id: 'cat:a',
+            primaryCasterCount: 0,
+            species: 'cat',
+        });
+        const placement = registry.register({
+            id: 'placement:1',
+            kind: 'placement',
+            profile: {
+                baseHalfLength: 0.6,
+                baseHalfWidth: 0.4,
+                baseOpacity: 0.2,
+                cutoffHeight: 1,
+                maxFootprintScale: 1.1,
+            },
+        });
+        registry.update('placement:1', groundedState);
+
+        assert.equal(placement.slot, 1);
+        assert.deepEqual(registry.getStats(), {
+            capacity: 3,
+            droppedCount: 0,
+            placementDroppedCount: 0,
+            placementRegisteredCount: 1,
+            placementUpdateCount: 1,
+            primaryCasterCount: 0,
+            registeredCount: 1,
+            updateCount: 0,
+        });
+
+        placement.unregister();
+        assert.equal(registry.getStats().placementRegisteredCount, 0);
+        assert.equal(registry.getStats().registeredCount, 1);
+    });
+
+    it('retains cumulative placement overflow evidence after unregister', () => {
+        const registry = new ActorGroundingShadowRegistry(1);
+        registry.register({
+            id: 'cat:a',
+            primaryCasterCount: 0,
+            species: 'cat',
+        });
+        const placement = registry.register({
+            id: 'placement:overflow',
+            kind: 'placement',
+            profile: {
+                baseHalfLength: 0.6,
+                baseHalfWidth: 0.4,
+                baseOpacity: 0.2,
+                cutoffHeight: 1,
+                maxFootprintScale: 1.1,
+            },
+        });
+
+        assert.equal(placement.slot, null);
+        assert.equal(registry.getStats().placementDroppedCount, 1);
+
+        placement.unregister();
+        assert.equal(registry.getStats().placementDroppedCount, 1);
+        assert.equal(registry.getStats().placementRegisteredCount, 0);
     });
 });

--- a/packages/game/src/entities/helpers/PlacementDropAnimation.tsx
+++ b/packages/game/src/entities/helpers/PlacementDropAnimation.tsx
@@ -1,6 +1,11 @@
 import { animated, useSpring } from '@react-spring/three';
-import { type PropsWithChildren, useEffect, useRef } from 'react';
-import { Vector3 } from 'three';
+import {
+    type PropsWithChildren,
+    useEffect,
+    useLayoutEffect,
+    useRef,
+} from 'react';
+import { type Group, Vector3 } from 'three';
 import {
     resolveBlockParticleType,
     useParticles,
@@ -12,6 +17,7 @@ import {
     getBlockPlacementDropAnimationForBlockId,
     useGameState,
 } from '../../useGameState';
+import { suppressPlacementShadowCasters } from './placementShadowCasters';
 
 const placementDropLift = 0.1;
 const reducedMotionQuery = '(prefers-reduced-motion: reduce)';
@@ -46,9 +52,13 @@ export function PlacementDropAnimation({
     const markParticlesSpawned = useGameState(
         (state) => state.markBlockPlacementDropParticlesSpawned,
     );
-    const completeAnimation = useGameState(
-        (state) => state.completeBlockPlacementDropAnimation,
+    const markVisualStarted = useGameState(
+        (state) => state.markBlockPlacementDropVisualStarted,
     );
+    const markVisualComplete = useGameState(
+        (state) => state.markBlockPlacementDropVisualComplete,
+    );
+    const placementRootRef = useRef<Group | null>(null);
     const startedSequence = useRef<number | null>(null);
     const [{ dropOffsetY }, api] = useSpring(() => ({
         dropOffsetY:
@@ -59,9 +69,29 @@ export function PlacementDropAnimation({
             friction: 10,
         },
     }));
+    const animationRenderId = animation?.renderId;
+    const visualStarted = animation?.visualStarted === true;
+
+    useLayoutEffect(() => {
+        if (animationRenderId !== undefined && !visualStarted) {
+            markVisualStarted(animationRenderId);
+        }
+    }, [animationRenderId, markVisualStarted, visualStarted]);
+
+    useLayoutEffect(() => {
+        const root = placementRootRef.current;
+        if (!visualStarted || animationRenderId === undefined || !root) {
+            return;
+        }
+
+        return suppressPlacementShadowCasters(root);
+    }, [animationRenderId, visualStarted]);
 
     useEffect(() => {
-        if (!animation || startedSequence.current === animation.sequence) {
+        if (
+            !animation?.visualStarted ||
+            startedSequence.current === animation.sequence
+        ) {
             return;
         }
 
@@ -80,7 +110,7 @@ export function PlacementDropAnimation({
         };
         const finish = () => {
             spawnLandingParticles();
-            completeAnimation(animationRenderId);
+            markVisualComplete(animationRenderId);
         };
 
         if (prefersReducedMotion()) {
@@ -98,7 +128,7 @@ export function PlacementDropAnimation({
         animation,
         api,
         block.name,
-        completeAnimation,
+        markVisualComplete,
         markParticlesSpawned,
         particlePosition,
         spawn,
@@ -106,6 +136,7 @@ export function PlacementDropAnimation({
 
     return (
         <group
+            ref={placementRootRef}
             name={`Animation:PlacementDrop:${block.name}:${block.id}`}
             position={position}
         >

--- a/packages/game/src/entities/helpers/PlacementGroundingShadows.tsx
+++ b/packages/game/src/entities/helpers/PlacementGroundingShadows.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import type { BlockData } from '@gredice/client';
+import { useMemo } from 'react';
+import { useBlockData } from '../../hooks/useBlockData';
+import type { Stack } from '../../types/Stack';
+import {
+    type BlockPlacementDropAnimation,
+    useGameState,
+} from '../../useGameState';
+import { getBlockHitboxSize } from '../../utils/blockHitbox';
+import { getStackHeight } from '../../utils/stackHeightCore';
+import { usePlacementGroundingShadow } from '../animals/ActorGroundingShadows';
+import type {
+    ActorGroundingShadowState,
+    GroundingShadowProfile,
+} from '../animals/actorGroundingShadowRegistry';
+
+const placementShadowOpacity = 0.24;
+const placementShadowMinimumHalfExtent = 0.12;
+
+export type PlacementGroundingShadowDescriptor = {
+    id: string;
+    profile: GroundingShadowProfile;
+    state: ActorGroundingShadowState;
+};
+
+export function resolvePlacementGroundingShadowProfile(
+    blockData: BlockData | null | undefined,
+): GroundingShadowProfile {
+    const hitbox = getBlockHitboxSize(blockData);
+
+    return {
+        baseHalfLength: Math.max(
+            placementShadowMinimumHalfExtent,
+            hitbox.depth / 2,
+        ),
+        baseHalfWidth: Math.max(
+            placementShadowMinimumHalfExtent,
+            hitbox.width / 2,
+        ),
+        baseOpacity: placementShadowOpacity,
+        cutoffHeight: Math.max(0.25, hitbox.height),
+        maxFootprintScale: 1.15,
+    };
+}
+
+export function resolvePlacementGroundingShadowDescriptors({
+    animations,
+    blockData,
+    stacks,
+}: {
+    animations: Readonly<Record<string, BlockPlacementDropAnimation>>;
+    blockData: BlockData[] | null | undefined;
+    stacks: Stack[] | undefined;
+}): PlacementGroundingShadowDescriptor[] {
+    if (!stacks?.length) {
+        return [];
+    }
+
+    const descriptors: PlacementGroundingShadowDescriptor[] = [];
+    for (const [blockId, animation] of Object.entries(animations)) {
+        if (!animation.visualStarted) {
+            continue;
+        }
+
+        let matched:
+            | {
+                  block: Stack['blocks'][number];
+                  stack: Stack;
+              }
+            | undefined;
+        for (const stack of stacks) {
+            const block = stack.blocks.find(
+                (candidate) =>
+                    candidate.id === blockId ||
+                    candidate.id === animation.sourceBlockId,
+            );
+            if (block) {
+                matched = { block, stack };
+                break;
+            }
+        }
+        if (!matched) {
+            continue;
+        }
+
+        const entity = blockData?.find(
+            (candidate) => candidate.information.name === matched?.block.name,
+        );
+        const receiverY =
+            matched.stack.position.y +
+            getStackHeight(blockData, matched.stack, matched.block);
+        descriptors.push({
+            id: `placement:${animation.renderId}`,
+            profile: resolvePlacementGroundingShadowProfile(entity),
+            state: {
+                actorY: receiverY,
+                receiverY,
+                visible: true,
+                x: matched.stack.position.x,
+                yaw: matched.block.rotation * (Math.PI / 2),
+                z: matched.stack.position.z,
+            },
+        });
+    }
+
+    return descriptors.sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function PlacementGroundingShadow({
+    descriptor,
+}: {
+    descriptor: PlacementGroundingShadowDescriptor;
+}) {
+    usePlacementGroundingShadow(descriptor);
+    return null;
+}
+
+export function PlacementGroundingShadows({
+    stacks,
+}: {
+    stacks: Stack[] | undefined;
+}) {
+    const { data: blockData } = useBlockData();
+    const animations = useGameState(
+        (state) => state.blockPlacementDropAnimations,
+    );
+    const descriptors = useMemo(
+        () =>
+            resolvePlacementGroundingShadowDescriptors({
+                animations,
+                blockData,
+                stacks,
+            }),
+        [animations, blockData, stacks],
+    );
+
+    return descriptors.map((descriptor) => (
+        <PlacementGroundingShadow key={descriptor.id} descriptor={descriptor} />
+    ));
+}

--- a/packages/game/src/entities/helpers/PlacementGroundingShadows.unit.ts
+++ b/packages/game/src/entities/helpers/PlacementGroundingShadows.unit.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Vector3 } from 'three';
+import { getLocalSandboxBlockData } from '../../localSandboxBlockData';
+import {
+    resolvePlacementGroundingShadowDescriptors,
+    resolvePlacementGroundingShadowProfile,
+} from './PlacementGroundingShadows';
+
+describe('placement grounding-shadow projection', () => {
+    it('uses a conservative hitbox footprint', () => {
+        const tree = getLocalSandboxBlockData().find(
+            (block) => block.information.name === 'Tree',
+        );
+        const profile = resolvePlacementGroundingShadowProfile(tree);
+
+        assert.ok(profile.baseHalfWidth >= 0.5);
+        assert.ok(profile.baseHalfLength >= 0.5);
+        assert.ok(profile.baseOpacity > 0);
+    });
+
+    it('keeps projected identity stable through an id rekey', () => {
+        const blockData = getLocalSandboxBlockData();
+        const animations = {
+            persisted: {
+                createdAt: 1,
+                mutationConfirmed: false,
+                particlesSpawned: false,
+                renderId: 42,
+                sequence: 1,
+                sourceBlockId: 'optimistic',
+                visualComplete: false,
+                visualStarted: true,
+            },
+        };
+        const stacks = [
+            {
+                blocks: [
+                    {
+                        id: 'persisted',
+                        name: 'Tree',
+                        rotation: 1,
+                    },
+                ],
+                position: new Vector3(3, 2, -4),
+            },
+        ];
+        const [descriptor] = resolvePlacementGroundingShadowDescriptors({
+            animations,
+            blockData,
+            stacks,
+        });
+
+        assert.ok(descriptor);
+        assert.equal(descriptor.id, 'placement:42');
+        assert.equal(descriptor.state.x, 3);
+        assert.equal(descriptor.state.receiverY, 2);
+        assert.equal(descriptor.state.z, -4);
+        assert.equal(descriptor.state.yaw, Math.PI / 2);
+    });
+
+    it('does not project a placement before its visual renderer commits', () => {
+        const blockData = getLocalSandboxBlockData();
+        const animations = {
+            optimistic: {
+                createdAt: 1,
+                mutationConfirmed: false,
+                particlesSpawned: false,
+                renderId: 42,
+                sequence: 1,
+                sourceBlockId: 'optimistic',
+                visualComplete: false,
+                visualStarted: false,
+            },
+        };
+        const stacks = [
+            {
+                blocks: [
+                    {
+                        id: 'optimistic',
+                        name: 'Tree',
+                        rotation: 0,
+                    },
+                ],
+                position: new Vector3(0, 0, 0),
+            },
+        ];
+
+        assert.deepEqual(
+            resolvePlacementGroundingShadowDescriptors({
+                animations,
+                blockData,
+                stacks,
+            }),
+            [],
+        );
+    });
+});

--- a/packages/game/src/entities/helpers/placementShadowCasters.ts
+++ b/packages/game/src/entities/helpers/placementShadowCasters.ts
@@ -1,0 +1,30 @@
+import { Line, Mesh, type Object3D, Points } from 'three';
+
+export function suppressPlacementShadowCasters(root: Object3D) {
+    const originalCastShadow = new Map<Object3D, boolean>();
+
+    root.traverse((object) => {
+        if (
+            !(object instanceof Mesh) &&
+            !(object instanceof Line) &&
+            !(object instanceof Points)
+        ) {
+            return;
+        }
+
+        originalCastShadow.set(object, object.castShadow);
+        object.castShadow = false;
+    });
+
+    let restored = false;
+    return () => {
+        if (restored) {
+            return;
+        }
+        restored = true;
+
+        for (const [object, castShadow] of originalCastShadow) {
+            object.castShadow = castShadow;
+        }
+    };
+}

--- a/packages/game/src/entities/helpers/placementShadowCasters.unit.ts
+++ b/packages/game/src/entities/helpers/placementShadowCasters.unit.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Group, Line, Mesh, Points } from 'three';
+import { suppressPlacementShadowCasters } from './placementShadowCasters';
+
+describe('suppressPlacementShadowCasters', () => {
+    it('suppresses nested caster objects and restores their exact state', () => {
+        const root = new Group();
+        const nested = new Group();
+        const mesh = new Mesh();
+        const line = new Line();
+        const points = new Points();
+        mesh.castShadow = true;
+        line.castShadow = false;
+        points.castShadow = true;
+        nested.add(mesh, line);
+        root.add(nested, points);
+
+        const restore = suppressPlacementShadowCasters(root);
+
+        assert.equal(mesh.castShadow, false);
+        assert.equal(line.castShadow, false);
+        assert.equal(points.castShadow, false);
+
+        restore();
+        assert.equal(mesh.castShadow, true);
+        assert.equal(line.castShadow, false);
+        assert.equal(points.castShadow, true);
+
+        restore();
+        assert.equal(mesh.castShadow, true);
+        assert.equal(line.castShadow, false);
+        assert.equal(points.castShadow, true);
+    });
+});

--- a/packages/game/src/entities/placementAnimationChunks.unit.ts
+++ b/packages/game/src/entities/placementAnimationChunks.unit.ts
@@ -29,10 +29,13 @@ function createAnimation(
 ): BlockPlacementDropAnimation {
     return {
         createdAt: sequence,
+        mutationConfirmed: false,
         particlesSpawned,
         renderId: sequence,
         sequence,
         sourceBlockId,
+        visualComplete: false,
+        visualStarted: true,
     };
 }
 

--- a/packages/game/src/hooks/useBlockPlace.ts
+++ b/packages/game/src/hooks/useBlockPlace.ts
@@ -127,8 +127,8 @@ export function useBlockPlace() {
     const queueBlockPlacementDropAnimation = useGameState(
         (state) => state.queueBlockPlacementDropAnimation,
     );
-    const rekeyBlockPlacementDropAnimation = useGameState(
-        (state) => state.rekeyBlockPlacementDropAnimation,
+    const confirmBlockPlacementDropAnimation = useGameState(
+        (state) => state.confirmBlockPlacementDropAnimation,
     );
     const cancelBlockPlacementDropAnimation = useGameState(
         (state) => state.cancelBlockPlacementDropAnimation,
@@ -279,7 +279,7 @@ export function useBlockPlace() {
                 return;
             }
 
-            rekeyBlockPlacementDropAnimation(
+            confirmBlockPlacementDropAnimation(
                 context.optimisticBlockId,
                 data.id,
             );
@@ -298,7 +298,6 @@ export function useBlockPlace() {
         onError: (error, _variables, context) => {
             console.error('Error creating block', error);
             if (context?.optimisticBlockId) {
-                cancelBlockPlacementDropAnimation(context.optimisticBlockId);
                 queryClient.setQueryData<CurrentGardenData | null>(
                     gardenQueryKey,
                     (currentGarden) =>
@@ -309,6 +308,7 @@ export function useBlockPlace() {
                               )
                             : currentGarden,
                 );
+                cancelBlockPlacementDropAnimation(context.optimisticBlockId);
             }
             if (context?.sunflowerAmount) {
                 queryClient.setQueryData<CurrentAccountData | null>(

--- a/packages/game/src/hooks/useGardenBoxPlaceBlock.ts
+++ b/packages/game/src/hooks/useGardenBoxPlaceBlock.ts
@@ -100,8 +100,8 @@ export function useGardenBoxPlaceBlock() {
     const queueBlockPlacementDropAnimation = useGameState(
         (state) => state.queueBlockPlacementDropAnimation,
     );
-    const rekeyBlockPlacementDropAnimation = useGameState(
-        (state) => state.rekeyBlockPlacementDropAnimation,
+    const confirmBlockPlacementDropAnimation = useGameState(
+        (state) => state.confirmBlockPlacementDropAnimation,
     );
     const cancelBlockPlacementDropAnimation = useGameState(
         (state) => state.cancelBlockPlacementDropAnimation,
@@ -190,7 +190,7 @@ export function useGardenBoxPlaceBlock() {
             }
 
             const optimisticBlockId = context.optimisticBlockId;
-            rekeyBlockPlacementDropAnimation(optimisticBlockId, data.id);
+            confirmBlockPlacementDropAnimation(optimisticBlockId, data.id);
             queryClient.setQueryData<CurrentGardenData | null>(
                 context.gardenQueryKey,
                 (garden) =>
@@ -205,9 +205,6 @@ export function useGardenBoxPlaceBlock() {
         },
         onError: (error, _variables, context) => {
             console.error('Error placing block from garden box', error);
-            if (context?.optimisticBlockId) {
-                cancelBlockPlacementDropAnimation(context.optimisticBlockId);
-            }
             if (context?.previousInventory) {
                 queryClient.setQueryData(
                     inventoryQueryKey,
@@ -219,6 +216,9 @@ export function useGardenBoxPlaceBlock() {
                     context.gardenQueryKey,
                     context.previousGarden,
                 );
+            }
+            if (context?.optimisticBlockId) {
+                cancelBlockPlacementDropAnimation(context.optimisticBlockId);
             }
         },
         onSettled: async (_data, _error, variables) => {

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -17,7 +17,6 @@ import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useLiveTime } from '../hooks/useLiveTime';
 import { useSnapshotTime } from '../hooks/useSnapshotTime';
 import { useWeatherNow } from '../hooks/useWeatherNow';
-import type { Stack } from '../types/Stack';
 import { type GameState, useGameState } from '../useGameState';
 import { defaultGameBackgroundPaletteIndex } from './backgroundPalettes';
 import { CloudLayer } from './CloudLayer';
@@ -37,7 +36,10 @@ import Snow from './Snow/Snow';
 import { resolveSnowParticleCounts } from './Snow/snowParticles';
 import { Stars } from './Stars';
 import { SunMoon } from './SunMoon';
-import { buildDirectionalShadowDepthSignature } from './shadowMapScheduling';
+import {
+    buildDirectionalShadowDepthSignature,
+    buildGardenShadowGeometrySignature,
+} from './shadowMapScheduling';
 import {
     resolveEnvironmentSkyBackgroundColors,
     resolveSkyBackgroundColor,
@@ -463,25 +465,6 @@ function useEnvironmentElements({
 const baseCameraShadowSize = 20;
 const defaultLocation = { lat: 45.739, lon: 16.572 };
 
-function roundShadowSignatureValue(value: number) {
-    return Number.isFinite(value) ? value.toFixed(4) : '0';
-}
-
-function buildStackShadowSignature(stacks: Stack[] | undefined) {
-    return (stacks ?? [])
-        .map((stack) => {
-            const blocks = stack.blocks
-                .map(
-                    (block) =>
-                        `${block.id}:${block.name}:${block.rotation}:${block.variant ?? ''}`,
-                )
-                .join(',');
-
-            return `${roundShadowSignatureValue(stack.position.x)},${roundShadowSignatureValue(stack.position.y)},${roundShadowSignatureValue(stack.position.z)}:${blocks}`;
-        })
-        .join('|');
-}
-
 export function StaticEnvironment({
     noBackground,
     quality,
@@ -611,14 +594,8 @@ export function Environment({
     const closeupBlockId = useGameState((state) => state.closeupBlock?.id);
     const pickupBlockId = useGameState((state) => state.pickupBlock?.id);
     const winterMode = useGameState((state) => state.winterMode);
-    const dropAnimationSignature = useGameState((state) =>
-        Object.entries(state.blockPlacementDropAnimations)
-            .map(
-                ([blockId, animation]) =>
-                    `${blockId}:${animation.sequence}:${animation.particlesSpawned ? 'particles' : 'pending'}`,
-            )
-            .sort()
-            .join('|'),
+    const activePlacementCount = useGameState(
+        (state) => Object.keys(state.blockPlacementDropAnimations).length,
     );
     const ambientAudioMixer = useGameState((state) => state.audio.ambient);
     const setSnowCoverage = useGameState((state) => state.setSnowCoverage);
@@ -896,7 +873,7 @@ export function Environment({
           smoothstep(0.08, 0.22, cloudCover) *
           (1 - smoothstep(0.5, 0.9, effectiveCloudCover));
     const gardenShadowSignature = useMemo(
-        () => buildStackShadowSignature(garden?.stacks),
+        () => buildGardenShadowGeometrySignature(garden?.stacks),
         [garden?.stacks],
     );
     const shadowInvalidationKey = buildDirectionalShadowDepthSignature({
@@ -905,11 +882,10 @@ export function Environment({
         shadowMapSize: qualityProfile.shadowMapSize,
         shadows: qualityProfile.shadows,
     });
-    const shadowSettleKey = [
+    const shadowGeometryKey = [
         `garden:${gardenShadowSignature}`,
         `view:${view}:${closeupBlockId ?? ''}`,
         `pickup:${pickupBlockId ?? ''}`,
-        `drop:${dropAnimationSignature}`,
         `winter:${winterMode}`,
     ].join('||');
     const shadowMapSize = qualityProfile.shadows
@@ -1023,9 +999,10 @@ export function Environment({
                 }
             />
             <ShadowMapController
+                activePlacementCount={activePlacementCount}
                 enabled={qualityProfile.shadows}
+                geometryKey={shadowGeometryKey}
                 invalidationKey={shadowInvalidationKey}
-                settleKey={shadowSettleKey}
             />
             {!noBackground && (
                 <>

--- a/packages/game/src/scene/GameProfileController.tsx
+++ b/packages/game/src/scene/GameProfileController.tsx
@@ -326,12 +326,16 @@ export function GameProfileController() {
                 if (!firstBlockId) {
                     return;
                 }
-                queueBlockPlacementDropAnimation(firstBlockId);
+                queueBlockPlacementDropAnimation(firstBlockId, {
+                    mutationConfirmed: true,
+                });
                 remainingBlockIds.forEach((blockId, index) => {
                     const timeout = window.setTimeout(
                         () => {
                             pendingTimeouts.delete(timeout);
-                            queueBlockPlacementDropAnimation(blockId);
+                            queueBlockPlacementDropAnimation(blockId, {
+                                mutationConfirmed: true,
+                            });
                         },
                         command.staggerMs * (index + 1),
                     );

--- a/packages/game/src/scene/ShadowMapController.tsx
+++ b/packages/game/src/scene/ShadowMapController.tsx
@@ -1,40 +1,48 @@
 'use client';
 
 import { useFrame, useThree } from '@react-three/fiber';
-import {
-    useCallback,
-    useEffect,
-    useLayoutEffect,
-    useRef,
-    useState,
-} from 'react';
+import { useCallback, useLayoutEffect, useRef } from 'react';
 import { updateGameProfileMetadata } from './gameProfileMetadata';
-import { useSceneResume, useSceneTimeInvalidation } from './SceneTime';
-import { requestPrimaryShadowMapRefresh } from './shadowMapScheduling';
-
-const shadowSettleMs = 900;
+import { useSceneResume } from './SceneTime';
+import {
+    consumeDeferredShadowRefresh,
+    createDeferredShadowRefreshState,
+    requestPrimaryShadowMapRefresh,
+    transitionDeferredShadowRefresh,
+} from './shadowMapScheduling';
 
 export function ShadowMapController({
+    activePlacementCount = 0,
     enabled,
+    geometryKey,
     invalidationKey,
-    settleKey,
 }: {
+    activePlacementCount?: number;
     enabled: boolean;
+    geometryKey?: string;
     invalidationKey: string;
-    settleKey?: string;
 }) {
     const gl = useThree((state) => state.gl);
     const invalidate = useThree((state) => state.invalidate);
+    const activePlacementCountRef = useRef(activePlacementCount);
+    activePlacementCountRef.current = activePlacementCount;
+    const deferredRefreshRef = useRef(
+        createDeferredShadowRefreshState(activePlacementCount),
+    );
+    const deferredChangeCountRef = useRef(0);
     const invalidationCountRef = useRef(0);
+    const placementFlushCountRef = useRef(0);
+    const previousGeometryKeyRef = useRef(geometryKey);
+    const previousInvalidationKeyRef = useRef(invalidationKey);
     const refreshCountRef = useRef(0);
-    const settleUntilRef = useRef(0);
-    const [shadowSettleGeneration, setShadowSettleGeneration] = useState(0);
-    const [shadowSettling, setShadowSettling] = useState(false);
-    useSceneTimeInvalidation(enabled && shadowSettling);
 
     const reportShadowMapState = useCallback(() => {
         updateGameProfileMetadata({
             animatedCasterShadowRefreshCount: 0,
+            placementShadowActiveCount:
+                deferredRefreshRef.current.activePlacementCount,
+            placementShadowDeferredChangeCount: deferredChangeCountRef.current,
+            placementShadowFlushCount: placementFlushCountRef.current,
             primaryShadowRefreshCount: refreshCountRef.current,
             shadowMapAutoUpdate: gl.shadowMap.autoUpdate,
             shadowMapDynamicRefreshMs: 0,
@@ -61,18 +69,41 @@ export function ShadowMapController({
         [enabled, gl, invalidate, reportShadowMapState],
     );
 
-    const settleShadows = useCallback(() => {
-        if (!enabled) {
-            return;
+    const queueDeferredRefresh = useCallback(
+        ({
+            activeCount = activePlacementCountRef.current,
+            forceDirty = false,
+            geometryChanged = false,
+        }: {
+            activeCount?: number;
+            forceDirty?: boolean;
+            geometryChanged?: boolean;
+        }) => {
+            const transition = transitionDeferredShadowRefresh(
+                deferredRefreshRef.current,
+                {
+                    activePlacementCount: activeCount,
+                    forceDirty,
+                    geometryChanged,
+                },
+            );
+            deferredRefreshRef.current = transition.state;
+            deferredChangeCountRef.current +=
+                transition.deferredChangeCountDelta;
+            if (enabled && transition.shouldInvalidate) {
+                invalidate();
+            }
+            reportShadowMapState();
+        },
+        [enabled, invalidate, reportShadowMapState],
+    );
+
+    const queueResumeRefresh = useCallback(() => {
+        if (enabled) {
+            queueDeferredRefresh({ forceDirty: true });
         }
-
-        requestShadowRefresh(true);
-        settleUntilRef.current = performance.now() + shadowSettleMs;
-        setShadowSettling(true);
-        setShadowSettleGeneration((generation) => generation + 1);
-    }, [enabled, requestShadowRefresh]);
-
-    useSceneResume(settleShadows);
+    }, [enabled, queueDeferredRefresh]);
+    useSceneResume(queueResumeRefresh);
 
     useLayoutEffect(() => {
         const previousAutoUpdate = gl.shadowMap.autoUpdate;
@@ -85,10 +116,9 @@ export function ShadowMapController({
         } else {
             gl.shadowMap.needsUpdate = true;
         }
-        if (!enabled) {
-            settleUntilRef.current = 0;
-            setShadowSettling(false);
-        }
+        deferredRefreshRef.current = createDeferredShadowRefreshState(
+            activePlacementCountRef.current,
+        );
         reportShadowMapState();
 
         return () => {
@@ -99,47 +129,43 @@ export function ShadowMapController({
     }, [enabled, gl, reportShadowMapState, requestShadowRefresh]);
 
     useLayoutEffect(() => {
-        void invalidationKey;
-
-        if (!enabled) {
-            return;
+        const invalidationChanged =
+            previousInvalidationKeyRef.current !== invalidationKey;
+        const geometryChanged = previousGeometryKeyRef.current !== geometryKey;
+        previousInvalidationKeyRef.current = invalidationKey;
+        previousGeometryKeyRef.current = geometryKey;
+        if (enabled && invalidationChanged) {
+            invalidationCountRef.current += 1;
         }
-
-        invalidationCountRef.current += 1;
-        requestShadowRefresh(true);
-    }, [enabled, invalidationKey, requestShadowRefresh]);
-
-    useLayoutEffect(() => {
-        void settleKey;
-        settleShadows();
-    }, [settleKey, settleShadows]);
-
-    useEffect(() => {
-        void shadowSettleGeneration;
-
-        if (!enabled || !shadowSettling) {
-            return;
-        }
-
-        const timeout = window.setTimeout(
-            () => {
-                setShadowSettling(false);
-            },
-            Math.max(0, settleUntilRef.current - performance.now()),
-        );
-
-        return () => window.clearTimeout(timeout);
-    }, [enabled, shadowSettleGeneration, shadowSettling]);
+        queueDeferredRefresh({
+            activeCount: activePlacementCount,
+            forceDirty: invalidationChanged,
+            geometryChanged,
+        });
+    }, [
+        activePlacementCount,
+        enabled,
+        geometryKey,
+        invalidationKey,
+        queueDeferredRefresh,
+    ]);
 
     useFrame(() => {
         if (!enabled) {
             return;
         }
 
-        if (performance.now() > settleUntilRef.current) {
+        const consumption = consumeDeferredShadowRefresh(
+            deferredRefreshRef.current,
+        );
+        if (!consumption.shouldRefresh) {
             return;
         }
 
+        deferredRefreshRef.current = consumption.state;
+        if (consumption.placementFlush) {
+            placementFlushCountRef.current += 1;
+        }
         requestShadowRefresh(false);
     });
 

--- a/packages/game/src/scene/gameProfileMetadata.ts
+++ b/packages/game/src/scene/gameProfileMetadata.ts
@@ -220,6 +220,12 @@ export type GameProfileMetadata = {
     placementChunkPhysicalRebuildDurationMaxMs?: number;
     placementChunkPhysicalRebuildDurationP95Ms?: number;
     placementChunkPhysicalTransformedInstanceCount?: number;
+    placementProjectedShadowCount?: number;
+    placementProjectedShadowDroppedCount?: number;
+    placementProjectedShadowPeakCount?: number;
+    placementShadowActiveCount?: number;
+    placementShadowDeferredChangeCount?: number;
+    placementShadowFlushCount?: number;
     qualityTier?: GameQualityProfileTier;
     rainParticleCount?: number;
     rainWetOverlayDistinctUniformCount?: number;

--- a/packages/game/src/scene/shadowMapScheduling.ts
+++ b/packages/game/src/scene/shadowMapScheduling.ts
@@ -1,3 +1,5 @@
+import type { Stack } from '../types/Stack';
+
 type ShadowLightPosition = {
     x: number;
     y: number;
@@ -27,6 +29,24 @@ function formatShadowSignatureValue(value: number) {
     return Number.isFinite(value) ? value.toFixed(4) : '0';
 }
 
+export function buildGardenShadowGeometrySignature(
+    stacks: Stack[] | undefined,
+) {
+    return (stacks ?? [])
+        .map((stack) => {
+            const blocks = stack.blocks
+                .map(
+                    (block) =>
+                        `${block.name}:${block.rotation}:${block.variant ?? ''}`,
+                )
+                .join(',');
+
+            return `${formatShadowSignatureValue(stack.position.x)},${formatShadowSignatureValue(stack.position.y)},${formatShadowSignatureValue(stack.position.z)}:${blocks}`;
+        })
+        .sort()
+        .join('|');
+}
+
 export function buildDirectionalShadowDepthSignature({
     lightPosition,
     shadowCameraSize,
@@ -46,4 +66,95 @@ export function buildDirectionalShadowDepthSignature({
         formatShadowSignatureValue(lightPosition.y),
         formatShadowSignatureValue(lightPosition.z),
     ].join('|');
+}
+
+export type DeferredShadowRefreshState = {
+    activePlacementCount: number;
+    dirty: boolean;
+    placementCyclePending: boolean;
+};
+
+export type DeferredShadowRefreshTransition = {
+    deferredChangeCountDelta: number;
+    shouldInvalidate: boolean;
+    state: DeferredShadowRefreshState;
+};
+
+function normalizeActivePlacementCount(activePlacementCount: number) {
+    return Number.isFinite(activePlacementCount)
+        ? Math.max(0, Math.floor(activePlacementCount))
+        : 0;
+}
+
+export function createDeferredShadowRefreshState(
+    activePlacementCount = 0,
+): DeferredShadowRefreshState {
+    const normalizedActivePlacementCount =
+        normalizeActivePlacementCount(activePlacementCount);
+    const placementActive = normalizedActivePlacementCount > 0;
+
+    return {
+        activePlacementCount: normalizedActivePlacementCount,
+        dirty: placementActive,
+        placementCyclePending: placementActive,
+    };
+}
+
+export function transitionDeferredShadowRefresh(
+    state: DeferredShadowRefreshState,
+    {
+        activePlacementCount,
+        forceDirty = false,
+        geometryChanged = false,
+    }: {
+        activePlacementCount: number;
+        forceDirty?: boolean;
+        geometryChanged?: boolean;
+    },
+): DeferredShadowRefreshTransition {
+    const nextActivePlacementCount =
+        normalizeActivePlacementCount(activePlacementCount);
+    const placementStarted =
+        state.activePlacementCount === 0 && nextActivePlacementCount > 0;
+    const placementCompleted =
+        state.activePlacementCount > 0 && nextActivePlacementCount === 0;
+    const dirtyEvent = forceDirty || geometryChanged || placementStarted;
+    const dirty = state.dirty || dirtyEvent;
+
+    return {
+        deferredChangeCountDelta:
+            nextActivePlacementCount > 0 && dirtyEvent ? 1 : 0,
+        shouldInvalidate:
+            nextActivePlacementCount === 0 &&
+            dirty &&
+            (dirtyEvent || placementCompleted),
+        state: {
+            activePlacementCount: nextActivePlacementCount,
+            dirty,
+            placementCyclePending:
+                state.placementCyclePending || placementStarted,
+        },
+    };
+}
+
+export function consumeDeferredShadowRefresh(
+    state: DeferredShadowRefreshState,
+) {
+    if (state.activePlacementCount > 0 || !state.dirty) {
+        return {
+            placementFlush: false,
+            shouldRefresh: false,
+            state,
+        };
+    }
+
+    return {
+        placementFlush: state.placementCyclePending,
+        shouldRefresh: true,
+        state: {
+            ...state,
+            dirty: false,
+            placementCyclePending: false,
+        },
+    };
 }

--- a/packages/game/src/scene/shadowMapScheduling.unit.ts
+++ b/packages/game/src/scene/shadowMapScheduling.unit.ts
@@ -1,8 +1,14 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { Vector3 } from 'three';
+import type { Stack } from '../types/Stack';
 import {
     buildDirectionalShadowDepthSignature,
+    buildGardenShadowGeometrySignature,
+    consumeDeferredShadowRefresh,
+    createDeferredShadowRefreshState,
     requestPrimaryShadowMapRefresh,
+    transitionDeferredShadowRefresh,
 } from './shadowMapScheduling';
 
 const baseShadowDepth = {
@@ -76,6 +82,249 @@ describe('primary shadow refresh accounting', () => {
         assert.deepEqual(shadowMap, {
             enabled: false,
             needsUpdate: false,
+        });
+    });
+});
+
+function createStack({
+    blockId = 'optimistic',
+    blockName = 'Tree',
+    rotation = 1,
+    variant = 2,
+    x = 4,
+}: {
+    blockId?: string;
+    blockName?: string;
+    rotation?: number;
+    variant?: number | null;
+    x?: number;
+} = {}): Stack {
+    return {
+        blocks: [
+            {
+                id: blockId,
+                name: blockName,
+                rotation,
+                variant,
+            },
+        ],
+        position: new Vector3(x, 0, -3),
+    };
+}
+
+describe('buildGardenShadowGeometrySignature', () => {
+    it('ignores optimistic-to-persisted id replacement and stack order', () => {
+        const optimistic = createStack();
+        const persisted = createStack({ blockId: 'persisted' });
+        const other = createStack({ blockId: 'other', x: 8 });
+
+        assert.equal(
+            buildGardenShadowGeometrySignature([optimistic, other]),
+            buildGardenShadowGeometrySignature([other, persisted]),
+        );
+    });
+
+    it('changes for geometry-affecting stack and block changes', () => {
+        const signature = buildGardenShadowGeometrySignature([createStack()]);
+        const changes = [
+            createStack({ x: 5 }),
+            createStack({ blockName: 'Pine' }),
+            createStack({ rotation: 2 }),
+            createStack({ variant: 3 }),
+        ];
+
+        for (const changedStack of changes) {
+            assert.notEqual(
+                buildGardenShadowGeometrySignature([changedStack]),
+                signature,
+            );
+        }
+        assert.notEqual(
+            buildGardenShadowGeometrySignature([
+                {
+                    ...createStack(),
+                    blocks: [
+                        ...createStack().blocks,
+                        {
+                            id: 'second',
+                            name: 'StoneSmall',
+                            rotation: 0,
+                        },
+                    ],
+                },
+            ]),
+            signature,
+        );
+    });
+});
+
+describe('deferred placement shadow refresh scheduling', () => {
+    it('defers simultaneous garden-bounds invalidation and geometry changes until completion', () => {
+        let state = createDeferredShadowRefreshState();
+        const placementStarted = transitionDeferredShadowRefresh(state, {
+            activePlacementCount: 1,
+            forceDirty: true,
+            geometryChanged: true,
+        });
+        state = placementStarted.state;
+
+        assert.equal(placementStarted.shouldInvalidate, false);
+        assert.equal(consumeDeferredShadowRefresh(state).shouldRefresh, false);
+
+        const placementCompleted = transitionDeferredShadowRefresh(state, {
+            activePlacementCount: 0,
+        });
+        const consumption = consumeDeferredShadowRefresh(
+            placementCompleted.state,
+        );
+
+        assert.equal(placementCompleted.shouldInvalidate, true);
+        assert.equal(consumption.shouldRefresh, true);
+        assert.equal(consumption.placementFlush, true);
+        assert.equal(
+            consumeDeferredShadowRefresh(consumption.state).shouldRefresh,
+            false,
+        );
+    });
+
+    it('coalesces overlapping placements into one final flush', () => {
+        let state = createDeferredShadowRefreshState();
+        let invalidationCount = 0;
+        let deferredChangeCount = 0;
+
+        for (const activePlacementCount of [1, 2, 1, 0]) {
+            const transition = transitionDeferredShadowRefresh(state, {
+                activePlacementCount,
+                geometryChanged: activePlacementCount === 2,
+            });
+            state = transition.state;
+            invalidationCount += Number(transition.shouldInvalidate);
+            deferredChangeCount += transition.deferredChangeCountDelta;
+
+            const consumption = consumeDeferredShadowRefresh(state);
+            if (activePlacementCount > 0) {
+                assert.equal(consumption.shouldRefresh, false);
+            } else {
+                assert.equal(consumption.shouldRefresh, true);
+                assert.equal(consumption.placementFlush, true);
+                state = consumption.state;
+            }
+        }
+
+        assert.equal(invalidationCount, 1);
+        assert.equal(deferredChangeCount, 2);
+        assert.equal(consumeDeferredShadowRefresh(state).shouldRefresh, false);
+    });
+
+    it('keeps a queued flush deferred if a new placement starts first', () => {
+        let state = createDeferredShadowRefreshState(1);
+        const completion = transitionDeferredShadowRefresh(state, {
+            activePlacementCount: 0,
+        });
+        assert.equal(completion.shouldInvalidate, true);
+        state = completion.state;
+
+        const restarted = transitionDeferredShadowRefresh(state, {
+            activePlacementCount: 1,
+        });
+        assert.equal(restarted.shouldInvalidate, false);
+        assert.equal(
+            consumeDeferredShadowRefresh(restarted.state).shouldRefresh,
+            false,
+        );
+
+        const finalCompletion = transitionDeferredShadowRefresh(
+            restarted.state,
+            { activePlacementCount: 0 },
+        );
+        const consumption = consumeDeferredShadowRefresh(finalCompletion.state);
+        assert.equal(consumption.shouldRefresh, true);
+        assert.equal(consumption.placementFlush, true);
+    });
+
+    it('coalesces cancellation rollback geometry before the frame', () => {
+        let state = createDeferredShadowRefreshState(1);
+        const cancelled = transitionDeferredShadowRefresh(state, {
+            activePlacementCount: 0,
+        });
+        state = cancelled.state;
+        const rolledBack = transitionDeferredShadowRefresh(state, {
+            activePlacementCount: 0,
+            geometryChanged: true,
+        });
+
+        assert.equal(cancelled.shouldInvalidate, true);
+        assert.equal(rolledBack.shouldInvalidate, true);
+        const consumption = consumeDeferredShadowRefresh(rolledBack.state);
+        assert.equal(consumption.shouldRefresh, true);
+        assert.equal(consumption.placementFlush, true);
+        assert.equal(
+            consumeDeferredShadowRefresh(consumption.state).shouldRefresh,
+            false,
+        );
+    });
+
+    it('keeps a visually completed placement active until a late rollback joins its final flush', () => {
+        let state = createDeferredShadowRefreshState();
+        state = transitionDeferredShadowRefresh(state, {
+            activePlacementCount: 1,
+            geometryChanged: true,
+        }).state;
+
+        const visualCompletion = transitionDeferredShadowRefresh(state, {
+            activePlacementCount: 1,
+        });
+        state = visualCompletion.state;
+        assert.equal(visualCompletion.shouldInvalidate, false);
+        assert.equal(consumeDeferredShadowRefresh(state).shouldRefresh, false);
+
+        const rollback = transitionDeferredShadowRefresh(state, {
+            activePlacementCount: 1,
+            geometryChanged: true,
+        });
+        state = rollback.state;
+        assert.equal(rollback.shouldInvalidate, false);
+        assert.equal(consumeDeferredShadowRefresh(state).shouldRefresh, false);
+
+        const cancellation = transitionDeferredShadowRefresh(state, {
+            activePlacementCount: 0,
+        });
+        const consumption = consumeDeferredShadowRefresh(cancellation.state);
+
+        assert.equal(cancellation.shouldInvalidate, true);
+        assert.equal(consumption.shouldRefresh, true);
+        assert.equal(consumption.placementFlush, true);
+        assert.equal(
+            consumeDeferredShadowRefresh(consumption.state).shouldRefresh,
+            false,
+        );
+    });
+
+    it('supports an ordinary coalesced scene refresh without a placement', () => {
+        const transitioned = transitionDeferredShadowRefresh(
+            createDeferredShadowRefreshState(),
+            {
+                activePlacementCount: 0,
+                forceDirty: true,
+            },
+        );
+        const consumption = consumeDeferredShadowRefresh(transitioned.state);
+
+        assert.equal(transitioned.shouldInvalidate, true);
+        assert.equal(consumption.shouldRefresh, true);
+        assert.equal(consumption.placementFlush, false);
+    });
+
+    it('normalizes invalid active counts', () => {
+        assert.deepEqual(createDeferredShadowRefreshState(Number.NaN), {
+            activePlacementCount: 0,
+            dirty: false,
+            placementCyclePending: false,
+        });
+        assert.deepEqual(createDeferredShadowRefreshState(-2), {
+            activePlacementCount: 0,
+            dirty: false,
+            placementCyclePending: false,
         });
     });
 });

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -165,10 +165,13 @@ export type PlacedBlockEffect = {
 
 export type BlockPlacementDropAnimation = {
     createdAt: number;
+    mutationConfirmed: boolean;
     particlesSpawned: boolean;
     renderId: number;
     sequence: number;
     sourceBlockId: string;
+    visualComplete: boolean;
+    visualStarted: boolean;
 };
 
 function findBlockPlacementDropAnimationByRenderId(
@@ -400,14 +403,18 @@ export type GameState = {
     ) => void;
     consumePlacedBlockEffect: (blockId: string) => PlacedBlockEffect | null;
     blockPlacementDropAnimations: Record<string, BlockPlacementDropAnimation>;
-    queueBlockPlacementDropAnimation: (blockId: string) => void;
-    rekeyBlockPlacementDropAnimation: (
+    queueBlockPlacementDropAnimation: (
+        blockId: string,
+        options?: { mutationConfirmed?: boolean },
+    ) => void;
+    confirmBlockPlacementDropAnimation: (
         sourceBlockId: string,
         targetBlockId: string,
     ) => void;
     cancelBlockPlacementDropAnimation: (blockId: string) => void;
     markBlockPlacementDropParticlesSpawned: (renderId: number) => boolean;
-    completeBlockPlacementDropAnimation: (renderId: number) => void;
+    markBlockPlacementDropVisualStarted: (renderId: number) => void;
+    markBlockPlacementDropVisualComplete: (renderId: number) => void;
     gardenVisitSummaryHighlight: GardenVisitSummaryHighlight | null;
     setGardenVisitSummaryHighlight: (
         highlight: Omit<GardenVisitSummaryHighlight, 'createdAt' | 'sequence'>,
@@ -778,7 +785,7 @@ export function createGameState({
             return effect;
         },
         blockPlacementDropAnimations: {},
-        queueBlockPlacementDropAnimation: (blockId) =>
+        queueBlockPlacementDropAnimation: (blockId, options) =>
             set((state) => {
                 nextBlockPlacementDropAnimationRenderId += 1;
                 return {
@@ -786,32 +793,47 @@ export function createGameState({
                         ...state.blockPlacementDropAnimations,
                         [blockId]: {
                             createdAt: Date.now(),
+                            mutationConfirmed:
+                                options?.mutationConfirmed === true,
                             particlesSpawned: false,
                             renderId: nextBlockPlacementDropAnimationRenderId,
                             sequence:
                                 (state.blockPlacementDropAnimations[blockId]
                                     ?.sequence ?? 0) + 1,
                             sourceBlockId: blockId,
+                            visualComplete: false,
+                            visualStarted: false,
                         },
                     },
                 };
             }),
-        rekeyBlockPlacementDropAnimation: (sourceBlockId, targetBlockId) =>
+        confirmBlockPlacementDropAnimation: (sourceBlockId, targetBlockId) =>
             set((state) => {
-                if (sourceBlockId === targetBlockId) {
+                const animation = getBlockPlacementDropAnimationForBlockId(
+                    state.blockPlacementDropAnimations,
+                    sourceBlockId,
+                );
+                if (!animation) {
                     return state;
                 }
-                const animation =
-                    state.blockPlacementDropAnimations[sourceBlockId];
-                if (!animation) {
+                const entry = findBlockPlacementDropAnimationByRenderId(
+                    state.blockPlacementDropAnimations,
+                    animation.renderId,
+                );
+                if (!entry) {
                     return state;
                 }
 
                 const blockPlacementDropAnimations = {
                     ...state.blockPlacementDropAnimations,
-                    [targetBlockId]: animation,
                 };
-                delete blockPlacementDropAnimations[sourceBlockId];
+                delete blockPlacementDropAnimations[entry.blockId];
+                if (animation.visualStarted && !animation.visualComplete) {
+                    blockPlacementDropAnimations[targetBlockId] = {
+                        ...animation,
+                        mutationConfirmed: true,
+                    };
+                }
 
                 return { blockPlacementDropAnimations };
             }),
@@ -869,15 +891,50 @@ export function createGameState({
             });
             return true;
         },
-        completeBlockPlacementDropAnimation: (renderId) => {
-            const entry = findBlockPlacementDropAnimationByRenderId(
-                get().blockPlacementDropAnimations,
-                renderId,
-            );
-            if (entry) {
-                get().cancelBlockPlacementDropAnimation(entry.blockId);
-            }
-        },
+        markBlockPlacementDropVisualStarted: (renderId) =>
+            set((state) => {
+                const entry = findBlockPlacementDropAnimationByRenderId(
+                    state.blockPlacementDropAnimations,
+                    renderId,
+                );
+                if (!entry || entry.animation.visualStarted) {
+                    return state;
+                }
+
+                return {
+                    blockPlacementDropAnimations: {
+                        ...state.blockPlacementDropAnimations,
+                        [entry.blockId]: {
+                            ...entry.animation,
+                            visualStarted: true,
+                        },
+                    },
+                };
+            }),
+        markBlockPlacementDropVisualComplete: (renderId) =>
+            set((state) => {
+                const entry = findBlockPlacementDropAnimationByRenderId(
+                    state.blockPlacementDropAnimations,
+                    renderId,
+                );
+                if (!entry) {
+                    return state;
+                }
+
+                const blockPlacementDropAnimations = {
+                    ...state.blockPlacementDropAnimations,
+                };
+                if (entry.animation.mutationConfirmed) {
+                    delete blockPlacementDropAnimations[entry.blockId];
+                } else {
+                    blockPlacementDropAnimations[entry.blockId] = {
+                        ...entry.animation,
+                        visualComplete: true,
+                    };
+                }
+
+                return { blockPlacementDropAnimations };
+            }),
         gardenVisitSummaryHighlight: null,
         setGardenVisitSummaryHighlight: (highlight) =>
             set((state) => ({

--- a/packages/game/src/useGameState.unit.ts
+++ b/packages/game/src/useGameState.unit.ts
@@ -196,7 +196,7 @@ test('clearPickupSelectionTargets resets every active pickup target', () => {
     }
 });
 
-test('placement animation keeps render and completion identity through optimistic rekey', () => {
+test('placement animation keeps render and completion identity through confirmed rekey', () => {
     const store = createGameState({
         appBaseUrl: '',
         freezeTime: new Date('2026-01-01T12:00:00.000Z'),
@@ -231,15 +231,23 @@ test('placement animation keeps render and completion identity through optimisti
 
         store
             .getState()
-            .rekeyBlockPlacementDropAnimation('optimistic', 'persisted');
+            .markBlockPlacementDropVisualStarted(animation.renderId);
+        store
+            .getState()
+            .confirmBlockPlacementDropAnimation('optimistic', 'persisted');
 
         assert.equal(
             store.getState().blockPlacementDropAnimations.optimistic,
             undefined,
         );
         assert.strictEqual(
-            store.getState().blockPlacementDropAnimations.persisted,
-            animation,
+            store.getState().blockPlacementDropAnimations.persisted?.renderId,
+            animation.renderId,
+        );
+        assert.equal(
+            store.getState().blockPlacementDropAnimations.persisted
+                ?.mutationConfirmed,
+            true,
         );
         assert.equal(
             resolveBlockPlacementDropAnimationRenderIdentity(
@@ -276,7 +284,7 @@ test('placement animation keeps render and completion identity through optimisti
 
         store
             .getState()
-            .completeBlockPlacementDropAnimation(animation.renderId);
+            .markBlockPlacementDropVisualComplete(animation.renderId);
         assert.deepEqual(store.getState().blockPlacementDropAnimations, {});
         assert.equal(
             resolveBlockPlacementDropAnimationRenderIdentity(
@@ -290,7 +298,7 @@ test('placement animation keeps render and completion identity through optimisti
     }
 });
 
-test('placement animation cancellation resolves the optimistic source after rekey', () => {
+test('placement animation waits for mutation confirmation after visual completion', () => {
     const store = createGameState({
         appBaseUrl: '',
         freezeTime: new Date('2026-01-01T12:00:00.000Z'),
@@ -299,13 +307,175 @@ test('placement animation cancellation resolves the optimistic source after reke
 
     try {
         store.getState().queueBlockPlacementDropAnimation('optimistic');
+        const animation =
+            store.getState().blockPlacementDropAnimations.optimistic;
+        assert.ok(animation);
+
         store
             .getState()
-            .rekeyBlockPlacementDropAnimation('optimistic', 'persisted');
+            .markBlockPlacementDropVisualStarted(animation.renderId);
+        store
+            .getState()
+            .markBlockPlacementDropVisualComplete(animation.renderId);
+        assert.equal(
+            store.getState().blockPlacementDropAnimations.optimistic
+                ?.visualComplete,
+            true,
+        );
+
+        store
+            .getState()
+            .confirmBlockPlacementDropAnimation('optimistic', 'persisted');
+        assert.deepEqual(store.getState().blockPlacementDropAnimations, {});
+    } finally {
+        store.getState().audio.dispose();
+    }
+});
+
+test('pre-confirmed synthetic placement releases after its visual completion', () => {
+    const store = createGameState({
+        appBaseUrl: '',
+        freezeTime: new Date('2026-01-01T12:00:00.000Z'),
+        isMock: true,
+    });
+
+    try {
+        store.getState().queueBlockPlacementDropAnimation('profile-block', {
+            mutationConfirmed: true,
+        });
+        const animation =
+            store.getState().blockPlacementDropAnimations['profile-block'];
+        assert.ok(animation);
+        assert.equal(
+            store.getState().blockPlacementDropAnimations['profile-block']
+                ?.mutationConfirmed,
+            true,
+        );
+
+        store
+            .getState()
+            .markBlockPlacementDropVisualStarted(animation.renderId);
+        store
+            .getState()
+            .markBlockPlacementDropVisualComplete(animation.renderId);
+        assert.deepEqual(store.getState().blockPlacementDropAnimations, {});
+    } finally {
+        store.getState().audio.dispose();
+    }
+});
+
+test('confirmed placement without a committed visual renderer finalizes immediately', () => {
+    const store = createGameState({
+        appBaseUrl: '',
+        freezeTime: new Date('2026-01-01T12:00:00.000Z'),
+        isMock: true,
+    });
+
+    try {
+        store.getState().queueBlockPlacementDropAnimation('suspended');
+        store
+            .getState()
+            .confirmBlockPlacementDropAnimation('suspended', 'persisted');
+
+        assert.deepEqual(store.getState().blockPlacementDropAnimations, {});
+    } finally {
+        store.getState().audio.dispose();
+    }
+});
+
+test('placement animation cancellation resolves the optimistic source after confirmed rekey', () => {
+    const store = createGameState({
+        appBaseUrl: '',
+        freezeTime: new Date('2026-01-01T12:00:00.000Z'),
+        isMock: true,
+    });
+
+    try {
+        store.getState().queueBlockPlacementDropAnimation('optimistic');
+        const animation =
+            store.getState().blockPlacementDropAnimations.optimistic;
+        assert.ok(animation);
+        store
+            .getState()
+            .markBlockPlacementDropVisualStarted(animation.renderId);
+        store
+            .getState()
+            .confirmBlockPlacementDropAnimation('optimistic', 'persisted');
         store.getState().cancelBlockPlacementDropAnimation('optimistic');
 
         assert.deepEqual(store.getState().blockPlacementDropAnimations, {});
         store.getState().cancelBlockPlacementDropAnimation('missing');
+        assert.deepEqual(store.getState().blockPlacementDropAnimations, {});
+    } finally {
+        store.getState().audio.dispose();
+    }
+});
+
+test('placement animation remains cancellable after its visual completes before a late mutation error', () => {
+    const store = createGameState({
+        appBaseUrl: '',
+        freezeTime: new Date('2026-01-01T12:00:00.000Z'),
+        isMock: true,
+    });
+
+    try {
+        store.getState().queueBlockPlacementDropAnimation('optimistic');
+        const animation =
+            store.getState().blockPlacementDropAnimations.optimistic;
+        assert.ok(animation);
+
+        store
+            .getState()
+            .markBlockPlacementDropVisualStarted(animation.renderId);
+        store
+            .getState()
+            .markBlockPlacementDropVisualComplete(animation.renderId);
+        assert.equal(
+            Object.keys(store.getState().blockPlacementDropAnimations).length,
+            1,
+        );
+
+        store.getState().cancelBlockPlacementDropAnimation('optimistic');
+        assert.deepEqual(store.getState().blockPlacementDropAnimations, {});
+    } finally {
+        store.getState().audio.dispose();
+    }
+});
+
+test('overlapping placement animations complete independently after confirmed rekey', () => {
+    const store = createGameState({
+        appBaseUrl: '',
+        freezeTime: new Date('2026-01-01T12:00:00.000Z'),
+        isMock: true,
+    });
+
+    try {
+        store.getState().queueBlockPlacementDropAnimation('first');
+        store.getState().queueBlockPlacementDropAnimation('second');
+        const first = store.getState().blockPlacementDropAnimations.first;
+        const second = store.getState().blockPlacementDropAnimations.second;
+        assert.ok(first);
+        assert.ok(second);
+        assert.equal(
+            Object.keys(store.getState().blockPlacementDropAnimations).length,
+            2,
+        );
+
+        store.getState().markBlockPlacementDropVisualStarted(first.renderId);
+        store
+            .getState()
+            .confirmBlockPlacementDropAnimation('first', 'first-persisted');
+        store.getState().markBlockPlacementDropVisualComplete(first.renderId);
+        assert.equal(
+            Object.keys(store.getState().blockPlacementDropAnimations).length,
+            1,
+        );
+        assert.strictEqual(
+            store.getState().blockPlacementDropAnimations.second,
+            second,
+        );
+
+        store.getState().cancelBlockPlacementDropAnimation('second');
         assert.deepEqual(store.getState().blockPlacementDropAnimations, {});
     } finally {
         store.getState().audio.dispose();


### PR DESCRIPTION
## Summary

- replace the 900 ms per-frame placement shadow refresh window with one deferred, coalesced primary-map refresh after the final placement completes or cancels
- keep transient placement geometry out of the 4096px primary shadow map and render conservative placement proxies through the existing instanced grounding-shadow batch
- make optimistic ID replacement shadow-signature neutral and harden success, rollback, overlap, Suspense-before-commit, and synthetic-profiler lifecycle ordering
- add strict profiler telemetry for active placements, deferred changes, final flushes, proxy peak/end/drop counts, and primary refreshes

## Verification

- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game test` — 656 passed
- `pnpm --filter garden typecheck`
- `pnpm --filter garden test:profile` — 31 passed
- production Garden build
- exact three-repeat `game-high-target-placement-desktop` profile — structural acceptance 3/3; every run reported projected peak/end/dropped `2/0/0`, deferred/flush/primary `1/1/1`, and final active count `0`
- `git diff --check`

The remaining headless performance-budget failures are the documented ANGLE SwiftShader `ReadPixels` stalls; draw/render and triangles/render remained `156.7` and `22,627` in all three runs.

Closes #4331