### PR TITLE
fix(app): keep surveys visible in admin sidebar

### DIFF
--- a/apps/app/app/admin/surveys/surveyWorkspaceQuery.unit.ts
+++ b/apps/app/app/admin/surveys/surveyWorkspaceQuery.unit.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { includesSelectedPath } from '../../../components/admin/navigation/adminNavigationPath';
-import { communicationAdminPageHrefs } from '../../../components/admin/navigation/adminPages';
+import { communicationMessagePageHrefs } from '../../../components/admin/navigation/adminPages';
 import { resolveAdminRouteTitle } from '../../../components/admin/navigation/adminRouteTitle';
 import { buildDashboardQuickActionOptions } from '../../../src/dashboardQuickActions';
 import { KnownPages } from '../../../src/KnownPages';
@@ -143,19 +143,24 @@ describe('survey admin navigation', () => {
         });
     });
 
-    it('keeps communication navigation open on survey descendants', () => {
-        assert.ok(communicationAdminPageHrefs.includes(KnownPages.Surveys));
+    it('keeps surveys outside the collapsed message navigation group', () => {
+        assert.equal(
+            new Set<string>(communicationMessagePageHrefs).has(
+                KnownPages.Surveys,
+            ),
+            false,
+        );
         assert.equal(
             includesSelectedPath(KnownPages.SurveyResponses('survey-id'), [
-                ...communicationAdminPageHrefs,
+                ...communicationMessagePageHrefs,
             ]),
-            true,
+            false,
         );
         assert.equal(
             includesSelectedPath(KnownPages.SurveyStatistics('survey-id'), [
-                ...communicationAdminPageHrefs,
+                ...communicationMessagePageHrefs,
             ]),
-            true,
+            false,
         );
     });
 });

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -55,7 +55,7 @@ import { getDashboardQuickActionBadge } from '../../../src/dashboardQuickActions
 import { KnownPages } from '../../../src/KnownPages';
 import { EntityTypeIcon } from '../directories/EntityTypeIcon';
 import { includesSelectedPath, isSelectedPath } from './adminNavigationPath';
-import { adminPages, communicationAdminPageHrefs } from './adminPages';
+import { adminPages, communicationMessagePageHrefs } from './adminPages';
 import { NavContext } from './NavContext';
 import { NavGroup } from './NavGroup';
 import { NavItem } from './NavItem';
@@ -799,7 +799,7 @@ export function Nav({
                     label="Poruke"
                     icon={<Inbox className="size-5" />}
                     forceOpen={includesSelectedPath(pathname, [
-                        ...communicationAdminPageHrefs,
+                        ...communicationMessagePageHrefs,
                     ])}
                     compact={compact}
                 >
@@ -828,14 +828,6 @@ export function Nav({
                         nested
                     />
                     <NavItem
-                        href={adminPages.Surveys.href}
-                        label={adminPages.Surveys.label}
-                        icon={<Tally3 className="size-5" />}
-                        onClick={onItemClick}
-                        compact={compact}
-                        nested
-                    />
-                    <NavItem
                         href={adminPages.Feedback.href}
                         label={adminPages.Feedback.label}
                         icon={<SmileHappy className="size-5" />}
@@ -844,6 +836,13 @@ export function Nav({
                         nested
                     />
                 </NavGroup>
+                <NavItem
+                    href={adminPages.Surveys.href}
+                    label={adminPages.Surveys.label}
+                    icon={<Tally3 className="size-5" />}
+                    onClick={onItemClick}
+                    compact={compact}
+                />
             </NavSection>
             <NavSection label="Sustavi" compact={compact}>
                 <NavItem

--- a/apps/app/components/admin/navigation/adminPages.ts
+++ b/apps/app/components/admin/navigation/adminPages.ts
@@ -109,11 +109,10 @@ export const adminPages = {
     },
 } as const;
 
-export const communicationAdminPageHrefs = [
+export const communicationMessagePageHrefs = [
     adminPages.CommunicationInbox.href,
     adminPages.CommunicationEmails.href,
     adminPages.Notifications.href,
-    adminPages.Surveys.href,
     adminPages.Feedback.href,
 ] as const;
 


### PR DESCRIPTION
## Summary

- render **Ankete** directly in the **Komunikacija** section so it is visible without expanding **Poruke**
- keep automatic **Poruke** expansion scoped to inbox, email, notification, and feedback routes
- add regression coverage proving survey response/statistics routes remain outside the collapsed message group

## Root cause

The survey workspace existed, but its navigation item was nested inside `Poruke`, whose default state is collapsed. This made surveys appear absent from the sidebar until an admin manually expanded the group.

## Validation

- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm --filter app test:unit` — 158/158 passed
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm --filter app exec biome check components/admin/navigation/Nav.tsx components/admin/navigation/adminPages.ts app/admin/surveys/surveyWorkspaceQuery.unit.ts`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm --filter app build`
- `git diff --check`

Closes #4334