### PR TITLE
perf(game): integrate weather surface materials

### DIFF
--- a/apps/garden/app/debug/profile/game/page.tsx
+++ b/apps/garden/app/debug/profile/game/page.tsx
@@ -9,10 +9,12 @@ import {
     highTargetOperationVisualHighlightTarget,
     resolveGameProfileFlags,
     resolveGameProfileOperationVisuals,
+    resolveGameProfileWeatherSurface,
 } from './profileFlags';
 import {
     gameProfileClearWeather,
     gameProfileCloudyWeather,
+    gameProfileSnowSparseWeather,
 } from './profileWeather';
 
 type GameProfileSearchParams = Promise<
@@ -25,6 +27,7 @@ type GameProfileMode =
     | 'details'
     | 'rain'
     | 'snow'
+    | 'snow-onset'
     | 'night'
     | 'storm'
     | 'autumn'
@@ -58,6 +61,7 @@ function resolveMode(value: string | undefined): GameProfileMode {
         value === 'details' ||
         value === 'rain' ||
         value === 'snow' ||
+        value === 'snow-onset' ||
         value === 'night' ||
         value === 'storm' ||
         value === 'autumn' ||
@@ -128,6 +132,15 @@ function resolveWeather(
             windDirection: 45,
             snowAccumulation: 24,
         };
+    }
+
+    if (mode === 'snow-onset') {
+        // High quality starts rendering snow at 0.02 coverage (0.6 cm).
+        // Keep this fixture just above that edge so sparse coverage and
+        // skirt continuity remain easy to compare without snow particles.
+        // A particle-free breeze keeps bees out of the deterministic
+        // high-target actor count.
+        return gameProfileSnowSparseWeather;
     }
 
     if (mode === 'night') {
@@ -268,6 +281,10 @@ export default async function GameProfilePage({
     const debugGameFlags = resolveGameProfileFlags(
         firstValue(params.blockGeometryMerging),
         firstValue(params.adaptiveHigh),
+        firstValue(params.weatherSurface),
+    );
+    const weatherSurfaceMode = resolveGameProfileWeatherSurface(
+        firstValue(params.weatherSurface),
     );
     const adaptiveHigh = debugGameFlags.enableAdaptiveHighQualityFlag;
     const blockGeometryMerging = debugGameFlags.enableBlockGeometryMergingFlag;
@@ -297,6 +314,7 @@ export default async function GameProfilePage({
             data-game-profile-outline={outlineProfile ? '1' : '0'}
             data-game-profile-placement={placementProfile ? '1' : '0'}
             data-game-profile-operation-visuals={operationVisuals ? '1' : '0'}
+            data-game-profile-weather-surface={weatherSurfaceMode}
             data-game-profile-operation-visual-highlight-raised-bed-id={
                 operationVisuals
                     ? highTargetOperationVisualHighlightTarget.raisedBedId

--- a/apps/garden/app/debug/profile/game/profileFlags.ts
+++ b/apps/garden/app/debug/profile/game/profileFlags.ts
@@ -1,5 +1,7 @@
 import type { GameSceneProps } from '@gredice/game';
 
+export type GameProfileWeatherSurfaceMode = 'integrated' | 'legacy';
+
 export const highTargetOperationVisualHighlightTarget = {
     fieldId: 201,
     positionIndex: 0,
@@ -20,16 +22,27 @@ export function resolveGameProfileOperationVisuals(value: string | undefined) {
     return value === '1';
 }
 
+export function resolveGameProfileWeatherSurface(
+    value: string | undefined,
+): GameProfileWeatherSurfaceMode {
+    return value === 'legacy' ? 'legacy' : 'integrated';
+}
+
 export function resolveGameProfileFlags(
     blockGeometryMerging: string | undefined,
     adaptiveHigh: string | undefined,
+    weatherSurface: string | undefined,
 ) {
+    const weatherSurfaceMode = resolveGameProfileWeatherSurface(weatherSurface);
+
     return {
         enableAdaptiveHighQualityFlag:
             resolveGameProfileAdaptiveHigh(adaptiveHigh),
         enableBlockGeometryMergingFlag:
             resolveGameProfileBlockGeometryMerging(blockGeometryMerging),
         enableDebugHudFlag: true,
+        enableIntegratedWeatherSurfacesFlag:
+            weatherSurfaceMode === 'integrated',
         enableRainWetOverlayFlag: true,
     } satisfies NonNullable<GameSceneProps['flags']>;
 }

--- a/apps/garden/app/debug/profile/game/profileFlags.unit.ts
+++ b/apps/garden/app/debug/profile/game/profileFlags.unit.ts
@@ -6,6 +6,7 @@ import {
     resolveGameProfileBlockGeometryMerging,
     resolveGameProfileFlags,
     resolveGameProfileOperationVisuals,
+    resolveGameProfileWeatherSurface,
 } from './profileFlags.ts';
 
 describe('resolveGameProfileAdaptiveHigh', () => {
@@ -50,18 +51,48 @@ describe('resolveGameProfileOperationVisuals', () => {
 });
 
 describe('resolveGameProfileFlags', () => {
-    it('preserves debug and rain flags while controlling profiler opt-ins', () => {
-        assert.deepEqual(resolveGameProfileFlags(undefined, undefined), {
-            enableAdaptiveHighQualityFlag: false,
-            enableBlockGeometryMergingFlag: false,
-            enableDebugHudFlag: true,
-            enableRainWetOverlayFlag: true,
-        });
-        assert.deepEqual(resolveGameProfileFlags('0', '1'), {
+    it('defaults production-profile weather surfaces to the integrated path', () => {
+        assert.deepEqual(
+            resolveGameProfileFlags(undefined, undefined, undefined),
+            {
+                enableAdaptiveHighQualityFlag: false,
+                enableBlockGeometryMergingFlag: false,
+                enableDebugHudFlag: true,
+                enableIntegratedWeatherSurfacesFlag: true,
+                enableRainWetOverlayFlag: true,
+            },
+        );
+        assert.deepEqual(resolveGameProfileFlags('0', '1', 'integrated'), {
             enableAdaptiveHighQualityFlag: true,
             enableBlockGeometryMergingFlag: false,
             enableDebugHudFlag: true,
+            enableIntegratedWeatherSurfacesFlag: true,
             enableRainWetOverlayFlag: true,
         });
+    });
+
+    it('allows an explicit legacy weather-surface comparison', () => {
+        assert.deepEqual(resolveGameProfileFlags('1', '0', 'legacy'), {
+            enableAdaptiveHighQualityFlag: false,
+            enableBlockGeometryMergingFlag: true,
+            enableDebugHudFlag: true,
+            enableIntegratedWeatherSurfacesFlag: false,
+            enableRainWetOverlayFlag: true,
+        });
+    });
+});
+
+describe('resolveGameProfileWeatherSurface', () => {
+    it('accepts only the exact legacy override', () => {
+        assert.equal(resolveGameProfileWeatherSurface('legacy'), 'legacy');
+        assert.equal(
+            resolveGameProfileWeatherSurface('integrated'),
+            'integrated',
+        );
+        assert.equal(resolveGameProfileWeatherSurface(undefined), 'integrated');
+        assert.equal(
+            resolveGameProfileWeatherSurface('unexpected'),
+            'integrated',
+        );
     });
 });

--- a/apps/garden/app/debug/profile/game/profileWeather.ts
+++ b/apps/garden/app/debug/profile/game/profileWeather.ts
@@ -3,7 +3,9 @@ import type { GameSceneProps } from '@gredice/game';
 export type GameProfileWeatherTransitionRequest =
     | 'clear-to-cloudy'
     | 'cloudy-to-clear'
-    | 'rain-to-clear';
+    | 'rain-to-clear'
+    | 'snow-integrated-to-sparse'
+    | 'snow-sparse-to-integrated';
 
 export const gameProfileWeatherTransitionEventName =
     'gredice:game-profile-weather-transition';
@@ -26,6 +28,17 @@ export const gameProfileCloudyWeather = {
     windDirection: 80,
 } satisfies NonNullable<GameSceneProps['weather']>;
 
+export const gameProfileSnowSparseWeather = {
+    ...gameProfileClearWeather,
+    snowAccumulation: 0.75,
+    windSpeed: 1.3,
+} satisfies NonNullable<GameSceneProps['weather']>;
+
+export const gameProfileSnowIntegratedWeather = {
+    ...gameProfileSnowSparseWeather,
+    snowAccumulation: 24,
+} satisfies NonNullable<GameSceneProps['weather']>;
+
 export function readGameProfileWeatherTransitionRequest(value: unknown) {
     if (typeof value !== 'object' || value === null) {
         return undefined;
@@ -34,7 +47,9 @@ export function readGameProfileWeatherTransitionRequest(value: unknown) {
     const request = Reflect.get(value, 'request');
     return request === 'clear-to-cloudy' ||
         request === 'cloudy-to-clear' ||
-        request === 'rain-to-clear'
+        request === 'rain-to-clear' ||
+        request === 'snow-integrated-to-sparse' ||
+        request === 'snow-sparse-to-integrated'
         ? request
         : undefined;
 }
@@ -42,7 +57,14 @@ export function readGameProfileWeatherTransitionRequest(value: unknown) {
 export function resolveGameProfileWeatherTransition(
     request: GameProfileWeatherTransitionRequest,
 ) {
-    return request === 'clear-to-cloudy'
-        ? gameProfileCloudyWeather
-        : gameProfileClearWeather;
+    if (request === 'clear-to-cloudy') {
+        return gameProfileCloudyWeather;
+    }
+    if (request === 'snow-sparse-to-integrated') {
+        return gameProfileSnowIntegratedWeather;
+    }
+    if (request === 'snow-integrated-to-sparse') {
+        return gameProfileSnowSparseWeather;
+    }
+    return gameProfileClearWeather;
 }

--- a/apps/garden/app/debug/profile/game/profileWeather.unit.ts
+++ b/apps/garden/app/debug/profile/game/profileWeather.unit.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    gameProfileSnowIntegratedWeather,
+    gameProfileSnowSparseWeather,
+    readGameProfileWeatherTransitionRequest,
+    resolveGameProfileWeatherTransition,
+} from './profileWeather.ts';
+
+test('snow surface transition requests remain particle-free and deterministic', () => {
+    assert.equal(
+        readGameProfileWeatherTransitionRequest({
+            request: 'snow-sparse-to-integrated',
+        }),
+        'snow-sparse-to-integrated',
+    );
+    assert.equal(
+        readGameProfileWeatherTransitionRequest({
+            request: 'snow-integrated-to-sparse',
+        }),
+        'snow-integrated-to-sparse',
+    );
+    assert.equal(
+        resolveGameProfileWeatherTransition('snow-sparse-to-integrated'),
+        gameProfileSnowIntegratedWeather,
+    );
+    assert.equal(
+        resolveGameProfileWeatherTransition('snow-integrated-to-sparse'),
+        gameProfileSnowSparseWeather,
+    );
+    assert.equal(gameProfileSnowSparseWeather.snowy, 0);
+    assert.equal(gameProfileSnowIntegratedWeather.snowy, 0);
+    assert.equal(gameProfileSnowSparseWeather.snowAccumulation, 0.75);
+    assert.equal(gameProfileSnowIntegratedWeather.snowAccumulation, 24);
+});
+
+test('weather transition parser rejects unknown requests', () => {
+    assert.equal(
+        readGameProfileWeatherTransitionRequest({
+            request: 'snow-unknown',
+        }),
+        undefined,
+    );
+});

--- a/apps/garden/package.json
+++ b/apps/garden/package.json
@@ -23,7 +23,7 @@
         "test": "pnpm run test:sw && pnpm run test:profile && pnpm run test:run",
         "test:prepare": "turbo build --filter=garden",
         "test:run": "playwright test",
-        "test:profile": "node --experimental-strip-types --test scripts/profile-game-scene.unit.mjs app/debug/profile/game/profileFlags.unit.ts",
+        "test:profile": "node --experimental-strip-types --test scripts/profile-game-scene.unit.mjs app/debug/profile/game/profileFlags.unit.ts app/debug/profile/game/profileWeather.unit.ts",
         "test:sw": "node --test tests/push-notifications-sw.node.spec.mjs",
         "test-ui": "pnpm run test:prepare && playwright test --ui",
         "generate-playwright:tutorial-task-list-icon": "playwright test --config playwright-generate.config.ts generate/tutorial-task-list-icon.specgen.tsx",

--- a/apps/garden/scripts/profile-game-scene.mjs
+++ b/apps/garden/scripts/profile-game-scene.mjs
@@ -29,6 +29,63 @@ const highTargetOperationVisualLegacyObjectCount = 452;
 const highTargetOperationVisualRenderedObjectLimit = 64;
 const highTargetGeneratedPlantDetailInstanceBudget = 179;
 const highTargetExpectedGeneratedPlantClusterTriangleCount = 3_354;
+const highTargetWeatherSurfaceExpectations = {
+    rain: {
+        avoidedOverlaySubmissionCount: 16,
+        avoidedOverlayTriangleCount: 2_556,
+        fallbackOverlaySubmissionCount: {
+            integrated: 29,
+            legacy: 45,
+        },
+        fallbackOverlayTriangleCount: {
+            integrated: 13_562,
+            legacy: 16_118,
+        },
+        integratedInstanceCount: 213,
+        integratedMaterialCount: 2,
+    },
+    snow: {
+        avoidedOverlaySubmissionCount: 8,
+        avoidedOverlayTriangleCount: 11_880,
+        fallbackOverlaySubmissionCount: {
+            integrated: 48,
+            legacy: 56,
+        },
+        fallbackOverlayTriangleCount: {
+            integrated: 72_608,
+            legacy: 84_488,
+        },
+        integratedInstanceCount: 270,
+        integratedMaterialCount: 1,
+    },
+};
+const highTargetWeatherSurfaceMaximumGpuMedianRatio = 0.98;
+const highTargetWeatherSurfaceMaximumGpuRunRatio = 1.05;
+const highTargetWeatherSurfaceMaximumProgramIncrease = 1;
+const highTargetWeatherSurfacePairedRunCount = 5;
+const highTargetWeatherSurfaceOnsetExpectation = {
+    avoidedOverlaySubmissionCount: 0,
+    avoidedOverlayTriangleCount: 0,
+    fallbackOverlaySubmissionCount: 51,
+    fallbackOverlayTriangleCount: 31_900,
+    integratedInstanceCount: 0,
+    integratedMaterialCount: 0,
+    pluginVariantCount: 0,
+    snowParticleCount: 0,
+};
+const highTargetWeatherSurfaceThresholdTransitionExpectation = {
+    exit: highTargetWeatherSurfaceOnsetExpectation,
+    peak: {
+        avoidedOverlaySubmissionCount: 16,
+        avoidedOverlayTriangleCount: 9_372,
+        fallbackOverlaySubmissionCount: 56,
+        fallbackOverlayTriangleCount: 74_500,
+        integratedInstanceCount: 213,
+        integratedMaterialCount: 2,
+        pluginVariantCount: 1,
+    },
+    trackedCount: 2,
+};
 const chromiumGraphicsBackends = ['angle-metal', 'auto', 'default'];
 
 const coreScenarios = [
@@ -259,6 +316,84 @@ const highTargetFoliageBudgetScenarios = [
         motion: 'foliage-detail-zoom',
         motionWarmupMs: 7_000,
         repeat: 3,
+    },
+];
+
+const highTargetWeatherMaterialScenarios = [
+    {
+        name: 'game-high-target-rain-legacy-weather-surfaces-desktop',
+        path: '/debug/profile/game?mode=rain&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&weatherSurface=legacy',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        comparisonPair: 'rain-weather-surfaces',
+        comparisonRole: 'legacy',
+        repeat: 5,
+    },
+    {
+        name: 'game-high-target-rain-integrated-weather-surfaces-desktop',
+        path: '/debug/profile/game?mode=rain&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&weatherSurface=integrated',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        comparisonPair: 'rain-weather-surfaces',
+        comparisonRole: 'integrated',
+        repeat: 5,
+    },
+    {
+        name: 'game-high-target-snow-legacy-weather-surfaces-desktop',
+        path: '/debug/profile/game?mode=snow&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&weatherSurface=legacy',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        comparisonPair: 'snow-weather-surfaces',
+        comparisonRole: 'legacy',
+        repeat: 5,
+    },
+    {
+        name: 'game-high-target-snow-integrated-weather-surfaces-desktop',
+        path: '/debug/profile/game?mode=snow&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&weatherSurface=integrated',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        comparisonPair: 'snow-weather-surfaces',
+        comparisonRole: 'integrated',
+        repeat: 5,
+    },
+];
+
+const highTargetWeatherOnsetScenarios = [
+    {
+        name: 'game-high-target-snow-onset-legacy-weather-surfaces-desktop',
+        path: '/debug/profile/game?mode=snow-onset&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&weatherSurface=legacy',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        repeat: 1,
+    },
+    {
+        name: 'game-high-target-snow-onset-integrated-weather-surfaces-desktop',
+        path: '/debug/profile/game?mode=snow-onset&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&weatherSurface=integrated',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        repeat: 1,
+    },
+    {
+        name: 'game-high-target-snow-threshold-transition-integrated-weather-surfaces-desktop',
+        path: '/debug/profile/game?mode=snow-onset&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&weatherSurface=integrated',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        repeat: 1,
+        weatherSurfaceTransition: 'snow-integration-cycle',
     },
 ];
 
@@ -642,6 +777,8 @@ const scenarioSets = {
     'high-target': highTargetScenarios,
     'high-target-foliage-budget': highTargetFoliageBudgetScenarios,
     'high-target-operation-visuals': highTargetOperationVisualScenarios,
+    'high-target-weather-materials': highTargetWeatherMaterialScenarios,
+    'high-target-weather-onset': highTargetWeatherOnsetScenarios,
     outline: outlineScenarios,
     placement: placementScenarios,
     'plant-closeup': plantCloseupScenarios,
@@ -937,7 +1074,7 @@ function printHelp(options) {
             '  --warmup-ms <ms>       Warmup wait after canvas appears. Default: 5000',
             '  --soak-ms <ms>         Run the scene before sampling. Default: 0',
             '  --sample-ms <ms>       requestAnimationFrame sample window. Default: 5000',
-            `  --scenario-set <set>    core, dense, dense-mobile, high-target, high-target-foliage-budget, high-target-operation-visuals, adaptive-high, outline, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or comma-separated names. Current: ${options.scenarioSet}`,
+            `  --scenario-set <set>    core, dense, dense-mobile, high-target, high-target-foliage-budget, high-target-operation-visuals, high-target-weather-materials, high-target-weather-onset, adaptive-high, outline, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or comma-separated names. Current: ${options.scenarioSet}`,
             '  --scenario <name>       Profile exact scenario name(s). Repeat or use commas.',
             '  --screenshots           Save a PNG screenshot for each scenario.',
             '  --fail-on-budget       Exit non-zero when a budget check fails.',
@@ -968,6 +1105,8 @@ function allScenarios() {
         ...highTargetScenarios,
         ...highTargetFoliageBudgetScenarios,
         ...highTargetOperationVisualScenarios,
+        ...highTargetWeatherMaterialScenarios,
+        ...highTargetWeatherOnsetScenarios,
         ...outlineScenarios,
         ...placementScenarios,
         ...plantCloseupScenarios,
@@ -1001,7 +1140,7 @@ function resolveScenarios(scenarioSet, scenarioNames = []) {
 
         if (!candidates.length) {
             throw new Error(
-                `Unknown scenario set or scenario: ${token}. Use core, dense, dense-mobile, high-target, high-target-operation-visuals, adaptive-high, outline, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or one of: ${knownScenarios.map((scenario) => scenario.name).join(', ')}.`,
+                `Unknown scenario set or scenario: ${token}. Use core, dense, dense-mobile, high-target, high-target-foliage-budget, high-target-operation-visuals, high-target-weather-materials, high-target-weather-onset, adaptive-high, outline, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or one of: ${knownScenarios.map((scenario) => scenario.name).join(', ')}.`,
             );
         }
 
@@ -1014,6 +1153,82 @@ function resolveScenarios(scenarioSet, scenarioNames = []) {
     }
 
     return scenarios;
+}
+
+function buildScenarioRunQueue(scenarios, { closeupRepeat = null } = {}) {
+    const queue = [];
+    const scheduled = new Set();
+    const repeatFor = (scenario) =>
+        scenario.plantCloseup
+            ? (closeupRepeat ?? scenario.plantCloseup.repeat)
+            : (scenario.repeat ?? 1);
+    const enqueue = (scenario, runIndex, repeat) => {
+        queue.push({
+            baseScenario: scenario,
+            repeat,
+            runIndex,
+            runScenario:
+                repeat === 1
+                    ? scenario
+                    : {
+                          ...scenario,
+                          name: `${scenario.name}-run-${runIndex}`,
+                      },
+        });
+    };
+
+    for (const scenario of scenarios) {
+        if (scheduled.has(scenario.name)) {
+            continue;
+        }
+
+        const paired =
+            typeof scenario.comparisonPair === 'string'
+                ? scenarios.filter(
+                      (candidate) =>
+                          candidate.comparisonPair ===
+                              scenario.comparisonPair &&
+                          (candidate.comparisonRole === 'legacy' ||
+                              candidate.comparisonRole === 'integrated'),
+                  )
+                : [];
+        const legacy = paired.find(
+            (candidate) => candidate.comparisonRole === 'legacy',
+        );
+        const integrated = paired.find(
+            (candidate) => candidate.comparisonRole === 'integrated',
+        );
+        if (legacy && integrated) {
+            const legacyRepeat = repeatFor(legacy);
+            const integratedRepeat = repeatFor(integrated);
+            if (legacyRepeat === integratedRepeat) {
+                for (
+                    let runIndex = 1;
+                    runIndex <= legacyRepeat;
+                    runIndex += 1
+                ) {
+                    const ordered =
+                        runIndex % 2 === 1
+                            ? [legacy, integrated]
+                            : [integrated, legacy];
+                    for (const candidate of ordered) {
+                        enqueue(candidate, runIndex, legacyRepeat);
+                    }
+                }
+                scheduled.add(legacy.name);
+                scheduled.add(integrated.name);
+                continue;
+            }
+        }
+
+        const repeat = repeatFor(scenario);
+        for (let runIndex = 1; runIndex <= repeat; runIndex += 1) {
+            enqueue(scenario, runIndex, repeat);
+        }
+        scheduled.add(scenario.name);
+    }
+
+    return queue;
 }
 
 function getScenarioRequest(path) {
@@ -1038,6 +1253,10 @@ function getScenarioRequest(path) {
         outline: url.searchParams.get('outline') ?? '0',
         placement: url.searchParams.get('placement') ?? '0',
         quality: url.searchParams.get('quality') ?? 'auto',
+        weatherSurface:
+            url.searchParams.get('weatherSurface') === 'legacy'
+                ? 'legacy'
+                : 'integrated',
     };
 }
 
@@ -1064,6 +1283,7 @@ function installBrowserMetrics({ externalGpuTimer = true } = {}) {
         instancedDrawCalls: 0,
         lastRenderedRafTick: -1,
         renderedFrames: 0,
+        rendererShaders: 0,
         submittedTriangles: 0,
     };
     globalThis.__gameProfileLongTasks = [];
@@ -1357,6 +1577,41 @@ function installBrowserMetrics({ externalGpuTimer = true } = {}) {
         };
         prototype[name].__gameProfilePatched = true;
     };
+    const livePrograms = new Set();
+    const updateRendererShaderCount = () => {
+        globalThis.__gameProfileMetrics.rendererShaders = livePrograms.size;
+    };
+    const patchProgramLifecycle = (Context) => {
+        const prototype = Context?.prototype;
+        if (
+            !prototype?.createProgram ||
+            prototype.createProgram.__gameProfilePatched
+        ) {
+            return;
+        }
+
+        const originalCreateProgram = prototype.createProgram;
+        prototype.createProgram = function patchedCreateProgram(...args) {
+            const program = originalCreateProgram.apply(this, args);
+            if (program) {
+                livePrograms.add(program);
+                updateRendererShaderCount();
+            }
+            return program;
+        };
+        prototype.createProgram.__gameProfilePatched = true;
+
+        const originalDeleteProgram = prototype.deleteProgram;
+        prototype.deleteProgram = function patchedDeleteProgram(...args) {
+            const result = originalDeleteProgram.apply(this, args);
+            if (args[0]) {
+                livePrograms.delete(args[0]);
+                updateRendererShaderCount();
+            }
+            return result;
+        };
+        prototype.deleteProgram.__gameProfilePatched = true;
+    };
 
     const patchContext = (Context) => {
         if (!Context) {
@@ -1392,6 +1647,8 @@ function installBrowserMetrics({ externalGpuTimer = true } = {}) {
         });
     };
 
+    patchProgramLifecycle(globalThis.WebGLRenderingContext);
+    patchProgramLifecycle(globalThis.WebGL2RenderingContext);
     patchContext(globalThis.WebGLRenderingContext);
     patchContext(globalThis.WebGL2RenderingContext);
 }
@@ -1487,6 +1744,7 @@ async function finishInteractiveProfileSample() {
         p99FrameMs: percentile(0.99),
         renderedFps: renderedFrames / safeElapsedSeconds,
         renderedFrames,
+        rendererShaders: metrics?.rendererShaders ?? null,
         submittedTriangles,
         trianglesPerFrame: submittedTriangles / safeRafFrames,
         trianglesPerRafFrame: submittedTriangles / safeRafFrames,
@@ -2387,6 +2645,7 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 element.dataset.gameProfileOperationVisuals ?? null,
             outline: element.dataset.gameProfileOutline ?? null,
             quality: element.dataset.gameProfileQuality ?? null,
+            weatherSurface: element.dataset.gameProfileWeatherSurface ?? null,
         };
     });
     const environment = await page.evaluate(() => {
@@ -2485,6 +2744,8 @@ async function measureScenario(browser, baseUrl, scenario, options) {
 
     const sampleMs = scenario.sampleMs ?? options.sampleMs;
     const weatherTransitionRequest = scenario.weatherTransition ?? null;
+    const weatherSurfaceTransitionRequest =
+        scenario.weatherSurfaceTransition ?? null;
     const placementProfileRequest = scenario.placementProfile ?? null;
     const samplePromise = page.evaluate(
         async (sampleOptions) => {
@@ -2499,6 +2760,7 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 sampleMs,
                 weatherTransitionEventName,
                 weatherTransitionRequest,
+                weatherSurfaceTransitionRequest,
             } = sampleOptions;
             const canvas = document.querySelector('canvas');
             const metrics = globalThis.__gameProfileMetrics;
@@ -2654,6 +2916,168 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 : false;
 
             let profileRecoveryFinished = !adaptiveHighProfileControlRecovery;
+            let weatherSurfaceTransitionFinished =
+                weatherSurfaceTransitionRequest !== 'snow-integration-cycle';
+            let weatherSurfaceTransitionProfile = null;
+            const weatherSurfaceTransitionPromise =
+                weatherSurfaceTransitionRequest === 'snow-integration-cycle'
+                    ? (async () => {
+                          const profile = {
+                              dwell: null,
+                              enterDispatched: false,
+                              entered: null,
+                              error: null,
+                              exitDispatched: false,
+                              exited: null,
+                              initial: null,
+                              request: weatherSurfaceTransitionRequest,
+                          };
+                          const readSnapshot = () => {
+                              const metadata =
+                                  globalThis.__grediceGameProfile ?? {};
+                              const numberOrNull = (value) =>
+                                  typeof value === 'number' ? value : null;
+                              return {
+                                  avoidedOverlaySubmissionCount: numberOrNull(
+                                      metadata.weatherSurfaceAvoidedOverlaySubmissionCount,
+                                  ),
+                                  avoidedOverlayTriangleCount: numberOrNull(
+                                      metadata.weatherSurfaceAvoidedOverlayTriangleCount,
+                                  ),
+                                  fallbackOverlaySubmissionCount: numberOrNull(
+                                      metadata.weatherSurfaceFallbackOverlaySubmissionCount,
+                                  ),
+                                  fallbackOverlayTriangleCount: numberOrNull(
+                                      metadata.weatherSurfaceFallbackOverlayTriangleCount,
+                                  ),
+                                  integratedInstanceCount: numberOrNull(
+                                      metadata.weatherSurfaceIntegratedInstanceCount,
+                                  ),
+                                  integratedMaterialCount: numberOrNull(
+                                      metadata.weatherSurfaceIntegratedMaterialCount,
+                                  ),
+                                  pluginVariantCount: numberOrNull(
+                                      metadata.weatherSurfacePluginVariantCount,
+                                  ),
+                                  readyCount: numberOrNull(
+                                      metadata.weatherSurfaceSnowIntegrationReadyCount,
+                                  ),
+                                  trackedCount: numberOrNull(
+                                      metadata.weatherSurfaceSnowIntegrationTrackedCount,
+                                  ),
+                                  transitionCount: numberOrNull(
+                                      metadata.weatherSurfaceSnowIntegrationTransitionCount,
+                                  ),
+                                  snowParticleCount: numberOrNull(
+                                      metadata.snowParticleCount,
+                                  ),
+                              };
+                          };
+                          const hasSparseFallbackState = (snapshot) =>
+                              (snapshot.trackedCount ?? 0) > 0 &&
+                              snapshot.readyCount === 0 &&
+                              snapshot.integratedInstanceCount === 0 &&
+                              snapshot.integratedMaterialCount === 0 &&
+                              snapshot.pluginVariantCount === 0 &&
+                              snapshot.avoidedOverlaySubmissionCount === 0 &&
+                              snapshot.avoidedOverlayTriangleCount === 0 &&
+                              (snapshot.fallbackOverlaySubmissionCount ?? 0) >
+                                  0 &&
+                              (snapshot.fallbackOverlayTriangleCount ?? 0) >
+                                  0 &&
+                              snapshot.snowParticleCount === 0;
+                          const hasIntegratedState = (snapshot, initial) =>
+                              snapshot.trackedCount === initial.trackedCount &&
+                              snapshot.readyCount === initial.trackedCount &&
+                              snapshot.transitionCount ===
+                                  initial.transitionCount +
+                                      initial.trackedCount &&
+                              (snapshot.integratedInstanceCount ?? 0) > 0 &&
+                              (snapshot.integratedMaterialCount ?? 0) > 0 &&
+                              snapshot.pluginVariantCount === 1 &&
+                              (snapshot.avoidedOverlaySubmissionCount ?? 0) >
+                                  0 &&
+                              (snapshot.avoidedOverlayTriangleCount ?? 0) > 0 &&
+                              (snapshot.fallbackOverlaySubmissionCount ?? 0) >
+                                  0 &&
+                              (snapshot.fallbackOverlayTriangleCount ?? 0) >
+                                  0 &&
+                              snapshot.snowParticleCount === 0;
+                          const hasReturnedToSparseState = (
+                              snapshot,
+                              initial,
+                          ) =>
+                              hasSparseFallbackState(snapshot) &&
+                              snapshot.trackedCount === initial.trackedCount &&
+                              snapshot.transitionCount ===
+                                  initial.transitionCount +
+                                      initial.trackedCount * 2 &&
+                              snapshot.fallbackOverlaySubmissionCount ===
+                                  initial.fallbackOverlaySubmissionCount &&
+                              snapshot.fallbackOverlayTriangleCount ===
+                                  initial.fallbackOverlayTriangleCount;
+                          const waitForState = async (label, predicate) => {
+                              const deadline = performance.now() + 15_000;
+                              while (performance.now() < deadline) {
+                                  const snapshot = readSnapshot();
+                                  if (predicate(snapshot)) {
+                                      return snapshot;
+                                  }
+                                  await new Promise((resolveWait) =>
+                                      setTimeout(resolveWait, 25),
+                                  );
+                              }
+                              throw new Error(
+                                  `Timed out waiting for snow surface ${label}.`,
+                              );
+                          };
+                          const dispatchWeather = (request) =>
+                              globalThis.dispatchEvent(
+                                  new CustomEvent(weatherTransitionEventName, {
+                                      detail: { request },
+                                  }),
+                              );
+
+                          try {
+                              profile.initial = await waitForState(
+                                  'sparse initial state',
+                                  hasSparseFallbackState,
+                              );
+                              profile.enterDispatched = dispatchWeather(
+                                  'snow-sparse-to-integrated',
+                              );
+                              profile.entered = await waitForState(
+                                  'integrated state',
+                                  (snapshot) =>
+                                      hasIntegratedState(
+                                          snapshot,
+                                          profile.initial,
+                                      ),
+                              );
+                              await new Promise((resolveWait) =>
+                                  setTimeout(resolveWait, 750),
+                              );
+                              profile.dwell = readSnapshot();
+                              profile.exitDispatched = dispatchWeather(
+                                  'snow-integrated-to-sparse',
+                              );
+                              profile.exited = await waitForState(
+                                  'sparse fallback state',
+                                  (snapshot) =>
+                                      hasReturnedToSparseState(
+                                          snapshot,
+                                          profile.initial,
+                                      ),
+                              );
+                          } catch (error) {
+                              profile.error = String(error);
+                          }
+
+                          weatherSurfaceTransitionProfile = profile;
+                      })().finally(() => {
+                          weatherSurfaceTransitionFinished = true;
+                      })
+                    : Promise.resolve();
             const sampleWindowPromise = new Promise((resolveSample) => {
                 const step = (now) => {
                     intervals.push(now - last);
@@ -2669,7 +3093,11 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                     ) {
                         rainUnmountMs = now - start;
                     }
-                    if (now - start >= sampleMs && profileRecoveryFinished) {
+                    if (
+                        now - start >= sampleMs &&
+                        profileRecoveryFinished &&
+                        weatherSurfaceTransitionFinished
+                    ) {
                         resolveSample();
                         return;
                     }
@@ -2756,7 +3184,11 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                       profileRecoveryFinished = true;
                   })
                 : Promise.resolve();
-            await Promise.all([sampleWindowPromise, profileRecoveryPromise]);
+            await Promise.all([
+                sampleWindowPromise,
+                profileRecoveryPromise,
+                weatherSurfaceTransitionPromise,
+            ]);
 
             const sampleEndedAt = performance.now();
             const frameIntervals = intervals.slice(1);
@@ -2965,6 +3397,7 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 reportedDpr: globalThis.devicePixelRatio,
                 renderedFps: renderedFrames / safeElapsedSeconds,
                 renderedFrames,
+                rendererShaders: metrics?.rendererShaders ?? null,
                 submittedTriangles,
                 trianglesPerFrame: submittedTriangles / safeRafFrames,
                 trianglesPerRafFrame: submittedTriangles / safeRafFrames,
@@ -2975,6 +3408,7 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 trianglesPerSecond: submittedTriangles / safeElapsedSeconds,
                 weatherTransitionDispatched,
                 weatherTransitionRequest,
+                weatherSurfaceTransitionProfile,
             };
             globalThis.__gameProfileGpuTimer?.stop();
 
@@ -3000,6 +3434,7 @@ async function measureScenario(browser, baseUrl, scenario, options) {
             sampleMs,
             weatherTransitionEventName: gameProfileWeatherTransitionEventName,
             weatherTransitionRequest,
+            weatherSurfaceTransitionRequest,
         },
     );
     const sampleCompletionPromise = samplePromise.then((sampleAtEndpoint) =>
@@ -3025,7 +3460,7 @@ async function measureScenario(browser, baseUrl, scenario, options) {
         ]),
     );
 
-    const runtime = await page.evaluate(() => {
+    const runtime = await page.evaluate((instrumentedRendererShaders) => {
         const metadata = globalThis.__grediceGameProfile;
         if (!metadata || typeof metadata !== 'object') {
             return null;
@@ -3530,6 +3965,9 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 typeof metadata.primaryShadowRefreshCount === 'number'
                     ? metadata.primaryShadowRefreshCount
                     : null,
+            rendererShaders:
+                numberOrNull(metadata.rendererShaders) ??
+                numberOrNull(instrumentedRendererShaders),
             shadowMapAutoUpdate:
                 typeof metadata.shadowMapAutoUpdate === 'boolean'
                     ? metadata.shadowMapAutoUpdate
@@ -3570,12 +4008,43 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 typeof metadata.snowParticleGeometryBuildCount === 'number'
                     ? metadata.snowParticleGeometryBuildCount
                     : null,
+            weatherSurfaceAvoidedOverlaySubmissionCount: numberOrNull(
+                metadata.weatherSurfaceAvoidedOverlaySubmissionCount,
+            ),
+            weatherSurfaceAvoidedOverlayTriangleCount: numberOrNull(
+                metadata.weatherSurfaceAvoidedOverlayTriangleCount,
+            ),
+            weatherSurfaceFallbackOverlaySubmissionCount: numberOrNull(
+                metadata.weatherSurfaceFallbackOverlaySubmissionCount,
+            ),
+            weatherSurfaceFallbackOverlayTriangleCount: numberOrNull(
+                metadata.weatherSurfaceFallbackOverlayTriangleCount,
+            ),
+            weatherSurfaceIntegratedInstanceCount: numberOrNull(
+                metadata.weatherSurfaceIntegratedInstanceCount,
+            ),
+            weatherSurfaceIntegratedMaterialCount: numberOrNull(
+                metadata.weatherSurfaceIntegratedMaterialCount,
+            ),
+            weatherSurfaceMode: stringOrNull(metadata.weatherSurfaceMode),
+            weatherSurfacePluginVariantCount: numberOrNull(
+                metadata.weatherSurfacePluginVariantCount,
+            ),
+            weatherSurfaceSnowIntegrationReadyCount: numberOrNull(
+                metadata.weatherSurfaceSnowIntegrationReadyCount,
+            ),
+            weatherSurfaceSnowIntegrationTrackedCount: numberOrNull(
+                metadata.weatherSurfaceSnowIntegrationTrackedCount,
+            ),
+            weatherSurfaceSnowIntegrationTransitionCount: numberOrNull(
+                metadata.weatherSurfaceSnowIntegrationTransitionCount,
+            ),
             weatherDisabled:
                 typeof metadata.weatherDisabled === 'boolean'
                     ? metadata.weatherDisabled
                     : null,
         };
-    });
+    }, sample.rendererShaders);
 
     const screenshotPath = options.screenshots
         ? resolve(options.outDir, 'screenshots', `${scenario.name}.png`)
@@ -3628,11 +4097,15 @@ async function measureScenario(browser, baseUrl, scenario, options) {
         runtimeGpuSource: scenario.runtimeGpuSource === true,
         sampleMs,
         viewport: scenario.viewport,
+        weatherSurface:
+            profileMetadata?.weatherSurface ?? request.weatherSurface,
+        weatherSurfaceTransition: weatherSurfaceTransitionRequest ?? 'none',
         weatherTransition: weatherTransitionRequest ?? 'none',
     };
     const budget = evaluateBudget(roundedSample, budgets[scenario.budget]);
     const acceptance = evaluateHighTargetAcceptance({
         apiErrors,
+        consoleMessages,
         environment,
         pageErrors,
         requested,
@@ -3794,6 +4267,7 @@ function evaluateBudget(sample, budget) {
 
 function evaluateHighTargetAcceptance({
     apiErrors = [],
+    consoleMessages = [],
     environment,
     pageErrors,
     requested,
@@ -3873,6 +4347,20 @@ function evaluateHighTargetAcceptance({
         : null;
     const operationVisualsRequested = requested.operationVisuals === '1';
     const foliageBudgetRequested = requested.foliageBudget === '1';
+    const weatherSurfaceRequested =
+        requested.weatherSurface === 'integrated' ||
+        requested.weatherSurface === 'legacy'
+            ? requested.weatherSurface
+            : null;
+    const weatherSurfaceExpectation =
+        requested.mode === 'rain' || requested.mode === 'snow'
+            ? highTargetWeatherSurfaceExpectations[requested.mode]
+            : null;
+    const weatherSurfaceOnsetSelfVerification =
+        requested.mode === 'snow-onset' &&
+        requested.weatherSurface === 'integrated';
+    const weatherSurfaceTransitionRequested =
+        requested.weatherSurfaceTransition === 'snow-integration-cycle';
     const expectedGeneratedPlantFieldCount = operationVisualsRequested
         ? highTargetOperationVisualExpectedGeneratedPlantFieldCount
         : highTargetExpectedGeneratedPlantFieldCount;
@@ -4118,6 +4606,12 @@ function evaluateHighTargetAcceptance({
         minimum('highTargetDrawCalls', sample.drawCalls, 1),
         minimum('highTargetSubmittedTriangles', sample.submittedTriangles, 1),
         exact('highTargetApiErrors', apiErrors.length, 0),
+        exact(
+            'highTargetConsoleErrors',
+            consoleMessages.filter((message) => message.type === 'error')
+                .length,
+            0,
+        ),
         exact('highTargetPageErrors', pageErrors.length, 0),
     ];
     if (operationVisualsRequested) {
@@ -4621,6 +5115,415 @@ function evaluateHighTargetAcceptance({
             ),
         );
     }
+    if (weatherSurfaceRequested && weatherSurfaceExpectation) {
+        checks.push(
+            exact(
+                'highTargetWeatherSurfaceMode',
+                runtime?.weatherSurfaceMode,
+                weatherSurfaceRequested,
+            ),
+            exact(
+                'highTargetWeatherSurfaceIntegratedInstances',
+                runtime?.weatherSurfaceIntegratedInstanceCount,
+                weatherSurfaceRequested === 'integrated'
+                    ? weatherSurfaceExpectation.integratedInstanceCount
+                    : 0,
+            ),
+            exact(
+                'highTargetWeatherSurfaceIntegratedMaterials',
+                runtime?.weatherSurfaceIntegratedMaterialCount,
+                weatherSurfaceRequested === 'integrated'
+                    ? weatherSurfaceExpectation.integratedMaterialCount
+                    : 0,
+            ),
+            exact(
+                'highTargetWeatherSurfacePluginVariants',
+                runtime?.weatherSurfacePluginVariantCount,
+                weatherSurfaceRequested === 'integrated' ? 1 : 0,
+            ),
+            exact(
+                'highTargetWeatherSurfaceAvoidedOverlaySubmissions',
+                runtime?.weatherSurfaceAvoidedOverlaySubmissionCount,
+                weatherSurfaceRequested === 'integrated'
+                    ? weatherSurfaceExpectation.avoidedOverlaySubmissionCount
+                    : 0,
+            ),
+            exact(
+                'highTargetWeatherSurfaceAvoidedOverlayTriangles',
+                runtime?.weatherSurfaceAvoidedOverlayTriangleCount,
+                weatherSurfaceRequested === 'integrated'
+                    ? weatherSurfaceExpectation.avoidedOverlayTriangleCount
+                    : 0,
+            ),
+            exact(
+                'highTargetWeatherSurfaceFallbackOverlaySubmissions',
+                runtime?.weatherSurfaceFallbackOverlaySubmissionCount,
+                weatherSurfaceExpectation.fallbackOverlaySubmissionCount[
+                    weatherSurfaceRequested
+                ],
+            ),
+            exact(
+                'highTargetWeatherSurfaceFallbackOverlayTriangles',
+                runtime?.weatherSurfaceFallbackOverlayTriangleCount,
+                weatherSurfaceExpectation.fallbackOverlayTriangleCount[
+                    weatherSurfaceRequested
+                ],
+            ),
+            minimum(
+                'highTargetWeatherSurfaceRendererPrograms',
+                runtime?.rendererShaders,
+                1,
+            ),
+        );
+    }
+    if (weatherSurfaceOnsetSelfVerification) {
+        checks.push(
+            exact(
+                'highTargetWeatherSurfaceOnsetRequestedMode',
+                requested.weatherSurface,
+                'integrated',
+            ),
+            exact(
+                'highTargetWeatherSurfaceOnsetRuntimeMode',
+                runtime?.weatherSurfaceMode,
+                'integrated',
+            ),
+            exact(
+                'highTargetWeatherSurfaceOnsetIntegratedInstances',
+                runtime?.weatherSurfaceIntegratedInstanceCount,
+                highTargetWeatherSurfaceOnsetExpectation.integratedInstanceCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceOnsetIntegratedMaterials',
+                runtime?.weatherSurfaceIntegratedMaterialCount,
+                highTargetWeatherSurfaceOnsetExpectation.integratedMaterialCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceOnsetPluginVariants',
+                runtime?.weatherSurfacePluginVariantCount,
+                highTargetWeatherSurfaceOnsetExpectation.pluginVariantCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceOnsetAvoidedOverlaySubmissions',
+                runtime?.weatherSurfaceAvoidedOverlaySubmissionCount,
+                highTargetWeatherSurfaceOnsetExpectation.avoidedOverlaySubmissionCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceOnsetAvoidedOverlayTriangles',
+                runtime?.weatherSurfaceAvoidedOverlayTriangleCount,
+                highTargetWeatherSurfaceOnsetExpectation.avoidedOverlayTriangleCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceOnsetFallbackOverlaySubmissions',
+                runtime?.weatherSurfaceFallbackOverlaySubmissionCount,
+                highTargetWeatherSurfaceOnsetExpectation.fallbackOverlaySubmissionCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceOnsetFallbackOverlayTriangles',
+                runtime?.weatherSurfaceFallbackOverlayTriangleCount,
+                highTargetWeatherSurfaceOnsetExpectation.fallbackOverlayTriangleCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceOnsetRainParticles',
+                runtime?.rainParticleCount,
+                0,
+            ),
+            exact(
+                'highTargetWeatherSurfaceOnsetSnowParticles',
+                runtime?.snowParticleCount,
+                highTargetWeatherSurfaceOnsetExpectation.snowParticleCount,
+            ),
+        );
+    }
+    if (weatherSurfaceTransitionRequested) {
+        const transition = sample.weatherSurfaceTransitionProfile;
+        const trackedCount = transition?.initial?.trackedCount ?? null;
+        const transitionDelta = (after, before) =>
+            typeof after === 'number' && typeof before === 'number'
+                ? after - before
+                : null;
+        checks.push(
+            exact(
+                'highTargetWeatherSurfaceTransitionRequest',
+                transition?.request,
+                'snow-integration-cycle',
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionError',
+                transition?.error,
+                null,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionEnterDispatched',
+                transition?.enterDispatched,
+                true,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionExitDispatched',
+                transition?.exitDispatched,
+                true,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionTrackedUniforms',
+                trackedCount,
+                highTargetWeatherSurfaceThresholdTransitionExpectation.trackedCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionInitialReady',
+                transition?.initial?.readyCount,
+                0,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionInitialHandoffs',
+                transition?.initial?.transitionCount,
+                0,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionInitialInstances',
+                transition?.initial?.integratedInstanceCount,
+                highTargetWeatherSurfaceThresholdTransitionExpectation.exit
+                    .integratedInstanceCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionInitialMaterials',
+                transition?.initial?.integratedMaterialCount,
+                highTargetWeatherSurfaceThresholdTransitionExpectation.exit
+                    .integratedMaterialCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionInitialPluginVariants',
+                transition?.initial?.pluginVariantCount,
+                highTargetWeatherSurfaceThresholdTransitionExpectation.exit
+                    .pluginVariantCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionInitialAvoidedSubmissions',
+                transition?.initial?.avoidedOverlaySubmissionCount,
+                highTargetWeatherSurfaceThresholdTransitionExpectation.exit
+                    .avoidedOverlaySubmissionCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionInitialAvoidedTriangleProxy',
+                transition?.initial?.avoidedOverlayTriangleCount,
+                highTargetWeatherSurfaceThresholdTransitionExpectation.exit
+                    .avoidedOverlayTriangleCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionInitialFallbackSubmissions',
+                transition?.initial?.fallbackOverlaySubmissionCount,
+                highTargetWeatherSurfaceThresholdTransitionExpectation.exit
+                    .fallbackOverlaySubmissionCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionInitialFallbackTriangleProxy',
+                transition?.initial?.fallbackOverlayTriangleCount,
+                highTargetWeatherSurfaceThresholdTransitionExpectation.exit
+                    .fallbackOverlayTriangleCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionInitialParticles',
+                transition?.initial?.snowParticleCount,
+                highTargetWeatherSurfaceThresholdTransitionExpectation.exit
+                    .snowParticleCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionEnteredTracked',
+                transition?.entered?.trackedCount,
+                trackedCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionEnteredReady',
+                transition?.entered?.readyCount,
+                trackedCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionEnteredInstances',
+                transition?.entered?.integratedInstanceCount,
+                highTargetWeatherSurfaceThresholdTransitionExpectation.peak
+                    .integratedInstanceCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionEnteredMaterials',
+                transition?.entered?.integratedMaterialCount,
+                highTargetWeatherSurfaceThresholdTransitionExpectation.peak
+                    .integratedMaterialCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionEnteredPluginVariants',
+                transition?.entered?.pluginVariantCount,
+                highTargetWeatherSurfaceThresholdTransitionExpectation.peak
+                    .pluginVariantCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionEnteredAvoidedSubmissions',
+                transition?.entered?.avoidedOverlaySubmissionCount,
+                highTargetWeatherSurfaceThresholdTransitionExpectation.peak
+                    .avoidedOverlaySubmissionCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionEnteredAvoidedTriangleProxy',
+                transition?.entered?.avoidedOverlayTriangleCount,
+                highTargetWeatherSurfaceThresholdTransitionExpectation.peak
+                    .avoidedOverlayTriangleCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionEnteredFallbackSubmissions',
+                transition?.entered?.fallbackOverlaySubmissionCount,
+                highTargetWeatherSurfaceThresholdTransitionExpectation.peak
+                    .fallbackOverlaySubmissionCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionEnteredFallbackTriangleProxy',
+                transition?.entered?.fallbackOverlayTriangleCount,
+                highTargetWeatherSurfaceThresholdTransitionExpectation.peak
+                    .fallbackOverlayTriangleCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionEnterHandoffs',
+                transitionDelta(
+                    transition?.entered?.transitionCount,
+                    transition?.initial?.transitionCount,
+                ),
+                trackedCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionDwellReady',
+                transition?.dwell?.readyCount,
+                trackedCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionDwellNoThrash',
+                transition?.dwell?.transitionCount,
+                transition?.entered?.transitionCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionDwellInstances',
+                transition?.dwell?.integratedInstanceCount,
+                transition?.entered?.integratedInstanceCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionDwellMaterials',
+                transition?.dwell?.integratedMaterialCount,
+                transition?.entered?.integratedMaterialCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionDwellPluginVariants',
+                transition?.dwell?.pluginVariantCount,
+                transition?.entered?.pluginVariantCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionDwellAvoidedSubmissions',
+                transition?.dwell?.avoidedOverlaySubmissionCount,
+                transition?.entered?.avoidedOverlaySubmissionCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionDwellAvoidedTriangleProxy',
+                transition?.dwell?.avoidedOverlayTriangleCount,
+                transition?.entered?.avoidedOverlayTriangleCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionDwellFallbackSubmissions',
+                transition?.dwell?.fallbackOverlaySubmissionCount,
+                transition?.entered?.fallbackOverlaySubmissionCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionDwellFallbackTriangleProxy',
+                transition?.dwell?.fallbackOverlayTriangleCount,
+                transition?.entered?.fallbackOverlayTriangleCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionDwellParticles',
+                transition?.dwell?.snowParticleCount,
+                0,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionExitedTracked',
+                transition?.exited?.trackedCount,
+                trackedCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionExitedReady',
+                transition?.exited?.readyCount,
+                0,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionExitedInstances',
+                transition?.exited?.integratedInstanceCount,
+                transition?.initial?.integratedInstanceCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionExitedMaterials',
+                transition?.exited?.integratedMaterialCount,
+                transition?.initial?.integratedMaterialCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionExitedPluginVariants',
+                transition?.exited?.pluginVariantCount,
+                transition?.initial?.pluginVariantCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionExitedAvoidedSubmissions',
+                transition?.exited?.avoidedOverlaySubmissionCount,
+                transition?.initial?.avoidedOverlaySubmissionCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionExitedAvoidedTriangleProxy',
+                transition?.exited?.avoidedOverlayTriangleCount,
+                transition?.initial?.avoidedOverlayTriangleCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionExitedFallbackSubmissions',
+                transition?.exited?.fallbackOverlaySubmissionCount,
+                transition?.initial?.fallbackOverlaySubmissionCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionExitedFallbackTriangleProxy',
+                transition?.exited?.fallbackOverlayTriangleCount,
+                transition?.initial?.fallbackOverlayTriangleCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionExitHandoffs',
+                transitionDelta(
+                    transition?.exited?.transitionCount,
+                    transition?.entered?.transitionCount,
+                ),
+                trackedCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionTotalHandoffs',
+                transitionDelta(
+                    transition?.exited?.transitionCount,
+                    transition?.initial?.transitionCount,
+                ),
+                typeof trackedCount === 'number' ? trackedCount * 2 : null,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionRuntimeReady',
+                runtime?.weatherSurfaceSnowIntegrationReadyCount,
+                0,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionRuntimeTracked',
+                runtime?.weatherSurfaceSnowIntegrationTrackedCount,
+                trackedCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionRuntimeTransitions',
+                runtime?.weatherSurfaceSnowIntegrationTransitionCount,
+                transition?.exited?.transitionCount,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionParticles',
+                transition?.entered?.snowParticleCount,
+                0,
+            ),
+            exact(
+                'highTargetWeatherSurfaceTransitionExitedParticles',
+                transition?.exited?.snowParticleCount,
+                0,
+            ),
+        );
+    }
     if (requested.mode === 'rain') {
         checks.push(
             exact(
@@ -4721,6 +5624,20 @@ function buildHighTargetMedians(scenarios) {
             const gpuElapsedP95Ms = metric(runs, (run) =>
                 run.sample.gpu?.valid ? run.sample.gpu.elapsedP95Ms : null,
             );
+            const gpuElapsedP95MsRuns = runs.map((run, index) => {
+                const value = run.sample.gpu?.elapsedP95Ms ?? null;
+                const valid =
+                    run.sample.gpu?.valid === true &&
+                    Number.isFinite(value) &&
+                    value >= 0;
+                return {
+                    disjoint: run.sample.gpu?.disjoint === true,
+                    profileRun: run.profileRun ?? index + 1,
+                    reason: run.sample.gpu?.reason ?? null,
+                    valid,
+                    value: valid ? value : null,
+                };
+            });
             const jsHeapMb = metric(runs, (run) => run.sample.jsHeapMb);
             const longTaskCount = metric(
                 runs,
@@ -4729,6 +5646,19 @@ function buildHighTargetMedians(scenarios) {
             const maxFrameMs = metric(runs, (run) => run.sample.maxFrameMs);
             const p95FrameMs = metric(runs, (run) => run.sample.p95FrameMs);
             const renderedFps = metric(runs, (run) => run.sample.renderedFps);
+            const rendererShaders = metric(
+                runs,
+                (run) => run.runtime?.rendererShaders,
+            );
+            const rendererShadersRuns = runs.map((run, index) => {
+                const value = run.runtime?.rendererShaders ?? null;
+                const valid = Number.isFinite(value) && value >= 0;
+                return {
+                    profileRun: run.profileRun ?? index + 1,
+                    valid,
+                    value: valid ? value : null,
+                };
+            });
             const trianglesPerFrame = metric(
                 runs,
                 (run) => run.sample.trianglesPerFrame,
@@ -4736,6 +5666,37 @@ function buildHighTargetMedians(scenarios) {
             const trianglesPerRenderedFrame = metric(
                 runs,
                 (run) => run.sample.trianglesPerRenderedFrame,
+            );
+            const weatherSurfaceAvoidedOverlaySubmissionCount = metric(
+                runs,
+                (run) =>
+                    run.runtime?.weatherSurfaceAvoidedOverlaySubmissionCount,
+            );
+            const weatherSurfaceAvoidedOverlayTriangleCount = metric(
+                runs,
+                (run) => run.runtime?.weatherSurfaceAvoidedOverlayTriangleCount,
+            );
+            const weatherSurfaceFallbackOverlaySubmissionCount = metric(
+                runs,
+                (run) =>
+                    run.runtime?.weatherSurfaceFallbackOverlaySubmissionCount,
+            );
+            const weatherSurfaceFallbackOverlayTriangleCount = metric(
+                runs,
+                (run) =>
+                    run.runtime?.weatherSurfaceFallbackOverlayTriangleCount,
+            );
+            const weatherSurfaceIntegratedInstanceCount = metric(
+                runs,
+                (run) => run.runtime?.weatherSurfaceIntegratedInstanceCount,
+            );
+            const weatherSurfaceIntegratedMaterialCount = metric(
+                runs,
+                (run) => run.runtime?.weatherSurfaceIntegratedMaterialCount,
+            );
+            const weatherSurfacePluginVariantCount = metric(
+                runs,
+                (run) => run.runtime?.weatherSurfacePluginVariantCount,
             );
             const medianSample = {
                 drawCallsPerFrame: drawCallsPerFrame.median,
@@ -4772,6 +5733,7 @@ function buildHighTargetMedians(scenarios) {
                     drawCallsPerRenderedFrame,
                     failedAcceptanceRuns,
                     gpuElapsedP95Ms,
+                    gpuElapsedP95MsRuns,
                     jsHeapMb,
                     longTaskCount,
                     maxFrameMs,
@@ -4785,8 +5747,19 @@ function buildHighTargetMedians(scenarios) {
                         (run) => run.performanceBudget?.pass === true,
                     ).length,
                     renderedFps,
+                    rendererShaders,
+                    rendererShadersRuns,
                     runCount: runs.length,
                     trianglesPerRenderedFrame,
+                    weatherSurfaceAvoidedOverlaySubmissionCount,
+                    weatherSurfaceAvoidedOverlayTriangleCount,
+                    weatherSurfaceFallbackOverlaySubmissionCount,
+                    weatherSurfaceFallbackOverlayTriangleCount,
+                    weatherSurfaceIntegratedInstanceCount,
+                    weatherSurfaceIntegratedMaterialCount,
+                    weatherSurfaceMode:
+                        runs[0]?.runtime?.weatherSurfaceMode ?? null,
+                    weatherSurfacePluginVariantCount,
                 },
             ];
         }),
@@ -4937,6 +5910,340 @@ function buildAdaptiveHighComparisons(highTargetMedians) {
     );
 }
 
+function buildWeatherSurfaceComparisons(highTargetMedians) {
+    const pairedSummaries = Object.entries(highTargetMedians).filter(
+        ([, summary]) =>
+            typeof summary.comparisonPair === 'string' &&
+            (summary.comparisonRole === 'legacy' ||
+                summary.comparisonRole === 'integrated'),
+    );
+    const grouped = Map.groupBy(
+        pairedSummaries,
+        ([, summary]) => summary.comparisonPair,
+    );
+    const metricComparison = (legacy, integrated, metricName) => {
+        const legacyValue = legacy[metricName]?.median ?? null;
+        const integratedValue = integrated[metricName]?.median ?? null;
+        return {
+            delta:
+                Number.isFinite(legacyValue) && Number.isFinite(integratedValue)
+                    ? round(integratedValue - legacyValue)
+                    : null,
+            integrated: integratedValue,
+            legacy: legacyValue,
+            percentDelta:
+                Number.isFinite(legacyValue) &&
+                legacyValue !== 0 &&
+                Number.isFinite(integratedValue)
+                    ? round(
+                          ((integratedValue - legacyValue) / legacyValue) * 100,
+                          1,
+                      )
+                    : null,
+        };
+    };
+    const passRate = (summary, passedField) =>
+        summary.runCount > 0
+            ? round((summary[passedField] / summary.runCount) * 100, 1)
+            : null;
+
+    return Object.fromEntries(
+        Array.from(grouped, ([pairName, entries]) => {
+            const legacyEntry = entries.find(
+                ([, summary]) => summary.comparisonRole === 'legacy',
+            );
+            const integratedEntry = entries.find(
+                ([, summary]) => summary.comparisonRole === 'integrated',
+            );
+            if (!legacyEntry || !integratedEntry) {
+                return null;
+            }
+            const [legacyName, legacy] = legacyEntry;
+            const [integratedName, integrated] = integratedEntry;
+            const fallbackOverlaySubmissions = metricComparison(
+                legacy,
+                integrated,
+                'weatherSurfaceFallbackOverlaySubmissionCount',
+            );
+            const fallbackOverlayTriangles = metricComparison(
+                legacy,
+                integrated,
+                'weatherSurfaceFallbackOverlayTriangleCount',
+            );
+            const drawCallsPerRenderedFrame = metricComparison(
+                legacy,
+                integrated,
+                'drawCallsPerRenderedFrame',
+            );
+            const gpuElapsedP95Ms = metricComparison(
+                legacy,
+                integrated,
+                'gpuElapsedP95Ms',
+            );
+            const rendererShaders = metricComparison(
+                legacy,
+                integrated,
+                'rendererShaders',
+            );
+            const trianglesPerRenderedFrame = metricComparison(
+                legacy,
+                integrated,
+                'trianglesPerRenderedFrame',
+            );
+            const lessThanLegacy = (name, comparison) => ({
+                actual: comparison.integrated,
+                comparison: 'less-than',
+                limit: comparison.legacy,
+                name,
+                pass:
+                    Number.isFinite(comparison.integrated) &&
+                    Number.isFinite(comparison.legacy) &&
+                    comparison.integrated < comparison.legacy,
+            });
+            const structuralChecks = [
+                lessThanLegacy(
+                    'weatherSurfaceFallbackSubmissionReduction',
+                    fallbackOverlaySubmissions,
+                ),
+                lessThanLegacy(
+                    'weatherSurfaceFallbackTriangleReduction',
+                    fallbackOverlayTriangles,
+                ),
+            ];
+            const structuralPass = structuralChecks.every(
+                (check) => check.pass,
+            );
+            const legacyGpuRuns = new Map(
+                (legacy.gpuElapsedP95MsRuns ?? []).map((run) => [
+                    run.profileRun,
+                    run,
+                ]),
+            );
+            const integratedGpuRuns = new Map(
+                (integrated.gpuElapsedP95MsRuns ?? []).map((run) => [
+                    run.profileRun,
+                    run,
+                ]),
+            );
+            const pairedGpuRuns = Array.from(
+                { length: highTargetWeatherSurfacePairedRunCount },
+                (_, index) => {
+                    const profileRun = index + 1;
+                    const legacyRun = legacyGpuRuns.get(profileRun);
+                    const integratedRun = integratedGpuRuns.get(profileRun);
+                    const valid =
+                        legacyRun?.valid === true &&
+                        integratedRun?.valid === true &&
+                        Number.isFinite(legacyRun.value) &&
+                        legacyRun.value > 0 &&
+                        Number.isFinite(integratedRun.value);
+                    return {
+                        integratedMs: integratedRun?.value ?? null,
+                        integratedReason: integratedRun?.reason ?? null,
+                        legacyMs: legacyRun?.value ?? null,
+                        legacyReason: legacyRun?.reason ?? null,
+                        profileRun,
+                        ratio: valid
+                            ? round(integratedRun.value / legacyRun.value, 4)
+                            : null,
+                        valid,
+                    };
+                },
+            );
+            const validGpuRatios = pairedGpuRuns
+                .filter((run) => run.valid)
+                .map((run) => run.integratedMs / run.legacyMs);
+            const gpuTimingStatus =
+                legacy.runCount === highTargetWeatherSurfacePairedRunCount &&
+                integrated.runCount ===
+                    highTargetWeatherSurfacePairedRunCount &&
+                validGpuRatios.length === highTargetWeatherSurfacePairedRunCount
+                    ? 'valid'
+                    : 'inconclusive';
+            const rawGpuMedianRatio =
+                gpuTimingStatus === 'valid' ? median(validGpuRatios) : null;
+            const rawGpuMaximumRunRatio =
+                gpuTimingStatus === 'valid'
+                    ? Math.max(...validGpuRatios)
+                    : null;
+            const gpuMedianRatio = round(rawGpuMedianRatio, 4);
+            const gpuMaximumRunRatio = round(rawGpuMaximumRunRatio, 4);
+            const legacyRendererProgramRuns = new Map(
+                (legacy.rendererShadersRuns ?? []).map((run) => [
+                    run.profileRun,
+                    run,
+                ]),
+            );
+            const integratedRendererProgramRuns = new Map(
+                (integrated.rendererShadersRuns ?? []).map((run) => [
+                    run.profileRun,
+                    run,
+                ]),
+            );
+            const pairedRendererProgramRuns = Array.from(
+                { length: highTargetWeatherSurfacePairedRunCount },
+                (_, index) => {
+                    const profileRun = index + 1;
+                    const legacyRun = legacyRendererProgramRuns.get(profileRun);
+                    const integratedRun =
+                        integratedRendererProgramRuns.get(profileRun);
+                    const valid =
+                        legacyRun?.valid === true &&
+                        integratedRun?.valid === true &&
+                        Number.isFinite(legacyRun.value) &&
+                        Number.isFinite(integratedRun.value);
+                    return {
+                        increase: valid
+                            ? integratedRun.value - legacyRun.value
+                            : null,
+                        integrated: integratedRun?.value ?? null,
+                        legacy: legacyRun?.value ?? null,
+                        profileRun,
+                        valid,
+                    };
+                },
+            );
+            const validRendererProgramIncreases = pairedRendererProgramRuns
+                .filter((run) => run.valid)
+                .map((run) => run.increase);
+            const rendererProgramPairsComplete =
+                legacy.runCount === highTargetWeatherSurfacePairedRunCount &&
+                integrated.runCount ===
+                    highTargetWeatherSurfacePairedRunCount &&
+                validRendererProgramIncreases.length ===
+                    highTargetWeatherSurfacePairedRunCount;
+            const rendererProgramMaximumIncrease = rendererProgramPairsComplete
+                ? Math.max(...validRendererProgramIncreases)
+                : null;
+            const relativePerformanceChecks = [
+                {
+                    actual: {
+                        integrated: integrated.runCount,
+                        legacy: legacy.runCount,
+                    },
+                    comparison: 'paired-run-count',
+                    limit: highTargetWeatherSurfacePairedRunCount,
+                    name: 'weatherSurfacePairedRunCount',
+                    pass:
+                        legacy.runCount ===
+                            highTargetWeatherSurfacePairedRunCount &&
+                        integrated.runCount ===
+                            highTargetWeatherSurfacePairedRunCount,
+                },
+                lessThanLegacy(
+                    'weatherSurfaceDrawCallReduction',
+                    drawCallsPerRenderedFrame,
+                ),
+                lessThanLegacy(
+                    'weatherSurfaceTriangleReduction',
+                    trianglesPerRenderedFrame,
+                ),
+                {
+                    actual: validGpuRatios.length,
+                    comparison: 'equal',
+                    limit: highTargetWeatherSurfacePairedRunCount,
+                    name: 'weatherSurfaceGpuPairCompleteness',
+                    pass: gpuTimingStatus === 'valid',
+                },
+                {
+                    actual: gpuMedianRatio,
+                    comparison: 'maximum',
+                    limit: highTargetWeatherSurfaceMaximumGpuMedianRatio,
+                    name: 'weatherSurfaceGpuMedianRatio',
+                    pass:
+                        gpuTimingStatus === 'valid' &&
+                        rawGpuMedianRatio <=
+                            highTargetWeatherSurfaceMaximumGpuMedianRatio,
+                },
+                {
+                    actual: gpuMaximumRunRatio,
+                    comparison: 'maximum',
+                    limit: highTargetWeatherSurfaceMaximumGpuRunRatio,
+                    name: 'weatherSurfaceGpuMaximumRunRatio',
+                    pass:
+                        gpuTimingStatus === 'valid' &&
+                        rawGpuMaximumRunRatio <=
+                            highTargetWeatherSurfaceMaximumGpuRunRatio,
+                },
+                {
+                    actual: rendererProgramMaximumIncrease,
+                    comparison: 'maximum-increase',
+                    limit: highTargetWeatherSurfaceMaximumProgramIncrease,
+                    name: 'weatherSurfaceRendererProgramBound',
+                    pass:
+                        rendererProgramPairsComplete &&
+                        rendererProgramMaximumIncrease <=
+                            highTargetWeatherSurfaceMaximumProgramIncrease,
+                },
+            ];
+            const relativePerformancePass = relativePerformanceChecks.every(
+                (check) => check.pass,
+            );
+            const pairedPass = structuralPass && relativePerformancePass;
+
+            return [
+                pairName,
+                {
+                    acceptancePassRate: {
+                        integrated: passRate(integrated, 'acceptedRunCount'),
+                        legacy: passRate(legacy, 'acceptedRunCount'),
+                    },
+                    aggregatePass: {
+                        integrated: integrated.pass && pairedPass,
+                        legacy: legacy.pass,
+                    },
+                    avoidedOverlaySubmissions:
+                        integrated.weatherSurfaceAvoidedOverlaySubmissionCount,
+                    avoidedOverlayTriangles:
+                        integrated.weatherSurfaceAvoidedOverlayTriangleCount,
+                    drawCallsPerRenderedFrame,
+                    fallbackOverlaySubmissions,
+                    fallbackOverlayTriangles,
+                    gpuElapsedP95Ms,
+                    gpuMaximumRunRatio,
+                    gpuMedianRatio,
+                    gpuTimingStatus,
+                    integratedInstanceCount:
+                        integrated.weatherSurfaceIntegratedInstanceCount,
+                    integratedMaterialCount:
+                        integrated.weatherSurfaceIntegratedMaterialCount,
+                    integratedName,
+                    integratedPluginVariantCount:
+                        integrated.weatherSurfacePluginVariantCount,
+                    legacyName,
+                    p95FrameMs: metricComparison(
+                        legacy,
+                        integrated,
+                        'p95FrameMs',
+                    ),
+                    pairedPass,
+                    performancePassRate: {
+                        integrated: passRate(
+                            integrated,
+                            'performancePassedRunCount',
+                        ),
+                        legacy: passRate(legacy, 'performancePassedRunCount'),
+                    },
+                    pairedGpuRuns,
+                    pairedRendererProgramRuns,
+                    renderedFps: metricComparison(
+                        legacy,
+                        integrated,
+                        'renderedFps',
+                    ),
+                    rendererShaders,
+                    rendererProgramMaximumIncrease,
+                    relativePerformanceChecks,
+                    relativePerformancePass,
+                    structuralChecks,
+                    structuralPass,
+                    trianglesPerRenderedFrame,
+                },
+            ];
+        }).filter(Boolean),
+    );
+}
+
 function buildProfileSummary(scenarios, highTargetMedians) {
     const nonHighTargetScenarios = scenarios.filter(
         (scenario) => scenario.requested?.gardenProfile !== 'high-target',
@@ -4947,6 +6254,11 @@ function buildProfileSummary(scenarios, highTargetMedians) {
     )
         .filter((comparison) => !comparison.relativePerformancePass)
         .map((comparison) => comparison.adaptiveName);
+    const weatherSurfaceFailureNames = Object.values(
+        buildWeatherSurfaceComparisons(highTargetMedians),
+    )
+        .filter((comparison) => !comparison.pairedPass)
+        .map((comparison) => comparison.integratedName);
     const failedScenarioNames = [
         ...new Set([
             ...nonHighTargetScenarios
@@ -4956,6 +6268,7 @@ function buildProfileSummary(scenarios, highTargetMedians) {
                 .filter(([, result]) => !result.pass)
                 .map(([name]) => name),
             ...comparativeFailureNames,
+            ...weatherSurfaceFailureNames,
         ]),
     ];
     const totalScenarios =
@@ -5693,7 +7006,7 @@ function buildMarkdown(report) {
                 ? ''
                 : `; operation objects ${operationVisualObjectCount}/${highTargetOperationVisualLegacyObjectCount} legacy`;
         const detailCounts = scenario.runtime
-            ? `field visuals ${scenario.runtime.raisedBedFieldVisualInstanceCount ?? 0} instances/${scenario.runtime.raisedBedFieldVisualObjectCount ?? 0} objects/${scenario.runtime.raisedBedFieldVisualBatchCount ?? 0} batches/${scenario.runtime.raisedBedFieldVisualChunkCount ?? 0} chunks, uploads ${scenario.runtime.raisedBedFieldVisualMatrixUploadCount ?? 0}/${scenario.runtime.raisedBedFieldVisualUploadedInstanceCount ?? 0}; mulch ${scenario.runtime.raisedBedMulchInstanceCount ?? scenario.runtime.raisedBedMulchOverlayCount ?? 0} instances/${scenario.runtime.raisedBedMulchObjectCount ?? 0} objects/${scenario.runtime.raisedBedMulchBatchCount ?? 0} batches/${scenario.runtime.raisedBedMulchGroupCount ?? 0} groups${operationVisualObjectDetail}; snow/decor ${scenario.runtime.instancedSnowOverlayCount ?? 0}+${scenario.runtime.raisedBedMulchOverlayCount ?? 0}/${scenario.runtime.groundDecorationCount ?? 0}, visible ${scenario.runtime.groundDecorationVisibleCount ?? 'n/a'}, pages ${scenario.runtime.groundDecorationAtlasPageCount ?? 'n/a'}, chunks ${scenario.runtime.groundDecorationChunkCount ?? 'n/a'}, surface materials/uniforms snow ${scenario.runtime.snowOverlayMaterialConsumerCount ?? 'n/a'}/${scenario.runtime.snowOverlayDistinctUniformCount ?? 'n/a'}, rain ${scenario.runtime.rainWetOverlayMaterialConsumerCount ?? 'n/a'}/${scenario.runtime.rainWetOverlayDistinctUniformCount ?? 'n/a'}`
+            ? `field visuals ${scenario.runtime.raisedBedFieldVisualInstanceCount ?? 0} instances/${scenario.runtime.raisedBedFieldVisualObjectCount ?? 0} objects/${scenario.runtime.raisedBedFieldVisualBatchCount ?? 0} batches/${scenario.runtime.raisedBedFieldVisualChunkCount ?? 0} chunks, uploads ${scenario.runtime.raisedBedFieldVisualMatrixUploadCount ?? 0}/${scenario.runtime.raisedBedFieldVisualUploadedInstanceCount ?? 0}; mulch ${scenario.runtime.raisedBedMulchInstanceCount ?? scenario.runtime.raisedBedMulchOverlayCount ?? 0} instances/${scenario.runtime.raisedBedMulchObjectCount ?? 0} objects/${scenario.runtime.raisedBedMulchBatchCount ?? 0} batches/${scenario.runtime.raisedBedMulchGroupCount ?? 0} groups${operationVisualObjectDetail}; snow/decor ${scenario.runtime.instancedSnowOverlayCount ?? 0}+${scenario.runtime.raisedBedMulchOverlayCount ?? 0}/${scenario.runtime.groundDecorationCount ?? 0}, visible ${scenario.runtime.groundDecorationVisibleCount ?? 'n/a'}, pages ${scenario.runtime.groundDecorationAtlasPageCount ?? 'n/a'}, chunks ${scenario.runtime.groundDecorationChunkCount ?? 'n/a'}, surface materials/uniforms snow ${scenario.runtime.snowOverlayMaterialConsumerCount ?? 'n/a'}/${scenario.runtime.snowOverlayDistinctUniformCount ?? 'n/a'}, rain ${scenario.runtime.rainWetOverlayMaterialConsumerCount ?? 'n/a'}/${scenario.runtime.rainWetOverlayDistinctUniformCount ?? 'n/a'}; weather surface ${scenario.runtime.weatherSurfaceMode ?? 'n/a'}, integrated ${scenario.runtime.weatherSurfaceIntegratedInstanceCount ?? 'n/a'} instances/${scenario.runtime.weatherSurfaceIntegratedMaterialCount ?? 'n/a'} materials/${scenario.runtime.weatherSurfacePluginVariantCount ?? 'n/a'} plugin variants, avoided ${scenario.runtime.weatherSurfaceAvoidedOverlaySubmissionCount ?? 'n/a'} submissions/${scenario.runtime.weatherSurfaceAvoidedOverlayTriangleCount ?? 'n/a'} overlay-triangle proxy, fallback ${scenario.runtime.weatherSurfaceFallbackOverlaySubmissionCount ?? 'n/a'} submissions/${scenario.runtime.weatherSurfaceFallbackOverlayTriangleCount ?? 'n/a'} overlay-triangle proxy`
             : 'n/a';
         const screenshot = scenario.screenshotPath ?? 'n/a';
         lines.push(
@@ -5736,6 +7049,55 @@ function buildMarkdown(report) {
         for (const [pairName, comparison] of adaptiveHighComparisons) {
             lines.push(
                 `| ${pairName} | ${comparison.fixedName} / ${comparison.adaptiveName} | ${comparison.acceptancePassRate.fixed ?? 'n/a'}% → ${comparison.acceptancePassRate.adaptive ?? 'n/a'}% | ${comparison.performancePassRate.fixed ?? 'n/a'}% → ${comparison.performancePassRate.adaptive ?? 'n/a'}% | ${formatComparison(comparison.p95FrameMs, ' ms')} | ${formatComparison(comparison.gpuElapsedP95Ms, ' ms')} | ${formatComparison(comparison.renderedFps)} | ${comparison.relativePerformancePass ? 'pass' : 'fail'} | ${comparison.aggregatePass.fixed ? 'pass' : 'fail'} → ${comparison.aggregatePass.adaptive ? 'pass' : 'fail'} |`,
+            );
+        }
+    }
+
+    const weatherSurfaceComparisons = Object.entries(
+        report.weatherSurfaceComparisons ??
+            buildWeatherSurfaceComparisons(report.highTargetMedians ?? {}),
+    );
+    if (weatherSurfaceComparisons.length > 0) {
+        lines.push(
+            '',
+            '## Integrated weather-surface paired comparison',
+            '',
+            '| Pair | Legacy / Integrated | Acceptance pass rate | Performance pass rate | Draw/render legacy → integrated | Triangles/render legacy → integrated | GPU p95 legacy → integrated | Paired GPU ratio median/max | Renderer programs legacy → integrated | Fallback submissions legacy → integrated | Fallback overlay-triangle proxy legacy → integrated | Integrated instances/materials/plugin variants | Avoided submissions/overlay-triangle proxy | Structural gate | Relative performance gate | Aggregate |',
+            '| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- |',
+        );
+        const formatComparison = (comparison, suffix = '') =>
+            `${comparison.legacy ?? 'n/a'} → ${comparison.integrated ?? 'n/a'}${suffix} (${comparison.percentDelta ?? 'n/a'}%)`;
+        for (const [pairName, comparison] of weatherSurfaceComparisons) {
+            lines.push(
+                `| ${pairName} | ${comparison.legacyName} / ${comparison.integratedName} | ${comparison.acceptancePassRate.legacy ?? 'n/a'}% → ${comparison.acceptancePassRate.integrated ?? 'n/a'}% | ${comparison.performancePassRate.legacy ?? 'n/a'}% → ${comparison.performancePassRate.integrated ?? 'n/a'}% | ${formatComparison(comparison.drawCallsPerRenderedFrame)} | ${formatComparison(comparison.trianglesPerRenderedFrame)} | ${formatComparison(comparison.gpuElapsedP95Ms, ' ms')} | ${comparison.gpuTimingStatus === 'valid' ? `${comparison.gpuMedianRatio}/${comparison.gpuMaximumRunRatio}` : 'inconclusive'} | ${formatComparison(comparison.rendererShaders)} | ${formatComparison(comparison.fallbackOverlaySubmissions)} | ${formatComparison(comparison.fallbackOverlayTriangles)} | ${comparison.integratedInstanceCount.median ?? 'n/a'}/${comparison.integratedMaterialCount.median ?? 'n/a'}/${comparison.integratedPluginVariantCount.median ?? 'n/a'} | ${comparison.avoidedOverlaySubmissions.median ?? 'n/a'}/${comparison.avoidedOverlayTriangles.median ?? 'n/a'} | ${comparison.structuralPass ? 'pass' : 'fail'} | ${comparison.relativePerformancePass ? 'pass' : 'fail'} | ${comparison.aggregatePass.legacy ? 'pass' : 'fail'} → ${comparison.aggregatePass.integrated ? 'pass' : 'fail'} |`,
+            );
+        }
+    }
+
+    const weatherSurfaceTransitions = report.scenarios.filter(
+        (scenario) => scenario.sample.weatherSurfaceTransitionProfile,
+    );
+    if (weatherSurfaceTransitions.length > 0) {
+        lines.push(
+            '',
+            '## Weather-surface threshold transition',
+            '',
+            '| Scenario | Tracked | Ready initial → entered → dwell → exited | Transition count initial → entered → dwell → exited | Integrated instances entered → exited | Avoided submissions/overlay-triangle proxy entered | Fallback submissions/overlay-triangle proxy entered → exited | Result |',
+            '| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
+        );
+        for (const scenario of weatherSurfaceTransitions) {
+            const transition = scenario.sample.weatherSurfaceTransitionProfile;
+            const formatPhaseValues = (field) =>
+                [
+                    transition.initial?.[field],
+                    transition.entered?.[field],
+                    transition.dwell?.[field],
+                    transition.exited?.[field],
+                ]
+                    .map((value) => value ?? 'n/a')
+                    .join(' → ');
+            lines.push(
+                `| ${scenario.name} | ${transition.initial?.trackedCount ?? 'n/a'} | ${formatPhaseValues('readyCount')} | ${formatPhaseValues('transitionCount')} | ${transition.entered?.integratedInstanceCount ?? 'n/a'} → ${transition.exited?.integratedInstanceCount ?? 'n/a'} | ${transition.entered?.avoidedOverlaySubmissionCount ?? 'n/a'}/${transition.entered?.avoidedOverlayTriangleCount ?? 'n/a'} | ${transition.entered?.fallbackOverlaySubmissionCount ?? 'n/a'}/${transition.entered?.fallbackOverlayTriangleCount ?? 'n/a'} → ${transition.exited?.fallbackOverlaySubmissionCount ?? 'n/a'}/${transition.exited?.fallbackOverlayTriangleCount ?? 'n/a'} | ${transition.error === null ? 'pass' : `fail: ${transition.error}`} |`,
             );
         }
     }
@@ -5787,6 +7149,23 @@ function buildMarkdown(report) {
                 .map(
                     (check) =>
                         `- ${pairName} relative: ${check.name} ${check.actual} missed ${check.limit}`,
+                ),
+        ),
+        ...weatherSurfaceComparisons.flatMap(([pairName, comparison]) =>
+            [
+                ...comparison.structuralChecks.map((check) => ({
+                    ...check,
+                    group: 'structural',
+                })),
+                ...comparison.relativePerformanceChecks.map((check) => ({
+                    ...check,
+                    group: 'relative',
+                })),
+            ]
+                .filter((check) => !check.pass)
+                .map(
+                    (check) =>
+                        `- ${pairName} ${check.group}: ${check.name} ${check.actual} missed ${check.limit}`,
                 ),
         ),
     ];
@@ -6099,36 +7478,34 @@ async function main() {
 
     try {
         const scenarios = [];
-        for (const scenario of profileScenarios) {
-            const repeat = scenario.plantCloseup
-                ? (options.closeupRepeat ?? scenario.plantCloseup.repeat)
-                : (scenario.repeat ?? 1);
-            for (let runIndex = 1; runIndex <= repeat; runIndex += 1) {
-                const runScenario =
-                    repeat === 1
-                        ? scenario
-                        : {
-                              ...scenario,
-                              name: `${scenario.name}-run-${runIndex}`,
-                          };
-                console.log(
-                    `Profiling ${scenario.name}${repeat > 1 ? ` (${runIndex}/${repeat})` : ''}...`,
-                );
-                const result = await measureScenario(
-                    browser,
-                    options.baseUrl,
-                    runScenario,
-                    options,
-                );
-                result.baseName = scenario.name;
-                result.profileRun = runIndex;
-                scenarios.push(result);
-            }
+        const runQueue = buildScenarioRunQueue(profileScenarios, {
+            closeupRepeat: options.closeupRepeat,
+        });
+        for (const {
+            baseScenario,
+            repeat,
+            runIndex,
+            runScenario,
+        } of runQueue) {
+            console.log(
+                `Profiling ${baseScenario.name}${repeat > 1 ? ` (${runIndex}/${repeat})` : ''}...`,
+            );
+            const result = await measureScenario(
+                browser,
+                options.baseUrl,
+                runScenario,
+                options,
+            );
+            result.baseName = baseScenario.name;
+            result.profileRun = runIndex;
+            scenarios.push(result);
         }
 
         const highTargetMedians = buildHighTargetMedians(scenarios);
         const adaptiveHighComparisons =
             buildAdaptiveHighComparisons(highTargetMedians);
+        const weatherSurfaceComparisons =
+            buildWeatherSurfaceComparisons(highTargetMedians);
         const profileSummary = buildProfileSummary(
             scenarios,
             highTargetMedians,
@@ -6163,6 +7540,7 @@ async function main() {
                 durationMs: Date.now() - startedAt,
                 ...profileSummary,
             },
+            weatherSurfaceComparisons,
         };
 
         await writeReports(report, options.outDir);
@@ -6190,6 +7568,8 @@ export {
     buildPlantCloseupAcceptance,
     buildPlantCloseupMedians,
     buildProfileSummary,
+    buildScenarioRunQueue,
+    buildWeatherSurfaceComparisons,
     drainProfileSample,
     evaluateBudget,
     evaluateHighTargetAcceptance,

--- a/apps/garden/scripts/profile-game-scene.unit.mjs
+++ b/apps/garden/scripts/profile-game-scene.unit.mjs
@@ -7,6 +7,8 @@ import {
     buildPlantCloseupAcceptance,
     buildPlantCloseupMedians,
     buildProfileSummary,
+    buildScenarioRunQueue,
+    buildWeatherSurfaceComparisons,
     drainProfileSample,
     evaluateBudget,
     evaluateHighTargetAcceptance,
@@ -196,6 +198,7 @@ test('operation-visual High scenario is isolated behind its own opt-in set', () 
         outline: '0',
         placement: '0',
         quality: 'high',
+        weatherSurface: 'integrated',
     });
     assert.equal(
         resolveScenarios('high-target').some(
@@ -228,6 +231,151 @@ test('foliage-budget High scenario reserves exact detail for explicit close-up',
     assert.equal(request.foliageBudget, '1');
     assert.equal(request.gardenProfile, 'high-target');
     assert.equal(request.quality, 'high');
+});
+
+test('weather-material High scenarios pair legacy and integrated rain and snow', () => {
+    const scenarios = resolveScenarios('high-target-weather-materials');
+
+    assert.deepEqual(
+        scenarios.map((scenario) => scenario.name),
+        [
+            'game-high-target-rain-legacy-weather-surfaces-desktop',
+            'game-high-target-rain-integrated-weather-surfaces-desktop',
+            'game-high-target-snow-legacy-weather-surfaces-desktop',
+            'game-high-target-snow-integrated-weather-surfaces-desktop',
+        ],
+    );
+    assert.deepEqual(
+        scenarios.map((scenario) => scenario.comparisonPair),
+        [
+            'rain-weather-surfaces',
+            'rain-weather-surfaces',
+            'snow-weather-surfaces',
+            'snow-weather-surfaces',
+        ],
+    );
+    assert.deepEqual(
+        scenarios.map((scenario) => scenario.comparisonRole),
+        ['legacy', 'integrated', 'legacy', 'integrated'],
+    );
+    assert.deepEqual(
+        scenarios.map((scenario) => getScenarioRequest(scenario.path).mode),
+        ['rain', 'rain', 'snow', 'snow'],
+    );
+    assert.deepEqual(
+        scenarios.map(
+            (scenario) => getScenarioRequest(scenario.path).weatherSurface,
+        ),
+        ['legacy', 'integrated', 'legacy', 'integrated'],
+    );
+    for (const scenario of scenarios) {
+        const request = getScenarioRequest(scenario.path);
+        assert.equal(request.gardenProfile, 'high-target');
+        assert.equal(request.quality, 'high');
+        assert.equal(scenario.budget, 'gameHighTarget');
+        assert.equal(scenario.dpr, 2);
+        assert.equal(scenario.isMobile, false);
+        assert.equal(scenario.repeat, 5);
+    }
+});
+
+test('weather-material runs interleave five legacy and integrated samples per pair', () => {
+    const queue = buildScenarioRunQueue(
+        resolveScenarios('high-target-weather-materials'),
+    );
+    const expectedPairOrder = [
+        'legacy:1',
+        'integrated:1',
+        'integrated:2',
+        'legacy:2',
+        'legacy:3',
+        'integrated:3',
+        'integrated:4',
+        'legacy:4',
+        'legacy:5',
+        'integrated:5',
+    ];
+
+    assert.equal(queue.length, 20);
+    for (const [pairIndex, pairName] of [
+        [0, 'rain-weather-surfaces'],
+        [1, 'snow-weather-surfaces'],
+    ]) {
+        assert.deepEqual(
+            queue
+                .slice(pairIndex * 10, pairIndex * 10 + 10)
+                .map(
+                    ({ baseScenario, runIndex }) =>
+                        `${baseScenario.comparisonRole}:${runIndex}`,
+                ),
+            expectedPairOrder,
+            `${pairName} should use an ABBA-balanced order`,
+        );
+    }
+
+    const unpairedQueue = buildScenarioRunQueue(
+        resolveScenarios('high-target-operation-visuals'),
+    );
+    assert.deepEqual(
+        unpairedQueue.map(({ runIndex }) => runIndex),
+        [1, 2, 3],
+    );
+});
+
+test('snow-onset High scenarios provide deterministic visual legacy and integrated cases', () => {
+    const scenarios = resolveScenarios('high-target-weather-onset');
+
+    assert.deepEqual(
+        scenarios.map((scenario) => scenario.name),
+        [
+            'game-high-target-snow-onset-legacy-weather-surfaces-desktop',
+            'game-high-target-snow-onset-integrated-weather-surfaces-desktop',
+            'game-high-target-snow-threshold-transition-integrated-weather-surfaces-desktop',
+        ],
+    );
+    assert.deepEqual(
+        scenarios.map((scenario) => scenario.comparisonPair),
+        [undefined, undefined, undefined],
+    );
+    assert.deepEqual(
+        scenarios.map((scenario) => scenario.comparisonRole),
+        [undefined, undefined, undefined],
+    );
+    assert.deepEqual(
+        scenarios.map((scenario) => getScenarioRequest(scenario.path).mode),
+        ['snow-onset', 'snow-onset', 'snow-onset'],
+    );
+    assert.deepEqual(
+        scenarios.map(
+            (scenario) => getScenarioRequest(scenario.path).weatherSurface,
+        ),
+        ['legacy', 'integrated', 'integrated'],
+    );
+    for (const scenario of scenarios) {
+        const request = getScenarioRequest(scenario.path);
+        assert.equal(request.gardenProfile, 'high-target');
+        assert.equal(request.quality, 'high');
+        assert.equal(scenario.budget, 'gameHighTarget');
+        assert.equal(scenario.dpr, 2);
+        assert.equal(scenario.isMobile, false);
+        assert.equal(scenario.repeat, 1);
+    }
+    assert.equal(
+        scenarios[2].weatherSurfaceTransition,
+        'snow-integration-cycle',
+    );
+});
+
+test('profile request defaults invalid weather-surface values to integrated', () => {
+    assert.equal(
+        getScenarioRequest('/debug/profile/game').weatherSurface,
+        'integrated',
+    );
+    assert.equal(
+        getScenarioRequest('/debug/profile/game?weatherSurface=unexpected')
+            .weatherSurface,
+        'integrated',
+    );
 });
 
 test('outline scenario deterministically targets the connected raised bed after warmup', () => {
@@ -414,6 +562,7 @@ test('profile request parses the High target fixture contract', () => {
         outline: '0',
         placement: '0',
         quality: 'high',
+        weatherSurface: 'integrated',
     });
 });
 
@@ -433,6 +582,9 @@ test('runtime GPU-source scenario disables only the external profiler timer', ()
         /if \(externalGpuTimer\) \{[\s\S]*__gameProfileGpuTimer/,
     );
     assert.match(source, /__gameProfileMetrics =/);
+    assert.match(source, /patchedCreateProgram/);
+    assert.match(source, /patchedDeleteProgram/);
+    assert.match(source, /rendererShaders: 0/);
 });
 
 test('render budgets gate calls and triangles per rendered frame', () => {
@@ -1001,6 +1153,23 @@ test('high target acceptance proves the intended workload rendered', () => {
         )?.pass,
         false,
     );
+
+    const shaderErrorResult = evaluateHighTargetAcceptance({
+        ...input,
+        consoleMessages: [
+            {
+                type: 'error',
+                text: 'THREE.WebGLProgram: Shader Error',
+            },
+        ],
+    });
+    assert.equal(shaderErrorResult.pass, false);
+    assert.equal(
+        shaderErrorResult.checks.find(
+            (check) => check.name === 'highTargetConsoleErrors',
+        )?.pass,
+        false,
+    );
 });
 
 test('operation-visual High acceptance gates batching, uploads, mulch, and highlight identity', () => {
@@ -1308,6 +1477,396 @@ test('foliage-budget High acceptance keeps normal-view foliage clustered', () =>
         expensiveClusters.checks.find(
             (check) =>
                 check.name === 'highTargetFoliageClusterPrimitiveTriangles',
+        )?.pass,
+        false,
+    );
+});
+
+test('weather-surface High acceptance proves integrated work without hiding fallbacks', () => {
+    const input = ({ mode, weatherSurface }) => {
+        const integrated = weatherSurface === 'integrated';
+        const rain = mode === 'rain';
+        return {
+            apiErrors: [],
+            pageErrors: [],
+            requested: {
+                blockGeometryMerging: '1',
+                gardenProfile: 'high-target',
+                mode,
+                motion: 'none',
+                quality: 'high',
+                weatherSurface,
+            },
+            runtime: {
+                actorGroundingShadowBatchCount: 1,
+                actorGroundingShadowCount: 4,
+                actorGroundingShadowDroppedCount: 0,
+                actorGroundingShadowPrimaryCasterCount: 0,
+                actorGroundingShadowVisibleCount: 4,
+                animatedCasterShadowRefreshCount: 0,
+                generatedPlantExpectedInstanceCount: 537,
+                generatedPlantFieldCount: 54,
+                generatedPlantInstanceCount: 537,
+                generatedPlantVisibleFieldCount: 54,
+                generatedPlantVisibleInstanceCount: 537,
+                groundDecorationCount: rain ? 596 : 0,
+                groundDecorationDensity: 1,
+                groundDecorationVisibleCount: rain ? 571 : null,
+                qualityTier: 'high',
+                rainParticleCount: rain ? 2_000 : 0,
+                rendererShaders: rain
+                    ? integrated
+                        ? 38
+                        : 39
+                    : integrated
+                      ? 42
+                      : 43,
+                shadowMapSize: 4_096,
+                shadowsEnabled: true,
+                snowParticleCapacity: rain ? 0 : 5_000,
+                snowParticleCount: rain ? 0 : 3_500,
+                weatherSurfaceAvoidedOverlaySubmissionCount: integrated
+                    ? rain
+                        ? 16
+                        : 8
+                    : 0,
+                weatherSurfaceAvoidedOverlayTriangleCount: integrated
+                    ? rain
+                        ? 2_556
+                        : 11_880
+                    : 0,
+                weatherSurfaceFallbackOverlaySubmissionCount: integrated
+                    ? rain
+                        ? 29
+                        : 48
+                    : rain
+                      ? 45
+                      : 56,
+                weatherSurfaceFallbackOverlayTriangleCount: integrated
+                    ? rain
+                        ? 13_562
+                        : 72_608
+                    : rain
+                      ? 16_118
+                      : 84_488,
+                weatherSurfaceIntegratedInstanceCount: integrated
+                    ? rain
+                        ? 213
+                        : 270
+                    : 0,
+                weatherSurfaceIntegratedMaterialCount: integrated
+                    ? rain
+                        ? 2
+                        : 1
+                    : 0,
+                weatherSurfaceMode: weatherSurface,
+                weatherSurfacePluginVariantCount: integrated ? 1 : 0,
+            },
+            sample: {
+                actorGroundingShadowUpdateCountDelta: 60,
+                animatedCasterShadowRefreshCountDelta: 0,
+                canvas: {
+                    clientHeight: 720,
+                    clientWidth: 1280,
+                    height: 1440,
+                    width: 2560,
+                },
+                drawCalls: 100,
+                elapsedMs: 5_000,
+                renderedFps: 12,
+                renderedFrames: 60,
+                reportedDpr: 2,
+                submittedTriangles: 1_000_000,
+            },
+        };
+    };
+
+    for (const mode of ['rain', 'snow']) {
+        assert.equal(
+            evaluateHighTargetAcceptance(
+                input({ mode, weatherSurface: 'legacy' }),
+            ).pass,
+            true,
+        );
+        assert.equal(
+            evaluateHighTargetAcceptance(
+                input({ mode, weatherSurface: 'integrated' }),
+            ).pass,
+            true,
+        );
+    }
+
+    const snowIntegrated = input({
+        mode: 'snow',
+        weatherSurface: 'integrated',
+    });
+    for (const [field, value, checkName] of [
+        [
+            'weatherSurfaceIntegratedInstanceCount',
+            213,
+            'highTargetWeatherSurfaceIntegratedInstances',
+        ],
+        [
+            'weatherSurfaceIntegratedMaterialCount',
+            2,
+            'highTargetWeatherSurfaceIntegratedMaterials',
+        ],
+        [
+            'weatherSurfaceAvoidedOverlaySubmissionCount',
+            16,
+            'highTargetWeatherSurfaceAvoidedOverlaySubmissions',
+        ],
+        [
+            'weatherSurfaceAvoidedOverlayTriangleCount',
+            9_372,
+            'highTargetWeatherSurfaceAvoidedOverlayTriangles',
+        ],
+        [
+            'weatherSurfaceFallbackOverlaySubmissionCount',
+            56,
+            'highTargetWeatherSurfaceFallbackOverlaySubmissions',
+        ],
+        [
+            'weatherSurfaceFallbackOverlayTriangleCount',
+            74_500,
+            'highTargetWeatherSurfaceFallbackOverlayTriangles',
+        ],
+    ]) {
+        const result = evaluateHighTargetAcceptance({
+            ...snowIntegrated,
+            runtime: {
+                ...snowIntegrated.runtime,
+                [field]: value,
+            },
+        });
+        assert.equal(
+            result.checks.find((check) => check.name === checkName)?.pass,
+            false,
+            `${checkName} should keep steady snow separate from the threshold transition fixture`,
+        );
+    }
+
+    const rainIntegrated = input({
+        mode: 'rain',
+        weatherSurface: 'integrated',
+    });
+    for (const [field, value, checkName] of [
+        [
+            'weatherSurfaceIntegratedInstanceCount',
+            212,
+            'highTargetWeatherSurfaceIntegratedInstances',
+        ],
+        [
+            'weatherSurfaceIntegratedMaterialCount',
+            0,
+            'highTargetWeatherSurfaceIntegratedMaterials',
+        ],
+        [
+            'weatherSurfacePluginVariantCount',
+            2,
+            'highTargetWeatherSurfacePluginVariants',
+        ],
+        [
+            'weatherSurfaceAvoidedOverlaySubmissionCount',
+            15,
+            'highTargetWeatherSurfaceAvoidedOverlaySubmissions',
+        ],
+        [
+            'weatherSurfaceAvoidedOverlayTriangleCount',
+            2_555,
+            'highTargetWeatherSurfaceAvoidedOverlayTriangles',
+        ],
+        [
+            'weatherSurfaceFallbackOverlaySubmissionCount',
+            28,
+            'highTargetWeatherSurfaceFallbackOverlaySubmissions',
+        ],
+        [
+            'weatherSurfaceFallbackOverlayTriangleCount',
+            13_561,
+            'highTargetWeatherSurfaceFallbackOverlayTriangles',
+        ],
+        ['rendererShaders', 0, 'highTargetWeatherSurfaceRendererPrograms'],
+    ]) {
+        const result = evaluateHighTargetAcceptance({
+            ...rainIntegrated,
+            runtime: {
+                ...rainIntegrated.runtime,
+                [field]: value,
+            },
+        });
+        assert.equal(
+            result.checks.find((check) => check.name === checkName)?.pass,
+            false,
+            `${checkName} should reject ${field}=${value}`,
+        );
+    }
+
+    assert.equal(
+        evaluateHighTargetAcceptance({
+            ...rainIntegrated,
+            runtime: {
+                ...rainIntegrated.runtime,
+                rainParticleCount: 1_999,
+            },
+        }).pass,
+        false,
+    );
+
+    const onsetIntegrated = {
+        ...input({ mode: 'rain', weatherSurface: 'integrated' }),
+        requested: {
+            ...rainIntegrated.requested,
+            mode: 'snow-onset',
+        },
+        runtime: {
+            ...rainIntegrated.runtime,
+            rainParticleCount: 0,
+            snowParticleCount: 0,
+            weatherSurfaceAvoidedOverlaySubmissionCount: 0,
+            weatherSurfaceAvoidedOverlayTriangleCount: 0,
+            weatherSurfaceFallbackOverlaySubmissionCount: 51,
+            weatherSurfaceFallbackOverlayTriangleCount: 31_900,
+            weatherSurfaceIntegratedInstanceCount: 0,
+            weatherSurfaceIntegratedMaterialCount: 0,
+            weatherSurfacePluginVariantCount: 0,
+        },
+    };
+    assert.equal(evaluateHighTargetAcceptance(onsetIntegrated).pass, true);
+    for (const [field, value, checkName] of [
+        [
+            'weatherSurfaceMode',
+            'legacy',
+            'highTargetWeatherSurfaceOnsetRuntimeMode',
+        ],
+        [
+            'weatherSurfaceIntegratedInstanceCount',
+            1,
+            'highTargetWeatherSurfaceOnsetIntegratedInstances',
+        ],
+        [
+            'weatherSurfaceIntegratedMaterialCount',
+            1,
+            'highTargetWeatherSurfaceOnsetIntegratedMaterials',
+        ],
+        [
+            'weatherSurfacePluginVariantCount',
+            1,
+            'highTargetWeatherSurfaceOnsetPluginVariants',
+        ],
+        [
+            'weatherSurfaceAvoidedOverlaySubmissionCount',
+            1,
+            'highTargetWeatherSurfaceOnsetAvoidedOverlaySubmissions',
+        ],
+        [
+            'weatherSurfaceAvoidedOverlayTriangleCount',
+            1,
+            'highTargetWeatherSurfaceOnsetAvoidedOverlayTriangles',
+        ],
+        [
+            'weatherSurfaceFallbackOverlaySubmissionCount',
+            50,
+            'highTargetWeatherSurfaceOnsetFallbackOverlaySubmissions',
+        ],
+        [
+            'weatherSurfaceFallbackOverlayTriangleCount',
+            31_899,
+            'highTargetWeatherSurfaceOnsetFallbackOverlayTriangles',
+        ],
+        ['snowParticleCount', 1, 'highTargetWeatherSurfaceOnsetSnowParticles'],
+    ]) {
+        const result = evaluateHighTargetAcceptance({
+            ...onsetIntegrated,
+            runtime: {
+                ...onsetIntegrated.runtime,
+                [field]: value,
+            },
+        });
+        assert.equal(
+            result.checks.find((check) => check.name === checkName)?.pass,
+            false,
+            `${checkName} should reject ${field}=${value}`,
+        );
+    }
+
+    const sparseSnapshot = {
+        avoidedOverlaySubmissionCount: 0,
+        avoidedOverlayTriangleCount: 0,
+        fallbackOverlaySubmissionCount: 51,
+        fallbackOverlayTriangleCount: 31_900,
+        integratedInstanceCount: 0,
+        integratedMaterialCount: 0,
+        pluginVariantCount: 0,
+        readyCount: 0,
+        snowParticleCount: 0,
+        trackedCount: 2,
+        transitionCount: 0,
+    };
+    const integratedSnapshot = {
+        avoidedOverlaySubmissionCount: 16,
+        avoidedOverlayTriangleCount: 9_372,
+        fallbackOverlaySubmissionCount: 56,
+        fallbackOverlayTriangleCount: 74_500,
+        integratedInstanceCount: 213,
+        integratedMaterialCount: 2,
+        pluginVariantCount: 1,
+        readyCount: 2,
+        snowParticleCount: 0,
+        trackedCount: 2,
+        transitionCount: 2,
+    };
+    const transitionRun = {
+        ...onsetIntegrated,
+        requested: {
+            ...onsetIntegrated.requested,
+            weatherSurfaceTransition: 'snow-integration-cycle',
+        },
+        runtime: {
+            ...onsetIntegrated.runtime,
+            weatherSurfaceSnowIntegrationReadyCount: 0,
+            weatherSurfaceSnowIntegrationTrackedCount: 2,
+            weatherSurfaceSnowIntegrationTransitionCount: 4,
+        },
+        sample: {
+            ...onsetIntegrated.sample,
+            weatherSurfaceTransitionProfile: {
+                dwell: integratedSnapshot,
+                enterDispatched: true,
+                entered: integratedSnapshot,
+                error: null,
+                exitDispatched: true,
+                exited: {
+                    ...sparseSnapshot,
+                    transitionCount: 4,
+                },
+                initial: sparseSnapshot,
+                request: 'snow-integration-cycle',
+            },
+        },
+    };
+    assert.equal(evaluateHighTargetAcceptance(transitionRun).pass, true);
+
+    const thrashedTransition = {
+        ...transitionRun,
+        sample: {
+            ...transitionRun.sample,
+            weatherSurfaceTransitionProfile: {
+                ...transitionRun.sample.weatherSurfaceTransitionProfile,
+                dwell: {
+                    ...integratedSnapshot,
+                    transitionCount: 4,
+                },
+            },
+        },
+    };
+    const thrashedResult = evaluateHighTargetAcceptance(thrashedTransition);
+    assert.equal(thrashedResult.pass, false);
+    assert.equal(
+        thrashedResult.checks.find(
+            (check) =>
+                check.name ===
+                'highTargetWeatherSurfaceTransitionDwellNoThrash',
         )?.pass,
         false,
     );
@@ -2280,6 +2839,9 @@ test('high target acceptance rejects zero work and an incomplete fixture', () =>
         apiErrors: [
             { status: 401, url: 'http://localhost/api/gardens/1/stacks' },
         ],
+        consoleMessages: [
+            { type: 'error', text: 'THREE.WebGLProgram: Shader Error' },
+        ],
         pageErrors: ['render failed'],
         requested: {
             blockGeometryMerging: '0',
@@ -2323,6 +2885,7 @@ function highTargetRun(value, index, acceptancePass = true) {
         budgetName: 'gameHighTarget',
         name: `game-high-target-clear-idle-desktop-run-${index + 1}`,
         performanceBudget: { pass: performancePass },
+        profileRun: index + 1,
         requested: { gardenProfile: 'high-target' },
         sample: {
             drawCallsPerFrame: 100,
@@ -2544,6 +3107,366 @@ test('adaptive High comparison reports paired pass rates and frame/GPU deltas', 
             .failedScenarioNames,
         ['game-high-target-adaptive-camera-motion-desktop'],
     );
+});
+
+test('weather-surface comparison gates render work, GPU time, and renderer programs', () => {
+    const pairedRun = ({ comparisonRole, index }) => {
+        const integrated = comparisonRole === 'integrated';
+        const baseName = `game-high-target-rain-${comparisonRole}-weather-surfaces-desktop`;
+        const run = highTargetRun(20, index);
+        return {
+            ...run,
+            baseName,
+            name: `${baseName}-run-${index + 1}`,
+            requested: {
+                ...run.requested,
+                comparisonPair: 'rain-weather-surfaces',
+                comparisonRole,
+            },
+            runtime: {
+                rendererShaders: integrated ? 41 : 40,
+                weatherSurfaceAvoidedOverlaySubmissionCount: integrated
+                    ? 16
+                    : 0,
+                weatherSurfaceAvoidedOverlayTriangleCount: integrated
+                    ? 2_556
+                    : 0,
+                weatherSurfaceFallbackOverlaySubmissionCount: integrated
+                    ? 29
+                    : 45,
+                weatherSurfaceFallbackOverlayTriangleCount: integrated
+                    ? 13_562
+                    : 16_118,
+                weatherSurfaceIntegratedInstanceCount: integrated ? 213 : 0,
+                weatherSurfaceIntegratedMaterialCount: integrated ? 16 : 0,
+                weatherSurfaceMode: comparisonRole,
+                weatherSurfacePluginVariantCount: integrated ? 1 : 0,
+            },
+            sample: {
+                ...run.sample,
+                drawCallsPerRenderedFrame: integrated ? 104 : 120,
+                gpu: {
+                    elapsedP95Ms: integrated ? 9.7 : 10,
+                    valid: true,
+                },
+                trianglesPerRenderedFrame: integrated ? 900_000 : 1_100_000,
+            },
+        };
+    };
+    const runs = [
+        ...[0, 1, 2, 3, 4].map((index) =>
+            pairedRun({ comparisonRole: 'legacy', index }),
+        ),
+        ...[0, 1, 2, 3, 4].map((index) =>
+            pairedRun({ comparisonRole: 'integrated', index }),
+        ),
+    ];
+    const medians = buildHighTargetMedians(runs);
+    const comparisons = buildWeatherSurfaceComparisons(medians);
+    const comparison = comparisons['rain-weather-surfaces'];
+
+    assert.deepEqual(comparison.acceptancePassRate, {
+        integrated: 100,
+        legacy: 100,
+    });
+    assert.deepEqual(comparison.fallbackOverlaySubmissions, {
+        delta: -16,
+        integrated: 29,
+        legacy: 45,
+        percentDelta: -35.6,
+    });
+    assert.deepEqual(comparison.fallbackOverlayTriangles, {
+        delta: -2_556,
+        integrated: 13_562,
+        legacy: 16_118,
+        percentDelta: -15.9,
+    });
+    assert.deepEqual(comparison.gpuElapsedP95Ms, {
+        delta: -0.3,
+        integrated: 9.7,
+        legacy: 10,
+        percentDelta: -3,
+    });
+    assert.equal(comparison.gpuTimingStatus, 'valid');
+    assert.equal(comparison.gpuMedianRatio, 0.97);
+    assert.equal(comparison.gpuMaximumRunRatio, 0.97);
+    assert.equal(comparison.pairedGpuRuns.length, 5);
+    assert.deepEqual(comparison.rendererShaders, {
+        delta: 1,
+        integrated: 41,
+        legacy: 40,
+        percentDelta: 2.5,
+    });
+    assert.equal(comparison.rendererProgramMaximumIncrease, 1);
+    assert.deepEqual(
+        comparison.pairedRendererProgramRuns.map(
+            ({ increase, integrated, legacy, profileRun, valid }) => ({
+                increase,
+                integrated,
+                legacy,
+                profileRun,
+                valid,
+            }),
+        ),
+        [1, 2, 3, 4, 5].map((profileRun) => ({
+            increase: 1,
+            integrated: 41,
+            legacy: 40,
+            profileRun,
+            valid: true,
+        })),
+    );
+    assert.equal(comparison.structuralPass, true);
+    assert.equal(comparison.relativePerformancePass, true);
+    assert.equal(comparison.pairedPass, true);
+    assert.equal(comparison.aggregatePass.integrated, true);
+    assert.equal(
+        comparison.relativePerformanceChecks.every((check) => check.pass),
+        true,
+    );
+    assert.equal(buildProfileSummary(runs, medians).failedScenarios, 0);
+    assert.match(
+        buildMarkdown({
+            adaptiveHighComparisons: {},
+            baseUrl: 'http://profile.local',
+            generatedAt: '2026-07-27T00:00:00.000Z',
+            highTargetMedians: medians,
+            options: {
+                build: false,
+                managedServer: false,
+                sampleMs: 5_000,
+                scenarios: [],
+                scenarioSet: 'high-target-weather-materials',
+                soakMs: 0,
+                warmupMs: 0,
+            },
+            plantCloseupMedians: {},
+            scenarios: [],
+            schemaVersion: 2,
+            sourceCommit: null,
+            summary: { failedScenarios: 0 },
+            weatherSurfaceComparisons: comparisons,
+        }),
+        /Integrated weather-surface paired comparison[\s\S]*overlay-triangle proxy[\s\S]*0\.97\/0\.97[\s\S]*40 → 41 \(2\.5%\)[\s\S]*45 → 29 \(-35\.6%\)[\s\S]*16118 → 13562 \(-15\.9%\)[\s\S]*213\/16\/1[\s\S]*16\/2556/,
+    );
+
+    const snowRuns = runs.map((run) => {
+        const comparisonRole = run.requested.comparisonRole;
+        const baseName = `game-high-target-snow-${comparisonRole}-weather-surfaces-desktop`;
+        return {
+            ...run,
+            baseName,
+            name: `${baseName}-run-${run.profileRun}`,
+            requested: {
+                ...run.requested,
+                comparisonPair: 'snow-weather-surfaces',
+            },
+            runtime: {
+                ...run.runtime,
+                rendererShaders: comparisonRole === 'integrated' ? 24 : 23,
+            },
+        };
+    });
+    const snowComparison = buildWeatherSurfaceComparisons(
+        buildHighTargetMedians(snowRuns),
+    )['snow-weather-surfaces'];
+    assert.equal(snowComparison.rendererProgramMaximumIncrease, 1);
+    assert.equal(snowComparison.relativePerformancePass, true);
+    assert.equal(snowComparison.pairedPass, true);
+
+    for (const [outlierCount, outlierValue, expectedMaximumIncrease] of [
+        [1, 42, 2],
+        [2, 100, 60],
+    ]) {
+        const programOutlierRuns = runs.map((run) =>
+            run.requested.comparisonRole === 'integrated' &&
+            run.profileRun <= outlierCount
+                ? {
+                      ...run,
+                      runtime: {
+                          ...run.runtime,
+                          rendererShaders: outlierValue,
+                      },
+                  }
+                : run,
+        );
+        const programOutlierMedians =
+            buildHighTargetMedians(programOutlierRuns);
+        const programOutlierComparison = buildWeatherSurfaceComparisons(
+            programOutlierMedians,
+        )['rain-weather-surfaces'];
+        const programBoundCheck =
+            programOutlierComparison.relativePerformanceChecks.find(
+                (check) => check.name === 'weatherSurfaceRendererProgramBound',
+            );
+
+        assert.equal(
+            programOutlierComparison.rendererShaders.integrated,
+            41,
+            'the median-only gate would not see these outliers',
+        );
+        assert.equal(
+            programOutlierComparison.rendererProgramMaximumIncrease,
+            expectedMaximumIncrease,
+        );
+        assert.deepEqual(programBoundCheck, {
+            actual: expectedMaximumIncrease,
+            comparison: 'maximum-increase',
+            limit: 1,
+            name: 'weatherSurfaceRendererProgramBound',
+            pass: false,
+        });
+        assert.equal(programOutlierComparison.relativePerformancePass, false);
+        assert.deepEqual(
+            buildProfileSummary(programOutlierRuns, programOutlierMedians)
+                .failedScenarioNames,
+            ['game-high-target-rain-integrated-weather-surfaces-desktop'],
+        );
+    }
+
+    const noFallbackReductionRuns = runs.map((run) =>
+        run.requested.comparisonRole === 'integrated'
+            ? {
+                  ...run,
+                  runtime: {
+                      ...run.runtime,
+                      weatherSurfaceFallbackOverlaySubmissionCount: 45,
+                  },
+              }
+            : run,
+    );
+    const noFallbackReductionMedians = buildHighTargetMedians(
+        noFallbackReductionRuns,
+    );
+    const failedComparison = buildWeatherSurfaceComparisons(
+        noFallbackReductionMedians,
+    )['rain-weather-surfaces'];
+    assert.equal(failedComparison.structuralPass, false);
+    assert.deepEqual(
+        buildProfileSummary(noFallbackReductionRuns, noFallbackReductionMedians)
+            .failedScenarioNames,
+        ['game-high-target-rain-integrated-weather-surfaces-desktop'],
+    );
+
+    for (const [name, mutate] of [
+        [
+            'draw calls',
+            (run) => ({
+                ...run,
+                sample: {
+                    ...run.sample,
+                    drawCallsPerRenderedFrame: 120,
+                },
+            }),
+        ],
+        [
+            'triangles',
+            (run) => ({
+                ...run,
+                sample: {
+                    ...run.sample,
+                    trianglesPerRenderedFrame: 1_100_000,
+                },
+            }),
+        ],
+        [
+            'GPU time',
+            (run) => ({
+                ...run,
+                sample: {
+                    ...run.sample,
+                    gpu: {
+                        elapsedP95Ms: 10,
+                        valid: true,
+                    },
+                },
+            }),
+        ],
+        [
+            'renderer programs',
+            (run) => ({
+                ...run,
+                runtime: {
+                    ...run.runtime,
+                    rendererShaders: 42,
+                },
+            }),
+        ],
+    ]) {
+        const regressedRuns = runs.map((run) =>
+            run.requested.comparisonRole === 'integrated' ? mutate(run) : run,
+        );
+        const regressedMedians = buildHighTargetMedians(regressedRuns);
+        const regressedComparison =
+            buildWeatherSurfaceComparisons(regressedMedians)[
+                'rain-weather-surfaces'
+            ];
+
+        assert.equal(
+            regressedComparison.relativePerformancePass,
+            false,
+            `${name} must fail the paired relative gate`,
+        );
+        assert.deepEqual(
+            buildProfileSummary(regressedRuns, regressedMedians)
+                .failedScenarioNames,
+            ['game-high-target-rain-integrated-weather-surfaces-desktop'],
+        );
+    }
+
+    const individualGpuOutlierRuns = runs.map((run) =>
+        run.requested.comparisonRole === 'integrated' && run.profileRun === 1
+            ? {
+                  ...run,
+                  sample: {
+                      ...run.sample,
+                      gpu: {
+                          elapsedP95Ms: 10.6,
+                          valid: true,
+                      },
+                  },
+              }
+            : run,
+    );
+    const individualGpuOutlierComparison = buildWeatherSurfaceComparisons(
+        buildHighTargetMedians(individualGpuOutlierRuns),
+    )['rain-weather-surfaces'];
+    assert.equal(individualGpuOutlierComparison.gpuMedianRatio, 0.97);
+    assert.equal(individualGpuOutlierComparison.gpuMaximumRunRatio, 1.06);
+    assert.equal(individualGpuOutlierComparison.relativePerformancePass, false);
+
+    for (const invalidGpu of [
+        {
+            disjoint: true,
+            elapsedP95Ms: null,
+            reason: 'GPU timer query results became disjoint',
+            valid: false,
+        },
+        {
+            elapsedP95Ms: null,
+            reason: 'EXT_disjoint_timer_query_webgl2 is unavailable',
+            valid: false,
+        },
+    ]) {
+        const incompleteGpuRuns = runs.map((run) =>
+            run.requested.comparisonRole === 'integrated' &&
+            run.profileRun === 1
+                ? {
+                      ...run,
+                      sample: {
+                          ...run.sample,
+                          gpu: invalidGpu,
+                      },
+                  }
+                : run,
+        );
+        const incompleteComparison = buildWeatherSurfaceComparisons(
+            buildHighTargetMedians(incompleteGpuRuns),
+        )['rain-weather-surfaces'];
+        assert.equal(incompleteComparison.gpuTimingStatus, 'inconclusive');
+        assert.equal(incompleteComparison.relativePerformancePass, false);
+        assert.equal(incompleteComparison.aggregatePass.integrated, false);
+    }
 });
 
 test('placement scenario resolves a deterministic staggered two-chunk run', () => {

--- a/packages/game/src/GameFlagsContext.tsx
+++ b/packages/game/src/GameFlagsContext.tsx
@@ -12,6 +12,7 @@ export interface GameFeatureFlags {
     enableRaisedBedFieldWateringFlag?: boolean;
     enableRaisedBedFieldDiaryFlag?: boolean;
     enableBlockGeometryMergingFlag?: boolean;
+    enableIntegratedWeatherSurfacesFlag?: boolean;
     enableRainWetOverlayFlag?: boolean;
     enableSuncokretChatFlag?: boolean;
     enableSuncokretDebugFlag?: boolean;

--- a/packages/game/src/entities/EntityInstances.tsx
+++ b/packages/game/src/entities/EntityInstances.tsx
@@ -325,6 +325,7 @@ export function EntityInstances({
                 name="Block_Grass"
                 groundPatch="grass"
                 renderRainWetOverlay
+                weatherSurface="base-ground"
                 yOffset={0.2}
                 geometry={(gltf) => gltf.nodes.Block_Grass_1_2.geometry}
                 material={(gltf) => gltf.nodes.Block_Grass_1_2.material}
@@ -411,6 +412,7 @@ export function EntityInstances({
                 name="Block_Sand"
                 groundPatch="sand"
                 renderRainWetOverlay
+                weatherSurface="base-ground"
                 yOffset={0.2}
                 geometry={(gltf) => gltf.nodes.Block_Sand_1.geometry}
                 material={(gltf) => gltf.nodes.Block_Sand_1.material}
@@ -470,6 +472,7 @@ export function EntityInstances({
                 stacks={stacks}
                 name="Block_Snow"
                 groundPatch="snow"
+                weatherSurface="base-ground"
                 yOffset={0.2}
                 geometry={(gltf) => gltf.nodes.Block_Sand_1.geometry}
                 material={() => snowMaterial}

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -4,24 +4,47 @@ import {
     memo,
     type ReactNode,
     useEffect,
+    useId,
     useLayoutEffect,
     useMemo,
     useRef,
 } from 'react';
-import type { InstancedMesh, Material } from 'three';
-import type { BufferGeometry } from 'three/src/Three.Core.js';
+import type { BufferGeometry, InstancedMesh, Material } from 'three';
 import {
     type ActiveDragPreviewTarget,
     activeDragPreviewTargetMatches,
     createActiveDragPreviewTarget,
     getActiveDragPreviewTargetPositionOffset,
 } from '../dragPreviewIdentity';
+import { useGameFlags } from '../GameFlagsContext';
 import { useBlockData } from '../hooks/useBlockData';
 import {
     RainWetOverlay,
     useRainWetOverlayMaterial,
     useRainWetOverlayVisible,
 } from '../rain/RainWetOverlay';
+import { registerCloudShadowAttenuationMaterialCandidate } from '../scene/cloudShadowAttenuation';
+import {
+    useRainSurfacePuddleStrengthUniform,
+    useRainSurfaceWetnessActive,
+    useRainSurfaceWetnessUniform,
+    useSnowSurfaceIntegrationState,
+} from '../scene/WeatherSurfaceUniformProvider';
+import {
+    countGeometryTriangles,
+    createWeatherSurfaceGeometry,
+    getWeatherSurfaceGeometryMetadata,
+} from '../scene/weatherSurfaceGeometry';
+import {
+    createIntegratedWeatherSurfaceMaterial,
+    getWeatherSurfacePluginVariantKey,
+    resolveWeatherSurfacePluginMode,
+    supportsIntegratedWeatherSurfaceMaterial,
+} from '../scene/weatherSurfaceMaterial';
+import {
+    registerWeatherSurfaceRenderEntry,
+    type WeatherSurfaceMode,
+} from '../scene/weatherSurfaceRenderRegistry';
 import { createSnowOverlayGeometry } from '../snow/createSnowOverlayGeometry';
 import {
     type SnowMaterialOptions,
@@ -61,6 +84,10 @@ import {
 
 const defaultLocalPosition: [number, number, number] = [0, 0, 0];
 const defaultLocalRotation: [number, number, number] = [0, 0, 0];
+const fallbackWeatherSurfaceBounds = {
+    max: [0.5, 0.5, 0.5] as const,
+    min: [-0.5, -0.5, -0.5] as const,
+};
 
 export type EntityInstancesBlockBaseProps = {
     stacks: Stack[] | undefined;
@@ -76,6 +103,7 @@ export type EntityInstancesBlockBaseProps = {
     snow?: SnowMaterialOptions;
     renderRainWetOverlay?: boolean;
     renderStableChunksAsMergedGeometry?: boolean;
+    weatherSurface?: 'base-ground';
     castShadow?: boolean;
     receiveShadow?: boolean;
     renderOrder?: number;
@@ -355,6 +383,7 @@ export function EntityInstancesBlock(
         snow,
         renderRainWetOverlay = false,
         renderStableChunksAsMergedGeometry,
+        weatherSurface,
         castShadow = true,
         receiveShadow = true,
         renderOrder,
@@ -381,9 +410,10 @@ export function EntityInstancesBlock(
         snow,
         snowLift,
         snowOverlayMinCoverage,
+        weatherSurface,
     };
 
-    if (props.material) {
+    if ('material' in props && props.material !== undefined) {
         return (
             <EntityInstancesGeometry
                 {...commonProps}
@@ -400,13 +430,220 @@ export function EntityInstancesBlock(
     );
 }
 
-export function EntityInstancesGeometry(
-    props: Omit<EntityInstancesBlockBaseProps, 'name' | 'stacks' | 'yOffset'> &
-        EntityInstancesBlockMaterialProps & {
-            instanceKey: string;
-            instances: EntityBlockInstance[] | undefined;
-        },
+type EntityInstancesGeometryProps = Omit<
+    EntityInstancesBlockBaseProps,
+    'name' | 'stacks' | 'yOffset'
+> &
+    EntityInstancesBlockMaterialProps & {
+        instanceKey: string;
+        instances: EntityBlockInstance[] | undefined;
+    };
+
+type IntegratedStableWeather = {
+    geometry: BufferGeometry;
+    integratesRain: boolean;
+    integratesSnow: boolean;
+    material: Material;
+    pluginVariantKey: string;
+};
+
+export function EntityInstancesGeometry(props: EntityInstancesGeometryProps) {
+    const flags = useGameFlags();
+    const weatherSurfaceMode: WeatherSurfaceMode =
+        flags.enableIntegratedWeatherSurfacesFlag === false
+            ? 'legacy'
+            : 'integrated';
+    const material = 'material' in props ? props.material : undefined;
+    const integrationEligible =
+        weatherSurfaceMode === 'integrated' &&
+        props.weatherSurface === 'base-ground' &&
+        props.snow !== undefined &&
+        !Array.isArray(material) &&
+        material !== undefined &&
+        supportsIntegratedWeatherSurfaceMaterial(material);
+
+    if (integrationEligible) {
+        return (
+            <IntegratedWeatherEntityInstancesGeometry
+                {...props}
+                sourceMaterial={material}
+                weatherSurfaceMode={weatherSurfaceMode}
+            />
+        );
+    }
+
+    return (
+        <EntityInstancesGeometryRenderer
+            {...props}
+            weatherSurfaceMode={weatherSurfaceMode}
+        />
+    );
+}
+
+function IntegratedWeatherEntityInstancesGeometry({
+    sourceMaterial,
+    ...props
+}: {
+    sourceMaterial: Parameters<
+        typeof createIntegratedWeatherSurfaceMaterial
+    >[0];
+    weatherSurfaceMode: WeatherSurfaceMode;
+} & EntityInstancesGeometryProps) {
+    const flags = useGameFlags();
+    const {
+        geometry,
+        renderRainWetOverlay = false,
+        renderSnow = true,
+        snow,
+        snowLift = 0,
+        snowOverlayMinCoverage,
+    } = props;
+    const wetnessUniform = useRainSurfaceWetnessUniform({
+        drySpeed: 1.8,
+        intensityMultiplier: 1,
+        wetSpeed: 5,
+    });
+    const puddleStrengthUniform = useRainSurfacePuddleStrengthUniform();
+    const rainOverlayVisible = useRainWetOverlayVisible();
+    const rainSurfaceActive =
+        renderRainWetOverlay &&
+        Boolean(flags.enableRainWetOverlayFlag) &&
+        Boolean(rainOverlayVisible);
+    const snowOverlayVisible = useSnowOverlayVisible({
+        coverageMultiplier: snow?.coverageMultiplier,
+        minCoverage: snowOverlayMinCoverage,
+        overrideSnow: snow?.overrideSnow,
+    });
+    const snowSurfaceActive = Boolean(snow && renderSnow && snowOverlayVisible);
+    const snowNoiseInfluence = snow?.noiseInfluence ?? 0.15;
+    const { amountUniform: snowAmountUniform, ready: snowIntegrationReady } =
+        useSnowSurfaceIntegrationState({
+            coverageMultiplier: snow?.coverageMultiplier ?? 1,
+            noiseInfluence: snowNoiseInfluence,
+            overrideSnow: snow?.overrideSnow,
+        });
+    const integratesSnow = snowSurfaceActive && snowIntegrationReady;
+    const integratesRain = rainSurfaceActive;
+    const hasIntegratedWeather = integratesRain || integratesSnow;
+    const pluginVariantKey = hasIntegratedWeather
+        ? getWeatherSurfacePluginVariantKey(
+              resolveWeatherSurfacePluginMode({
+                  rainEnabled: integratesRain,
+                  snowEnabled: integratesSnow,
+              }),
+          )
+        : undefined;
+    const rainBounds = useMemo(() => {
+        if (!geometry.boundingBox) {
+            geometry.computeBoundingBox();
+        }
+        const bounds = geometry.boundingBox;
+        if (!bounds) {
+            return fallbackWeatherSurfaceBounds;
+        }
+        return {
+            max: [bounds.max.x, bounds.max.y, bounds.max.z] as const,
+            min: [bounds.min.x, bounds.min.y, bounds.min.z] as const,
+        };
+    }, [geometry]);
+    const preparedGeometry = useMemo(
+        () =>
+            integratesSnow
+                ? createWeatherSurfaceGeometry(geometry, {
+                      includeSnowSkirts: true,
+                  })
+                : geometry,
+        [geometry, integratesSnow],
+    );
+    const integratedMaterial = useMemo(() => {
+        if (!hasIntegratedWeather) {
+            return undefined;
+        }
+        return createIntegratedWeatherSurfaceMaterial(sourceMaterial, {
+            rain: {
+                bounds: rainBounds,
+                darkness: 1,
+                enabled: rainSurfaceActive,
+                glossiness: 0.7,
+                puddleStrengthUniform,
+                topSurfaceBias: 1.8,
+                wetnessUniform,
+            },
+            snow: {
+                amountUniform: snowAmountUniform,
+                color: snow?.color ?? '#f7f7ff',
+                enabled: integratesSnow,
+                lift: snowLift || 0.003,
+                maxThickness: snow?.maxThickness ?? 0.18,
+                noiseAmplitude: snow?.noiseAmplitude ?? 0.35,
+                noiseInfluence: snowNoiseInfluence,
+                noiseScale: snow?.noiseScale ?? 2.5,
+                slopeExponent: snow?.slopeExponent ?? 2.4,
+            },
+        });
+    }, [
+        hasIntegratedWeather,
+        puddleStrengthUniform,
+        rainBounds,
+        rainSurfaceActive,
+        integratesSnow,
+        snow,
+        snowAmountUniform,
+        snowLift,
+        snowNoiseInfluence,
+        sourceMaterial,
+        wetnessUniform,
+    ]);
+    const integratedStableWeather = useMemo(
+        () =>
+            integratedMaterial && pluginVariantKey
+                ? {
+                      geometry: preparedGeometry,
+                      integratesRain,
+                      integratesSnow,
+                      material: integratedMaterial,
+                      pluginVariantKey,
+                  }
+                : undefined,
+        [
+            integratedMaterial,
+            integratesRain,
+            integratesSnow,
+            pluginVariantKey,
+            preparedGeometry,
+        ],
+    );
+
+    useLayoutEffect(() => {
+        if (!integratedMaterial) {
+            return;
+        }
+        return registerCloudShadowAttenuationMaterialCandidate(
+            integratedMaterial,
+        );
+    }, [integratedMaterial]);
+    useEffect(() => {
+        if (!integratedMaterial) {
+            return;
+        }
+        return () => integratedMaterial.dispose();
+    }, [integratedMaterial]);
+
+    return (
+        <EntityInstancesGeometryRenderer
+            {...props}
+            integratedStableWeather={integratedStableWeather}
+        />
+    );
+}
+
+function EntityInstancesGeometryRenderer(
+    props: EntityInstancesGeometryProps & {
+        integratedStableWeather?: IntegratedStableWeather;
+        weatherSurfaceMode: WeatherSurfaceMode;
+    },
 ) {
+    const flags = useGameFlags();
     const {
         instanceKey,
         instances: incomingInstances,
@@ -420,6 +657,8 @@ export function EntityInstancesGeometry(
         snowOverlayMinCoverage,
         renderRainWetOverlay = false,
         renderStableChunksAsMergedGeometry = false,
+        integratedStableWeather,
+        weatherSurfaceMode,
         castShadow = true,
         receiveShadow = true,
         renderOrder,
@@ -510,7 +749,149 @@ export function EntityInstancesGeometry(
     }, [addressedChunks, placementSignatureByChunkKey]);
 
     const material = 'material' in props ? props.material : undefined;
-    const materialNode = 'materialNode' in props ? props.materialNode : null;
+    const materialNode =
+        'materialNode' in props ? props.materialNode : undefined;
+    const stableGeometry = integratedStableWeather?.geometry ?? geometry;
+    const stableMaterial = integratedStableWeather?.material ?? material;
+    const integratesStableRain =
+        integratedStableWeather?.integratesRain === true;
+    const integratesStableSnow =
+        integratedStableWeather?.integratesSnow === true;
+    const stableMaterialNode = integratedStableWeather
+        ? undefined
+        : materialNode;
+    const weatherRegistryId = useId();
+    const rainOverlayVisible = useRainWetOverlayVisible();
+    const rainOverlayEnabled =
+        renderRainWetOverlay && Boolean(flags.enableRainWetOverlayFlag);
+    const rainWetnessActive = useRainSurfaceWetnessActive({
+        drySpeed: 1.8,
+        enabled: rainOverlayEnabled,
+        intensityMultiplier: 1,
+        minimumWetness: 0.01,
+        wetSpeed: 5,
+    });
+    const snowOverlayVisible = useSnowOverlayVisible({
+        coverageMultiplier: snow?.coverageMultiplier,
+        minCoverage: snowOverlayMinCoverage,
+        overrideSnow: snow?.overrideSnow,
+    });
+    const sourceTriangleCount = useMemo(
+        () => countGeometryTriangles(geometry),
+        [geometry],
+    );
+    const activeRainOverlay = rainOverlayEnabled && rainOverlayVisible;
+    const activeAnimatedRainOverlay =
+        rainOverlayEnabled && (rainOverlayVisible || rainWetnessActive);
+    const activeSnowOverlay = Boolean(snow) && renderSnow && snowOverlayVisible;
+    const snowOverlayTriangleCount = useMemo(() => {
+        if (!activeSnowOverlay) {
+            return 0;
+        }
+        if (integratesStableSnow && integratedStableWeather) {
+            const metadata = getWeatherSurfaceGeometryMetadata(
+                integratedStableWeather.geometry,
+            );
+            if (!metadata?.includesSnowSkirts) {
+                throw new Error(
+                    'Integrated snow surface is missing its prepared boundary skirts.',
+                );
+            }
+            return metadata.preparedTriangleCount;
+        }
+        return countGeometryTriangles(createSnowOverlayGeometry(geometry));
+    }, [
+        activeSnowOverlay,
+        geometry,
+        integratedStableWeather,
+        integratesStableSnow,
+    ]);
+    const stableInstanceCount = useMemo(
+        () =>
+            stableChunks.reduce(
+                (total, chunk) => total + chunk.instances.length,
+                0,
+            ),
+        [stableChunks],
+    );
+    const stableRainOverlaySubmissionCount = activeRainOverlay
+        ? stableChunks.length
+        : 0;
+    const stableSnowOverlaySubmissionCount = activeSnowOverlay
+        ? stableChunks.length
+        : 0;
+    const stableRainOverlayTriangleCount = activeRainOverlay
+        ? stableInstanceCount * sourceTriangleCount
+        : 0;
+    const stableSnowOverlayTriangleCount = activeSnowOverlay
+        ? stableInstanceCount * snowOverlayTriangleCount
+        : 0;
+    const animatedOverlaySubmissionCount =
+        (activeAnimatedRainOverlay ? animatedInstances.length : 0) +
+        (activeSnowOverlay ? animatedInstances.length : 0);
+    const animatedOverlayTriangleCount =
+        (activeAnimatedRainOverlay
+            ? animatedInstances.length * sourceTriangleCount
+            : 0) +
+        (activeSnowOverlay
+            ? animatedInstances.length * snowOverlayTriangleCount
+            : 0);
+    const hasWeatherSurface =
+        renderRainWetOverlay || Boolean(snow && renderSnow);
+
+    useEffect(() => {
+        if (!hasWeatherSurface) {
+            return;
+        }
+
+        const integrated = integratedStableWeather !== undefined;
+        const avoidedOverlaySubmissionCount =
+            (integratesStableRain ? stableRainOverlaySubmissionCount : 0) +
+            (integratesStableSnow ? stableSnowOverlaySubmissionCount : 0);
+        const avoidedOverlayTriangleCount =
+            (integratesStableRain ? stableRainOverlayTriangleCount : 0) +
+            (integratesStableSnow ? stableSnowOverlayTriangleCount : 0);
+        const fallbackStableOverlaySubmissionCount =
+            (integratesStableRain ? 0 : stableRainOverlaySubmissionCount) +
+            (integratesStableSnow ? 0 : stableSnowOverlaySubmissionCount);
+        const fallbackStableOverlayTriangleCount =
+            (integratesStableRain ? 0 : stableRainOverlayTriangleCount) +
+            (integratesStableSnow ? 0 : stableSnowOverlayTriangleCount);
+        return registerWeatherSurfaceRenderEntry(
+            `${weatherRegistryId}:${instanceKey}`,
+            {
+                avoidedOverlaySubmissionCount,
+                avoidedOverlayTriangleCount,
+                fallbackOverlaySubmissionCount:
+                    animatedOverlaySubmissionCount +
+                    fallbackStableOverlaySubmissionCount,
+                fallbackOverlayTriangleCount:
+                    animatedOverlayTriangleCount +
+                    fallbackStableOverlayTriangleCount,
+                integratedInstanceCount: integrated ? stableInstanceCount : 0,
+                integratedMaterialCount: integrated ? 1 : 0,
+                mode: weatherSurfaceMode,
+                pluginVariantKeys: integrated
+                    ? [integratedStableWeather.pluginVariantKey]
+                    : [],
+            },
+        );
+    }, [
+        animatedOverlaySubmissionCount,
+        animatedOverlayTriangleCount,
+        hasWeatherSurface,
+        instanceKey,
+        integratedStableWeather,
+        integratesStableRain,
+        integratesStableSnow,
+        stableInstanceCount,
+        stableRainOverlaySubmissionCount,
+        stableRainOverlayTriangleCount,
+        stableSnowOverlaySubmissionCount,
+        stableSnowOverlayTriangleCount,
+        weatherRegistryId,
+        weatherSurfaceMode,
+    ]);
 
     if (!instances?.length) {
         return null;
@@ -620,10 +1001,10 @@ export function EntityInstancesGeometry(
                         castShadow={castShadow}
                         chunk={chunk}
                         debugName={`MergedBlockChunk:${instanceKey}:chunk:${chunk.key}:count:${chunk.instances.length}`}
-                        geometry={geometry}
+                        geometry={stableGeometry}
                         localTransform={localTransform}
-                        material={material}
-                        materialNode={materialNode}
+                        material={stableMaterial}
+                        materialNode={stableMaterialNode}
                         placementSignature={placementSignature}
                         receiveShadow={receiveShadow}
                         renderOrder={renderOrder}
@@ -635,10 +1016,10 @@ export function EntityInstancesGeometry(
                         castShadow={castShadow}
                         chunk={chunk}
                         debugName={`BlockInstances:${instanceKey}:chunk:${chunk.key}:count:${chunk.instances.length}`}
-                        geometry={geometry}
+                        geometry={stableGeometry}
                         localTransform={localTransform}
-                        material={material}
-                        materialNode={materialNode}
+                        material={stableMaterial}
+                        materialNode={stableMaterialNode}
                         placementSignature={placementSignature}
                         receiveShadow={receiveShadow}
                         renderOrder={renderOrder}
@@ -671,7 +1052,7 @@ export function EntityInstancesGeometry(
                     </HoverOutline>
                 ) : null,
             )}
-            {renderRainWetOverlay && (
+            {!integratesStableRain && renderRainWetOverlay && (
                 <InstancedRainWetOverlays
                     chunks={stableChunks}
                     geometry={geometry}
@@ -680,7 +1061,7 @@ export function EntityInstancesGeometry(
                     scale={stableScale}
                 />
             )}
-            {snow && renderSnow && (
+            {!integratesStableSnow && snow && renderSnow && (
                 <InstancedSnowOverlays
                     chunks={stableChunks}
                     geometry={geometry}

--- a/packages/game/src/entities/helpers/groundPatchMaterial.ts
+++ b/packages/game/src/entities/helpers/groundPatchMaterial.ts
@@ -14,7 +14,7 @@ export type GroundPatchWetPatch = {
     strength?: number;
 };
 
-type GroundPatchOptions = {
+export type GroundPatchOptions = {
     wetColor?: string;
     wetPatches?: readonly GroundPatchWetPatch[];
     wetStrength?: number;
@@ -328,7 +328,7 @@ function createWetPatchUniforms(
     };
 }
 
-function applyGroundPatchMaterial(
+export function applyGroundPatchMaterial(
     material: MeshStandardMaterial,
     surface: GroundPatchSurface,
     options: GroundPatchOptions,
@@ -341,6 +341,31 @@ function applyGroundPatchMaterial(
 
     material.onBeforeCompile = (shader, renderer) => {
         originalOnBeforeCompile(shader, renderer);
+        const weatherWorldPositionAvailable =
+            shader.vertexShader.includes(
+                'varying vec3 vGrediceWeatherWorldPosition;',
+            ) &&
+            shader.fragmentShader.includes(
+                'varying vec3 vGrediceWeatherWorldPosition;',
+            );
+        const worldPositionVarying = weatherWorldPositionAvailable
+            ? 'vGrediceWeatherWorldPosition'
+            : 'vGroundPatchWorldPosition';
+        const resolvedFragmentParameters =
+            groundPatchFragmentParameters.replaceAll(
+                'vGroundPatchWorldPosition',
+                worldPositionVarying,
+            );
+        const fragmentParameters = weatherWorldPositionAvailable
+            ? resolvedFragmentParameters.replace(
+                  `varying vec3 ${worldPositionVarying};`,
+                  '',
+              )
+            : resolvedFragmentParameters;
+        const colorFragment = groundPatchColorFragment.replaceAll(
+            'vGroundPatchWorldPosition',
+            worldPositionVarying,
+        );
 
         shader.uniforms.uGroundPatchMode = { value: preset.mode };
         shader.uniforms.uGroundPatchLightColor = {
@@ -359,24 +384,31 @@ function applyGroundPatchMaterial(
             shader.uniforms,
             createWetPatchUniforms(wetPatches, options),
         );
-        shader.vertexShader = shader.vertexShader
-            .replace(
-                '#include <common>',
-                `#include <common>\n${groundPatchVertexParameters}`,
-            )
-            .replace(
-                '#include <worldpos_vertex>',
-                `#include <worldpos_vertex>\n${groundPatchWorldPosition}`,
-            );
-        shader.fragmentShader = shader.fragmentShader
-            .replace(
-                '#include <common>',
-                `#include <common>\n${groundPatchFragmentParameters}`,
-            )
-            .replace(
-                '#include <color_fragment>',
-                `#include <color_fragment>\n${groundPatchColorFragment}`,
-            );
+        if (!weatherWorldPositionAvailable) {
+            shader.vertexShader = shader.vertexShader
+                .replace(
+                    '#include <common>',
+                    `#include <common>\n${groundPatchVertexParameters}`,
+                )
+                .replace(
+                    '#include <worldpos_vertex>',
+                    `#include <worldpos_vertex>\n${groundPatchWorldPosition}`,
+                );
+        }
+        shader.fragmentShader = (
+            weatherWorldPositionAvailable
+                ? shader.fragmentShader.replace(
+                      'void main() {',
+                      `${fragmentParameters}\nvoid main() {`,
+                  )
+                : shader.fragmentShader.replace(
+                      '#include <common>',
+                      `#include <common>\n${fragmentParameters}`,
+                  )
+        ).replace(
+            '#include <color_fragment>',
+            `#include <color_fragment>\n${colorFragment}`,
+        );
     };
     material.customProgramCacheKey = () =>
         `${originalCustomProgramCacheKey()}:ground-patch:${surface}`;

--- a/packages/game/src/rain/RainWetOverlay.tsx
+++ b/packages/game/src/rain/RainWetOverlay.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo } from 'react';
-import type { BufferGeometry, Vector3Tuple } from 'three';
+import type { BufferGeometry, IUniform, Vector3Tuple } from 'three';
 import { ShaderMaterial, UniformsLib, UniformsUtils, Vector3 } from 'three';
 import { useGameFlags } from '../GameFlagsContext';
 import {
     useRainSurfacePuddleStrengthUniform,
+    useRainSurfaceWetnessState,
     useRainSurfaceWetnessUniform,
 } from '../scene/WeatherSurfaceUniformProvider';
 import { useGameState } from '../useGameState';
@@ -101,7 +102,7 @@ export function useRainWetOverlayVisible({
     minRain = 0.08,
 }: Pick<RainWetOverlayProps, 'intensityMultiplier' | 'minRain'> = {}) {
     const flags = useGameFlags();
-    const rainAmount = useGameState((state) => state.weather?.rainy ?? 0);
+    const rainAmount = useGameState((state) => state.rainSurfaceIntensity);
 
     return (
         flags.enableRainWetOverlayFlag &&
@@ -134,6 +135,31 @@ export function useRainWetOverlayMaterial({
         intensityMultiplier,
         wetSpeed,
     });
+    return useRainWetOverlayMaterialWithWetnessUniform({
+        bounds,
+        darkness,
+        geometry,
+        glossiness,
+        topSurfaceBias,
+        wetnessUniform,
+    });
+}
+
+function useRainWetOverlayMaterialWithWetnessUniform({
+    bounds,
+    darkness,
+    geometry,
+    glossiness,
+    topSurfaceBias,
+    wetnessUniform,
+}: {
+    bounds: RainWetOverlayProps['bounds'];
+    darkness: number;
+    geometry: BufferGeometry;
+    glossiness: number;
+    topSurfaceBias: number;
+    wetnessUniform: IUniform<number>;
+}) {
     const puddleStrengthUniform = useRainSurfacePuddleStrengthUniform();
     const resolvedBounds = useMemo(() => {
         if (bounds) return bounds;
@@ -218,18 +244,22 @@ function RainWetOverlayEffect({
         intensityMultiplier,
         minRain,
     });
-    const material = useRainWetOverlayMaterial({
-        bounds,
-        darkness,
+    const { active: dryingDown, wetnessUniform } = useRainSurfaceWetnessState({
         drySpeed,
-        geometry,
-        glossiness,
         intensityMultiplier,
-        topSurfaceBias,
+        minimumWetness: 0.01,
         wetSpeed,
     });
+    const material = useRainWetOverlayMaterialWithWetnessUniform({
+        bounds,
+        darkness,
+        geometry,
+        glossiness,
+        topSurfaceBias,
+        wetnessUniform,
+    });
 
-    if (!shouldRender && material.uniforms.uWetness.value < 0.01) {
+    if (!shouldRender && !dryingDown) {
         return null;
     }
 

--- a/packages/game/src/scene/CloudShadowAttenuationLayer.tsx
+++ b/packages/game/src/scene/CloudShadowAttenuationLayer.tsx
@@ -16,6 +16,7 @@ import {
     type CloudShadowMaterialLeaseMap,
     type CloudShadowProjection,
     type CloudShadowSample,
+    getCloudShadowAttenuationMaterialCandidateRevision,
     getCloudShadowAttenuationMaterialUniforms,
     releaseCloudShadowAttenuationMaterials,
     resolveCloudShadowAttenuationActivation,
@@ -145,6 +146,7 @@ export function CloudShadowAttenuation({
     const leasesRef = useRef<CloudShadowMaterialLeaseMap>(new Map());
     const attenuationActiveRef = useRef(false);
     const nextMaterialScanAtRef = useRef(0);
+    const materialCandidateRevisionRef = useRef(-1);
     const nextUpdateAtRef = useRef(0);
     const forceUpdateRef = useRef(true);
     const updateCountRef = useRef(0);
@@ -209,6 +211,8 @@ export function CloudShadowAttenuation({
         updateGameProfileMetadata({
             cloudAttenuationMaterialCount: materialCount,
         });
+        materialCandidateRevisionRef.current =
+            getCloudShadowAttenuationMaterialCandidateRevision();
 
         return () => {
             releaseCloudShadowAttenuationMaterials(leases);
@@ -256,7 +260,14 @@ export function CloudShadowAttenuation({
         uniforms.strength.value = attenuationActive ? strength : 0;
 
         const now = performance.now();
-        if (now >= nextMaterialScanAtRef.current) {
+        const materialCandidateRevision =
+            getCloudShadowAttenuationMaterialCandidateRevision();
+        if (
+            materialCandidateRevision !==
+                materialCandidateRevisionRef.current ||
+            now >= nextMaterialScanAtRef.current
+        ) {
+            materialCandidateRevisionRef.current = materialCandidateRevision;
             nextMaterialScanAtRef.current = now + materialScanMs;
             const materialCount = syncCloudShadowAttenuationMaterials({
                 enabled: materialIntegrationEnabled,

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -600,6 +600,9 @@ export function Environment({
         (state) => Object.keys(state.blockPlacementDropAnimations).length,
     );
     const ambientAudioMixer = useGameState((state) => state.audio.ambient);
+    const setRainSurfaceIntensity = useGameState(
+        (state) => state.setRainSurfaceIntensity,
+    );
     const setSnowCoverage = useGameState((state) => state.setSnowCoverage);
     const setWaterColors = useGameState((state) => state.setWaterColors);
     const weatherVisualizationDisabled = useGameState(
@@ -808,6 +811,10 @@ export function Environment({
     const rain = blendedWeather?.rainy ?? 0;
     const { activeCount: rainParticleCount, intensity: rainParticleIntensity } =
         resolveRainParticleState(rain, qualityProfile.rainParticleMultiplier);
+
+    useEffect(() => {
+        setRainSurfaceIntensity(weatherDisabled ? 0 : rain);
+    }, [rain, setRainSurfaceIntensity, weatherDisabled]);
 
     // Handle snow particles - based on current weather (snowy intensity 0-1)
     const snowParticles = blendedWeather?.snowy ?? 0;

--- a/packages/game/src/scene/WeatherSurfaceUniformProvider.tsx
+++ b/packages/game/src/scene/WeatherSurfaceUniformProvider.tsx
@@ -4,10 +4,12 @@ import { useFrame } from '@react-three/fiber';
 import {
     createContext,
     type PropsWithChildren,
+    useCallback,
     useContext,
     useEffect,
     useMemo,
     useRef,
+    useSyncExternalStore,
 } from 'react';
 import type { IUniform } from 'three';
 import { useOptionalGameState } from '../useGameState';
@@ -28,6 +30,12 @@ function reportWeatherSurfaceUniformStats(stats: WeatherSurfaceUniformStats) {
         rainWetOverlayMaterialConsumerCount: stats.rainConsumerCount,
         snowOverlayDistinctUniformCount: stats.snowDistinctUniformCount,
         snowOverlayMaterialConsumerCount: stats.snowConsumerCount,
+        weatherSurfaceSnowIntegrationReadyCount:
+            stats.snowIntegrationReadyCount,
+        weatherSurfaceSnowIntegrationTrackedCount:
+            stats.snowIntegrationTrackedCount,
+        weatherSurfaceSnowIntegrationTransitionCount:
+            stats.snowIntegrationTransitionCount,
     });
 }
 
@@ -49,7 +57,7 @@ export function WeatherSurfaceUniformProvider({ children }: PropsWithChildren) {
         [],
     );
     const rainAmount = useOptionalGameState(
-        (state) => state.weather?.rainy ?? 0,
+        (state) => state.rainSurfaceIntensity,
         0,
     );
     const snowCoverage = useOptionalGameState((state) => state.snowCoverage, 0);
@@ -62,6 +70,9 @@ export function WeatherSurfaceUniformProvider({ children }: PropsWithChildren) {
                 rainDistinctUniformCount: 0,
                 snowConsumerCount: 0,
                 snowDistinctUniformCount: 0,
+                snowIntegrationReadyCount: 0,
+                snowIntegrationTrackedCount: 0,
+                snowIntegrationTransitionCount: 0,
             });
     }, [registry]);
 
@@ -84,6 +95,16 @@ export function useSnowSurfaceAmountUniform({
     coverageMultiplier,
     overrideSnow,
 }: SnowSurfaceUniformOptions): IUniform<number> {
+    return useRetainedSnowSurfaceEntry({
+        coverageMultiplier,
+        overrideSnow,
+    }).uniform;
+}
+
+function useRetainedSnowSurfaceEntry({
+    coverageMultiplier,
+    overrideSnow,
+}: SnowSurfaceUniformOptions) {
     const registry = useWeatherSurfaceUniformRegistry();
     const entry = useMemo(
         () =>
@@ -96,7 +117,38 @@ export function useSnowSurfaceAmountUniform({
 
     useEffect(() => registry.retain(entry), [entry, registry]);
 
-    return entry.uniform;
+    return entry;
+}
+
+export function useSnowSurfaceIntegrationState({
+    coverageMultiplier,
+    noiseInfluence,
+    overrideSnow,
+}: SnowSurfaceUniformOptions & { noiseInfluence: number }) {
+    const registry = useWeatherSurfaceUniformRegistry();
+    const entry = useRetainedSnowSurfaceEntry({
+        coverageMultiplier,
+        overrideSnow,
+    });
+    const subscribe = useCallback(
+        (listener: () => void) =>
+            registry.subscribeSnowIntegrationReadiness(
+                entry,
+                noiseInfluence,
+                listener,
+            ),
+        [entry, noiseInfluence, registry],
+    );
+    const getSnapshot = useCallback(
+        () => registry.getSnowIntegrationReady(entry, noiseInfluence),
+        [entry, noiseInfluence, registry],
+    );
+    const ready = useSyncExternalStore(subscribe, getSnapshot, () => false);
+
+    return {
+        amountUniform: entry.uniform,
+        ready,
+    };
 }
 
 export function useRainSurfaceWetnessUniform({
@@ -104,8 +156,20 @@ export function useRainSurfaceWetnessUniform({
     intensityMultiplier,
     wetSpeed,
 }: RainSurfaceUniformOptions): IUniform<number> {
+    return useRetainedRainSurfaceEntry({
+        drySpeed,
+        intensityMultiplier,
+        wetSpeed,
+    }).uniform;
+}
+
+function useRainSurfaceEntry({
+    drySpeed,
+    intensityMultiplier,
+    wetSpeed,
+}: RainSurfaceUniformOptions) {
     const registry = useWeatherSurfaceUniformRegistry();
-    const entry = useMemo(
+    return useMemo(
         () =>
             registry.getRainEntry({
                 drySpeed,
@@ -114,10 +178,88 @@ export function useRainSurfaceWetnessUniform({
             }),
         [drySpeed, intensityMultiplier, registry, wetSpeed],
     );
+}
+
+function useRetainedRainSurfaceEntry(options: RainSurfaceUniformOptions) {
+    const registry = useWeatherSurfaceUniformRegistry();
+    const entry = useRainSurfaceEntry(options);
 
     useEffect(() => registry.retain(entry), [entry, registry]);
 
-    return entry.uniform;
+    return entry;
+}
+
+function useRainSurfaceEntryActivity({
+    enabled,
+    entry,
+    minimumWetness,
+}: {
+    enabled: boolean;
+    entry: ReturnType<WeatherSurfaceUniformRegistry['getRainEntry']>;
+    minimumWetness: number;
+}) {
+    const registry = useWeatherSurfaceUniformRegistry();
+    const subscribe = useCallback(
+        (listener: () => void) =>
+            enabled
+                ? registry.subscribeRainSurfaceActivity(
+                      entry,
+                      minimumWetness,
+                      listener,
+                  )
+                : () => undefined,
+        [enabled, entry, minimumWetness, registry],
+    );
+    const getSnapshot = useCallback(
+        () => enabled && registry.getRainSurfaceActive(entry, minimumWetness),
+        [enabled, entry, minimumWetness, registry],
+    );
+    return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}
+
+export function useRainSurfaceWetnessState({
+    drySpeed,
+    intensityMultiplier,
+    minimumWetness = 0.01,
+    wetSpeed,
+}: RainSurfaceUniformOptions & { minimumWetness?: number }) {
+    const entry = useRetainedRainSurfaceEntry({
+        drySpeed,
+        intensityMultiplier,
+        wetSpeed,
+    });
+    const active = useRainSurfaceEntryActivity({
+        enabled: true,
+        entry,
+        minimumWetness,
+    });
+
+    return {
+        active,
+        wetnessUniform: entry.uniform,
+    };
+}
+
+export function useRainSurfaceWetnessActive({
+    drySpeed,
+    enabled,
+    intensityMultiplier,
+    minimumWetness = 0.01,
+    wetSpeed,
+}: RainSurfaceUniformOptions & {
+    enabled: boolean;
+    minimumWetness?: number;
+}) {
+    const entry = useRainSurfaceEntry({
+        drySpeed,
+        intensityMultiplier,
+        wetSpeed,
+    });
+    return useRainSurfaceEntryActivity({
+        enabled,
+        entry,
+        minimumWetness,
+    });
 }
 
 export function useRainSurfacePuddleStrengthUniform(): IUniform<number> {

--- a/packages/game/src/scene/cloudShadowAttenuation.ts
+++ b/packages/game/src/scene/cloudShadowAttenuation.ts
@@ -35,12 +35,16 @@ const cloudShadowVertex = /* glsl */ `
 #endif
 `;
 
-const cloudShadowFragmentPars = /* glsl */ `
+const cloudShadowFragmentUniformPars = /* glsl */ `
 uniform sampler2D grediceCloudShadowMap;
 uniform vec4 grediceCloudShadowBounds;
 uniform vec2 grediceCloudShadowProjection;
 uniform float grediceCloudShadowStrength;
 uniform float grediceCloudShadowHardness;
+`;
+
+const cloudShadowFragmentPars = /* glsl */ `
+${cloudShadowFragmentUniformPars}
 varying vec3 vGrediceCloudShadowWorldPosition;
 `;
 
@@ -143,6 +147,8 @@ const materialPatchStates = new WeakMap<
     Material,
     CloudShadowMaterialPatchState
 >();
+const registeredMaterialCandidateTokens = new Map<Material, Set<symbol>>();
+let registeredMaterialCandidateRevision = 0;
 // The production garden owns one active weather scene, so one stable uniform
 // set lets shared materials keep a single compiled program across transitions.
 // Concurrent weather scenes with different masks would contend for these
@@ -212,6 +218,61 @@ export function resolveCloudShadowAttenuationConfig({
 
 export function getCloudShadowAttenuationMaterialUniforms() {
     return sharedCloudShadowMaterialUniforms;
+}
+
+/**
+ * Dynamic materials can announce their lifecycle without owning the cloud
+ * shader decorator. The cloud layer observes the revision before rendering,
+ * patches new candidates with its current uniforms, and releases disappeared
+ * candidates on the same frame instead of waiting for the periodic scene
+ * traversal.
+ */
+export function registerCloudShadowAttenuationMaterialCandidate(
+    material: Material,
+) {
+    const token = Symbol(material.uuid);
+    const tokens =
+        registeredMaterialCandidateTokens.get(material) ?? new Set<symbol>();
+    tokens.add(token);
+    registeredMaterialCandidateTokens.set(material, tokens);
+    registeredMaterialCandidateRevision += 1;
+
+    let registered = true;
+    return () => {
+        if (!registered) {
+            return;
+        }
+        registered = false;
+        const activeTokens = registeredMaterialCandidateTokens.get(material);
+        activeTokens?.delete(token);
+        if (activeTokens?.size === 0) {
+            registeredMaterialCandidateTokens.delete(material);
+        }
+        registeredMaterialCandidateRevision += 1;
+    };
+}
+
+export function getCloudShadowAttenuationMaterialCandidateRevision() {
+    return registeredMaterialCandidateRevision;
+}
+
+/**
+ * Material clones do not carry compile callbacks automatically. Consumers
+ * that deliberately compose a new callback must also avoid copying this
+ * scene-owned decorator: the cloud layer will discover and decorate the clone
+ * itself. Returning the pre-cloud hooks prevents duplicate shader injection.
+ */
+export function getMaterialShaderHooksWithoutCloudShadowAttenuation(
+    material: Material,
+) {
+    const state = materialPatchStates.get(material);
+    return {
+        customProgramCacheKey:
+            state?.originalCustomProgramCacheKey ??
+            material.customProgramCacheKey,
+        onBeforeCompile:
+            state?.originalOnBeforeCompile ?? material.onBeforeCompile,
+    };
 }
 
 export function resolveCloudShadowAttenuationActivation({
@@ -363,18 +424,33 @@ function injectCloudShadowAttenuationShader(
     shader.uniforms.grediceCloudShadowStrength = uniforms.strength;
     shader.uniforms.grediceCloudShadowHardness = uniforms.hardness;
 
-    shader.vertexShader = shader.vertexShader
-        .replace(
-            '#include <common>',
-            `#include <common>\n${cloudShadowVertexPars}`,
-        )
-        .replace('#include <worldpos_vertex>', cloudShadowVertex);
+    const weatherWorldPositionAvailable =
+        shader.vertexShader.includes(
+            'varying vec3 vGrediceWeatherWorldPosition;',
+        ) &&
+        shader.fragmentShader.includes(
+            'varying vec3 vGrediceWeatherWorldPosition;',
+        );
+    if (!weatherWorldPositionAvailable) {
+        shader.vertexShader = shader.vertexShader
+            .replace(
+                '#include <common>',
+                `#include <common>\n${cloudShadowVertexPars}`,
+            )
+            .replace('#include <worldpos_vertex>', cloudShadowVertex);
+    }
+    const fragmentPars = weatherWorldPositionAvailable
+        ? cloudShadowFragmentUniformPars
+        : cloudShadowFragmentPars;
+    const fragmentChunk = weatherWorldPositionAvailable
+        ? cloudShadowFragmentShaderChunk.replaceAll(
+              'vGrediceCloudShadowWorldPosition',
+              'vGrediceWeatherWorldPosition',
+          )
+        : cloudShadowFragmentShaderChunk;
     shader.fragmentShader = shader.fragmentShader
-        .replace(
-            '#include <common>',
-            `#include <common>\n${cloudShadowFragmentPars}`,
-        )
-        .replace('#include <aomap_fragment>', cloudShadowFragmentShaderChunk);
+        .replace('#include <common>', `#include <common>\n${fragmentPars}`)
+        .replace('#include <aomap_fragment>', fragmentChunk);
 }
 
 export function retainCloudShadowAttenuationMaterial(
@@ -469,22 +545,26 @@ export function syncCloudShadowAttenuationMaterials({
     const activeMaterialIds = new Set<string>();
 
     if (enabled) {
+        const activateMaterial = (material: Material) => {
+            if (!supportsCloudShadowAttenuation(material)) {
+                return;
+            }
+
+            activeMaterialIds.add(material.uuid);
+            if (!leases.has(material.uuid)) {
+                leases.set(
+                    material.uuid,
+                    retainCloudShadowAttenuationMaterial(material, uniforms),
+                );
+            }
+        };
+
+        for (const material of registeredMaterialCandidateTokens.keys()) {
+            activateMaterial(material);
+        }
         root.traverse((object) => {
             for (const material of getObjectMaterials(object)) {
-                if (!supportsCloudShadowAttenuation(material)) {
-                    continue;
-                }
-
-                activeMaterialIds.add(material.uuid);
-                if (!leases.has(material.uuid)) {
-                    leases.set(
-                        material.uuid,
-                        retainCloudShadowAttenuationMaterial(
-                            material,
-                            uniforms,
-                        ),
-                    );
-                }
+                activateMaterial(material);
             }
         });
     }

--- a/packages/game/src/scene/cloudShadowAttenuation.unit.ts
+++ b/packages/game/src/scene/cloudShadowAttenuation.unit.ts
@@ -13,7 +13,9 @@ import CustomShaderMaterial from 'three-custom-shader-material/vanilla';
 import {
     type CloudShadowMaterialLeaseMap,
     cloudShadowFragmentShaderChunk,
+    getCloudShadowAttenuationMaterialCandidateRevision,
     projectCloudShadowReceiverToGround,
+    registerCloudShadowAttenuationMaterialCandidate,
     releaseCloudShadowAttenuationMaterials,
     resolveCloudShadowAttenuationActivation,
     resolveCloudShadowAttenuationConfig,
@@ -393,5 +395,48 @@ describe('cloud shadow material integration', () => {
         assert.equal(material.onBeforeCompile, originalOnBeforeCompile);
 
         releaseCloudShadowAttenuationMaterials(leases);
+    });
+
+    it('patches explicitly registered dynamic materials without a scene scan gap', () => {
+        const root = new Object3D();
+        const material = new MeshStandardMaterial();
+        const leases: CloudShadowMaterialLeaseMap = new Map();
+        const originalOnBeforeCompile = material.onBeforeCompile;
+        const revisionBefore =
+            getCloudShadowAttenuationMaterialCandidateRevision();
+        const unregister =
+            registerCloudShadowAttenuationMaterialCandidate(material);
+
+        assert.equal(
+            getCloudShadowAttenuationMaterialCandidateRevision(),
+            revisionBefore + 1,
+        );
+        assert.equal(
+            syncCloudShadowAttenuationMaterials({
+                enabled: true,
+                leases,
+                root,
+                uniforms,
+            }),
+            1,
+        );
+        assert.notEqual(material.onBeforeCompile, originalOnBeforeCompile);
+
+        unregister();
+        unregister();
+        assert.equal(
+            getCloudShadowAttenuationMaterialCandidateRevision(),
+            revisionBefore + 2,
+        );
+        assert.equal(
+            syncCloudShadowAttenuationMaterials({
+                enabled: true,
+                leases,
+                root,
+                uniforms,
+            }),
+            0,
+        );
+        assert.equal(material.onBeforeCompile, originalOnBeforeCompile);
     });
 });

--- a/packages/game/src/scene/gameProfileMetadata.ts
+++ b/packages/game/src/scene/gameProfileMetadata.ts
@@ -337,6 +337,17 @@ export type GameProfileMetadata = {
     snowParticleCount?: number;
     snowParticleGeometryBuildCount?: number;
     weatherDisabled?: boolean;
+    weatherSurfaceAvoidedOverlaySubmissionCount?: number;
+    weatherSurfaceAvoidedOverlayTriangleCount?: number;
+    weatherSurfaceFallbackOverlaySubmissionCount?: number;
+    weatherSurfaceFallbackOverlayTriangleCount?: number;
+    weatherSurfaceIntegratedInstanceCount?: number;
+    weatherSurfaceIntegratedMaterialCount?: number;
+    weatherSurfaceMode?: 'integrated' | 'legacy';
+    weatherSurfacePluginVariantCount?: number;
+    weatherSurfaceSnowIntegrationReadyCount?: number;
+    weatherSurfaceSnowIntegrationTrackedCount?: number;
+    weatherSurfaceSnowIntegrationTransitionCount?: number;
 };
 
 declare global {

--- a/packages/game/src/scene/weatherSurfaceGeometry.ts
+++ b/packages/game/src/scene/weatherSurfaceGeometry.ts
@@ -1,0 +1,547 @@
+import {
+    BufferAttribute,
+    type BufferGeometry,
+    Float32BufferAttribute,
+    type InterleavedBufferAttribute,
+    type TypedArrayConstructor,
+    Uint16BufferAttribute,
+    Uint32BufferAttribute,
+    Vector3,
+} from 'three';
+
+export const WEATHER_SURFACE_GEOMETRY_BRAND =
+    'gredice.weather-surface-geometry.v1' as const;
+
+export const WEATHER_SURFACE_GEOMETRY_USER_DATA_KEY =
+    'weatherSurfaceGeometry' as const;
+
+export const WEATHER_SURFACE_ATTRIBUTE_NAMES = {
+    localPosition: 'aWeatherLocalPosition',
+    snowLayer: 'aSnowLayer',
+    snowTopDistance: 'aSnowTopDistance',
+    surface: 'aWeatherSurface',
+} as const;
+
+export const WEATHER_SURFACE_BASE = 0;
+export const WEATHER_SURFACE_SKIRT = 1;
+
+type Vector3Tuple = readonly [number, number, number];
+
+export type WeatherSurfaceGeometryMetadata = {
+    appendedVertexCount: number;
+    boundaryEdgeCount: number;
+    brand: typeof WEATHER_SURFACE_GEOMETRY_BRAND;
+    includesSnowSkirts: boolean;
+    preparedTriangleCount: number;
+    sourceBounds: {
+        max: Vector3Tuple;
+        min: Vector3Tuple;
+    };
+    sourceTopY: number;
+    sourceTriangleCount: number;
+    sourceVertexCount: number;
+    skirtTriangleCount: number;
+};
+
+export type WeatherSurfaceGeometryTriangleStats = {
+    avoidedTriangleCount: number;
+    baseTriangleCount: number;
+    separatePassTriangleCount: number;
+    singlePassTriangleCount: number;
+    skirtTriangleCount: number;
+};
+
+type GeometryAttribute = BufferAttribute | InterleavedBufferAttribute;
+
+type BoundaryEdge = {
+    count: number;
+    end: number;
+    start: number;
+};
+
+type SkirtVertex = {
+    normal: Vector3Tuple;
+    snowLayer: number;
+    sourceIndex: number;
+};
+
+const baseGeometryCache = new WeakMap<BufferGeometry, BufferGeometry>();
+const skirtedGeometryCache = new WeakMap<BufferGeometry, BufferGeometry>();
+const up = new Vector3(0, 1, 0);
+const vertexA = new Vector3();
+const vertexB = new Vector3();
+const edgeDirection = new Vector3();
+const edgeMidpoint = new Vector3();
+const outward = new Vector3();
+const centerDirection = new Vector3();
+
+function requireAttribute(
+    geometry: BufferGeometry,
+    name: string,
+): GeometryAttribute {
+    const attribute = geometry.getAttribute(name);
+    if (!attribute) {
+        throw new Error(
+            `Unable to prepare weather surface: missing "${name}" attribute.`,
+        );
+    }
+    return attribute;
+}
+
+function readIndices(geometry: BufferGeometry, vertexCount: number) {
+    const index = geometry.getIndex();
+    const indices = index
+        ? Array.from({ length: index.count }, (_, offset) => index.getX(offset))
+        : Array.from({ length: vertexCount }, (_, offset) => offset);
+
+    if (indices.length % 3 !== 0) {
+        throw new Error(
+            `Unable to prepare weather surface: index count ${indices.length} does not describe complete triangles.`,
+        );
+    }
+
+    for (const vertexIndex of indices) {
+        if (
+            !Number.isInteger(vertexIndex) ||
+            vertexIndex < 0 ||
+            vertexIndex >= vertexCount
+        ) {
+            throw new Error(
+                `Unable to prepare weather surface: vertex index ${vertexIndex} is outside 0..${vertexCount - 1}.`,
+            );
+        }
+    }
+
+    return indices;
+}
+
+function normalizedNumberKey(value: number) {
+    return Object.is(value, -0) ? '0' : String(value);
+}
+
+/**
+ * Snow displacement depends on both source position and normal. Treating those
+ * values as the topological identity welds coplanar non-indexed triangles and
+ * UV seams, while retaining a skirt where a hard-normal seam can pull apart.
+ */
+function displacementVertexKey(
+    position: GeometryAttribute,
+    normal: GeometryAttribute,
+    index: number,
+) {
+    return [
+        position.getX(index),
+        position.getY(index),
+        position.getZ(index),
+        normal.getX(index),
+        normal.getY(index),
+        normal.getZ(index),
+    ]
+        .map(normalizedNumberKey)
+        .join(':');
+}
+
+function collectBoundaryEdges(
+    indices: readonly number[],
+    position: GeometryAttribute,
+    normal: GeometryAttribute,
+) {
+    const vertexKeys = Array.from({ length: position.count }, (_, index) =>
+        displacementVertexKey(position, normal, index),
+    );
+    const edges = new Map<string, BoundaryEdge>();
+
+    const registerEdge = (start: number, end: number) => {
+        const startKey = vertexKeys[start];
+        const endKey = vertexKeys[end];
+        const key =
+            startKey < endKey
+                ? `${startKey}|${endKey}`
+                : `${endKey}|${startKey}`;
+        const existing = edges.get(key);
+        if (existing) {
+            existing.count += 1;
+            return;
+        }
+        edges.set(key, { count: 1, end, start });
+    };
+
+    for (let offset = 0; offset < indices.length; offset += 3) {
+        const a = indices[offset];
+        const b = indices[offset + 1];
+        const c = indices[offset + 2];
+        registerEdge(a, b);
+        registerEdge(b, c);
+        registerEdge(c, a);
+    }
+
+    return [...edges.values()].filter((edge) => edge.count === 1);
+}
+
+function collectSkirtVertices(
+    boundaryEdges: readonly BoundaryEdge[],
+    position: GeometryAttribute,
+    boundsCenter: Vector3,
+) {
+    const vertices: SkirtVertex[] = [];
+
+    for (const edge of boundaryEdges) {
+        vertexA.fromBufferAttribute(position, edge.start);
+        vertexB.fromBufferAttribute(position, edge.end);
+        edgeDirection.subVectors(vertexB, vertexA);
+        if (edgeDirection.lengthSq() < 1e-8) {
+            continue;
+        }
+
+        outward.crossVectors(edgeDirection, up);
+        if (outward.lengthSq() < 1e-8) {
+            continue;
+        }
+        outward.normalize();
+
+        edgeMidpoint.addVectors(vertexA, vertexB).multiplyScalar(0.5);
+        centerDirection.subVectors(edgeMidpoint, boundsCenter);
+        if (centerDirection.dot(outward) < 0) {
+            outward.negate();
+        }
+        const normal = Object.freeze([
+            outward.x,
+            outward.y,
+            outward.z,
+        ]) as Vector3Tuple;
+
+        vertices.push(
+            { normal, snowLayer: 1, sourceIndex: edge.start },
+            { normal, snowLayer: 1, sourceIndex: edge.end },
+            { normal, snowLayer: 0, sourceIndex: edge.end },
+            { normal, snowLayer: 0, sourceIndex: edge.start },
+        );
+    }
+
+    return vertices;
+}
+
+function expandAttribute(
+    attribute: GeometryAttribute,
+    skirtVertices: readonly SkirtVertex[],
+    overrides?: (vertex: SkirtVertex, component: number) => number,
+) {
+    const flattened = attribute.clone();
+    const AttributeArray = flattened.array.constructor as TypedArrayConstructor;
+    const expandedArray = new AttributeArray(
+        (flattened.count + skirtVertices.length) * flattened.itemSize,
+    );
+    expandedArray.set(flattened.array);
+
+    skirtVertices.forEach((vertex, skirtIndex) => {
+        const targetOffset =
+            (flattened.count + skirtIndex) * flattened.itemSize;
+        const sourceOffset = vertex.sourceIndex * flattened.itemSize;
+        for (let component = 0; component < flattened.itemSize; component++) {
+            expandedArray[targetOffset + component] = overrides
+                ? overrides(vertex, component)
+                : flattened.array[sourceOffset + component];
+        }
+    });
+
+    const expanded = new BufferAttribute(
+        expandedArray,
+        flattened.itemSize,
+        flattened.normalized,
+    );
+    expanded.name = flattened.name;
+    expanded.gpuType = flattened.gpuType;
+    expanded.setUsage(flattened.usage);
+    return expanded;
+}
+
+function createWeatherAttributes(
+    position: GeometryAttribute,
+    skirtVertices: readonly SkirtVertex[],
+    sourceTopY: number,
+) {
+    const vertexCount = position.count + skirtVertices.length;
+    const localPositions = new Float32Array(vertexCount * 3);
+    const snowLayers = new Float32Array(vertexCount);
+    const snowTopDistances = new Float32Array(vertexCount);
+    const surfaces = new Float32Array(vertexCount);
+
+    const writeVertex = (
+        targetIndex: number,
+        sourceIndex: number,
+        snowLayer: number,
+        surface: number,
+    ) => {
+        const x = position.getX(sourceIndex);
+        const y = position.getY(sourceIndex);
+        const z = position.getZ(sourceIndex);
+        const positionOffset = targetIndex * 3;
+        localPositions[positionOffset] = x;
+        localPositions[positionOffset + 1] = y;
+        localPositions[positionOffset + 2] = z;
+        snowLayers[targetIndex] = snowLayer;
+        snowTopDistances[targetIndex] = Math.max(sourceTopY - y, 0);
+        surfaces[targetIndex] = surface;
+    };
+
+    for (let index = 0; index < position.count; index++) {
+        writeVertex(index, index, 1, WEATHER_SURFACE_BASE);
+    }
+    skirtVertices.forEach((vertex, skirtIndex) => {
+        writeVertex(
+            position.count + skirtIndex,
+            vertex.sourceIndex,
+            vertex.snowLayer,
+            WEATHER_SURFACE_SKIRT,
+        );
+    });
+
+    return {
+        localPosition: new Float32BufferAttribute(localPositions, 3),
+        snowLayer: new Float32BufferAttribute(snowLayers, 1),
+        snowTopDistance: new Float32BufferAttribute(snowTopDistances, 1),
+        surface: new Float32BufferAttribute(surfaces, 1),
+    };
+}
+
+function createMetadata({
+    boundaryEdgeCount,
+    boundsMax,
+    boundsMin,
+    includesSnowSkirts,
+    preparedTriangleCount,
+    sourceTriangleCount,
+    sourceVertexCount,
+}: {
+    boundaryEdgeCount: number;
+    boundsMax: Vector3Tuple;
+    boundsMin: Vector3Tuple;
+    includesSnowSkirts: boolean;
+    preparedTriangleCount: number;
+    sourceTriangleCount: number;
+    sourceVertexCount: number;
+}): WeatherSurfaceGeometryMetadata {
+    const skirtTriangleCount = boundaryEdgeCount * 2;
+    return Object.freeze({
+        appendedVertexCount: boundaryEdgeCount * 4,
+        boundaryEdgeCount,
+        brand: WEATHER_SURFACE_GEOMETRY_BRAND,
+        includesSnowSkirts,
+        preparedTriangleCount,
+        sourceBounds: Object.freeze({
+            max: Object.freeze([...boundsMax]) as Vector3Tuple,
+            min: Object.freeze([...boundsMin]) as Vector3Tuple,
+        }),
+        sourceTopY: boundsMax[1],
+        sourceTriangleCount,
+        sourceVertexCount,
+        skirtTriangleCount,
+    });
+}
+
+export function countGeometryTriangles(geometry: BufferGeometry) {
+    const index = geometry.getIndex();
+    const elementCount =
+        index?.count ?? geometry.getAttribute('position')?.count;
+    if (elementCount === undefined) {
+        throw new Error(
+            'Unable to count geometry triangles: missing "position" attribute.',
+        );
+    }
+    if (elementCount % 3 !== 0) {
+        throw new Error(
+            `Unable to count geometry triangles: element count ${elementCount} does not describe complete triangles.`,
+        );
+    }
+    return elementCount / 3;
+}
+
+export function getWeatherSurfaceGeometryMetadata(
+    geometry: BufferGeometry,
+): WeatherSurfaceGeometryMetadata | undefined {
+    const metadata = Reflect.get(
+        geometry.userData,
+        WEATHER_SURFACE_GEOMETRY_USER_DATA_KEY,
+    );
+    if (
+        typeof metadata !== 'object' ||
+        metadata === null ||
+        Reflect.get(metadata, 'brand') !== WEATHER_SURFACE_GEOMETRY_BRAND
+    ) {
+        return undefined;
+    }
+    return metadata as WeatherSurfaceGeometryMetadata;
+}
+
+export function isWeatherSurfaceGeometry(geometry: BufferGeometry) {
+    return getWeatherSurfaceGeometryMetadata(geometry) !== undefined;
+}
+
+export function getWeatherSurfaceGeometryTriangleStats(
+    geometry: BufferGeometry,
+): WeatherSurfaceGeometryTriangleStats {
+    const metadata = getWeatherSurfaceGeometryMetadata(geometry);
+    if (!metadata) {
+        throw new Error(
+            'Unable to inspect weather surface triangles: geometry is not prepared.',
+        );
+    }
+    const singlePassTriangleCount = countGeometryTriangles(geometry);
+    if (singlePassTriangleCount !== metadata.preparedTriangleCount) {
+        throw new Error(
+            'Unable to inspect weather surface triangles: topology changed after preparation.',
+        );
+    }
+
+    return {
+        avoidedTriangleCount: metadata.sourceTriangleCount,
+        baseTriangleCount: metadata.sourceTriangleCount,
+        separatePassTriangleCount:
+            metadata.sourceTriangleCount + singlePassTriangleCount,
+        singlePassTriangleCount,
+        skirtTriangleCount: metadata.skirtTriangleCount,
+    };
+}
+
+/**
+ * Clones source topology into a geometry that can render base, rain, and snow
+ * in one material pass. Original triangles stay at the front of the index
+ * stream; only degenerate boundary skirts are appended for snow displacement.
+ *
+ * The returned geometry is cached by source identity. It owns every attribute
+ * and index buffer it exposes and never mutates or disposes the source.
+ */
+export function createWeatherSurfaceGeometry(
+    source: BufferGeometry,
+    {
+        includeSnowSkirts = true,
+    }: {
+        includeSnowSkirts?: boolean;
+    } = {},
+): BufferGeometry {
+    const sourceMetadata = getWeatherSurfaceGeometryMetadata(source);
+    if (sourceMetadata?.includesSnowSkirts === includeSnowSkirts) {
+        return source;
+    }
+
+    const geometryCache = includeSnowSkirts
+        ? skirtedGeometryCache
+        : baseGeometryCache;
+    const cached = geometryCache.get(source);
+    if (cached) {
+        return cached;
+    }
+
+    const result = source.clone();
+    if (!result.getAttribute('normal')) {
+        result.computeVertexNormals();
+    }
+    result.computeBoundingBox();
+    const bounds = result.boundingBox;
+    if (!bounds) {
+        throw new Error(
+            'Unable to prepare weather surface: geometry has no bounds.',
+        );
+    }
+
+    const position = requireAttribute(result, 'position');
+    const normal = requireAttribute(result, 'normal');
+    const sourceVertexCount = position.count;
+    const indices = readIndices(result, sourceVertexCount);
+    const sourceTriangleCount = indices.length / 3;
+    const boundaryEdges = includeSnowSkirts
+        ? collectBoundaryEdges(indices, position, normal)
+        : [];
+    const boundsCenter = bounds.getCenter(new Vector3());
+    const skirtVertices = collectSkirtVertices(
+        boundaryEdges,
+        position,
+        boundsCenter,
+    );
+    const boundaryEdgeCount = skirtVertices.length / 4;
+
+    for (const [name, attribute] of Object.entries(result.attributes)) {
+        result.setAttribute(
+            name,
+            expandAttribute(
+                attribute,
+                skirtVertices,
+                name === 'normal'
+                    ? (vertex, component) => vertex.normal[component] ?? 0
+                    : undefined,
+            ),
+        );
+    }
+
+    for (const [name, attributes] of Object.entries(result.morphAttributes)) {
+        Reflect.set(
+            result.morphAttributes,
+            name,
+            attributes.map((attribute) =>
+                expandAttribute(attribute, skirtVertices),
+            ),
+        );
+    }
+
+    const weatherAttributes = createWeatherAttributes(
+        position,
+        skirtVertices,
+        bounds.max.y,
+    );
+    result.setAttribute(
+        WEATHER_SURFACE_ATTRIBUTE_NAMES.localPosition,
+        weatherAttributes.localPosition,
+    );
+    result.setAttribute(
+        WEATHER_SURFACE_ATTRIBUTE_NAMES.snowLayer,
+        weatherAttributes.snowLayer,
+    );
+    result.setAttribute(
+        WEATHER_SURFACE_ATTRIBUTE_NAMES.snowTopDistance,
+        weatherAttributes.snowTopDistance,
+    );
+    result.setAttribute(
+        WEATHER_SURFACE_ATTRIBUTE_NAMES.surface,
+        weatherAttributes.surface,
+    );
+
+    const firstSkirtVertex = sourceVertexCount;
+    for (
+        let skirtOffset = 0;
+        skirtOffset < skirtVertices.length;
+        skirtOffset += 4
+    ) {
+        const topA = firstSkirtVertex + skirtOffset;
+        const topB = topA + 1;
+        const baseB = topA + 2;
+        const baseA = topA + 3;
+        indices.push(topA, topB, baseB, topA, baseB, baseA);
+    }
+
+    const IndexAttribute =
+        sourceVertexCount + skirtVertices.length > 65_535
+            ? Uint32BufferAttribute
+            : Uint16BufferAttribute;
+    result.setIndex(new IndexAttribute(indices, 1));
+    result.setDrawRange(0, indices.length);
+    result.computeBoundingBox();
+    result.computeBoundingSphere();
+
+    const preparedTriangleCount = indices.length / 3;
+    const metadata = createMetadata({
+        boundaryEdgeCount,
+        boundsMax: [bounds.max.x, bounds.max.y, bounds.max.z],
+        boundsMin: [bounds.min.x, bounds.min.y, bounds.min.z],
+        includesSnowSkirts: includeSnowSkirts,
+        preparedTriangleCount,
+        sourceTriangleCount,
+        sourceVertexCount,
+    });
+    result.userData = {
+        ...result.userData,
+        [WEATHER_SURFACE_GEOMETRY_USER_DATA_KEY]: metadata,
+    };
+
+    geometryCache.set(source, result);
+    return result;
+}

--- a/packages/game/src/scene/weatherSurfaceGeometry.unit.ts
+++ b/packages/game/src/scene/weatherSurfaceGeometry.unit.ts
@@ -1,0 +1,288 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { BufferGeometry, Float32BufferAttribute } from 'three';
+import { createMergedChunkGeometry } from '../entities/chunkedMeshGeometry';
+import { createSnowOverlayGeometry } from '../snow/createSnowOverlayGeometry';
+import {
+    countGeometryTriangles,
+    createWeatherSurfaceGeometry,
+    getWeatherSurfaceGeometryMetadata,
+    getWeatherSurfaceGeometryTriangleStats,
+    isWeatherSurfaceGeometry,
+    WEATHER_SURFACE_ATTRIBUTE_NAMES,
+    WEATHER_SURFACE_BASE,
+    WEATHER_SURFACE_SKIRT,
+} from './weatherSurfaceGeometry';
+
+const indexedQuadIndices = [0, 2, 1, 0, 3, 2];
+const quadPositions = [-1, 0, -1, 1, 0, -1, 1, 0, 1, -1, 0, 1];
+const quadNormals = [0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0];
+
+function createIndexedQuad() {
+    const geometry = new BufferGeometry();
+    geometry.setAttribute(
+        'position',
+        new Float32BufferAttribute(quadPositions, 3),
+    );
+    geometry.setAttribute('normal', new Float32BufferAttribute(quadNormals, 3));
+    geometry.setAttribute(
+        'uv',
+        new Float32BufferAttribute([0, 0, 1, 0, 1, 1, 0, 1], 2),
+    );
+    geometry.setIndex(indexedQuadIndices);
+    return geometry;
+}
+
+function createNonIndexedQuad() {
+    const geometry = new BufferGeometry();
+    const positions: number[] = [];
+    const normals: number[] = [];
+    for (const index of indexedQuadIndices) {
+        positions.push(
+            quadPositions[index * 3],
+            quadPositions[index * 3 + 1],
+            quadPositions[index * 3 + 2],
+        );
+        normals.push(0, 1, 0);
+    }
+    geometry.setAttribute('position', new Float32BufferAttribute(positions, 3));
+    geometry.setAttribute('normal', new Float32BufferAttribute(normals, 3));
+    return geometry;
+}
+
+describe('createWeatherSurfaceGeometry', () => {
+    it('retains indexed base triangles once and appends only boundary skirts', () => {
+        const source = createIndexedQuad();
+        const prepared = createWeatherSurfaceGeometry(source);
+        const metadata = getWeatherSurfaceGeometryMetadata(prepared);
+
+        assert.ok(metadata);
+        assert.equal(metadata.sourceTriangleCount, 2);
+        assert.equal(metadata.boundaryEdgeCount, 4);
+        assert.equal(metadata.includesSnowSkirts, true);
+        assert.equal(metadata.skirtTriangleCount, 8);
+        assert.equal(metadata.preparedTriangleCount, 10);
+        assert.equal(metadata.sourceVertexCount, 4);
+        assert.equal(metadata.appendedVertexCount, 16);
+        assert.deepEqual(metadata.sourceBounds, {
+            min: [-1, 0, -1],
+            max: [1, 0, 1],
+        });
+        assert.equal(metadata.sourceTopY, 0);
+        assert.deepEqual(
+            Array.from(prepared.getIndex()?.array ?? []).slice(0, 6),
+            indexedQuadIndices,
+        );
+        assert.equal(prepared.getAttribute('position').count, 20);
+        assert.equal(countGeometryTriangles(prepared), 10);
+        assert.equal(isWeatherSurfaceGeometry(prepared), true);
+    });
+
+    it('welds a non-indexed coplanar diagonal instead of generating an internal skirt', () => {
+        const source = createNonIndexedQuad();
+        const prepared = createWeatherSurfaceGeometry(source);
+        const metadata = getWeatherSurfaceGeometryMetadata(prepared);
+
+        assert.ok(metadata);
+        assert.equal(metadata.sourceTriangleCount, 2);
+        assert.equal(metadata.boundaryEdgeCount, 4);
+        assert.equal(metadata.skirtTriangleCount, 8);
+        assert.equal(metadata.preparedTriangleCount, 10);
+        assert.deepEqual(
+            Array.from(prepared.getIndex()?.array ?? []).slice(0, 6),
+            [0, 1, 2, 3, 4, 5],
+        );
+    });
+
+    it('prepares a base-only weather geometry when snow skirts are inactive', () => {
+        const source = createIndexedQuad();
+        const prepared = createWeatherSurfaceGeometry(source, {
+            includeSnowSkirts: false,
+        });
+        const skirted = createWeatherSurfaceGeometry(source);
+        const metadata = getWeatherSurfaceGeometryMetadata(prepared);
+
+        assert.ok(metadata);
+        assert.equal(metadata.includesSnowSkirts, false);
+        assert.equal(metadata.boundaryEdgeCount, 0);
+        assert.equal(metadata.skirtTriangleCount, 0);
+        assert.equal(metadata.appendedVertexCount, 0);
+        assert.equal(metadata.sourceTriangleCount, 2);
+        assert.equal(metadata.preparedTriangleCount, 2);
+        assert.equal(prepared.getAttribute('position').count, 4);
+        assert.equal(countGeometryTriangles(prepared), 2);
+        assert.notEqual(prepared, skirted);
+        assert.equal(
+            createWeatherSurfaceGeometry(source, {
+                includeSnowSkirts: false,
+            }),
+            prepared,
+        );
+    });
+
+    it('adds compact shader attributes for base and skirt vertices', () => {
+        const source = createIndexedQuad();
+        const prepared = createWeatherSurfaceGeometry(source);
+        const localPosition = prepared.getAttribute(
+            WEATHER_SURFACE_ATTRIBUTE_NAMES.localPosition,
+        );
+        const snowLayer = prepared.getAttribute(
+            WEATHER_SURFACE_ATTRIBUTE_NAMES.snowLayer,
+        );
+        const snowTopDistance = prepared.getAttribute(
+            WEATHER_SURFACE_ATTRIBUTE_NAMES.snowTopDistance,
+        );
+        const surface = prepared.getAttribute(
+            WEATHER_SURFACE_ATTRIBUTE_NAMES.surface,
+        );
+
+        assert.equal(localPosition.count, 20);
+        assert.equal(snowLayer.count, 20);
+        assert.equal(snowTopDistance.count, 20);
+        assert.equal(surface.count, 20);
+        assert.deepEqual(
+            Array.from(surface.array).slice(0, 4),
+            new Array(4).fill(WEATHER_SURFACE_BASE),
+        );
+        assert.deepEqual(
+            Array.from(surface.array).slice(4),
+            new Array(16).fill(WEATHER_SURFACE_SKIRT),
+        );
+        for (let offset = 4; offset < snowLayer.count; offset += 4) {
+            assert.deepEqual(
+                Array.from(snowLayer.array).slice(offset, offset + 4),
+                [1, 1, 0, 0],
+            );
+        }
+        assert.deepEqual(
+            Array.from(snowTopDistance.array),
+            new Array(20).fill(0),
+        );
+        assert.deepEqual(
+            Array.from(localPosition.array).slice(0, 12),
+            quadPositions,
+        );
+    });
+
+    it('stores nonnegative source-local distance from the source top', () => {
+        const source = new BufferGeometry();
+        source.setAttribute(
+            'position',
+            new Float32BufferAttribute([0, 2, 0, 1, -1, 0, 0, 0.5, 1], 3),
+        );
+        source.setIndex([0, 1, 2]);
+
+        const prepared = createWeatherSurfaceGeometry(source);
+        const distance = prepared.getAttribute(
+            WEATHER_SURFACE_ATTRIBUTE_NAMES.snowTopDistance,
+        );
+        const metadata = getWeatherSurfaceGeometryMetadata(prepared);
+
+        assert.ok(metadata);
+        assert.equal(metadata.sourceTopY, 2);
+        assert.deepEqual(Array.from(distance.array).slice(0, 3), [0, 3, 1.5]);
+        assert.ok(Array.from(distance.array).every((value) => value >= 0));
+    });
+
+    it('caches by source identity without sharing, mutating, or disposing source buffers', () => {
+        const source = createIndexedQuad();
+        source.userData = { owner: 'source' };
+        const sourcePosition = source.getAttribute('position');
+        const sourceIndex = source.getIndex();
+        const positionSnapshot = Array.from(sourcePosition.array);
+        const indexSnapshot = Array.from(sourceIndex?.array ?? []);
+        let sourceDisposeCount = 0;
+        source.addEventListener('dispose', () => {
+            sourceDisposeCount += 1;
+        });
+
+        const first = createWeatherSurfaceGeometry(source);
+        const second = createWeatherSurfaceGeometry(source);
+
+        assert.equal(first, second);
+        assert.notEqual(first, source);
+        assert.notEqual(
+            first.getAttribute('position').array,
+            sourcePosition.array,
+        );
+        assert.notEqual(first.getIndex()?.array, sourceIndex?.array);
+        assert.deepEqual(Array.from(sourcePosition.array), positionSnapshot);
+        assert.deepEqual(Array.from(sourceIndex?.array ?? []), indexSnapshot);
+        assert.equal(source.getAttribute('aSnowLayer'), undefined);
+        assert.equal(source.boundingBox, null);
+        assert.deepEqual(source.userData, { owner: 'source' });
+        assert.equal(sourceDisposeCount, 0);
+    });
+
+    it('accounts exactly for the base replay avoided versus the legacy overlay', () => {
+        const source = createIndexedQuad();
+        const legacyOverlay = createSnowOverlayGeometry(source);
+        const prepared = createWeatherSurfaceGeometry(source);
+        const stats = getWeatherSurfaceGeometryTriangleStats(prepared);
+        const legacySeparatePassTriangles =
+            countGeometryTriangles(source) +
+            countGeometryTriangles(legacyOverlay);
+
+        assert.deepEqual(stats, {
+            avoidedTriangleCount: 2,
+            baseTriangleCount: 2,
+            separatePassTriangleCount: 12,
+            singlePassTriangleCount: 10,
+            skirtTriangleCount: 8,
+        });
+        assert.equal(
+            stats.separatePassTriangleCount,
+            legacySeparatePassTriangles,
+        );
+        assert.equal(
+            legacySeparatePassTriangles - stats.singlePassTriangleCount,
+            stats.avoidedTriangleCount,
+        );
+    });
+
+    it('keeps legacy source-local snow-noise coordinates across merged tiles', () => {
+        const source = createIndexedQuad();
+        const prepared = createWeatherSurfaceGeometry(source);
+        const merged = createMergedChunkGeometry({
+            geometry: prepared,
+            instances: [
+                { position: [0, 0, 0], rotation: 0 },
+                { position: [10, 3, -2], rotation: 0 },
+            ],
+            localTransform: {
+                position: [0, 0, 0],
+                rotation: [0, 0, 0],
+            },
+            scale: 1,
+        });
+
+        assert.equal(countGeometryTriangles(merged), 20);
+        for (const name of Object.values(WEATHER_SURFACE_ATTRIBUTE_NAMES)) {
+            assert.equal(merged.getAttribute(name).count, 40);
+        }
+
+        const position = merged.getAttribute('position');
+        const localPosition = merged.getAttribute(
+            WEATHER_SURFACE_ATTRIBUTE_NAMES.localPosition,
+        );
+        const snowTopDistance = merged.getAttribute(
+            WEATHER_SURFACE_ATTRIBUTE_NAMES.snowTopDistance,
+        );
+        const preparedPosition = prepared.getAttribute('position');
+        const localPositionValues = Array.from(localPosition.array);
+        assert.deepEqual(
+            localPositionValues.slice(0, 20 * 3),
+            localPositionValues.slice(20 * 3, 40 * 3),
+            'each baked tile must retain the source-local noise coordinate sampled by the legacy instanced overlay',
+        );
+        assert.equal(position.getX(20), preparedPosition.getX(0) + 10);
+        assert.equal(position.getY(20), preparedPosition.getY(0) + 3);
+        assert.equal(position.getZ(20), preparedPosition.getZ(0) - 2);
+        assert.equal(
+            snowTopDistance.getX(20),
+            prepared
+                .getAttribute(WEATHER_SURFACE_ATTRIBUTE_NAMES.snowTopDistance)
+                .getX(0),
+        );
+    });
+});

--- a/packages/game/src/scene/weatherSurfaceMaterial.ts
+++ b/packages/game/src/scene/weatherSurfaceMaterial.ts
@@ -1,0 +1,818 @@
+import type { ColorRepresentation, IUniform, Material } from 'three';
+import { Color, MeshStandardMaterial, NormalBlending, Vector3 } from 'three';
+import { getMaterialShaderHooksWithoutCloudShadowAttenuation } from './cloudShadowAttenuation';
+
+const WEATHER_SURFACE_PLUGIN_VARIANT_KEY_PREFIX = 'gredice-weather-surface-v2';
+
+type Vector3Tuple = readonly [number, number, number];
+
+export type WeatherSurfacePluginMode = 'combined' | 'rain-only' | 'snow-only';
+
+export type WeatherSurfacePluginActivation = {
+    rainEnabled: boolean;
+    snowEnabled: boolean;
+};
+
+export type WeatherSurfaceMaterialOptions = {
+    rain: {
+        bounds: {
+            max: Vector3Tuple;
+            min: Vector3Tuple;
+        };
+        darkness: number;
+        enabled: boolean;
+        glossiness: number;
+        puddleStrengthUniform: IUniform<number>;
+        topSurfaceBias: number;
+        wetnessUniform: IUniform<number>;
+    };
+    snow: {
+        amountUniform: IUniform<number>;
+        color: ColorRepresentation;
+        enabled: boolean;
+        lift: number;
+        maxThickness: number;
+        noiseAmplitude: number;
+        noiseInfluence: number;
+        noiseScale: number;
+        slopeExponent: number;
+    };
+};
+
+export function resolveWeatherSurfacePluginMode({
+    rainEnabled,
+    snowEnabled,
+}: WeatherSurfacePluginActivation): WeatherSurfacePluginMode {
+    if (rainEnabled && snowEnabled) {
+        return 'combined';
+    }
+    if (rainEnabled) {
+        return 'rain-only';
+    }
+    if (snowEnabled) {
+        return 'snow-only';
+    }
+    throw new Error(
+        'Integrated weather surface requires rain, snow, or both to be enabled.',
+    );
+}
+
+export function getWeatherSurfacePluginVariantKey(
+    mode: WeatherSurfacePluginMode,
+) {
+    return `${WEATHER_SURFACE_PLUGIN_VARIANT_KEY_PREFIX}:${mode}`;
+}
+
+function modeIncludesRain(mode: WeatherSurfacePluginMode) {
+    return mode === 'rain-only' || mode === 'combined';
+}
+
+function modeIncludesSnow(mode: WeatherSurfacePluginMode) {
+    return mode === 'snow-only' || mode === 'combined';
+}
+
+const weatherWorldPositionVertexPars = `
+varying vec3 vGrediceWeatherWorldPosition;
+`;
+
+const weatherWorldNormalVertexPars = `
+varying vec3 vGrediceWeatherWorldNormal;
+`;
+
+const weatherRainOnlyNormalVertexPars = `
+varying float vGrediceWeatherWorldNormalY;
+`;
+
+const weatherSnowVertexPars = `
+attribute vec3 aWeatherLocalPosition;
+attribute float aWeatherSurface;
+attribute float aSnowLayer;
+attribute float aSnowTopDistance;
+
+uniform float uGrediceSnowAmount;
+uniform float uGrediceSnowLift;
+uniform float uGrediceSnowMaxThickness;
+uniform float uGrediceSnowNoiseAmplitude;
+uniform float uGrediceSnowNoiseScale;
+uniform float uGrediceSnowSlopeExponent;
+
+varying float vGrediceSnowCoverage;
+varying float vGrediceSnowNoise;
+varying float vGrediceSnowSideDepth;
+varying float vGrediceSnowSideFactor;
+varying float vGrediceSnowSurface;
+varying float vGrediceSnowThickness;
+
+float grediceWeatherHash(vec3 p) {
+    return fract(sin(dot(p, vec3(12.9898, 78.233, 37.719))) * 43758.5453);
+}
+
+float grediceWeatherNoise(vec3 p) {
+    vec3 i = floor(p);
+    vec3 f = fract(p);
+    vec3 u = f * f * (3.0 - 2.0 * f);
+
+    float n000 = grediceWeatherHash(i);
+    float n100 = grediceWeatherHash(i + vec3(1.0, 0.0, 0.0));
+    float n010 = grediceWeatherHash(i + vec3(0.0, 1.0, 0.0));
+    float n110 = grediceWeatherHash(i + vec3(1.0, 1.0, 0.0));
+    float n001 = grediceWeatherHash(i + vec3(0.0, 0.0, 1.0));
+    float n101 = grediceWeatherHash(i + vec3(1.0, 0.0, 1.0));
+    float n011 = grediceWeatherHash(i + vec3(0.0, 1.0, 1.0));
+    float n111 = grediceWeatherHash(i + vec3(1.0, 1.0, 1.0));
+
+    float nx00 = mix(n000, n100, u.x);
+    float nx10 = mix(n010, n110, u.x);
+    float nx01 = mix(n001, n101, u.x);
+    float nx11 = mix(n011, n111, u.x);
+
+    return mix(mix(nx00, nx10, u.y), mix(nx01, nx11, u.y), u.z) * 2.0 - 1.0;
+}
+`;
+
+const weatherWorldNormalVertex = `
+vec3 grediceWeatherWorldNormal = normalize(
+    inverseTransformDirection(transformedNormal, viewMatrix)
+);
+vGrediceWeatherWorldNormal = grediceWeatherWorldNormal;
+`;
+
+const weatherRainOnlyNormalVertex = `
+vGrediceWeatherWorldNormalY = normalize(
+    inverseTransformDirection(transformedNormal, viewMatrix)
+).y;
+`;
+
+function weatherSnowVertexDisplacement(useBuiltInViewNormal: boolean) {
+    const worldNormalSetup = useBuiltInViewNormal
+        ? ''
+        : `
+vec3 grediceWeatherWorldNormal = normalize(
+    inverseTransformDirection(transformedNormal, viewMatrix)
+);
+`;
+    const slopeAlignment = useBuiltInViewNormal
+        ? `dot(vNormal, viewMatrix[1].xyz)`
+        : `dot(grediceWeatherWorldNormal, grediceWeatherWorldUp)`;
+    const worldNormalAssignment = useBuiltInViewNormal
+        ? ''
+        : `
+vGrediceWeatherWorldNormal = grediceWeatherWorldNormal;`;
+    return `
+mat4 grediceWeatherObjectMatrix = modelMatrix;
+#ifdef USE_INSTANCING
+    grediceWeatherObjectMatrix = grediceWeatherObjectMatrix * instanceMatrix;
+#endif
+#ifdef USE_BATCHING
+    grediceWeatherObjectMatrix = grediceWeatherObjectMatrix * batchingMatrix;
+#endif
+
+${worldNormalSetup}
+float grediceSnowCoverage = 0.0;
+float grediceSnowDistanceForSide = 0.0;
+float grediceSnowNoise = 0.0;
+float grediceSnowSideFactor = 0.0;
+float grediceSnowThickness = 0.0;
+
+if (uGrediceSnowAmount > 0.001) {
+    vec3 grediceWeatherWorldUp = vec3(0.0, 1.0, 0.0);
+    vec3 grediceWeatherLocalUp = normalize(
+        transpose(mat3(grediceWeatherObjectMatrix)) *
+            grediceWeatherWorldUp
+    );
+    float grediceSnowSlopeAlignment = clamp(
+        ${slopeAlignment},
+        0.0,
+        1.0
+    );
+    float grediceSnowSlopeCoverage = pow(
+        grediceSnowSlopeAlignment,
+        uGrediceSnowSlopeExponent
+    );
+    // Legacy stable overlays sample source-local position before applying the
+    // per-block instance matrix. Merged base chunks bake that matrix into
+    // position, so this preserved attribute retains the legacy noise phase.
+    grediceSnowNoise = grediceWeatherNoise(
+        aWeatherLocalPosition * uGrediceSnowNoiseScale
+    );
+    float grediceSnowBaseThickness =
+        uGrediceSnowMaxThickness *
+        (
+            1.0 +
+            grediceSnowNoise * uGrediceSnowNoiseAmplitude
+        );
+    float grediceSnowSafeThickness = max(
+        grediceSnowBaseThickness,
+        0.0001
+    );
+    grediceSnowSideFactor = 1.0 - smoothstep(
+        0.4,
+        0.85,
+        grediceSnowSlopeAlignment
+    );
+    grediceSnowDistanceForSide = mix(
+        aSnowTopDistance,
+        0.0,
+        grediceSnowSideFactor
+    );
+    float grediceSnowSideBand = clamp(
+        1.0 -
+            grediceSnowDistanceForSide /
+                grediceSnowSafeThickness,
+        0.0,
+        1.0
+    );
+    grediceSnowCoverage = clamp(
+        uGrediceSnowAmount *
+            mix(
+                grediceSnowSlopeCoverage,
+                grediceSnowSideBand,
+                grediceSnowSideFactor
+            ),
+        0.0,
+        1.0
+    );
+    grediceSnowThickness =
+        grediceSnowCoverage * grediceSnowBaseThickness;
+    float grediceSnowSideDisplacement = clamp(
+        grediceSnowThickness - grediceSnowDistanceForSide,
+        0.0,
+        grediceSnowThickness
+    );
+    float grediceSnowDisplacementAmount = mix(
+        grediceSnowThickness,
+        grediceSnowSideDisplacement,
+        grediceSnowSideFactor
+    ) * clamp(aSnowLayer, 0.0, 1.0);
+    grediceSnowDisplacementAmount +=
+        uGrediceSnowLift *
+        smoothstep(0.001, 0.04, grediceSnowCoverage) *
+        clamp(aSnowLayer, 0.0, 1.0);
+    vec3 grediceSnowDisplacementDirection = normalize(
+        mix(
+            objectNormal,
+            grediceWeatherLocalUp,
+            grediceSnowSideFactor
+        )
+    );
+    transformed +=
+        grediceSnowDisplacementDirection *
+        grediceSnowDisplacementAmount;
+}
+
+vGrediceSnowCoverage = grediceSnowCoverage;
+vGrediceSnowNoise = grediceSnowNoise;
+vGrediceSnowSideDepth = grediceSnowDistanceForSide;
+vGrediceSnowSideFactor = grediceSnowSideFactor;
+vGrediceSnowSurface = aWeatherSurface;
+vGrediceSnowThickness = grediceSnowThickness;
+${worldNormalAssignment}
+`;
+}
+
+const weatherWorldPosition = `
+#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined( USE_SHADOWMAP ) || defined( USE_TRANSMISSION ) || NUM_SPOT_LIGHT_COORDS > 0
+    vGrediceWeatherWorldPosition = worldPosition.xyz;
+#else
+    vec4 grediceWeatherWorldPosition = vec4(transformed, 1.0);
+    #ifdef USE_BATCHING
+        grediceWeatherWorldPosition =
+            batchingMatrix * grediceWeatherWorldPosition;
+    #endif
+    #ifdef USE_INSTANCING
+        grediceWeatherWorldPosition =
+            instanceMatrix * grediceWeatherWorldPosition;
+    #endif
+    grediceWeatherWorldPosition =
+        modelMatrix * grediceWeatherWorldPosition;
+    vGrediceWeatherWorldPosition =
+        grediceWeatherWorldPosition.xyz;
+#endif
+`;
+
+const weatherWorldPositionFragmentPars = `
+varying vec3 vGrediceWeatherWorldPosition;
+`;
+
+const weatherWorldNormalFragmentPars = `
+varying vec3 vGrediceWeatherWorldNormal;
+`;
+
+const weatherRainOnlyNormalFragmentPars = `
+varying float vGrediceWeatherWorldNormalY;
+`;
+
+const weatherRainFragmentPars = `
+uniform float uGrediceRainDarkness;
+uniform float uGrediceRainGlossiness;
+uniform float uGrediceRainPuddleStrength;
+uniform float uGrediceRainTopSurfaceBias;
+uniform float uGrediceRainWetness;
+uniform vec3 uGrediceRainBoundsMax;
+uniform vec3 uGrediceRainBoundsMin;
+
+float grediceWeatherFragmentNoise(vec3 p) {
+    return fract(sin(dot(p, vec3(12.9898, 78.233, 45.164))) * 43758.5453123);
+}
+`;
+
+const weatherSnowFragmentPars = `
+uniform float uGrediceSnowAmount;
+uniform vec3 uGrediceSnowColor;
+uniform float uGrediceSnowNoiseInfluence;
+
+varying float vGrediceSnowCoverage;
+varying float vGrediceSnowNoise;
+varying float vGrediceSnowSideDepth;
+varying float vGrediceSnowSideFactor;
+varying float vGrediceSnowSurface;
+varying float vGrediceSnowThickness;
+
+float grediceWeatherResolveSnowCoverage() {
+    float coverage = clamp(
+        (
+            vGrediceSnowCoverage +
+                vGrediceSnowNoise *
+                    uGrediceSnowNoiseInfluence
+        ),
+        0.0,
+        1.0
+    );
+    if (
+        vGrediceSnowSideFactor > 0.001 &&
+        vGrediceSnowThickness > 0.0001
+    ) {
+        float normalizedSide = clamp(
+            (
+                vGrediceSnowThickness -
+                vGrediceSnowSideDepth
+            ) / vGrediceSnowThickness,
+            0.0,
+            1.0
+        );
+        coverage *= mix(
+            1.0,
+            normalizedSide,
+            clamp(vGrediceSnowSideFactor, 0.0, 1.0)
+        );
+    }
+    return coverage;
+}
+`;
+
+function weatherFastSnowFragment(useBuiltInViewNormal: boolean) {
+    const earlyNormal = useBuiltInViewNormal
+        ? `normalize(vNormal)`
+        : `normalize(
+        mat3(viewMatrix) *
+            normalize(vGrediceWeatherWorldNormal)
+    )`;
+    return `
+float grediceWeatherEarlySnowCoverage =
+    grediceWeatherResolveSnowCoverage();
+float grediceWeatherEarlySnowStrength = smoothstep(
+    0.05,
+    0.85,
+    grediceWeatherEarlySnowCoverage
+);
+if (
+    grediceWeatherEarlySnowStrength >= 0.01 ||
+    vGrediceSnowSurface > 0.5
+) {
+    vec3 grediceWeatherEarlyNormal = ${earlyNormal};
+    vec3 grediceWeatherEarlyLight = vec3(0.8);
+    #if NUM_DIR_LIGHTS > 0
+        for (int i = 0; i < NUM_DIR_LIGHTS; i++) {
+            float grediceWeatherEarlyDiffuse = max(
+                dot(
+                    grediceWeatherEarlyNormal,
+                    directionalLights[i].direction
+                ),
+                0.0
+            );
+            grediceWeatherEarlyLight +=
+                directionalLights[i].color *
+                grediceWeatherEarlyDiffuse *
+                0.8;
+        }
+    #endif
+    float grediceWeatherEarlyHemi =
+        grediceWeatherEarlyNormal.y * 0.5 + 0.5;
+    grediceWeatherEarlyLight += mix(
+        vec3(0.2),
+        vec3(0.3),
+        grediceWeatherEarlyHemi
+    );
+    vec3 grediceWeatherEarlySnowColor = mix(
+        uGrediceSnowColor * 0.85,
+        uGrediceSnowColor,
+        grediceWeatherEarlySnowStrength
+    );
+    gl_FragColor = vec4(
+        grediceWeatherEarlySnowColor *
+            clamp(grediceWeatherEarlyLight, 0.5, 2.5),
+        1.0
+    );
+    // Keep the legacy SnowOverlay output contract: it writes the lit linear
+    // color directly and only applies scene fog. Besides preserving the
+    // established snow brightness, this keeps the covered-fragment path tiny.
+    #include <fog_fragment>
+    return;
+}
+`;
+}
+
+const weatherSnowColorFragment = `
+float grediceWeatherSnowCoverage =
+    grediceWeatherEarlySnowCoverage;
+float grediceWeatherSnowStrength = smoothstep(
+    0.05,
+    0.85,
+    grediceWeatherSnowCoverage
+);
+vec3 grediceWeatherSnowColor = mix(
+    uGrediceSnowColor * 0.85,
+    uGrediceSnowColor,
+    grediceWeatherSnowStrength
+);
+float grediceWeatherSnowPresence = max(
+    step(0.01, grediceWeatherSnowStrength),
+    step(0.5, vGrediceSnowSurface)
+);
+diffuseColor.rgb = mix(
+    diffuseColor.rgb,
+    grediceWeatherSnowColor,
+    grediceWeatherSnowPresence
+);
+`;
+
+const weatherCombinedRainColorFragment = `
+float grediceWeatherTopness = 0.0;
+float grediceWeatherNormalY = 0.0;
+float grediceWeatherWet = 0.0;
+float grediceWeatherPuddle = 0.0;
+if (uGrediceRainWetness > 0.001) {
+    grediceWeatherNormalY = max(
+        normalize(vGrediceWeatherWorldNormal).y,
+        0.0
+    );
+    grediceWeatherTopness = clamp(
+        pow(
+            grediceWeatherNormalY,
+            uGrediceRainTopSurfaceBias
+        ),
+        0.0,
+        1.0
+    );
+    vec3 grediceWeatherRainLocal =
+        (
+            vGrediceWeatherWorldPosition -
+            uGrediceRainBoundsMin
+        ) /
+        max(
+            vec3(0.001),
+            uGrediceRainBoundsMax -
+            uGrediceRainBoundsMin
+        );
+    float grediceWeatherRainVariation =
+        0.75 +
+        grediceWeatherFragmentNoise(
+            grediceWeatherRainLocal * 17.0
+        ) *
+        0.25;
+    grediceWeatherWet = clamp(
+        uGrediceRainWetness *
+            grediceWeatherTopness *
+            grediceWeatherRainVariation *
+            (1.0 - grediceWeatherSnowPresence),
+        0.0,
+        1.0
+    );
+    float grediceWeatherPuddleMask =
+        smoothstep(0.6, 1.0, grediceWeatherWet) *
+        grediceWeatherTopness;
+    float grediceWeatherPuddleNoise =
+        grediceWeatherFragmentNoise(
+            grediceWeatherRainLocal * 23.0 +
+                vec3(3.1, 7.9, 1.4)
+        );
+    grediceWeatherPuddle =
+        smoothstep(0.78, 0.98, grediceWeatherPuddleNoise) *
+        grediceWeatherPuddleMask *
+        uGrediceRainPuddleStrength;
+}
+`;
+
+const weatherRainOnlyComputationFragment = `
+float grediceWeatherTopness = 0.0;
+float grediceWeatherNormalY = 0.0;
+float grediceWeatherWet = 0.0;
+float grediceWeatherPuddle = 0.0;
+if (uGrediceRainWetness > 0.001) {
+    grediceWeatherNormalY = max(
+        vGrediceWeatherWorldNormalY,
+        0.0
+    );
+    if (grediceWeatherNormalY > 0.0) {
+        grediceWeatherTopness = clamp(
+            pow(
+                grediceWeatherNormalY,
+                uGrediceRainTopSurfaceBias
+            ),
+            0.0,
+            1.0
+        );
+        vec3 grediceWeatherRainLocal =
+            (
+                vGrediceWeatherWorldPosition -
+                uGrediceRainBoundsMin
+            ) /
+            max(
+                vec3(0.001),
+                uGrediceRainBoundsMax -
+                uGrediceRainBoundsMin
+            );
+        float grediceWeatherRainVariation =
+            0.75 +
+            grediceWeatherFragmentNoise(
+                grediceWeatherRainLocal * 17.0
+            ) *
+            0.25;
+        grediceWeatherWet = clamp(
+            uGrediceRainWetness *
+                grediceWeatherTopness *
+                grediceWeatherRainVariation,
+            0.0,
+            1.0
+        );
+        float grediceWeatherPuddleMask =
+            smoothstep(0.6, 1.0, grediceWeatherWet) *
+            grediceWeatherTopness;
+        if (grediceWeatherPuddleMask > 0.0) {
+            float grediceWeatherPuddleNoise =
+                grediceWeatherFragmentNoise(
+                    grediceWeatherRainLocal * 23.0 +
+                        vec3(3.1, 7.9, 1.4)
+                );
+            grediceWeatherPuddle =
+                smoothstep(
+                    0.78,
+                    0.98,
+                    grediceWeatherPuddleNoise
+                ) *
+                grediceWeatherPuddleMask *
+                uGrediceRainPuddleStrength;
+        }
+    }
+}
+`;
+
+const weatherRoughnessFragment = `
+roughnessFactor = mix(
+    roughnessFactor,
+    0.92,
+    grediceWeatherSnowStrength
+);
+`;
+
+const weatherMetalnessFragment = `
+metalnessFactor = mix(
+    metalnessFactor,
+    0.0,
+    grediceWeatherSnowStrength
+);
+`;
+
+const weatherOutputFragment = `
+float grediceWeatherRainAlpha = max(
+    grediceWeatherWet * 0.4,
+    grediceWeatherPuddle * 0.5
+);
+float grediceWeatherGlint =
+    pow(grediceWeatherNormalY, 20.0) *
+    grediceWeatherWet *
+    uGrediceRainGlossiness;
+vec3 grediceWeatherRainColor =
+    vec3(0.02) * uGrediceRainDarkness +
+    vec3(
+        grediceWeatherGlint * 0.18 +
+        grediceWeatherPuddle * 0.12
+    );
+gl_FragColor.rgb = mix(
+    gl_FragColor.rgb,
+    grediceWeatherRainColor,
+    grediceWeatherRainAlpha
+);
+`;
+
+function replaceShaderChunk(
+    source: string,
+    chunk: string,
+    replacement: string,
+) {
+    if (!source.includes(chunk)) {
+        throw new Error(
+            `Weather surface shader is missing required chunk ${chunk}.`,
+        );
+    }
+    return source.replace(chunk, replacement);
+}
+
+export function supportsIntegratedWeatherSurfaceMaterial(
+    material: Material,
+): material is MeshStandardMaterial {
+    const transmission = Reflect.get(material, 'transmission');
+    return (
+        (material instanceof MeshStandardMaterial ||
+            Reflect.get(material, 'isMeshPhysicalMaterial') === true) &&
+        material.transparent === false &&
+        material.opacity >= 0.999 &&
+        material.depthTest &&
+        material.depthWrite &&
+        material.blending === NormalBlending &&
+        (typeof transmission !== 'number' || transmission <= 0)
+    );
+}
+
+function injectWeatherSurfaceShader(
+    shader: Parameters<Material['onBeforeCompile']>[0],
+    options: WeatherSurfaceMaterialOptions,
+    mode: WeatherSurfacePluginMode,
+    flatShaded: boolean,
+) {
+    const includesRain = modeIncludesRain(mode);
+    const includesSnow = modeIncludesSnow(mode);
+    const usesBuiltInSnowViewNormal = mode === 'snow-only' && !flatShaded;
+
+    if (includesRain) {
+        shader.uniforms.uGrediceRainDarkness = {
+            value: options.rain.darkness,
+        };
+        shader.uniforms.uGrediceRainBoundsMax = {
+            value: new Vector3(...options.rain.bounds.max),
+        };
+        shader.uniforms.uGrediceRainBoundsMin = {
+            value: new Vector3(...options.rain.bounds.min),
+        };
+        shader.uniforms.uGrediceRainGlossiness = {
+            value: options.rain.glossiness,
+        };
+        shader.uniforms.uGrediceRainPuddleStrength =
+            options.rain.puddleStrengthUniform;
+        shader.uniforms.uGrediceRainTopSurfaceBias = {
+            value: options.rain.topSurfaceBias,
+        };
+        shader.uniforms.uGrediceRainWetness = options.rain.wetnessUniform;
+    }
+    if (includesSnow) {
+        shader.uniforms.uGrediceSnowAmount = options.snow.amountUniform;
+        shader.uniforms.uGrediceSnowColor = {
+            value: new Color(options.snow.color),
+        };
+        shader.uniforms.uGrediceSnowLift = { value: options.snow.lift };
+        shader.uniforms.uGrediceSnowMaxThickness = {
+            value: options.snow.maxThickness,
+        };
+        shader.uniforms.uGrediceSnowNoiseAmplitude = {
+            value: options.snow.noiseAmplitude,
+        };
+        shader.uniforms.uGrediceSnowNoiseInfluence = {
+            value: options.snow.noiseInfluence,
+        };
+        shader.uniforms.uGrediceSnowNoiseScale = {
+            value: options.snow.noiseScale,
+        };
+        shader.uniforms.uGrediceSnowSlopeExponent = {
+            value: options.snow.slopeExponent,
+        };
+    }
+
+    shader.vertexShader = replaceShaderChunk(
+        shader.vertexShader,
+        '#include <common>',
+        `#include <common>\n${weatherWorldPositionVertexPars}${
+            mode === 'rain-only'
+                ? weatherRainOnlyNormalVertexPars
+                : usesBuiltInSnowViewNormal
+                  ? ''
+                  : weatherWorldNormalVertexPars
+        }${includesSnow ? weatherSnowVertexPars : ''}`,
+    );
+    shader.vertexShader = replaceShaderChunk(
+        shader.vertexShader,
+        '#include <project_vertex>',
+        `${
+            includesSnow
+                ? weatherSnowVertexDisplacement(usesBuiltInSnowViewNormal)
+                : mode === 'rain-only'
+                  ? weatherRainOnlyNormalVertex
+                  : weatherWorldNormalVertex
+        }\n#include <project_vertex>`,
+    );
+    shader.vertexShader = replaceShaderChunk(
+        shader.vertexShader,
+        '#include <worldpos_vertex>',
+        `#include <worldpos_vertex>\n${weatherWorldPosition}`,
+    );
+    shader.fragmentShader = replaceShaderChunk(
+        shader.fragmentShader,
+        '#include <common>',
+        `#include <common>\n${weatherWorldPositionFragmentPars}${
+            mode === 'rain-only'
+                ? weatherRainOnlyNormalFragmentPars
+                : usesBuiltInSnowViewNormal
+                  ? ''
+                  : weatherWorldNormalFragmentPars
+        }${
+            includesRain ? weatherRainFragmentPars : ''
+        }${includesSnow ? weatherSnowFragmentPars : ''}`,
+    );
+    if (includesSnow) {
+        shader.fragmentShader = replaceShaderChunk(
+            shader.fragmentShader,
+            '#include <map_fragment>',
+            `${weatherFastSnowFragment(
+                usesBuiltInSnowViewNormal,
+            )}\n#include <map_fragment>`,
+        );
+    }
+    if (includesSnow) {
+        const colorFragments = [
+            weatherSnowColorFragment,
+            mode === 'combined' ? weatherCombinedRainColorFragment : '',
+        ].join('');
+        shader.fragmentShader = replaceShaderChunk(
+            shader.fragmentShader,
+            '#include <color_fragment>',
+            `#include <color_fragment>\n${colorFragments}`,
+        );
+    }
+    if (includesSnow) {
+        shader.fragmentShader = replaceShaderChunk(
+            shader.fragmentShader,
+            '#include <roughnessmap_fragment>',
+            `#include <roughnessmap_fragment>\n${weatherRoughnessFragment}`,
+        );
+        shader.fragmentShader = replaceShaderChunk(
+            shader.fragmentShader,
+            '#include <metalnessmap_fragment>',
+            `#include <metalnessmap_fragment>\n${weatherMetalnessFragment}`,
+        );
+    }
+    if (includesRain) {
+        const rainOutputFragment =
+            mode === 'rain-only'
+                ? `${weatherRainOnlyComputationFragment}\n${weatherOutputFragment}`
+                : weatherOutputFragment;
+        shader.fragmentShader = replaceShaderChunk(
+            shader.fragmentShader,
+            '#include <dithering_fragment>',
+            `${rainOutputFragment}\n#include <dithering_fragment>`,
+        );
+    }
+}
+
+export function createIntegratedWeatherSurfaceMaterial(
+    source: MeshStandardMaterial,
+    options: WeatherSurfaceMaterialOptions,
+) {
+    const pluginMode = resolveWeatherSurfacePluginMode({
+        rainEnabled: options.rain.enabled,
+        snowEnabled: options.snow.enabled,
+    });
+    const pluginVariantKey = getWeatherSurfacePluginVariantKey(pluginMode);
+    const material = source.clone();
+    material.name = `${source.name || source.type}:IntegratedWeatherSurface`;
+    const sourceHooks =
+        getMaterialShaderHooksWithoutCloudShadowAttenuation(source);
+
+    // Three's clone/copy intentionally omits compile callbacks. Inject first,
+    // then let the source decorator insert its base-color work immediately
+    // after Three's chunks and before the weather blend. Scene-owned cloud
+    // attenuation is intentionally unwrapped; the scene patches this clone.
+    material.onBeforeCompile = sourceHooks.onBeforeCompile;
+    material.customProgramCacheKey = sourceHooks.customProgramCacheKey;
+    const originalOnBeforeCompile = material.onBeforeCompile;
+    const originalCustomProgramCacheKey = material.customProgramCacheKey;
+
+    material.onBeforeCompile = (shader, renderer) => {
+        injectWeatherSurfaceShader(
+            shader,
+            options,
+            pluginMode,
+            material.flatShading,
+        );
+        originalOnBeforeCompile.call(material, shader, renderer);
+    };
+    material.customProgramCacheKey = () =>
+        `${originalCustomProgramCacheKey.call(material)}|${pluginVariantKey}`;
+    material.userData = {
+        ...material.userData,
+        grediceWeatherSurface: true,
+        grediceWeatherSurfacePluginMode: pluginMode,
+        grediceWeatherSurfacePluginVariantKey: pluginVariantKey,
+    };
+    material.needsUpdate = true;
+
+    return material;
+}

--- a/packages/game/src/scene/weatherSurfaceMaterial.unit.ts
+++ b/packages/game/src/scene/weatherSurfaceMaterial.unit.ts
@@ -1,0 +1,626 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    AdditiveBlending,
+    MeshBasicMaterial,
+    MeshStandardMaterial,
+    ShaderMaterial,
+} from 'three';
+import { applyGroundPatchMaterial } from '../entities/helpers/groundPatchMaterial';
+import {
+    getCloudShadowAttenuationMaterialUniforms,
+    retainCloudShadowAttenuationMaterial,
+} from './cloudShadowAttenuation';
+import {
+    createIntegratedWeatherSurfaceMaterial,
+    getWeatherSurfacePluginVariantKey,
+    resolveWeatherSurfacePluginMode,
+    supportsIntegratedWeatherSurfaceMaterial,
+} from './weatherSurfaceMaterial';
+
+const options = {
+    rain: {
+        bounds: {
+            max: [4, 0.75, 5] as const,
+            min: [-2, -0.25, -3] as const,
+        },
+        darkness: 1,
+        enabled: true,
+        glossiness: 0.7,
+        puddleStrengthUniform: { value: 0.4 },
+        topSurfaceBias: 1.8,
+        wetnessUniform: { value: 0.75 },
+    },
+    snow: {
+        amountUniform: { value: 0.5 },
+        color: '#f7f7ff',
+        enabled: true,
+        lift: 0.01,
+        maxThickness: 0.1,
+        noiseAmplitude: 0.35,
+        noiseInfluence: 0.15,
+        noiseScale: 0.2,
+        slopeExponent: 2.4,
+    },
+};
+
+function shaderFixture() {
+    return {
+        fragmentShader: `
+#include <common>
+void main() {
+    vec4 diffuseColor = vec4(1.0);
+    #include <map_fragment>
+    #include <color_fragment>
+    #include <aomap_fragment>
+    #include <roughnessmap_fragment>
+    #include <metalnessmap_fragment>
+    #include <opaque_fragment>
+    #include <tonemapping_fragment>
+    #include <colorspace_fragment>
+    #include <fog_fragment>
+    #include <dithering_fragment>
+}`,
+        uniforms: {},
+        vertexShader: `
+#include <common>
+void main() {
+    vec3 transformed = position;
+    #include <project_vertex>
+    #include <worldpos_vertex>
+}`,
+    };
+}
+
+test('integrated weather material composes existing shader hooks', () => {
+    const source = new MeshStandardMaterial();
+    let sourceHookCount = 0;
+    source.onBeforeCompile = (shader) => {
+        sourceHookCount += 1;
+        shader.fragmentShader = shader.fragmentShader.replace(
+            '#include <color_fragment>',
+            `#include <color_fragment>
+float grediceGroundPatchApplied = 1.0;`,
+        );
+    };
+    source.customProgramCacheKey = () => 'ground-patch:grass';
+    const material = createIntegratedWeatherSurfaceMaterial(source, options);
+    const shader = shaderFixture();
+
+    Reflect.apply(material.onBeforeCompile, material, [shader, undefined]);
+
+    assert.equal(sourceHookCount, 1);
+    assert.match(shader.fragmentShader, /grediceGroundPatchApplied/);
+    assert.match(shader.fragmentShader, /grediceWeatherWet/);
+    assert.match(shader.fragmentShader, /grediceWeatherSnowStrength/);
+    assert.match(shader.vertexShader, /aSnowTopDistance/);
+    assert.match(
+        shader.vertexShader,
+        /varying vec3 vGrediceWeatherWorldNormal;/,
+    );
+    assert.doesNotMatch(
+        shader.vertexShader,
+        /varying float vGrediceWeatherWorldNormalY;/,
+    );
+    assert.match(
+        shader.vertexShader,
+        /uGrediceSnowAmount > 0\.001[\s\S]*grediceWeatherNoise/,
+    );
+    assert.match(
+        shader.vertexShader,
+        /dot\(grediceWeatherWorldNormal, grediceWeatherWorldUp\)/,
+    );
+    assert.match(
+        shader.fragmentShader,
+        /mat3\(viewMatrix\) \*[\s\S]*normalize\(vGrediceWeatherWorldNormal\)/,
+    );
+    assert.match(
+        shader.vertexShader,
+        /grediceWeatherNoise\(\s*aWeatherLocalPosition \* uGrediceSnowNoiseScale/,
+    );
+    assert.match(
+        shader.vertexShader,
+        /defined\( USE_SHADOWMAP \)[\s\S]*vGrediceWeatherWorldPosition = worldPosition\.xyz;[\s\S]*#else/,
+    );
+    assert.ok(
+        shader.fragmentShader.indexOf('grediceGroundPatchApplied') <
+            shader.fragmentShader.indexOf('float grediceWeatherSnowCoverage'),
+        'base ground-patch color must run before the weather blend',
+    );
+    assert.match(shader.fragmentShader, /if \(uGrediceRainWetness > 0\.001\)/);
+    assert.match(
+        shader.fragmentShader,
+        /normalize\(vGrediceWeatherWorldNormal\)\.y/,
+    );
+    assert.ok(
+        shader.fragmentShader.indexOf('float grediceWeatherTopness') >
+            shader.fragmentShader.indexOf('#include <color_fragment>'),
+    );
+    assert.ok(
+        shader.fragmentShader.indexOf('float grediceWeatherTopness') <
+            shader.fragmentShader.indexOf('#include <aomap_fragment>'),
+        'combined rain computation remains at the color stage',
+    );
+    assert.deepEqual(
+        Reflect.get(shader.uniforms, 'uGrediceRainBoundsMin').value.toArray(),
+        [-2, -0.25, -3],
+    );
+    assert.deepEqual(
+        Reflect.get(shader.uniforms, 'uGrediceRainBoundsMax').value.toArray(),
+        [4, 0.75, 5],
+    );
+    assert.match(
+        shader.fragmentShader,
+        /vec3 grediceWeatherRainLocal =[\s\S]*vGrediceWeatherWorldPosition -[\s\S]*uGrediceRainBoundsMin[\s\S]*uGrediceRainBoundsMax -[\s\S]*uGrediceRainBoundsMin/,
+    );
+    assert.match(
+        shader.fragmentShader,
+        /grediceWeatherFragmentNoise\(\s*grediceWeatherRainLocal \* 17\.0/,
+    );
+    assert.match(
+        shader.fragmentShader,
+        /grediceWeatherFragmentNoise\(\s*grediceWeatherRainLocal \* 23\.0/,
+    );
+    assert.doesNotMatch(
+        shader.fragmentShader,
+        /vGrediceWeatherWorldPosition \* (17|23)\.0/,
+    );
+    assert.match(shader.fragmentShader, /pow\(grediceWeatherNormalY, 20\.0\)/);
+    assert.doesNotMatch(
+        shader.fragmentShader,
+        /pow\(grediceWeatherTopness, 20\.0\)/,
+    );
+    assert.doesNotMatch(
+        shader.fragmentShader,
+        /mix\(\s*roughnessFactor,\s*0\.18/,
+    );
+    assert.ok(
+        shader.fragmentShader.indexOf('#include <fog_fragment>') <
+            shader.fragmentShader.indexOf('float grediceWeatherRainAlpha'),
+        'legacy rain blending happens in final output space after fog',
+    );
+    assert.ok(
+        shader.fragmentShader.indexOf('float grediceWeatherRainAlpha') <
+            shader.fragmentShader.indexOf('#include <dithering_fragment>'),
+        'dithering remains the final output step',
+    );
+    assert.match(
+        shader.fragmentShader,
+        /uGrediceSnowNoiseInfluence[\s\S]*\),\s*0\.0,\s*1\.0/,
+    );
+    assert.match(
+        shader.fragmentShader,
+        /grediceWeatherEarlySnowStrength >= 0\.01[\s\S]*vGrediceSnowSurface > 0\.5[\s\S]*return;/,
+    );
+    const fastSnowPath = shader.fragmentShader.slice(
+        shader.fragmentShader.indexOf('float grediceWeatherEarlySnowCoverage'),
+        shader.fragmentShader.indexOf('float grediceWeatherSnowCoverage'),
+    );
+    assert.match(fastSnowPath, /#include <fog_fragment>/);
+    assert.doesNotMatch(fastSnowPath, /#include <colorspace_fragment>/);
+    assert.doesNotMatch(fastSnowPath, /#include <tonemapping_fragment>/);
+    assert.doesNotMatch(
+        shader.fragmentShader,
+        /uGrediceSnowNoiseInfluence\s*\*\s*uGrediceSnowAmount/,
+    );
+    assert.doesNotMatch(
+        shader.fragmentShader,
+        /\bdiscard\b/,
+        'opaque terrain must retain early depth testing',
+    );
+    assert.equal(
+        material.customProgramCacheKey(),
+        `ground-patch:grass|${getWeatherSurfacePluginVariantKey('combined')}`,
+    );
+    assert.equal(source.userData.grediceWeatherSurface, undefined);
+    assert.equal(material.userData.grediceWeatherSurface, true);
+    assert.equal(material.userData.grediceWeatherSurfacePluginMode, 'combined');
+    assert.equal(
+        material.userData.grediceWeatherSurfacePluginVariantKey,
+        getWeatherSurfacePluginVariantKey('combined'),
+    );
+
+    material.dispose();
+    source.dispose();
+});
+
+test('cloud attenuation decorates an integrated clone exactly once', () => {
+    const source = new MeshStandardMaterial();
+    source.onBeforeCompile = (shader) => {
+        shader.fragmentShader = shader.fragmentShader.replace(
+            '#include <color_fragment>',
+            `#include <color_fragment>
+float grediceGroundPatchApplied = 1.0;`,
+        );
+    };
+    source.customProgramCacheKey = () => 'ground-patch:grass';
+    const uniforms = getCloudShadowAttenuationMaterialUniforms();
+    const sourceCloudLease = retainCloudShadowAttenuationMaterial(
+        source,
+        uniforms,
+    );
+    const material = createIntegratedWeatherSurfaceMaterial(source, options);
+    const integratedCloudLease = retainCloudShadowAttenuationMaterial(
+        material,
+        uniforms,
+    );
+    const shader = shaderFixture();
+
+    Reflect.apply(material.onBeforeCompile, material, [shader, undefined]);
+
+    assert.equal(
+        shader.vertexShader.match(
+            /varying vec3 vGrediceCloudShadowWorldPosition;/g,
+        )?.length ?? 0,
+        0,
+    );
+    assert.equal(
+        shader.fragmentShader.match(
+            /varying vec3 vGrediceCloudShadowWorldPosition;/g,
+        )?.length ?? 0,
+        0,
+    );
+    assert.equal(
+        shader.vertexShader.match(/varying vec3 vGrediceWeatherWorldPosition;/g)
+            ?.length,
+        1,
+    );
+    assert.match(shader.fragmentShader, /vGrediceWeatherWorldPosition\.xz/);
+    assert.match(shader.fragmentShader, /grediceGroundPatchApplied/);
+    assert.match(shader.fragmentShader, /grediceCloudShadowAttenuation/);
+    assert.equal(
+        material.customProgramCacheKey(),
+        `ground-patch:grass|${getWeatherSurfacePluginVariantKey('combined')}|gredice-cloud-shadow-attenuation-v1`,
+    );
+
+    integratedCloudLease.release();
+    sourceCloudLease.release();
+    material.dispose();
+    source.dispose();
+});
+
+test('ground patches reuse the integrated weather world position varying', () => {
+    const source = applyGroundPatchMaterial(
+        new MeshStandardMaterial(),
+        'grass',
+        {},
+    );
+    const material = createIntegratedWeatherSurfaceMaterial(source, options);
+    const shader = shaderFixture();
+
+    Reflect.apply(material.onBeforeCompile, material, [shader, undefined]);
+
+    assert.equal(
+        shader.vertexShader.match(/varying vec3 vGrediceWeatherWorldPosition;/g)
+            ?.length,
+        1,
+    );
+    assert.equal(
+        shader.fragmentShader.match(
+            /varying vec3 vGrediceWeatherWorldPosition;/g,
+        )?.length,
+        1,
+    );
+    assert.doesNotMatch(shader.vertexShader, /vGroundPatchWorldPosition/);
+    assert.doesNotMatch(shader.fragmentShader, /vGroundPatchWorldPosition/);
+    assert.doesNotMatch(shader.vertexShader, /vec4 groundPatchWorldPosition/);
+    assert.match(
+        shader.fragmentShader,
+        /applyGroundPatches\(diffuseColor\.rgb, vGrediceWeatherWorldPosition\)/,
+    );
+    assert.ok(
+        shader.fragmentShader.indexOf(
+            'diffuseColor.rgb = applyGroundPatches(',
+        ) < shader.fragmentShader.indexOf('float grediceWeatherSnowCoverage'),
+    );
+
+    material.dispose();
+    source.dispose();
+});
+
+test('rain-only specialization omits every snow shader input and operation', () => {
+    const source = new MeshStandardMaterial();
+    source.customProgramCacheKey = () => 'base';
+    const material = createIntegratedWeatherSurfaceMaterial(source, {
+        rain: options.rain,
+        snow: {
+            ...options.snow,
+            enabled: false,
+        },
+    });
+    const shader = shaderFixture();
+
+    Reflect.apply(material.onBeforeCompile, material, [shader, undefined]);
+
+    assert.match(
+        shader.vertexShader,
+        /varying float vGrediceWeatherWorldNormalY;/,
+    );
+    assert.match(
+        shader.fragmentShader,
+        /varying float vGrediceWeatherWorldNormalY;/,
+    );
+    assert.doesNotMatch(
+        shader.vertexShader,
+        /varying vec3 vGrediceWeatherWorldNormal;/,
+    );
+    assert.doesNotMatch(
+        shader.fragmentShader,
+        /varying vec3 vGrediceWeatherWorldNormal;/,
+    );
+    assert.match(
+        shader.vertexShader,
+        /vGrediceWeatherWorldNormalY = normalize\(\s*inverseTransformDirection\(transformedNormal, viewMatrix\)\s*\)\.y;/,
+    );
+    assert.match(shader.vertexShader, /vGrediceWeatherWorldPosition/);
+    assert.match(shader.fragmentShader, /grediceWeatherRainLocal/);
+    assert.match(shader.fragmentShader, /grediceWeatherRainAlpha/);
+    assert.doesNotMatch(
+        shader.fragmentShader,
+        /normalize\(vGrediceWeatherWorldNormal/,
+    );
+    const colorStage = shader.fragmentShader.slice(
+        shader.fragmentShader.indexOf('#include <color_fragment>'),
+        shader.fragmentShader.indexOf('#include <aomap_fragment>'),
+    );
+    assert.doesNotMatch(
+        colorStage,
+        /grediceWeatherTopness|grediceWeatherRainLocal|grediceWeatherWet/,
+    );
+    const rainComputationIndex = shader.fragmentShader.indexOf(
+        'float grediceWeatherTopness',
+    );
+    const rainOutputIndex = shader.fragmentShader.indexOf(
+        'float grediceWeatherRainAlpha',
+    );
+    assert.equal(
+        shader.fragmentShader.match(/float grediceWeatherTopness/g)?.length,
+        1,
+    );
+    assert.ok(
+        rainComputationIndex >
+            shader.fragmentShader.indexOf('#include <fog_fragment>'),
+        'rain-only computation runs after the base PBR output and fog',
+    );
+    assert.ok(rainOutputIndex > rainComputationIndex);
+    assert.ok(
+        rainOutputIndex <
+            shader.fragmentShader.indexOf('#include <dithering_fragment>'),
+    );
+    assert.doesNotMatch(
+        shader.fragmentShader.slice(rainComputationIndex, rainOutputIndex),
+        /#include </,
+        'rain-only computation is adjacent to its final output blend',
+    );
+    assert.match(
+        shader.fragmentShader,
+        /grediceWeatherNormalY = max\(\s*vGrediceWeatherWorldNormalY,\s*0\.0\s*\);\s*if \(grediceWeatherNormalY > 0\.0\) \{[\s\S]*vec3 grediceWeatherRainLocal/,
+    );
+    assert.match(
+        shader.fragmentShader,
+        /float grediceWeatherPuddleMask =[\s\S]*if \(grediceWeatherPuddleMask > 0\.0\) \{\s*float grediceWeatherPuddleNoise =\s*grediceWeatherFragmentNoise/,
+    );
+    assert.doesNotMatch(
+        shader.vertexShader,
+        /aSnow|aWeather|uGrediceSnow|vGrediceSnow|grediceSnow|grediceWeatherNoise/,
+    );
+    assert.doesNotMatch(
+        shader.fragmentShader,
+        /uGrediceSnow|vGrediceSnow|grediceWeatherSnow|grediceWeatherEarlySnow/,
+    );
+    assert.doesNotMatch(
+        shader.fragmentShader,
+        /roughnessFactor\s*=\s*mix|metalnessFactor\s*=\s*mix/,
+    );
+    assert.equal(
+        Object.keys(shader.uniforms).some((key) =>
+            key.startsWith('uGrediceSnow'),
+        ),
+        false,
+    );
+    assert.equal(
+        material.customProgramCacheKey(),
+        `base|${getWeatherSurfacePluginVariantKey('rain-only')}`,
+    );
+
+    material.dispose();
+    source.dispose();
+});
+
+test('snow-only specialization omits every rain shader input and operation', () => {
+    const source = new MeshStandardMaterial();
+    source.customProgramCacheKey = () => 'base';
+    const material = createIntegratedWeatherSurfaceMaterial(source, {
+        rain: {
+            ...options.rain,
+            enabled: false,
+        },
+        snow: options.snow,
+    });
+    const shader = shaderFixture();
+
+    Reflect.apply(material.onBeforeCompile, material, [shader, undefined]);
+
+    assert.match(shader.vertexShader, /aSnowTopDistance/);
+    assert.match(shader.vertexShader, /grediceWeatherNoise/);
+    assert.doesNotMatch(shader.vertexShader, /vGrediceWeatherWorldNormal/);
+    assert.doesNotMatch(shader.fragmentShader, /vGrediceWeatherWorldNormal/);
+    assert.doesNotMatch(
+        shader.vertexShader,
+        /varying float vGrediceWeatherWorldNormalY;/,
+    );
+    assert.match(shader.vertexShader, /dot\(vNormal, viewMatrix\[1\]\.xyz\)/);
+    assert.doesNotMatch(
+        shader.vertexShader,
+        /inverseTransformDirection\(transformedNormal, viewMatrix\)/,
+    );
+    assert.match(
+        shader.fragmentShader,
+        /vec3 grediceWeatherEarlyNormal = normalize\(vNormal\);/,
+    );
+    assert.doesNotMatch(shader.fragmentShader, /mat3\(viewMatrix\)/);
+    assert.match(shader.fragmentShader, /grediceWeatherEarlySnowStrength/);
+    assert.match(shader.fragmentShader, /grediceWeatherSnowStrength/);
+    assert.match(shader.fragmentShader, /roughnessFactor\s*=\s*mix/);
+    assert.match(shader.fragmentShader, /metalnessFactor\s*=\s*mix/);
+    assert.doesNotMatch(shader.vertexShader, /uGrediceRain|grediceWeatherRain/);
+    assert.doesNotMatch(
+        shader.fragmentShader,
+        /uGrediceRain|grediceWeatherRain|grediceWeatherWet|grediceWeatherPuddle|grediceWeatherFragmentNoise/,
+    );
+    assert.equal(
+        Object.keys(shader.uniforms).some((key) =>
+            key.startsWith('uGrediceRain'),
+        ),
+        false,
+    );
+    assert.equal(
+        material.customProgramCacheKey(),
+        `base|${getWeatherSurfacePluginVariantKey('snow-only')}`,
+    );
+
+    material.dispose();
+    source.dispose();
+});
+
+test('snow-only flat shading retains the custom world-normal fallback', () => {
+    const source = new MeshStandardMaterial({ flatShading: true });
+    source.customProgramCacheKey = () => 'base-flat';
+    const material = createIntegratedWeatherSurfaceMaterial(source, {
+        rain: {
+            ...options.rain,
+            enabled: false,
+        },
+        snow: options.snow,
+    });
+    const shader = shaderFixture();
+
+    Reflect.apply(material.onBeforeCompile, material, [shader, undefined]);
+
+    assert.match(
+        shader.vertexShader,
+        /varying vec3 vGrediceWeatherWorldNormal;/,
+    );
+    assert.match(
+        shader.fragmentShader,
+        /varying vec3 vGrediceWeatherWorldNormal;/,
+    );
+    assert.match(
+        shader.vertexShader,
+        /inverseTransformDirection\(transformedNormal, viewMatrix\)/,
+    );
+    assert.match(
+        shader.vertexShader,
+        /dot\(grediceWeatherWorldNormal, grediceWeatherWorldUp\)/,
+    );
+    assert.match(
+        shader.vertexShader,
+        /vGrediceWeatherWorldNormal = grediceWeatherWorldNormal;/,
+    );
+    assert.match(
+        shader.fragmentShader,
+        /mat3\(viewMatrix\) \*[\s\S]*normalize\(vGrediceWeatherWorldNormal\)/,
+    );
+    assert.doesNotMatch(
+        shader.vertexShader,
+        /dot\(vNormal, viewMatrix\[1\]\.xyz\)/,
+    );
+    assert.doesNotMatch(
+        shader.fragmentShader,
+        /grediceWeatherEarlyNormal = normalize\(vNormal\)/,
+    );
+    assert.equal(
+        material.customProgramCacheKey(),
+        `base-flat|${getWeatherSurfacePluginVariantKey('snow-only')}`,
+    );
+
+    material.dispose();
+    source.dispose();
+});
+
+test('weather plugin modes have three distinct bounded program keys', () => {
+    assert.equal(
+        resolveWeatherSurfacePluginMode({
+            rainEnabled: true,
+            snowEnabled: false,
+        }),
+        'rain-only',
+    );
+    assert.equal(
+        resolveWeatherSurfacePluginMode({
+            rainEnabled: false,
+            snowEnabled: true,
+        }),
+        'snow-only',
+    );
+    assert.equal(
+        resolveWeatherSurfacePluginMode({
+            rainEnabled: true,
+            snowEnabled: true,
+        }),
+        'combined',
+    );
+    assert.throws(
+        () =>
+            resolveWeatherSurfacePluginMode({
+                rainEnabled: false,
+                snowEnabled: false,
+            }),
+        /requires rain, snow, or both/,
+    );
+    assert.equal(
+        new Set(
+            (['rain-only', 'snow-only', 'combined'] as const).map(
+                getWeatherSurfacePluginVariantKey,
+            ),
+        ).size,
+        3,
+    );
+});
+
+test('weather values stay uniforms instead of multiplying program variants', () => {
+    const source = new MeshStandardMaterial();
+    source.customProgramCacheKey = () => 'base';
+    const clear = createIntegratedWeatherSurfaceMaterial(source, options);
+    const storm = createIntegratedWeatherSurfaceMaterial(source, {
+        rain: {
+            ...options.rain,
+            darkness: 0.6,
+            wetnessUniform: { value: 1 },
+        },
+        snow: {
+            ...options.snow,
+            amountUniform: { value: 0 },
+            maxThickness: 0.4,
+        },
+    });
+
+    assert.equal(clear.customProgramCacheKey(), storm.customProgramCacheKey());
+
+    clear.dispose();
+    storm.dispose();
+    source.dispose();
+});
+
+test('weather integration accepts only opaque depth-writing standard materials', () => {
+    const standard = new MeshStandardMaterial();
+    assert.equal(supportsIntegratedWeatherSurfaceMaterial(standard), true);
+
+    standard.transparent = true;
+    assert.equal(supportsIntegratedWeatherSurfaceMaterial(standard), false);
+    standard.transparent = false;
+    standard.depthWrite = false;
+    assert.equal(supportsIntegratedWeatherSurfaceMaterial(standard), false);
+    standard.depthWrite = true;
+    standard.blending = AdditiveBlending;
+    assert.equal(supportsIntegratedWeatherSurfaceMaterial(standard), false);
+
+    assert.equal(
+        supportsIntegratedWeatherSurfaceMaterial(new MeshBasicMaterial()),
+        false,
+    );
+    assert.equal(
+        supportsIntegratedWeatherSurfaceMaterial(new ShaderMaterial()),
+        false,
+    );
+});

--- a/packages/game/src/scene/weatherSurfaceRenderRegistry.ts
+++ b/packages/game/src/scene/weatherSurfaceRenderRegistry.ts
@@ -1,0 +1,101 @@
+'use client';
+
+import { updateGameProfileMetadata } from './gameProfileMetadata';
+
+export type WeatherSurfaceMode = 'integrated' | 'legacy';
+
+export type WeatherSurfaceRenderSnapshot = {
+    avoidedOverlaySubmissionCount: number;
+    avoidedOverlayTriangleCount: number;
+    fallbackOverlaySubmissionCount: number;
+    fallbackOverlayTriangleCount: number;
+    integratedInstanceCount: number;
+    integratedMaterialCount: number;
+    mode: WeatherSurfaceMode;
+    pluginVariantKeys: readonly string[];
+};
+
+type WeatherSurfaceRenderRegistration = {
+    snapshot: WeatherSurfaceRenderSnapshot;
+    token: symbol;
+};
+
+const registrations = new Map<string, WeatherSurfaceRenderRegistration>();
+
+export function getWeatherSurfaceRenderRegistrySnapshot() {
+    let avoidedOverlaySubmissionCount = 0;
+    let avoidedOverlayTriangleCount = 0;
+    let fallbackOverlaySubmissionCount = 0;
+    let fallbackOverlayTriangleCount = 0;
+    let integratedInstanceCount = 0;
+    let integratedMaterialCount = 0;
+    let mode: WeatherSurfaceMode = 'legacy';
+    const pluginVariantKeys = new Set<string>();
+
+    for (const registration of registrations.values()) {
+        const snapshot = registration.snapshot;
+        avoidedOverlaySubmissionCount += snapshot.avoidedOverlaySubmissionCount;
+        avoidedOverlayTriangleCount += snapshot.avoidedOverlayTriangleCount;
+        fallbackOverlaySubmissionCount +=
+            snapshot.fallbackOverlaySubmissionCount;
+        fallbackOverlayTriangleCount += snapshot.fallbackOverlayTriangleCount;
+        integratedInstanceCount += snapshot.integratedInstanceCount;
+        integratedMaterialCount += snapshot.integratedMaterialCount;
+        if (snapshot.mode === 'integrated') {
+            mode = 'integrated';
+        }
+        for (const key of snapshot.pluginVariantKeys) {
+            pluginVariantKeys.add(key);
+        }
+    }
+
+    return {
+        avoidedOverlaySubmissionCount,
+        avoidedOverlayTriangleCount,
+        fallbackOverlaySubmissionCount,
+        fallbackOverlayTriangleCount,
+        integratedInstanceCount,
+        integratedMaterialCount,
+        mode,
+        pluginVariantCount: pluginVariantKeys.size,
+    };
+}
+
+function publishWeatherSurfaceRenderSnapshot() {
+    const snapshot = getWeatherSurfaceRenderRegistrySnapshot();
+    updateGameProfileMetadata({
+        weatherSurfaceAvoidedOverlaySubmissionCount:
+            snapshot.avoidedOverlaySubmissionCount,
+        weatherSurfaceAvoidedOverlayTriangleCount:
+            snapshot.avoidedOverlayTriangleCount,
+        weatherSurfaceFallbackOverlaySubmissionCount:
+            snapshot.fallbackOverlaySubmissionCount,
+        weatherSurfaceFallbackOverlayTriangleCount:
+            snapshot.fallbackOverlayTriangleCount,
+        weatherSurfaceIntegratedInstanceCount: snapshot.integratedInstanceCount,
+        weatherSurfaceIntegratedMaterialCount: snapshot.integratedMaterialCount,
+        weatherSurfaceMode: snapshot.mode,
+        weatherSurfacePluginVariantCount: snapshot.pluginVariantCount,
+    });
+}
+
+export function registerWeatherSurfaceRenderEntry(
+    entryKey: string,
+    snapshot: WeatherSurfaceRenderSnapshot,
+) {
+    const token = Symbol(entryKey);
+    registrations.set(entryKey, { snapshot, token });
+    publishWeatherSurfaceRenderSnapshot();
+
+    return () => {
+        if (registrations.get(entryKey)?.token !== token) {
+            return;
+        }
+        registrations.delete(entryKey);
+        publishWeatherSurfaceRenderSnapshot();
+    };
+}
+
+export function resetWeatherSurfaceRenderRegistryForTests() {
+    registrations.clear();
+}

--- a/packages/game/src/scene/weatherSurfaceRenderRegistry.unit.ts
+++ b/packages/game/src/scene/weatherSurfaceRenderRegistry.unit.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    getWeatherSurfaceRenderRegistrySnapshot,
+    registerWeatherSurfaceRenderEntry,
+    resetWeatherSurfaceRenderRegistryForTests,
+} from './weatherSurfaceRenderRegistry';
+
+test('weather surface registry aggregates avoided and fallback work', () => {
+    resetWeatherSurfaceRenderRegistryForTests();
+    const releaseGrass = registerWeatherSurfaceRenderEntry('grass', {
+        avoidedOverlaySubmissionCount: 9,
+        avoidedOverlayTriangleCount: 1_440,
+        fallbackOverlaySubmissionCount: 0,
+        fallbackOverlayTriangleCount: 0,
+        integratedInstanceCount: 175,
+        integratedMaterialCount: 1,
+        mode: 'integrated',
+        pluginVariantKeys: ['weather-rain-snow-v1'],
+    });
+    const releaseProps = registerWeatherSurfaceRenderEntry('props', {
+        avoidedOverlaySubmissionCount: 0,
+        avoidedOverlayTriangleCount: 0,
+        fallbackOverlaySubmissionCount: 4,
+        fallbackOverlayTriangleCount: 320,
+        integratedInstanceCount: 0,
+        integratedMaterialCount: 0,
+        mode: 'integrated',
+        pluginVariantKeys: [],
+    });
+
+    assert.deepEqual(getWeatherSurfaceRenderRegistrySnapshot(), {
+        avoidedOverlaySubmissionCount: 9,
+        avoidedOverlayTriangleCount: 1_440,
+        fallbackOverlaySubmissionCount: 4,
+        fallbackOverlayTriangleCount: 320,
+        integratedInstanceCount: 175,
+        integratedMaterialCount: 1,
+        mode: 'integrated',
+        pluginVariantCount: 1,
+    });
+
+    releaseProps();
+    releaseGrass();
+});
+
+test('weather surface registry deduplicates variants and ignores stale cleanup', () => {
+    resetWeatherSurfaceRenderRegistryForTests();
+    const snapshot = {
+        avoidedOverlaySubmissionCount: 1,
+        avoidedOverlayTriangleCount: 12,
+        fallbackOverlaySubmissionCount: 0,
+        fallbackOverlayTriangleCount: 0,
+        integratedInstanceCount: 1,
+        integratedMaterialCount: 1,
+        mode: 'integrated' as const,
+        pluginVariantKeys: ['weather-rain-snow-v1'],
+    };
+    const releaseFirst = registerWeatherSurfaceRenderEntry('terrain', snapshot);
+    const releaseSecond = registerWeatherSurfaceRenderEntry(
+        'terrain',
+        snapshot,
+    );
+    registerWeatherSurfaceRenderEntry('snow', snapshot);
+
+    releaseFirst();
+    assert.deepEqual(getWeatherSurfaceRenderRegistrySnapshot(), {
+        avoidedOverlaySubmissionCount: 2,
+        avoidedOverlayTriangleCount: 24,
+        fallbackOverlaySubmissionCount: 0,
+        fallbackOverlayTriangleCount: 0,
+        integratedInstanceCount: 2,
+        integratedMaterialCount: 2,
+        mode: 'integrated',
+        pluginVariantCount: 1,
+    });
+    releaseSecond();
+});

--- a/packages/game/src/scene/weatherSurfaceUniforms.ts
+++ b/packages/game/src/scene/weatherSurfaceUniforms.ts
@@ -16,16 +16,19 @@ export type WeatherSurfaceUniformStats = {
     rainDistinctUniformCount: number;
     snowConsumerCount: number;
     snowDistinctUniformCount: number;
+    snowIntegrationReadyCount: number;
+    snowIntegrationTrackedCount: number;
+    snowIntegrationTransitionCount: number;
 };
 
-type SnowSurfaceUniformEntry = SnowSurfaceUniformOptions & {
+export type SnowSurfaceUniformEntry = SnowSurfaceUniformOptions & {
     consumerCount: number;
     key: string;
     kind: 'snow';
     uniform: IUniform<number>;
 };
 
-type RainSurfaceUniformEntry = RainSurfaceUniformOptions & {
+export type RainSurfaceUniformEntry = RainSurfaceUniformOptions & {
     consumerCount: number;
     key: string;
     kind: 'rain';
@@ -41,7 +44,24 @@ type WeatherSurfaceValues = {
     snowCoverage: number;
 };
 
+type BooleanTransitionTracker<TEntry> = {
+    active: boolean;
+    entry: TEntry;
+    listeners: Set<() => void>;
+};
+
+type SnowIntegrationTracker =
+    BooleanTransitionTracker<SnowSurfaceUniformEntry> & {
+        noiseInfluence: number;
+    };
+
+type RainActivityTracker = BooleanTransitionTracker<RainSurfaceUniformEntry> & {
+    minimumWetness: number;
+};
+
 const snowDampingSpeed = 6;
+const integratedSnowMinimumFragmentCoverage = 0.1;
+const integratedSnowActivationSafetyMargin = 0.02;
 
 function clampUnit(value: number) {
     return Math.min(1, Math.max(0, value));
@@ -68,6 +88,47 @@ export function resolveSnowSurfaceTarget(
     );
 }
 
+/**
+ * A single opaque pass cannot discard the prepared boundary skirt where
+ * legacy sparse snow has holes without forfeiting early depth rejection for
+ * the entire material. Keep sparse snow on the legacy overlay until even the
+ * lowest-noise fragment is past its visibility threshold.
+ */
+export function canIntegrateSnowSurface(
+    snowCoverage: number,
+    options: SnowSurfaceUniformOptions & { noiseInfluence: number },
+) {
+    return resolveSnowSurfaceIntegrationReadiness({
+        amount: resolveSnowSurfaceTarget(snowCoverage, options),
+        noiseInfluence: options.noiseInfluence,
+        wasReady: false,
+    });
+}
+
+/**
+ * Integration enters above the safe sparse-snow boundary and exits at that
+ * boundary. The gap prevents a noisy weather target near the cutoff from
+ * repeatedly rebuilding prepared geometry and materials, while the lower
+ * threshold still guarantees that an integrated opaque pass never exposes
+ * fragments that the legacy overlay would discard.
+ */
+export function resolveSnowSurfaceIntegrationReadiness({
+    amount,
+    noiseInfluence,
+    wasReady,
+}: {
+    amount: number;
+    noiseInfluence: number;
+    wasReady: boolean;
+}) {
+    const minimumCoverage = clampUnit(amount) - Math.max(0, noiseInfluence);
+    const threshold = wasReady
+        ? integratedSnowMinimumFragmentCoverage
+        : integratedSnowMinimumFragmentCoverage +
+          integratedSnowActivationSafetyMargin;
+    return minimumCoverage >= threshold;
+}
+
 export function resolveRainSurfaceTarget(
     rainAmount: number,
     options: Pick<RainSurfaceUniformOptions, 'intensityMultiplier'>,
@@ -82,8 +143,17 @@ export function resolveRainPuddleStrength(rainAmount: number) {
 export class WeatherSurfaceUniformRegistry {
     readonly rainPuddleStrengthUniform: IUniform<number> = { value: 0 };
 
+    private readonly rainActivityTrackers = new Map<
+        string,
+        RainActivityTracker
+    >();
     private readonly rainEntries = new Map<string, RainSurfaceUniformEntry>();
+    private readonly snowIntegrationTrackers = new Map<
+        string,
+        SnowIntegrationTracker
+    >();
     private readonly snowEntries = new Map<string, SnowSurfaceUniformEntry>();
+    private snowIntegrationTransitionCount = 0;
 
     constructor(
         private readonly onStatsChange?: (
@@ -91,9 +161,7 @@ export class WeatherSurfaceUniformRegistry {
         ) => void,
     ) {}
 
-    getSnowEntry(
-        options: SnowSurfaceUniformOptions,
-    ): WeatherSurfaceUniformEntry {
+    getSnowEntry(options: SnowSurfaceUniformOptions): SnowSurfaceUniformEntry {
         const key = snowEntryKey(options);
         const existing = this.snowEntries.get(key);
         if (existing) {
@@ -111,9 +179,7 @@ export class WeatherSurfaceUniformRegistry {
         return entry;
     }
 
-    getRainEntry(
-        options: RainSurfaceUniformOptions,
-    ): WeatherSurfaceUniformEntry {
+    getRainEntry(options: RainSurfaceUniformOptions): RainSurfaceUniformEntry {
         const key = rainEntryKey(options);
         const existing = this.rainEntries.get(key);
         if (existing) {
@@ -134,6 +200,7 @@ export class WeatherSurfaceUniformRegistry {
     retain(entry: WeatherSurfaceUniformEntry) {
         if (entry.consumerCount === 0) {
             entry.uniform.value = 0;
+            this.refreshTransitionTrackers(entry);
         }
         entry.consumerCount += 1;
         this.publishStats();
@@ -166,6 +233,7 @@ export class WeatherSurfaceUniformRegistry {
                 snowDampingSpeed,
                 delta,
             );
+            this.refreshSnowIntegrationTrackers(entry);
         }
 
         for (const entry of this.rainEntries.values()) {
@@ -182,7 +250,70 @@ export class WeatherSurfaceUniformRegistry {
                 speed,
                 delta,
             );
+            this.refreshRainActivityTrackers(entry);
         }
+    }
+
+    getSnowIntegrationReady(
+        entry: SnowSurfaceUniformEntry,
+        noiseInfluence: number,
+    ) {
+        return this.getSnowIntegrationTracker(entry, noiseInfluence).active;
+    }
+
+    subscribeSnowIntegrationReadiness(
+        entry: SnowSurfaceUniformEntry,
+        noiseInfluence: number,
+        listener: () => void,
+    ) {
+        const tracker = this.getSnowIntegrationTracker(entry, noiseInfluence);
+        tracker.listeners.add(listener);
+        this.publishStats();
+
+        let subscribed = true;
+        return () => {
+            if (!subscribed) {
+                return;
+            }
+            subscribed = false;
+            tracker.listeners.delete(listener);
+            if (tracker.listeners.size === 0) {
+                this.snowIntegrationTrackers.delete(
+                    this.snowIntegrationTrackerKey(entry, noiseInfluence),
+                );
+            }
+            this.publishStats();
+        };
+    }
+
+    getRainSurfaceActive(
+        entry: RainSurfaceUniformEntry,
+        minimumWetness: number,
+    ) {
+        return this.getRainActivityTracker(entry, minimumWetness).active;
+    }
+
+    subscribeRainSurfaceActivity(
+        entry: RainSurfaceUniformEntry,
+        minimumWetness: number,
+        listener: () => void,
+    ) {
+        const tracker = this.getRainActivityTracker(entry, minimumWetness);
+        tracker.listeners.add(listener);
+
+        let subscribed = true;
+        return () => {
+            if (!subscribed) {
+                return;
+            }
+            subscribed = false;
+            tracker.listeners.delete(listener);
+            if (tracker.listeners.size === 0) {
+                this.rainActivityTrackers.delete(
+                    this.rainActivityTrackerKey(entry, minimumWetness),
+                );
+            }
+        };
     }
 
     getStats(): WeatherSurfaceUniformStats {
@@ -190,6 +321,8 @@ export class WeatherSurfaceUniformRegistry {
         let rainDistinctUniformCount = 0;
         let snowConsumerCount = 0;
         let snowDistinctUniformCount = 0;
+        let snowIntegrationReadyCount = 0;
+        let snowIntegrationTrackedCount = 0;
 
         for (const entry of this.rainEntries.values()) {
             rainConsumerCount += entry.consumerCount;
@@ -205,15 +338,144 @@ export class WeatherSurfaceUniformRegistry {
             }
         }
 
+        for (const tracker of this.snowIntegrationTrackers.values()) {
+            if (tracker.listeners.size === 0) {
+                continue;
+            }
+            snowIntegrationTrackedCount += 1;
+            if (tracker.active) {
+                snowIntegrationReadyCount += 1;
+            }
+        }
+
         return {
             rainConsumerCount,
             rainDistinctUniformCount,
             snowConsumerCount,
             snowDistinctUniformCount,
+            snowIntegrationReadyCount,
+            snowIntegrationTrackedCount,
+            snowIntegrationTransitionCount: this.snowIntegrationTransitionCount,
         };
     }
 
     publishStats() {
         this.onStatsChange?.(this.getStats());
+    }
+
+    private snowIntegrationTrackerKey(
+        entry: SnowSurfaceUniformEntry,
+        noiseInfluence: number,
+    ) {
+        return `${entry.key}:${Math.max(0, noiseInfluence)}`;
+    }
+
+    private getSnowIntegrationTracker(
+        entry: SnowSurfaceUniformEntry,
+        noiseInfluence: number,
+    ) {
+        const normalizedNoiseInfluence = Math.max(0, noiseInfluence);
+        const key = this.snowIntegrationTrackerKey(
+            entry,
+            normalizedNoiseInfluence,
+        );
+        const existing = this.snowIntegrationTrackers.get(key);
+        if (existing) {
+            return existing;
+        }
+
+        const tracker: SnowIntegrationTracker = {
+            active: resolveSnowSurfaceIntegrationReadiness({
+                amount: entry.uniform.value,
+                noiseInfluence: normalizedNoiseInfluence,
+                wasReady: false,
+            }),
+            entry,
+            listeners: new Set(),
+            noiseInfluence: normalizedNoiseInfluence,
+        };
+        this.snowIntegrationTrackers.set(key, tracker);
+        return tracker;
+    }
+
+    private rainActivityTrackerKey(
+        entry: RainSurfaceUniformEntry,
+        minimumWetness: number,
+    ) {
+        return `${entry.key}:${Math.max(0, minimumWetness)}`;
+    }
+
+    private getRainActivityTracker(
+        entry: RainSurfaceUniformEntry,
+        minimumWetness: number,
+    ) {
+        const normalizedMinimumWetness = Math.max(0, minimumWetness);
+        const key = this.rainActivityTrackerKey(
+            entry,
+            normalizedMinimumWetness,
+        );
+        const existing = this.rainActivityTrackers.get(key);
+        if (existing) {
+            return existing;
+        }
+
+        const tracker: RainActivityTracker = {
+            active: entry.uniform.value >= normalizedMinimumWetness,
+            entry,
+            listeners: new Set(),
+            minimumWetness: normalizedMinimumWetness,
+        };
+        this.rainActivityTrackers.set(key, tracker);
+        return tracker;
+    }
+
+    private refreshTransitionTrackers(entry: WeatherSurfaceUniformEntry) {
+        if (entry.kind === 'snow') {
+            this.refreshSnowIntegrationTrackers(entry);
+            return;
+        }
+        this.refreshRainActivityTrackers(entry);
+    }
+
+    private refreshSnowIntegrationTrackers(entry: SnowSurfaceUniformEntry) {
+        let changed = false;
+        for (const tracker of this.snowIntegrationTrackers.values()) {
+            if (tracker.entry !== entry) {
+                continue;
+            }
+            const active = resolveSnowSurfaceIntegrationReadiness({
+                amount: entry.uniform.value,
+                noiseInfluence: tracker.noiseInfluence,
+                wasReady: tracker.active,
+            });
+            if (active === tracker.active) {
+                continue;
+            }
+            tracker.active = active;
+            this.snowIntegrationTransitionCount += 1;
+            changed = true;
+            for (const listener of tracker.listeners) {
+                listener();
+            }
+        }
+        if (changed) {
+            this.publishStats();
+        }
+    }
+
+    private refreshRainActivityTrackers(entry: RainSurfaceUniformEntry) {
+        for (const tracker of this.rainActivityTrackers.values()) {
+            if (tracker.entry !== entry) {
+                continue;
+            }
+            const active = entry.uniform.value >= tracker.minimumWetness;
+            if (active === tracker.active) {
+                continue;
+            }
+            tracker.active = active;
+            for (const listener of tracker.listeners) {
+                listener();
+            }
+        }
     }
 }

--- a/packages/game/src/scene/weatherSurfaceUniforms.unit.ts
+++ b/packages/game/src/scene/weatherSurfaceUniforms.unit.ts
@@ -2,8 +2,10 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { MathUtils } from 'three';
 import {
+    canIntegrateSnowSurface,
     resolveRainPuddleStrength,
     resolveRainSurfaceTarget,
+    resolveSnowSurfaceIntegrationReadiness,
     resolveSnowSurfaceTarget,
     WeatherSurfaceUniformRegistry,
     type WeatherSurfaceUniformStats,
@@ -38,6 +40,68 @@ describe('weather surface targets', () => {
                 overrideSnow: undefined,
             }),
             0,
+        );
+    });
+
+    it('keeps sparse snow on the legacy overlay until noise gaps close', () => {
+        assert.equal(
+            canIntegrateSnowSurface(0.025, {
+                coverageMultiplier: 1.5,
+                noiseInfluence: 0.15,
+                overrideSnow: undefined,
+            }),
+            false,
+        );
+        assert.equal(
+            canIntegrateSnowSurface(0.8, {
+                coverageMultiplier: 0.9,
+                noiseInfluence: 0.15,
+                overrideSnow: undefined,
+            }),
+            true,
+        );
+        assert.equal(
+            canIntegrateSnowSurface(0, {
+                coverageMultiplier: 1,
+                noiseInfluence: 0.15,
+                overrideSnow: 0.3,
+            }),
+            true,
+        );
+    });
+
+    it('uses a safe activation margin and a safe hysteresis exit', () => {
+        assert.equal(
+            resolveSnowSurfaceIntegrationReadiness({
+                amount: 0.269,
+                noiseInfluence: 0.15,
+                wasReady: false,
+            }),
+            false,
+        );
+        assert.equal(
+            resolveSnowSurfaceIntegrationReadiness({
+                amount: 0.28,
+                noiseInfluence: 0.15,
+                wasReady: false,
+            }),
+            true,
+        );
+        assert.equal(
+            resolveSnowSurfaceIntegrationReadiness({
+                amount: 0.251,
+                noiseInfluence: 0.15,
+                wasReady: true,
+            }),
+            true,
+        );
+        assert.equal(
+            resolveSnowSurfaceIntegrationReadiness({
+                amount: 0.249,
+                noiseInfluence: 0.15,
+                wasReady: true,
+            }),
+            false,
         );
     });
 
@@ -80,6 +144,9 @@ describe('WeatherSurfaceUniformRegistry', () => {
             rainDistinctUniformCount: 0,
             snowConsumerCount: 2,
             snowDistinctUniformCount: 1,
+            snowIntegrationReadyCount: 0,
+            snowIntegrationTrackedCount: 0,
+            snowIntegrationTransitionCount: 0,
         });
 
         registry.advance({ rainAmount: 0, snowCoverage: 0.6 }, 1 / 30);
@@ -126,6 +193,9 @@ describe('WeatherSurfaceUniformRegistry', () => {
             rainDistinctUniformCount: 2,
             snowConsumerCount: 2,
             snowDistinctUniformCount: 2,
+            snowIntegrationReadyCount: 0,
+            snowIntegrationTrackedCount: 0,
+            snowIntegrationTransitionCount: 0,
         });
     });
 
@@ -170,6 +240,9 @@ describe('WeatherSurfaceUniformRegistry', () => {
             rainDistinctUniformCount: 0,
             snowConsumerCount: 0,
             snowDistinctUniformCount: 0,
+            snowIntegrationReadyCount: 0,
+            snowIntegrationTrackedCount: 0,
+            snowIntegrationTransitionCount: 0,
         });
 
         registry.retain(entry);
@@ -197,13 +270,99 @@ describe('WeatherSurfaceUniformRegistry', () => {
                 rainDistinctUniformCount: 1,
                 snowConsumerCount: 0,
                 snowDistinctUniformCount: 0,
+                snowIntegrationReadyCount: 0,
+                snowIntegrationTrackedCount: 0,
+                snowIntegrationTransitionCount: 0,
             },
             {
                 rainConsumerCount: 0,
                 rainDistinctUniformCount: 0,
                 snowConsumerCount: 0,
                 snowDistinctUniformCount: 0,
+                snowIntegrationReadyCount: 0,
+                snowIntegrationTrackedCount: 0,
+                snowIntegrationTransitionCount: 0,
             },
         ]);
+    });
+
+    it('reacts to damped snow readiness once and holds through hysteresis', () => {
+        const registry = new WeatherSurfaceUniformRegistry();
+        const entry = registry.getSnowEntry({
+            coverageMultiplier: 1,
+            overrideSnow: undefined,
+        });
+        registry.retain(entry);
+        let notificationCount = 0;
+        const unsubscribe = registry.subscribeSnowIntegrationReadiness(
+            entry,
+            0.15,
+            () => {
+                notificationCount += 1;
+            },
+        );
+
+        registry.advance({ rainAmount: 0, snowCoverage: 1 }, 0.01);
+        assert.equal(
+            registry.getSnowIntegrationReady(entry, 0.15),
+            false,
+            'a high target must not integrate before the rendered uniform catches up',
+        );
+
+        registry.advance({ rainAmount: 0, snowCoverage: 0.28 }, 10);
+        assert.equal(registry.getSnowIntegrationReady(entry, 0.15), true);
+        assert.equal(notificationCount, 1);
+
+        registry.advance({ rainAmount: 0, snowCoverage: 0.26 }, 10);
+        assert.equal(registry.getSnowIntegrationReady(entry, 0.15), true);
+        assert.equal(notificationCount, 1);
+
+        registry.advance({ rainAmount: 0, snowCoverage: 0.24 }, 10);
+        assert.equal(registry.getSnowIntegrationReady(entry, 0.15), false);
+        assert.equal(notificationCount, 2);
+        assert.deepEqual(registry.getStats(), {
+            rainConsumerCount: 0,
+            rainDistinctUniformCount: 0,
+            snowConsumerCount: 1,
+            snowDistinctUniformCount: 1,
+            snowIntegrationReadyCount: 0,
+            snowIntegrationTrackedCount: 1,
+            snowIntegrationTransitionCount: 2,
+        });
+
+        unsubscribe();
+        assert.equal(registry.getStats().snowIntegrationTrackedCount, 0);
+    });
+
+    it('notifies rain dry-down activity when rendered wetness clears', () => {
+        const registry = new WeatherSurfaceUniformRegistry();
+        const entry = registry.getRainEntry({
+            drySpeed: 1.8,
+            intensityMultiplier: 1,
+            wetSpeed: 5,
+        });
+        registry.retain(entry);
+        let notificationCount = 0;
+        const unsubscribe = registry.subscribeRainSurfaceActivity(
+            entry,
+            0.01,
+            () => {
+                notificationCount += 1;
+            },
+        );
+
+        registry.advance({ rainAmount: 1, snowCoverage: 0 }, 1);
+        assert.equal(registry.getRainSurfaceActive(entry, 0.01), true);
+        registry.advance({ rainAmount: 0, snowCoverage: 0 }, 0.1);
+        assert.equal(
+            registry.getRainSurfaceActive(entry, 0.01),
+            true,
+            'the overlay remains active while its damped uniform is wet',
+        );
+        registry.advance({ rainAmount: 0, snowCoverage: 0 }, 10);
+        assert.equal(registry.getRainSurfaceActive(entry, 0.01), false);
+        assert.equal(notificationCount, 2);
+
+        unsubscribe();
     });
 });

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -464,6 +464,8 @@ export type GameState = {
     clearEnvironmentOverrides: () => void;
 
     // Environment derived state
+    rainSurfaceIntensity: number;
+    setRainSurfaceIntensity: (rainSurfaceIntensity: number) => void;
     snowCoverage: number;
     setSnowCoverage: (snowCoverage: number) => void;
     waterColors: WaterColors;
@@ -1092,6 +1094,9 @@ export function createGameState({
                 sunsetTime: sunset,
             });
         },
+        rainSurfaceIntensity: 0,
+        setRainSurfaceIntensity: (rainSurfaceIntensity) =>
+            set({ rainSurfaceIntensity }),
         snowCoverage: 0,
         setSnowCoverage: (snowCoverage) => set({ snowCoverage }),
         waterColors: defaultWaterColors,

--- a/packages/game/src/useGameState.unit.ts
+++ b/packages/game/src/useGameState.unit.ts
@@ -543,3 +543,19 @@ test('syncTimeOfDay refreshes time of day for a new garden location', () => {
         store.getState().audio.dispose();
     }
 });
+
+test('environment can publish blended rain intensity for surface effects', () => {
+    const store = createGameState({
+        appBaseUrl: '',
+        freezeTime: new Date('2026-01-01T12:00:00.000Z'),
+        isMock: true,
+    });
+
+    try {
+        assert.equal(store.getState().rainSurfaceIntensity, 0);
+        store.getState().setRainSurfaceIntensity(0.72);
+        assert.equal(store.getState().rainSurfaceIntensity, 0.72);
+    } finally {
+        store.getState().audio.dispose();
+    }
+});


### PR DESCRIPTION
Closes #4325

## What changed

- renders compatible stable opaque rain and snow surfaces in the base material pass instead of duplicate overlay passes
- prepares cached snow-skirt geometry while preserving source-local noise through merged and instanced transforms
- specializes bounded rain-only, snow-only, and combined shader programs
- shares weather uniforms and displaced world-position data with ground-patch and cloud-shadow shader hooks
- keeps animated and unsupported entities on explicit legacy fallbacks
- adds deterministic rain, snow, onset, and threshold-transition profiler coverage with five interleaved paired GPU samples

## High-target evidence

Final 2560x1440 DPR-2 matrix, 5 paired runs per mode:

- Rain: 225 -> 212 draws/render (-5.8%), 34,820 -> 32,300 triangles/render (-7.2%), GPU p95 20.28 -> 19.62 ms (-3.3%), paired ratio median/max 0.9684/1.0409, programs 30 -> 30
- Snow: 205 -> 197 draws/render (-3.9%), 64,846 -> 61,606 triangles/render (-5.0%), GPU p95 4.49 -> 4.37 ms (-2.7%), paired ratio median/max 0.9505/1.0317, programs 23 -> 24
- Rain fallback submissions: 45 -> 29; snow: 56 -> 48
- Onset and threshold lifecycle passed with ready 0 -> 2 -> 2 -> 0 and transitions 0 -> 2 -> 2 -> 4
- Legacy/integrated screenshots were manually inspected for parity

## Validation

- pnpm --filter @gredice/game test (747/747)
- pnpm --filter garden test:profile (60/60)
- pnpm --filter @gredice/game typecheck
- pnpm --filter garden typecheck
- pnpm --filter www typecheck
- pnpm --filter garden build
- scoped Biome checks
- git diff --check
- three independent final reviews: runtime/shaders, React/resource lifecycle, and profiler acceptance