### PR TITLE
fix(app): stop survey workspace page crashes

### DIFF
--- a/apps/app/app/admin/surveys/SurveyAdminWorkspace.tsx
+++ b/apps/app/app/admin/surveys/SurveyAdminWorkspace.tsx
@@ -15,7 +15,10 @@ import {
     type SurveyAnalyticsSearchParams,
     SurveyStatisticsWorkspace,
 } from './SurveyStatisticsWorkspace';
-import type { SurveyWorkspaceSearchParams } from './surveyWorkspaceQuery';
+import {
+    firstSurveyQueryParam,
+    type SurveyWorkspaceSearchParams,
+} from './surveyWorkspaceQuery';
 import type { SurveyWorkspaceView } from './surveyWorkspaceTypes';
 
 export type { SurveyWorkspaceView } from './surveyWorkspaceTypes';

--- a/apps/app/app/admin/surveys/SurveyResponsePagination.tsx
+++ b/apps/app/app/admin/surveys/SurveyResponsePagination.tsx
@@ -4,6 +4,7 @@ import { KnownPages } from '../../../src/KnownPages';
 import {
     type SurveyResponseQuery,
     surveyResponseHref,
+    surveyResponsePaginationPages,
     surveyResponseQueryForPage,
 } from './surveyResponseQuery';
 
