### PR TITLE
perf(game): batch raised-bed operation visuals

### DIFF
--- a/apps/garden/app/debug/profile/game/page.tsx
+++ b/apps/garden/app/debug/profile/game/page.tsx
@@ -5,7 +5,11 @@ import {
     operationVisualRewardDebugScenarios,
 } from '@gredice/game';
 import { ProfileGameScene } from './ProfileGameScene';
-import { resolveGameProfileFlags } from './profileFlags';
+import {
+    highTargetOperationVisualHighlightTarget,
+    resolveGameProfileFlags,
+    resolveGameProfileOperationVisuals,
+} from './profileFlags';
 import {
     gameProfileClearWeather,
     gameProfileCloudyWeather,
@@ -258,6 +262,9 @@ export default async function GameProfilePage({
     );
     const outlineProfile = firstValue(params.outline) === '1';
     const placementProfile = firstValue(params.placement) === '1';
+    const operationVisuals =
+        mockGardenProfile === 'high-target' &&
+        resolveGameProfileOperationVisuals(firstValue(params.operationVisuals));
     const debugGameFlags = resolveGameProfileFlags(
         firstValue(params.blockGeometryMerging),
         firstValue(params.adaptiveHigh),
@@ -289,6 +296,22 @@ export default async function GameProfilePage({
             }
             data-game-profile-outline={outlineProfile ? '1' : '0'}
             data-game-profile-placement={placementProfile ? '1' : '0'}
+            data-game-profile-operation-visuals={operationVisuals ? '1' : '0'}
+            data-game-profile-operation-visual-highlight-raised-bed-id={
+                operationVisuals
+                    ? highTargetOperationVisualHighlightTarget.raisedBedId
+                    : undefined
+            }
+            data-game-profile-operation-visual-highlight-field-id={
+                operationVisuals
+                    ? highTargetOperationVisualHighlightTarget.fieldId
+                    : undefined
+            }
+            data-game-profile-operation-visual-highlight-position-index={
+                operationVisuals
+                    ? highTargetOperationVisualHighlightTarget.positionIndex
+                    : undefined
+            }
         >
             <ProfileGameScene
                 key={mode}
@@ -303,7 +326,8 @@ export default async function GameProfilePage({
                     adaptiveHigh ||
                     closeupRaisedBedId !== null ||
                     outlineProfile ||
-                    placementProfile
+                    placementProfile ||
+                    operationVisuals
                 }
                 mockGarden
                 mockGardenProfile={mockGardenProfile}

--- a/apps/garden/app/debug/profile/game/profileFlags.ts
+++ b/apps/garden/app/debug/profile/game/profileFlags.ts
@@ -1,5 +1,11 @@
 import type { GameSceneProps } from '@gredice/game';
 
+export const highTargetOperationVisualHighlightTarget = {
+    fieldId: 201,
+    positionIndex: 0,
+    raisedBedId: 2,
+} as const;
+
 export function resolveGameProfileBlockGeometryMerging(
     value: string | undefined,
 ) {
@@ -7,6 +13,10 @@ export function resolveGameProfileBlockGeometryMerging(
 }
 
 export function resolveGameProfileAdaptiveHigh(value: string | undefined) {
+    return value === '1';
+}
+
+export function resolveGameProfileOperationVisuals(value: string | undefined) {
     return value === '1';
 }
 

--- a/apps/garden/app/debug/profile/game/profileFlags.unit.ts
+++ b/apps/garden/app/debug/profile/game/profileFlags.unit.ts
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+    highTargetOperationVisualHighlightTarget,
     resolveGameProfileAdaptiveHigh,
     resolveGameProfileBlockGeometryMerging,
     resolveGameProfileFlags,
+    resolveGameProfileOperationVisuals,
 } from './profileFlags.ts';
 
 describe('resolveGameProfileAdaptiveHigh', () => {
@@ -27,6 +29,23 @@ describe('resolveGameProfileBlockGeometryMerging', () => {
     it('supports explicit enabled and disabled profile comparisons', () => {
         assert.equal(resolveGameProfileBlockGeometryMerging('1'), true);
         assert.equal(resolveGameProfileBlockGeometryMerging('0'), false);
+    });
+});
+
+describe('resolveGameProfileOperationVisuals', () => {
+    it('keeps the high-target workload behind an explicit opt-in', () => {
+        assert.equal(resolveGameProfileOperationVisuals(undefined), false);
+        assert.equal(resolveGameProfileOperationVisuals('0'), false);
+        assert.equal(resolveGameProfileOperationVisuals('unexpected'), false);
+        assert.equal(resolveGameProfileOperationVisuals('1'), true);
+    });
+
+    it('exposes the deterministic transient highlight target', () => {
+        assert.deepEqual(highTargetOperationVisualHighlightTarget, {
+            fieldId: 201,
+            positionIndex: 0,
+            raisedBedId: 2,
+        });
     });
 });
 

--- a/apps/garden/package.json
+++ b/apps/garden/package.json
@@ -16,6 +16,7 @@
         "profile:game:dense": "GAME_PROFILE_SCENARIO_SET=dense pnpm run profile:game",
         "profile:game:dense-mobile": "GAME_PROFILE_SCENARIO_SET=dense-mobile pnpm run profile:game",
         "profile:game:high-target": "GAME_PROFILE_SCENARIO_SET=high-target pnpm run profile:game",
+        "profile:game:high-target-operation-visuals": "GAME_PROFILE_SCENARIO_SET=high-target-operation-visuals pnpm run profile:game",
         "profile:game:existing": "node scripts/profile-game-scene.mjs",
         "profile:game:start": "GAME_PROFILE_BASE_URL=http://localhost:3101 GAME_PROFILE_START_SERVER=1 node scripts/profile-game-scene.mjs",
         "profile:game:ci": "GAME_PROFILE_FAIL_ON_BUDGET=1 pnpm run profile:game",

--- a/apps/garden/scripts/profile-game-scene.mjs
+++ b/apps/garden/scripts/profile-game-scene.mjs
@@ -751,6 +751,8 @@ const budgets = {
 
 function parseArgs(argv) {
     const options = {
+        allowLegacyOperationVisuals:
+            process.env.GAME_PROFILE_ALLOW_LEGACY_OPERATION_VISUALS === '1',
         baseUrl: process.env.GAME_PROFILE_BASE_URL ?? defaultBaseUrl,
         build: process.env.GAME_PROFILE_BUILD === '1',
         closeupRepeat: process.env.GAME_PROFILE_CLOSEUP_REPEAT
@@ -781,6 +783,9 @@ function parseArgs(argv) {
         const next = argv[index + 1];
 
         switch (arg) {
+            case '--allow-legacy-operation-visuals':
+                options.allowLegacyOperationVisuals = true;
+                break;
             case '--':
                 break;
             case '--base-url':
@@ -887,6 +892,8 @@ function printHelp(options) {
             'Usage: pnpm run profile:game -- [options]',
             '',
             'Options:',
+            '  --allow-legacy-operation-visuals',
+            '                         Measure the pre-batching operation scene without waiting for batch telemetry.',
             `  --base-url <url>       Garden server URL. Current: ${options.baseUrl}`,
             '  --build                Run pnpm run build before profiling.',
             `  --closeup-repeat <n>   Override close-up scenario repeats. Current: ${options.closeupRepeat ?? 'scenario default'}`,
@@ -905,6 +912,7 @@ function printHelp(options) {
             '  --help                 Show this help.',
             '',
             'Environment aliases:',
+            '  GAME_PROFILE_ALLOW_LEGACY_OPERATION_VISUALS=1,',
             '  GAME_PROFILE_BASE_URL, GAME_PROFILE_BUILD=1,',
             '  GAME_PROFILE_CLOSEUP_REPEAT, GAME_PROFILE_CLOSEUP_TIMEOUT_MS,',
             '  GAME_PROFILE_GRAPHICS_BACKEND,',
@@ -2199,6 +2207,7 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 expectedFieldVisualInstanceCount,
                 expectedInstanceCount,
                 expectedMulchInstanceCount,
+                allowLegacyOperationVisuals,
                 operationVisuals,
             }) => {
                 const profile = globalThis.__grediceGameProfile;
@@ -2215,6 +2224,7 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                         profile.generatedPlantVisibleInstanceCount ===
                             expectedInstanceCount &&
                         (!operationVisuals ||
+                            allowLegacyOperationVisuals ||
                             (profile.raisedBedFieldVisualInstanceCount ===
                                 expectedFieldVisualInstanceCount &&
                                 profile.raisedBedMulchInstanceCount ===
@@ -2234,6 +2244,8 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                         : highTargetExpectedGeneratedPlantInstanceCount,
                 expectedMulchInstanceCount:
                     highTargetOperationVisualExpectedMulchInstanceCount,
+                allowLegacyOperationVisuals:
+                    options.allowLegacyOperationVisuals,
                 operationVisuals: request.operationVisuals === '1',
             },
             { timeout: 60000 },
@@ -5879,6 +5891,8 @@ async function main() {
                 process.env.GITHUB_SHA ??
                 null,
             options: {
+                allowLegacyOperationVisuals:
+                    options.allowLegacyOperationVisuals,
                 build: options.build,
                 closeupRepeat: options.closeupRepeat,
                 closeupTimeoutMs: options.closeupTimeoutMs,

--- a/apps/garden/scripts/profile-game-scene.mjs
+++ b/apps/garden/scripts/profile-game-scene.mjs
@@ -20,6 +20,13 @@ const adaptiveHighQualityProfileControlEventName =
     'gredice:adaptive-high-profile-control';
 const highTargetExpectedGeneratedPlantFieldCount = 54;
 const highTargetExpectedGeneratedPlantInstanceCount = 537;
+const highTargetOperationVisualExpectedGeneratedPlantFieldCount = 34;
+const highTargetOperationVisualExpectedGeneratedPlantInstanceCount = 286;
+const highTargetOperationVisualExpectedFieldInstanceCount = 396;
+const highTargetOperationVisualExpectedMulchInstanceCount = 54;
+const highTargetOperationVisualHighlightObjectCount = 2;
+const highTargetOperationVisualLegacyObjectCount = 452;
+const highTargetOperationVisualRenderedObjectLimit = 64;
 const chromiumGraphicsBackends = ['angle-metal', 'auto', 'default'];
 
 const coreScenarios = [
@@ -204,6 +211,18 @@ const highTargetScenarios = [
     {
         name: 'game-high-target-snow-desktop',
         path: '/debug/profile/game?mode=snow&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        repeat: 3,
+    },
+];
+
+const highTargetOperationVisualScenarios = [
+    {
+        name: 'game-high-target-operation-visuals-desktop',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&operationVisuals=1',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -590,6 +609,7 @@ const scenarioSets = {
     dense: denseScenarios,
     'dense-mobile': denseMobileScenarios,
     'high-target': highTargetScenarios,
+    'high-target-operation-visuals': highTargetOperationVisualScenarios,
     outline: outlineScenarios,
     placement: placementScenarios,
     'plant-closeup': plantCloseupScenarios,
@@ -878,7 +898,7 @@ function printHelp(options) {
             '  --warmup-ms <ms>       Warmup wait after canvas appears. Default: 5000',
             '  --soak-ms <ms>         Run the scene before sampling. Default: 0',
             '  --sample-ms <ms>       requestAnimationFrame sample window. Default: 5000',
-            `  --scenario-set <set>    core, dense, dense-mobile, high-target, adaptive-high, outline, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or comma-separated names. Current: ${options.scenarioSet}`,
+            `  --scenario-set <set>    core, dense, dense-mobile, high-target, high-target-operation-visuals, adaptive-high, outline, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or comma-separated names. Current: ${options.scenarioSet}`,
             '  --scenario <name>       Profile exact scenario name(s). Repeat or use commas.',
             '  --screenshots           Save a PNG screenshot for each scenario.',
             '  --fail-on-budget       Exit non-zero when a budget check fails.',
@@ -906,6 +926,7 @@ function allScenarios() {
         ...denseScenarios,
         ...denseMobileScenarios,
         ...highTargetScenarios,
+        ...highTargetOperationVisualScenarios,
         ...outlineScenarios,
         ...placementScenarios,
         ...plantCloseupScenarios,
@@ -939,7 +960,7 @@ function resolveScenarios(scenarioSet, scenarioNames = []) {
 
         if (!candidates.length) {
             throw new Error(
-                `Unknown scenario set or scenario: ${token}. Use core, dense, dense-mobile, high-target, adaptive-high, outline, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or one of: ${knownScenarios.map((scenario) => scenario.name).join(', ')}.`,
+                `Unknown scenario set or scenario: ${token}. Use core, dense, dense-mobile, high-target, high-target-operation-visuals, adaptive-high, outline, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or one of: ${knownScenarios.map((scenario) => scenario.name).join(', ')}.`,
             );
         }
 
@@ -971,6 +992,7 @@ function getScenarioRequest(path) {
         gardenProfile: url.searchParams.get('profile') ?? 'default',
         hud: url.searchParams.get('hud') ?? '0',
         mode: url.searchParams.get('mode') ?? 'baseline',
+        operationVisuals: url.searchParams.get('operationVisuals') ?? '0',
         outline: url.searchParams.get('outline') ?? '0',
         placement: url.searchParams.get('placement') ?? '0',
         quality: url.searchParams.get('quality') ?? 'auto',
@@ -2172,7 +2194,13 @@ async function measureScenario(browser, baseUrl, scenario, options) {
     const request = getScenarioRequest(scenario.path);
     if (request.gardenProfile === 'high-target') {
         await page.waitForFunction(
-            ({ expectedFieldCount, expectedInstanceCount }) => {
+            ({
+                expectedFieldCount,
+                expectedFieldVisualInstanceCount,
+                expectedInstanceCount,
+                expectedMulchInstanceCount,
+                operationVisuals,
+            }) => {
                 const profile = globalThis.__grediceGameProfile;
                 return Boolean(
                     profile?.qualityTier === 'high' &&
@@ -2185,13 +2213,28 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                         profile.generatedPlantVisibleFieldCount ===
                             expectedFieldCount &&
                         profile.generatedPlantVisibleInstanceCount ===
-                            expectedInstanceCount,
+                            expectedInstanceCount &&
+                        (!operationVisuals ||
+                            (profile.raisedBedFieldVisualInstanceCount ===
+                                expectedFieldVisualInstanceCount &&
+                                profile.raisedBedMulchInstanceCount ===
+                                    expectedMulchInstanceCount)),
                 );
             },
             {
-                expectedFieldCount: highTargetExpectedGeneratedPlantFieldCount,
+                expectedFieldCount:
+                    request.operationVisuals === '1'
+                        ? highTargetOperationVisualExpectedGeneratedPlantFieldCount
+                        : highTargetExpectedGeneratedPlantFieldCount,
+                expectedFieldVisualInstanceCount:
+                    highTargetOperationVisualExpectedFieldInstanceCount,
                 expectedInstanceCount:
-                    highTargetExpectedGeneratedPlantInstanceCount,
+                    request.operationVisuals === '1'
+                        ? highTargetOperationVisualExpectedGeneratedPlantInstanceCount
+                        : highTargetExpectedGeneratedPlantInstanceCount,
+                expectedMulchInstanceCount:
+                    highTargetOperationVisualExpectedMulchInstanceCount,
+                operationVisuals: request.operationVisuals === '1',
             },
             { timeout: 60000 },
         );
@@ -2247,6 +2290,8 @@ async function measureScenario(browser, baseUrl, scenario, options) {
             gardenProfile: element.dataset.gameProfileGardenProfile ?? null,
             hud: element.dataset.gameProfileHud ?? null,
             mode: element.dataset.gameProfileMode ?? null,
+            operationVisuals:
+                element.dataset.gameProfileOperationVisuals ?? null,
             outline: element.dataset.gameProfileOutline ?? null,
             quality: element.dataset.gameProfileQuality ?? null,
         };
@@ -2320,6 +2365,9 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 isMobile: scenario.isMobile,
                 mode: profileMetadata?.mode ?? request.mode,
                 motion: 'raised-bed-closeup',
+                operationVisuals:
+                    profileMetadata?.operationVisuals ??
+                    request.operationVisuals,
                 outline: profileMetadata?.outline ?? request.outline,
                 outlineProfile: 'none',
                 quality: profileMetadata?.quality ?? request.quality,
@@ -3162,6 +3210,21 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 typeof metadata.generatedPlantVisibleInstanceCount === 'number'
                     ? metadata.generatedPlantVisibleInstanceCount
                     : null,
+            operationVisualHighlightProfileDispatched: booleanOrNull(
+                metadata.operationVisualHighlightProfileDispatched,
+            ),
+            operationVisualHighlightProfileTargetFieldId: numberOrNull(
+                metadata.operationVisualHighlightProfileTargetFieldId,
+            ),
+            operationVisualHighlightProfileTargetGardenId: numberOrNull(
+                metadata.operationVisualHighlightProfileTargetGardenId,
+            ),
+            operationVisualHighlightProfileTargetPositionIndex: numberOrNull(
+                metadata.operationVisualHighlightProfileTargetPositionIndex,
+            ),
+            operationVisualHighlightProfileTargetRaisedBedId: numberOrNull(
+                metadata.operationVisualHighlightProfileTargetRaisedBedId,
+            ),
             instancedInteractionControllerCount:
                 typeof metadata.instancedInteractionControllerCount === 'number'
                     ? metadata.instancedInteractionControllerCount
@@ -3260,6 +3323,36 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 typeof metadata.rainWetOverlayMaterialConsumerCount === 'number'
                     ? metadata.rainWetOverlayMaterialConsumerCount
                     : null,
+            raisedBedFieldVisualBatchCount: numberOrNull(
+                metadata.raisedBedFieldVisualBatchCount,
+            ),
+            raisedBedFieldVisualChunkCount: numberOrNull(
+                metadata.raisedBedFieldVisualChunkCount,
+            ),
+            raisedBedFieldVisualInstanceCount: numberOrNull(
+                metadata.raisedBedFieldVisualInstanceCount,
+            ),
+            raisedBedFieldVisualMatrixUploadCount: numberOrNull(
+                metadata.raisedBedFieldVisualMatrixUploadCount,
+            ),
+            raisedBedFieldVisualObjectCount: numberOrNull(
+                metadata.raisedBedFieldVisualObjectCount,
+            ),
+            raisedBedFieldVisualUploadedInstanceCount: numberOrNull(
+                metadata.raisedBedFieldVisualUploadedInstanceCount,
+            ),
+            raisedBedMulchBatchCount: numberOrNull(
+                metadata.raisedBedMulchBatchCount,
+            ),
+            raisedBedMulchGroupCount: numberOrNull(
+                metadata.raisedBedMulchGroupCount,
+            ),
+            raisedBedMulchInstanceCount: numberOrNull(
+                metadata.raisedBedMulchInstanceCount,
+            ),
+            raisedBedMulchObjectCount: numberOrNull(
+                metadata.raisedBedMulchObjectCount,
+            ),
             raisedBedMulchOverlayCount:
                 typeof metadata.raisedBedMulchOverlayCount === 'number'
                     ? metadata.raisedBedMulchOverlayCount
@@ -3350,6 +3443,8 @@ async function measureScenario(browser, baseUrl, scenario, options) {
         isMobile: scenario.isMobile,
         mode: profileMetadata?.mode ?? request.mode,
         motion: scenario.motion ?? scenario.interaction ?? 'none',
+        operationVisuals:
+            profileMetadata?.operationVisuals ?? request.operationVisuals,
         outline: profileMetadata?.outline ?? request.outline,
         outlineProfile:
             outlineProfileRequest === null ? 'none' : 'connected-raised-bed',
@@ -3606,6 +3701,20 @@ function evaluateHighTargetAcceptance({
     const adaptiveHighDprCap = adaptiveHighRequested
         ? (sample.adaptiveHighDprCapAtEnd ?? runtime?.adaptiveHighDprCap)
         : null;
+    const operationVisualsRequested = requested.operationVisuals === '1';
+    const expectedGeneratedPlantFieldCount = operationVisualsRequested
+        ? highTargetOperationVisualExpectedGeneratedPlantFieldCount
+        : highTargetExpectedGeneratedPlantFieldCount;
+    const expectedGeneratedPlantInstanceCount = operationVisualsRequested
+        ? highTargetOperationVisualExpectedGeneratedPlantInstanceCount
+        : highTargetExpectedGeneratedPlantInstanceCount;
+    const operationVisualRenderedObjectCount =
+        typeof runtime?.raisedBedFieldVisualObjectCount === 'number' &&
+        typeof runtime?.raisedBedMulchObjectCount === 'number'
+            ? runtime.raisedBedFieldVisualObjectCount +
+              runtime.raisedBedMulchObjectCount +
+              highTargetOperationVisualHighlightObjectCount
+            : null;
     const effectiveDpr = adaptiveHighRequested
         ? (sample.effectiveDprAtEnd ?? adaptiveHighDprCap)
         : sample.reportedDpr;
@@ -3675,12 +3784,12 @@ function evaluateHighTargetAcceptance({
         exact(
             'highTargetGeneratedPlantFields',
             runtime?.generatedPlantFieldCount,
-            highTargetExpectedGeneratedPlantFieldCount,
+            expectedGeneratedPlantFieldCount,
         ),
         exact(
             'highTargetExpectedGeneratedPlantInstances',
             runtime?.generatedPlantExpectedInstanceCount,
-            highTargetExpectedGeneratedPlantInstanceCount,
+            expectedGeneratedPlantInstanceCount,
         ),
         exact(
             'highTargetGeneratedPlantInstances',
@@ -3690,12 +3799,12 @@ function evaluateHighTargetAcceptance({
         exact(
             'highTargetVisiblePlantFields',
             runtime?.generatedPlantVisibleFieldCount,
-            highTargetExpectedGeneratedPlantFieldCount,
+            expectedGeneratedPlantFieldCount,
         ),
         exact(
             'highTargetVisiblePlantInstances',
             runtime?.generatedPlantVisibleInstanceCount,
-            highTargetExpectedGeneratedPlantInstanceCount,
+            expectedGeneratedPlantInstanceCount,
         ),
         exact(
             'highTargetActorGroundingShadowCount',
@@ -3748,6 +3857,105 @@ function evaluateHighTargetAcceptance({
         exact('highTargetApiErrors', apiErrors.length, 0),
         exact('highTargetPageErrors', pageErrors.length, 0),
     ];
+    if (operationVisualsRequested) {
+        checks.push(
+            exact(
+                'highTargetOperationVisualHighlightDispatched',
+                runtime?.operationVisualHighlightProfileDispatched,
+                true,
+            ),
+            exact(
+                'highTargetOperationVisualHighlightGarden',
+                runtime?.operationVisualHighlightProfileTargetGardenId,
+                99_996,
+            ),
+            exact(
+                'highTargetOperationVisualHighlightRaisedBed',
+                runtime?.operationVisualHighlightProfileTargetRaisedBedId,
+                2,
+            ),
+            exact(
+                'highTargetOperationVisualHighlightField',
+                runtime?.operationVisualHighlightProfileTargetFieldId,
+                201,
+            ),
+            exact(
+                'highTargetOperationVisualHighlightPosition',
+                runtime?.operationVisualHighlightProfileTargetPositionIndex,
+                0,
+            ),
+            range(
+                'highTargetOperationVisualFieldBatches',
+                runtime?.raisedBedFieldVisualBatchCount,
+                1,
+                16,
+            ),
+            range(
+                'highTargetOperationVisualFieldChunks',
+                runtime?.raisedBedFieldVisualChunkCount,
+                1,
+                3,
+            ),
+            exact(
+                'highTargetOperationVisualFieldInstances',
+                runtime?.raisedBedFieldVisualInstanceCount,
+                highTargetOperationVisualExpectedFieldInstanceCount,
+            ),
+            range(
+                'highTargetOperationVisualFieldObjects',
+                runtime?.raisedBedFieldVisualObjectCount,
+                1,
+                highTargetOperationVisualRenderedObjectLimit,
+            ),
+            exact(
+                'highTargetOperationVisualFieldMatrixUploads',
+                runtime?.raisedBedFieldVisualMatrixUploadCount,
+                runtime?.raisedBedFieldVisualBatchCount,
+            ),
+            exact(
+                'highTargetOperationVisualFieldUploadedInstances',
+                runtime?.raisedBedFieldVisualUploadedInstanceCount,
+                highTargetOperationVisualExpectedFieldInstanceCount,
+            ),
+            range(
+                'highTargetOperationVisualMulchBatches',
+                runtime?.raisedBedMulchBatchCount,
+                1,
+                32,
+            ),
+            range(
+                'highTargetOperationVisualMulchGroups',
+                runtime?.raisedBedMulchGroupCount,
+                1,
+                16,
+            ),
+            exact(
+                'highTargetOperationVisualMulchInstances',
+                runtime?.raisedBedMulchInstanceCount,
+                highTargetOperationVisualExpectedMulchInstanceCount,
+            ),
+            range(
+                'highTargetOperationVisualMulchObjects',
+                runtime?.raisedBedMulchObjectCount,
+                1,
+                highTargetOperationVisualRenderedObjectLimit,
+            ),
+            exact(
+                'highTargetOperationVisualMulchOverlays',
+                runtime?.raisedBedMulchOverlayCount,
+                highTargetOperationVisualExpectedMulchInstanceCount,
+            ),
+            {
+                ...range(
+                    'highTargetOperationVisualRenderedObjects',
+                    operationVisualRenderedObjectCount,
+                    4,
+                    highTargetOperationVisualRenderedObjectLimit,
+                ),
+                legacy: highTargetOperationVisualLegacyObjectCount,
+            },
+        );
+    }
     if (adaptiveHighRequested) {
         checks.push(
             exact(
@@ -5208,8 +5416,21 @@ function buildMarkdown(report) {
             scenario.sample.rainUnmountMs === null
                 ? 'n/a'
                 : `${scenario.sample.rainUnmountMs} ms`;
+        const operationVisualObjectCount =
+            scenario.requested.operationVisuals === '1' &&
+            typeof scenario.runtime?.raisedBedFieldVisualObjectCount ===
+                'number' &&
+            typeof scenario.runtime?.raisedBedMulchObjectCount === 'number'
+                ? scenario.runtime.raisedBedFieldVisualObjectCount +
+                  scenario.runtime.raisedBedMulchObjectCount +
+                  highTargetOperationVisualHighlightObjectCount
+                : null;
+        const operationVisualObjectDetail =
+            operationVisualObjectCount === null
+                ? ''
+                : `; operation objects ${operationVisualObjectCount}/${highTargetOperationVisualLegacyObjectCount} legacy`;
         const detailCounts = scenario.runtime
-            ? `${scenario.runtime.instancedSnowOverlayCount ?? 0}+${scenario.runtime.raisedBedMulchOverlayCount ?? 0}/${scenario.runtime.groundDecorationCount ?? 0} decor, visible ${scenario.runtime.groundDecorationVisibleCount ?? 'n/a'}, pages ${scenario.runtime.groundDecorationAtlasPageCount ?? 'n/a'}, chunks ${scenario.runtime.groundDecorationChunkCount ?? 'n/a'}, surface materials/uniforms snow ${scenario.runtime.snowOverlayMaterialConsumerCount ?? 'n/a'}/${scenario.runtime.snowOverlayDistinctUniformCount ?? 'n/a'}, rain ${scenario.runtime.rainWetOverlayMaterialConsumerCount ?? 'n/a'}/${scenario.runtime.rainWetOverlayDistinctUniformCount ?? 'n/a'}`
+            ? `field visuals ${scenario.runtime.raisedBedFieldVisualInstanceCount ?? 0} instances/${scenario.runtime.raisedBedFieldVisualObjectCount ?? 0} objects/${scenario.runtime.raisedBedFieldVisualBatchCount ?? 0} batches/${scenario.runtime.raisedBedFieldVisualChunkCount ?? 0} chunks, uploads ${scenario.runtime.raisedBedFieldVisualMatrixUploadCount ?? 0}/${scenario.runtime.raisedBedFieldVisualUploadedInstanceCount ?? 0}; mulch ${scenario.runtime.raisedBedMulchInstanceCount ?? scenario.runtime.raisedBedMulchOverlayCount ?? 0} instances/${scenario.runtime.raisedBedMulchObjectCount ?? 0} objects/${scenario.runtime.raisedBedMulchBatchCount ?? 0} batches/${scenario.runtime.raisedBedMulchGroupCount ?? 0} groups${operationVisualObjectDetail}; snow/decor ${scenario.runtime.instancedSnowOverlayCount ?? 0}+${scenario.runtime.raisedBedMulchOverlayCount ?? 0}/${scenario.runtime.groundDecorationCount ?? 0}, visible ${scenario.runtime.groundDecorationVisibleCount ?? 'n/a'}, pages ${scenario.runtime.groundDecorationAtlasPageCount ?? 'n/a'}, chunks ${scenario.runtime.groundDecorationChunkCount ?? 'n/a'}, surface materials/uniforms snow ${scenario.runtime.snowOverlayMaterialConsumerCount ?? 'n/a'}/${scenario.runtime.snowOverlayDistinctUniformCount ?? 'n/a'}, rain ${scenario.runtime.rainWetOverlayMaterialConsumerCount ?? 'n/a'}/${scenario.runtime.rainWetOverlayDistinctUniformCount ?? 'n/a'}`
             : 'n/a';
         const screenshot = scenario.screenshotPath ?? 'n/a';
         lines.push(

--- a/apps/garden/scripts/profile-game-scene.unit.mjs
+++ b/apps/garden/scripts/profile-game-scene.unit.mjs
@@ -160,6 +160,7 @@ test('high target scenario set covers representative High DPR 2 phases', () => {
         assert.equal(request.details, '1');
         assert.equal(request.gardenProfile, 'high-target');
         assert.equal(request.hud, '0');
+        assert.equal(request.operationVisuals, '0');
         assert.equal(request.quality, 'high');
         assert.equal(scenario.repeat, 3);
     }
@@ -168,6 +169,40 @@ test('high target scenario set covers representative High DPR 2 phases', () => {
     assert.equal(scenarios[2].interaction, 'hover-scan');
     assert.equal(scenarios[3].placementProfile.action, 'run');
     assert.equal(getScenarioRequest(scenarios[3].path).placement, '1');
+});
+
+test('operation-visual High scenario is isolated behind its own opt-in set', () => {
+    const scenarios = resolveScenarios('high-target-operation-visuals');
+
+    assert.equal(scenarios.length, 1);
+    const [scenario] = scenarios;
+    assert.equal(scenario.name, 'game-high-target-operation-visuals-desktop');
+    assert.equal(scenario.budget, 'gameHighTarget');
+    assert.equal(scenario.dpr, 2);
+    assert.equal(scenario.isMobile, false);
+    assert.equal(scenario.repeat, 3);
+    assert.deepEqual(getScenarioRequest(scenario.path), {
+        adaptiveHigh: '0',
+        blockGeometryMerging: '1',
+        closeupRaisedBedId: null,
+        controls: '1',
+        debugHud: '0',
+        details: '1',
+        gardenProfile: 'high-target',
+        hud: '0',
+        mode: 'details',
+        operationVisuals: '1',
+        outline: '0',
+        placement: '0',
+        quality: 'high',
+    });
+    assert.equal(
+        resolveScenarios('high-target').some(
+            (candidate) =>
+                getScenarioRequest(candidate.path).operationVisuals === '1',
+        ),
+        false,
+    );
 });
 
 test('outline scenario deterministically targets the connected raised bed after warmup', () => {
@@ -340,6 +375,7 @@ test('profile request parses the High target fixture contract', () => {
         gardenProfile: 'high-target',
         hud: '0',
         mode: 'snow',
+        operationVisuals: '0',
         outline: '0',
         placement: '0',
         quality: 'high',
@@ -927,6 +963,213 @@ test('high target acceptance proves the intended workload rendered', () => {
         casterResult.checks.find(
             (check) =>
                 check.name === 'highTargetActorGroundingShadowPrimaryCasters',
+        )?.pass,
+        false,
+    );
+});
+
+test('operation-visual High acceptance gates batching, uploads, mulch, and highlight identity', () => {
+    const input = {
+        apiErrors: [],
+        pageErrors: [],
+        requested: {
+            blockGeometryMerging: '1',
+            gardenProfile: 'high-target',
+            mode: 'details',
+            motion: 'none',
+            operationVisuals: '1',
+            quality: 'high',
+        },
+        runtime: {
+            actorGroundingShadowBatchCount: 1,
+            actorGroundingShadowCount: 5,
+            actorGroundingShadowDroppedCount: 0,
+            actorGroundingShadowPrimaryCasterCount: 0,
+            actorGroundingShadowVisibleCount: 5,
+            animatedCasterShadowRefreshCount: 0,
+            generatedPlantExpectedInstanceCount: 286,
+            generatedPlantFieldCount: 34,
+            generatedPlantInstanceCount: 286,
+            generatedPlantVisibleFieldCount: 34,
+            generatedPlantVisibleInstanceCount: 286,
+            groundDecorationCount: 596,
+            groundDecorationDensity: 1,
+            groundDecorationVisibleCount: 571,
+            operationVisualHighlightProfileDispatched: true,
+            operationVisualHighlightProfileTargetFieldId: 201,
+            operationVisualHighlightProfileTargetGardenId: 99_996,
+            operationVisualHighlightProfileTargetPositionIndex: 0,
+            operationVisualHighlightProfileTargetRaisedBedId: 2,
+            qualityTier: 'high',
+            raisedBedFieldVisualBatchCount: 7,
+            raisedBedFieldVisualChunkCount: 2,
+            raisedBedFieldVisualInstanceCount: 396,
+            raisedBedFieldVisualMatrixUploadCount: 7,
+            raisedBedFieldVisualObjectCount: 7,
+            raisedBedFieldVisualUploadedInstanceCount: 396,
+            raisedBedMulchBatchCount: 12,
+            raisedBedMulchGroupCount: 12,
+            raisedBedMulchInstanceCount: 54,
+            raisedBedMulchObjectCount: 12,
+            raisedBedMulchOverlayCount: 54,
+            shadowMapSize: 4_096,
+            shadowsEnabled: true,
+        },
+        sample: {
+            actorGroundingShadowUpdateCountDelta: 60,
+            animatedCasterShadowRefreshCountDelta: 0,
+            canvas: {
+                clientHeight: 720,
+                clientWidth: 1280,
+                height: 1440,
+                width: 2560,
+            },
+            drawCalls: 100,
+            elapsedMs: 5_000,
+            renderedFps: 12,
+            renderedFrames: 60,
+            reportedDpr: 2,
+            submittedTriangles: 1_000_000,
+        },
+    };
+    const result = evaluateHighTargetAcceptance(input);
+
+    assert.equal(result.pass, true);
+    assert.deepEqual(
+        result.checks.find(
+            (check) =>
+                check.name === 'highTargetOperationVisualRenderedObjects',
+        ),
+        {
+            actual: 21,
+            comparison: 'range',
+            legacy: 452,
+            limit: {
+                maximum: 64,
+                minimum: 4,
+            },
+            name: 'highTargetOperationVisualRenderedObjects',
+            pass: true,
+        },
+    );
+    const markdown = buildMarkdown({
+        adaptiveHighComparisons: {},
+        baseUrl: 'http://profile.local',
+        generatedAt: '2026-07-27T00:00:00.000Z',
+        highTargetMedians: {},
+        options: {
+            build: false,
+            managedServer: false,
+            sampleMs: 5_000,
+            scenarios: [],
+            scenarioSet: 'high-target-operation-visuals',
+            soakMs: 0,
+            warmupMs: 0,
+        },
+        plantCloseupMedians: {},
+        scenarios: [
+            {
+                budget: { checks: result.checks, pass: true },
+                consoleMessages: [],
+                environment: null,
+                name: 'game-high-target-operation-visuals-desktop',
+                pageErrors: [],
+                requested: {
+                    controls: '1',
+                    debugHud: '0',
+                    details: '1',
+                    hud: '0',
+                    ...input.requested,
+                },
+                runtime: input.runtime,
+                sample: {
+                    drawCallsPerFrame: 2,
+                    drawCallsPerRenderedFrame: 20,
+                    fps: 60,
+                    jsHeapMb: 100,
+                    longTaskCount: 0,
+                    maxFrameMs: 20,
+                    p95FrameMs: 16,
+                    rainUnmountMs: null,
+                    trianglesPerFrame: 15_000,
+                    trianglesPerRenderedFrame: 300_000,
+                    ...input.sample,
+                },
+                screenshotPath: null,
+            },
+        ],
+        schemaVersion: 2,
+        sourceCommit: null,
+        summary: { failedScenarios: 0 },
+    });
+    assert.match(
+        markdown,
+        /field visuals 396 instances\/7 objects\/7 batches\/2 chunks, uploads 7\/396; mulch 54 instances\/12 objects\/12 batches\/12 groups; operation objects 21\/452 legacy/,
+    );
+
+    for (const [field, value, checkName] of [
+        [
+            'generatedPlantExpectedInstanceCount',
+            287,
+            'highTargetExpectedGeneratedPlantInstances',
+        ],
+        [
+            'operationVisualHighlightProfileDispatched',
+            false,
+            'highTargetOperationVisualHighlightDispatched',
+        ],
+        [
+            'raisedBedFieldVisualInstanceCount',
+            395,
+            'highTargetOperationVisualFieldInstances',
+        ],
+        [
+            'raisedBedFieldVisualMatrixUploadCount',
+            8,
+            'highTargetOperationVisualFieldMatrixUploads',
+        ],
+        [
+            'raisedBedFieldVisualUploadedInstanceCount',
+            395,
+            'highTargetOperationVisualFieldUploadedInstances',
+        ],
+        [
+            'raisedBedMulchInstanceCount',
+            53,
+            'highTargetOperationVisualMulchInstances',
+        ],
+        [
+            'raisedBedMulchOverlayCount',
+            53,
+            'highTargetOperationVisualMulchOverlays',
+        ],
+    ]) {
+        const invalid = evaluateHighTargetAcceptance({
+            ...input,
+            runtime: {
+                ...input.runtime,
+                [field]: value,
+            },
+        });
+        assert.equal(
+            invalid.checks.find((check) => check.name === checkName)?.pass,
+            false,
+            `${checkName} should reject ${field}=${value}`,
+        );
+    }
+
+    const tooManyObjects = evaluateHighTargetAcceptance({
+        ...input,
+        runtime: {
+            ...input.runtime,
+            raisedBedFieldVisualObjectCount: 32,
+            raisedBedMulchObjectCount: 33,
+        },
+    });
+    assert.equal(
+        tooManyObjects.checks.find(
+            (check) =>
+                check.name === 'highTargetOperationVisualRenderedObjects',
         )?.pass,
         false,
     );

--- a/apps/garden/scripts/profile-game-scene.unit.mjs
+++ b/apps/garden/scripts/profile-game-scene.unit.mjs
@@ -299,6 +299,15 @@ test('graphics backend CLI overrides the portable auto default explicitly', () =
     );
 });
 
+test('legacy operation visual profiling bypass is explicit', () => {
+    assert.equal(parseArgs([]).allowLegacyOperationVisuals, false);
+    assert.equal(
+        parseArgs(['--allow-legacy-operation-visuals'])
+            .allowLegacyOperationVisuals,
+        true,
+    );
+});
+
 test('adaptive High scenario set pairs fixed and adaptive motion and preserves runtime features', () => {
     const scenarios = resolveScenarios('adaptive-high');
 

--- a/packages/game/src/entities/AdditionalEntityInstances.tsx
+++ b/packages/game/src/entities/AdditionalEntityInstances.tsx
@@ -48,6 +48,7 @@ import {
 import { HoverOutline } from './helpers/HoverOutline';
 import { resolveEntityNeighbors } from './helpers/useEntityNeighbors';
 import { RaisedBedFields } from './raisedBed/RaisedBedFields';
+import { RaisedBedFieldVisualBatches } from './raisedBed/RaisedBedFieldVisualBatches';
 import { RaisedBedHarvestBaskets } from './raisedBed/RaisedBedHarvestBasket';
 import {
     getRaisedBedSoilWetPatches,
@@ -759,11 +760,28 @@ function RaisedBedInstances({
     const { data: currentGarden } = useCurrentGarden();
     const { data: operations } = useOperations();
     const currentTime = useSnapshotTime();
-    const instances = useEntityBlockInstances({
+    const raisedBedInstances = useEntityBlockInstances({
         name: 'Raised_Bed',
         stacks,
         yOffset: 1,
-    })?.map((instance) => resolveRaisedBedInstance(instance, stacks));
+    });
+    const instances = useMemo(
+        () =>
+            raisedBedInstances?.map((instance) =>
+                resolveRaisedBedInstance(instance, stacks),
+            ),
+        [raisedBedInstances, stacks],
+    );
+    const raisedBedFieldVisualBlocks = useMemo(
+        () =>
+            instances?.map((instance, index) => ({
+                blockId: instance.block.id,
+                chunkPosition:
+                    raisedBedInstances?.[index]?.position ?? instance.position,
+                position: instance.position,
+            })) ?? [],
+        [instances, raisedBedInstances],
+    );
     const raisedBedContextByBlockId = useMemo(() => {
         const context = new Map<
             string,
@@ -918,6 +936,7 @@ function RaisedBedInstances({
                     />
                 </group>
             ))}
+            <RaisedBedFieldVisualBatches blocks={raisedBedFieldVisualBlocks} />
             <RaisedBedHarvestBaskets />
             <RaisedBedHoverOutlines
                 instances={instances}

--- a/packages/game/src/entities/raisedBed/RaisedBedFieldVisualBatches.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFieldVisualBatches.tsx
@@ -37,10 +37,7 @@ import {
     type OperationVisualDefinitionInput,
     resolveOperationVisualRewards,
 } from '../../operationVisualRewards';
-import {
-    readGameProfileMetadata,
-    updateGameProfileMetadata,
-} from '../../scene/gameProfileMetadata';
+import { updateGameProfileMetadata } from '../../scene/gameProfileMetadata';
 import { useGameState } from '../../useGameState';
 import { getRaisedBedBlockIds } from '../../utils/raisedBedBlocks';
 import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
@@ -638,6 +635,23 @@ function createFieldVisualGeometries() {
     };
 }
 
+const fieldVisualProfileUploads = new Map<
+    string,
+    {
+        instanceCount: number;
+        token: symbol;
+    }
+>();
+
+function publishFieldVisualProfileUploads() {
+    updateGameProfileMetadata({
+        raisedBedFieldVisualMatrixUploadCount: fieldVisualProfileUploads.size,
+        raisedBedFieldVisualUploadedInstanceCount: Array.from(
+            fieldVisualProfileUploads.values(),
+        ).reduce((total, upload) => total + upload.instanceCount, 0),
+    });
+}
+
 const FieldVisualInstancedMesh = memo(function FieldVisualInstancedMesh({
     batch,
     castShadow = false,
@@ -657,6 +671,7 @@ const FieldVisualInstancedMesh = memo(function FieldVisualInstancedMesh({
 }) {
     const meshRef = useRef<InstancedMesh | null>(null);
     const scratch = useMemo(() => new Object3D(), []);
+    const profileUploadToken = useRef(Symbol(batch.key)).current;
 
     useLayoutEffect(() => {
         const mesh = meshRef.current;
@@ -681,16 +696,24 @@ const FieldVisualInstancedMesh = memo(function FieldVisualInstancedMesh({
             typeof window !== 'undefined' &&
             window.location.pathname.startsWith('/debug/profile/game')
         ) {
-            const metadata = readGameProfileMetadata();
-            updateGameProfileMetadata({
-                raisedBedFieldVisualMatrixUploadCount:
-                    (metadata?.raisedBedFieldVisualMatrixUploadCount ?? 0) + 1,
-                raisedBedFieldVisualUploadedInstanceCount:
-                    (metadata?.raisedBedFieldVisualUploadedInstanceCount ?? 0) +
-                    batch.instances.length,
+            fieldVisualProfileUploads.set(batch.key, {
+                instanceCount: batch.instances.length,
+                token: profileUploadToken,
             });
+            publishFieldVisualProfileUploads();
         }
-    }, [batch, scratch]);
+
+        return () => {
+            if (
+                fieldVisualProfileUploads.get(batch.key)?.token !==
+                profileUploadToken
+            ) {
+                return;
+            }
+            fieldVisualProfileUploads.delete(batch.key);
+            publishFieldVisualProfileUploads();
+        };
+    }, [batch, profileUploadToken, scratch]);
 
     return (
         <instancedMesh

--- a/packages/game/src/entities/raisedBed/RaisedBedFieldVisualBatches.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFieldVisualBatches.tsx
@@ -1,0 +1,921 @@
+'use client';
+
+import { calculatePlantsPerField } from '@gredice/js/plants';
+import { animated, useSpring } from '@react-spring/three';
+import {
+    memo,
+    type ReactNode,
+    Suspense,
+    useEffect,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+} from 'react';
+import {
+    BoxGeometry,
+    type BufferGeometry,
+    ConeGeometry,
+    CylinderGeometry,
+    DynamicDrawUsage,
+    type InstancedMesh,
+    type Material,
+    MeshStandardMaterial,
+    Object3D,
+    PlaneGeometry,
+} from 'three';
+import { useGameSceneDetails } from '../../GameSceneDetailContext';
+import { resolveInGamePlantPreset } from '../../generators/plant/lib/inGamePlantPresets';
+import { highTargetMockPlantRenderAttributesBySortId } from '../../hooks/mockGardenProfileFixtures';
+import {
+    useCurrentGarden,
+    useIsSandboxGarden,
+} from '../../hooks/useCurrentGarden';
+import { useOperations } from '../../hooks/useOperations';
+import { useAllSorts } from '../../hooks/usePlantSorts';
+import { useShoppingCart } from '../../hooks/useShoppingCart';
+import {
+    type OperationVisualDefinitionInput,
+    resolveOperationVisualRewards,
+} from '../../operationVisualRewards';
+import {
+    readGameProfileMetadata,
+    updateGameProfileMetadata,
+} from '../../scene/gameProfileMetadata';
+import { useGameState } from '../../useGameState';
+import { getRaisedBedBlockIds } from '../../utils/raisedBedBlocks';
+import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
+import type { RaisedBedOrientation } from '../../utils/raisedBedOrientation';
+import { useGameGLTF } from '../../utils/useGameGLTF';
+import { mockPlantPresetLabelsBySortId } from './RaisedBedPlantField';
+import {
+    hasActiveRaisedBedProtectiveCover,
+    resolveRaisedBedProtectiveCoverPositions,
+} from './raisedBedAgrotextileRewards';
+import {
+    type FieldVisualChunk,
+    reconcileFieldVisualChunks,
+} from './raisedBedFieldVisualChunks';
+import {
+    createRaisedBedFieldCoverPrimitives,
+    createRaisedBedFieldSeedDescriptors,
+    createRaisedBedFieldSupportDescriptor,
+    createRaisedBedFieldWeedTransforms,
+    createRaisedBedWholeCoverPrimitives,
+    getRaisedBedFieldVisualChunkKey,
+    type RaisedBedCoverPrimitive,
+    type RaisedBedFieldVisualTransform,
+    type RaisedBedFieldVisualVector3,
+} from './raisedBedFieldVisualLayout';
+import { resolveRaisedBedSupportPositions } from './raisedBedSupportRewards';
+import { resolveRaisedBedFieldWeedLevel } from './raisedBedWeedState';
+
+type CurrentGardenData = NonNullable<
+    NonNullable<ReturnType<typeof useCurrentGarden>['data']>
+>;
+type PlantSortData = NonNullable<
+    ReturnType<typeof useAllSorts>['data']
+>[number];
+type ShoppingCartData = NonNullable<ReturnType<typeof useShoppingCart>['data']>;
+
+export type RaisedBedFieldVisualBatchBlock = {
+    blockId: string;
+    chunkPosition?: RaisedBedFieldVisualVector3;
+    position: RaisedBedFieldVisualVector3;
+};
+
+export type RaisedBedFieldVisualLayer =
+    | 'cover-bar'
+    | 'cover-hem'
+    | 'cover-plane'
+    | 'seed-pending'
+    | 'seed-sown'
+    | 'support'
+    | 'weed';
+
+export type RaisedBedFieldVisualInstance = {
+    id: string;
+    position: readonly [number, number, number];
+    rotation: readonly [number, number, number];
+    scale: readonly [number, number, number];
+};
+
+export type RaisedBedFieldVisualBatch = {
+    capacity: number;
+    chunkKey: string;
+    instances: RaisedBedFieldVisualInstance[];
+    key: string;
+    layer: RaisedBedFieldVisualLayer;
+    signature: string;
+};
+
+type DisplayedField = {
+    id: number | string;
+    plantSortId: number | null | undefined;
+    plantStatus?: string | null;
+    plantSowDate?: string | null;
+    positionIndex: number;
+};
+
+type MutableBatch = Omit<RaisedBedFieldVisualBatch, 'capacity' | 'signature'>;
+
+function nextPowerOfTwo(value: number) {
+    let capacity = 1;
+    while (capacity < value) {
+        capacity *= 2;
+    }
+    return capacity;
+}
+
+function addVisualInstance(
+    batches: Map<string, MutableBatch>,
+    chunkKey: string,
+    layer: RaisedBedFieldVisualLayer,
+    instance: RaisedBedFieldVisualInstance,
+    batchGroupKey?: string,
+) {
+    const key = [chunkKey, layer, batchGroupKey].filter(Boolean).join(':');
+    const existing = batches.get(key);
+    if (existing) {
+        existing.instances.push(instance);
+        return;
+    }
+
+    batches.set(key, {
+        chunkKey,
+        instances: [instance],
+        key,
+        layer,
+    });
+}
+
+function addTransformInstance({
+    batches,
+    chunkKey,
+    id,
+    layer,
+    transform,
+    batchGroupKey,
+}: {
+    batches: Map<string, MutableBatch>;
+    chunkKey: string;
+    id: string;
+    layer: RaisedBedFieldVisualLayer;
+    transform: RaisedBedFieldVisualTransform;
+    batchGroupKey?: string;
+}) {
+    addVisualInstance(
+        batches,
+        chunkKey,
+        layer,
+        {
+            id,
+            ...transform,
+        },
+        batchGroupKey,
+    );
+}
+
+function addCoverPrimitives({
+    batches,
+    chunkKey,
+    coverPlaneGroupKey,
+    primitives,
+}: {
+    batches: Map<string, MutableBatch>;
+    chunkKey: string;
+    coverPlaneGroupKey: string;
+    primitives: readonly RaisedBedCoverPrimitive[];
+}) {
+    for (const primitive of primitives) {
+        const layer =
+            primitive.layer === 'cover-surface'
+                ? 'cover-plane'
+                : primitive.layer;
+        addTransformInstance({
+            batches,
+            chunkKey,
+            id: primitive.key,
+            layer,
+            transform: primitive.transform,
+            // Three sorts transparent objects, not individual instances.
+            // One plane batch per bed preserves depth ordering between beds
+            // while still collapsing every coplanar field cover in that bed.
+            batchGroupKey:
+                layer === 'cover-plane' ? coverPlaneGroupKey : undefined,
+        });
+    }
+}
+
+function shouldRenderGeneratedPlantField(field: DisplayedField) {
+    return (
+        Boolean(field.plantSowDate) &&
+        (field.plantStatus === 'sprouted' ||
+            field.plantStatus === 'ready' ||
+            field.plantStatus === 'harvested')
+    );
+}
+
+function addSeedInstances({
+    batches,
+    blockIndex,
+    blockPosition,
+    chunkKey,
+    field,
+    highTargetProfile,
+    isMock,
+    isSandbox,
+    localPositionIndex,
+    orientation,
+    raisedBedId,
+    sortData,
+}: {
+    batches: Map<string, MutableBatch>;
+    blockIndex: number;
+    blockPosition: RaisedBedFieldVisualVector3;
+    chunkKey: string;
+    field: DisplayedField;
+    highTargetProfile: boolean;
+    isMock: boolean;
+    isSandbox: boolean;
+    localPositionIndex: number;
+    orientation: RaisedBedOrientation;
+    raisedBedId: number;
+    sortData: PlantSortData[] | undefined;
+}) {
+    const plantSortId = field.plantSortId;
+    if (!plantSortId) {
+        return;
+    }
+    const sort = sortData?.find((item) => item.id === plantSortId);
+    const highTargetAttributes = highTargetProfile
+        ? highTargetMockPlantRenderAttributesBySortId[plantSortId]
+        : undefined;
+    const resolvedPlantPreset = resolveInGamePlantPreset([
+        sort?.information.name,
+        sort?.information.plant.information?.name,
+        sort?.information.plant.information?.latinName,
+        isMock || isSandbox
+            ? mockPlantPresetLabelsBySortId[plantSortId]
+            : undefined,
+    ]);
+    if (resolvedPlantPreset && shouldRenderGeneratedPlantField(field)) {
+        return;
+    }
+
+    const { plantsPerRow, totalPlants } = calculatePlantsPerField(
+        highTargetAttributes?.seedingDistance ??
+            sort?.information.plant.attributes?.seedingDistance,
+    );
+    const descriptors = createRaisedBedFieldSeedDescriptors({
+        blockIndex,
+        blockPosition,
+        keyPrefix: `seed:${raisedBedId}:${field.positionIndex}:${field.id}`,
+        orientation,
+        plantsPerRow,
+        positionIndex: localPositionIndex,
+        sown: Boolean(field.plantSowDate),
+        totalPlants,
+    });
+
+    for (const descriptor of descriptors) {
+        addTransformInstance({
+            batches,
+            chunkKey,
+            id: descriptor.key,
+            layer: descriptor.layer,
+            transform: descriptor.transform,
+        });
+    }
+}
+
+function batchSignature(instances: readonly RaisedBedFieldVisualInstance[]) {
+    return instances
+        .map(
+            (instance) =>
+                `${instance.id}:${instance.position.join(',')}:${instance.rotation.join(',')}:${instance.scale.join(',')}`,
+        )
+        .join('|');
+}
+
+export function reconcileRaisedBedFieldVisualBatches(
+    previous: readonly RaisedBedFieldVisualBatch[],
+    next: readonly RaisedBedFieldVisualBatch[],
+) {
+    const groupByChunk = (
+        batches: readonly RaisedBedFieldVisualBatch[],
+    ): FieldVisualChunk<RaisedBedFieldVisualBatch>[] => {
+        const chunks = new Map<
+            string,
+            FieldVisualChunk<RaisedBedFieldVisualBatch>
+        >();
+
+        for (const batch of batches) {
+            const chunk = chunks.get(batch.chunkKey);
+            if (chunk) {
+                chunks.set(batch.chunkKey, {
+                    ...chunk,
+                    layers: [...chunk.layers, batch],
+                });
+            } else {
+                chunks.set(batch.chunkKey, {
+                    key: batch.chunkKey,
+                    layers: [batch],
+                });
+            }
+        }
+
+        return Array.from(chunks.values());
+    };
+    const reconciled = reconcileFieldVisualChunks(
+        groupByChunk(previous),
+        groupByChunk(next),
+    ).flatMap((chunk) => chunk.layers);
+    const unchanged =
+        previous.length === reconciled.length &&
+        previous.every((batch, index) => batch === reconciled[index]);
+
+    return unchanged ? previous : reconciled;
+}
+
+export function compileRaisedBedFieldVisualBatches({
+    blocks,
+    cart,
+    currentGarden,
+    highTargetProfile,
+    isMock,
+    isSandbox,
+    operations,
+    sortData,
+}: {
+    blocks: readonly RaisedBedFieldVisualBatchBlock[];
+    cart: ShoppingCartData | null | undefined;
+    currentGarden: CurrentGardenData | null | undefined;
+    highTargetProfile: boolean;
+    isMock: boolean;
+    isSandbox: boolean;
+    operations: OperationVisualDefinitionInput[] | undefined;
+    sortData: PlantSortData[] | undefined;
+}): RaisedBedFieldVisualBatch[] {
+    if (!currentGarden) {
+        return [];
+    }
+
+    const blockById = new Map(blocks.map((block) => [block.blockId, block]));
+    const mutableBatches = new Map<string, MutableBatch>();
+
+    for (const raisedBed of currentGarden.raisedBeds) {
+        const blockIds = getRaisedBedBlockIds(currentGarden, raisedBed.id);
+        const raisedBedBlocks = blockIds.flatMap((blockId, blockIndex) => {
+            const block = blockById.get(blockId);
+            return block ? [{ ...block, blockIndex }] : [];
+        });
+        if (raisedBedBlocks.length === 0) {
+            continue;
+        }
+
+        const orientation = raisedBed.orientation ?? 'vertical';
+        const chunkKey = getRaisedBedFieldVisualChunkKey({
+            positions: raisedBedBlocks.map(
+                (block) => block.chunkPosition ?? block.position,
+            ),
+        });
+        if (!chunkKey) {
+            continue;
+        }
+        const visualRewards = resolveOperationVisualRewards({
+            appliedOperations: (raisedBed.appliedOperations ?? []).map(
+                (operation) => ({
+                    ...operation,
+                    raisedBedId: raisedBed.id,
+                }),
+            ),
+            operationItems: [],
+            operations: operations ?? [],
+        });
+        const hasWholeBedCover = hasActiveRaisedBedProtectiveCover({
+            raisedBedId: raisedBed.id,
+            visualRewards,
+        });
+
+        if (hasWholeBedCover) {
+            addCoverPrimitives({
+                batches: mutableBatches,
+                chunkKey,
+                coverPlaneGroupKey: `raised-bed-${raisedBed.id}`,
+                primitives: createRaisedBedWholeCoverPrimitives({
+                    blocks: raisedBedBlocks,
+                    keyPrefix: `cover:${raisedBed.id}:whole`,
+                    orientation,
+                }),
+            });
+        }
+
+        for (const [blockIndex, blockId] of blockIds.entries()) {
+            const block = blockById.get(blockId);
+            if (!block) {
+                continue;
+            }
+            const blockOffset =
+                Math.max(blockIds.length - 1 - blockIndex, 0) * 9;
+            const protectiveCoverPositions =
+                resolveRaisedBedProtectiveCoverPositions({
+                    blockOffset,
+                    fields: raisedBed.fields,
+                    raisedBedId: raisedBed.id,
+                    visualRewards,
+                });
+            const protectiveCoverPositionSet = new Set(
+                protectiveCoverPositions,
+            );
+            const fieldCoverPositions = hasWholeBedCover
+                ? []
+                : protectiveCoverPositions;
+            const supportPositions = resolveRaisedBedSupportPositions({
+                blockOffset,
+                fields: raisedBed.fields,
+                raisedBedId: raisedBed.id,
+                visualRewards,
+            }).filter(
+                (positionIndex) =>
+                    !protectiveCoverPositionSet.has(positionIndex),
+            );
+
+            for (const localPositionIndex of fieldCoverPositions) {
+                addCoverPrimitives({
+                    batches: mutableBatches,
+                    chunkKey,
+                    coverPlaneGroupKey: `raised-bed-${raisedBed.id}`,
+                    primitives: createRaisedBedFieldCoverPrimitives({
+                        blockIndex,
+                        blockPosition: block.position,
+                        keyPrefix: `cover:${raisedBed.id}:${blockIndex}:${localPositionIndex}`,
+                        orientation,
+                        positionIndex: localPositionIndex,
+                    }),
+                });
+            }
+            for (const localPositionIndex of supportPositions) {
+                const descriptor = createRaisedBedFieldSupportDescriptor({
+                    blockIndex,
+                    blockPosition: block.position,
+                    key: `support:${raisedBed.id}:${blockIndex}:${localPositionIndex}`,
+                    orientation,
+                    positionIndex: localPositionIndex,
+                });
+                addTransformInstance({
+                    batches: mutableBatches,
+                    chunkKey,
+                    id: descriptor.key,
+                    layer: descriptor.layer,
+                    transform: descriptor.transform,
+                });
+            }
+
+            const persistedFields = raisedBed.fields
+                .filter(
+                    (field) =>
+                        isRaisedBedFieldOccupied(field) &&
+                        field.positionIndex >= blockOffset &&
+                        field.positionIndex < blockOffset + 9,
+                )
+                .map(
+                    (field): DisplayedField => ({
+                        id: field.id,
+                        plantSortId: field.plantSortId,
+                        plantStatus: field.plantStatus,
+                        plantSowDate: field.plantSowDate,
+                        positionIndex: field.positionIndex,
+                    }),
+                );
+            const cartFields =
+                cart?.items.flatMap((item): DisplayedField[] => {
+                    if (
+                        item.gardenId !== currentGarden.id ||
+                        item.raisedBedId !== raisedBed.id ||
+                        item.entityTypeName !== 'plantSort' ||
+                        typeof item.positionIndex !== 'number' ||
+                        item.positionIndex < blockOffset ||
+                        item.positionIndex >= blockOffset + 9
+                    ) {
+                        return [];
+                    }
+                    return [
+                        {
+                            id: `cart-item-${item.id}`,
+                            plantSortId: Number(item.entityId),
+                            positionIndex: item.positionIndex,
+                        },
+                    ];
+                }) ?? [];
+
+            for (
+                let localPositionIndex = 0;
+                localPositionIndex < 9;
+                localPositionIndex += 1
+            ) {
+                if (protectiveCoverPositionSet.has(localPositionIndex)) {
+                    continue;
+                }
+                const positionIndex = blockOffset + localPositionIndex;
+                const field = raisedBed.fields.find(
+                    (candidate) =>
+                        candidate.active &&
+                        candidate.positionIndex === positionIndex,
+                );
+                const weedLevel = resolveRaisedBedFieldWeedLevel({
+                    fieldWeedState: field?.weedState,
+                    raisedBedFieldId:
+                        typeof field?.id === 'number' ? field.id : null,
+                    raisedBedId: raisedBed.id,
+                    raisedBedWeedState: raisedBed.weedState,
+                    visualRewards,
+                });
+                if (weedLevel) {
+                    const transforms = createRaisedBedFieldWeedTransforms({
+                        blockIndex,
+                        blockPosition: block.position,
+                        level: weedLevel,
+                        orientation,
+                        positionIndex: localPositionIndex,
+                    });
+                    const seedPositionIndex =
+                        blockIndex * 9 + localPositionIndex;
+
+                    transforms.forEach((transform, bladeIndex) => {
+                        addTransformInstance({
+                            batches: mutableBatches,
+                            chunkKey,
+                            id: `weed:${raisedBed.id}:${seedPositionIndex}:${bladeIndex}`,
+                            layer: 'weed',
+                            transform,
+                        });
+                    });
+                }
+            }
+
+            for (const field of [...persistedFields, ...cartFields]) {
+                const localPositionIndex = field.positionIndex - blockOffset;
+                if (protectiveCoverPositionSet.has(localPositionIndex)) {
+                    continue;
+                }
+                addSeedInstances({
+                    batches: mutableBatches,
+                    blockIndex,
+                    blockPosition: block.position,
+                    chunkKey,
+                    field,
+                    highTargetProfile,
+                    isMock,
+                    isSandbox,
+                    localPositionIndex,
+                    orientation,
+                    raisedBedId: raisedBed.id,
+                    sortData,
+                });
+            }
+        }
+    }
+
+    return Array.from(mutableBatches.values())
+        .map((batch): RaisedBedFieldVisualBatch => {
+            const instances = batch.instances.sort((left, right) =>
+                left.id.localeCompare(right.id),
+            );
+            return {
+                ...batch,
+                capacity: nextPowerOfTwo(instances.length),
+                instances,
+                signature: batchSignature(instances),
+            };
+        })
+        .sort((left, right) => left.key.localeCompare(right.key));
+}
+
+function createFieldVisualMaterials() {
+    const materials = {
+        coverBar: new MeshStandardMaterial({
+            color: '#c9c2ad',
+            roughness: 1,
+        }),
+        coverHem: new MeshStandardMaterial({
+            color: '#eee9d8',
+            roughness: 1,
+        }),
+        coverPlane: new MeshStandardMaterial({
+            color: '#dcd7c6',
+            depthWrite: false,
+            opacity: 0.76,
+            polygonOffset: true,
+            polygonOffsetFactor: -4,
+            roughness: 1,
+            transparent: true,
+        }),
+        seedSown: new MeshStandardMaterial({
+            color: '#4b3223',
+            opacity: 0.72,
+            roughness: 0.95,
+            transparent: true,
+        }),
+        support: new MeshStandardMaterial({
+            color: '#7a4f2b',
+            roughness: 0.9,
+        }),
+        weed: new MeshStandardMaterial({
+            color: '#4b7f3b',
+            roughness: 1,
+        }),
+    };
+
+    return materials;
+}
+
+function createFieldVisualGeometries() {
+    return {
+        box: new BoxGeometry(1, 1, 1),
+        coverPlane: new PlaneGeometry(1, 1),
+        support: new CylinderGeometry(0.018, 0.022, 0.78, 6),
+        weed: new ConeGeometry(1, 1, 4),
+    };
+}
+
+const FieldVisualInstancedMesh = memo(function FieldVisualInstancedMesh({
+    batch,
+    castShadow = false,
+    children,
+    geometry,
+    material,
+    receiveShadow = false,
+    renderOrder,
+}: {
+    batch: RaisedBedFieldVisualBatch;
+    castShadow?: boolean;
+    children?: ReactNode;
+    geometry: BufferGeometry;
+    material?: Material;
+    receiveShadow?: boolean;
+    renderOrder?: number;
+}) {
+    const meshRef = useRef<InstancedMesh | null>(null);
+    const scratch = useMemo(() => new Object3D(), []);
+
+    useLayoutEffect(() => {
+        const mesh = meshRef.current;
+        if (!mesh) {
+            return;
+        }
+        mesh.instanceMatrix.setUsage(DynamicDrawUsage);
+        mesh.instanceMatrix.clearUpdateRanges();
+        batch.instances.forEach((instance, index) => {
+            scratch.position.set(...instance.position);
+            scratch.rotation.set(...instance.rotation);
+            scratch.scale.set(...instance.scale);
+            scratch.updateMatrix();
+            mesh.setMatrixAt(index, scratch.matrix);
+        });
+        mesh.count = batch.instances.length;
+        mesh.instanceMatrix.addUpdateRange(0, batch.instances.length * 16);
+        mesh.instanceMatrix.needsUpdate = true;
+        mesh.computeBoundingBox();
+        mesh.computeBoundingSphere();
+        if (
+            typeof window !== 'undefined' &&
+            window.location.pathname.startsWith('/debug/profile/game')
+        ) {
+            const metadata = readGameProfileMetadata();
+            updateGameProfileMetadata({
+                raisedBedFieldVisualMatrixUploadCount:
+                    (metadata?.raisedBedFieldVisualMatrixUploadCount ?? 0) + 1,
+                raisedBedFieldVisualUploadedInstanceCount:
+                    (metadata?.raisedBedFieldVisualUploadedInstanceCount ?? 0) +
+                    batch.instances.length,
+            });
+        }
+    }, [batch, scratch]);
+
+    return (
+        <instancedMesh
+            ref={meshRef}
+            args={[geometry, material, batch.capacity]}
+            castShadow={castShadow}
+            name={`RaisedBedFieldVisualBatch:${batch.key}:count:${batch.instances.length}`}
+            receiveShadow={receiveShadow}
+            renderOrder={renderOrder}
+        >
+            {children}
+        </instancedMesh>
+    );
+});
+
+const SeedFieldVisualInstancedMesh = memo(
+    function SeedFieldVisualInstancedMesh({
+        batch,
+        children,
+        material,
+    }: {
+        batch: RaisedBedFieldVisualBatch;
+        children?: ReactNode;
+        material?: Material;
+    }) {
+        const { nodes } = useGameGLTF('Seed');
+
+        return (
+            <FieldVisualInstancedMesh
+                batch={batch}
+                castShadow
+                geometry={nodes.Seed.geometry}
+                material={material}
+                receiveShadow
+            >
+                {children}
+            </FieldVisualInstancedMesh>
+        );
+    },
+);
+
+export function RaisedBedFieldVisualBatches({
+    blocks,
+}: {
+    blocks: RaisedBedFieldVisualBatchBlock[];
+}) {
+    const { includePendingCartPlants, renderDetails } = useGameSceneDetails();
+    const { data: currentGarden } = useCurrentGarden();
+    const { data: operations } = useOperations();
+    const isMock = useGameState((state) => state.isMock);
+    const mockGardenProfile = useGameState((state) => state.mockGardenProfile);
+    const isSandbox = useIsSandboxGarden();
+    const isLocalSandbox = useGameState(
+        (state) => state.localSandboxStorageKey !== null,
+    );
+    const { data: sortData } = useAllSorts(!isMock);
+    const { data: cart } = useShoppingCart(
+        includePendingCartPlants && renderDetails && !isLocalSandbox && !isMock,
+    );
+    const materials = useMemo(createFieldVisualMaterials, []);
+    const geometries = useMemo(createFieldVisualGeometries, []);
+    const previousBatchesRef = useRef<readonly RaisedBedFieldVisualBatch[]>([]);
+    const compiledBatches = useMemo(
+        () =>
+            renderDetails
+                ? compileRaisedBedFieldVisualBatches({
+                      blocks,
+                      cart,
+                      currentGarden,
+                      highTargetProfile: mockGardenProfile === 'high-target',
+                      isMock,
+                      isSandbox,
+                      operations,
+                      sortData,
+                  })
+                : [],
+        [
+            blocks,
+            cart,
+            currentGarden,
+            isMock,
+            isSandbox,
+            mockGardenProfile,
+            operations,
+            renderDetails,
+            sortData,
+        ],
+    );
+    const batches = useMemo(() => {
+        const reconciled = reconcileRaisedBedFieldVisualBatches(
+            previousBatchesRef.current,
+            compiledBatches,
+        );
+        previousBatchesRef.current = reconciled;
+        return reconciled;
+    }, [compiledBatches]);
+    const seedPulse = useSpring({
+        cancel: !batches.some((batch) => batch.layer === 'seed-pending'),
+        duration: 1000,
+        from: { opacity: 1 },
+        loop: true,
+        to: [{ opacity: 0.5 }, { opacity: 1 }],
+    });
+
+    useEffect(
+        () => () => {
+            for (const material of Object.values(materials)) {
+                material.dispose();
+            }
+            for (const geometry of Object.values(geometries)) {
+                geometry.dispose();
+            }
+        },
+        [geometries, materials],
+    );
+    useEffect(() => {
+        if (
+            typeof window === 'undefined' ||
+            !window.location.pathname.startsWith('/debug/profile/game')
+        ) {
+            return;
+        }
+        updateGameProfileMetadata({
+            raisedBedFieldVisualBatchCount: batches.length,
+            raisedBedFieldVisualChunkCount: new Set(
+                batches.map((batch) => batch.chunkKey),
+            ).size,
+            raisedBedFieldVisualInstanceCount: batches.reduce(
+                (total, batch) => total + batch.instances.length,
+                0,
+            ),
+            raisedBedFieldVisualObjectCount: batches.length,
+        });
+    }, [batches]);
+
+    if (!renderDetails || batches.length === 0) {
+        return null;
+    }
+
+    return (
+        <group name={`RaisedBedFieldVisualBatches:batches:${batches.length}`}>
+            {batches.map((batch) => {
+                switch (batch.layer) {
+                    case 'weed':
+                        return (
+                            <FieldVisualInstancedMesh
+                                key={`${batch.key}:${batch.capacity}`}
+                                batch={batch}
+                                geometry={geometries.weed}
+                                material={materials.weed}
+                            />
+                        );
+                    case 'support':
+                        return (
+                            <FieldVisualInstancedMesh
+                                key={`${batch.key}:${batch.capacity}`}
+                                batch={batch}
+                                castShadow
+                                geometry={geometries.support}
+                                material={materials.support}
+                                renderOrder={8}
+                            />
+                        );
+                    case 'cover-plane':
+                        return (
+                            <FieldVisualInstancedMesh
+                                key={`${batch.key}:${batch.capacity}`}
+                                batch={batch}
+                                geometry={geometries.coverPlane}
+                                material={materials.coverPlane}
+                                renderOrder={4}
+                            />
+                        );
+                    case 'cover-hem':
+                        return (
+                            <FieldVisualInstancedMesh
+                                key={`${batch.key}:${batch.capacity}`}
+                                batch={batch}
+                                geometry={geometries.box}
+                                material={materials.coverHem}
+                                renderOrder={5}
+                            />
+                        );
+                    case 'cover-bar':
+                        return (
+                            <FieldVisualInstancedMesh
+                                key={`${batch.key}:${batch.capacity}`}
+                                batch={batch}
+                                geometry={geometries.box}
+                                material={materials.coverBar}
+                                renderOrder={6}
+                            />
+                        );
+                    case 'seed-sown':
+                        return (
+                            <Suspense
+                                key={`${batch.key}:${batch.capacity}`}
+                                fallback={null}
+                            >
+                                <SeedFieldVisualInstancedMesh
+                                    batch={batch}
+                                    material={materials.seedSown}
+                                />
+                            </Suspense>
+                        );
+                    case 'seed-pending':
+                        return (
+                            <Suspense
+                                key={`${batch.key}:${batch.capacity}`}
+                                fallback={null}
+                            >
+                                <SeedFieldVisualInstancedMesh batch={batch}>
+                                    <animated.meshStandardMaterial
+                                        color="#6495ED"
+                                        opacity={seedPulse.opacity}
+                                        roughness={0.95}
+                                        transparent
+                                    />
+                                </SeedFieldVisualInstancedMesh>
+                            </Suspense>
+                        );
+                    default:
+                        return null;
+                }
+            })}
+        </group>
+    );
+}

--- a/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
@@ -1,11 +1,6 @@
 import { animated, useSpring } from '@react-spring/three';
 import { useGameSceneDetails } from '../../GameSceneDetailContext';
-import { resolveInGamePlantPreset } from '../../generators/plant/lib/inGamePlantPresets';
-import {
-    useCurrentGarden,
-    useIsSandboxGarden,
-} from '../../hooks/useCurrentGarden';
-import { useAllSorts } from '../../hooks/usePlantSorts';
+import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useRaisedBedOperationVisualRewards } from '../../hooks/useRaisedBedOperationVisualRewards';
 import { useShoppingCart } from '../../hooks/useShoppingCart';
 import { useGameState } from '../../useGameState';
@@ -16,10 +11,7 @@ import {
 import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
 import type { RaisedBedOrientation } from '../../utils/raisedBedOrientation';
 import { resolveEntityNeighbors } from '../helpers/useEntityNeighbors';
-import {
-    mockPlantPresetLabelsBySortId,
-    RaisedBedPlantField,
-} from './RaisedBedPlantField';
+import { RaisedBedPlantField } from './RaisedBedPlantField';
 import {
     hasActiveRaisedBedProtectiveCover,
     resolveRaisedBedProtectiveCoverPositions,
@@ -234,19 +226,6 @@ function RaisedBedFieldVisitSummaryHighlight({
                 />
             </mesh>
         </animated.group>
-    );
-}
-
-function shouldRenderGeneratedPlantField(field: {
-    positionIndex: number;
-    plantStatus?: string | null;
-    plantSowDate?: string | null;
-}) {
-    return (
-        Boolean(field.plantSowDate) &&
-        (field.plantStatus === 'sprouted' ||
-            field.plantStatus === 'ready' ||
-            field.plantStatus === 'harvested')
     );
 }
 
@@ -528,15 +507,16 @@ export function RaisedBedFields({
 }) {
     const { renderDetails } = useGameSceneDetails();
     const { data: currentGarden } = useCurrentGarden();
-    const { data: sortData } = useAllSorts();
-    const isMock = useGameState((state) => state.isMock);
-    const isSandbox = useIsSandboxGarden();
     const isLocalSandbox = useGameState(
         (state) => state.localSandboxStorageKey !== null,
     );
-    const { data: cart } = useShoppingCart(renderDetails && !isLocalSandbox);
+    const { data: cart } = useShoppingCart(
+        renderDetails && !isLocalSandbox && !generatedPlantsHandledExternally,
+    );
     const raisedBed = findRaisedBedByBlockId(currentGarden, blockId);
-    const visualRewards = useRaisedBedOperationVisualRewards(raisedBed);
+    const visualRewards = useRaisedBedOperationVisualRewards(
+        generatedPlantsHandledExternally ? undefined : raisedBed,
+    );
     const orientation = raisedBed?.orientation ?? 'vertical';
     const visitSummaryHighlight = useGameState(
         (state) => state.gardenVisitSummaryHighlight,
@@ -562,75 +542,80 @@ export function RaisedBedFields({
             item.positionIndex < blockOffset + 9,
     );
 
-    const displayedFields = [
-        ...(raisedBed?.fields?.filter(
-            (field) =>
-                isRaisedBedFieldOccupied(field) &&
-                field.positionIndex >= blockOffset &&
-                field.positionIndex < blockOffset + 9,
-        ) || []),
-        ...(cartItems?.map((item) => {
-            if (item.positionIndex === null) return null;
-            const field = {
-                id: `cart-item-${item.id}`,
-                positionIndex: item.positionIndex,
-                plantSortId: Number(item.entityId),
-            };
-            return field;
-        }) || []),
-    ];
+    const displayedFields = generatedPlantsHandledExternally
+        ? []
+        : [
+              ...(raisedBed?.fields?.filter(
+                  (field) =>
+                      isRaisedBedFieldOccupied(field) &&
+                      field.positionIndex >= blockOffset &&
+                      field.positionIndex < blockOffset + 9,
+              ) || []),
+              ...(cartItems?.map((item) => {
+                  if (item.positionIndex === null) return null;
+                  const field = {
+                      id: `cart-item-${item.id}`,
+                      positionIndex: item.positionIndex,
+                      plantSortId: Number(item.entityId),
+                  };
+                  return field;
+              }) || []),
+          ];
 
     if (!renderDetails) {
         return null;
     }
 
-    const weedFieldVisuals = raisedBed
-        ? Array.from({ length: 9 }, (_, localPositionIndex) => {
-              const positionIndex = blockOffset + localPositionIndex;
-              const field = raisedBed.fields.find(
-                  (candidate) =>
-                      candidate.active &&
-                      candidate.positionIndex === positionIndex,
-              );
-              const weedLevel = resolveRaisedBedFieldWeedLevel({
-                  fieldWeedState: field?.weedState,
-                  raisedBedFieldId:
-                      typeof field?.id === 'number' ? field.id : null,
-                  raisedBedId: raisedBed.id,
-                  raisedBedWeedState: raisedBed.weedState,
-                  visualRewards,
-              });
+    const weedFieldVisuals =
+        !generatedPlantsHandledExternally && raisedBed
+            ? Array.from({ length: 9 }, (_, localPositionIndex) => {
+                  const positionIndex = blockOffset + localPositionIndex;
+                  const field = raisedBed.fields.find(
+                      (candidate) =>
+                          candidate.active &&
+                          candidate.positionIndex === positionIndex,
+                  );
+                  const weedLevel = resolveRaisedBedFieldWeedLevel({
+                      fieldWeedState: field?.weedState,
+                      raisedBedFieldId:
+                          typeof field?.id === 'number' ? field.id : null,
+                      raisedBedId: raisedBed.id,
+                      raisedBedWeedState: raisedBed.weedState,
+                      visualRewards,
+                  });
 
-              return weedLevel
-                  ? {
-                        level: weedLevel,
-                        positionIndex: localPositionIndex,
-                    }
-                  : null;
-          }).filter(
-              (
-                  visual,
-              ): visual is {
-                  level: VisibleRaisedBedWeedLevel;
-                  positionIndex: number;
-              } => Boolean(visual),
-          )
-        : [];
-    const protectiveCoverPositions = raisedBed
-        ? resolveRaisedBedProtectiveCoverPositions({
-              blockOffset,
-              fields: raisedBed.fields,
-              raisedBedId: raisedBed.id,
-              visualRewards,
-          })
-        : [];
+                  return weedLevel
+                      ? {
+                            level: weedLevel,
+                            positionIndex: localPositionIndex,
+                        }
+                      : null;
+              }).filter(
+                  (
+                      visual,
+                  ): visual is {
+                      level: VisibleRaisedBedWeedLevel;
+                      positionIndex: number;
+                  } => Boolean(visual),
+              )
+            : [];
+    const protectiveCoverPositions =
+        !generatedPlantsHandledExternally && raisedBed
+            ? resolveRaisedBedProtectiveCoverPositions({
+                  blockOffset,
+                  fields: raisedBed.fields,
+                  raisedBedId: raisedBed.id,
+                  visualRewards,
+              })
+            : [];
     const protectiveCoverPositionSet = new Set(protectiveCoverPositions);
-    const hasRaisedBedProtectiveCover = raisedBed
-        ? hasActiveRaisedBedProtectiveCover({
-              raisedBedId: raisedBed.id,
-              visualRewards,
-          })
-        : false;
+    const hasRaisedBedProtectiveCover =
+        !generatedPlantsHandledExternally && raisedBed
+            ? hasActiveRaisedBedProtectiveCover({
+                  raisedBedId: raisedBed.id,
+                  visualRewards,
+              })
+            : false;
     const wholeBedProtectiveCoverLayout =
         hasRaisedBedProtectiveCover &&
         currentGarden &&
@@ -646,25 +631,27 @@ export function RaisedBedFields({
     const fieldProtectiveCoverPositions = hasRaisedBedProtectiveCover
         ? []
         : protectiveCoverPositions;
-    const supportPositions = raisedBed
-        ? resolveRaisedBedSupportPositions({
-              blockOffset,
-              fields: raisedBed.fields,
-              raisedBedId: raisedBed.id,
-              visualRewards,
-          })
-        : [];
+    const supportPositions =
+        !generatedPlantsHandledExternally && raisedBed
+            ? resolveRaisedBedSupportPositions({
+                  blockOffset,
+                  fields: raisedBed.fields,
+                  raisedBedId: raisedBed.id,
+                  visualRewards,
+              })
+            : [];
     const visibleSupportPositions = supportPositions.filter(
         (positionIndex) => !protectiveCoverPositionSet.has(positionIndex),
     );
-    const harvestPositions = raisedBed
-        ? resolveRaisedBedHarvestPositions({
-              blockOffset,
-              fields: raisedBed.fields,
-              raisedBedId: raisedBed.id,
-              visualRewards,
-          })
-        : [];
+    const harvestPositions =
+        !generatedPlantsHandledExternally && raisedBed
+            ? resolveRaisedBedHarvestPositions({
+                  blockOffset,
+                  fields: raisedBed.fields,
+                  raisedBedId: raisedBed.id,
+                  visualRewards,
+              })
+            : [];
     const visibleHarvestPositions = harvestPositions.filter(
         (positionIndex) => !protectiveCoverPositionSet.has(positionIndex),
     );
@@ -712,28 +699,6 @@ export function RaisedBedFields({
 
                 if (protectiveCoverPositionSet.has(localPositionIndex)) {
                     return null;
-                }
-
-                if (
-                    generatedPlantsHandledExternally &&
-                    field.plantSortId &&
-                    shouldRenderGeneratedPlantField(field)
-                ) {
-                    const sort = sortData?.find(
-                        (item) => item.id === field.plantSortId,
-                    );
-                    const resolvedPlantPreset = resolveInGamePlantPreset([
-                        sort?.information.name,
-                        sort?.information.plant.information?.name,
-                        sort?.information.plant.information?.latinName,
-                        isMock || isSandbox
-                            ? mockPlantPresetLabelsBySortId[field.plantSortId]
-                            : undefined,
-                    ]);
-
-                    if (resolvedPlantPreset) {
-                        return null;
-                    }
                 }
 
                 return (

--- a/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantFieldBatches.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantFieldBatches.tsx
@@ -24,15 +24,19 @@ import { resolvePlantLeafGeometryDetail } from '../../generators/plant/lib/plant
 import type { PlantLodLevel } from '../../generators/plant/lib/plantLod';
 import {
     getHighTargetMockGardenPlantInstanceCount,
+    getHighTargetOperationVisualFixtureCounts,
     highTargetMockPlantRenderAttributesBySortId,
+    resolveHighTargetOperationVisualsEnabled,
 } from '../../hooks/mockGardenProfileFixtures';
 import {
     useCurrentGarden,
     useIsSandboxGarden,
 } from '../../hooks/useCurrentGarden';
+import { useOperations } from '../../hooks/useOperations';
 import { useAllSorts } from '../../hooks/usePlantSorts';
 import { useShoppingCart } from '../../hooks/useShoppingCart';
 import { useSnapshotTime } from '../../hooks/useSnapshotTime';
+import { resolveOperationVisualRewards } from '../../operationVisualRewards';
 import { updateGameProfileMetadata } from '../../scene/gameProfileMetadata';
 import type { GameQualityProfile } from '../../scene/gameQuality';
 import {
@@ -61,6 +65,7 @@ import {
     type RaisedBedGeneratedPlantBatchInstance,
 } from './RaisedBedGeneratedPlantBatch';
 import { mockPlantPresetLabelsBySortId } from './RaisedBedPlantField';
+import { resolveRaisedBedProtectiveCoverPositions } from './raisedBedAgrotextileRewards';
 
 export interface RaisedBedGeneratedPlantFieldBatchBlock {
     blockId: string;
@@ -398,6 +403,7 @@ export function RaisedBedGeneratedPlantFieldBatches({
 }) {
     const { includePendingCartPlants, renderDetails } = useGameSceneDetails();
     const { data: currentGarden } = useCurrentGarden();
+    const { data: operations } = useOperations();
     const isMock = useGameState((state) => state.isMock);
     const mockGardenProfile = useGameState((state) => state.mockGardenProfile);
     const { data: sortData } = useAllSorts(!isMock);
@@ -421,6 +427,22 @@ export function RaisedBedGeneratedPlantFieldBatches({
             return fields;
         }
 
+        const visualRewardsByRaisedBedId = new Map(
+            currentGarden.raisedBeds.map((raisedBed) => [
+                raisedBed.id,
+                resolveOperationVisualRewards({
+                    appliedOperations: (raisedBed.appliedOperations ?? []).map(
+                        (operation) => ({
+                            ...operation,
+                            raisedBedId: raisedBed.id,
+                        }),
+                    ),
+                    operationItems: [],
+                    operations: operations ?? [],
+                }),
+            ]),
+        );
+
         for (const block of blocks) {
             const raisedBed = findRaisedBedByBlockId(
                 currentGarden,
@@ -435,6 +457,15 @@ export function RaisedBedGeneratedPlantFieldBatches({
             const blockIndex = blockIds.indexOf(block.blockId);
             const blockOffset =
                 Math.max(blockIds.length - 1 - blockIndex, 0) * 9;
+            const protectiveCoverPositionSet = new Set(
+                resolveRaisedBedProtectiveCoverPositions({
+                    blockOffset,
+                    fields: raisedBed.fields,
+                    raisedBedId: raisedBed.id,
+                    visualRewards:
+                        visualRewardsByRaisedBedId.get(raisedBed.id) ?? [],
+                }),
+            );
             const cartItems = cart?.items.filter(
                 (item) =>
                     item.gardenId === currentGarden.id &&
@@ -475,6 +506,13 @@ export function RaisedBedGeneratedPlantFieldBatches({
             ];
 
             for (const field of displayedFields) {
+                if (
+                    protectiveCoverPositionSet.has(
+                        field.positionIndex - blockOffset,
+                    )
+                ) {
+                    continue;
+                }
                 const plantSortId = field.plantSortId;
                 const sort = sortData?.find((item) => item.id === plantSortId);
                 const highTargetAttributes =
@@ -592,6 +630,7 @@ export function RaisedBedGeneratedPlantFieldBatches({
         isMock,
         isSandbox,
         mockGardenProfile,
+        operations,
         renderDetails,
         sortData,
     ]);
@@ -673,6 +712,11 @@ export function RaisedBedGeneratedPlantFieldBatches({
 
         return Array.from(batchMap.values());
     }, [focusActive, generatedFields, lods, selectedRaisedBedId]);
+    const highTargetOperationVisuals =
+        mockGardenProfile === 'high-target' &&
+        resolveHighTargetOperationVisualsEnabled(
+            typeof window === 'undefined' ? undefined : window.location.search,
+        );
     useEffect(() => {
         updateGameProfileMetadata({
             generatedPlantBatchCount: batches.length,
@@ -683,7 +727,10 @@ export function RaisedBedGeneratedPlantFieldBatches({
             ),
             generatedPlantExpectedInstanceCount:
                 mockGardenProfile === 'high-target'
-                    ? getHighTargetMockGardenPlantInstanceCount()
+                    ? highTargetOperationVisuals
+                        ? getHighTargetOperationVisualFixtureCounts()
+                              .generatedPlantInstanceCount
+                        : getHighTargetMockGardenPlantInstanceCount()
                     : undefined,
             generatedPlantVisibleFieldCount: generatedFields.filter(
                 (field) => lods.get(field.fieldKey)?.visible === true,
@@ -696,7 +743,13 @@ export function RaisedBedGeneratedPlantFieldBatches({
                 0,
             ),
         });
-    }, [batches.length, generatedFields, lods, mockGardenProfile]);
+    }, [
+        batches.length,
+        generatedFields,
+        highTargetOperationVisuals,
+        lods,
+        mockGardenProfile,
+    ]);
 
     if (!renderDetails || batches.length === 0) {
         return null;

--- a/packages/game/src/entities/raisedBed/RaisedBedMulchOverlays.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedMulchOverlays.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import type { BufferGeometry } from 'three';
 import {
     type ActiveDragPreviewTarget,
@@ -14,7 +14,6 @@ import {
     type GameQualityProfile,
     resolveGameQualityProfile,
 } from '../../scene/gameQuality';
-import { SnowOverlay } from '../../snow/SnowOverlay';
 import { snowPresets } from '../../snow/snowPresets';
 import type { Block } from '../../types/Block';
 import type { Stack } from '../../types/Stack';
@@ -27,6 +26,11 @@ import {
     type RaisedBedOrientation,
 } from '../../utils/raisedBedOrientation';
 import { useGameGLTF } from '../../utils/useGameGLTF';
+import { chunkMeshInstances } from '../chunkedMeshGeometry';
+import {
+    type EntityBlockInstance,
+    EntityInstancesGeometry,
+} from '../EntityInstancesBlock';
 import { MulchPatchMaterial, useMulchPatchGeometries } from './MulchPatch';
 import {
     fullMulchPatchConnectionMask,
@@ -36,6 +40,10 @@ import {
     resolveMulchPatchConnectionMask,
 } from './mulchPatchGeometry';
 import { appliedMulchOperationsOldestFirst } from './raisedBedMulchOperationOrder';
+import {
+    getRaisedBedMulchRenderGroups,
+    type RaisedBedMulchRenderPatch,
+} from './raisedBedMulchRenderGroups';
 import {
     isFieldMulchApplication,
     resolveActiveFieldMulchRewardsByFieldId,
@@ -79,9 +87,12 @@ type RaisedBedPlacement = {
 type FieldMulchPatch = {
     blockName: MulchBlockName;
     key: string;
+    placement: RaisedBedPlacement;
     position: [number, number, number];
     scale: [number, number, number];
 };
+
+type MulchRenderPatch = RaisedBedMulchRenderPatch<EntityBlockInstance>;
 
 function timestampMs(value: Date | string | null | undefined) {
     if (!value) {
@@ -456,43 +467,74 @@ function getFieldMulchPatchTargets(
     }));
 }
 
-function MulchMesh({
-    blockName,
-    geometry,
-    minSnowCoverage,
+function createMulchRenderInstance({
+    cache,
+    key,
+    placement,
     position,
-    renderSnow,
-    scale,
 }: {
-    blockName: MulchBlockName;
-    geometry: BufferGeometry;
-    minSnowCoverage: number;
+    cache: Map<string, EntityBlockInstance>;
+    key: string;
+    placement: RaisedBedPlacement;
     position: [number, number, number];
-    renderSnow: boolean;
-    scale: [number, number, number];
-}) {
-    return (
-        <group position={position}>
-            <mesh castShadow receiveShadow scale={scale} geometry={geometry}>
-                <MulchPatchMaterial blockName={blockName} />
-                {renderSnow && (
-                    <SnowOverlay
-                        geometry={geometry}
-                        minCoverage={minSnowCoverage}
-                        {...snowPresets.mulch}
-                    />
-                )}
-            </mesh>
-        </group>
-    );
+}): EntityBlockInstance {
+    const cached = cache.get(key);
+    if (
+        cached &&
+        cached.blockIndex === placement.stackBlockIndex &&
+        cached.position[0] === position[0] &&
+        cached.position[1] === position[1] &&
+        cached.position[2] === position[2]
+    ) {
+        return cached;
+    }
+
+    const instance = {
+        block:
+            cached?.block ??
+            ({
+                ...placement.block,
+                id: key,
+                rotation: 0,
+            } satisfies Block),
+        blockIndex: placement.stackBlockIndex,
+        id: key,
+        pickupOutlineVisible: false,
+        position,
+        rotation: 0,
+        // The synthetic block ID intentionally opts mulch overlays out of block
+        // placement animations; retain a stable stack identity for comparisons.
+        stack: cached?.stack ?? placement.stack,
+        stackHeight: position[1],
+    } satisfies EntityBlockInstance;
+    cache.set(key, instance);
+    return instance;
 }
 
-function RaisedBedMulchProfileMetadata({ count }: { count: number }) {
+// EntityInstancesGeometry treats zero as "use the default lift". A truthy value
+// below floating-point resolution preserves the legacy coincident snow overlay.
+const legacyMulchSnowLift = Number.MIN_VALUE;
+
+function RaisedBedMulchProfileMetadata({
+    batchCount,
+    count,
+    groupCount,
+    objectCount,
+}: {
+    batchCount: number;
+    count: number;
+    groupCount: number;
+    objectCount: number;
+}) {
     useEffect(() => {
         updateGameProfileMetadata({
+            raisedBedMulchBatchCount: batchCount,
+            raisedBedMulchGroupCount: groupCount,
+            raisedBedMulchInstanceCount: count,
+            raisedBedMulchObjectCount: objectCount,
             raisedBedMulchOverlayCount: count,
         });
-    }, [count]);
+    }, [batchCount, count, groupCount, objectCount]);
 
     return null;
 }
@@ -507,6 +549,7 @@ export function RaisedBedMulchOverlays({
     const { data: blockData } = useBlockData();
     const { nodes: raisedBedNodes } = useGameGLTF('RaisedBed');
     const mulchPatchGeometries = useMulchPatchGeometries();
+    const renderInstanceCache = useRef(new Map<string, EntityBlockInstance>());
     const qualityProfile = quality ?? resolveGameQualityProfile();
     const activeDragPreview = useGameState((state) =>
         activeDragPreviewTouchesRaisedBed(
@@ -518,202 +561,282 @@ export function RaisedBedMulchOverlays({
     );
     const snowCoverage = useGameState((state) => state.snowCoverage);
     const renderSnow = snowCoverage >= qualityProfile.snowOverlayMinCoverage;
-
-    if (!currentGarden || !blockData || !operations) {
-        return <RaisedBedMulchProfileMetadata count={0} />;
-    }
-
-    const mulchVisualByOperationId = resolveMulchVisualByOperationId(
-        operations,
-        blockData,
-    );
-    if (mulchVisualByOperationId.size === 0) {
-        return <RaisedBedMulchProfileMetadata count={0} />;
-    }
-
-    const overlays = [];
-
-    for (const raisedBed of currentGarden.raisedBeds) {
-        const blockIds = getRaisedBedBlockIds(currentGarden, raisedBed.id);
-        const placements: RaisedBedPlacement[] = [];
-
-        for (const [blockIndex, blockId] of blockIds.entries()) {
-            const placement = getBlockPlacement(currentGarden, blockId);
-            if (!placement) {
-                continue;
-            }
-
-            const neighbors = getRaisedBedNeighbors(
-                currentGarden,
-                placement.stack,
-                placement.block,
-            );
-            const surfaceGeometry = getRaisedBedSurfaceGeometry(neighbors);
-            const origin = getRaisedBedOrigin(
-                blockData,
-                placement.stack,
-                placement.block,
-                neighbors,
-            );
-            const dragPreviewOffset = getActiveDragPreviewTargetPositionOffset(
-                createActiveDragPreviewTarget({
-                    blockId: placement.block.id,
-                    blockIndex: placement.stackBlockIndex,
-                    stackPosition: placement.stack.position,
-                }),
-                activeDragPreview,
-            );
-
-            placements.push({
-                block: placement.block,
-                blockIndex,
-                blockOffset: Math.max(blockIds.length - 1 - blockIndex, 0) * 9,
-                dirtGeometryName: surfaceGeometry.dirtGeometryName,
-                origin: [
-                    origin[0] + (dragPreviewOffset?.x ?? 0),
-                    origin[1] + (dragPreviewOffset?.y ?? 0),
-                    origin[2] + (dragPreviewOffset?.z ?? 0),
-                ],
-                rotationQuarterTurns: surfaceGeometry.rotationQuarterTurns,
-                stack: placement.stack,
-                stackBlockIndex: placement.stackBlockIndex,
-            });
+    const renderPatches = useMemo(() => {
+        if (!currentGarden || !blockData || !operations) {
+            return [];
         }
 
-        if (placements.length === 0) {
-            continue;
-        }
-        const activeRaisedBedMulchReward = resolveActiveRaisedBedMulchReward({
-            appliedOperations: raisedBed.appliedOperations ?? [],
+        const mulchVisualByOperationId = resolveMulchVisualByOperationId(
             operations,
-            raisedBedId: raisedBed.id,
-        });
-
-        const fullBedAppliedMulch =
-            activeRaisedBedMulchReward &&
-            mulchVisualByOperationId.get(activeRaisedBedMulchReward.entityId);
-
-        if (fullBedAppliedMulch) {
-            const visual = fullBedAppliedMulch;
-            const mulchGeometry = mulchPatchGeometries.get(
-                fullMulchPatchConnectionMask,
-            );
-            if (visual && isMulchBlockName(visual.blockName) && mulchGeometry) {
-                const surfaceBounds = getFullBedSurfaceBounds(
-                    placements,
-                    raisedBedNodes,
-                );
-                overlays.push(
-                    <MulchMesh
-                        key={`raised-bed-mulch-${raisedBed.id}-${visual.blockId}`}
-                        blockName={visual.blockName}
-                        geometry={mulchGeometry}
-                        minSnowCoverage={qualityProfile.snowOverlayMinCoverage}
-                        position={getFullBedPosition(
-                            surfaceBounds,
-                            getRaisedBedSurfaceY(placements[0].origin),
-                        )}
-                        renderSnow={renderSnow}
-                        scale={getFullBedScale(surfaceBounds)}
-                    />,
-                );
-            }
-            continue;
+            blockData,
+        );
+        if (mulchVisualByOperationId.size === 0) {
+            return [];
         }
 
-        const fieldMulchByPositionIndex = new Map<number, MulchBlockName>();
-        const appliedFieldMulchRewardsByFieldId =
-            resolveActiveFieldMulchRewardsByFieldId({
-                appliedOperations: raisedBed.appliedOperations ?? [],
-                operations,
-                raisedBedId: raisedBed.id,
-            });
+        const patches: MulchRenderPatch[] = [];
 
-        for (const reward of appliedMulchOperationsOldestFirst(
-            Array.from(appliedFieldMulchRewardsByFieldId.values()),
-        )) {
-            const visual = mulchVisualByOperationId.get(reward.entityId);
-            if (
-                !visual ||
-                !isMulchBlockName(visual.blockName) ||
-                !isFieldMulchApplication(visual.application)
-            ) {
+        for (const raisedBed of currentGarden.raisedBeds) {
+            const blockIds = getRaisedBedBlockIds(currentGarden, raisedBed.id);
+            const placements: RaisedBedPlacement[] = [];
+
+            for (const [blockIndex, blockId] of blockIds.entries()) {
+                const placement = getBlockPlacement(currentGarden, blockId);
+                if (!placement) {
+                    continue;
+                }
+
+                const neighbors = getRaisedBedNeighbors(
+                    currentGarden,
+                    placement.stack,
+                    placement.block,
+                );
+                const surfaceGeometry = getRaisedBedSurfaceGeometry(neighbors);
+                const origin = getRaisedBedOrigin(
+                    blockData,
+                    placement.stack,
+                    placement.block,
+                    neighbors,
+                );
+                const dragPreviewOffset =
+                    getActiveDragPreviewTargetPositionOffset(
+                        createActiveDragPreviewTarget({
+                            blockId: placement.block.id,
+                            blockIndex: placement.stackBlockIndex,
+                            stackPosition: placement.stack.position,
+                        }),
+                        activeDragPreview,
+                    );
+
+                placements.push({
+                    block: placement.block,
+                    blockIndex,
+                    blockOffset:
+                        Math.max(blockIds.length - 1 - blockIndex, 0) * 9,
+                    dirtGeometryName: surfaceGeometry.dirtGeometryName,
+                    origin: [
+                        origin[0] + (dragPreviewOffset?.x ?? 0),
+                        origin[1] + (dragPreviewOffset?.y ?? 0),
+                        origin[2] + (dragPreviewOffset?.z ?? 0),
+                    ],
+                    rotationQuarterTurns: surfaceGeometry.rotationQuarterTurns,
+                    stack: placement.stack,
+                    stackBlockIndex: placement.stackBlockIndex,
+                });
+            }
+
+            if (placements.length === 0) {
+                continue;
+            }
+            const activeRaisedBedMulchReward =
+                resolveActiveRaisedBedMulchReward({
+                    appliedOperations: raisedBed.appliedOperations ?? [],
+                    operations,
+                    raisedBedId: raisedBed.id,
+                });
+
+            const fullBedAppliedMulch =
+                activeRaisedBedMulchReward &&
+                mulchVisualByOperationId.get(
+                    activeRaisedBedMulchReward.entityId,
+                );
+
+            if (fullBedAppliedMulch) {
+                const visual = fullBedAppliedMulch;
+                const ownerPlacement = placements[0];
+                const mulchGeometry = mulchPatchGeometries.get(
+                    fullMulchPatchConnectionMask,
+                );
+                if (
+                    visual &&
+                    ownerPlacement &&
+                    isMulchBlockName(visual.blockName) &&
+                    mulchGeometry
+                ) {
+                    const surfaceBounds = getFullBedSurfaceBounds(
+                        placements,
+                        raisedBedNodes,
+                    );
+                    const key = `raised-bed-mulch-${raisedBed.id}-${visual.blockId}`;
+                    const position = getFullBedPosition(
+                        surfaceBounds,
+                        getRaisedBedSurfaceY(ownerPlacement.origin),
+                    );
+                    patches.push({
+                        blockName: visual.blockName,
+                        instance: createMulchRenderInstance({
+                            cache: renderInstanceCache.current,
+                            key,
+                            placement: ownerPlacement,
+                            position,
+                        }),
+                        mask: fullMulchPatchConnectionMask,
+                        scale: getFullBedScale(surfaceBounds),
+                    });
+                }
                 continue;
             }
 
-            const field = raisedBed.fields.find(
-                (candidate) => candidate.id === reward.raisedBedFieldId,
-            );
-            if (!field || !isRaisedBedFieldOccupied(field)) {
-                continue;
+            const fieldMulchByPositionIndex = new Map<number, MulchBlockName>();
+            const appliedFieldMulchRewardsByFieldId =
+                resolveActiveFieldMulchRewardsByFieldId({
+                    appliedOperations: raisedBed.appliedOperations ?? [],
+                    operations,
+                    raisedBedId: raisedBed.id,
+                });
+
+            for (const reward of appliedMulchOperationsOldestFirst(
+                Array.from(appliedFieldMulchRewardsByFieldId.values()),
+            )) {
+                const visual = mulchVisualByOperationId.get(reward.entityId);
+                if (
+                    !visual ||
+                    !isMulchBlockName(visual.blockName) ||
+                    !isFieldMulchApplication(visual.application)
+                ) {
+                    continue;
+                }
+
+                const field = raisedBed.fields.find(
+                    (candidate) => candidate.id === reward.raisedBedFieldId,
+                );
+                if (!field || !isRaisedBedFieldOccupied(field)) {
+                    continue;
+                }
+
+                if (!isOperationAppliedToActivePlantCycle(reward, field)) {
+                    continue;
+                }
+
+                fieldMulchByPositionIndex.set(
+                    field.positionIndex,
+                    visual.blockName,
+                );
             }
 
-            if (!isOperationAppliedToActivePlantCycle(reward, field)) {
-                continue;
-            }
+            const orientation = raisedBed.orientation ?? 'vertical';
+            const fieldMulchPatches: FieldMulchPatch[] = [];
+            const fieldScale = getFieldMulchScale(orientation);
 
-            fieldMulchByPositionIndex.set(
-                field.positionIndex,
-                visual.blockName,
-            );
-        }
-
-        const orientation = raisedBed.orientation ?? 'vertical';
-        const fieldMulchPatches: FieldMulchPatch[] = [];
-        const fieldScale = getFieldMulchScale(orientation);
-
-        for (const [positionIndex, blockName] of fieldMulchByPositionIndex) {
-            const placement = getPlacementForPositionIndex(
-                placements,
+            for (const [
                 positionIndex,
-            );
-            if (!placement) {
-                continue;
-            }
-
-            fieldMulchPatches.push({
                 blockName,
-                key: `raised-bed-field-mulch-${raisedBed.id}-${positionIndex}-${blockName}`,
-                position: getFieldWorldPosition({
-                    blockIndex: placement.blockIndex,
-                    localPositionIndex: placement.localPositionIndex,
-                    orientation,
-                    origin: placement.origin,
-                }),
-                scale: fieldScale,
-            });
-        }
+            ] of fieldMulchByPositionIndex) {
+                const placement = getPlacementForPositionIndex(
+                    placements,
+                    positionIndex,
+                );
+                if (!placement) {
+                    continue;
+                }
 
-        const fieldTargets = getFieldMulchPatchTargets(fieldMulchPatches);
-        for (const [patchIndex, patch] of fieldMulchPatches.entries()) {
-            const target = fieldTargets[patchIndex];
-            const mask = target
-                ? resolveMulchPatchConnectionMask(target, fieldTargets)
-                : fullMulchPatchConnectionMask;
-            const geometry = mulchPatchGeometries.get(mask);
-
-            if (!geometry) {
-                continue;
+                fieldMulchPatches.push({
+                    blockName,
+                    key: `raised-bed-field-mulch-${raisedBed.id}-${positionIndex}-${blockName}`,
+                    placement,
+                    position: getFieldWorldPosition({
+                        blockIndex: placement.blockIndex,
+                        localPositionIndex: placement.localPositionIndex,
+                        orientation,
+                        origin: placement.origin,
+                    }),
+                    scale: fieldScale,
+                });
             }
 
-            overlays.push(
-                <MulchMesh
-                    key={patch.key}
-                    blockName={patch.blockName}
-                    geometry={geometry}
-                    minSnowCoverage={qualityProfile.snowOverlayMinCoverage}
-                    position={patch.position}
-                    renderSnow={renderSnow}
-                    scale={patch.scale}
-                />,
-            );
+            const fieldTargets = getFieldMulchPatchTargets(fieldMulchPatches);
+            for (const [patchIndex, patch] of fieldMulchPatches.entries()) {
+                const target = fieldTargets[patchIndex];
+                const mask = target
+                    ? resolveMulchPatchConnectionMask(target, fieldTargets)
+                    : fullMulchPatchConnectionMask;
+                const geometry = mulchPatchGeometries.get(mask);
+
+                if (!geometry) {
+                    continue;
+                }
+
+                patches.push({
+                    blockName: patch.blockName,
+                    instance: createMulchRenderInstance({
+                        cache: renderInstanceCache.current,
+                        key: patch.key,
+                        placement: patch.placement,
+                        position: patch.position,
+                    }),
+                    mask,
+                    scale: patch.scale,
+                });
+            }
         }
-    }
+
+        const activePatchKeys = new Set(
+            patches.map((patch) => patch.instance.id),
+        );
+        for (const key of renderInstanceCache.current.keys()) {
+            if (!activePatchKeys.has(key)) {
+                renderInstanceCache.current.delete(key);
+            }
+        }
+
+        return patches;
+    }, [
+        activeDragPreview,
+        blockData,
+        currentGarden,
+        mulchPatchGeometries,
+        operations,
+        raisedBedNodes,
+    ]);
+    const renderGroups = useMemo(
+        () => getRaisedBedMulchRenderGroups(renderPatches),
+        [renderPatches],
+    );
+    const renderBatchCount = useMemo(
+        () =>
+            renderGroups.reduce(
+                (total, group) =>
+                    total + chunkMeshInstances(group.instances).length,
+                0,
+            ),
+        [renderGroups],
+    );
 
     return (
         <>
-            <RaisedBedMulchProfileMetadata count={overlays.length} />
-            {overlays}
+            <RaisedBedMulchProfileMetadata
+                batchCount={renderBatchCount}
+                count={renderPatches.length}
+                groupCount={renderGroups.length}
+                objectCount={renderBatchCount * (renderSnow ? 2 : 1)}
+            />
+            {renderGroups.map((group) => {
+                const geometry = mulchPatchGeometries.get(group.mask);
+                if (!geometry) {
+                    return null;
+                }
+
+                return (
+                    <EntityInstancesGeometry
+                        key={group.key}
+                        castShadow
+                        geometry={geometry}
+                        instanceKey={`raised-bed-mulch:${group.key}`}
+                        instances={group.instances}
+                        materialNode={
+                            <MulchPatchMaterial blockName={group.blockName} />
+                        }
+                        receiveShadow
+                        renderSnow={renderSnow}
+                        scale={group.scale}
+                        snow={snowPresets.mulch}
+                        snowLift={legacyMulchSnowLift}
+                        snowOverlayMinCoverage={
+                            qualityProfile.snowOverlayMinCoverage
+                        }
+                    />
+                );
+            })}
         </>
     );
 }

--- a/packages/game/src/entities/raisedBed/raisedBedFieldVisualChunks.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedFieldVisualChunks.ts
@@ -1,0 +1,100 @@
+export type FieldVisualLayerBase = {
+    key: string;
+    /**
+     * Must cover every render-relevant property of the layer. Equal signatures
+     * intentionally preserve the previous layer object and its instance arrays.
+     */
+    signature: string;
+};
+
+export type FieldVisualChunk<Layer extends FieldVisualLayerBase> = {
+    key: string;
+    layers: readonly Layer[];
+};
+
+function assertUniqueKeys(
+    keys: readonly string[],
+    description: 'chunk' | 'layer',
+) {
+    const seen = new Set<string>();
+
+    for (const key of keys) {
+        if (seen.has(key)) {
+            throw new Error(
+                `Duplicate field visual ${description} key: ${key}`,
+            );
+        }
+        seen.add(key);
+    }
+}
+
+function reconcileChunkLayers<Layer extends FieldVisualLayerBase>(
+    previous: FieldVisualChunk<Layer>,
+    next: FieldVisualChunk<Layer>,
+) {
+    assertUniqueKeys(
+        next.layers.map((layer) => layer.key),
+        'layer',
+    );
+    const previousLayerByKey = new Map(
+        previous.layers.map((layer) => [layer.key, layer]),
+    );
+    const layers = next.layers.map((layer) => {
+        const previousLayer = previousLayerByKey.get(layer.key);
+
+        return previousLayer?.signature === layer.signature
+            ? previousLayer
+            : layer;
+    });
+    const canReusePreviousChunk =
+        previous.layers.length === layers.length &&
+        previous.layers.every((layer, index) => layer === layers[index]);
+
+    return canReusePreviousChunk
+        ? previous
+        : {
+              key: next.key,
+              layers,
+          };
+}
+
+/**
+ * Reconciles immutable render descriptions while preserving unchanged layer
+ * and chunk references. This lets memoized renderers update GPU buffers only
+ * for the spatial chunk and compatible layer whose signature changed.
+ */
+export function reconcileFieldVisualChunks<Layer extends FieldVisualLayerBase>(
+    previous: readonly FieldVisualChunk<Layer>[] | undefined,
+    next: readonly FieldVisualChunk<Layer>[],
+): readonly FieldVisualChunk<Layer>[] {
+    assertUniqueKeys(
+        next.map((chunk) => chunk.key),
+        'chunk',
+    );
+    for (const chunk of next) {
+        assertUniqueKeys(
+            chunk.layers.map((layer) => layer.key),
+            'layer',
+        );
+    }
+
+    if (!previous) {
+        return next;
+    }
+
+    const previousChunkByKey = new Map(
+        previous.map((chunk) => [chunk.key, chunk]),
+    );
+    const reconciled = next.map((chunk) => {
+        const previousChunk = previousChunkByKey.get(chunk.key);
+
+        return previousChunk
+            ? reconcileChunkLayers(previousChunk, chunk)
+            : chunk;
+    });
+    const canReusePreviousList =
+        previous.length === reconciled.length &&
+        previous.every((chunk, index) => chunk === reconciled[index]);
+
+    return canReusePreviousList ? previous : reconciled;
+}

--- a/packages/game/src/entities/raisedBed/raisedBedFieldVisualChunks.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedFieldVisualChunks.unit.ts
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    type FieldVisualChunk,
+    type FieldVisualLayerBase,
+    reconcileFieldVisualChunks,
+} from './raisedBedFieldVisualChunks';
+
+type TestLayer = FieldVisualLayerBase & {
+    instances: readonly number[];
+};
+
+function layer(
+    key: string,
+    signature: string,
+    instances: readonly number[],
+): TestLayer {
+    return { instances, key, signature };
+}
+
+function chunk(
+    key: string,
+    layers: readonly TestLayer[],
+): FieldVisualChunk<TestLayer> {
+    return { key, layers };
+}
+
+describe('field visual chunk reconciliation', () => {
+    it('returns the incoming descriptions unchanged on the first compile', () => {
+        const next = [chunk('0:0', [layer('weeds', 'v1', [1, 2])])];
+
+        assert.equal(reconcileFieldVisualChunks(undefined, next), next);
+    });
+
+    it('reuses the complete previous graph when all signatures match', () => {
+        const previousWeeds = layer('weeds', 'v1', [1, 2]);
+        const previousSupport = layer('support', 'v1', [3]);
+        const previous = [
+            chunk('0:0', [previousWeeds, previousSupport]),
+            chunk('1:0', [layer('weeds', 'v2', [4])]),
+        ];
+        const next = [
+            chunk('0:0', [
+                layer('weeds', 'v1', [100, 200]),
+                layer('support', 'v1', [300]),
+            ]),
+            chunk('1:0', [layer('weeds', 'v2', [400])]),
+        ];
+
+        const reconciled = reconcileFieldVisualChunks(previous, next);
+
+        assert.equal(reconciled, previous);
+        assert.equal(reconciled[0]?.layers[0], previousWeeds);
+        assert.equal(reconciled[0]?.layers[1], previousSupport);
+    });
+
+    it('replaces only the owning chunk and affected layer for a one-field update', () => {
+        const previousWeeds = layer('weeds', 'bed-1:heavy', [1, 2]);
+        const previousSupport = layer('support', 'bed-1:none', []);
+        const untouchedChunk = chunk('-1:0', [
+            layer('weeds', 'bed-2:heavy', [7, 8]),
+        ]);
+        const previous = [
+            chunk('0:0', [previousWeeds, previousSupport]),
+            untouchedChunk,
+        ];
+        const changedWeeds = layer('weeds', 'bed-1:field-3-clean', [1]);
+        const next = [
+            chunk('0:0', [changedWeeds, layer('support', 'bed-1:none', [999])]),
+            chunk('-1:0', [layer('weeds', 'bed-2:heavy', [700, 800])]),
+        ];
+
+        const reconciled = reconcileFieldVisualChunks(previous, next);
+
+        assert.notEqual(reconciled, previous);
+        assert.notEqual(reconciled[0], previous[0]);
+        assert.equal(reconciled[1], untouchedChunk);
+        assert.equal(reconciled[0]?.layers[0], changedWeeds);
+        assert.equal(reconciled[0]?.layers[1], previousSupport);
+        assert.equal(
+            reconciled[0]?.layers[1]?.instances,
+            previousSupport.instances,
+        );
+    });
+
+    it('follows next ordering while retaining matching layer objects', () => {
+        const weeds = layer('weeds', 'v1', [1]);
+        const support = layer('support', 'v1', [2]);
+        const previous = [chunk('0:0', [weeds, support])];
+        const next = [
+            chunk('0:0', [
+                layer('support', 'v1', [20]),
+                layer('weeds', 'v1', [10]),
+            ]),
+        ];
+
+        const reconciled = reconcileFieldVisualChunks(previous, next);
+
+        assert.notEqual(reconciled[0], previous[0]);
+        assert.equal(reconciled[0]?.layers[0], support);
+        assert.equal(reconciled[0]?.layers[1], weeds);
+    });
+
+    it('rejects duplicate chunk and layer keys', () => {
+        assert.throws(
+            () =>
+                reconcileFieldVisualChunks(undefined, [
+                    chunk('0:0', []),
+                    chunk('0:0', []),
+                ]),
+            /Duplicate field visual chunk key/,
+        );
+        assert.throws(
+            () =>
+                reconcileFieldVisualChunks(undefined, [
+                    chunk('0:0', [
+                        layer('weeds', 'v1', []),
+                        layer('weeds', 'v2', []),
+                    ]),
+                ]),
+            /Duplicate field visual layer key/,
+        );
+    });
+});

--- a/packages/game/src/entities/raisedBed/raisedBedFieldVisualLayout.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedFieldVisualLayout.ts
@@ -1,0 +1,573 @@
+import type { RaisedBedOrientation } from '../../utils/raisedBedOrientation';
+import { getRaisedBedFieldSurfacePosition } from './raisedBedSoilWetPatches';
+
+export const raisedBedFieldVisualChunkSize = 8;
+
+const fieldCoverSize = 0.25;
+const fieldCoverHalfSize = fieldCoverSize / 2;
+const wholeCoverPadding = 0.02;
+const wholeCoverHemThickness = 0.018;
+const weedFieldScatterRadius = 0.082;
+const weedBladeCount = {
+    heavy: 10,
+    light: 5,
+} as const;
+
+export type RaisedBedFieldVisualVector3 = readonly [
+    x: number,
+    y: number,
+    z: number,
+];
+
+export type RaisedBedFieldVisualTransform = {
+    position: [number, number, number];
+    rotation: [number, number, number];
+    scale: [number, number, number];
+};
+
+export type RaisedBedFieldVisualBlock = {
+    blockIndex: number;
+    position: RaisedBedFieldVisualVector3;
+};
+
+export type RaisedBedFieldWeedLevel = keyof typeof weedBladeCount;
+
+export type RaisedBedCoverPrimitive = {
+    geometry: 'box' | 'plane';
+    key: string;
+    layer: 'cover-bar' | 'cover-hem' | 'cover-surface';
+    renderOrder: 4 | 5 | 6;
+    transform: RaisedBedFieldVisualTransform;
+};
+
+export type RaisedBedSupportDescriptor = {
+    key: string;
+    layer: 'support';
+    renderOrder: 8;
+    transform: RaisedBedFieldVisualTransform;
+};
+
+export type RaisedBedSeedDescriptor = {
+    key: string;
+    layer: 'seed-pending' | 'seed-sown';
+    transform: RaisedBedFieldVisualTransform;
+};
+
+export function getRaisedBedFieldLocalPosition({
+    blockIndex,
+    orientation,
+    positionIndex,
+    y,
+}: {
+    blockIndex: number;
+    orientation: RaisedBedOrientation;
+    positionIndex: number;
+    y: number;
+}) {
+    return getRaisedBedFieldSurfacePosition({
+        blockIndex,
+        orientation,
+        positionIndex,
+        y,
+    });
+}
+
+export function getRaisedBedFieldWorldPosition({
+    blockIndex,
+    blockPosition,
+    orientation,
+    positionIndex,
+    y,
+}: {
+    blockIndex: number;
+    blockPosition: RaisedBedFieldVisualVector3;
+    orientation: RaisedBedOrientation;
+    positionIndex: number;
+    y: number;
+}) {
+    const localPosition = getRaisedBedFieldLocalPosition({
+        blockIndex,
+        orientation,
+        positionIndex,
+        y,
+    });
+
+    return [
+        blockPosition[0] + localPosition[0],
+        blockPosition[1] + localPosition[1],
+        blockPosition[2] + localPosition[2],
+    ] satisfies [number, number, number];
+}
+
+/**
+ * Assign all visual layers for a raised bed to one spatial owner. Using the
+ * X/Z bounds centroid, rather than each field position, keeps a connected bed
+ * in one chunk even when it straddles a chunk boundary.
+ */
+export function getRaisedBedFieldVisualChunkKey({
+    chunkSize = raisedBedFieldVisualChunkSize,
+    positions,
+}: {
+    chunkSize?: number;
+    positions: readonly RaisedBedFieldVisualVector3[];
+}) {
+    if (!Number.isFinite(chunkSize) || chunkSize <= 0) {
+        throw new RangeError(
+            'Raised-bed field visual chunk size must be positive.',
+        );
+    }
+    if (positions.length === 0) {
+        return null;
+    }
+
+    let minX = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let minZ = Number.POSITIVE_INFINITY;
+    let maxZ = Number.NEGATIVE_INFINITY;
+
+    for (const position of positions) {
+        if (!Number.isFinite(position[0]) || !Number.isFinite(position[2])) {
+            throw new RangeError(
+                'Raised-bed field visual positions must contain finite X/Z values.',
+            );
+        }
+        minX = Math.min(minX, position[0]);
+        maxX = Math.max(maxX, position[0]);
+        minZ = Math.min(minZ, position[2]);
+        maxZ = Math.max(maxZ, position[2]);
+    }
+
+    const centerX = (minX + maxX) / 2;
+    const centerZ = (minZ + maxZ) / 2;
+
+    return `${Math.floor(centerX / chunkSize)}:${Math.floor(
+        centerZ / chunkSize,
+    )}`;
+}
+
+function seededWeedRandom(
+    positionIndex: number,
+    bladeIndex: number,
+    channel: number,
+) {
+    const value = Math.sin(
+        (positionIndex + 1) * 12.9898 +
+            (bladeIndex + 1) * 78.233 +
+            channel * 37.719,
+    );
+    const scaledValue = value * 43758.5453;
+
+    return scaledValue - Math.floor(scaledValue);
+}
+
+function weedRange(
+    positionIndex: number,
+    bladeIndex: number,
+    channel: number,
+    min: number,
+    max: number,
+) {
+    return (
+        min + seededWeedRandom(positionIndex, bladeIndex, channel) * (max - min)
+    );
+}
+
+/**
+ * Produces matrices for a unit, four-sided cone. Scaling the unit cone by the
+ * returned radius/height/radius exactly matches the legacy per-blade geometry.
+ */
+export function createRaisedBedFieldWeedTransforms({
+    blockIndex,
+    blockPosition,
+    level,
+    orientation,
+    positionIndex,
+}: {
+    blockIndex: number;
+    blockPosition: RaisedBedFieldVisualVector3;
+    level: RaisedBedFieldWeedLevel;
+    orientation: RaisedBedOrientation;
+    positionIndex: number;
+}) {
+    const fieldPosition = getRaisedBedFieldWorldPosition({
+        blockIndex,
+        blockPosition,
+        orientation,
+        positionIndex,
+        y: -0.72,
+    });
+    const seedPositionIndex = blockIndex * 9 + positionIndex;
+
+    return Array.from(
+        { length: weedBladeCount[level] },
+        (_, bladeIndex): RaisedBedFieldVisualTransform => {
+            const height =
+                level === 'heavy'
+                    ? weedRange(seedPositionIndex, bladeIndex, 0, 0.052, 0.085)
+                    : weedRange(seedPositionIndex, bladeIndex, 0, 0.038, 0.062);
+            const radius =
+                level === 'heavy'
+                    ? weedRange(seedPositionIndex, bladeIndex, 1, 0.005, 0.008)
+                    : weedRange(seedPositionIndex, bladeIndex, 1, 0.004, 0.006);
+            const x = weedRange(
+                seedPositionIndex,
+                bladeIndex,
+                2,
+                -weedFieldScatterRadius,
+                weedFieldScatterRadius,
+            );
+            const z = weedRange(
+                seedPositionIndex,
+                bladeIndex,
+                3,
+                -weedFieldScatterRadius,
+                weedFieldScatterRadius,
+            );
+
+            return {
+                position: [
+                    fieldPosition[0] + x,
+                    fieldPosition[1] + height / 2,
+                    fieldPosition[2] + z,
+                ],
+                rotation: [
+                    weedRange(seedPositionIndex, bladeIndex, 4, -0.18, 0.18),
+                    weedRange(seedPositionIndex, bladeIndex, 6, 0, Math.PI * 2),
+                    weedRange(seedPositionIndex, bladeIndex, 5, -0.18, 0.18),
+                ],
+                scale: [radius, height, radius],
+            };
+        },
+    );
+}
+
+function coverPrimitive({
+    geometry,
+    key,
+    layer,
+    position,
+    renderOrder,
+    rotation = [0, 0, 0],
+    scale,
+}: {
+    geometry: RaisedBedCoverPrimitive['geometry'];
+    key: string;
+    layer: RaisedBedCoverPrimitive['layer'];
+    position: [number, number, number];
+    renderOrder: RaisedBedCoverPrimitive['renderOrder'];
+    rotation?: [number, number, number];
+    scale: [number, number, number];
+}): RaisedBedCoverPrimitive {
+    return {
+        geometry,
+        key,
+        layer,
+        renderOrder,
+        transform: {
+            position,
+            rotation,
+            scale,
+        },
+    };
+}
+
+export function createRaisedBedFieldCoverPrimitives({
+    blockIndex,
+    blockPosition,
+    keyPrefix,
+    orientation,
+    positionIndex,
+}: {
+    blockIndex: number;
+    blockPosition: RaisedBedFieldVisualVector3;
+    keyPrefix: string;
+    orientation: RaisedBedOrientation;
+    positionIndex: number;
+}) {
+    const center = getRaisedBedFieldWorldPosition({
+        blockIndex,
+        blockPosition,
+        orientation,
+        positionIndex,
+        y: -0.704,
+    });
+
+    return [
+        coverPrimitive({
+            geometry: 'plane',
+            key: `${keyPrefix}:surface`,
+            layer: 'cover-surface',
+            position: [center[0], center[1] + 0.004, center[2]],
+            renderOrder: 4,
+            rotation: [-Math.PI / 2, 0, 0],
+            scale: [fieldCoverSize, fieldCoverSize, 1],
+        }),
+        coverPrimitive({
+            geometry: 'box',
+            key: `${keyPrefix}:hem:north`,
+            layer: 'cover-hem',
+            position: [center[0], center[1] + 0.012, center[2] - 0.118],
+            renderOrder: 5,
+            scale: [0.255, 0.008, 0.012],
+        }),
+        coverPrimitive({
+            geometry: 'box',
+            key: `${keyPrefix}:hem:south`,
+            layer: 'cover-hem',
+            position: [center[0], center[1] + 0.012, center[2] + 0.118],
+            renderOrder: 5,
+            scale: [0.255, 0.008, 0.012],
+        }),
+        coverPrimitive({
+            geometry: 'box',
+            key: `${keyPrefix}:hem:east`,
+            layer: 'cover-hem',
+            position: [center[0] - 0.118, center[1] + 0.012, center[2]],
+            renderOrder: 5,
+            scale: [0.012, 0.008, 0.255],
+        }),
+        coverPrimitive({
+            geometry: 'box',
+            key: `${keyPrefix}:hem:west`,
+            layer: 'cover-hem',
+            position: [center[0] + 0.118, center[1] + 0.012, center[2]],
+            renderOrder: 5,
+            scale: [0.012, 0.008, 0.255],
+        }),
+        coverPrimitive({
+            geometry: 'box',
+            key: `${keyPrefix}:bar:x`,
+            layer: 'cover-bar',
+            position: [center[0], center[1] + 0.014, center[2]],
+            renderOrder: 6,
+            scale: [0.22, 0.006, 0.008],
+        }),
+        coverPrimitive({
+            geometry: 'box',
+            key: `${keyPrefix}:bar:z`,
+            layer: 'cover-bar',
+            position: [center[0], center[1] + 0.015, center[2]],
+            renderOrder: 6,
+            scale: [0.008, 0.006, 0.22],
+        }),
+    ] satisfies RaisedBedCoverPrimitive[];
+}
+
+export function createRaisedBedWholeCoverPrimitives({
+    blocks,
+    keyPrefix,
+    orientation,
+}: {
+    blocks: readonly RaisedBedFieldVisualBlock[];
+    keyPrefix: string;
+    orientation: RaisedBedOrientation;
+}) {
+    if (blocks.length === 0) {
+        return [] as RaisedBedCoverPrimitive[];
+    }
+
+    let minX = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let minZ = Number.POSITIVE_INFINITY;
+    let maxZ = Number.NEGATIVE_INFINITY;
+
+    for (const block of blocks) {
+        for (let positionIndex = 0; positionIndex < 9; positionIndex += 1) {
+            const center = getRaisedBedFieldWorldPosition({
+                blockIndex: block.blockIndex,
+                blockPosition: block.position,
+                orientation,
+                positionIndex,
+                y: 0,
+            });
+            minX = Math.min(minX, center[0] - fieldCoverHalfSize);
+            maxX = Math.max(maxX, center[0] + fieldCoverHalfSize);
+            minZ = Math.min(minZ, center[2] - fieldCoverHalfSize);
+            maxZ = Math.max(maxZ, center[2] + fieldCoverHalfSize);
+        }
+    }
+
+    minX -= wholeCoverPadding;
+    maxX += wholeCoverPadding;
+    minZ -= wholeCoverPadding;
+    maxZ += wholeCoverPadding;
+
+    const owner = blocks.find((block) => block.blockIndex === 0) ?? blocks[0];
+    const width = maxX - minX;
+    const depth = maxZ - minZ;
+    const halfWidth = width / 2;
+    const halfDepth = depth / 2;
+    const center: [number, number, number] = [
+        (minX + maxX) / 2,
+        owner.position[1] - 0.704,
+        (minZ + maxZ) / 2,
+    ];
+
+    return [
+        coverPrimitive({
+            geometry: 'plane',
+            key: `${keyPrefix}:surface`,
+            layer: 'cover-surface',
+            position: [center[0], center[1] + 0.004, center[2]],
+            renderOrder: 4,
+            rotation: [-Math.PI / 2, 0, 0],
+            scale: [width, depth, 1],
+        }),
+        coverPrimitive({
+            geometry: 'box',
+            key: `${keyPrefix}:hem:north`,
+            layer: 'cover-hem',
+            position: [center[0], center[1] + 0.012, center[2] - halfDepth],
+            renderOrder: 5,
+            scale: [
+                width + wholeCoverHemThickness,
+                0.008,
+                wholeCoverHemThickness,
+            ],
+        }),
+        coverPrimitive({
+            geometry: 'box',
+            key: `${keyPrefix}:hem:south`,
+            layer: 'cover-hem',
+            position: [center[0], center[1] + 0.012, center[2] + halfDepth],
+            renderOrder: 5,
+            scale: [
+                width + wholeCoverHemThickness,
+                0.008,
+                wholeCoverHemThickness,
+            ],
+        }),
+        coverPrimitive({
+            geometry: 'box',
+            key: `${keyPrefix}:hem:east`,
+            layer: 'cover-hem',
+            position: [center[0] - halfWidth, center[1] + 0.012, center[2]],
+            renderOrder: 5,
+            scale: [
+                wholeCoverHemThickness,
+                0.008,
+                depth + wholeCoverHemThickness,
+            ],
+        }),
+        coverPrimitive({
+            geometry: 'box',
+            key: `${keyPrefix}:hem:west`,
+            layer: 'cover-hem',
+            position: [center[0] + halfWidth, center[1] + 0.012, center[2]],
+            renderOrder: 5,
+            scale: [
+                wholeCoverHemThickness,
+                0.008,
+                depth + wholeCoverHemThickness,
+            ],
+        }),
+    ] satisfies RaisedBedCoverPrimitive[];
+}
+
+export function createRaisedBedFieldSupportDescriptor({
+    blockIndex,
+    blockPosition,
+    key,
+    orientation,
+    positionIndex,
+}: {
+    blockIndex: number;
+    blockPosition: RaisedBedFieldVisualVector3;
+    key: string;
+    orientation: RaisedBedOrientation;
+    positionIndex: number;
+}): RaisedBedSupportDescriptor {
+    const fieldPosition = getRaisedBedFieldWorldPosition({
+        blockIndex,
+        blockPosition,
+        orientation,
+        positionIndex,
+        y: -0.724,
+    });
+
+    return {
+        key,
+        layer: 'support',
+        renderOrder: 8,
+        transform: {
+            position: [
+                fieldPosition[0],
+                fieldPosition[1] + 0.39,
+                fieldPosition[2],
+            ],
+            rotation: [0, 0, 0],
+            scale: [1, 1, 1],
+        },
+    };
+}
+
+const seedLayoutByPlantsPerRow = [
+    { multiplier: 0, offset: 0, scale: 2 },
+    { multiplier: 0, offset: 0, scale: 2 },
+    { multiplier: 0.13, offset: 0.03, scale: 1.8 },
+    { multiplier: 0.09, offset: 0.025, scale: 1.6 },
+    { multiplier: 0.07, offset: 0.0225, scale: 1.4 },
+] as const;
+
+export function createRaisedBedFieldSeedDescriptors({
+    blockIndex,
+    blockPosition,
+    keyPrefix,
+    orientation,
+    plantsPerRow,
+    positionIndex,
+    sown,
+    totalPlants = Math.max(Math.floor(plantsPerRow), 1) ** 2,
+}: {
+    blockIndex: number;
+    blockPosition: RaisedBedFieldVisualVector3;
+    keyPrefix: string;
+    orientation: RaisedBedOrientation;
+    plantsPerRow: number;
+    positionIndex: number;
+    sown: boolean;
+    totalPlants?: number;
+}) {
+    const safePlantsPerRow = Math.max(Math.floor(plantsPerRow), 1);
+    const seedLayout =
+        seedLayoutByPlantsPerRow[safePlantsPerRow] ??
+        seedLayoutByPlantsPerRow[seedLayoutByPlantsPerRow.length - 1];
+    const fieldPosition = getRaisedBedFieldWorldPosition({
+        blockIndex,
+        blockPosition,
+        orientation,
+        positionIndex,
+        y: -0.75,
+    });
+    const safeTotalPlants = Math.max(Math.floor(totalPlants), 0);
+
+    return Array.from(
+        { length: safeTotalPlants },
+        (_, index): RaisedBedSeedDescriptor => {
+            const slotX =
+                Math.floor(index / safePlantsPerRow) * seedLayout.multiplier -
+                safePlantsPerRow * seedLayout.offset;
+            const slotZ =
+                (index % safePlantsPerRow) * seedLayout.multiplier -
+                safePlantsPerRow * seedLayout.offset;
+
+            return {
+                key: `${keyPrefix}:${index}`,
+                layer: sown ? 'seed-sown' : 'seed-pending',
+                transform: {
+                    position: [
+                        fieldPosition[0] + slotX,
+                        fieldPosition[1],
+                        fieldPosition[2] + slotZ,
+                    ],
+                    rotation: [0, 0, 0],
+                    scale: [
+                        seedLayout.scale,
+                        seedLayout.scale,
+                        seedLayout.scale,
+                    ],
+                },
+            };
+        },
+    );
+}

--- a/packages/game/src/entities/raisedBed/raisedBedFieldVisualLayout.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedFieldVisualLayout.unit.ts
@@ -1,0 +1,290 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    createRaisedBedFieldCoverPrimitives,
+    createRaisedBedFieldSeedDescriptors,
+    createRaisedBedFieldSupportDescriptor,
+    createRaisedBedFieldWeedTransforms,
+    createRaisedBedWholeCoverPrimitives,
+    getRaisedBedFieldLocalPosition,
+    getRaisedBedFieldVisualChunkKey,
+    getRaisedBedFieldWorldPosition,
+} from './raisedBedFieldVisualLayout';
+
+function approximatelyEqual(
+    actual: number,
+    expected: number,
+    tolerance = 0.000_000_1,
+) {
+    assert.ok(
+        Math.abs(actual - expected) <= tolerance,
+        `Expected ${actual.toString()} to be within ${tolerance.toString()} of ${expected.toString()}`,
+    );
+}
+
+describe('raised-bed field visual layout', () => {
+    it('matches the existing vertical and horizontal block-local field grid', () => {
+        assert.deepEqual(
+            getRaisedBedFieldLocalPosition({
+                blockIndex: 0,
+                orientation: 'vertical',
+                positionIndex: 0,
+                y: -0.72,
+            }),
+            [-0.31, -0.72, 0.27],
+        );
+        assert.deepEqual(
+            getRaisedBedFieldLocalPosition({
+                blockIndex: 1,
+                orientation: 'vertical',
+                positionIndex: 0,
+                y: -0.72,
+            }),
+            [-0.26, -0.72, 0.27],
+        );
+        assert.deepEqual(
+            getRaisedBedFieldLocalPosition({
+                blockIndex: 0,
+                orientation: 'horizontal',
+                positionIndex: 0,
+                y: -0.72,
+            }),
+            [0.27, -0.72, 0.29999999999999993],
+        );
+        assert.deepEqual(
+            getRaisedBedFieldLocalPosition({
+                blockIndex: 1,
+                orientation: 'horizontal',
+                positionIndex: 0,
+                y: -0.72,
+            }),
+            [0.27, -0.72, 0.24999999999999994],
+        );
+    });
+
+    it('adds a resolved block origin without rotating the field grid twice', () => {
+        const position = getRaisedBedFieldWorldPosition({
+            blockIndex: 1,
+            blockPosition: [4, 2, -3],
+            orientation: 'horizontal',
+            positionIndex: 0,
+            y: -0.72,
+        });
+
+        assert.deepEqual(position, [4.27, 1.28, -2.75]);
+    });
+
+    it('assigns an entire bed from its bounds centroid to one 8m chunk', () => {
+        assert.equal(
+            getRaisedBedFieldVisualChunkKey({
+                positions: [
+                    [-3.4, 1, -1.2],
+                    [-2.6, 1, 0.7],
+                ],
+            }),
+            '-1:-1',
+        );
+        assert.equal(
+            getRaisedBedFieldVisualChunkKey({
+                positions: [
+                    [7.8, 1, 0],
+                    [8.2, 1, 0],
+                ],
+            }),
+            '1:0',
+        );
+        assert.equal(getRaisedBedFieldVisualChunkKey({ positions: [] }), null);
+        assert.throws(
+            () =>
+                getRaisedBedFieldVisualChunkKey({
+                    chunkSize: 0,
+                    positions: [[0, 0, 0]],
+                }),
+            /chunk size must be positive/,
+        );
+    });
+});
+
+describe('raised-bed weed transforms', () => {
+    it('creates ten deterministic heavy blades and five light blades', () => {
+        const input = {
+            blockIndex: 1,
+            blockPosition: [4, 2, -3] as const,
+            orientation: 'horizontal' as const,
+            positionIndex: 6,
+        };
+        const heavy = createRaisedBedFieldWeedTransforms({
+            ...input,
+            level: 'heavy',
+        });
+        const repeated = createRaisedBedFieldWeedTransforms({
+            ...input,
+            level: 'heavy',
+        });
+        const light = createRaisedBedFieldWeedTransforms({
+            ...input,
+            level: 'light',
+        });
+
+        assert.equal(heavy.length, 10);
+        assert.equal(light.length, 5);
+        assert.deepEqual(repeated, heavy);
+
+        const fieldCenter = getRaisedBedFieldWorldPosition({
+            ...input,
+            y: -0.72,
+        });
+        for (const transform of heavy) {
+            assert.ok(
+                Math.abs(transform.position[0] - fieldCenter[0]) <= 0.082,
+            );
+            assert.ok(
+                Math.abs(transform.position[2] - fieldCenter[2]) <= 0.082,
+            );
+            assert.ok(
+                transform.scale[0] >= 0.005 && transform.scale[0] <= 0.008,
+            );
+            assert.ok(
+                transform.scale[1] >= 0.052 && transform.scale[1] <= 0.085,
+            );
+            assert.equal(transform.scale[0], transform.scale[2]);
+            approximatelyEqual(
+                transform.position[1],
+                fieldCenter[1] + transform.scale[1] / 2,
+            );
+        }
+    });
+
+    it('keeps the legacy field seed dependent on block index', () => {
+        const firstBlock = createRaisedBedFieldWeedTransforms({
+            blockIndex: 0,
+            blockPosition: [0, 1, 0],
+            level: 'heavy',
+            orientation: 'vertical',
+            positionIndex: 4,
+        });
+        const secondBlock = createRaisedBedFieldWeedTransforms({
+            blockIndex: 1,
+            blockPosition: [0, 1, 1],
+            level: 'heavy',
+            orientation: 'vertical',
+            positionIndex: 4,
+        });
+
+        assert.notDeepEqual(secondBlock[0]?.rotation, firstBlock[0]?.rotation);
+        assert.notDeepEqual(secondBlock[0]?.scale, firstBlock[0]?.scale);
+    });
+});
+
+describe('raised-bed cover, support, and seed descriptors', () => {
+    it('compiles each field cover into one surface, four hems, and two bars', () => {
+        const primitives = createRaisedBedFieldCoverPrimitives({
+            blockIndex: 0,
+            blockPosition: [0, 1, 0],
+            keyPrefix: 'bed:1:field:0',
+            orientation: 'vertical',
+            positionIndex: 0,
+        });
+
+        assert.equal(primitives.length, 7);
+        assert.equal(
+            primitives.filter(
+                (primitive) => primitive.layer === 'cover-surface',
+            ).length,
+            1,
+        );
+        assert.equal(
+            primitives.filter((primitive) => primitive.layer === 'cover-hem')
+                .length,
+            4,
+        );
+        assert.equal(
+            primitives.filter((primitive) => primitive.layer === 'cover-bar')
+                .length,
+            2,
+        );
+        assert.deepEqual(
+            primitives.map((primitive) => primitive.renderOrder),
+            [4, 5, 5, 5, 5, 6, 6],
+        );
+    });
+
+    it('compiles a horizontal and vertical 1x2 whole cover into five primitives', () => {
+        const blocks = [
+            { blockIndex: 0, position: [0, 1, 0] as const },
+            { blockIndex: 1, position: [0, 1, 1] as const },
+        ];
+        const horizontal = createRaisedBedWholeCoverPrimitives({
+            blocks,
+            keyPrefix: 'horizontal',
+            orientation: 'horizontal',
+        });
+        const vertical = createRaisedBedWholeCoverPrimitives({
+            blocks,
+            keyPrefix: 'vertical',
+            orientation: 'vertical',
+        });
+
+        for (const primitives of [horizontal, vertical]) {
+            assert.equal(primitives.length, 5);
+            assert.equal(
+                primitives.filter(
+                    (primitive) => primitive.layer === 'cover-surface',
+                ).length,
+                1,
+            );
+            assert.equal(
+                primitives.filter(
+                    (primitive) => primitive.layer === 'cover-hem',
+                ).length,
+                4,
+            );
+            assert.equal(
+                primitives.filter(
+                    (primitive) => primitive.layer === 'cover-bar',
+                ).length,
+                0,
+            );
+        }
+
+        const horizontalSurface = horizontal[0];
+        const verticalSurface = vertical[0];
+        assert.equal(horizontalSurface?.geometry, 'plane');
+        assert.equal(verticalSurface?.geometry, 'plane');
+        assert.notDeepEqual(
+            horizontalSurface?.transform.scale,
+            verticalSurface?.transform.scale,
+        );
+    });
+
+    it('preserves the support center and seed density layout', () => {
+        const support = createRaisedBedFieldSupportDescriptor({
+            blockIndex: 0,
+            blockPosition: [0, 1, 0],
+            key: 'support:0',
+            orientation: 'vertical',
+            positionIndex: 0,
+        });
+        const seeds = createRaisedBedFieldSeedDescriptors({
+            blockIndex: 0,
+            blockPosition: [0, 1, 0],
+            keyPrefix: 'seeds:0',
+            orientation: 'vertical',
+            plantsPerRow: 3,
+            positionIndex: 0,
+            sown: true,
+        });
+
+        assert.deepEqual(support.transform.position, [-0.31, 0.666, 0.27]);
+        assert.equal(seeds.length, 9);
+        assert.ok(seeds.every((seed) => seed.layer === 'seed-sown'));
+        assert.ok(
+            seeds.every(
+                (seed) =>
+                    seed.transform.scale[0] === 1.6 &&
+                    seed.transform.scale[1] === 1.6 &&
+                    seed.transform.scale[2] === 1.6,
+            ),
+        );
+    });
+});

--- a/packages/game/src/entities/raisedBed/raisedBedMulchRenderGroups.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedMulchRenderGroups.ts
@@ -1,0 +1,53 @@
+import type { MulchBlockName } from './mulchPatchGeometry';
+
+export type RaisedBedMulchRenderPatch<TInstance> = {
+    blockName: MulchBlockName;
+    instance: TInstance;
+    mask: number;
+    scale: [number, number, number];
+};
+
+export type RaisedBedMulchRenderGroup<TInstance> = {
+    blockName: MulchBlockName;
+    instances: TInstance[];
+    key: string;
+    mask: number;
+    scale: [number, number, number];
+};
+
+function raisedBedMulchRenderGroupKey(
+    patch: RaisedBedMulchRenderPatch<unknown>,
+) {
+    return [
+        patch.blockName,
+        patch.mask,
+        patch.scale[0],
+        patch.scale[1],
+        patch.scale[2],
+    ].join(':');
+}
+
+export function getRaisedBedMulchRenderGroups<TInstance>(
+    patches: readonly RaisedBedMulchRenderPatch<TInstance>[],
+) {
+    const groups = new Map<string, RaisedBedMulchRenderGroup<TInstance>>();
+
+    for (const patch of patches) {
+        const key = raisedBedMulchRenderGroupKey(patch);
+        const group = groups.get(key);
+        if (group) {
+            group.instances.push(patch.instance);
+            continue;
+        }
+
+        groups.set(key, {
+            blockName: patch.blockName,
+            instances: [patch.instance],
+            key,
+            mask: patch.mask,
+            scale: patch.scale,
+        });
+    }
+
+    return [...groups.values()];
+}

--- a/packages/game/src/entities/raisedBed/raisedBedMulchRenderGroups.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedMulchRenderGroups.unit.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    getRaisedBedMulchRenderGroups,
+    type RaisedBedMulchRenderPatch,
+} from './raisedBedMulchRenderGroups';
+
+type TestInstance = {
+    id: string;
+};
+
+function patch(
+    id: string,
+    overrides: Partial<RaisedBedMulchRenderPatch<TestInstance>> = {},
+): RaisedBedMulchRenderPatch<TestInstance> {
+    return {
+        blockName: 'MulchHey',
+        instance: { id },
+        mask: 3,
+        scale: [0.285, 1, 0.27],
+        ...overrides,
+    };
+}
+
+test('groups mulch patches only when material, mask, and scale are compatible', () => {
+    const groups = getRaisedBedMulchRenderGroups([
+        patch('first'),
+        patch('second'),
+        patch('different-material', { blockName: 'MulchWood' }),
+        patch('different-mask', { mask: 7 }),
+        patch('different-scale', { scale: [0.27, 1, 0.285] }),
+    ]);
+
+    assert.equal(groups.length, 4);
+    assert.deepEqual(
+        groups.map((group) => ({
+            blockName: group.blockName,
+            instanceIds: group.instances.map((instance) => instance.id),
+            mask: group.mask,
+            scale: group.scale,
+        })),
+        [
+            {
+                blockName: 'MulchHey',
+                instanceIds: ['first', 'second'],
+                mask: 3,
+                scale: [0.285, 1, 0.27],
+            },
+            {
+                blockName: 'MulchWood',
+                instanceIds: ['different-material'],
+                mask: 3,
+                scale: [0.285, 1, 0.27],
+            },
+            {
+                blockName: 'MulchHey',
+                instanceIds: ['different-mask'],
+                mask: 7,
+                scale: [0.285, 1, 0.27],
+            },
+            {
+                blockName: 'MulchHey',
+                instanceIds: ['different-scale'],
+                mask: 3,
+                scale: [0.27, 1, 0.285],
+            },
+        ],
+    );
+});
+
+test('keeps first-seen group order and instance order deterministic', () => {
+    const groups = getRaisedBedMulchRenderGroups([
+        patch('wood-first', { blockName: 'MulchWood', mask: 12 }),
+        patch('hay-first'),
+        patch('wood-second', { blockName: 'MulchWood', mask: 12 }),
+        patch('hay-second'),
+    ]);
+
+    assert.deepEqual(
+        groups.map((group) => ({
+            key: group.key,
+            ids: group.instances.map((instance) => instance.id),
+        })),
+        [
+            {
+                key: 'MulchWood:12:0.285:1:0.27',
+                ids: ['wood-first', 'wood-second'],
+            },
+            {
+                key: 'MulchHey:3:0.285:1:0.27',
+                ids: ['hay-first', 'hay-second'],
+            },
+        ],
+    );
+});

--- a/packages/game/src/hooks/mockGardenProfileFixtures.ts
+++ b/packages/game/src/hooks/mockGardenProfileFixtures.ts
@@ -33,6 +33,9 @@ export type HighTargetMockPlantRenderAttributes = {
     seedingDistance: number;
 };
 
+export const highTargetOperationVisualsQueryParam = 'operationVisuals';
+export const highTargetOperationVisualsQueryValue = '1';
+
 const demoPlantSortIds = {
     tomato: 337,
     carrot: 230,
@@ -223,6 +226,44 @@ export const highTargetMockGardenRaisedBedFixtures: readonly HighTargetMockGarde
     ];
 
 /**
+ * Opt-in operation-visual workload layered over the regular high-target
+ * garden. The default profile remains unchanged.
+ *
+ * The three beds deliberately own different dense visual families so they can
+ * coexist in one deterministic capture:
+ * - bed 1: 18 heavy-weed fields;
+ * - bed 2: 18 supported fields, including one pending and one newly sown seed
+ *   field;
+ * - bed 3: 18 field-scoped protective covers;
+ * - all beds: 54 field-scoped mulch patches.
+ *
+ * The highlight target is exposed to the profile page for a follow-up
+ * controller command. Highlights remain transient and outside the static
+ * operation batches.
+ */
+export const highTargetOperationVisualFixture = {
+    coverRaisedBedId: 3,
+    heavyWeedRaisedBedId: 1,
+    highlight: {
+        fieldId: 201,
+        gardenId: 99996,
+        positionIndex: 0,
+        raisedBedId: 2,
+    },
+    pendingSeed: {
+        fieldId: 201,
+        positionIndex: 0,
+        raisedBedId: 2,
+    },
+    sownSeed: {
+        fieldId: 202,
+        positionIndex: 1,
+        raisedBedId: 2,
+    },
+    supportRaisedBedId: 2,
+} as const;
+
+/**
  * Freeze the plant-density and lifecycle inputs used by the high-quality
  * benchmark. These intentionally span dense row crops and sparse large plants
  * so the 54 fields exercise a representative foliage workload without relying
@@ -333,26 +374,108 @@ export function getHighTargetMockGardenCardinality() {
     };
 }
 
-export function getHighTargetMockGardenPlantInstanceCount() {
-    const instancesPerRaisedBed = mockRaisedBedFieldFixtures.reduce(
-        (total, field) => {
-            const attributes =
-                highTargetMockPlantRenderAttributesBySortId[field.plantSortId];
-            if (!attributes) {
-                throw new Error(
-                    `Missing high-target plant attributes for sort ${field.plantSortId.toString()}.`,
-                );
-            }
-
-            return (
-                total +
-                calculatePlantsPerField(attributes.seedingDistance).totalPlants
+function getHighTargetMockGardenPlantInstancesPerRaisedBed() {
+    return mockRaisedBedFieldFixtures.reduce((total, field) => {
+        const attributes =
+            highTargetMockPlantRenderAttributesBySortId[field.plantSortId];
+        if (!attributes) {
+            throw new Error(
+                `Missing high-target plant attributes for sort ${field.plantSortId.toString()}.`,
             );
-        },
-        0,
-    );
+        }
 
-    return instancesPerRaisedBed * highTargetMockGardenRaisedBedFixtures.length;
+        return (
+            total +
+            calculatePlantsPerField(attributes.seedingDistance).totalPlants
+        );
+    }, 0);
+}
+
+export function getHighTargetMockGardenPlantInstanceCount() {
+    return (
+        getHighTargetMockGardenPlantInstancesPerRaisedBed() *
+        highTargetMockGardenRaisedBedFixtures.length
+    );
+}
+
+function getHighTargetFieldPlantInstanceCount(positionIndex: number) {
+    const field = mockRaisedBedFieldFixtures.find(
+        (candidate) => candidate.positionIndex === positionIndex,
+    );
+    if (!field) {
+        throw new Error(
+            `Missing high-target field fixture at position ${positionIndex.toString()}.`,
+        );
+    }
+
+    const attributes =
+        highTargetMockPlantRenderAttributesBySortId[field.plantSortId];
+    if (!attributes) {
+        throw new Error(
+            `Missing high-target plant attributes for sort ${field.plantSortId.toString()}.`,
+        );
+    }
+
+    return calculatePlantsPerField(attributes.seedingDistance).totalPlants;
+}
+
+export function getHighTargetOperationVisualFixtureCounts() {
+    const fieldCountPerRaisedBed = mockRaisedBedFieldFixtures.length;
+    const seedInstanceCount =
+        getHighTargetFieldPlantInstanceCount(
+            highTargetOperationVisualFixture.pendingSeed.positionIndex,
+        ) +
+        getHighTargetFieldPlantInstanceCount(
+            highTargetOperationVisualFixture.sownSeed.positionIndex,
+        );
+    const heavyWeedBladeCount = fieldCountPerRaisedBed * 10;
+    const supportCount = fieldCountPerRaisedBed;
+    const fieldCoverCount = fieldCountPerRaisedBed;
+    const fieldCoverMeshCount = fieldCoverCount * 7;
+    const fieldMulchCount =
+        fieldCountPerRaisedBed * highTargetMockGardenRaisedBedFixtures.length;
+    const transientHighlightMeshCount = 2;
+    const legacyClearMeshCount =
+        heavyWeedBladeCount +
+        supportCount +
+        fieldCoverMeshCount +
+        fieldMulchCount +
+        seedInstanceCount +
+        transientHighlightMeshCount;
+
+    return {
+        assignedFieldCount: fieldMulchCount,
+        fieldCoverCount,
+        fieldCoverMeshCount,
+        fieldMulchCount,
+        generatedPlantInstanceCount:
+            getHighTargetMockGardenPlantInstanceCount() -
+            getHighTargetMockGardenPlantInstancesPerRaisedBed() -
+            seedInstanceCount,
+        heavyWeedBladeCount,
+        heavyWeedFieldCount: fieldCountPerRaisedBed,
+        legacyClearMeshCount,
+        legacySnowMeshCount: legacyClearMeshCount + fieldMulchCount,
+        pendingSeedFieldCount: 1,
+        seedInstanceCount,
+        sownSeedFieldCount: 1,
+        supportCount,
+        transientHighlightMeshCount,
+    };
+}
+
+export function resolveHighTargetOperationVisualsEnabled(
+    search: string | undefined,
+) {
+    if (!search) {
+        return false;
+    }
+
+    const query = search.startsWith('?') ? search.slice(1) : search;
+    return (
+        new URLSearchParams(query).get(highTargetOperationVisualsQueryParam) ===
+        highTargetOperationVisualsQueryValue
+    );
 }
 
 export function resolveMockGardenProfileReferenceDate(

--- a/packages/game/src/hooks/mockGardenProfileFixtures.unit.ts
+++ b/packages/game/src/hooks/mockGardenProfileFixtures.unit.ts
@@ -2,6 +2,10 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { Vector3 } from 'three';
 import {
+    highTargetOperationVisualOperationDefinitions,
+    highTargetOperationVisualOperationIds,
+} from '../operationVisualRewardDebugProfile';
+import {
     getConnectedRaisedBedBlockIds,
     getRaisedBedBlockIds,
     isRaisedBedShapeValid,
@@ -10,12 +14,15 @@ import {
     createHighTargetMockGardenStackPositions,
     getHighTargetMockGardenCardinality,
     getHighTargetMockGardenPlantInstanceCount,
+    getHighTargetOperationVisualFixtureCounts,
     highTargetMockGardenDetailFixtures,
     highTargetMockGardenRaisedBedFixtures,
     highTargetMockGardenReferenceDate,
     highTargetMockPlantRenderAttributesBySortId,
+    highTargetOperationVisualFixture,
     mockRaisedBedFieldFixtures,
     plantHeavyMockGardenReferenceDate,
+    resolveHighTargetOperationVisualsEnabled,
     resolveMockGardenProfileReferenceDate,
 } from './mockGardenProfileFixtures';
 
@@ -121,6 +128,83 @@ test('high-target garden cardinality matches the high-quality workload', () => {
             ({ plantSortId }) =>
                 highTargetMockPlantRenderAttributesBySortId[plantSortId] !==
                 undefined,
+        ),
+        true,
+    );
+});
+
+test('high-target operation visuals retain the target and expose exact legacy work', () => {
+    assert.deepEqual(highTargetOperationVisualFixture, {
+        coverRaisedBedId: 3,
+        heavyWeedRaisedBedId: 1,
+        highlight: {
+            fieldId: 201,
+            gardenId: 99996,
+            positionIndex: 0,
+            raisedBedId: 2,
+        },
+        pendingSeed: {
+            fieldId: 201,
+            positionIndex: 0,
+            raisedBedId: 2,
+        },
+        sownSeed: {
+            fieldId: 202,
+            positionIndex: 1,
+            raisedBedId: 2,
+        },
+        supportRaisedBedId: 2,
+    });
+    assert.deepEqual(getHighTargetOperationVisualFixtureCounts(), {
+        assignedFieldCount: 54,
+        fieldCoverCount: 18,
+        fieldCoverMeshCount: 126,
+        fieldMulchCount: 54,
+        generatedPlantInstanceCount: 286,
+        heavyWeedBladeCount: 180,
+        heavyWeedFieldCount: 18,
+        legacyClearMeshCount: 452,
+        legacySnowMeshCount: 506,
+        pendingSeedFieldCount: 1,
+        seedInstanceCount: 72,
+        sownSeedFieldCount: 1,
+        supportCount: 18,
+        transientHighlightMeshCount: 2,
+    });
+    assert.deepEqual(getHighTargetMockGardenCardinality(), {
+        stackCount: 270,
+        baseBlockCount: 270,
+        detailBlockCount: 24,
+        raisedBedCount: 3,
+        raisedBedBlockCount: 6,
+        occupiedFieldCount: 54,
+        totalBlockCount: 300,
+    });
+
+    const fieldMulchDefinition =
+        highTargetOperationVisualOperationDefinitions.find(
+            ({ id }) => id === highTargetOperationVisualOperationIds.fieldMulch,
+        );
+    assert.equal(fieldMulchDefinition?.attributes.application, 'plant');
+    assert.equal(fieldMulchDefinition?.attributes.visualReward, 'mulch');
+});
+
+test('high-target operation visuals require the exact query opt-in', () => {
+    assert.equal(resolveHighTargetOperationVisualsEnabled(undefined), false);
+    assert.equal(resolveHighTargetOperationVisualsEnabled(''), false);
+    assert.equal(
+        resolveHighTargetOperationVisualsEnabled('?operationVisuals=0'),
+        false,
+    );
+    assert.equal(
+        resolveHighTargetOperationVisualsEnabled(
+            '?profile=high-target&operationVisuals=unexpected',
+        ),
+        false,
+    );
+    assert.equal(
+        resolveHighTargetOperationVisualsEnabled(
+            '?profile=high-target&operationVisuals=1',
         ),
         true,
     );

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -17,6 +17,7 @@ import {
     localSandboxGardenId,
 } from '../localSandboxGarden';
 import {
+    highTargetOperationVisualOperationIds,
     isOperationVisualRewardDebugProfile,
     type OperationVisualRewardDebugBedState,
     type OperationVisualRewardDebugScenario,
@@ -39,7 +40,9 @@ import {
     createHighTargetMockGardenStackPositions,
     highTargetMockGardenDetailFixtures,
     highTargetMockGardenRaisedBedFixtures,
+    highTargetOperationVisualFixture,
     mockRaisedBedFieldFixtures,
+    resolveHighTargetOperationVisualsEnabled,
     resolveMockGardenProfileReferenceDate,
 } from './mockGardenProfileFixtures';
 import { useGardenAccountGroups } from './useGardenAccountGroups';
@@ -53,6 +56,7 @@ export const currentGardenKeys = (
     gardenId?: number | null,
     mockGardenProfile?: MockGardenProfile,
     localSandboxStorageKey?: string | null,
+    mockGardenVariant?: string | null,
 ) => [
     ...useGardensKeys,
     'current',
@@ -62,6 +66,7 @@ export const currentGardenKeys = (
         ? ['local-sandbox', localSandboxStorageKey]
         : []),
     ...(mockGardenProfile != null ? [mockGardenProfile] : []),
+    ...(mockGardenVariant ? [mockGardenVariant] : []),
 ];
 
 type useCurrentGardenResponse = Omit<
@@ -778,8 +783,107 @@ function denseMockGarden(
     };
 }
 
+function applyHighTargetOperationVisualFixture(
+    raisedBeds: useCurrentGardenResponse['raisedBeds'],
+) {
+    const heavyWeedRaisedBed = raisedBeds.find(
+        (raisedBed) =>
+            raisedBed.id ===
+            highTargetOperationVisualFixture.heavyWeedRaisedBedId,
+    );
+    const supportRaisedBed = raisedBeds.find(
+        (raisedBed) =>
+            raisedBed.id ===
+            highTargetOperationVisualFixture.supportRaisedBedId,
+    );
+    const coverRaisedBed = raisedBeds.find(
+        (raisedBed) =>
+            raisedBed.id === highTargetOperationVisualFixture.coverRaisedBedId,
+    );
+    if (!heavyWeedRaisedBed || !supportRaisedBed || !coverRaisedBed) {
+        throw new Error(
+            'High-target operation visual fixture raised beds are missing.',
+        );
+    }
+
+    heavyWeedRaisedBed.weedState = heavyDebugWeedState(
+        operationVisualRewardDebugOlderTimestamp,
+        9601,
+    );
+    supportRaisedBed.appliedOperations = [
+        completedDebugAppliedOperation({
+            completedAt: operationVisualRewardDebugTimestamp,
+            entityId: operationVisualRewardDebugOperationIds.supports,
+            id: 9602,
+            raisedBedId: supportRaisedBed.id,
+        }),
+    ];
+
+    for (const raisedBed of raisedBeds) {
+        for (const field of raisedBed.fields) {
+            if (typeof field.id !== 'number') {
+                continue;
+            }
+
+            raisedBed.appliedOperations.push(
+                completedDebugAppliedOperation({
+                    completedAt: operationVisualRewardDebugTimestamp,
+                    entityId: highTargetOperationVisualOperationIds.fieldMulch,
+                    id: 9700 + raisedBed.id * 100 + field.positionIndex,
+                    raisedBedFieldId: field.id,
+                    raisedBedId: raisedBed.id,
+                }),
+            );
+        }
+    }
+
+    for (const field of coverRaisedBed.fields) {
+        if (typeof field.id !== 'number') {
+            continue;
+        }
+
+        coverRaisedBed.appliedOperations.push(
+            completedDebugAppliedOperation({
+                completedAt: operationVisualRewardDebugTimestamp,
+                entityId: operationVisualRewardDebugOperationIds.agrotextile,
+                id: 10_300 + field.positionIndex,
+                raisedBedFieldId: field.id,
+                raisedBedId: coverRaisedBed.id,
+            }),
+        );
+    }
+
+    const pendingSeedField = supportRaisedBed.fields.find(
+        (field) =>
+            field.id === highTargetOperationVisualFixture.pendingSeed.fieldId &&
+            field.positionIndex ===
+                highTargetOperationVisualFixture.pendingSeed.positionIndex,
+    );
+    const sownSeedField = supportRaisedBed.fields.find(
+        (field) =>
+            field.id === highTargetOperationVisualFixture.sownSeed.fieldId &&
+            field.positionIndex ===
+                highTargetOperationVisualFixture.sownSeed.positionIndex,
+    );
+    if (!pendingSeedField || !sownSeedField) {
+        throw new Error(
+            'High-target operation visual seed fields are missing.',
+        );
+    }
+
+    pendingSeedField.plantStatus = 'planned';
+    pendingSeedField.plantSowDate = undefined;
+    pendingSeedField.plantGrowthDate = undefined;
+    pendingSeedField.plantReadyDate = undefined;
+
+    sownSeedField.plantStatus = 'new';
+    sownSeedField.plantGrowthDate = undefined;
+    sownSeedField.plantReadyDate = undefined;
+}
+
 function highTargetMockGarden(
     winterMode: WinterMode,
+    operationVisuals = false,
 ): useCurrentGardenResponse {
     const now = resolveMockGardenProfileReferenceDate('high-target');
     const { stackByPosition, stacks } = createHighTargetMockStacks(winterMode);
@@ -800,6 +904,10 @@ function highTargetMockGarden(
                 `High-target raised bed ${fixture.id.toString()} is outside the fixture grid.`,
             );
         }
+    }
+
+    if (operationVisuals) {
+        applyHighTargetOperationVisualFixture(raisedBeds);
     }
 
     return {
@@ -868,6 +976,7 @@ function operationRewardDebugMockGarden(
 function mockGarden(
     winterMode: WinterMode,
     profile: MockGardenProfile,
+    highTargetOperationVisuals = false,
 ): useCurrentGardenResponse {
     if (isOperationVisualRewardDebugProfile(profile)) {
         return operationRewardDebugMockGarden(winterMode);
@@ -878,7 +987,7 @@ function mockGarden(
     }
 
     if (profile === 'high-target') {
-        return highTargetMockGarden(winterMode);
+        return highTargetMockGarden(winterMode, highTargetOperationVisuals);
     }
 
     const treeName =
@@ -1134,6 +1243,15 @@ function mockGarden(
     };
 }
 
+function isHighTargetOperationVisualsProfile(profile: MockGardenProfile) {
+    return (
+        profile === 'high-target' &&
+        resolveHighTargetOperationVisualsEnabled(
+            typeof window === 'undefined' ? undefined : window.location.search,
+        )
+    );
+}
+
 export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | null> {
     const isMock = useGameState((state) => state.isMock);
     const localSandboxStorageKey = useGameState(
@@ -1145,6 +1263,8 @@ export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | nu
     const mockGardenProfile = useGameState((state) => state.mockGardenProfile);
     const winterMode = useGameState((state) => state.winterMode);
     const isLocalSandbox = localSandboxStorageKey !== null;
+    const highTargetOperationVisuals =
+        isMock && isHighTargetOperationVisualsProfile(mockGardenProfile);
     const { data: gardens } = useGardens(isMock || isLocalSandbox);
     const { data: accountGroups } = useGardenAccountGroups(
         isMock || isLocalSandbox,
@@ -1170,6 +1290,7 @@ export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | nu
             currentGardenId,
             isMock ? mockGardenProfile : undefined,
             localSandboxStorageKey,
+            highTargetOperationVisuals ? 'operation-visuals' : undefined,
         ),
         queryFn: async () => {
             if (localSandboxStorageKey) {
@@ -1180,7 +1301,11 @@ export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | nu
 
             if (isMock) {
                 console.debug('Using mock garden data');
-                return mockGarden(winterMode, mockGardenProfile);
+                return mockGarden(
+                    winterMode,
+                    mockGardenProfile,
+                    highTargetOperationVisuals,
+                );
             }
 
             if (currentGardenId == null) {
@@ -1285,6 +1410,8 @@ export function useCurrentGardenCache() {
     const mockGardenProfile = useGameState((state) => state.mockGardenProfile);
     const winterMode = useGameState((state) => state.winterMode);
     const isLocalSandbox = localSandboxStorageKey !== null;
+    const highTargetOperationVisuals =
+        isMock && isHighTargetOperationVisualsProfile(mockGardenProfile);
     const { data: gardens } = useGardens(isMock || isLocalSandbox);
     const { data: accountGroups } = useGardenAccountGroups(
         isMock || isLocalSandbox,
@@ -1309,9 +1436,11 @@ export function useCurrentGardenCache() {
                 currentGardenId,
                 isMock ? mockGardenProfile : undefined,
                 localSandboxStorageKey,
+                highTargetOperationVisuals ? 'operation-visuals' : undefined,
             ),
         [
             currentGardenId,
+            highTargetOperationVisuals,
             isMock,
             localSandboxStorageKey,
             mockGardenProfile,

--- a/packages/game/src/hooks/useOperations.ts
+++ b/packages/game/src/hooks/useOperations.ts
@@ -1,10 +1,12 @@
 import { directoriesClient } from '@gredice/client';
 import { useQuery } from '@tanstack/react-query';
 import {
+    highTargetOperationVisualOperationDefinitions,
     isOperationVisualRewardDebugProfile,
     operationVisualRewardDebugOperationDefinitions,
 } from '../operationVisualRewardDebugProfile';
 import { useOptionalGameState } from '../useGameState';
+import { resolveHighTargetOperationVisualsEnabled } from './mockGardenProfileFixtures';
 
 export const operationDefinitionsQueryKey = {
     all: ['operation-definitions'] as const,
@@ -24,6 +26,19 @@ async function getOperations({ includeInternal = false } = {}) {
         .sort((a, b) => a.information.name.localeCompare(b.information.name));
 }
 
+function isHighTargetOperationVisualsProfile(
+    isMock: boolean,
+    mockGardenProfile: string,
+) {
+    return (
+        isMock &&
+        mockGardenProfile === 'high-target' &&
+        resolveHighTargetOperationVisualsEnabled(
+            typeof window === 'undefined' ? undefined : window.location.search,
+        )
+    );
+}
+
 export function useOperations() {
     const isMock = useOptionalGameState((state) => state.isMock, false);
     const mockGardenProfile = useOptionalGameState(
@@ -32,20 +47,31 @@ export function useOperations() {
     );
     const isOperationRewardDebug =
         isMock && isOperationVisualRewardDebugProfile(mockGardenProfile);
-    const isDeterministicEmptyMock =
-        isMock && mockGardenProfile === 'high-target';
+    const isHighTargetMock = isMock && mockGardenProfile === 'high-target';
+    const highTargetOperationVisuals = isHighTargetOperationVisualsProfile(
+        isMock,
+        mockGardenProfile,
+    );
 
     return useQuery({
         queryKey:
-            isOperationRewardDebug || isDeterministicEmptyMock
-                ? ['operations', mockGardenProfile]
+            isOperationRewardDebug || isHighTargetMock
+                ? [
+                      'operations',
+                      mockGardenProfile,
+                      highTargetOperationVisuals
+                          ? 'operation-visuals'
+                          : 'empty',
+                  ]
                 : ['operations'],
         queryFn: async () =>
             isOperationRewardDebug
                 ? operationVisualRewardDebugOperationDefinitions
-                : isDeterministicEmptyMock
-                  ? []
-                  : getOperations(),
+                : highTargetOperationVisuals
+                  ? highTargetOperationVisualOperationDefinitions
+                  : isHighTargetMock
+                    ? []
+                    : getOperations(),
         staleTime: 1000 * 60 * 60, // 1 hour
     });
 }
@@ -58,21 +84,28 @@ export function useOperationDefinitions() {
     );
     const isOperationRewardDebug =
         isMock && isOperationVisualRewardDebugProfile(mockGardenProfile);
-    const isDeterministicEmptyMock =
-        isMock && mockGardenProfile === 'high-target';
+    const isHighTargetMock = isMock && mockGardenProfile === 'high-target';
+    const highTargetOperationVisuals = isHighTargetOperationVisualsProfile(
+        isMock,
+        mockGardenProfile,
+    );
 
     return useQuery({
         queryKey: operationDefinitionsQueryKey.byProfile(
-            isOperationRewardDebug || isDeterministicEmptyMock
-                ? mockGardenProfile
+            isOperationRewardDebug || isHighTargetMock
+                ? `${mockGardenProfile}:${
+                      highTargetOperationVisuals ? 'operation-visuals' : 'empty'
+                  }`
                 : null,
         ),
         queryFn: async () =>
             isOperationRewardDebug
                 ? operationVisualRewardDebugOperationDefinitions
-                : isDeterministicEmptyMock
-                  ? []
-                  : getOperations({ includeInternal: true }),
+                : highTargetOperationVisuals
+                  ? highTargetOperationVisualOperationDefinitions
+                  : isHighTargetMock
+                    ? []
+                    : getOperations({ includeInternal: true }),
         staleTime: 1000 * 60 * 60, // 1 hour
     });
 }

--- a/packages/game/src/operationVisualRewardDebugProfile.ts
+++ b/packages/game/src/operationVisualRewardDebugProfile.ts
@@ -22,6 +22,10 @@ export const operationVisualRewardDebugOperationIds = {
     weeding: 9402,
 } satisfies Record<OperationVisualRewardKind, number>;
 
+export const highTargetOperationVisualOperationIds = {
+    fieldMulch: 9411,
+} as const;
+
 export type OperationVisualRewardDebugBedState = {
     label: 'Before' | 'After';
     raisedBedId: number;
@@ -318,6 +322,17 @@ export const operationVisualRewardDebugOperationDefinitions = [
         name: 'debugHarvestReward',
         label: 'Debug harvest reward',
         application: 'raisedBedFull',
+    }),
+] satisfies OperationVisualRewardDebugOperationData[];
+
+export const highTargetOperationVisualOperationDefinitions = [
+    ...operationVisualRewardDebugOperationDefinitions,
+    debugOperation({
+        id: highTargetOperationVisualOperationIds.fieldMulch,
+        kind: 'mulch',
+        name: 'debugPlantMulchReward',
+        label: 'Debug field mulch reward',
+        application: 'plant',
     }),
 ] satisfies OperationVisualRewardDebugOperationData[];
 

--- a/packages/game/src/scene/GameProfileController.tsx
+++ b/packages/game/src/scene/GameProfileController.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { invalidate } from '@react-three/fiber';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useHoveredBlockStore } from '../controls/useHoveredBlockStore';
 import { meshChunkSize } from '../entities/chunkedMeshGeometry';
 import { instancedBlockNames } from '../entities/EntityInstances';
@@ -14,7 +14,10 @@ import {
     useRemoveRaisedBedCloseupParam,
     useSetRaisedBedCloseupParam,
 } from '../useRaisedBedCloseup';
-import { updateGameProfileMetadata } from './gameProfileMetadata';
+import {
+    type GameProfileMetadata,
+    updateGameProfileMetadata,
+} from './gameProfileMetadata';
 import {
     failGeneratedPlantProfile,
     recordGeneratedPlantProfileCamera,
@@ -30,8 +33,14 @@ export const gameProfileOutlineCommandEventName =
     'gredice:game-profile-outline-command';
 
 type ProfileGarden = {
+    id?: number;
     raisedBeds: Array<{
         blockId?: string | null;
+        fields?: Array<{
+            active: boolean;
+            id?: number | null;
+            positionIndex: number;
+        }>;
         id: number;
         name?: string | null;
     }>;
@@ -73,6 +82,112 @@ export type GameProfileOutlineCommand =
           action: 'show';
           raisedBedId: number;
       };
+
+export type GameProfileOperationVisualHighlightRequest = {
+    fieldId: number;
+    positionIndex: number;
+    raisedBedId: number;
+};
+
+type OperationVisualHighlightProfileMetadataUpdate = Pick<
+    GameProfileMetadata,
+    | 'operationVisualHighlightProfileDispatched'
+    | 'operationVisualHighlightProfileTargetFieldId'
+    | 'operationVisualHighlightProfileTargetGardenId'
+    | 'operationVisualHighlightProfileTargetPositionIndex'
+    | 'operationVisualHighlightProfileTargetRaisedBedId'
+>;
+
+function readProfileInteger(value: string | null | undefined, minimum: number) {
+    if (typeof value !== 'string' || value.length === 0) {
+        return null;
+    }
+    const parsed = Number(value);
+    return Number.isInteger(parsed) && parsed >= minimum ? parsed : null;
+}
+
+export function readGameProfileOperationVisualHighlightRequest({
+    enabled,
+    fieldId,
+    positionIndex,
+    raisedBedId,
+}: {
+    enabled?: string | null;
+    fieldId?: string | null;
+    positionIndex?: string | null;
+    raisedBedId?: string | null;
+}): GameProfileOperationVisualHighlightRequest | null {
+    if (enabled !== '1') {
+        return null;
+    }
+
+    const parsedFieldId = readProfileInteger(fieldId, 1);
+    const parsedPositionIndex = readProfileInteger(positionIndex, 0);
+    const parsedRaisedBedId = readProfileInteger(raisedBedId, 1);
+    if (
+        parsedFieldId === null ||
+        parsedPositionIndex === null ||
+        parsedRaisedBedId === null
+    ) {
+        return null;
+    }
+
+    return {
+        fieldId: parsedFieldId,
+        positionIndex: parsedPositionIndex,
+        raisedBedId: parsedRaisedBedId,
+    };
+}
+
+export function resolveGameProfileOperationVisualHighlight(
+    garden: ProfileGarden | null | undefined,
+    request: GameProfileOperationVisualHighlightRequest | null,
+) {
+    const gardenId = garden?.id;
+    if (
+        !garden ||
+        !request ||
+        typeof gardenId !== 'number' ||
+        !Number.isInteger(gardenId) ||
+        gardenId <= 0
+    ) {
+        return null;
+    }
+
+    const raisedBed = garden.raisedBeds.find(
+        (candidate) => candidate.id === request.raisedBedId,
+    );
+    if (!raisedBed) {
+        return null;
+    }
+
+    const field = raisedBed.fields?.find(
+        (candidate) =>
+            candidate.active &&
+            candidate.id === request.fieldId &&
+            candidate.positionIndex === request.positionIndex,
+    );
+    if (!field || typeof field.id !== 'number') {
+        return null;
+    }
+
+    const raisedBedName = raisedBed?.name?.trim() || null;
+    return {
+        fieldId: field.id,
+        gardenId,
+        label: `Polje ${field.positionIndex + 1}`,
+        message: 'Profil operacijskih vizuala',
+        positionIndex: field.positionIndex,
+        raisedBedId: raisedBed.id,
+        raisedBedName,
+    };
+}
+
+function updateOperationVisualHighlightProfileMetadata(
+    metadata: OperationVisualHighlightProfileMetadataUpdate,
+) {
+    updateGameProfileMetadata(metadata);
+}
 
 export function readGameProfileCloseupCommand(
     value: unknown,
@@ -231,6 +346,7 @@ export function resolveGameProfileRaisedBedTarget(
 
 export function GameProfileController() {
     const { data: garden } = useCurrentGarden();
+    const operationVisualHighlightDispatchKeyRef = useRef<string | null>(null);
     const view = useGameState((current) => current.view);
     const closeupCameraActive = useGameState(
         (current) => current.closeupCameraActive,
@@ -244,6 +360,12 @@ export function GameProfileController() {
     );
     const cancelBlockPlacementDropAnimation = useGameState(
         (current) => current.cancelBlockPlacementDropAnimation,
+    );
+    const setGardenVisitSummaryHighlight = useGameState(
+        (current) => current.setGardenVisitSummaryHighlight,
+    );
+    const clearGardenVisitSummaryHighlight = useGameState(
+        (current) => current.clearGardenVisitSummaryHighlight,
     );
     const { mutate: removeRaisedBedCloseupParam } =
         useRemoveRaisedBedCloseupParam();
@@ -269,6 +391,98 @@ export function GameProfileController() {
             recordGeneratedPlantProfileCamera({ zoom: snapshot.zoom });
         });
     }, [gameCamera]);
+
+    useEffect(() => {
+        const profileElement = document.querySelector(
+            '[data-game-profile-operation-visuals]',
+        );
+        if (!(profileElement instanceof HTMLElement)) {
+            return;
+        }
+
+        const request = readGameProfileOperationVisualHighlightRequest({
+            enabled: profileElement.getAttribute(
+                'data-game-profile-operation-visuals',
+            ),
+            fieldId: profileElement.getAttribute(
+                'data-game-profile-operation-visual-highlight-field-id',
+            ),
+            positionIndex: profileElement.getAttribute(
+                'data-game-profile-operation-visual-highlight-position-index',
+            ),
+            raisedBedId: profileElement.getAttribute(
+                'data-game-profile-operation-visual-highlight-raised-bed-id',
+            ),
+        });
+        if (
+            !request ||
+            !garden ||
+            typeof garden.id !== 'number' ||
+            !Number.isInteger(garden.id) ||
+            garden.id <= 0
+        ) {
+            return;
+        }
+
+        const highlight = resolveGameProfileOperationVisualHighlight(
+            garden,
+            request,
+        );
+        if (!highlight) {
+            if (operationVisualHighlightDispatchKeyRef.current !== null) {
+                clearGardenVisitSummaryHighlight();
+                operationVisualHighlightDispatchKeyRef.current = null;
+            }
+            updateOperationVisualHighlightProfileMetadata({
+                operationVisualHighlightProfileDispatched: false,
+                operationVisualHighlightProfileTargetFieldId: request.fieldId,
+                operationVisualHighlightProfileTargetGardenId: garden.id,
+                operationVisualHighlightProfileTargetPositionIndex:
+                    request.positionIndex,
+                operationVisualHighlightProfileTargetRaisedBedId:
+                    request.raisedBedId,
+            });
+            return;
+        }
+
+        const dispatchKey = [
+            highlight.gardenId,
+            highlight.raisedBedId,
+            highlight.fieldId,
+            highlight.positionIndex,
+        ].join(':');
+        if (operationVisualHighlightDispatchKeyRef.current === dispatchKey) {
+            return;
+        }
+
+        setGardenVisitSummaryHighlight(highlight);
+        operationVisualHighlightDispatchKeyRef.current = dispatchKey;
+        invalidate(undefined, 2);
+        updateOperationVisualHighlightProfileMetadata({
+            operationVisualHighlightProfileDispatched: true,
+            operationVisualHighlightProfileTargetFieldId: highlight.fieldId,
+            operationVisualHighlightProfileTargetGardenId: highlight.gardenId,
+            operationVisualHighlightProfileTargetPositionIndex:
+                highlight.positionIndex,
+            operationVisualHighlightProfileTargetRaisedBedId:
+                highlight.raisedBedId,
+        });
+    }, [
+        clearGardenVisitSummaryHighlight,
+        garden,
+        setGardenVisitSummaryHighlight,
+    ]);
+
+    useEffect(
+        () => () => {
+            if (operationVisualHighlightDispatchKeyRef.current === null) {
+                return;
+            }
+            clearGardenVisitSummaryHighlight();
+            operationVisualHighlightDispatchKeyRef.current = null;
+        },
+        [clearGardenVisitSummaryHighlight],
+    );
 
     useEffect(() => {
         const handleCommand = (event: Event) => {

--- a/packages/game/src/scene/GameProfileController.unit.ts
+++ b/packages/game/src/scene/GameProfileController.unit.ts
@@ -3,8 +3,10 @@ import test from 'node:test';
 import type { Block } from '../types/Block';
 import {
     readGameProfileCloseupCommand,
+    readGameProfileOperationVisualHighlightRequest,
     readGameProfileOutlineCommand,
     readGameProfilePlacementCommand,
+    resolveGameProfileOperationVisualHighlight,
     resolveGameProfilePlacementBlockIds,
     resolveGameProfileRaisedBedTarget,
 } from './GameProfileController';
@@ -87,6 +89,124 @@ test('profile target resolution uses the raised bed primary block', () => {
             },
             3,
         ),
+        null,
+    );
+});
+
+test('profile operation visual highlight request requires the exact opt-in and target', () => {
+    assert.deepEqual(
+        readGameProfileOperationVisualHighlightRequest({
+            enabled: '1',
+            fieldId: '201',
+            positionIndex: '0',
+            raisedBedId: '2',
+        }),
+        {
+            fieldId: 201,
+            positionIndex: 0,
+            raisedBedId: 2,
+        },
+    );
+    assert.equal(
+        readGameProfileOperationVisualHighlightRequest({
+            enabled: '0',
+            fieldId: '201',
+            positionIndex: '0',
+            raisedBedId: '2',
+        }),
+        null,
+    );
+    assert.equal(
+        readGameProfileOperationVisualHighlightRequest({
+            enabled: '1',
+            fieldId: '201-extra',
+            positionIndex: '0',
+            raisedBedId: '2',
+        }),
+        null,
+    );
+    assert.equal(
+        readGameProfileOperationVisualHighlightRequest({
+            enabled: '1',
+            fieldId: '201',
+            positionIndex: '-1',
+            raisedBedId: '2',
+        }),
+        null,
+    );
+});
+
+test('profile operation visual highlight resolves one exact active field after garden readiness', () => {
+    const request = {
+        fieldId: 201,
+        positionIndex: 0,
+        raisedBedId: 2,
+    };
+    const garden = {
+        id: 99996,
+        raisedBeds: [
+            {
+                fields: [
+                    {
+                        active: true,
+                        id: 201,
+                        positionIndex: 0,
+                    },
+                    {
+                        active: true,
+                        id: 202,
+                        positionIndex: 1,
+                    },
+                ],
+                id: 2,
+                name: '  Profile raised bed 2  ',
+            },
+        ],
+        stacks: [],
+    };
+
+    assert.deepEqual(
+        resolveGameProfileOperationVisualHighlight(garden, request),
+        {
+            fieldId: 201,
+            gardenId: 99996,
+            label: 'Polje 1',
+            message: 'Profil operacijskih vizuala',
+            positionIndex: 0,
+            raisedBedId: 2,
+            raisedBedName: 'Profile raised bed 2',
+        },
+    );
+    assert.equal(
+        resolveGameProfileOperationVisualHighlight(garden, {
+            ...request,
+            positionIndex: 1,
+        }),
+        null,
+    );
+    assert.equal(
+        resolveGameProfileOperationVisualHighlight(
+            {
+                ...garden,
+                raisedBeds: [
+                    {
+                        ...garden.raisedBeds[0],
+                        fields: [
+                            {
+                                active: false,
+                                id: 201,
+                                positionIndex: 0,
+                            },
+                        ],
+                    },
+                ],
+            },
+            request,
+        ),
+        null,
+    );
+    assert.equal(
+        resolveGameProfileOperationVisualHighlight(null, request),
         null,
     );
 });

--- a/packages/game/src/scene/gameProfileMetadata.ts
+++ b/packages/game/src/scene/gameProfileMetadata.ts
@@ -259,6 +259,11 @@ export type GameProfileMetadata = {
     instancedInteractionResolvedTargetCount?: number;
     instancedInteractionTargetCount?: number;
     instancedSnowOverlayCount?: number;
+    operationVisualHighlightProfileDispatched?: boolean;
+    operationVisualHighlightProfileTargetFieldId?: number;
+    operationVisualHighlightProfileTargetGardenId?: number;
+    operationVisualHighlightProfileTargetPositionIndex?: number;
+    operationVisualHighlightProfileTargetRaisedBedId?: number;
     placementChunkLogicalTouchedCount?: number;
     placementChunkLogicalUpdateCount?: number;
     placementChunkPhysicalRebuildCount?: number;
@@ -275,6 +280,16 @@ export type GameProfileMetadata = {
     rainParticleCount?: number;
     rainWetOverlayDistinctUniformCount?: number;
     rainWetOverlayMaterialConsumerCount?: number;
+    raisedBedFieldVisualBatchCount?: number;
+    raisedBedFieldVisualChunkCount?: number;
+    raisedBedFieldVisualInstanceCount?: number;
+    raisedBedFieldVisualMatrixUploadCount?: number;
+    raisedBedFieldVisualObjectCount?: number;
+    raisedBedFieldVisualUploadedInstanceCount?: number;
+    raisedBedMulchBatchCount?: number;
+    raisedBedMulchGroupCount?: number;
+    raisedBedMulchInstanceCount?: number;
+    raisedBedMulchObjectCount?: number;
     raisedBedMulchOverlayCount?: number;
     primaryShadowRefreshCount?: number;
     rendererGeometries?: number;


### PR DESCRIPTION
## Summary
- add a deterministic DPR-2 High workload with 300 blocks, three filled 1x2 raised beds, 54 fields, and representative weed, support, cover, seed, mulch, and highlight visuals
- batch 396 field visual instances into seven spatially owned meshes while preserving bed-level transparent sorting and exact transforms
- group and chunk-instance 54 mulch overlays by material, connection mask, and scale while retaining drag and snow behavior
- keep generated plants hidden under protective covers and keep the transient visit highlight separate
- verify one live matrix upload per field batch and expose explicit legacy-baseline profiling

## Measured result
Three 5-second High/DPR-2 runs on Apple M4 Pro through ANGLE Metal, using the same development runtime for both revisions:

| Metric | Legacy | Optimized | Change |
| --- | ---: | ---: | ---: |
| Draw calls / rendered frame | 551 | 202 | -63.3% |
| Operation visual objects | 452 | 33 | -92.7% |
| GPU elapsed p95 | 16.45 ms | 15.56 ms | -5.4% |
| JS heap median | 117.3 MB | 104.0 MB | -11.3% |
| Frame p95 | 27.1 ms | 27.1 ms | unchanged |

The optimized target passed 3/3 acceptance and performance runs. Screenshot comparison found only 0.056% of pixels above an 8/255 channel delta, including normal animation-phase differences.

## Validation
- game, Garden, and WWW TypeScript checks
- game unit suite: 703/703
- profiler and flag suite: 48/48
- scoped Biome checks and git diff check
- three-run Metal profile with screenshots and all gates passing

Closes #4321