### PR TITLE
[Game] Adapt High quality to runtime load

### DIFF
--- a/apps/garden/app/debug/profile/game/page.tsx
+++ b/apps/garden/app/debug/profile/game/page.tsx
@@ -259,7 +259,9 @@ export default async function GameProfilePage({
     const placementProfile = firstValue(params.placement) === '1';
     const debugGameFlags = resolveGameProfileFlags(
         firstValue(params.blockGeometryMerging),
+        firstValue(params.adaptiveHigh),
     );
+    const adaptiveHigh = debugGameFlags.enableAdaptiveHighQualityFlag;
     const blockGeometryMerging = debugGameFlags.enableBlockGeometryMergingFlag;
     const isOperationRewardDebug =
         isOperationVisualRewardDebugProfile(mockGardenProfile);
@@ -277,6 +279,7 @@ export default async function GameProfilePage({
             data-game-profile-hud={showHud ? '1' : '0'}
             data-game-profile-garden-profile={mockGardenProfile}
             data-game-profile-quality={quality ?? 'auto'}
+            data-game-profile-adaptive-high={adaptiveHigh ? '1' : '0'}
             data-game-profile-block-geometry-merging={
                 blockGeometryMerging ? '1' : '0'
             }
@@ -295,7 +298,9 @@ export default async function GameProfilePage({
                 hideHud={!showHud}
                 initialQualitySetting={quality}
                 enableGameProfileController={
-                    closeupRaisedBedId !== null || placementProfile
+                    adaptiveHigh ||
+                    closeupRaisedBedId !== null ||
+                    placementProfile
                 }
                 mockGarden
                 mockGardenProfile={mockGardenProfile}

--- a/apps/garden/app/debug/profile/game/profileFlags.ts
+++ b/apps/garden/app/debug/profile/game/profileFlags.ts
@@ -6,10 +6,17 @@ export function resolveGameProfileBlockGeometryMerging(
     return value === '1';
 }
 
+export function resolveGameProfileAdaptiveHigh(value: string | undefined) {
+    return value === '1';
+}
+
 export function resolveGameProfileFlags(
     blockGeometryMerging: string | undefined,
+    adaptiveHigh: string | undefined,
 ) {
     return {
+        enableAdaptiveHighQualityFlag:
+            resolveGameProfileAdaptiveHigh(adaptiveHigh),
         enableBlockGeometryMergingFlag:
             resolveGameProfileBlockGeometryMerging(blockGeometryMerging),
         enableDebugHudFlag: true,

--- a/apps/garden/app/debug/profile/game/profileFlags.unit.ts
+++ b/apps/garden/app/debug/profile/game/profileFlags.unit.ts
@@ -1,9 +1,19 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+    resolveGameProfileAdaptiveHigh,
     resolveGameProfileBlockGeometryMerging,
     resolveGameProfileFlags,
 } from './profileFlags.ts';
+
+describe('resolveGameProfileAdaptiveHigh', () => {
+    it('keeps adaptive High opt-in', () => {
+        assert.equal(resolveGameProfileAdaptiveHigh(undefined), false);
+        assert.equal(resolveGameProfileAdaptiveHigh('0'), false);
+        assert.equal(resolveGameProfileAdaptiveHigh('unexpected'), false);
+        assert.equal(resolveGameProfileAdaptiveHigh('1'), true);
+    });
+});
 
 describe('resolveGameProfileBlockGeometryMerging', () => {
     it('preserves the existing profiler default', () => {
@@ -21,13 +31,15 @@ describe('resolveGameProfileBlockGeometryMerging', () => {
 });
 
 describe('resolveGameProfileFlags', () => {
-    it('preserves debug and rain flags while controlling geometry merging', () => {
-        assert.deepEqual(resolveGameProfileFlags(undefined), {
+    it('preserves debug and rain flags while controlling profiler opt-ins', () => {
+        assert.deepEqual(resolveGameProfileFlags(undefined, undefined), {
+            enableAdaptiveHighQualityFlag: false,
             enableBlockGeometryMergingFlag: false,
             enableDebugHudFlag: true,
             enableRainWetOverlayFlag: true,
         });
-        assert.deepEqual(resolveGameProfileFlags('0'), {
+        assert.deepEqual(resolveGameProfileFlags('0', '1'), {
+            enableAdaptiveHighQualityFlag: true,
             enableBlockGeometryMergingFlag: false,
             enableDebugHudFlag: true,
             enableRainWetOverlayFlag: true,

--- a/apps/garden/app/flags.ts
+++ b/apps/garden/app/flags.ts
@@ -31,6 +31,14 @@ export const blockGeometryMergingFlag = flag<boolean>({
     options: booleanFlagOptions,
 });
 
+export const adaptiveHighQualityFlag = flag<boolean>({
+    key: 'adaptiveHighQuality',
+    description:
+        'Adapt the runtime ceiling of manually selected High game quality.',
+    decide: () => true,
+    options: booleanFlagOptions,
+});
+
 export const enableDebugCloseupFlag = flag<boolean>({
     key: 'enableDebugCloseup',
     decide: () => false,

--- a/apps/garden/app/page.tsx
+++ b/apps/garden/app/page.tsx
@@ -5,6 +5,7 @@ import type { ComponentProps } from 'react';
 import LoginModal from '../components/auth/LoginModal';
 import { GameSceneWithAnalytics } from '../components/game/GameSceneWithAnalytics';
 import {
+    adaptiveHighQualityFlag,
     blockGeometryMergingFlag,
     enableDebugHudFlag,
     enableSuncokretChatFlag,
@@ -30,6 +31,7 @@ export default async function Home() {
     const suppressOpeningHud =
         cookieStore.get(impersonationFlagCookieName)?.value === '1';
     const flags: ComponentProps<typeof GameSceneWithAnalytics>['flags'] = {
+        enableAdaptiveHighQualityFlag: await adaptiveHighQualityFlag(),
         enableBlockGeometryMergingFlag: await blockGeometryMergingFlag(),
         enableDebugHudFlag: await enableDebugHudFlag(),
         enableRainWetOverlayFlag: await rainWetOverlayFlag(),

--- a/apps/garden/scripts/profile-game-scene.mjs
+++ b/apps/garden/scripts/profile-game-scene.mjs
@@ -14,6 +14,8 @@ const gameProfileCloseupCommandEventName =
     'gredice:game-profile-closeup-command';
 const gameProfilePlacementCommandEventName =
     'gredice:game-profile-placement-command';
+const adaptiveHighQualityProfileControlEventName =
+    'gredice:adaptive-high-profile-control';
 const highTargetExpectedGeneratedPlantFieldCount = 54;
 const highTargetExpectedGeneratedPlantInstanceCount = 537;
 
@@ -199,6 +201,109 @@ const highTargetScenarios = [
     {
         name: 'game-high-target-snow-desktop',
         path: '/debug/profile/game?mode=snow&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        repeat: 3,
+    },
+];
+
+const adaptiveHighScenarios = [
+    {
+        name: 'game-high-target-adaptive-pair-fixed-camera-motion-desktop',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        comparisonPair: 'adaptive-camera-motion',
+        comparisonRole: 'fixed',
+        motion: 'pan-zoom-rotate',
+        repeat: 3,
+    },
+    {
+        name: 'game-high-target-adaptive-camera-motion-desktop',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&adaptiveHigh=1',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        comparisonPair: 'adaptive-camera-motion',
+        comparisonRole: 'adaptive',
+        motion: 'pan-zoom-rotate',
+        profileControl: true,
+        repeat: 3,
+    },
+    {
+        name: 'game-high-target-adaptive-motion-recovery-desktop',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&adaptiveHigh=1',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        motion: 'pan-zoom-rotate-then-idle',
+        motionMs: 650,
+        profileControl: true,
+        profileControlRecovery: true,
+        sampleMs: 7_500,
+        repeat: 3,
+    },
+    {
+        name: 'game-high-target-adaptive-runtime-gpu-source-desktop',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&adaptiveHigh=1',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        externalGpuTimer: false,
+        runtimeGpuSource: true,
+        repeat: 3,
+    },
+    {
+        name: 'game-high-target-adaptive-placement-desktop',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&placement=1&adaptiveHigh=1',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        placementProfile: {
+            action: 'run',
+            staggerMs: 120,
+        },
+        profileControl: true,
+        repeat: 3,
+    },
+    {
+        name: 'game-high-target-adaptive-rain-desktop',
+        path: '/debug/profile/game?mode=rain&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&adaptiveHigh=1',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        repeat: 3,
+    },
+    {
+        name: 'game-high-target-adaptive-snow-desktop',
+        path: '/debug/profile/game?mode=snow&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&adaptiveHigh=1',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        repeat: 3,
+    },
+    {
+        name: 'game-high-target-adaptive-cloudy-desktop',
+        path: '/debug/profile/game?mode=cloudy&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&adaptiveHigh=1',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        repeat: 3,
+    },
+    {
+        name: 'game-high-target-adaptive-windy-plants-desktop',
+        path: '/debug/profile/game?mode=windy&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&adaptiveHigh=1',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -460,6 +565,7 @@ const weatherTransitionScenarios = [
 ];
 
 const scenarioSets = {
+    'adaptive-high': adaptiveHighScenarios,
     'auto-quality': autoQualityScenarios,
     core: coreScenarios,
     dense: denseScenarios,
@@ -741,7 +847,7 @@ function printHelp(options) {
             '  --warmup-ms <ms>       Warmup wait after canvas appears. Default: 5000',
             '  --soak-ms <ms>         Run the scene before sampling. Default: 0',
             '  --sample-ms <ms>       requestAnimationFrame sample window. Default: 5000',
-            `  --scenario-set <set>    core, dense, dense-mobile, high-target, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or comma-separated names. Current: ${options.scenarioSet}`,
+            `  --scenario-set <set>    core, dense, dense-mobile, high-target, adaptive-high, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or comma-separated names. Current: ${options.scenarioSet}`,
             '  --scenario <name>       Profile exact scenario name(s). Repeat or use commas.',
             '  --screenshots           Save a PNG screenshot for each scenario.',
             '  --fail-on-budget       Exit non-zero when a budget check fails.',
@@ -763,6 +869,7 @@ function printHelp(options) {
 
 function allScenarios() {
     return [
+        ...adaptiveHighScenarios,
         ...coreScenarios,
         ...denseScenarios,
         ...denseMobileScenarios,
@@ -799,7 +906,7 @@ function resolveScenarios(scenarioSet, scenarioNames = []) {
 
         if (!candidates.length) {
             throw new Error(
-                `Unknown scenario set or scenario: ${token}. Use core, dense, dense-mobile, high-target, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or one of: ${knownScenarios.map((scenario) => scenario.name).join(', ')}.`,
+                `Unknown scenario set or scenario: ${token}. Use core, dense, dense-mobile, high-target, adaptive-high, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or one of: ${knownScenarios.map((scenario) => scenario.name).join(', ')}.`,
             );
         }
 
@@ -817,6 +924,7 @@ function resolveScenarios(scenarioSet, scenarioNames = []) {
 function getScenarioRequest(path) {
     const url = new URL(path, 'http://profile.local');
     return {
+        adaptiveHigh: url.searchParams.get('adaptiveHigh') ?? '0',
         blockGeometryMerging:
             url.searchParams.get('blockGeometryMerging') ?? 'default',
         controls: url.searchParams.get('controls') ?? '0',
@@ -848,7 +956,7 @@ function installNavigatorMetrics({ deviceMemory, hardwareConcurrency }) {
     });
 }
 
-function installBrowserMetrics() {
+function installBrowserMetrics({ externalGpuTimer = true } = {}) {
     if (globalThis.__gameProfileMetrics) {
         return;
     }
@@ -957,6 +1065,16 @@ function installBrowserMetrics() {
         if (gpuTimer.disjoint) {
             return;
         }
+        if (
+            gl.getQuery(
+                gpuTimer.extension.TIME_ELAPSED_EXT,
+                gl.CURRENT_QUERY,
+            ) !== null
+        ) {
+            gpuTimer.reason =
+                'Another GPU elapsed-time query is currently active';
+            return;
+        }
         const query = gl.createQuery();
         if (!query) {
             gpuTimer.supported = false;
@@ -975,7 +1093,7 @@ function installBrowserMetrics() {
         gpuTimer.recording = false;
         endGpuQuery();
     };
-    globalThis.__gameProfileGpuTimer = {
+    const externalGpuTimerController = {
         async finish() {
             stopGpuTimer();
             const generation = gpuTimer.generation;
@@ -1058,6 +1176,9 @@ function installBrowserMetrics() {
         },
         stop: stopGpuTimer,
     };
+    if (externalGpuTimer) {
+        globalThis.__gameProfileGpuTimer = externalGpuTimerController;
+    }
     const trackRafTick = () => {
         rafTick += 1;
         pollGpuQueries();
@@ -1347,9 +1468,47 @@ async function wait(milliseconds) {
     await new Promise((resolveWait) => setTimeout(resolveWait, milliseconds));
 }
 
+async function startAdaptiveHighProfileControl(page) {
+    const dispatched = await page.evaluate(
+        (eventName) =>
+            globalThis.dispatchEvent(
+                new CustomEvent(eventName, {
+                    detail: { action: 'start' },
+                }),
+            ),
+        adaptiveHighQualityProfileControlEventName,
+    );
+    await page.waitForFunction(
+        () => {
+            const profile = globalThis.__grediceGameProfile;
+            const canvas = document.querySelector('canvas');
+            const effectiveDpr =
+                canvas instanceof HTMLCanvasElement &&
+                canvas.clientWidth > 0 &&
+                canvas.clientHeight > 0
+                    ? Math.min(
+                          canvas.width / canvas.clientWidth,
+                          canvas.height / canvas.clientHeight,
+                      )
+                    : null;
+            return (
+                profile?.adaptiveHighProfileControlActive === true &&
+                profile.adaptiveHighLevel === 0 &&
+                profile.adaptiveHighDprCap === 2 &&
+                effectiveDpr !== null &&
+                Math.abs(effectiveDpr - 2) <= 0.01
+            );
+        },
+        undefined,
+        { timeout: 10_000 },
+    );
+    return dispatched;
+}
+
 async function runScenarioMotion(page, scenario, sampleMs) {
     if (
         scenario.motion !== 'pan-zoom-rotate' &&
+        scenario.motion !== 'pan-zoom-rotate-then-idle' &&
         scenario.interaction !== 'hover-scan'
     ) {
         await wait(sampleMs);
@@ -1395,8 +1554,12 @@ async function runScenarioMotion(page, scenario, sampleMs) {
     }
 
     let direction = 1;
+    const motionMs =
+        scenario.motion === 'pan-zoom-rotate-then-idle'
+            ? Math.min(sampleMs, scenario.motionMs ?? 650)
+            : sampleMs;
 
-    while (Date.now() - startedAt < sampleMs - 120) {
+    while (Date.now() - startedAt < motionMs - 120) {
         const panKey = direction > 0 ? 'ArrowLeft' : 'ArrowRight';
         await page.keyboard.down(panKey);
         await wait(120);
@@ -1826,7 +1989,9 @@ async function measureScenario(browser, baseUrl, scenario, options) {
             scenario.navigatorMetrics,
         );
     }
-    await page.addInitScript(installBrowserMetrics);
+    await page.addInitScript(installBrowserMetrics, {
+        externalGpuTimer: scenario.externalGpuTimer !== false,
+    });
 
     page.on('console', (message) => {
         if (message.type() === 'error' || message.type() === 'warning') {
@@ -1914,6 +2079,9 @@ async function measureScenario(browser, baseUrl, scenario, options) {
     if (options.soakMs > 0) {
         await wait(options.soakMs);
     }
+    const adaptiveHighProfileControlStarted = scenario.profileControl
+        ? await startAdaptiveHighProfileControl(page)
+        : false;
     const profileMetadata = await page.evaluate(() => {
         const element = document.querySelector('[data-game-profile-mode]');
         if (!(element instanceof HTMLElement)) {
@@ -1922,6 +2090,7 @@ async function measureScenario(browser, baseUrl, scenario, options) {
         const deviceMemory = Reflect.get(window.navigator, 'deviceMemory');
 
         return {
+            adaptiveHigh: element.dataset.gameProfileAdaptiveHigh ?? null,
             autoQualityMetrics: {
                 coarsePointer:
                     typeof window.matchMedia === 'function' &&
@@ -1996,6 +2165,8 @@ async function measureScenario(browser, baseUrl, scenario, options) {
             pageErrors,
             path: scenario.path,
             requested: {
+                adaptiveHigh:
+                    profileMetadata?.adaptiveHigh ?? request.adaptiveHigh,
                 autoQualityDeviceClass:
                     scenario.autoQualityDeviceClass ?? 'unspecified',
                 autoQualityMetrics: profileMetadata?.autoQualityMetrics ?? null,
@@ -2034,11 +2205,15 @@ async function measureScenario(browser, baseUrl, scenario, options) {
         beforeMetrics.metrics.map((metric) => [metric.name, metric.value]),
     );
 
+    const sampleMs = scenario.sampleMs ?? options.sampleMs;
     const weatherTransitionRequest = scenario.weatherTransition ?? null;
     const placementProfileRequest = scenario.placementProfile ?? null;
     const samplePromise = page.evaluate(
         async (sampleOptions) => {
             const {
+                adaptiveHighProfileControlEventName,
+                adaptiveHighProfileControlRecovery,
+                adaptiveHighProfileControlStarted,
                 placementProfileEventName,
                 placementProfileRequest,
                 sampleMs,
@@ -2060,6 +2235,88 @@ async function measureScenario(browser, baseUrl, scenario, options) {
             const intervals = [];
             const start = performance.now();
             let last = start;
+            let adaptiveHighDprCapMin = null;
+            let adaptiveHighGpuSourceObserved = false;
+            let adaptiveHighInteractionObserved = false;
+            let adaptiveHighLevelMax = null;
+            let adaptiveHighProfileControlObserved = false;
+            let effectiveDprMin = null;
+            const readProfileNumber = (field) => {
+                const value = globalThis.__grediceGameProfile?.[field];
+                return typeof value === 'number' ? value : null;
+            };
+            const readEffectiveDpr = () => {
+                if (
+                    !canvas ||
+                    canvas.clientWidth <= 0 ||
+                    canvas.clientHeight <= 0
+                ) {
+                    return null;
+                }
+                return Math.min(
+                    canvas.width / canvas.clientWidth,
+                    canvas.height / canvas.clientHeight,
+                );
+            };
+            const recordEffectiveDpr = () => {
+                const effectiveDpr = readEffectiveDpr();
+                if (effectiveDpr === null) {
+                    return;
+                }
+                effectiveDprMin =
+                    effectiveDprMin === null
+                        ? effectiveDpr
+                        : Math.min(effectiveDprMin, effectiveDpr);
+            };
+            const recordAdaptiveHighState = () => {
+                const profile = globalThis.__grediceGameProfile;
+                const dprCap =
+                    typeof profile?.adaptiveHighDprCap === 'number'
+                        ? profile.adaptiveHighDprCap
+                        : null;
+                const level =
+                    typeof profile?.adaptiveHighLevel === 'number'
+                        ? profile.adaptiveHighLevel
+                        : null;
+                if (dprCap !== null) {
+                    adaptiveHighDprCapMin =
+                        adaptiveHighDprCapMin === null
+                            ? dprCap
+                            : Math.min(adaptiveHighDprCapMin, dprCap);
+                }
+                if (level !== null) {
+                    adaptiveHighLevelMax =
+                        adaptiveHighLevelMax === null
+                            ? level
+                            : Math.max(adaptiveHighLevelMax, level);
+                }
+                adaptiveHighInteractionObserved ||=
+                    profile?.adaptiveHighInteractionActive === true;
+                adaptiveHighGpuSourceObserved ||=
+                    profile?.adaptiveHighSampleSource === 'gpu';
+                adaptiveHighProfileControlObserved ||=
+                    profile?.adaptiveHighProfileControlActive === true;
+            };
+            recordEffectiveDpr();
+            recordAdaptiveHighState();
+            const adaptiveHighDeclineCountAtStart = readProfileNumber(
+                'adaptiveHighDeclineCount',
+            );
+            const adaptiveHighDprCapAtStart =
+                readProfileNumber('adaptiveHighDprCap');
+            const adaptiveHighLevelAtStart =
+                readProfileNumber('adaptiveHighLevel');
+            const adaptiveHighRecoveryCountAtStart = readProfileNumber(
+                'adaptiveHighRecoveryCount',
+            );
+            const adaptiveHighProfileControlSampleCountAtStart =
+                readProfileNumber('adaptiveHighProfileControlSampleCount');
+            const adaptiveHighTransitionCountAtStart = readProfileNumber(
+                'adaptiveHighTransitionCount',
+            );
+            const cloudAttenuationUpdateCountAtStart = readProfileNumber(
+                'cloudAttenuationUpdateCount',
+            );
             const interactionResolvedTargetCountAtStart =
                 typeof globalThis.__grediceGameProfile
                     ?.instancedInteractionResolvedTargetCount === 'number'
@@ -2116,10 +2373,13 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                   )
                 : false;
 
-            await new Promise((resolveSample) => {
+            let profileRecoveryFinished = !adaptiveHighProfileControlRecovery;
+            const sampleWindowPromise = new Promise((resolveSample) => {
                 const step = (now) => {
                     intervals.push(now - last);
                     last = now;
+                    recordAdaptiveHighState();
+                    recordEffectiveDpr();
                     const rainParticleCount =
                         globalThis.__grediceGameProfile?.rainParticleCount;
                     if (
@@ -2129,7 +2389,7 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                     ) {
                         rainUnmountMs = now - start;
                     }
-                    if (now - start >= sampleMs) {
+                    if (now - start >= sampleMs && profileRecoveryFinished) {
                         resolveSample();
                         return;
                     }
@@ -2137,6 +2397,86 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 };
                 requestAnimationFrame(step);
             });
+            const profileRecoveryPromise = adaptiveHighProfileControlRecovery
+                ? (async () => {
+                      const waitForControl = (milliseconds) =>
+                          new Promise((resolveControlWait) =>
+                              setTimeout(resolveControlWait, milliseconds),
+                          );
+                      const interactionDeadline =
+                          performance.now() + Math.max(sampleMs * 2, 15_000);
+                      const interactionQuietMs = 750;
+                      let interactionIdleSinceMs = null;
+                      while (true) {
+                          const profile = globalThis.__grediceGameProfile;
+                          const declined =
+                              (profile?.adaptiveHighLevel ?? 0) >= 1 &&
+                              (profile?.adaptiveHighDeclineCount ?? 0) >= 1;
+                          if (
+                              declined &&
+                              profile?.adaptiveHighInteractionActive === false
+                          ) {
+                              interactionIdleSinceMs ??= performance.now();
+                              if (
+                                  performance.now() - interactionIdleSinceMs >=
+                                  interactionQuietMs
+                              ) {
+                                  break;
+                              }
+                          } else {
+                              interactionIdleSinceMs = null;
+                          }
+                          if (performance.now() >= interactionDeadline) {
+                              return;
+                          }
+                          await waitForControl(25);
+                      }
+
+                      const controlledSampleCount = 22;
+                      const controlledSampleIntervalMs = 250;
+                      const controlledStartedAt = performance.now();
+                      for (
+                          let sampleIndex = 0;
+                          sampleIndex < controlledSampleCount;
+                          sampleIndex += 1
+                      ) {
+                          globalThis.dispatchEvent(
+                              new CustomEvent(
+                                  adaptiveHighProfileControlEventName,
+                                  {
+                                      detail: {
+                                          action: 'sample',
+                                          normalizedLoad: 0.7,
+                                          source: 'frame',
+                                      },
+                                  },
+                              ),
+                          );
+                          const nextSampleAt =
+                              controlledStartedAt +
+                              (sampleIndex + 1) * controlledSampleIntervalMs;
+                          const remainingMs = nextSampleAt - performance.now();
+                          if (remainingMs > 0) {
+                              await waitForControl(remainingMs);
+                          }
+                      }
+                      if (typeof adaptiveHighDprCapAtStart === 'number') {
+                          const canvasDeadline = performance.now() + 5_000;
+                          while (
+                              Math.abs(
+                                  (readEffectiveDpr() ?? 0) -
+                                      adaptiveHighDprCapAtStart,
+                              ) > 0.01 &&
+                              performance.now() < canvasDeadline
+                          ) {
+                              await waitForControl(25);
+                          }
+                      }
+                  })().finally(() => {
+                      profileRecoveryFinished = true;
+                  })
+                : Promise.resolve();
+            await Promise.all([sampleWindowPromise, profileRecoveryPromise]);
 
             const sampleEndedAt = performance.now();
             const frameIntervals = intervals.slice(1);
@@ -2196,7 +2536,67 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                     ?.placementShadowFlushCount === 'number'
                     ? globalThis.__grediceGameProfile.placementShadowFlushCount
                     : null;
+            recordAdaptiveHighState();
+            const adaptiveHighDeclineCountAtEnd = readProfileNumber(
+                'adaptiveHighDeclineCount',
+            );
+            const adaptiveHighDprCapAtEnd =
+                readProfileNumber('adaptiveHighDprCap');
+            const adaptiveHighLevelAtEnd =
+                readProfileNumber('adaptiveHighLevel');
+            const adaptiveHighRecoveryCountAtEnd = readProfileNumber(
+                'adaptiveHighRecoveryCount',
+            );
+            const adaptiveHighProfileControlSampleCountAtEnd =
+                readProfileNumber('adaptiveHighProfileControlSampleCount');
+            const adaptiveHighTransitionCountAtEnd = readProfileNumber(
+                'adaptiveHighTransitionCount',
+            );
+            const cloudAttenuationUpdateCountAtEnd = readProfileNumber(
+                'cloudAttenuationUpdateCount',
+            );
             const nonGpuSample = {
+                adaptiveHighDeclineCountDelta:
+                    adaptiveHighDeclineCountAtStart === null ||
+                    adaptiveHighDeclineCountAtEnd === null
+                        ? null
+                        : adaptiveHighDeclineCountAtEnd -
+                          adaptiveHighDeclineCountAtStart,
+                adaptiveHighDeclineObserved:
+                    (adaptiveHighLevelAtStart !== null &&
+                        adaptiveHighLevelMax !== null &&
+                        adaptiveHighLevelMax > adaptiveHighLevelAtStart) ||
+                    (adaptiveHighDprCapAtStart !== null &&
+                        adaptiveHighDprCapMin !== null &&
+                        adaptiveHighDprCapMin < adaptiveHighDprCapAtStart),
+                adaptiveHighDprCapAtEnd,
+                adaptiveHighDprCapAtStart,
+                adaptiveHighDprCapMin,
+                adaptiveHighGpuSourceObserved,
+                adaptiveHighInteractionObserved,
+                adaptiveHighLevelAtEnd,
+                adaptiveHighLevelAtStart,
+                adaptiveHighLevelMax,
+                adaptiveHighRecoveryCountDelta:
+                    adaptiveHighRecoveryCountAtStart === null ||
+                    adaptiveHighRecoveryCountAtEnd === null
+                        ? null
+                        : adaptiveHighRecoveryCountAtEnd -
+                          adaptiveHighRecoveryCountAtStart,
+                adaptiveHighProfileControlObserved,
+                adaptiveHighProfileControlSampleCountDelta:
+                    adaptiveHighProfileControlSampleCountAtStart === null ||
+                    adaptiveHighProfileControlSampleCountAtEnd === null
+                        ? null
+                        : adaptiveHighProfileControlSampleCountAtEnd -
+                          adaptiveHighProfileControlSampleCountAtStart,
+                adaptiveHighProfileControlStarted,
+                adaptiveHighTransitionCountDelta:
+                    adaptiveHighTransitionCountAtStart === null ||
+                    adaptiveHighTransitionCountAtEnd === null
+                        ? null
+                        : adaptiveHighTransitionCountAtEnd -
+                          adaptiveHighTransitionCountAtStart,
                 actorGroundingShadowUpdateCountDelta:
                     actorGroundingShadowUpdateCountAtStart === null ||
                     actorGroundingShadowUpdateCountAtEnd === null
@@ -2224,6 +2624,14 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 drawCallsPerRenderedFrame:
                     renderedFrames > 0 ? drawCalls / safeRenderedFrames : 0,
                 drawCallsPerSecond: drawCalls / safeElapsedSeconds,
+                cloudAttenuationUpdateCountDelta:
+                    cloudAttenuationUpdateCountAtStart === null ||
+                    cloudAttenuationUpdateCountAtEnd === null
+                        ? null
+                        : cloudAttenuationUpdateCountAtEnd -
+                          cloudAttenuationUpdateCountAtStart,
+                effectiveDprAtEnd: readEffectiveDpr(),
+                effectiveDprMin,
                 elapsedMs: elapsedSeconds * 1000,
                 fps: rafFrames / safeElapsedSeconds,
                 frames: rafFrames,
@@ -2297,9 +2705,14 @@ async function measureScenario(browser, baseUrl, scenario, options) {
             };
         },
         {
+            adaptiveHighProfileControlEventName:
+                adaptiveHighQualityProfileControlEventName,
+            adaptiveHighProfileControlRecovery:
+                scenario.profileControlRecovery === true,
+            adaptiveHighProfileControlStarted,
             placementProfileEventName: gameProfilePlacementCommandEventName,
             placementProfileRequest,
-            sampleMs: options.sampleMs,
+            sampleMs,
             weatherTransitionEventName: gameProfileWeatherTransitionEventName,
             weatherTransitionRequest,
         },
@@ -2313,7 +2726,7 @@ async function measureScenario(browser, baseUrl, scenario, options) {
     );
     const motionPromise =
         scenario.motion || scenario.interaction
-            ? runScenarioMotion(page, scenario, options.sampleMs)
+            ? runScenarioMotion(page, scenario, sampleMs)
             : Promise.resolve();
     const [sampleCompletion] = await Promise.all([
         sampleCompletionPromise,
@@ -2332,8 +2745,67 @@ async function measureScenario(browser, baseUrl, scenario, options) {
         if (!metadata || typeof metadata !== 'object') {
             return null;
         }
+        const booleanOrNull = (value) =>
+            typeof value === 'boolean' ? value : null;
+        const numberOrNull = (value) =>
+            typeof value === 'number' ? value : null;
+        const stringOrNull = (value) =>
+            typeof value === 'string' ? value : null;
 
         return {
+            adaptiveHighAmbientFps: numberOrNull(
+                metadata.adaptiveHighAmbientFps,
+            ),
+            adaptiveHighCloudUpdateMs: numberOrNull(
+                metadata.adaptiveHighCloudUpdateMs,
+            ),
+            adaptiveHighDeclineCount: numberOrNull(
+                metadata.adaptiveHighDeclineCount,
+            ),
+            adaptiveHighDprCap: numberOrNull(metadata.adaptiveHighDprCap),
+            adaptiveHighEnabled: booleanOrNull(metadata.adaptiveHighEnabled),
+            adaptiveHighEwmaMs: numberOrNull(metadata.adaptiveHighEwmaMs),
+            adaptiveHighFactor: numberOrNull(metadata.adaptiveHighFactor),
+            adaptiveHighGpuTimerDisjointCount: numberOrNull(
+                metadata.adaptiveHighGpuTimerDisjointCount,
+            ),
+            adaptiveHighGpuTimerPendingCount: numberOrNull(
+                metadata.adaptiveHighGpuTimerPendingCount,
+            ),
+            adaptiveHighGpuTimerSupported: booleanOrNull(
+                metadata.adaptiveHighGpuTimerSupported,
+            ),
+            adaptiveHighInteractionActive: booleanOrNull(
+                metadata.adaptiveHighInteractionActive,
+            ),
+            adaptiveHighLevel: numberOrNull(metadata.adaptiveHighLevel),
+            adaptiveHighLevelDwellMs: numberOrNull(
+                metadata.adaptiveHighLevelDwellMs,
+            ),
+            adaptiveHighLoad: numberOrNull(metadata.adaptiveHighLoad),
+            adaptiveHighOscillationCount: numberOrNull(
+                metadata.adaptiveHighOscillationCount,
+            ),
+            adaptiveHighProfileControlActive: booleanOrNull(
+                metadata.adaptiveHighProfileControlActive,
+            ),
+            adaptiveHighProfileControlEnabled: booleanOrNull(
+                metadata.adaptiveHighProfileControlEnabled,
+            ),
+            adaptiveHighProfileControlSampleCount: numberOrNull(
+                metadata.adaptiveHighProfileControlSampleCount,
+            ),
+            adaptiveHighReason: stringOrNull(metadata.adaptiveHighReason),
+            adaptiveHighRecoveryCount: numberOrNull(
+                metadata.adaptiveHighRecoveryCount,
+            ),
+            adaptiveHighSampleMs: numberOrNull(metadata.adaptiveHighSampleMs),
+            adaptiveHighSampleSource: stringOrNull(
+                metadata.adaptiveHighSampleSource,
+            ),
+            adaptiveHighTransitionCount: numberOrNull(
+                metadata.adaptiveHighTransitionCount,
+            ),
             actorGroundingShadowBatchCount:
                 typeof metadata.actorGroundingShadowBatchCount === 'number'
                     ? metadata.actorGroundingShadowBatchCount
@@ -2658,12 +3130,15 @@ async function measureScenario(browser, baseUrl, scenario, options) {
 
     const roundedSample = roundSample(sample);
     const requested = {
+        adaptiveHigh: profileMetadata?.adaptiveHigh ?? request.adaptiveHigh,
         autoQualityDeviceClass:
             scenario.autoQualityDeviceClass ?? 'unspecified',
         autoQualityMetrics: profileMetadata?.autoQualityMetrics ?? null,
         blockGeometryMerging:
             profileMetadata?.blockGeometryMerging ??
             request.blockGeometryMerging,
+        comparisonPair: scenario.comparisonPair ?? null,
+        comparisonRole: scenario.comparisonRole ?? null,
         controls: profileMetadata?.controls ?? request.controls,
         details: profileMetadata?.details ?? request.details,
         debugHud: profileMetadata?.debugHud ?? request.debugHud,
@@ -2676,7 +3151,11 @@ async function measureScenario(browser, baseUrl, scenario, options) {
         scenarioName: scenario.name,
         placementProfile:
             placementProfileRequest === null ? 'none' : 'placement-drop',
+        profileControl: scenario.profileControl === true,
+        profileControlRecovery: scenario.profileControlRecovery === true,
         quality: profileMetadata?.quality ?? request.quality,
+        runtimeGpuSource: scenario.runtimeGpuSource === true,
+        sampleMs,
         viewport: scenario.viewport,
         weatherTransition: weatherTransitionRequest ?? 'none',
     };
@@ -2759,11 +3238,16 @@ function normalizeRenderWork(sample) {
 function roundSample(sample) {
     return {
         ...sample,
+        adaptiveHighDprCapAtEnd: round(sample.adaptiveHighDprCapAtEnd, 3),
+        adaptiveHighDprCapAtStart: round(sample.adaptiveHighDprCapAtStart, 3),
+        adaptiveHighDprCapMin: round(sample.adaptiveHighDprCapMin, 3),
         averageFrameMs: round(sample.averageFrameMs),
         drawCallsPerFrame: round(sample.drawCallsPerFrame, 1),
         drawCallsPerRafFrame: round(sample.drawCallsPerRafFrame, 1),
         drawCallsPerRenderedFrame: round(sample.drawCallsPerRenderedFrame, 1),
         drawCallsPerSecond: round(sample.drawCallsPerSecond, 1),
+        effectiveDprAtEnd: round(sample.effectiveDprAtEnd, 3),
+        effectiveDprMin: round(sample.effectiveDprMin, 3),
         elapsedMs: round(sample.elapsedMs),
         fps: round(sample.fps, 1),
         gpu: sample.gpu
@@ -2861,21 +3345,115 @@ function evaluateHighTargetAcceptance({
         name,
         pass: typeof actual === 'number' && actual >= limit,
     });
+    const range = (name, actual, minimumValue, maximumValue) => ({
+        actual,
+        comparison: 'range',
+        limit: {
+            maximum: maximumValue,
+            minimum: minimumValue,
+        },
+        name,
+        pass:
+            typeof actual === 'number' &&
+            actual >= minimumValue &&
+            actual <= maximumValue,
+    });
+    const canvasMatchesDpr = (name, actual, clientSize, dpr) => {
+        const expected =
+            typeof clientSize === 'number' && typeof dpr === 'number'
+                ? Math.round(clientSize * dpr)
+                : null;
+        return {
+            actual,
+            comparison: 'within-pixels',
+            limit: expected,
+            name,
+            pass:
+                typeof actual === 'number' &&
+                expected !== null &&
+                Math.abs(actual - expected) <= 2,
+        };
+    };
+    const adaptiveHighRequested = requested.adaptiveHigh === '1';
+    const adaptiveHighInteractionExpected =
+        adaptiveHighRequested &&
+        (requested.motion === 'pan-zoom-rotate' ||
+            requested.motion === 'pan-zoom-rotate-then-idle' ||
+            requested.placementProfile === 'placement-drop');
+    const adaptiveHighRecoveryExpected =
+        adaptiveHighRequested &&
+        requested.motion === 'pan-zoom-rotate-then-idle';
+    const adaptiveHighProfileControlExpected =
+        adaptiveHighRequested && requested.profileControl === true;
+    const adaptiveHighDprCap = adaptiveHighRequested
+        ? (sample.adaptiveHighDprCapAtEnd ?? runtime?.adaptiveHighDprCap)
+        : null;
+    const effectiveDpr = adaptiveHighRequested
+        ? (sample.effectiveDprAtEnd ?? adaptiveHighDprCap)
+        : sample.reportedDpr;
     const minimumRenderedFrames = Math.max(
         1,
         Math.floor((sample.elapsedMs ?? 0) / 1_000),
     );
     const expectedActorGroundingShadowCount =
-        requested.mode === 'rain' || requested.mode === 'snow' ? 4 : 5;
+        requested.mode === 'details' ? 5 : 4;
     const checks = [
         exact('highTargetQualityRequest', requested.quality, 'high'),
         exact('highTargetQualityTier', runtime?.qualityTier, 'high'),
+        exact('highTargetShadowsEnabled', runtime?.shadowsEnabled, true),
+        exact('highTargetShadowMapSize', runtime?.shadowMapSize, 4_096),
+        exact(
+            'highTargetGroundDecorationDensity',
+            runtime?.groundDecorationDensity,
+            1,
+        ),
+        exact(
+            'highTargetGroundDecorationCount',
+            runtime?.groundDecorationCount,
+            requested.mode === 'snow' ? 0 : 596,
+        ),
+        requested.mode === 'snow'
+            ? exact(
+                  'highTargetGroundDecorationVisibleCount',
+                  runtime?.groundDecorationVisibleCount,
+                  null,
+              )
+            : minimum(
+                  'highTargetGroundDecorationVisibleCount',
+                  runtime?.groundDecorationVisibleCount,
+                  500,
+              ),
         exact('highTargetGeometryMerging', requested.blockGeometryMerging, '1'),
-        exact('highTargetReportedDpr', sample.reportedDpr, 2),
         exact('highTargetCanvasClientWidth', sample.canvas?.clientWidth, 1280),
         exact('highTargetCanvasClientHeight', sample.canvas?.clientHeight, 720),
-        exact('highTargetCanvasWidth', sample.canvas?.width, 2560),
-        exact('highTargetCanvasHeight', sample.canvas?.height, 1440),
+        ...(adaptiveHighRequested
+            ? [
+                  range('highTargetEffectiveDpr', effectiveDpr, 1.5, 2),
+                  range(
+                      'highTargetMinimumEffectiveDpr',
+                      sample.effectiveDprMin,
+                      1.5,
+                      2,
+                  ),
+                  range('highTargetAdaptiveDprCap', adaptiveHighDprCap, 1.5, 2),
+                  canvasMatchesDpr(
+                      'highTargetAdaptiveCanvasWidth',
+                      sample.canvas?.width,
+                      sample.canvas?.clientWidth,
+                      adaptiveHighDprCap,
+                  ),
+                  canvasMatchesDpr(
+                      'highTargetAdaptiveCanvasHeight',
+                      sample.canvas?.height,
+                      sample.canvas?.clientHeight,
+                      adaptiveHighDprCap,
+                  ),
+              ]
+            : [
+                  exact('highTargetReportedDpr', sample.reportedDpr, 2),
+                  exact('highTargetCanvasWidth', sample.canvas?.width, 2560),
+                  exact('highTargetCanvasHeight', sample.canvas?.height, 1440),
+              ]),
         exact(
             'highTargetGeneratedPlantFields',
             runtime?.generatedPlantFieldCount,
@@ -2952,6 +3530,156 @@ function evaluateHighTargetAcceptance({
         exact('highTargetApiErrors', apiErrors.length, 0),
         exact('highTargetPageErrors', pageErrors.length, 0),
     ];
+    if (adaptiveHighRequested) {
+        checks.push(
+            exact(
+                'highTargetAdaptiveHighEnabled',
+                runtime?.adaptiveHighEnabled,
+                true,
+            ),
+            exact(
+                'highTargetAdaptiveAtmosphereEnabled',
+                runtime?.weatherDisabled,
+                false,
+            ),
+        );
+        if (adaptiveHighProfileControlExpected) {
+            checks.push(
+                exact(
+                    'highTargetAdaptiveProfileControlEnabled',
+                    runtime?.adaptiveHighProfileControlEnabled,
+                    true,
+                ),
+                exact(
+                    'highTargetAdaptiveProfileControlActive',
+                    runtime?.adaptiveHighProfileControlActive,
+                    true,
+                ),
+                exact(
+                    'highTargetAdaptiveProfileControlStarted',
+                    sample.adaptiveHighProfileControlStarted,
+                    true,
+                ),
+                exact(
+                    'highTargetAdaptiveProfileControlObserved',
+                    sample.adaptiveHighProfileControlObserved,
+                    true,
+                ),
+            );
+        }
+        checks.push(
+            adaptiveHighRecoveryExpected
+                ? range(
+                      'highTargetAdaptiveRecoveryDirectionChanges',
+                      runtime?.adaptiveHighOscillationCount,
+                      1,
+                      1,
+                  )
+                : exact(
+                      'highTargetAdaptiveOscillations',
+                      runtime?.adaptiveHighOscillationCount,
+                      0,
+                  ),
+        );
+        if (adaptiveHighInteractionExpected) {
+            checks.push(
+                exact(
+                    'highTargetAdaptiveLocalDeclineObserved',
+                    sample.adaptiveHighDeclineObserved,
+                    true,
+                ),
+                minimum(
+                    'highTargetAdaptiveTransitionsDuringSample',
+                    sample.adaptiveHighTransitionCountDelta,
+                    1,
+                ),
+                minimum(
+                    'highTargetAdaptiveMaximumLevelDuringSample',
+                    sample.adaptiveHighLevelMax,
+                    1,
+                ),
+                range(
+                    'highTargetAdaptiveMinimumDprCapDuringSample',
+                    sample.adaptiveHighDprCapMin,
+                    1.5,
+                    1.75,
+                ),
+                exact(
+                    'highTargetAdaptiveInteractionObserved',
+                    sample.adaptiveHighInteractionObserved,
+                    true,
+                ),
+            );
+            if (typeof sample.adaptiveHighDeclineCountDelta === 'number') {
+                checks.push(
+                    minimum(
+                        'highTargetAdaptiveDeclinesDuringSample',
+                        sample.adaptiveHighDeclineCountDelta,
+                        1,
+                    ),
+                );
+            }
+        }
+        if (adaptiveHighRecoveryExpected) {
+            checks.push(
+                minimum(
+                    'highTargetAdaptiveRecoveryTransitionsDuringSample',
+                    sample.adaptiveHighTransitionCountDelta,
+                    2,
+                ),
+                exact(
+                    'highTargetAdaptiveRecoveredLevel',
+                    sample.adaptiveHighLevelAtEnd,
+                    0,
+                ),
+                exact(
+                    'highTargetAdaptiveRecoveredDprCap',
+                    adaptiveHighDprCap,
+                    2,
+                ),
+                exact(
+                    'highTargetAdaptiveRecoveredEffectiveDpr',
+                    sample.effectiveDprAtEnd,
+                    2,
+                ),
+            );
+            if (adaptiveHighProfileControlExpected) {
+                checks.push(
+                    minimum(
+                        'highTargetAdaptiveControlledHeadroomSamples',
+                        sample.adaptiveHighProfileControlSampleCountDelta,
+                        21,
+                    ),
+                );
+            }
+            if (typeof sample.adaptiveHighRecoveryCountDelta === 'number') {
+                checks.push(
+                    minimum(
+                        'highTargetAdaptiveRecoveriesDuringSample',
+                        sample.adaptiveHighRecoveryCountDelta,
+                        1,
+                    ),
+                );
+            }
+        }
+        if (
+            requested.runtimeGpuSource === true &&
+            runtime?.adaptiveHighGpuTimerSupported === true
+        ) {
+            checks.push(
+                exact(
+                    'highTargetAdaptiveRuntimeGpuSource',
+                    runtime?.adaptiveHighSampleSource,
+                    'gpu',
+                ),
+                exact(
+                    'highTargetAdaptiveRuntimeGpuSourceObserved',
+                    sample.adaptiveHighGpuSourceObserved,
+                    true,
+                ),
+            );
+        }
+    }
     if (
         requested.scenarioName?.startsWith(
             'game-high-target-clear-idle-desktop',
@@ -3035,12 +3763,51 @@ function evaluateHighTargetAcceptance({
     }
     if (requested.mode === 'rain') {
         checks.push(
-            minimum('highTargetRainParticles', runtime?.rainParticleCount, 1),
+            exact(
+                'highTargetFullQualityRainParticles',
+                runtime?.rainParticleCount,
+                2_000,
+            ),
         );
     }
     if (requested.mode === 'snow') {
         checks.push(
-            minimum('highTargetSnowParticles', runtime?.snowParticleCount, 1),
+            exact(
+                'highTargetFullQualitySnowParticles',
+                runtime?.snowParticleCount,
+                3_500,
+            ),
+            exact(
+                'highTargetFullQualitySnowCapacity',
+                runtime?.snowParticleCapacity,
+                5_000,
+            ),
+        );
+    }
+    if (
+        adaptiveHighRequested &&
+        (requested.mode === 'cloudy' || requested.mode === 'windy')
+    ) {
+        checks.push(
+            exact(
+                'highTargetAdaptiveFullCloudVisuals',
+                runtime?.cloudVisualCount,
+                requested.mode === 'windy' ? 7 : 8,
+            ),
+            minimum(
+                'highTargetAdaptiveCloudMovementUpdates',
+                sample.cloudAttenuationUpdateCountDelta,
+                1,
+            ),
+        );
+    }
+    if (adaptiveHighRequested && requested.mode === 'windy') {
+        checks.push(
+            minimum(
+                'highTargetAdaptivePlantMotionCadence',
+                runtime?.adaptiveHighAmbientFps,
+                20,
+            ),
         );
     }
 
@@ -3140,6 +3907,8 @@ function buildHighTargetMedians(scenarios) {
                     acceptancePass,
                     acceptedRunCount: runs.length - failedAcceptanceRuns.length,
                     budgetName,
+                    comparisonPair: runs[0]?.requested?.comparisonPair ?? null,
+                    comparisonRole: runs[0]?.requested?.comparisonRole ?? null,
                     drawCallsPerRenderedFrame,
                     failedAcceptanceRuns,
                     gpuElapsedP95Ms,
@@ -3164,18 +3933,170 @@ function buildHighTargetMedians(scenarios) {
     );
 }
 
+function buildAdaptiveHighComparisons(highTargetMedians) {
+    const pairedSummaries = Object.entries(highTargetMedians).filter(
+        ([, summary]) =>
+            typeof summary.comparisonPair === 'string' &&
+            (summary.comparisonRole === 'fixed' ||
+                summary.comparisonRole === 'adaptive'),
+    );
+    const grouped = Map.groupBy(
+        pairedSummaries,
+        ([, summary]) => summary.comparisonPair,
+    );
+    const metricComparison = (fixed, adaptive, metricName) => {
+        const fixedValue = fixed[metricName]?.median ?? null;
+        const adaptiveValue = adaptive[metricName]?.median ?? null;
+        return {
+            adaptive: adaptiveValue,
+            delta:
+                Number.isFinite(fixedValue) && Number.isFinite(adaptiveValue)
+                    ? round(adaptiveValue - fixedValue)
+                    : null,
+            fixed: fixedValue,
+            percentDelta:
+                Number.isFinite(fixedValue) &&
+                fixedValue !== 0 &&
+                Number.isFinite(adaptiveValue)
+                    ? round(
+                          ((adaptiveValue - fixedValue) / fixedValue) * 100,
+                          1,
+                      )
+                    : null,
+        };
+    };
+    const passRate = (summary, passedField) =>
+        summary.runCount > 0
+            ? round((summary[passedField] / summary.runCount) * 100, 1)
+            : null;
+
+    return Object.fromEntries(
+        Array.from(grouped, ([pairName, entries]) => {
+            const fixedEntry = entries.find(
+                ([, summary]) => summary.comparisonRole === 'fixed',
+            );
+            const adaptiveEntry = entries.find(
+                ([, summary]) => summary.comparisonRole === 'adaptive',
+            );
+            if (!fixedEntry || !adaptiveEntry) {
+                return null;
+            }
+            const [fixedName, fixed] = fixedEntry;
+            const [adaptiveName, adaptive] = adaptiveEntry;
+            const gpuElapsedP95Ms = metricComparison(
+                fixed,
+                adaptive,
+                'gpuElapsedP95Ms',
+            );
+            const p95FrameMs = metricComparison(fixed, adaptive, 'p95FrameMs');
+            const renderedFps = metricComparison(
+                fixed,
+                adaptive,
+                'renderedFps',
+            );
+            const maximumRelativeCheck = (name, comparison, multiplier) => ({
+                actual: comparison.adaptive,
+                limit: Number.isFinite(comparison.fixed)
+                    ? round(comparison.fixed * multiplier)
+                    : null,
+                name,
+                pass:
+                    Number.isFinite(comparison.adaptive) &&
+                    Number.isFinite(comparison.fixed) &&
+                    comparison.adaptive <= comparison.fixed * multiplier,
+                skipped: false,
+            });
+            const minimumRelativeCheck = (name, comparison, multiplier) => ({
+                actual: comparison.adaptive,
+                limit: Number.isFinite(comparison.fixed)
+                    ? round(comparison.fixed * multiplier)
+                    : null,
+                name,
+                pass:
+                    Number.isFinite(comparison.adaptive) &&
+                    Number.isFinite(comparison.fixed) &&
+                    comparison.adaptive >= comparison.fixed * multiplier,
+                skipped: false,
+            });
+            const gpuTimerAvailable =
+                Number.isFinite(gpuElapsedP95Ms.fixed) &&
+                Number.isFinite(gpuElapsedP95Ms.adaptive);
+            const relativePerformanceChecks = [
+                maximumRelativeCheck('adaptiveP95Regression', p95FrameMs, 1.15),
+                minimumRelativeCheck(
+                    'adaptiveRenderedFpsRegression',
+                    renderedFps,
+                    0.9,
+                ),
+                gpuTimerAvailable
+                    ? maximumRelativeCheck(
+                          'adaptiveGpuP95Regression',
+                          gpuElapsedP95Ms,
+                          1.1,
+                      )
+                    : {
+                          actual: gpuElapsedP95Ms.adaptive,
+                          limit: null,
+                          name: 'adaptiveGpuP95Regression',
+                          pass: true,
+                          skipped: true,
+                      },
+            ];
+            const relativePerformancePass = relativePerformanceChecks.every(
+                (check) => check.pass,
+            );
+
+            return [
+                pairName,
+                {
+                    acceptancePassRate: {
+                        adaptive: passRate(adaptive, 'acceptedRunCount'),
+                        fixed: passRate(fixed, 'acceptedRunCount'),
+                    },
+                    adaptiveName,
+                    aggregatePass: {
+                        adaptive: adaptive.pass && relativePerformancePass,
+                        fixed: fixed.pass,
+                    },
+                    fixedName,
+                    gpuElapsedP95Ms,
+                    p95FrameMs,
+                    performancePassRate: {
+                        adaptive: passRate(
+                            adaptive,
+                            'performancePassedRunCount',
+                        ),
+                        fixed: passRate(fixed, 'performancePassedRunCount'),
+                    },
+                    relativePerformanceChecks,
+                    relativePerformancePass,
+                    renderedFps,
+                },
+            ];
+        }).filter(Boolean),
+    );
+}
+
 function buildProfileSummary(scenarios, highTargetMedians) {
     const nonHighTargetScenarios = scenarios.filter(
         (scenario) => scenario.requested?.gardenProfile !== 'high-target',
     );
     const highTargetResults = Object.entries(highTargetMedians);
+    const comparativeFailureNames = Object.values(
+        buildAdaptiveHighComparisons(highTargetMedians),
+    )
+        .filter((comparison) => !comparison.relativePerformancePass)
+        .map((comparison) => comparison.adaptiveName);
     const failedScenarioNames = [
-        ...nonHighTargetScenarios
-            .filter((scenario) => !scenario.budget.pass)
-            .map((scenario) => scenario.name),
-        ...highTargetResults
-            .filter(([, result]) => !result.pass)
-            .map(([name]) => name),
+        ...new Set([
+            ...nonHighTargetScenarios
+                .filter((scenario) => !scenario.budget.pass)
+                .map((scenario) => scenario.name),
+            ...highTargetResults
+                .filter(([, result]) => !result.pass)
+                .map(([name]) => name),
+            ...comparativeFailureNames,
+        ]),
     ];
     const totalScenarios =
         nonHighTargetScenarios.length + highTargetResults.length;
@@ -3925,20 +4846,77 @@ function buildMarkdown(report) {
         }
     }
 
+    const adaptiveHighComparisons = Object.entries(
+        report.adaptiveHighComparisons ??
+            buildAdaptiveHighComparisons(report.highTargetMedians ?? {}),
+    );
+    if (adaptiveHighComparisons.length > 0) {
+        lines.push(
+            '',
+            '## Adaptive High paired comparison',
+            '',
+            '| Pair | Fixed / Adaptive | Acceptance pass rate | Performance pass rate | p95 fixed → adaptive | GPU p95 fixed → adaptive | Rendered FPS fixed → adaptive | Relative gate | Aggregate |',
+            '| --- | --- | ---: | ---: | ---: | ---: | ---: | --- | --- |',
+        );
+        const formatComparison = (comparison, suffix = '') =>
+            `${comparison.fixed ?? 'n/a'} → ${comparison.adaptive ?? 'n/a'}${suffix} (${comparison.percentDelta ?? 'n/a'}%)`;
+        for (const [pairName, comparison] of adaptiveHighComparisons) {
+            lines.push(
+                `| ${pairName} | ${comparison.fixedName} / ${comparison.adaptiveName} | ${comparison.acceptancePassRate.fixed ?? 'n/a'}% → ${comparison.acceptancePassRate.adaptive ?? 'n/a'}% | ${comparison.performancePassRate.fixed ?? 'n/a'}% → ${comparison.performancePassRate.adaptive ?? 'n/a'}% | ${formatComparison(comparison.p95FrameMs, ' ms')} | ${formatComparison(comparison.gpuElapsedP95Ms, ' ms')} | ${formatComparison(comparison.renderedFps)} | ${comparison.relativePerformancePass ? 'pass' : 'fail'} | ${comparison.aggregatePass.fixed ? 'pass' : 'fail'} → ${comparison.aggregatePass.adaptive ? 'pass' : 'fail'} |`,
+            );
+        }
+    }
+
+    const adaptiveHighProfiles = report.scenarios.filter(
+        (scenario) => scenario.requested.adaptiveHigh === '1',
+    );
+    if (adaptiveHighProfiles.length > 0) {
+        lines.push(
+            '',
+            '## Adaptive High governor evidence',
+            '',
+            '| Scenario | Window | Control | Level start/max/end | DPR cap start/min/end | Transitions/declines/recoveries | Interaction | Runtime source | Ambient/cloud cadence | Rain/Snow/Clouds |',
+            '| --- | ---: | --- | ---: | ---: | ---: | --- | --- | ---: | ---: |',
+        );
+        for (const scenario of adaptiveHighProfiles) {
+            const profileControl = scenario.requested.profileControl
+                ? `controlled (${scenario.sample.adaptiveHighProfileControlSampleCountDelta ?? 0} synthetic samples)`
+                : 'native';
+            const runtimeSourceDetail = scenario.requested.profileControl
+                ? 'profile control'
+                : scenario.runtime?.adaptiveHighGpuTimerSupported
+                  ? 'GPU timer'
+                  : 'frame fallback';
+            lines.push(
+                `| ${scenario.name} | ${scenario.requested.sampleMs ?? report.options.sampleMs} ms | ${profileControl} | ${scenario.sample.adaptiveHighLevelAtStart ?? 'n/a'}/${scenario.sample.adaptiveHighLevelMax ?? 'n/a'}/${scenario.sample.adaptiveHighLevelAtEnd ?? 'n/a'} | ${scenario.sample.adaptiveHighDprCapAtStart ?? 'n/a'}/${scenario.sample.adaptiveHighDprCapMin ?? 'n/a'}/${scenario.sample.adaptiveHighDprCapAtEnd ?? 'n/a'} | ${scenario.sample.adaptiveHighTransitionCountDelta ?? 'n/a'}/${scenario.sample.adaptiveHighDeclineCountDelta ?? 'derived'}/${scenario.sample.adaptiveHighRecoveryCountDelta ?? 'derived'} | ${scenario.sample.adaptiveHighInteractionObserved ? 'observed' : 'idle'} | ${scenario.runtime?.adaptiveHighSampleSource ?? 'n/a'} (${runtimeSourceDetail}) | ${scenario.runtime?.adaptiveHighAmbientFps ?? 'n/a'} fps/${scenario.runtime?.adaptiveHighCloudUpdateMs ?? 'n/a'} ms | ${scenario.runtime?.rainParticleCount ?? 0}/${scenario.runtime?.snowParticleCount ?? 0}/${scenario.runtime?.cloudVisualCount ?? 0} |`,
+            );
+        }
+    }
+
     lines.push('', '## High-target Aggregate Failures', '');
-    const highTargetFailures = highTargetMedians.flatMap(([name, summary]) => [
-        ...(summary.acceptancePass
-            ? []
-            : [
-                  `- ${name}: acceptance failed for ${summary.failedAcceptanceRuns.join(', ')}`,
-              ]),
-        ...summary.performanceBudget.checks
-            .filter((check) => !check.pass)
-            .map(
-                (check) =>
-                    `- ${name} median: ${check.name} ${check.actual} > ${check.limit}`,
-            ),
-    ]);
+    const highTargetFailures = [
+        ...highTargetMedians.flatMap(([name, summary]) => [
+            ...(summary.acceptancePass
+                ? []
+                : [
+                      `- ${name}: acceptance failed for ${summary.failedAcceptanceRuns.join(', ')}`,
+                  ]),
+            ...summary.performanceBudget.checks
+                .filter((check) => !check.pass)
+                .map(
+                    (check) =>
+                        `- ${name} median: ${check.name} ${check.actual} > ${check.limit}`,
+                ),
+        ]),
+        ...adaptiveHighComparisons.flatMap(([pairName, comparison]) =>
+            comparison.relativePerformanceChecks
+                .filter((check) => !check.pass && !check.skipped)
+                .map(
+                    (check) =>
+                        `- ${pairName} relative: ${check.name} ${check.actual} missed ${check.limit}`,
+                ),
+        ),
+    ];
     lines.push(
         ...(highTargetFailures.length ? highTargetFailures : ['- None']),
     );
@@ -3948,6 +4926,12 @@ function buildMarkdown(report) {
         scenario.budget.checks
             .filter((check) => !check.pass)
             .map((check) => {
+                if (check.comparison === 'range') {
+                    return `- ${scenario.name}: ${check.name} ${check.actual} outside [${check.limit.minimum}, ${check.limit.maximum}]`;
+                }
+                if (check.comparison === 'within-pixels') {
+                    return `- ${scenario.name}: ${check.name} ${check.actual} not within 2px of ${check.limit}`;
+                }
                 const operator =
                     check.comparison === 'minimum'
                         ? '<'
@@ -4262,6 +5246,8 @@ async function main() {
         }
 
         const highTargetMedians = buildHighTargetMedians(scenarios);
+        const adaptiveHighComparisons =
+            buildAdaptiveHighComparisons(highTargetMedians);
         const profileSummary = buildProfileSummary(
             scenarios,
             highTargetMedians,
@@ -4285,6 +5271,7 @@ async function main() {
                 soakMs: options.soakMs,
                 warmupMs: options.warmupMs,
             },
+            adaptiveHighComparisons,
             scenarios,
             highTargetMedians,
             plantCloseupMedians: buildPlantCloseupMedians(scenarios),
@@ -4313,6 +5300,7 @@ async function main() {
 }
 
 export {
+    buildAdaptiveHighComparisons,
     buildHighTargetMedians,
     buildMarkdown,
     buildPlantCloseupAcceptance,
@@ -4324,6 +5312,7 @@ export {
     finalizeProfileSampleAtEndpoint,
     finishInteractiveProfileSample,
     getScenarioRequest,
+    installBrowserMetrics,
     mergeProfileSampleDrain,
     normalizeRenderWork,
     resolveScenarios,

--- a/apps/garden/scripts/profile-game-scene.unit.mjs
+++ b/apps/garden/scripts/profile-game-scene.unit.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    buildAdaptiveHighComparisons,
     buildHighTargetMedians,
     buildMarkdown,
     buildPlantCloseupAcceptance,
@@ -12,6 +13,7 @@ import {
     finalizeProfileSampleAtEndpoint,
     finishInteractiveProfileSample,
     getScenarioRequest,
+    installBrowserMetrics,
     mergeProfileSampleDrain,
     normalizeRenderWork,
     resolveScenarios,
@@ -164,6 +166,55 @@ test('high target scenario set covers representative High DPR 2 phases', () => {
     assert.equal(getScenarioRequest(scenarios[3].path).placement, '1');
 });
 
+test('adaptive High scenario set pairs fixed and adaptive motion and preserves runtime features', () => {
+    const scenarios = resolveScenarios('adaptive-high');
+
+    assert.deepEqual(
+        scenarios.map((scenario) => scenario.name),
+        [
+            'game-high-target-adaptive-pair-fixed-camera-motion-desktop',
+            'game-high-target-adaptive-camera-motion-desktop',
+            'game-high-target-adaptive-motion-recovery-desktop',
+            'game-high-target-adaptive-runtime-gpu-source-desktop',
+            'game-high-target-adaptive-placement-desktop',
+            'game-high-target-adaptive-rain-desktop',
+            'game-high-target-adaptive-snow-desktop',
+            'game-high-target-adaptive-cloudy-desktop',
+            'game-high-target-adaptive-windy-plants-desktop',
+        ],
+    );
+    assert.equal(scenarios[0].motion, 'pan-zoom-rotate');
+    assert.equal(scenarios[0].comparisonRole, 'fixed');
+    assert.equal(scenarios[1].comparisonRole, 'adaptive');
+    assert.equal(scenarios[1].profileControl, true);
+    assert.equal(scenarios[2].motion, 'pan-zoom-rotate-then-idle');
+    assert.equal(scenarios[2].motionMs, 650);
+    assert.equal(scenarios[2].profileControl, true);
+    assert.equal(scenarios[2].profileControlRecovery, true);
+    assert.equal(scenarios[2].sampleMs, 7_500);
+    assert.equal(scenarios[3].externalGpuTimer, false);
+    assert.equal(scenarios[3].runtimeGpuSource, true);
+    assert.equal(scenarios[4].placementProfile.action, 'run');
+    assert.equal(scenarios[4].profileControl, true);
+    assert.equal(getScenarioRequest(scenarios[4].path).placement, '1');
+    assert.deepEqual(
+        scenarios
+            .slice(5)
+            .map((scenario) => getScenarioRequest(scenario.path).mode),
+        ['rain', 'snow', 'cloudy', 'windy'],
+    );
+    assert.equal(getScenarioRequest(scenarios[0].path).adaptiveHigh, '0');
+    for (const scenario of scenarios.slice(1)) {
+        const request = getScenarioRequest(scenario.path);
+        assert.equal(request.adaptiveHigh, '1');
+        assert.equal(request.gardenProfile, 'high-target');
+        assert.equal(request.quality, 'high');
+        assert.equal(scenario.dpr, 2);
+        assert.equal(scenario.repeat, 3);
+    }
+    assert.equal(scenarios[0].repeat, 3);
+});
+
 test('historical dense High stays at DPR 1 while high-target uses DPR 2', () => {
     const denseHigh = resolveScenarios('dense').find(
         (scenario) => scenario.name === 'game-dense-25x25-high-desktop',
@@ -182,6 +233,7 @@ test('profile request parses the High target fixture contract', () => {
     );
 
     assert.deepEqual(request, {
+        adaptiveHigh: '0',
         blockGeometryMerging: '1',
         closeupRaisedBedId: null,
         controls: '1',
@@ -193,6 +245,24 @@ test('profile request parses the High target fixture contract', () => {
         placement: '0',
         quality: 'high',
     });
+});
+
+test('injected GPU timing yields to an existing elapsed-time query', () => {
+    assert.match(
+        installBrowserMetrics.toString(),
+        /getQuery\([\s\S]*TIME_ELAPSED_EXT[\s\S]*CURRENT_QUERY/,
+    );
+});
+
+test('runtime GPU-source scenario disables only the external profiler timer', () => {
+    const source = installBrowserMetrics.toString();
+
+    assert.match(source, /externalGpuTimer = true/);
+    assert.match(
+        source,
+        /if \(externalGpuTimer\) \{[\s\S]*__gameProfileGpuTimer/,
+    );
+    assert.match(source, /__gameProfileMetrics =/);
 });
 
 test('render budgets gate calls and triangles per rendered frame', () => {
@@ -316,6 +386,97 @@ test('markdown reports per-rAF and per-render work in separate columns', () => {
         /\| Draw\/frame \| Draw\/render \| Triangles\/frame \| Triangles\/render \|/,
     );
     assert.match(markdown, /\| 2 \| 40 \| 15000 \| 300000 \|/);
+});
+
+test('markdown distinguishes controlled governor evidence and formats range failures', () => {
+    const markdown = buildMarkdown({
+        adaptiveHighComparisons: {},
+        baseUrl: 'http://profile.local',
+        generatedAt: '2026-07-26T00:00:00.000Z',
+        highTargetMedians: {},
+        options: {
+            build: false,
+            managedServer: false,
+            sampleMs: 5_000,
+            scenarios: [],
+            scenarioSet: 'adaptive-high',
+            soakMs: 0,
+            warmupMs: 0,
+        },
+        plantCloseupMedians: {},
+        scenarios: [
+            {
+                budget: {
+                    checks: [
+                        {
+                            actual: 2,
+                            comparison: 'range',
+                            limit: { maximum: 1.75, minimum: 1.5 },
+                            name: 'adaptiveDpr',
+                            pass: false,
+                        },
+                    ],
+                    pass: false,
+                },
+                consoleMessages: [],
+                environment: null,
+                name: 'controlled-adaptive',
+                pageErrors: [],
+                requested: {
+                    adaptiveHigh: '1',
+                    blockGeometryMerging: '1',
+                    controls: '1',
+                    debugHud: '0',
+                    details: '1',
+                    gardenProfile: 'high-target',
+                    hud: '0',
+                    mode: 'details',
+                    motion: 'pan-zoom-rotate',
+                    profileControl: true,
+                    sampleMs: 5_000,
+                },
+                runtime: {
+                    adaptiveHighAmbientFps: 30,
+                    adaptiveHighCloudUpdateMs: 96,
+                    adaptiveHighGpuTimerSupported: false,
+                    adaptiveHighSampleSource: 'frame',
+                },
+                sample: {
+                    adaptiveHighDeclineCountDelta: 1,
+                    adaptiveHighDprCapAtEnd: 1.75,
+                    adaptiveHighDprCapAtStart: 2,
+                    adaptiveHighDprCapMin: 1.75,
+                    adaptiveHighInteractionObserved: true,
+                    adaptiveHighLevelAtEnd: 1,
+                    adaptiveHighLevelAtStart: 0,
+                    adaptiveHighLevelMax: 1,
+                    adaptiveHighProfileControlSampleCountDelta: 22,
+                    adaptiveHighRecoveryCountDelta: 0,
+                    adaptiveHighTransitionCountDelta: 1,
+                    canvas: null,
+                    drawCallsPerFrame: 1,
+                    drawCallsPerRenderedFrame: 1,
+                    fps: 30,
+                    jsHeapMb: 100,
+                    longTaskCount: 0,
+                    maxFrameMs: 20,
+                    p95FrameMs: 16,
+                    rainUnmountMs: null,
+                    renderedFps: 30,
+                    trianglesPerFrame: 1,
+                    trianglesPerRenderedFrame: 1,
+                },
+                screenshotPath: null,
+            },
+        ],
+        schemaVersion: 2,
+        sourceCommit: null,
+        summary: { failedScenarios: 1 },
+    });
+
+    assert.match(markdown, /controlled \(22 synthetic samples\)/);
+    assert.match(markdown, /frame \(profile control\)/);
+    assert.match(markdown, /adaptiveDpr 2 outside \[1\.5, 1\.75\]/);
 });
 
 test('interactive sampling stops at the endpoint and drains bounded long tasks later', async () => {
@@ -581,6 +742,9 @@ test('high target acceptance proves the intended workload rendered', () => {
             actorGroundingShadowPrimaryCasterCount: 0,
             actorGroundingShadowVisibleCount: 4,
             animatedCasterShadowRefreshCount: 0,
+            groundDecorationCount: 596,
+            groundDecorationDensity: 1,
+            groundDecorationVisibleCount: 571,
             generatedPlantFieldCount: 54,
             generatedPlantExpectedInstanceCount: 537,
             generatedPlantInstanceCount: 537,
@@ -589,7 +753,9 @@ test('high target acceptance proves the intended workload rendered', () => {
             instancedInteractionResolutionCount: 1,
             instancedInteractionResolvedTargetCount: 1,
             qualityTier: 'high',
-            rainParticleCount: 1_000,
+            rainParticleCount: 2_000,
+            shadowMapSize: 4_096,
+            shadowsEnabled: true,
         },
         sample: {
             actorGroundingShadowUpdateCountDelta: 60,
@@ -625,6 +791,31 @@ test('high target acceptance proves the intended workload rendered', () => {
         true,
     );
 
+    const missingDecorations = evaluateHighTargetAcceptance({
+        ...input,
+        runtime: {
+            ...input.runtime,
+            groundDecorationCount: 0,
+        },
+    });
+    assert.equal(missingDecorations.pass, false);
+    assert.equal(
+        missingDecorations.checks.find(
+            (check) => check.name === 'highTargetGroundDecorationCount',
+        )?.pass,
+        false,
+    );
+    assert.equal(
+        evaluateHighTargetAcceptance({
+            ...input,
+            runtime: {
+                ...input.runtime,
+                groundDecorationVisibleCount: 0,
+            },
+        }).pass,
+        false,
+    );
+
     const casterResult = evaluateHighTargetAcceptance({
         ...input,
         runtime: {
@@ -640,6 +831,362 @@ test('high target acceptance proves the intended workload rendered', () => {
         )?.pass,
         false,
     );
+});
+
+test('adaptive High acceptance allows bounded effective DPR during interaction', () => {
+    const input = {
+        apiErrors: [],
+        pageErrors: [],
+        requested: {
+            adaptiveHigh: '1',
+            blockGeometryMerging: '1',
+            gardenProfile: 'high-target',
+            mode: 'details',
+            motion: 'pan-zoom-rotate',
+            quality: 'high',
+        },
+        runtime: {
+            actorGroundingShadowBatchCount: 1,
+            actorGroundingShadowCount: 5,
+            actorGroundingShadowDroppedCount: 0,
+            actorGroundingShadowPrimaryCasterCount: 0,
+            actorGroundingShadowVisibleCount: 5,
+            adaptiveHighDprCap: 1.75,
+            adaptiveHighEnabled: true,
+            adaptiveHighOscillationCount: 0,
+            adaptiveHighTransitionCount: 1,
+            animatedCasterShadowRefreshCount: 0,
+            groundDecorationCount: 596,
+            groundDecorationDensity: 1,
+            groundDecorationVisibleCount: 571,
+            generatedPlantExpectedInstanceCount: 537,
+            generatedPlantFieldCount: 54,
+            generatedPlantInstanceCount: 537,
+            generatedPlantVisibleFieldCount: 54,
+            generatedPlantVisibleInstanceCount: 537,
+            qualityTier: 'high',
+            shadowMapSize: 4_096,
+            shadowsEnabled: true,
+            weatherDisabled: false,
+        },
+        sample: {
+            actorGroundingShadowUpdateCountDelta: 60,
+            adaptiveHighDeclineCountDelta: 1,
+            adaptiveHighDeclineObserved: true,
+            adaptiveHighDprCapAtEnd: 1.75,
+            adaptiveHighDprCapAtStart: 2,
+            adaptiveHighDprCapMin: 1.75,
+            adaptiveHighInteractionObserved: true,
+            adaptiveHighLevelAtEnd: 1,
+            adaptiveHighLevelAtStart: 0,
+            adaptiveHighLevelMax: 1,
+            adaptiveHighTransitionCountDelta: 1,
+            animatedCasterShadowRefreshCountDelta: 0,
+            canvas: {
+                clientHeight: 720,
+                clientWidth: 1280,
+                height: 1260,
+                width: 2240,
+            },
+            drawCalls: 100,
+            effectiveDprAtEnd: 1.75,
+            effectiveDprMin: 1.75,
+            elapsedMs: 5_000,
+            renderedFps: 12,
+            renderedFrames: 60,
+            reportedDpr: 2,
+            submittedTriangles: 1_000_000,
+        },
+    };
+
+    assert.equal(evaluateHighTargetAcceptance(input).pass, true);
+
+    const controlled = {
+        ...input,
+        requested: {
+            ...input.requested,
+            profileControl: true,
+        },
+        runtime: {
+            ...input.runtime,
+            adaptiveHighProfileControlActive: true,
+            adaptiveHighProfileControlEnabled: true,
+        },
+        sample: {
+            ...input.sample,
+            adaptiveHighProfileControlObserved: true,
+            adaptiveHighProfileControlStarted: true,
+        },
+    };
+    assert.equal(evaluateHighTargetAcceptance(controlled).pass, true);
+    for (const sample of [
+        {
+            ...controlled.sample,
+            adaptiveHighProfileControlObserved: false,
+        },
+        {
+            ...controlled.sample,
+            adaptiveHighProfileControlStarted: false,
+        },
+    ]) {
+        assert.equal(
+            evaluateHighTargetAcceptance({ ...controlled, sample }).pass,
+            false,
+        );
+    }
+
+    for (const runtime of [
+        { ...input.runtime, adaptiveHighOscillationCount: 1 },
+        { ...input.runtime, weatherDisabled: true },
+    ]) {
+        assert.equal(
+            evaluateHighTargetAcceptance({ ...input, runtime }).pass,
+            false,
+        );
+    }
+
+    for (const sample of [
+        { ...input.sample, adaptiveHighTransitionCountDelta: 0 },
+        { ...input.sample, adaptiveHighDeclineObserved: false },
+        { ...input.sample, adaptiveHighDprCapMin: 2 },
+        { ...input.sample, adaptiveHighInteractionObserved: false },
+        { ...input.sample, adaptiveHighLevelMax: 0 },
+    ]) {
+        assert.equal(
+            evaluateHighTargetAcceptance({ ...input, sample }).pass,
+            false,
+        );
+    }
+
+    assert.equal(
+        evaluateHighTargetAcceptance({
+            ...input,
+            sample: {
+                ...input.sample,
+                canvas: {
+                    ...input.sample.canvas,
+                    width: 2560,
+                },
+            },
+        }).pass,
+        false,
+    );
+    assert.equal(
+        evaluateHighTargetAcceptance({
+            ...input,
+            runtime: {
+                ...input.runtime,
+                adaptiveHighDprCap: 1.4,
+            },
+            sample: {
+                ...input.sample,
+                adaptiveHighDprCapAtEnd: 1.4,
+                effectiveDprAtEnd: 1.4,
+                effectiveDprMin: 1.4,
+            },
+        }).pass,
+        false,
+    );
+
+    const recovered = {
+        ...input,
+        requested: {
+            ...input.requested,
+            motion: 'pan-zoom-rotate-then-idle',
+            profileControl: true,
+            profileControlRecovery: true,
+        },
+        runtime: {
+            ...input.runtime,
+            adaptiveHighDprCap: 2,
+            adaptiveHighOscillationCount: 1,
+            adaptiveHighProfileControlActive: true,
+            adaptiveHighProfileControlEnabled: true,
+        },
+        sample: {
+            ...input.sample,
+            adaptiveHighDprCapAtEnd: 2,
+            adaptiveHighLevelAtEnd: 0,
+            adaptiveHighRecoveryCountDelta: 1,
+            adaptiveHighProfileControlObserved: true,
+            adaptiveHighProfileControlSampleCountDelta: 22,
+            adaptiveHighProfileControlStarted: true,
+            adaptiveHighTransitionCountDelta: 2,
+            canvas: {
+                ...input.sample.canvas,
+                height: 1440,
+                width: 2560,
+            },
+            effectiveDprAtEnd: 2,
+        },
+    };
+    assert.equal(evaluateHighTargetAcceptance(recovered).pass, true);
+    assert.equal(
+        evaluateHighTargetAcceptance({
+            ...recovered,
+            sample: {
+                ...recovered.sample,
+                adaptiveHighDprCapMin: 2,
+                adaptiveHighDeclineObserved: false,
+                adaptiveHighLevelMax: 0,
+                adaptiveHighRecoveryCountDelta: 0,
+                adaptiveHighTransitionCountDelta: 0,
+            },
+        }).pass,
+        false,
+    );
+    assert.equal(
+        evaluateHighTargetAcceptance({
+            ...recovered,
+            runtime: {
+                ...recovered.runtime,
+                adaptiveHighDprCap: 1.75,
+            },
+            sample: {
+                ...recovered.sample,
+                adaptiveHighDprCapAtEnd: 1.75,
+                adaptiveHighLevelAtEnd: 1,
+                effectiveDprAtEnd: 1.75,
+            },
+        }).pass,
+        false,
+    );
+
+    const runtimeGpuSource = {
+        ...input,
+        requested: {
+            ...input.requested,
+            motion: 'none',
+            runtimeGpuSource: true,
+        },
+        runtime: {
+            ...input.runtime,
+            adaptiveHighGpuTimerSupported: true,
+            adaptiveHighSampleSource: 'gpu',
+        },
+        sample: {
+            ...input.sample,
+            adaptiveHighGpuSourceObserved: true,
+        },
+    };
+    assert.equal(evaluateHighTargetAcceptance(runtimeGpuSource).pass, true);
+    assert.equal(
+        evaluateHighTargetAcceptance({
+            ...runtimeGpuSource,
+            runtime: {
+                ...runtimeGpuSource.runtime,
+                adaptiveHighSampleSource: 'frame',
+            },
+        }).pass,
+        false,
+    );
+    assert.equal(
+        evaluateHighTargetAcceptance({
+            ...runtimeGpuSource,
+            runtime: {
+                ...runtimeGpuSource.runtime,
+                adaptiveHighGpuTimerSupported: false,
+                adaptiveHighSampleSource: 'frame',
+            },
+            sample: {
+                ...runtimeGpuSource.sample,
+                adaptiveHighGpuSourceObserved: false,
+            },
+        }).pass,
+        true,
+    );
+
+    const cloudy = {
+        ...input,
+        requested: {
+            ...input.requested,
+            mode: 'cloudy',
+            motion: 'none',
+        },
+        runtime: {
+            ...input.runtime,
+            actorGroundingShadowCount: 4,
+            actorGroundingShadowVisibleCount: 4,
+            cloudVisualCount: 8,
+        },
+        sample: {
+            ...input.sample,
+            cloudAttenuationUpdateCountDelta: 1,
+        },
+    };
+    assert.equal(evaluateHighTargetAcceptance(cloudy).pass, true);
+    assert.equal(
+        evaluateHighTargetAcceptance({
+            ...cloudy,
+            sample: {
+                ...cloudy.sample,
+                cloudAttenuationUpdateCountDelta: 0,
+            },
+        }).pass,
+        false,
+    );
+
+    const windy = {
+        ...cloudy,
+        requested: {
+            ...cloudy.requested,
+            mode: 'windy',
+        },
+        runtime: {
+            ...cloudy.runtime,
+            adaptiveHighAmbientFps: 20,
+            cloudVisualCount: 7,
+        },
+    };
+    assert.equal(evaluateHighTargetAcceptance(windy).pass, true);
+    assert.equal(
+        evaluateHighTargetAcceptance({
+            ...windy,
+            runtime: {
+                ...windy.runtime,
+                adaptiveHighAmbientFps: 0,
+            },
+        }).pass,
+        false,
+    );
+
+    for (const [mode, particleField, particleCount] of [
+        ['rain', 'rainParticleCount', 2_000],
+        ['snow', 'snowParticleCount', 3_500],
+    ]) {
+        const weather = {
+            ...input,
+            requested: {
+                ...input.requested,
+                mode,
+                motion: 'none',
+            },
+            runtime: {
+                ...input.runtime,
+                actorGroundingShadowCount: 4,
+                actorGroundingShadowVisibleCount: 4,
+                [particleField]: particleCount,
+                ...(mode === 'snow'
+                    ? {
+                          groundDecorationCount: 0,
+                          groundDecorationVisibleCount: null,
+                          snowParticleCapacity: 5_000,
+                      }
+                    : {}),
+            },
+        };
+        assert.equal(evaluateHighTargetAcceptance(weather).pass, true);
+        assert.equal(
+            evaluateHighTargetAcceptance({
+                ...weather,
+                runtime: {
+                    ...weather.runtime,
+                    [particleField]: 0,
+                },
+            }).pass,
+            false,
+        );
+    }
 });
 
 test('high target acceptance distinguishes a cached map from refreshes and resets', () => {
@@ -665,12 +1212,17 @@ test('high target acceptance distinguishes a cached map from refreshes and reset
                 actorGroundingShadowPrimaryCasterCount: 0,
                 actorGroundingShadowVisibleCount: 4,
                 animatedCasterShadowRefreshCount: 0,
+                groundDecorationCount: 596,
+                groundDecorationDensity: 1,
+                groundDecorationVisibleCount: 571,
                 generatedPlantExpectedInstanceCount: 537,
                 generatedPlantFieldCount: 54,
                 generatedPlantInstanceCount: 537,
                 generatedPlantVisibleFieldCount: 54,
                 generatedPlantVisibleInstanceCount: 537,
                 qualityTier: 'high',
+                shadowMapSize: 4_096,
+                shadowsEnabled: true,
             },
             sample: {
                 actorGroundingShadowUpdateCountDelta: 60,
@@ -736,6 +1288,9 @@ test('high target placement acceptance requires one deferred final shadow flush'
             actorGroundingShadowPrimaryCasterCount: 0,
             actorGroundingShadowVisibleCount: 4,
             animatedCasterShadowRefreshCount: 0,
+            groundDecorationCount: 596,
+            groundDecorationDensity: 1,
+            groundDecorationVisibleCount: 571,
             generatedPlantExpectedInstanceCount: 537,
             generatedPlantFieldCount: 54,
             generatedPlantInstanceCount: 537,
@@ -747,6 +1302,8 @@ test('high target placement acceptance requires one deferred final shadow flush'
             placementProjectedShadowPeakCount: projectedPeak,
             placementShadowActiveCount: activeCount,
             qualityTier: 'high',
+            shadowMapSize: 4_096,
+            shadowsEnabled: true,
         },
         sample: {
             actorGroundingShadowUpdateCountDelta: 60,
@@ -1082,6 +1639,149 @@ test('high target aggregate fails when the median exceeds a performance budget',
     assert.equal(aggregate.medianSample.p95FrameMs, 40);
     assert.equal(aggregate.performanceBudget.pass, false);
     assert.equal(aggregate.pass, false);
+});
+
+test('adaptive High comparison reports paired pass rates and frame/GPU deltas', () => {
+    const pairedRun = ({
+        baseName,
+        comparisonRole,
+        gpuP95,
+        index,
+        p95,
+        renderedFps,
+    }) => {
+        const run = highTargetRun(p95, index);
+        return {
+            ...run,
+            baseName,
+            name: `${baseName}-run-${index + 1}`,
+            requested: {
+                ...run.requested,
+                comparisonPair: 'adaptive-camera-motion',
+                comparisonRole,
+            },
+            sample: {
+                ...run.sample,
+                gpu: {
+                    elapsedP95Ms: gpuP95,
+                    valid: true,
+                },
+                renderedFps,
+            },
+        };
+    };
+    const runs = [
+        ...[18, 20, 22].map((p95, index) =>
+            pairedRun({
+                baseName:
+                    'game-high-target-adaptive-pair-fixed-camera-motion-desktop',
+                comparisonRole: 'fixed',
+                gpuP95: 10,
+                index,
+                p95,
+                renderedFps: 50,
+            }),
+        ),
+        ...[14, 15, 16].map((p95, index) =>
+            pairedRun({
+                baseName: 'game-high-target-adaptive-camera-motion-desktop',
+                comparisonRole: 'adaptive',
+                gpuP95: 8,
+                index,
+                p95,
+                renderedFps: 60,
+            }),
+        ),
+    ];
+    const medians = buildHighTargetMedians(runs);
+    const comparison =
+        buildAdaptiveHighComparisons(medians)['adaptive-camera-motion'];
+
+    assert.deepEqual(comparison.acceptancePassRate, {
+        adaptive: 100,
+        fixed: 100,
+    });
+    assert.deepEqual(comparison.p95FrameMs, {
+        adaptive: 15,
+        delta: -5,
+        fixed: 20,
+        percentDelta: -25,
+    });
+    assert.deepEqual(comparison.gpuElapsedP95Ms, {
+        adaptive: 8,
+        delta: -2,
+        fixed: 10,
+        percentDelta: -20,
+    });
+    assert.deepEqual(comparison.renderedFps, {
+        adaptive: 60,
+        delta: 10,
+        fixed: 50,
+        percentDelta: 20,
+    });
+    assert.equal(comparison.relativePerformancePass, true);
+    assert.equal(
+        comparison.relativePerformanceChecks.every((check) => check.pass),
+        true,
+    );
+    assert.match(
+        buildMarkdown({
+            adaptiveHighComparisons: buildAdaptiveHighComparisons(medians),
+            baseUrl: 'http://profile.local',
+            generatedAt: '2026-07-26T00:00:00.000Z',
+            highTargetMedians: medians,
+            options: {
+                build: false,
+                managedServer: false,
+                sampleMs: 5_000,
+                scenarios: [],
+                scenarioSet: 'adaptive-high',
+                soakMs: 0,
+                warmupMs: 0,
+            },
+            plantCloseupMedians: {},
+            scenarios: [],
+            schemaVersion: 2,
+            sourceCommit: null,
+            summary: { failedScenarios: 0 },
+        }),
+        /Adaptive High paired comparison[\s\S]*20 → 15 ms \(-25%\)[\s\S]*10 → 8 ms \(-20%\)/,
+    );
+
+    const regressedRuns = runs.map((run) =>
+        run.requested.comparisonRole === 'adaptive'
+            ? {
+                  ...run,
+                  sample: {
+                      ...run.sample,
+                      gpu: {
+                          elapsedP95Ms: 12,
+                          valid: true,
+                      },
+                      p95FrameMs: 30,
+                      renderedFps: 40,
+                  },
+              }
+            : run,
+    );
+    const regressedMedians = buildHighTargetMedians(regressedRuns);
+    const regressedComparison =
+        buildAdaptiveHighComparisons(regressedMedians)[
+            'adaptive-camera-motion'
+        ];
+
+    assert.equal(
+        regressedMedians['game-high-target-adaptive-camera-motion-desktop']
+            .pass,
+        true,
+    );
+    assert.equal(regressedComparison.relativePerformancePass, false);
+    assert.equal(regressedComparison.aggregatePass.adaptive, false);
+    assert.deepEqual(
+        buildProfileSummary(regressedRuns, regressedMedians)
+            .failedScenarioNames,
+        ['game-high-target-adaptive-camera-motion-desktop'],
+    );
 });
 
 test('placement scenario resolves a deterministic staggered two-chunk run', () => {

--- a/docs/game-performance-optimization-results.md
+++ b/docs/game-performance-optimization-results.md
@@ -604,6 +604,64 @@ budgets remain red because of the documented `ReadPixels` stalls; all three
 placement acceptance runs passed independently of those aspirational
 physical-device budgets.
 
+### Adaptive High runtime ceiling
+
+Issue `#4319` keeps the user-selected High profile as the visual ceiling while
+adapting its runtime cost to measured load. Automatic, Medium, Low, and custom
+quality remain unchanged. High continues to use the 4096px primary shadow map,
+full plant and decoration density, rain, snow, moving clouds, plant wind, and
+the existing High particle counts.
+
+The controller prefers asynchronous
+`EXT_disjoint_timer_query_webgl2` elapsed-time samples. It discards disjoint,
+timed-out, suspended, and context-lost samples without synchronously waiting
+for the GPU. Browsers without a usable timer query fall back to rendered-frame
+cadence. A one-second EWMA filters either source, while asymmetric evidence
+windows avoid quality chatter:
+
+- camera or placement interaction immediately moves from `L0` to `L1` and
+  owns a 60fps scene-time lease while active;
+- load above `1.10` must persist for 750ms and at least three samples before
+  another decline;
+- load below `0.80` must persist for five seconds before recovering one level;
+  and
+- three direction reversals inside 60 seconds lock recovery for 30 seconds,
+  but never prevent a needed decline.
+
+At a DPR-2 display ceiling, the runtime levels are:
+
+| Level | DPR cap | Ambient cadence | Cloud-mask minimum cadence |
+| --- | ---: | ---: | ---: |
+| `L0` | 2.00 | 30fps | 96ms |
+| `L1` | 1.75 | 30fps | 96ms |
+| `L2` | 1.50 | 30fps | 96ms |
+| `L3` | 1.50 | 20fps | 160ms |
+
+The same sequence is derived from the current display ceiling, so DPR-1
+displays are never upscaled and monitor or browser-zoom changes reset the
+ceiling safely. Duplicate stages are skipped on constrained displays. Scene
+resume and WebGL context restoration clear timing evidence without adding
+hidden wall time to level dwell or resetting transition telemetry.
+
+The `adaptive-high` production profile set pairs fixed and adaptive camera
+motion and adds stateful motion-to-idle recovery, placement, runtime GPU-source,
+rain, snow, cloudy, and windy-plant scenarios. Its acceptance checks use
+sample-local level, DPR, transition, decline, recovery, interaction, and
+atmosphere evidence; starting a fresh page at full quality cannot satisfy the
+recovery gate.
+
+The local Chromium 149 / ANGLE SwiftShader integration run passed the
+fixed-camera and adaptive-camera structural gates in all six repeats. Adaptive
+camera motion reduced median submitted work from `147.7` to `141.0` draws and
+from `21,083` to `20,210` triangles per rendered frame (`4.5%` and `4.1%`),
+while median p95 moved from `623.9` to `615.8 ms` and rendered FPS remained
+`1.8`. The relative regression gate passed. The separate motion-to-idle
+scenario also passed all three repeats, recording `L0 -> L1 -> L0`, DPR cap
+`2 -> 1.75 -> 2`, one decline, one recovery, and 22 controlled headroom
+samples each time. The software renderer's absolute p95 and long-task budgets
+remain red because of its documented `ReadPixels` stalls; draw, triangle,
+workload-preservation, and controller-lifecycle gates pass independently.
+
 ## Raised-bed close-up profiling foundation
 
 Added 2026-07-23 for the L-system close-up optimization series.

--- a/packages/game/src/GameFlagsContext.tsx
+++ b/packages/game/src/GameFlagsContext.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext } from 'react';
 
 export interface GameFeatureFlags {
+    enableAdaptiveHighQualityFlag?: boolean;
     enableDebugHudFlag?: boolean;
     enableRaisedBedWateringFlag?: boolean;
     enableRaisedBedDiaryFlag?: boolean;

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -52,6 +52,10 @@ import { GardenLoadingIndicator } from './indicators/GardenLoadingIndicator';
 import { PlacementGrid } from './indicators/PlacementGrid';
 import { isOperationVisualRewardDebugProfile } from './operationVisualRewardDebugProfile';
 import { ParticleSystemProvider } from './particles/ParticleSystem';
+import {
+    type AdaptiveHighQualityLevelProfile,
+    adaptiveHighQualityLevels,
+} from './scene/adaptiveHighQuality';
 import { Environment } from './scene/Environment';
 import {
     type GameQualityAutoProfileMetrics,
@@ -69,6 +73,7 @@ import {
     getBlockPlacementDropAnimationRenderIdForBlockId,
     type MockGardenProfile,
     useGameState,
+    useGameStateStore,
     type WinterMode,
 } from './useGameState';
 import { useRaisedBedCloseup } from './useRaisedBedCloseup';
@@ -106,6 +111,7 @@ export type GameSceneProps = HTMLAttributes<HTMLDivElement> & {
 };
 
 type GameSceneInnerProps = Omit<GameSceneProps, 'initialQualitySetting'>;
+const adaptiveHighInteractionHoldMs = 350;
 
 function useAutoQualityProfileMetrics(enabled: boolean) {
     const [metrics, setMetrics] = useState<
@@ -155,6 +161,82 @@ function useAutoQualityProfileMetrics(enabled: boolean) {
     }, [enabled]);
 
     return metrics;
+}
+
+function useAdaptiveHighInteractionActivity(enabled: boolean) {
+    const gameStateStore = useGameStateStore();
+    const placementActive = useGameState(
+        (state) =>
+            enabled &&
+            (state.isDragging ||
+                state.pickupBlock !== null ||
+                state.activeDragPreview !== null ||
+                state.hudPlacementDrag !== null ||
+                Object.keys(state.blockPlacementDropAnimations).length > 0),
+    );
+    const [cameraActive, setCameraActive] = useState(false);
+    const cameraActiveRef = useRef(false);
+    const cameraActivityTimeoutRef = useRef<number | null>(null);
+
+    useEffect(() => {
+        if (!enabled) {
+            if (cameraActivityTimeoutRef.current !== null) {
+                window.clearTimeout(cameraActivityTimeoutRef.current);
+                cameraActivityTimeoutRef.current = null;
+            }
+            cameraActiveRef.current = false;
+            setCameraActive(false);
+            return;
+        }
+
+        let previousCameraVersion =
+            gameStateStore.getState().gameCameraSnapshot?.version ?? null;
+        const unsubscribe = gameStateStore.subscribe((state) => {
+            const cameraVersion = state.gameCameraSnapshot?.version ?? null;
+            if (
+                previousCameraVersion === null ||
+                cameraVersion === null ||
+                cameraVersion === previousCameraVersion
+            ) {
+                previousCameraVersion = cameraVersion;
+                return;
+            }
+            previousCameraVersion = cameraVersion;
+
+            if (!cameraActiveRef.current) {
+                cameraActiveRef.current = true;
+                setCameraActive(true);
+            }
+            if (cameraActivityTimeoutRef.current !== null) {
+                window.clearTimeout(cameraActivityTimeoutRef.current);
+            }
+            cameraActivityTimeoutRef.current = window.setTimeout(() => {
+                cameraActivityTimeoutRef.current = null;
+                cameraActiveRef.current = false;
+                setCameraActive(false);
+            }, adaptiveHighInteractionHoldMs);
+        });
+
+        return () => {
+            unsubscribe();
+            if (cameraActivityTimeoutRef.current !== null) {
+                window.clearTimeout(cameraActivityTimeoutRef.current);
+                cameraActivityTimeoutRef.current = null;
+            }
+            cameraActiveRef.current = false;
+        };
+    }, [enabled, gameStateStore]);
+
+    useEffect(
+        () => () => {
+            if (cameraActivityTimeoutRef.current !== null) {
+                window.clearTimeout(cameraActivityTimeoutRef.current);
+            }
+        },
+        [],
+    );
+
+    return enabled && (placementActive || cameraActive);
 }
 
 function GameSceneEntitySlot({
@@ -213,6 +295,7 @@ export function GameScene({
     weather,
     deferDetails,
     renderDetails: renderDetailsOverride,
+    enableGameProfileController,
     ...rest
 }: GameSceneInnerProps) {
     useFocusPlacedBlock();
@@ -257,6 +340,16 @@ export function GameScene({
         gameQualitySetting,
         quality,
     ]);
+    const adaptiveHighEnabled = Boolean(
+        flags?.enableAdaptiveHighQualityFlag &&
+            qualityProfile.tier === 'high' &&
+            (quality === 'high' ||
+                (quality === undefined && gameQualitySetting === 'high')),
+    );
+    const adaptiveHighInteractionActive =
+        useAdaptiveHighInteractionActivity(adaptiveHighEnabled);
+    const [adaptiveHighProfile, setAdaptiveHighProfile] =
+        useState<AdaptiveHighQualityLevelProfile>(adaptiveHighQualityLevels.L0);
 
     // Start non-critical metadata early, but don't block the first scene frame.
     useBlockData();
@@ -334,6 +427,15 @@ export function GameScene({
                 value={{ includePendingCartPlants: true, renderDetails }}
             >
                 <Scene
+                    adaptiveHighEnabled={adaptiveHighEnabled}
+                    adaptiveHighInteractionActive={
+                        adaptiveHighInteractionActive
+                    }
+                    adaptiveHighProfileControlEnabled={Boolean(
+                        enableGameProfileController && adaptiveHighEnabled,
+                    )}
+                    adaptiveHighProfile={adaptiveHighProfile}
+                    onAdaptiveHighProfileChange={setAdaptiveHighProfile}
                     debugStats={showDebugHud}
                     position={sceneCameraPosition}
                     quality={qualityProfile}
@@ -345,6 +447,11 @@ export function GameScene({
                             <PlacementGrid />
                             {!hideHud ? <HudPlacementDragPreview /> : null}
                             <Environment
+                                cloudShadowUpdateMs={
+                                    adaptiveHighEnabled
+                                        ? adaptiveHighProfile.cloudShadowUpdateMs
+                                        : undefined
+                                }
                                 noBackground={noBackground}
                                 noWeather={weatherDisabled}
                                 noSound={noSound}

--- a/packages/game/src/GameSceneWrapper.tsx
+++ b/packages/game/src/GameSceneWrapper.tsx
@@ -91,7 +91,13 @@ export function GameSceneWrapper({
                 <GardenSelectionGate
                     disabled={Boolean(mockGarden || localSandboxStorageKey)}
                 >
-                    <GameScene flags={flags} {...rest} />
+                    <GameScene
+                        enableGameProfileController={
+                            enableGameProfileController
+                        }
+                        flags={flags}
+                        {...rest}
+                    />
                     {enableGameProfileController ? (
                         <GameProfileController />
                     ) : null}

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -787,6 +787,15 @@ export function DebugHud() {
                                     value={`${qualityTier} · DPR ${formatMetric(profileSnapshot?.dprCap)}/${formatMetric(profileSnapshot?.reportedDpr)}`}
                                 />
                                 <InfoRow
+                                    icon={Graph}
+                                    label="Adaptive High"
+                                    value={
+                                        profileSnapshot?.adaptiveHighEnabled
+                                            ? `L${profileSnapshot.adaptiveHighLevel ?? 0} · ${formatMetric(profileSnapshot.adaptiveHighFactor)}× · DPR ${formatMetric(profileSnapshot.adaptiveHighDprCap)} · ${profileSnapshot.adaptiveHighAmbientFps ?? 0}fps/${profileSnapshot.adaptiveHighCloudUpdateMs ?? 0}ms · ${profileSnapshot.adaptiveHighSampleSource ?? 'frame'} ${formatMetric(profileSnapshot.adaptiveHighSampleMs)}/${formatMetric(profileSnapshot.adaptiveHighEwmaMs)}ms · ${profileSnapshot.adaptiveHighReason ?? 'stable'} · ${profileSnapshot.adaptiveHighTransitionCount ?? 0} transitions/${profileSnapshot.adaptiveHighOscillationCount ?? 0} oscillations`
+                                            : 'off'
+                                    }
+                                />
+                                <InfoRow
                                     icon={FullWidth}
                                     label="Canvas"
                                     value={canvasSize}

--- a/packages/game/src/scene/AdaptiveHighQualityController.tsx
+++ b/packages/game/src/scene/AdaptiveHighQualityController.tsx
@@ -1,0 +1,730 @@
+'use client';
+
+import { useFrame, useThree } from '@react-three/fiber';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+    type AdaptiveHighQualityLevelProfile,
+    type AdaptiveHighQualityLoadSource,
+    type AdaptiveHighQualityState,
+    adaptiveHighQualityLevels,
+    createAdaptiveHighQualityState,
+    getAdaptiveHighQualitySnapshot,
+    resumeAdaptiveHighQualityState,
+    updateAdaptiveHighQuality,
+} from './adaptiveHighQuality';
+import {
+    adaptiveHighQualityProfileControlEventName,
+    readAdaptiveHighQualityProfileControlCommand,
+} from './adaptiveHighQualityProfileControl';
+import { updateGameProfileMetadata } from './gameProfileMetadata';
+import {
+    sceneFrameRates,
+    useSceneResume,
+    useSceneTimeInvalidation,
+} from './SceneTime';
+
+const governorSampleIntervalMs = 250;
+const interactiveGpuBudgetMs = 1_000 / 60;
+const idleGpuBudgetMs = 25;
+const frameOnTimeRatio = 1.2;
+const maximumPendingGpuQueries = 4;
+const gpuQueryTimeoutMs = 2_000;
+const gpuDisjointQuarantineMs = 2_000;
+const governorLongFrameGapMs = 1_000;
+
+type PendingGpuQuery = {
+    query: WebGLQuery;
+    startedAtMs: number;
+};
+
+type DisjointTimerQueryWebGl2Extension = {
+    GPU_DISJOINT_EXT: number;
+    TIME_ELAPSED_EXT: number;
+};
+
+type GpuTimerState = {
+    active: WebGLQuery | null;
+    context: WebGL2RenderingContext | null;
+    contextLost: boolean;
+    disjointCount: number;
+    extension: DisjointTimerQueryWebGl2Extension | null;
+    pending: PendingGpuQuery[];
+    quarantinedUntilMs: number;
+    samplesMs: number[];
+    supported: boolean | null;
+};
+
+type FrameWindow = {
+    elapsedMs: number[];
+    onTimeCount: number;
+};
+
+function createGpuTimerState(): GpuTimerState {
+    return {
+        active: null,
+        context: null,
+        contextLost: false,
+        disjointCount: 0,
+        extension: null,
+        pending: [],
+        quarantinedUntilMs: 0,
+        samplesMs: [],
+        supported: null,
+    };
+}
+
+function createFrameWindow(): FrameWindow {
+    return {
+        elapsedMs: [],
+        onTimeCount: 0,
+    };
+}
+
+function isWebGl2Context(
+    context: WebGLRenderingContext | WebGL2RenderingContext,
+): context is WebGL2RenderingContext {
+    return (
+        typeof WebGL2RenderingContext !== 'undefined' &&
+        context instanceof WebGL2RenderingContext
+    );
+}
+
+function hasExternalGpuTimer() {
+    return (
+        typeof window !== 'undefined' &&
+        Reflect.get(window, '__gameProfileGpuTimer') !== undefined
+    );
+}
+
+function getDevicePixelRatio() {
+    if (typeof window === 'undefined') {
+        return 1;
+    }
+
+    const devicePixelRatio = window.devicePixelRatio;
+    return Number.isFinite(devicePixelRatio) && devicePixelRatio > 0
+        ? devicePixelRatio
+        : 1;
+}
+
+function average(values: number[]) {
+    if (values.length === 0) {
+        return 0;
+    }
+
+    return values.reduce((total, value) => total + value, 0) / values.length;
+}
+
+function resolveFrameWindowLoad(window: FrameWindow) {
+    const sampleCount = window.elapsedMs.length;
+    if (sampleCount === 0) {
+        return null;
+    }
+
+    const onTimeRate = window.onTimeCount / sampleCount;
+    if (onTimeRate >= 0.95) {
+        return 0.7;
+    }
+    if (onTimeRate < 0.8) {
+        return 1.2 + (0.8 - onTimeRate);
+    }
+    return 0.95;
+}
+
+function deletePendingQueries(timer: GpuTimerState) {
+    const { context } = timer;
+    if (context && !timer.contextLost) {
+        for (const entry of timer.pending) {
+            context.deleteQuery(entry.query);
+        }
+    }
+    timer.pending = [];
+}
+
+function disposeGpuTimerQueries(timer: GpuTimerState) {
+    const { context, extension } = timer;
+    const activeQuery = timer.active;
+    timer.active = null;
+
+    if (context && !timer.contextLost && activeQuery) {
+        if (extension) {
+            const currentQuery = context.getQuery(
+                extension.TIME_ELAPSED_EXT,
+                context.CURRENT_QUERY,
+            );
+            if (currentQuery === activeQuery) {
+                context.endQuery(extension.TIME_ELAPSED_EXT);
+            }
+        }
+        context.deleteQuery(activeQuery);
+    }
+
+    deletePendingQueries(timer);
+    timer.samplesMs = [];
+}
+
+function pollGpuQueries(timer: GpuTimerState, nowMs: number) {
+    const { context, extension } = timer;
+    if (!context || !extension || timer.contextLost) {
+        return;
+    }
+
+    if (context.getParameter(extension.GPU_DISJOINT_EXT)) {
+        deletePendingQueries(timer);
+        timer.samplesMs = [];
+        timer.disjointCount += 1;
+        timer.quarantinedUntilMs = nowMs + gpuDisjointQuarantineMs;
+        return;
+    }
+
+    const remaining: PendingGpuQuery[] = [];
+    for (const entry of timer.pending) {
+        if (
+            context.getQueryParameter(
+                entry.query,
+                context.QUERY_RESULT_AVAILABLE,
+            )
+        ) {
+            const elapsedNanoseconds = context.getQueryParameter(
+                entry.query,
+                context.QUERY_RESULT,
+            );
+            if (typeof elapsedNanoseconds === 'number') {
+                timer.samplesMs.push(elapsedNanoseconds / 1_000_000);
+            }
+            context.deleteQuery(entry.query);
+            continue;
+        }
+
+        if (nowMs - entry.startedAtMs >= gpuQueryTimeoutMs) {
+            context.deleteQuery(entry.query);
+            timer.supported = false;
+            continue;
+        }
+
+        remaining.push(entry);
+    }
+    timer.pending = remaining;
+}
+
+function finishGpuQuery(
+    timer: GpuTimerState,
+    query: WebGLQuery,
+    startedAtMs: number,
+) {
+    const { context, extension } = timer;
+    if (timer.active !== query || !context || !extension || timer.contextLost) {
+        return;
+    }
+
+    timer.active = null;
+    const currentQuery = context.getQuery(
+        extension.TIME_ELAPSED_EXT,
+        context.CURRENT_QUERY,
+    );
+    if (currentQuery !== query) {
+        context.deleteQuery(query);
+        return;
+    }
+
+    context.endQuery(extension.TIME_ELAPSED_EXT);
+    timer.pending.push({ query, startedAtMs });
+}
+
+function beginGpuQuery(
+    timer: GpuTimerState,
+    rendererContext: WebGLRenderingContext | WebGL2RenderingContext,
+    nowMs: number,
+) {
+    if (
+        timer.contextLost ||
+        hasExternalGpuTimer() ||
+        nowMs < timer.quarantinedUntilMs
+    ) {
+        return;
+    }
+
+    if (timer.context === null) {
+        if (!isWebGl2Context(rendererContext)) {
+            timer.supported = false;
+            return;
+        }
+
+        timer.context = rendererContext;
+        timer.extension = rendererContext.getExtension(
+            'EXT_disjoint_timer_query_webgl2',
+        );
+        timer.supported = timer.extension !== null;
+    }
+
+    const { context, extension } = timer;
+    if (
+        !context ||
+        !extension ||
+        timer.supported !== true ||
+        timer.active ||
+        timer.pending.length >= maximumPendingGpuQueries
+    ) {
+        return;
+    }
+
+    pollGpuQueries(timer, nowMs);
+    if (
+        nowMs < timer.quarantinedUntilMs ||
+        context.getQuery(extension.TIME_ELAPSED_EXT, context.CURRENT_QUERY) !==
+            null
+    ) {
+        return;
+    }
+
+    const query = context.createQuery();
+    if (!query) {
+        timer.supported = false;
+        return;
+    }
+
+    context.beginQuery(extension.TIME_ELAPSED_EXT, query);
+    timer.active = query;
+    queueMicrotask(() => finishGpuQuery(timer, query, nowMs));
+}
+
+export function AdaptiveHighQualityController({
+    effectiveDprCeiling,
+    enabled,
+    interactionActive,
+    onProfileChange,
+    profileControlEnabled,
+}: {
+    effectiveDprCeiling: number;
+    enabled: boolean;
+    interactionActive: boolean;
+    onProfileChange: (profile: AdaptiveHighQualityLevelProfile) => void;
+    profileControlEnabled: boolean;
+}) {
+    const gl = useThree((state) => state.gl);
+    const governorStateRef = useRef<AdaptiveHighQualityState>(
+        createAdaptiveHighQualityState({ effectiveDprCeiling }),
+    );
+    const gpuTimerRef = useRef<GpuTimerState>(createGpuTimerState());
+    const frameWindowRef = useRef<FrameWindow>(createFrameWindow());
+    const interactionActiveRef = useRef(interactionActive);
+    const [displayDpr, setDisplayDpr] = useState(getDevicePixelRatio);
+    const currentProfileRef = useRef<AdaptiveHighQualityLevelProfile>(
+        adaptiveHighQualityLevels.L0,
+    );
+    const lastFrameAtMsRef = useRef<number | null>(null);
+    const lastGovernorSampleAtMsRef = useRef(0);
+    const lastRawSampleAtMsRef = useRef(0);
+    const rawSampleEwmaMsRef = useRef<number | null>(null);
+    const reasonRef = useRef('full-quality');
+    const onProfileChangeRef = useRef(onProfileChange);
+    const profileControlActiveRef = useRef(false);
+    const profileControlSampleCountRef = useRef(0);
+    onProfileChangeRef.current = onProfileChange;
+    interactionActiveRef.current = interactionActive;
+    useSceneTimeInvalidation(
+        enabled && interactionActive,
+        sceneFrameRates.interactive,
+    );
+
+    const publishSnapshot = useCallback(
+        ({ nowMs, rawSampleMs }: { nowMs: number; rawSampleMs: number }) => {
+            const snapshot = getAdaptiveHighQualitySnapshot(
+                governorStateRef.current,
+                nowMs,
+            );
+            const timer = gpuTimerRef.current;
+
+            updateGameProfileMetadata({
+                adaptiveHighAmbientFps: snapshot.profile.ambientFramesPerSecond,
+                adaptiveHighCloudUpdateMs: snapshot.profile.cloudShadowUpdateMs,
+                adaptiveHighDeclineCount: snapshot.declineCount,
+                adaptiveHighDprCap: snapshot.profile.dpr,
+                adaptiveHighEnabled: enabled,
+                adaptiveHighEwmaMs: rawSampleEwmaMsRef.current ?? rawSampleMs,
+                adaptiveHighFactor: snapshot.profile.factor,
+                adaptiveHighGpuTimerDisjointCount: timer.disjointCount,
+                adaptiveHighGpuTimerPendingCount:
+                    timer.pending.length + (timer.active ? 1 : 0),
+                adaptiveHighGpuTimerSupported: timer.supported === true,
+                adaptiveHighInteractionActive: interactionActiveRef.current,
+                adaptiveHighLevel: Number.parseInt(snapshot.level.slice(1), 10),
+                adaptiveHighLevelDwellMs: snapshot.currentLevelDwellMs,
+                adaptiveHighLoad:
+                    snapshot.normalizedLoadEwma ?? snapshot.normalizedLoad ?? 0,
+                adaptiveHighOscillationCount: snapshot.oscillationCount,
+                adaptiveHighProfileControlActive:
+                    profileControlActiveRef.current,
+                adaptiveHighProfileControlEnabled: profileControlEnabled,
+                adaptiveHighProfileControlSampleCount:
+                    profileControlSampleCountRef.current,
+                adaptiveHighReason: reasonRef.current,
+                adaptiveHighRecoveryCount: snapshot.recoveryCount,
+                adaptiveHighSampleMs: rawSampleMs,
+                adaptiveHighSampleSource: snapshot.source ?? 'frame',
+                adaptiveHighTransitionCount: snapshot.transitionCount,
+            });
+        },
+        [enabled, profileControlEnabled],
+    );
+
+    const processGovernorSample = useCallback(
+        ({
+            normalizedLoad,
+            nowMs,
+            rawSampleMs,
+            source,
+        }: {
+            normalizedLoad: number;
+            nowMs: number;
+            rawSampleMs: number;
+            source: AdaptiveHighQualityLoadSource;
+        }) => {
+            const previousRawSampleAtMs = lastRawSampleAtMsRef.current;
+            const previousRawSampleEwmaMs = rawSampleEwmaMsRef.current;
+            const elapsedMs =
+                previousRawSampleAtMs === 0
+                    ? governorSampleIntervalMs
+                    : nowMs - previousRawSampleAtMs;
+            const alpha = 1 - Math.exp(-elapsedMs / 1_000);
+            rawSampleEwmaMsRef.current =
+                previousRawSampleEwmaMs === null
+                    ? rawSampleMs
+                    : previousRawSampleEwmaMs +
+                      alpha * (rawSampleMs - previousRawSampleEwmaMs);
+            lastRawSampleAtMsRef.current = nowMs;
+
+            const update = updateAdaptiveHighQuality(governorStateRef.current, {
+                interactionActive: interactionActiveRef.current,
+                normalizedLoad,
+                nowMs,
+                source,
+            });
+            governorStateRef.current = update.state;
+            if (update.transition) {
+                reasonRef.current = update.transition.reason;
+                currentProfileRef.current = getAdaptiveHighQualitySnapshot(
+                    update.state,
+                    nowMs,
+                ).profile;
+                onProfileChangeRef.current(currentProfileRef.current);
+            }
+            publishSnapshot({ nowMs, rawSampleMs });
+        },
+        [publishSnapshot],
+    );
+
+    const resetSamplingAfterPause = useCallback(
+        (nowMs: number, reason: 'sampling-gap' | 'scene-resume') => {
+            governorStateRef.current = resumeAdaptiveHighQualityState(
+                governorStateRef.current,
+                nowMs,
+            );
+            disposeGpuTimerQueries(gpuTimerRef.current);
+            frameWindowRef.current = createFrameWindow();
+            lastFrameAtMsRef.current = null;
+            lastGovernorSampleAtMsRef.current = nowMs;
+            lastRawSampleAtMsRef.current = 0;
+            rawSampleEwmaMsRef.current = null;
+            reasonRef.current = reason;
+        },
+        [],
+    );
+    const handleSceneResume = useCallback(() => {
+        resetSamplingAfterPause(performance.now(), 'scene-resume');
+    }, [resetSamplingAfterPause]);
+    useSceneResume(handleSceneResume);
+
+    useEffect(() => {
+        if (!enabled) {
+            return;
+        }
+
+        let resolutionQuery: MediaQueryList | null = null;
+        const handleDisplayDprChange = () => {
+            setDisplayDpr(getDevicePixelRatio());
+            subscribeToCurrentResolution();
+        };
+        const subscribeToCurrentResolution = () => {
+            resolutionQuery?.removeEventListener(
+                'change',
+                handleDisplayDprChange,
+            );
+            if (typeof window.matchMedia !== 'function') {
+                resolutionQuery = null;
+                return;
+            }
+            resolutionQuery = window.matchMedia(
+                `(resolution: ${getDevicePixelRatio()}dppx)`,
+            );
+            resolutionQuery.addEventListener('change', handleDisplayDprChange);
+        };
+
+        handleDisplayDprChange();
+        window.addEventListener('resize', handleDisplayDprChange);
+        window.addEventListener('orientationchange', handleDisplayDprChange);
+        return () => {
+            resolutionQuery?.removeEventListener(
+                'change',
+                handleDisplayDprChange,
+            );
+            window.removeEventListener('resize', handleDisplayDprChange);
+            window.removeEventListener(
+                'orientationchange',
+                handleDisplayDprChange,
+            );
+        };
+    }, [enabled]);
+
+    useEffect(() => {
+        const nowMs = performance.now();
+        const currentDisplayDpr = enabled ? getDevicePixelRatio() : displayDpr;
+        const effectiveCeiling = Math.min(
+            effectiveDprCeiling,
+            currentDisplayDpr,
+        );
+        governorStateRef.current = createAdaptiveHighQualityState({
+            effectiveDprCeiling: effectiveCeiling,
+            nowMs,
+        });
+        profileControlActiveRef.current = false;
+        profileControlSampleCountRef.current = 0;
+        disposeGpuTimerQueries(gpuTimerRef.current);
+        gpuTimerRef.current = createGpuTimerState();
+        frameWindowRef.current = createFrameWindow();
+        lastFrameAtMsRef.current = null;
+        lastGovernorSampleAtMsRef.current = nowMs;
+        lastRawSampleAtMsRef.current = 0;
+        rawSampleEwmaMsRef.current = null;
+        reasonRef.current = enabled ? 'full-quality' : 'disabled';
+
+        const snapshot = getAdaptiveHighQualitySnapshot(
+            governorStateRef.current,
+            nowMs,
+        );
+        currentProfileRef.current = snapshot.profile;
+        onProfileChangeRef.current(snapshot.profile);
+        publishSnapshot({ nowMs, rawSampleMs: 0 });
+    }, [displayDpr, effectiveDprCeiling, enabled, publishSnapshot]);
+
+    useEffect(() => {
+        if (!enabled || !profileControlEnabled) {
+            return;
+        }
+
+        const startProfileControl = (nowMs: number) => {
+            const effectiveCeiling = Math.min(
+                effectiveDprCeiling,
+                getDevicePixelRatio(),
+            );
+            governorStateRef.current = createAdaptiveHighQualityState({
+                effectiveDprCeiling: effectiveCeiling,
+                nowMs,
+            });
+            disposeGpuTimerQueries(gpuTimerRef.current);
+            gpuTimerRef.current = createGpuTimerState();
+            frameWindowRef.current = createFrameWindow();
+            lastFrameAtMsRef.current = null;
+            lastGovernorSampleAtMsRef.current = nowMs;
+            lastRawSampleAtMsRef.current = 0;
+            rawSampleEwmaMsRef.current = null;
+            profileControlActiveRef.current = true;
+            profileControlSampleCountRef.current = 0;
+            reasonRef.current = 'profile-control-start';
+
+            const snapshot = getAdaptiveHighQualitySnapshot(
+                governorStateRef.current,
+                nowMs,
+            );
+            currentProfileRef.current = snapshot.profile;
+            onProfileChangeRef.current(snapshot.profile);
+            publishSnapshot({ nowMs, rawSampleMs: 0 });
+        };
+        const stopProfileControl = (nowMs: number) => {
+            profileControlActiveRef.current = false;
+            resetSamplingAfterPause(nowMs, 'scene-resume');
+            reasonRef.current = 'profile-control-stop';
+            publishSnapshot({ nowMs, rawSampleMs: 0 });
+        };
+        const handleProfileControlCommand = (event: Event) => {
+            const command =
+                event instanceof CustomEvent
+                    ? readAdaptiveHighQualityProfileControlCommand(event.detail)
+                    : null;
+            if (!command) {
+                return;
+            }
+
+            const nowMs = performance.now();
+            if (command.action === 'start') {
+                startProfileControl(nowMs);
+                return;
+            }
+            if (command.action === 'stop') {
+                if (profileControlActiveRef.current) {
+                    stopProfileControl(nowMs);
+                }
+                return;
+            }
+            if (!profileControlActiveRef.current) {
+                return;
+            }
+
+            profileControlSampleCountRef.current += 1;
+            const sampleBudgetMs =
+                command.source === 'gpu'
+                    ? interactionActiveRef.current
+                        ? interactiveGpuBudgetMs
+                        : idleGpuBudgetMs
+                    : 1_000 /
+                      (interactionActiveRef.current
+                          ? sceneFrameRates.interactive
+                          : currentProfileRef.current.ambientFramesPerSecond);
+            processGovernorSample({
+                normalizedLoad: command.normalizedLoad,
+                nowMs,
+                rawSampleMs: command.normalizedLoad * sampleBudgetMs,
+                source: command.source,
+            });
+        };
+
+        window.addEventListener(
+            adaptiveHighQualityProfileControlEventName,
+            handleProfileControlCommand,
+        );
+        return () => {
+            window.removeEventListener(
+                adaptiveHighQualityProfileControlEventName,
+                handleProfileControlCommand,
+            );
+            profileControlActiveRef.current = false;
+        };
+    }, [
+        effectiveDprCeiling,
+        enabled,
+        processGovernorSample,
+        profileControlEnabled,
+        publishSnapshot,
+        resetSamplingAfterPause,
+    ]);
+
+    useEffect(() => {
+        if (!enabled) {
+            return;
+        }
+        if (!interactionActive) {
+            if (profileControlActiveRef.current) {
+                publishSnapshot({
+                    nowMs: performance.now(),
+                    rawSampleMs: rawSampleEwmaMsRef.current ?? 0,
+                });
+            }
+            return;
+        }
+
+        processGovernorSample({
+            normalizedLoad: governorStateRef.current.normalizedLoadEwma ?? 1,
+            nowMs: performance.now(),
+            rawSampleMs: rawSampleEwmaMsRef.current ?? 0,
+            source: governorStateRef.current.source ?? 'frame',
+        });
+    }, [enabled, interactionActive, processGovernorSample, publishSnapshot]);
+
+    useEffect(() => {
+        const canvas = gl.domElement;
+        const handleContextLost = () => {
+            const timer = gpuTimerRef.current;
+            timer.contextLost = true;
+            timer.supported = false;
+            disposeGpuTimerQueries(timer);
+        };
+        const handleContextRestored = () => {
+            resetSamplingAfterPause(performance.now(), 'scene-resume');
+            gpuTimerRef.current = createGpuTimerState();
+        };
+        canvas.addEventListener('webglcontextlost', handleContextLost);
+        canvas.addEventListener('webglcontextrestored', handleContextRestored);
+        return () => {
+            canvas.removeEventListener('webglcontextlost', handleContextLost);
+            canvas.removeEventListener(
+                'webglcontextrestored',
+                handleContextRestored,
+            );
+            disposeGpuTimerQueries(gpuTimerRef.current);
+        };
+    }, [gl.domElement, resetSamplingAfterPause]);
+
+    useFrame(() => {
+        if (!enabled) {
+            return;
+        }
+        if (profileControlActiveRef.current) {
+            return;
+        }
+
+        const nowMs = performance.now();
+        const targetFrameMs = interactionActiveRef.current
+            ? interactiveGpuBudgetMs
+            : 1_000 / currentProfileRef.current.ambientFramesPerSecond;
+        const lastFrameAtMs = lastFrameAtMsRef.current;
+        if (lastFrameAtMs !== null) {
+            const elapsedMs = nowMs - lastFrameAtMs;
+            if (elapsedMs <= governorLongFrameGapMs) {
+                frameWindowRef.current.elapsedMs.push(elapsedMs);
+                if (elapsedMs <= targetFrameMs * frameOnTimeRatio) {
+                    frameWindowRef.current.onTimeCount += 1;
+                }
+            } else {
+                resetSamplingAfterPause(nowMs, 'sampling-gap');
+            }
+        }
+        lastFrameAtMsRef.current = nowMs;
+
+        const timer = gpuTimerRef.current;
+        pollGpuQueries(timer, nowMs);
+        beginGpuQuery(timer, gl.getContext(), nowMs);
+
+        if (
+            nowMs - lastGovernorSampleAtMsRef.current <
+            governorSampleIntervalMs
+        ) {
+            return;
+        }
+        lastGovernorSampleAtMsRef.current = nowMs;
+
+        if (
+            timer.supported === true &&
+            !hasExternalGpuTimer() &&
+            timer.samplesMs.length > 0
+        ) {
+            const sampleMs = average(timer.samplesMs);
+            timer.samplesMs = [];
+            frameWindowRef.current = createFrameWindow();
+            const budgetMs = interactionActiveRef.current
+                ? interactiveGpuBudgetMs
+                : idleGpuBudgetMs;
+            processGovernorSample({
+                normalizedLoad: sampleMs / budgetMs,
+                nowMs,
+                rawSampleMs: sampleMs,
+                source: 'gpu',
+            });
+            return;
+        }
+
+        const frameLoad = resolveFrameWindowLoad(frameWindowRef.current);
+        if (frameLoad === null) {
+            return;
+        }
+        const frameSampleMs = average(frameWindowRef.current.elapsedMs);
+        frameWindowRef.current = createFrameWindow();
+        processGovernorSample({
+            normalizedLoad: frameLoad,
+            nowMs,
+            rawSampleMs: frameSampleMs,
+            source: 'frame',
+        });
+    });
+
+    return null;
+}

--- a/packages/game/src/scene/CloudLayer.tsx
+++ b/packages/game/src/scene/CloudLayer.tsx
@@ -153,6 +153,7 @@ type CloudLayerProps = {
     cloudy: number;
     foggy: number;
     quality: GameQualityProfile;
+    shadowUpdateMs?: number;
     shadowStrength: number;
     stacks: Stack[] | undefined;
     sunPosition: Vector3;
@@ -285,6 +286,7 @@ export function CloudLayer({
     cloudy,
     foggy,
     quality,
+    shadowUpdateMs,
     shadowStrength,
     stacks,
     sunPosition,
@@ -314,10 +316,11 @@ export function CloudLayer({
     const attenuationConfig = useMemo(
         () =>
             resolveCloudShadowAttenuationConfig({
+                minimumUpdateMs: shadowUpdateMs,
                 prefersReducedMotion,
                 quality,
             }),
-        [prefersReducedMotion, quality],
+        [prefersReducedMotion, quality, shadowUpdateMs],
     );
     const shadowProjection = useMemo(
         () => resolveCloudShadowProjection(sunPosition),

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -253,6 +253,7 @@ export function environmentState(
 }
 
 export type EnvironmentProps = {
+    cloudShadowUpdateMs?: number;
     noBackground?: boolean;
     noSound?: boolean;
     noWeather?: boolean;
@@ -568,6 +569,7 @@ export function StaticEnvironment({
 }
 
 export function Environment({
+    cloudShadowUpdateMs,
     noBackground,
     noSound,
     noWeather,
@@ -1079,6 +1081,7 @@ export function Environment({
                     cloudy={blendedWeather.cloudy ?? 0}
                     foggy={blendedWeather.foggy ?? 0}
                     quality={qualityProfile}
+                    shadowUpdateMs={cloudShadowUpdateMs}
                     shadowStrength={
                         qualityProfile.shadows ? cloudShadowStrength : 0
                     }

--- a/packages/game/src/scene/Scene.tsx
+++ b/packages/game/src/scene/Scene.tsx
@@ -26,6 +26,11 @@ import {
 } from '../entities/helpers/HoverOutline';
 import { getGeneratedLSystemCacheSnapshot } from '../generators/plant/hooks/generatedLSystemCache';
 import { useOptionalGameState } from '../useGameState';
+import { AdaptiveHighQualityController } from './AdaptiveHighQualityController';
+import {
+    type AdaptiveHighQualityLevelProfile,
+    adaptiveHighQualityLevels,
+} from './adaptiveHighQuality';
 import { updateGameProfileMetadata } from './gameProfileMetadata';
 import {
     type GameQualityProfile,
@@ -36,8 +41,15 @@ import { WeatherSurfaceUniformProvider } from './WeatherSurfaceUniformProvider';
 
 export type SceneProps = HTMLAttributes<HTMLDivElement> &
     PropsWithChildren<{
+        adaptiveHighEnabled?: boolean;
+        adaptiveHighInteractionActive?: boolean;
+        adaptiveHighProfile?: AdaptiveHighQualityLevelProfile;
+        adaptiveHighProfileControlEnabled?: boolean;
         debugStats?: boolean;
         fixedTimeSeconds?: number;
+        onAdaptiveHighProfileChange?: (
+            profile: AdaptiveHighQualityLevelProfile,
+        ) => void;
         pixelRatio?: number;
         position: FiberVector3;
         quality?: GameQualityProfile;
@@ -216,9 +228,14 @@ function SceneDebugName() {
 }
 
 export function Scene({
+    adaptiveHighEnabled = false,
+    adaptiveHighInteractionActive = false,
+    adaptiveHighProfile = adaptiveHighQualityLevels.L0,
+    adaptiveHighProfileControlEnabled = false,
     children,
     debugStats,
     fixedTimeSeconds,
+    onAdaptiveHighProfileChange,
     pixelRatio,
     position,
     quality,
@@ -228,6 +245,14 @@ export function Scene({
     ...rest
 }: SceneProps) {
     const qualityProfile = quality ?? resolveGameQualityProfile();
+    const adaptiveHighActive =
+        adaptiveHighEnabled && qualityProfile.tier === 'high';
+    const effectiveDprCap = adaptiveHighActive
+        ? adaptiveHighProfile.dpr
+        : qualityProfile.dpr;
+    const ambientFramesPerSecond = adaptiveHighActive
+        ? adaptiveHighProfile.ambientFramesPerSecond
+        : sceneFrameRates.ambient;
     const wireframeDebugVisible = useOptionalGameState(
         (state) => state.wireframeDebugVisible,
         false,
@@ -235,19 +260,19 @@ export function Scene({
 
     useEffect(() => {
         updateGameProfileMetadata({
-            dprCap: qualityProfile.dpr,
+            dprCap: effectiveDprCap,
             groundDecorationDensity: qualityProfile.groundDecorationDensity,
             qualityTier: qualityProfile.tier,
             shadowMapSize: qualityProfile.shadowMapSize,
             shadowsEnabled: qualityProfile.shadows,
             snowOverlayMinCoverage: qualityProfile.snowOverlayMinCoverage,
         });
-    }, [qualityProfile]);
+    }, [effectiveDprCap, qualityProfile]);
 
     return (
         <Canvas
             orthographic
-            dpr={pixelRatio ?? [1, qualityProfile.dpr]}
+            dpr={pixelRatio ?? [1, effectiveDprCap]}
             gl={rendererOptions}
             shadows={
                 qualityProfile.shadows
@@ -267,10 +292,21 @@ export function Scene({
             frameloop="demand"
         >
             <SceneTimeProvider
-                baseFramesPerSecond={sceneFrameRates.ambient}
+                baseFramesPerSecond={ambientFramesPerSecond}
                 fixedTimeSeconds={fixedTimeSeconds}
                 suspendWhenOffscreen={suspendWhenOffscreen}
             >
+                <AdaptiveHighQualityController
+                    effectiveDprCeiling={qualityProfile.dpr}
+                    enabled={adaptiveHighActive}
+                    interactionActive={adaptiveHighInteractionActive}
+                    onProfileChange={
+                        onAdaptiveHighProfileChange ?? (() => undefined)
+                    }
+                    profileControlEnabled={
+                        adaptiveHighActive && adaptiveHighProfileControlEnabled
+                    }
+                />
                 <WeatherSurfaceUniformProvider>
                     <ActorGroundingShadowProvider
                         enabled={qualityProfile.shadows}

--- a/packages/game/src/scene/SceneTime.tsx
+++ b/packages/game/src/scene/SceneTime.tsx
@@ -56,7 +56,9 @@ export function SceneTimeProvider({
         normalizeSceneFramesPerSecond(baseFramesPerSecond),
     );
     const canvasVisibleRef = useRef(true);
-    const continuousRenderLeasesRef = useRef(new Map<symbol, number>());
+    const continuousRenderLeasesRef = useRef(
+        new Map<symbol, number | undefined>(),
+    );
     const disposedRef = useRef(false);
     const documentVisibleRef = useRef(
         typeof document !== 'undefined' ? !document.hidden : false,
@@ -162,9 +164,11 @@ export function SceneTimeProvider({
     ]);
 
     const acquireContinuousRender = useCallback(
-        (framesPerSecond: number = sceneFrameRates.ambient) => {
+        (framesPerSecond?: number) => {
             const normalizedFramesPerSecond =
-                normalizeSceneFramesPerSecond(framesPerSecond);
+                framesPerSecond === undefined
+                    ? undefined
+                    : normalizeSceneFramesPerSecond(framesPerSecond);
             if (normalizedFramesPerSecond === 0) {
                 return () => undefined;
             }
@@ -317,7 +321,7 @@ export function useSceneTimeUniform() {
 
 export function useSceneTimeInvalidation(
     enabled = true,
-    framesPerSecond: number = sceneFrameRates.ambient,
+    framesPerSecond?: number,
 ) {
     const sceneTime = useContext(SceneTimeContext);
     if (!sceneTime) {

--- a/packages/game/src/scene/adaptiveHighQuality.ts
+++ b/packages/game/src/scene/adaptiveHighQuality.ts
@@ -1,0 +1,552 @@
+export type AdaptiveHighQualityLevel = 'L0' | 'L1' | 'L2' | 'L3';
+export type AdaptiveHighQualityLoadSource = 'frame' | 'gpu';
+export type AdaptiveHighQualityTransitionDirection = 'decline' | 'recover';
+export type AdaptiveHighQualityTransitionReason =
+    | 'headroom'
+    | 'interaction'
+    | 'overload';
+
+export type AdaptiveHighQualityLevelProfile = {
+    ambientFramesPerSecond: number;
+    cloudShadowUpdateMs: number;
+    dpr: number;
+    factor: number;
+};
+
+export const adaptiveHighQualityLevelOrder = [
+    'L0',
+    'L1',
+    'L2',
+    'L3',
+] as const satisfies readonly AdaptiveHighQualityLevel[];
+
+function normalizeEffectiveDprCeiling(effectiveDprCeiling: number) {
+    if (!Number.isFinite(effectiveDprCeiling)) {
+        return 2;
+    }
+
+    return Math.min(2, Math.max(1, effectiveDprCeiling));
+}
+
+function roundDpr(dpr: number) {
+    return Math.round(dpr * 1_000) / 1_000;
+}
+
+export function resolveAdaptiveHighQualityLevels(
+    effectiveDprCeiling = 2,
+): Record<AdaptiveHighQualityLevel, AdaptiveHighQualityLevelProfile> {
+    const ceiling = normalizeEffectiveDprCeiling(effectiveDprCeiling);
+    const firstDeclineDpr = roundDpr(Math.max(1, ceiling - 0.25));
+    const secondDeclineDpr = roundDpr(Math.max(1, ceiling * 0.75));
+
+    return {
+        L0: {
+            ambientFramesPerSecond: 30,
+            cloudShadowUpdateMs: 96,
+            dpr: roundDpr(ceiling),
+            factor: 1,
+        },
+        L1: {
+            ambientFramesPerSecond: 30,
+            cloudShadowUpdateMs: 96,
+            dpr: firstDeclineDpr,
+            factor: 0.875,
+        },
+        L2: {
+            ambientFramesPerSecond: 30,
+            cloudShadowUpdateMs: 96,
+            dpr: secondDeclineDpr,
+            factor: 0.75,
+        },
+        L3: {
+            ambientFramesPerSecond: 20,
+            cloudShadowUpdateMs: 160,
+            dpr: secondDeclineDpr,
+            factor: 0.7,
+        },
+    };
+}
+
+export const adaptiveHighQualityLevels = resolveAdaptiveHighQualityLevels();
+
+function hasSameRuntimeCost(
+    first: AdaptiveHighQualityLevelProfile,
+    second: AdaptiveHighQualityLevelProfile,
+) {
+    return (
+        first.ambientFramesPerSecond === second.ambientFramesPerSecond &&
+        first.cloudShadowUpdateMs === second.cloudShadowUpdateMs &&
+        first.dpr === second.dpr
+    );
+}
+
+export function resolveAdaptiveHighQualityLevelOrder(effectiveDprCeiling = 2) {
+    const levels = resolveAdaptiveHighQualityLevels(effectiveDprCeiling);
+    const resolvedOrder: AdaptiveHighQualityLevel[] = [];
+
+    for (const level of adaptiveHighQualityLevelOrder) {
+        const previousLevel = resolvedOrder.at(-1);
+        if (
+            previousLevel === undefined ||
+            !hasSameRuntimeCost(levels[previousLevel], levels[level])
+        ) {
+            resolvedOrder.push(level);
+        }
+    }
+
+    return resolvedOrder;
+}
+
+export const adaptiveHighQualityPolicy = {
+    declineCooldownMs: 1_250,
+    ewmaTimeConstantMs: 1_000,
+    headroomLoad: 0.8,
+    headroomSustainMs: 5_000,
+    overloadLoad: 1.1,
+    overloadMinimumSamples: 3,
+    overloadSustainMs: 750,
+    recoveryLockMs: 30_000,
+    reversalLockCount: 3,
+    reversalWindowMs: 60_000,
+} as const;
+
+type AdaptiveHighQualityEvidence = {
+    samples: number;
+    sinceMs: number | null;
+};
+
+export type AdaptiveHighQualityTransition = {
+    atMs: number;
+    direction: AdaptiveHighQualityTransitionDirection;
+    from: AdaptiveHighQualityLevel;
+    reason: AdaptiveHighQualityTransitionReason;
+    to: AdaptiveHighQualityLevel;
+};
+
+export type AdaptiveHighQualityState = {
+    declineCount: number;
+    dwellMsByLevel: Record<AdaptiveHighQualityLevel, number>;
+    effectiveDprCeiling: number;
+    headroomEvidence: AdaptiveHighQualityEvidence;
+    interactionActive: boolean;
+    ewmaSampleCount: number;
+    lastDeclineAtMs: number | null;
+    lastSampleAtMs: number;
+    lastTransition: AdaptiveHighQualityTransition | null;
+    lastTransitionDirection: AdaptiveHighQualityTransitionDirection | null;
+    level: AdaptiveHighQualityLevel;
+    levelEnteredAtMs: number;
+    loadSampleCount: number;
+    normalizedLoad: number | null;
+    normalizedLoadEwma: number | null;
+    oscillationCount: number;
+    overloadEvidence: AdaptiveHighQualityEvidence;
+    recentReversalAtMs: number[];
+    recoveryCount: number;
+    recoveryLockedUntilMs: number;
+    source: AdaptiveHighQualityLoadSource | null;
+    transitionCount: number;
+};
+
+export type AdaptiveHighQualitySample = {
+    interactionActive: boolean;
+    normalizedLoad: number;
+    nowMs: number;
+    source: AdaptiveHighQualityLoadSource;
+};
+
+export type AdaptiveHighQualityUpdate = {
+    state: AdaptiveHighQualityState;
+    transition: AdaptiveHighQualityTransition | null;
+};
+
+export type AdaptiveHighQualitySnapshot = {
+    currentLevelDwellMs: number;
+    declineCount: number;
+    dwellMsByLevel: Record<AdaptiveHighQualityLevel, number>;
+    ewmaSampleCount: number;
+    level: AdaptiveHighQualityLevel;
+    loadSampleCount: number;
+    normalizedLoad: number | null;
+    normalizedLoadEwma: number | null;
+    oscillationCount: number;
+    profile: AdaptiveHighQualityLevelProfile;
+    recoveryCount: number;
+    recoveryLocked: boolean;
+    recoveryLockedUntilMs: number;
+    source: AdaptiveHighQualityLoadSource | null;
+    transitionCount: number;
+};
+
+const emptyEvidence = (): AdaptiveHighQualityEvidence => ({
+    samples: 0,
+    sinceMs: null,
+});
+
+const emptyDwellMsByLevel = (): Record<AdaptiveHighQualityLevel, number> => ({
+    L0: 0,
+    L1: 0,
+    L2: 0,
+    L3: 0,
+});
+
+function normalizeNowMs(nowMs: number, minimum = 0) {
+    if (!Number.isFinite(nowMs)) {
+        return minimum;
+    }
+
+    return Math.max(minimum, nowMs);
+}
+
+export function createAdaptiveHighQualityState({
+    effectiveDprCeiling = 2,
+    level = 'L0',
+    nowMs = 0,
+    source = null,
+}: {
+    effectiveDprCeiling?: number;
+    level?: AdaptiveHighQualityLevel;
+    nowMs?: number;
+    source?: AdaptiveHighQualityLoadSource | null;
+} = {}): AdaptiveHighQualityState {
+    const normalizedDprCeiling =
+        normalizeEffectiveDprCeiling(effectiveDprCeiling);
+    const normalizedNowMs = normalizeNowMs(nowMs);
+
+    return {
+        declineCount: 0,
+        dwellMsByLevel: emptyDwellMsByLevel(),
+        effectiveDprCeiling: normalizedDprCeiling,
+        ewmaSampleCount: 0,
+        headroomEvidence: emptyEvidence(),
+        interactionActive: false,
+        lastDeclineAtMs: null,
+        lastSampleAtMs: normalizedNowMs,
+        lastTransition: null,
+        lastTransitionDirection: null,
+        level: canonicalLevel(level, normalizedDprCeiling),
+        levelEnteredAtMs: normalizedNowMs,
+        loadSampleCount: 0,
+        normalizedLoad: null,
+        normalizedLoadEwma: null,
+        oscillationCount: 0,
+        overloadEvidence: emptyEvidence(),
+        recentReversalAtMs: [],
+        recoveryCount: 0,
+        recoveryLockedUntilMs: 0,
+        source,
+        transitionCount: 0,
+    };
+}
+
+export function resumeAdaptiveHighQualityState(
+    currentState: AdaptiveHighQualityState,
+    nowMs: number,
+): AdaptiveHighQualityState {
+    const normalizedNowMs = normalizeNowMs(nowMs, currentState.lastSampleAtMs);
+    const currentLevelDwellMs = Math.max(
+        0,
+        currentState.lastSampleAtMs - currentState.levelEnteredAtMs,
+    );
+
+    return {
+        ...currentState,
+        ewmaSampleCount: 0,
+        headroomEvidence: emptyEvidence(),
+        interactionActive: false,
+        lastSampleAtMs: normalizedNowMs,
+        lastTransition: null,
+        levelEnteredAtMs: normalizedNowMs - currentLevelDwellMs,
+        normalizedLoad: null,
+        normalizedLoadEwma: null,
+        overloadEvidence: emptyEvidence(),
+        source: null,
+    };
+}
+
+function accrueDwell(
+    state: AdaptiveHighQualityState,
+    nowMs: number,
+): AdaptiveHighQualityState {
+    const elapsedMs = nowMs - state.lastSampleAtMs;
+    if (elapsedMs === 0) {
+        return state;
+    }
+
+    return {
+        ...state,
+        dwellMsByLevel: {
+            ...state.dwellMsByLevel,
+            [state.level]: state.dwellMsByLevel[state.level] + elapsedMs,
+        },
+        lastSampleAtMs: nowMs,
+    };
+}
+
+function updateEvidence(
+    evidence: AdaptiveHighQualityEvidence,
+    condition: boolean,
+    nowMs: number,
+): AdaptiveHighQualityEvidence {
+    if (!condition) {
+        return emptyEvidence();
+    }
+
+    return {
+        samples: evidence.samples + 1,
+        sinceMs: evidence.sinceMs ?? nowMs,
+    };
+}
+
+function evidenceDurationMs(
+    evidence: AdaptiveHighQualityEvidence,
+    nowMs: number,
+) {
+    return evidence.sinceMs === null ? 0 : nowMs - evidence.sinceMs;
+}
+
+function canonicalLevel(
+    requestedLevel: AdaptiveHighQualityLevel,
+    effectiveDprCeiling: number,
+) {
+    const levels = resolveAdaptiveHighQualityLevels(effectiveDprCeiling);
+    const requestedIndex =
+        adaptiveHighQualityLevelOrder.indexOf(requestedLevel);
+    let canonicalIndex = requestedIndex;
+    while (canonicalIndex > 0) {
+        const currentLevel = adaptiveHighQualityLevelOrder[canonicalIndex];
+        const previousLevel = adaptiveHighQualityLevelOrder[canonicalIndex - 1];
+        if (
+            currentLevel === undefined ||
+            previousLevel === undefined ||
+            !hasSameRuntimeCost(levels[currentLevel], levels[previousLevel])
+        ) {
+            break;
+        }
+        canonicalIndex -= 1;
+    }
+
+    return adaptiveHighQualityLevelOrder[canonicalIndex] ?? requestedLevel;
+}
+
+function adjacentLevel(
+    state: AdaptiveHighQualityState,
+    direction: AdaptiveHighQualityTransitionDirection,
+) {
+    const resolvedOrder = resolveAdaptiveHighQualityLevelOrder(
+        state.effectiveDprCeiling,
+    );
+    const levelIndex = resolvedOrder.indexOf(state.level);
+    const nextIndex = direction === 'decline' ? levelIndex + 1 : levelIndex - 1;
+    return resolvedOrder[nextIndex] ?? null;
+}
+
+function transitionLevel(
+    state: AdaptiveHighQualityState,
+    to: AdaptiveHighQualityLevel,
+    reason: AdaptiveHighQualityTransitionReason,
+    nowMs: number,
+): AdaptiveHighQualityUpdate {
+    const fromIndex = adaptiveHighQualityLevelOrder.indexOf(state.level);
+    const toIndex = adaptiveHighQualityLevelOrder.indexOf(to);
+    const direction =
+        toIndex > fromIndex ? ('decline' as const) : ('recover' as const);
+    const transition = {
+        atMs: nowMs,
+        direction,
+        from: state.level,
+        reason,
+        to,
+    } satisfies AdaptiveHighQualityTransition;
+    const reversal =
+        state.lastTransitionDirection !== null &&
+        state.lastTransitionDirection !== direction;
+    const reversalWindowStartMs =
+        nowMs - adaptiveHighQualityPolicy.reversalWindowMs;
+    const recentReversalAtMs = state.recentReversalAtMs.filter(
+        (reversalAtMs) => reversalAtMs >= reversalWindowStartMs,
+    );
+    const previousReversalCount = recentReversalAtMs.length;
+    if (reversal) {
+        recentReversalAtMs.push(nowMs);
+    }
+    const recoveryLockedUntilMs =
+        reversal &&
+        previousReversalCount < adaptiveHighQualityPolicy.reversalLockCount &&
+        recentReversalAtMs.length >= adaptiveHighQualityPolicy.reversalLockCount
+            ? Math.max(
+                  state.recoveryLockedUntilMs,
+                  nowMs + adaptiveHighQualityPolicy.recoveryLockMs,
+              )
+            : state.recoveryLockedUntilMs;
+
+    return {
+        state: {
+            ...state,
+            declineCount:
+                state.declineCount + (direction === 'decline' ? 1 : 0),
+            ewmaSampleCount: 0,
+            headroomEvidence: emptyEvidence(),
+            lastDeclineAtMs:
+                direction === 'decline' ? nowMs : state.lastDeclineAtMs,
+            lastTransition: transition,
+            lastTransitionDirection: direction,
+            level: to,
+            levelEnteredAtMs: nowMs,
+            normalizedLoadEwma: null,
+            oscillationCount: state.oscillationCount + (reversal ? 1 : 0),
+            overloadEvidence: emptyEvidence(),
+            recentReversalAtMs,
+            recoveryCount:
+                state.recoveryCount + (direction === 'recover' ? 1 : 0),
+            recoveryLockedUntilMs,
+            transitionCount: state.transitionCount + 1,
+        },
+        transition,
+    };
+}
+
+function updateNormalizedLoadEwma({
+    elapsedMs,
+    normalizedLoad,
+    previousEwma,
+}: {
+    elapsedMs: number;
+    normalizedLoad: number;
+    previousEwma: number | null;
+}) {
+    if (previousEwma === null) {
+        return normalizedLoad;
+    }
+
+    const alpha =
+        1 - Math.exp(-elapsedMs / adaptiveHighQualityPolicy.ewmaTimeConstantMs);
+    return previousEwma + alpha * (normalizedLoad - previousEwma);
+}
+
+export function updateAdaptiveHighQuality(
+    currentState: AdaptiveHighQualityState,
+    sample: AdaptiveHighQualitySample,
+): AdaptiveHighQualityUpdate {
+    if (!Number.isFinite(sample.normalizedLoad) || sample.normalizedLoad <= 0) {
+        return { state: currentState, transition: null };
+    }
+
+    const nowMs = normalizeNowMs(sample.nowMs, currentState.lastSampleAtMs);
+    const elapsedMs = nowMs - currentState.lastSampleAtMs;
+    const sourceChanged = currentState.source !== sample.source;
+    let state = accrueDwell(currentState, nowMs);
+    const normalizedLoadEwma = updateNormalizedLoadEwma({
+        elapsedMs,
+        normalizedLoad: sample.normalizedLoad,
+        previousEwma: sourceChanged ? null : currentState.normalizedLoadEwma,
+    });
+
+    state = {
+        ...state,
+        headroomEvidence: sourceChanged
+            ? emptyEvidence()
+            : state.headroomEvidence,
+        interactionActive: sample.interactionActive,
+        ewmaSampleCount: sourceChanged ? 1 : state.ewmaSampleCount + 1,
+        lastTransition: null,
+        loadSampleCount: state.loadSampleCount + 1,
+        normalizedLoad: sample.normalizedLoad,
+        normalizedLoadEwma,
+        overloadEvidence: sourceChanged
+            ? emptyEvidence()
+            : state.overloadEvidence,
+        source: sample.source,
+    };
+
+    if (sample.interactionActive && state.level === 'L0') {
+        const interactionLevel = adjacentLevel(state, 'decline');
+        if (interactionLevel !== null) {
+            return transitionLevel(
+                state,
+                interactionLevel,
+                'interaction',
+                nowMs,
+            );
+        }
+    }
+
+    const overloadEvidence = updateEvidence(
+        state.overloadEvidence,
+        normalizedLoadEwma > adaptiveHighQualityPolicy.overloadLoad,
+        nowMs,
+    );
+    const headroomEvidence = updateEvidence(
+        state.headroomEvidence,
+        !sample.interactionActive &&
+            normalizedLoadEwma < adaptiveHighQualityPolicy.headroomLoad,
+        nowMs,
+    );
+    state = {
+        ...state,
+        headroomEvidence,
+        overloadEvidence,
+    };
+
+    const declineLevel = adjacentLevel(state, 'decline');
+    const declineCooldownElapsed =
+        state.lastDeclineAtMs === null ||
+        nowMs - state.lastDeclineAtMs >=
+            adaptiveHighQualityPolicy.declineCooldownMs;
+    if (
+        declineLevel !== null &&
+        declineCooldownElapsed &&
+        overloadEvidence.samples >=
+            adaptiveHighQualityPolicy.overloadMinimumSamples &&
+        evidenceDurationMs(overloadEvidence, nowMs) >=
+            adaptiveHighQualityPolicy.overloadSustainMs
+    ) {
+        return transitionLevel(state, declineLevel, 'overload', nowMs);
+    }
+
+    const recoveryLevel = adjacentLevel(state, 'recover');
+    if (
+        recoveryLevel !== null &&
+        !sample.interactionActive &&
+        nowMs >= state.recoveryLockedUntilMs &&
+        evidenceDurationMs(headroomEvidence, nowMs) >=
+            adaptiveHighQualityPolicy.headroomSustainMs
+    ) {
+        return transitionLevel(state, recoveryLevel, 'headroom', nowMs);
+    }
+
+    return { state, transition: null };
+}
+
+export function getAdaptiveHighQualitySnapshot(
+    state: AdaptiveHighQualityState,
+    nowMs: number,
+): AdaptiveHighQualitySnapshot {
+    const normalizedNowMs = normalizeNowMs(nowMs, state.lastSampleAtMs);
+    const dwellMsByLevel = {
+        ...state.dwellMsByLevel,
+        [state.level]:
+            state.dwellMsByLevel[state.level] +
+            (normalizedNowMs - state.lastSampleAtMs),
+    };
+
+    return {
+        currentLevelDwellMs: normalizedNowMs - state.levelEnteredAtMs,
+        declineCount: state.declineCount,
+        dwellMsByLevel,
+        ewmaSampleCount: state.ewmaSampleCount,
+        level: state.level,
+        loadSampleCount: state.loadSampleCount,
+        normalizedLoad: state.normalizedLoad,
+        normalizedLoadEwma: state.normalizedLoadEwma,
+        oscillationCount: state.oscillationCount,
+        profile: resolveAdaptiveHighQualityLevels(state.effectiveDprCeiling)[
+            state.level
+        ],
+        recoveryCount: state.recoveryCount,
+        recoveryLocked: normalizedNowMs < state.recoveryLockedUntilMs,
+        recoveryLockedUntilMs: state.recoveryLockedUntilMs,
+        source: state.source,
+        transitionCount: state.transitionCount,
+    };
+}

--- a/packages/game/src/scene/adaptiveHighQuality.unit.ts
+++ b/packages/game/src/scene/adaptiveHighQuality.unit.ts
@@ -1,0 +1,459 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    type AdaptiveHighQualityLoadSource,
+    type AdaptiveHighQualityState,
+    adaptiveHighQualityLevelOrder,
+    adaptiveHighQualityLevels,
+    createAdaptiveHighQualityState,
+    getAdaptiveHighQualitySnapshot,
+    resolveAdaptiveHighQualityLevelOrder,
+    resolveAdaptiveHighQualityLevels,
+    resumeAdaptiveHighQualityState,
+    updateAdaptiveHighQuality,
+} from './adaptiveHighQuality';
+
+function sample(
+    state: AdaptiveHighQualityState,
+    {
+        interactionActive = false,
+        load,
+        nowMs,
+        source = 'gpu',
+    }: {
+        interactionActive?: boolean;
+        load: number;
+        nowMs: number;
+        source?: AdaptiveHighQualityLoadSource;
+    },
+) {
+    return updateAdaptiveHighQuality(state, {
+        interactionActive,
+        normalizedLoad: load,
+        nowMs,
+        source,
+    });
+}
+
+function settleEwma(
+    state: AdaptiveHighQualityState,
+    {
+        durationMs,
+        intervalMs = 250,
+        load,
+        source = 'gpu',
+        startMs,
+    }: {
+        durationMs: number;
+        intervalMs?: number;
+        load: number;
+        source?: AdaptiveHighQualityLoadSource;
+        startMs: number;
+    },
+) {
+    let nextState = state;
+    for (
+        let nowMs = startMs;
+        nowMs <= startMs + durationMs;
+        nowMs += intervalMs
+    ) {
+        nextState = sample(nextState, {
+            load,
+            nowMs,
+            source,
+        }).state;
+    }
+    return nextState;
+}
+
+function forceDecline(state: AdaptiveHighQualityState, startMs: number) {
+    let nextState = state;
+    for (let nowMs = startMs; nowMs <= startMs + 10_000; nowMs += 250) {
+        const update = sample(nextState, {
+            load: 2,
+            nowMs,
+        });
+        nextState = update.state;
+        if (update.transition?.direction === 'decline') {
+            return nextState;
+        }
+    }
+    throw new Error('Expected a decline transition');
+}
+
+function forceRecovery(state: AdaptiveHighQualityState, startMs: number) {
+    let nextState = state;
+    for (let nowMs = startMs; nowMs <= startMs + 15_000; nowMs += 250) {
+        const update = sample(nextState, {
+            load: 0.2,
+            nowMs,
+        });
+        nextState = update.state;
+        if (update.transition?.direction === 'recover') {
+            return nextState;
+        }
+    }
+    throw new Error('Expected a recovery transition');
+}
+
+test('adaptive High level order exposes the staged visual ceiling', () => {
+    assert.deepEqual(adaptiveHighQualityLevelOrder, ['L0', 'L1', 'L2', 'L3']);
+    assert.deepEqual(adaptiveHighQualityLevels, {
+        L0: {
+            ambientFramesPerSecond: 30,
+            cloudShadowUpdateMs: 96,
+            dpr: 2,
+            factor: 1,
+        },
+        L1: {
+            ambientFramesPerSecond: 30,
+            cloudShadowUpdateMs: 96,
+            dpr: 1.75,
+            factor: 0.875,
+        },
+        L2: {
+            ambientFramesPerSecond: 30,
+            cloudShadowUpdateMs: 96,
+            dpr: 1.5,
+            factor: 0.75,
+        },
+        L3: {
+            ambientFramesPerSecond: 20,
+            cloudShadowUpdateMs: 160,
+            dpr: 1.5,
+            factor: 0.7,
+        },
+    });
+});
+
+test('level DPR reductions derive from the effective display ceiling', () => {
+    assert.deepEqual(
+        Object.fromEntries(
+            Object.entries(resolveAdaptiveHighQualityLevels(1.5)).map(
+                ([level, profile]) => [level, profile.dpr],
+            ),
+        ),
+        {
+            L0: 1.5,
+            L1: 1.25,
+            L2: 1.125,
+            L3: 1.125,
+        },
+    );
+    assert.deepEqual(
+        Object.fromEntries(
+            Object.entries(resolveAdaptiveHighQualityLevels(0.5)).map(
+                ([level, profile]) => [level, profile.dpr],
+            ),
+        ),
+        {
+            L0: 1,
+            L1: 1,
+            L2: 1,
+            L3: 1,
+        },
+    );
+    assert.equal(resolveAdaptiveHighQualityLevels(3).L0.dpr, 2);
+    assert.deepEqual(resolveAdaptiveHighQualityLevelOrder(1), ['L0', 'L3']);
+    assert.deepEqual(resolveAdaptiveHighQualityLevelOrder(1.25), [
+        'L0',
+        'L1',
+        'L3',
+    ]);
+});
+
+test('governor skips duplicate runtime stages at a constrained DPR ceiling', () => {
+    let state = createAdaptiveHighQualityState({
+        effectiveDprCeiling: 1,
+        level: 'L2',
+    });
+    assert.equal(state.level, 'L0');
+
+    state = sample(state, {
+        interactionActive: true,
+        load: 1,
+        nowMs: 10,
+    }).state;
+    assert.equal(state.level, 'L3');
+
+    state = forceRecovery(state, 260);
+    assert.equal(state.level, 'L0');
+});
+
+test('EWMA has a one-second time constant over normalized load', () => {
+    let state = sample(createAdaptiveHighQualityState(), {
+        load: 1,
+        nowMs: 0,
+    }).state;
+    state = sample(state, { load: 2, nowMs: 1_000 }).state;
+
+    assert.ok(state.normalizedLoadEwma !== null);
+    assert.ok(Math.abs(state.normalizedLoadEwma - 1.6321) < 0.001);
+});
+
+test('interaction immediately declines L0 once and blocks recovery while held', () => {
+    let state = createAdaptiveHighQualityState();
+    const firstUpdate = sample(state, {
+        interactionActive: true,
+        load: 0.2,
+        nowMs: 10,
+    });
+    state = firstUpdate.state;
+
+    assert.deepEqual(firstUpdate.transition, {
+        atMs: 10,
+        direction: 'decline',
+        from: 'L0',
+        reason: 'interaction',
+        to: 'L1',
+    });
+    assert.equal(state.declineCount, 1);
+
+    state = settleEwma(state, {
+        durationMs: 10_000,
+        load: 0.2,
+        startMs: 260,
+    });
+    assert.equal(state.level, 'L0');
+
+    let heldState = sample(createAdaptiveHighQualityState(), {
+        interactionActive: true,
+        load: 0.2,
+        nowMs: 10,
+    }).state;
+    for (let nowMs = 260; nowMs <= 10_260; nowMs += 250) {
+        heldState = sample(heldState, {
+            interactionActive: true,
+            load: 0.2,
+            nowMs,
+        }).state;
+    }
+    assert.equal(heldState.level, 'L1');
+    assert.equal(heldState.transitionCount, 1);
+});
+
+test('overload requires threshold hysteresis, duration, samples, and cooldown', () => {
+    let state = sample(createAdaptiveHighQualityState(), {
+        load: 1.11,
+        nowMs: 0,
+    }).state;
+    state = sample(state, { load: 1.11, nowMs: 500 }).state;
+    state = sample(state, { load: 1.11, nowMs: 749 }).state;
+    assert.equal(state.level, 'L0');
+
+    state = sample(state, { load: 1.11, nowMs: 750 }).state;
+    assert.equal(state.level, 'L1');
+    assert.equal(state.lastTransition?.reason, 'overload');
+
+    state = sample(state, { load: 1.4, nowMs: 1_000 }).state;
+    state = sample(state, { load: 1.4, nowMs: 1_500 }).state;
+    state = sample(state, { load: 1.4, nowMs: 1_749 }).state;
+    assert.equal(state.level, 'L1');
+
+    state = sample(state, { load: 1.4, nowMs: 2_000 }).state;
+    assert.equal(state.level, 'L2');
+    assert.equal(state.declineCount, 2);
+});
+
+test('loads inside the hysteresis band neither decline nor recover', () => {
+    let state = createAdaptiveHighQualityState({ level: 'L2' });
+    state = settleEwma(state, {
+        durationMs: 20_000,
+        load: 0.95,
+        startMs: 0,
+    });
+
+    assert.equal(state.level, 'L2');
+    assert.equal(state.transitionCount, 0);
+    assert.equal(state.oscillationCount, 0);
+});
+
+test('headroom recovers exactly one level after five sustained seconds', () => {
+    let state = createAdaptiveHighQualityState({ level: 'L3' });
+    state = sample(state, { load: 0.75, nowMs: 0 }).state;
+    state = sample(state, { load: 0.75, nowMs: 4_999 }).state;
+    assert.equal(state.level, 'L3');
+
+    state = sample(state, { load: 0.75, nowMs: 5_000 }).state;
+    assert.equal(state.level, 'L2');
+    assert.equal(state.recoveryCount, 1);
+    assert.equal(state.lastTransition?.reason, 'headroom');
+
+    state = sample(state, { load: 0.75, nowMs: 5_001 }).state;
+    state = sample(state, { load: 0.75, nowMs: 10_000 }).state;
+    assert.equal(state.level, 'L2');
+    state = sample(state, { load: 0.75, nowMs: 10_001 }).state;
+    assert.equal(state.level, 'L1');
+});
+
+test('source changes reset EWMA and sustained evidence', () => {
+    let state = sample(createAdaptiveHighQualityState(), {
+        load: 1.5,
+        nowMs: 0,
+        source: 'gpu',
+    }).state;
+    state = sample(state, {
+        load: 1.5,
+        nowMs: 500,
+        source: 'gpu',
+    }).state;
+    state = sample(state, {
+        load: 1.5,
+        nowMs: 749,
+        source: 'gpu',
+    }).state;
+
+    state = sample(state, {
+        load: 1.2,
+        nowMs: 750,
+        source: 'frame',
+    }).state;
+    assert.equal(state.level, 'L0');
+    assert.equal(state.normalizedLoadEwma, 1.2);
+    assert.deepEqual(state.overloadEvidence, {
+        samples: 1,
+        sinceMs: 750,
+    });
+
+    state = sample(state, {
+        load: 1.2,
+        nowMs: 1_499,
+        source: 'frame',
+    }).state;
+    assert.equal(state.level, 'L0');
+    state = sample(state, {
+        load: 1.2,
+        nowMs: 1_500,
+        source: 'frame',
+    }).state;
+    assert.equal(state.level, 'L1');
+});
+
+test('three direction reversals lock recovery for 30 seconds without locking decline', () => {
+    let state = createAdaptiveHighQualityState();
+    state = forceDecline(state, 0);
+    assert.equal(state.level, 'L1');
+    state = forceRecovery(state, state.lastSampleAtMs + 250);
+    assert.equal(state.level, 'L0');
+    state = forceDecline(state, state.lastSampleAtMs + 250);
+    assert.equal(state.level, 'L1');
+    state = forceRecovery(state, state.lastSampleAtMs + 250);
+    assert.equal(state.level, 'L0');
+    assert.equal(state.oscillationCount, 3);
+    const recoveryLockedUntilMs = state.lastSampleAtMs + 30_000;
+    assert.equal(state.recoveryLockedUntilMs, recoveryLockedUntilMs);
+
+    state = forceDecline(state, state.lastSampleAtMs + 250);
+    assert.equal(state.level, 'L1');
+    assert.equal(state.declineCount, 3);
+    assert.equal(state.recoveryLockedUntilMs, recoveryLockedUntilMs);
+
+    state = settleEwma(state, {
+        durationMs: 10_000,
+        load: 0.2,
+        startMs: state.lastSampleAtMs + 250,
+    });
+    assert.equal(state.level, 'L1');
+    assert.equal(state.recoveryCount, 2);
+
+    state = forceRecovery(state, recoveryLockedUntilMs);
+    assert.equal(state.level, 'L0');
+    assert.equal(state.recoveryCount, 3);
+});
+
+test('transition telemetry counts dwell by level without mutating snapshots', () => {
+    let state = createAdaptiveHighQualityState({ nowMs: 100 });
+    state = sample(state, {
+        interactionActive: true,
+        load: 1,
+        nowMs: 600,
+    }).state;
+    state = sample(state, { load: 0.9, nowMs: 1_600 }).state;
+
+    const snapshot = getAdaptiveHighQualitySnapshot(state, 2_600);
+    assert.deepEqual(snapshot.dwellMsByLevel, {
+        L0: 500,
+        L1: 2_000,
+        L2: 0,
+        L3: 0,
+    });
+    assert.equal(snapshot.currentLevelDwellMs, 2_000);
+    assert.equal(snapshot.transitionCount, 1);
+    assert.equal(snapshot.declineCount, 1);
+    assert.equal(snapshot.recoveryCount, 0);
+    assert.equal(snapshot.oscillationCount, 0);
+    assert.equal(snapshot.loadSampleCount, 2);
+    assert.equal(snapshot.ewmaSampleCount, 1);
+    assert.equal(snapshot.normalizedLoad, 0.9);
+    assert.equal(snapshot.normalizedLoadEwma, state.normalizedLoadEwma);
+    assert.deepEqual(snapshot.profile, adaptiveHighQualityLevels.L1);
+    assert.deepEqual(state.dwellMsByLevel, {
+        L0: 500,
+        L1: 1_000,
+        L2: 0,
+        L3: 0,
+    });
+});
+
+test('snapshot resolves the active profile against the state DPR ceiling', () => {
+    let state = createAdaptiveHighQualityState({
+        effectiveDprCeiling: 1.5,
+    });
+    state = sample(state, {
+        interactionActive: true,
+        load: 1,
+        nowMs: 10,
+    }).state;
+
+    assert.equal(getAdaptiveHighQualitySnapshot(state, 10).profile.dpr, 1.25);
+});
+
+test('scene resume clears timed evidence without counting suspended dwell', () => {
+    let state = createAdaptiveHighQualityState({ nowMs: 100 });
+    state = sample(state, {
+        interactionActive: true,
+        load: 1,
+        nowMs: 600,
+    }).state;
+    state = sample(state, {
+        load: 0.75,
+        nowMs: 1_600,
+    }).state;
+
+    const beforeResume = getAdaptiveHighQualitySnapshot(state, 1_600);
+    const resumed = resumeAdaptiveHighQualityState(state, 11_600);
+    const afterResume = getAdaptiveHighQualitySnapshot(resumed, 11_600);
+
+    assert.equal(resumed.level, 'L1');
+    assert.equal(resumed.transitionCount, 1);
+    assert.equal(resumed.declineCount, 1);
+    assert.equal(resumed.recoveryCount, 0);
+    assert.equal(resumed.lastSampleAtMs, 11_600);
+    assert.equal(resumed.normalizedLoad, null);
+    assert.equal(resumed.normalizedLoadEwma, null);
+    assert.equal(resumed.ewmaSampleCount, 0);
+    assert.equal(resumed.source, null);
+    assert.deepEqual(resumed.headroomEvidence, {
+        samples: 0,
+        sinceMs: null,
+    });
+    assert.deepEqual(resumed.overloadEvidence, {
+        samples: 0,
+        sinceMs: null,
+    });
+    assert.deepEqual(afterResume.dwellMsByLevel, beforeResume.dwellMsByLevel);
+    assert.equal(
+        afterResume.currentLevelDwellMs,
+        beforeResume.currentLevelDwellMs,
+    );
+
+    const firstResumedSample = sample(resumed, {
+        load: 0.75,
+        nowMs: 11_850,
+    }).state;
+    assert.deepEqual(firstResumedSample.headroomEvidence, {
+        samples: 1,
+        sinceMs: 11_850,
+    });
+    assert.equal(firstResumedSample.level, 'L1');
+});

--- a/packages/game/src/scene/adaptiveHighQualityProfileControl.ts
+++ b/packages/game/src/scene/adaptiveHighQualityProfileControl.ts
@@ -1,0 +1,51 @@
+import type { AdaptiveHighQualityLoadSource } from './adaptiveHighQuality';
+
+export const adaptiveHighQualityProfileControlEventName =
+    'gredice:adaptive-high-profile-control';
+
+export type AdaptiveHighQualityProfileControlCommand =
+    | {
+          action: 'sample';
+          normalizedLoad: number;
+          source: AdaptiveHighQualityLoadSource;
+      }
+    | {
+          action: 'start';
+      }
+    | {
+          action: 'stop';
+      };
+
+export function readAdaptiveHighQualityProfileControlCommand(
+    value: unknown,
+): AdaptiveHighQualityProfileControlCommand | null {
+    if (!value || typeof value !== 'object') {
+        return null;
+    }
+
+    const action = Reflect.get(value, 'action');
+    if (action === 'start' || action === 'stop') {
+        return { action };
+    }
+    if (action !== 'sample') {
+        return null;
+    }
+
+    const normalizedLoad = Reflect.get(value, 'normalizedLoad');
+    const source = Reflect.get(value, 'source');
+    if (
+        typeof normalizedLoad !== 'number' ||
+        !Number.isFinite(normalizedLoad) ||
+        normalizedLoad <= 0 ||
+        normalizedLoad > 10 ||
+        (source !== 'frame' && source !== 'gpu')
+    ) {
+        return null;
+    }
+
+    return {
+        action,
+        normalizedLoad,
+        source,
+    };
+}

--- a/packages/game/src/scene/adaptiveHighQualityProfileControl.unit.ts
+++ b/packages/game/src/scene/adaptiveHighQualityProfileControl.unit.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readAdaptiveHighQualityProfileControlCommand } from './adaptiveHighQualityProfileControl';
+
+test('adaptive High profile control accepts the bounded command contract', () => {
+    assert.deepEqual(
+        readAdaptiveHighQualityProfileControlCommand({ action: 'start' }),
+        { action: 'start' },
+    );
+    assert.deepEqual(
+        readAdaptiveHighQualityProfileControlCommand({
+            action: 'sample',
+            normalizedLoad: 0.7,
+            source: 'frame',
+        }),
+        {
+            action: 'sample',
+            normalizedLoad: 0.7,
+            source: 'frame',
+        },
+    );
+    assert.deepEqual(
+        readAdaptiveHighQualityProfileControlCommand({
+            action: 'sample',
+            normalizedLoad: 1.2,
+            source: 'gpu',
+        }),
+        {
+            action: 'sample',
+            normalizedLoad: 1.2,
+            source: 'gpu',
+        },
+    );
+    assert.deepEqual(
+        readAdaptiveHighQualityProfileControlCommand({ action: 'stop' }),
+        { action: 'stop' },
+    );
+});
+
+test('adaptive High profile control rejects malformed synthetic samples', () => {
+    for (const value of [
+        null,
+        {},
+        { action: 'sample' },
+        { action: 'sample', normalizedLoad: 0, source: 'frame' },
+        { action: 'sample', normalizedLoad: 11, source: 'frame' },
+        { action: 'sample', normalizedLoad: Number.NaN, source: 'frame' },
+        { action: 'sample', normalizedLoad: 0.7, source: 'synthetic' },
+        { action: 'reset' },
+    ]) {
+        assert.equal(readAdaptiveHighQualityProfileControlCommand(value), null);
+    }
+});

--- a/packages/game/src/scene/cloudShadowAttenuation.ts
+++ b/packages/game/src/scene/cloudShadowAttenuation.ts
@@ -176,9 +176,11 @@ function resolveBaseCloudShadowAttenuationConfig(quality: GameQualityProfile) {
 }
 
 export function resolveCloudShadowAttenuationConfig({
+    minimumUpdateMs,
     prefersReducedMotion,
     quality,
 }: {
+    minimumUpdateMs?: number;
     prefersReducedMotion: boolean;
     quality: GameQualityProfile;
 }): CloudShadowAttenuationConfig {
@@ -191,14 +193,20 @@ export function resolveCloudShadowAttenuationConfig({
     }
 
     const base = resolveBaseCloudShadowAttenuationConfig(quality);
+    const reducedMotionUpdateMs = prefersReducedMotion
+        ? Math.max(base.updateMs, 320)
+        : base.updateMs;
+    const updateMs =
+        typeof minimumUpdateMs === 'number' && Number.isFinite(minimumUpdateMs)
+            ? Math.max(reducedMotionUpdateMs, minimumUpdateMs)
+            : reducedMotionUpdateMs;
+
     return {
         enabled: true,
         maskResolution: prefersReducedMotion
             ? Math.min(base.maskResolution, 128)
             : base.maskResolution,
-        updateMs: prefersReducedMotion
-            ? Math.max(base.updateMs, 320)
-            : base.updateMs,
+        updateMs,
     };
 }
 

--- a/packages/game/src/scene/cloudShadowAttenuation.unit.ts
+++ b/packages/game/src/scene/cloudShadowAttenuation.unit.ts
@@ -92,6 +92,33 @@ describe('cloud shadow attenuation quality', () => {
         );
     });
 
+    it('honors an adaptive minimum cadence without changing High fidelity', () => {
+        assert.deepEqual(
+            resolveCloudShadowAttenuationConfig({
+                minimumUpdateMs: 160,
+                prefersReducedMotion: false,
+                quality: gameQualityProfiles.high,
+            }),
+            {
+                enabled: true,
+                maskResolution: 192,
+                updateMs: 160,
+            },
+        );
+        assert.deepEqual(
+            resolveCloudShadowAttenuationConfig({
+                minimumUpdateMs: 96,
+                prefersReducedMotion: true,
+                quality: gameQualityProfiles.high,
+            }),
+            {
+                enabled: true,
+                maskResolution: 128,
+                updateMs: 320,
+            },
+        );
+    });
+
     it('disables attenuation with user shadows', () => {
         assert.deepEqual(
             resolveCloudShadowAttenuationConfig({

--- a/packages/game/src/scene/gameProfileMetadata.ts
+++ b/packages/game/src/scene/gameProfileMetadata.ts
@@ -168,6 +168,29 @@ export type GeneratedPlantProfileSnapshot = {
 };
 
 export type GameProfileMetadata = {
+    adaptiveHighAmbientFps?: number;
+    adaptiveHighCloudUpdateMs?: number;
+    adaptiveHighDeclineCount?: number;
+    adaptiveHighDprCap?: number;
+    adaptiveHighEnabled?: boolean;
+    adaptiveHighEwmaMs?: number;
+    adaptiveHighFactor?: number;
+    adaptiveHighGpuTimerDisjointCount?: number;
+    adaptiveHighGpuTimerPendingCount?: number;
+    adaptiveHighGpuTimerSupported?: boolean;
+    adaptiveHighInteractionActive?: boolean;
+    adaptiveHighLevel?: number;
+    adaptiveHighLevelDwellMs?: number;
+    adaptiveHighLoad?: number;
+    adaptiveHighOscillationCount?: number;
+    adaptiveHighProfileControlActive?: boolean;
+    adaptiveHighProfileControlEnabled?: boolean;
+    adaptiveHighProfileControlSampleCount?: number;
+    adaptiveHighReason?: string;
+    adaptiveHighRecoveryCount?: number;
+    adaptiveHighSampleMs?: number;
+    adaptiveHighSampleSource?: string;
+    adaptiveHighTransitionCount?: number;
     actorGroundingShadowBatchCount?: number;
     actorGroundingShadowCapacity?: number;
     actorGroundingShadowCount?: number;

--- a/packages/game/src/scene/sceneFrameScheduler.ts
+++ b/packages/game/src/scene/sceneFrameScheduler.ts
@@ -12,7 +12,7 @@ export function normalizeSceneFramesPerSecond(framesPerSecond: number) {
 
 export function resolveSceneFramesPerSecond(
     baseFramesPerSecond: number,
-    leaseFrameRates: Iterable<number>,
+    leaseFrameRates: Iterable<number | undefined>,
 ) {
     let resolvedFramesPerSecond =
         normalizeSceneFramesPerSecond(baseFramesPerSecond);
@@ -20,7 +20,9 @@ export function resolveSceneFramesPerSecond(
     for (const leaseFrameRate of leaseFrameRates) {
         resolvedFramesPerSecond = Math.max(
             resolvedFramesPerSecond,
-            normalizeSceneFramesPerSecond(leaseFrameRate),
+            normalizeSceneFramesPerSecond(
+                leaseFrameRate ?? baseFramesPerSecond,
+            ),
         );
     }
 

--- a/packages/game/src/scene/sceneFrameScheduler.unit.ts
+++ b/packages/game/src/scene/sceneFrameScheduler.unit.ts
@@ -41,6 +41,17 @@ describe('resolveSceneFramesPerSecond', () => {
         leases.delete(interactionLease);
         assert.equal(resolveSceneFramesPerSecond(30, leases.values()), 30);
     });
+
+    it('lets ambient leases inherit a changing provider base', () => {
+        const leases = new Map<symbol, number | undefined>();
+        leases.set(Symbol('ambient'), undefined);
+
+        assert.equal(resolveSceneFramesPerSecond(30, leases.values()), 30);
+        assert.equal(resolveSceneFramesPerSecond(20, leases.values()), 20);
+
+        leases.set(Symbol('interactive'), 60);
+        assert.equal(resolveSceneFramesPerSecond(20, leases.values()), 60);
+    });
 });
 
 describe('resolveSceneVisibility', () => {

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -1147,6 +1147,14 @@ export function useGameState<T>(selector: (state: GameState) => T): T {
     return useStore(store, selector);
 }
 
+export function useGameStateStore() {
+    const store = useContext(GameStateContext);
+    if (!store) {
+        throw new Error('Missing GameStateContext.Provider in the tree');
+    }
+    return store;
+}
+
 export function useOptionalGameState<T>(
     selector: (state: GameState) => T,
     fallback: T,


### PR DESCRIPTION
## Summary

- add an adaptive governor for explicitly selected High quality, driven by async WebGL2 GPU timing when available and a non-blocking frame-cadence fallback otherwise
- preserve High's 4096px primary shadow map, full plants/decorations, precipitation, moving clouds, and wind while staging DPR/cadence cost from L0 through L3
- add hysteresis, interaction-first decline, sustained recovery, anti-oscillation locking, display-DPR changes, suspend/resume handling, query cleanup, and profiling telemetry
- extend the deterministic high-target profiler with fixed/adaptive comparisons, motion-to-idle recovery, placement, native source, rain, snow, cloudy, and windy scenarios plus relative regression gates

## Verification

- `pnpm --filter @gredice/game test` — 673/673
- `pnpm --filter garden test:profile` — 38/38
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter garden build` — full Turbopack production build and 35 routes
- targeted Biome checks and `git diff --check`
- independent final review: no remaining actionable findings

## Profile evidence

- fixed/adaptive camera workload acceptance: 3/3 + 3/3
- adaptive p95: 623.9 → 615.8 ms (-1.3%) on local SwiftShader
- draws/render: 147.7 → 141.0 (-4.5%)
- triangles/render: 21,083 → 20,210 (-4.1%)
- motion-to-idle: 3/3 with `L0 → L1 → L0`, DPR `2 → 1.75 → 2`, one decline and one recovery
- adaptive placement, GPU-source fallback, rain, snow, cloudy, and windy: 3/3 structural acceptance each

SwiftShader's absolute p95/long-task targets remain red because of its documented `ReadPixels` stalls; relative, submitted-work, workload-preservation, and lifecycle gates pass.

Closes #4319