@@ -23,14 +24,24 @@ export function SurveyResponsePagination({
     if (pageCount === 0) return null;
 
     const listPath = KnownPages.SurveyResponses(surveyId);
-    const previousHref = surveyResponseHref(
-        listPath,
-        surveyResponseQueryForPage(query, page - 1),
+    const { nextPage, previousPage } = surveyResponsePaginationPages(
+        page,
+        pageCount,
     );
-    const nextHref = surveyResponseHref(
-        listPath,
-        surveyResponseQueryForPage(query, page + 1),
-    );
+    const previousHref =
+        previousPage === null
+            ? null
+            : surveyResponseHref(
+                  listPath,
+                  surveyResponseQueryForPage(query, previousPage),
+              );
+    const nextHref =
+        nextPage === null
+            ? null
+            : surveyResponseHref(
+                  listPath,
+                  surveyResponseQueryForPage(query, nextPage),
+              );
 
     return (
         <div className="flex flex-col gap-3 border-t px-3 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-4">
@@ -38,22 +49,24 @@ export function SurveyResponsePagination({
                 Stranica {page} od {pageCount} · ukupno {totalCount} odgovora
             </Typography>
             <div className="flex gap-2">
-                <Button
-                    disabled={page <= 1}
-                    href={previousHref}
-                    size="sm"
-                    variant="outlined"
-                >
-                    Prethodna
-                </Button>
-                <Button
-                    disabled={page >= pageCount}
-                    href={nextHref}
-                    size="sm"
-                    variant="outlined"
-                >
-                    Sljedeća
-                </Button>
+                {previousHref === null ? (
+                    <Button disabled size="sm" variant="outlined">
+                        Prethodna
+                    </Button>
+                ) : (
+                    <Button href={previousHref} size="sm" variant="outlined">
+                        Prethodna
+                    </Button>
+                )}
+                {nextHref === null ? (
+                    <Button disabled size="sm" variant="outlined">
+                        Sljedeća
+                    </Button>
+                ) : (
+                    <Button href={nextHref} size="sm" variant="outlined">
+                        Sljedeća
+                    </Button>
+                )}
             </div>
         </div>
     );

--- a/apps/app/app/admin/surveys/surveyResponseQuery.ts
+++ b/apps/app/app/admin/surveys/surveyResponseQuery.ts
@@ -150,3 +150,10 @@ export function surveyResponseQueryForPage(
         page: Number.isSafeInteger(page) && page > 0 ? page : 1,
     };
 }
+
+export function surveyResponsePaginationPages(page: number, pageCount: number) {
+    return {
+        previousPage: pageCount > 0 && page > 1 ? page - 1 : null,
+        nextPage: pageCount > 0 && page < pageCount ? page + 1 : null,
+    };
+}

--- a/apps/app/app/admin/surveys/surveyResponseQuery.unit.ts
+++ b/apps/app/app/admin/surveys/surveyResponseQuery.unit.ts
@@ -1,13 +1,30 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 import {
     canonicalSurveyResponseQuery,
     parseSurveyResponseQuery,
     serializeSurveyResponseQuery,
     surveyResponseHref,
+    surveyResponsePaginationPages,
     surveyResponseQueryForPage,
     toSurveyResponseFilters,
 } from './surveyResponseQuery';
+
+test('response pagination never renders a disabled link button', async () => {
+    const source = await readFile(
+        new URL('./SurveyResponsePagination.tsx', import.meta.url),
+        'utf8',
+    );
+    const buttonTags = source.match(/<Button[\s\S]*?>/g) ?? [];
+
+    assert.equal(
+        buttonTags.some(
+            (tag) => /\bdisabled=/.test(tag) && /\bhref=/.test(tag),
+        ),
+        false,
+    );
+});
 
 test('response query parsing uses first values and rejects invalid inputs', () => {
     assert.deepEqual(
@@ -113,4 +130,27 @@ test('response navigation preserves filters, canonicalizes version, and resets p
         'context=delivery&page=2',
     );
     assert.equal(canonical.page, 3);
+});
+
+test('response pagination covers empty, first, middle, last, and single pages', () => {
+    assert.deepEqual(surveyResponsePaginationPages(1, 0), {
+        previousPage: null,
+        nextPage: null,
+    });
+    assert.deepEqual(surveyResponsePaginationPages(1, 3), {
+        previousPage: null,
+        nextPage: 2,
+    });
+    assert.deepEqual(surveyResponsePaginationPages(2, 3), {
+        previousPage: 1,
+        nextPage: 3,
+    });
+    assert.deepEqual(surveyResponsePaginationPages(3, 3), {
+        previousPage: 2,
+        nextPage: null,
+    });
+    assert.deepEqual(surveyResponsePaginationPages(1, 1), {
+        previousPage: null,
+        nextPage: null,
+    });
 });

--- a/apps/app/app/admin/surveys/surveyWorkspaceQuery.unit.ts
+++ b/apps/app/app/admin/surveys/surveyWorkspaceQuery.unit.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
 import { includesSelectedPath } from '../../../components/admin/navigation/adminNavigationPath';
 import { communicationMessagePageHrefs } from '../../../components/admin/navigation/adminPages';
@@ -34,6 +35,18 @@ const surveys = [
 ];
 
 describe('survey workspace query', () => {
+    it('imports the query helper used by the design workspace at runtime', async () => {
+        const source = await readFile(
+            new URL('./SurveyAdminWorkspace.tsx', import.meta.url),
+            'utf8',
+        );
+        const runtimeImport = source.match(
+            /import\s*\{([^}]*)\}\s*from '\.\/surveyWorkspaceQuery';/,
+        )?.[1];
+
+        assert.match(runtimeImport ?? '', /\bfirstSurveyQueryParam\b/);
+    });
+
     it('uses the first scalar query value and normalizes filters', () => {
         assert.equal(firstSurveyQueryParam([' first ', 'second']), ' first ');
         assert.deepEqual(


### PR DESCRIPTION
## Summary

- restore the runtime import used by survey design query handling
- render disabled response pagination endpoints as native buttons instead of disabled links
- cover empty, first, middle, last, and single-page response pagination states
- add regression guards for both observed React server-component failures

## Production evidence and root cause

Vercel runtime logs showed two independent failures on the survey workspace:

- **Dizajn:** `ReferenceError: firstSurveyQueryParam is not defined` because `SurveyAdminWorkspace` called the helper without a runtime import.
- **Odgovori:** `Event handlers cannot be passed to Client Component props` because a server-rendered `Button` combined `disabled` and `href`, causing its link path to create an `onClick` handler across the server/client boundary.

## Validation

- focused regression tests: 13/13 passed (both tests failed before the fix)
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm --filter app test:unit` — 161/161 passed
- scoped Biome check — passed
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm --filter app build` — passed
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm typecheck --filter app` — configured package graph passed
- `git diff --check` — passed

A direct whole-app `tsc --noEmit` remains red on pre-existing errors outside the touched survey files; it reports no errors in this change.

Closes #4336