### PR TITLE
perf(game): cache static opaque scene layers

### DIFF
--- a/apps/garden/app/debug/profile/game/page.tsx
+++ b/apps/garden/app/debug/profile/game/page.tsx
@@ -9,6 +9,8 @@ import {
     highTargetOperationVisualHighlightTarget,
     resolveGameProfileFlags,
     resolveGameProfileOperationVisuals,
+    resolveGameProfileStaticSceneCache,
+    resolveGameProfileStaticSceneCacheOcclusionFixture,
     resolveGameProfileWeatherSurface,
 } from './profileFlags';
 import {
@@ -48,6 +50,15 @@ function resolvePositiveInteger(value: string | undefined) {
 
     const parsed = Number.parseInt(value, 10);
     return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function resolveNonNegativeNumber(value: string | undefined) {
+    if (!value) {
+        return null;
+    }
+
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
 }
 
 function resolveMode(value: string | undefined): GameProfileMode {
@@ -273,6 +284,9 @@ export default async function GameProfilePage({
     const closeupRaisedBedId = resolvePositiveInteger(
         firstValue(params.closeupRaisedBedId),
     );
+    const fixedTimeSeconds = resolveNonNegativeNumber(
+        firstValue(params.fixedTimeSeconds),
+    );
     const outlineProfile = firstValue(params.outline) === '1';
     const placementProfile = firstValue(params.placement) === '1';
     const operationVisuals =
@@ -282,7 +296,16 @@ export default async function GameProfilePage({
         firstValue(params.blockGeometryMerging),
         firstValue(params.adaptiveHigh),
         firstValue(params.weatherSurface),
+        firstValue(params.staticSceneCache),
     );
+    const staticSceneCacheMode = resolveGameProfileStaticSceneCache(
+        firstValue(params.staticSceneCache),
+    );
+    const staticSceneCacheOcclusionFixture =
+        staticSceneCacheMode === 'cache' &&
+        resolveGameProfileStaticSceneCacheOcclusionFixture(
+            firstValue(params.staticSceneCacheOcclusionFixture),
+        );
     const weatherSurfaceMode = resolveGameProfileWeatherSurface(
         firstValue(params.weatherSurface),
     );
@@ -300,6 +323,7 @@ export default async function GameProfilePage({
             data-game-profile-mode={mode}
             data-game-profile-controls={enableControls ? '1' : '0'}
             data-game-profile-details={renderDetails ? '1' : '0'}
+            data-game-profile-fixed-time-seconds={fixedTimeSeconds ?? undefined}
             data-game-profile-debug-hud={showDebugHud ? '1' : '0'}
             data-game-profile-hud={showHud ? '1' : '0'}
             data-game-profile-garden-profile={mockGardenProfile}
@@ -314,6 +338,10 @@ export default async function GameProfilePage({
             data-game-profile-outline={outlineProfile ? '1' : '0'}
             data-game-profile-placement={placementProfile ? '1' : '0'}
             data-game-profile-operation-visuals={operationVisuals ? '1' : '0'}
+            data-game-profile-static-scene-cache={staticSceneCacheMode}
+            data-game-profile-static-scene-cache-occlusion-fixture={
+                staticSceneCacheOcclusionFixture ? '1' : '0'
+            }
             data-game-profile-weather-surface={weatherSurfaceMode}
             data-game-profile-operation-visual-highlight-raised-bed-id={
                 operationVisuals
@@ -336,6 +364,7 @@ export default async function GameProfilePage({
                 className="h-full w-full"
                 dayNightCycleDisabled={false}
                 flags={debugGameFlags}
+                fixedTimeSeconds={fixedTimeSeconds ?? undefined}
                 freezeTime={freezeTime}
                 debugHud={showDebugHud}
                 hideHud={!showHud}
@@ -346,6 +375,9 @@ export default async function GameProfilePage({
                     outlineProfile ||
                     placementProfile ||
                     operationVisuals
+                }
+                enableStaticOpaqueSceneCacheOcclusionFixture={
+                    staticSceneCacheOcclusionFixture
                 }
                 mockGarden
                 mockGardenProfile={mockGardenProfile}

--- a/apps/garden/app/debug/profile/game/profileFlags.ts
+++ b/apps/garden/app/debug/profile/game/profileFlags.ts
@@ -1,5 +1,6 @@
 import type { GameSceneProps } from '@gredice/game';
 
+export type GameProfileStaticSceneCacheMode = 'cache' | 'legacy';
 export type GameProfileWeatherSurfaceMode = 'integrated' | 'legacy';
 
 export const highTargetOperationVisualHighlightTarget = {
@@ -22,6 +23,18 @@ export function resolveGameProfileOperationVisuals(value: string | undefined) {
     return value === '1';
 }
 
+export function resolveGameProfileStaticSceneCache(
+    value: string | undefined,
+): GameProfileStaticSceneCacheMode {
+    return value === 'legacy' ? 'legacy' : 'cache';
+}
+
+export function resolveGameProfileStaticSceneCacheOcclusionFixture(
+    value: string | undefined,
+) {
+    return value === '1';
+}
+
 export function resolveGameProfileWeatherSurface(
     value: string | undefined,
 ): GameProfileWeatherSurfaceMode {
@@ -32,8 +45,11 @@ export function resolveGameProfileFlags(
     blockGeometryMerging: string | undefined,
     adaptiveHigh: string | undefined,
     weatherSurface: string | undefined,
+    staticSceneCache: string | undefined,
 ) {
     const weatherSurfaceMode = resolveGameProfileWeatherSurface(weatherSurface);
+    const staticSceneCacheMode =
+        resolveGameProfileStaticSceneCache(staticSceneCache);
 
     return {
         enableAdaptiveHighQualityFlag:
@@ -44,5 +60,6 @@ export function resolveGameProfileFlags(
         enableIntegratedWeatherSurfacesFlag:
             weatherSurfaceMode === 'integrated',
         enableRainWetOverlayFlag: true,
+        enableStaticOpaqueSceneCacheFlag: staticSceneCacheMode === 'cache',
     } satisfies NonNullable<GameSceneProps['flags']>;
 }

--- a/apps/garden/app/debug/profile/game/profileFlags.unit.ts
+++ b/apps/garden/app/debug/profile/game/profileFlags.unit.ts
@@ -6,6 +6,8 @@ import {
     resolveGameProfileBlockGeometryMerging,
     resolveGameProfileFlags,
     resolveGameProfileOperationVisuals,
+    resolveGameProfileStaticSceneCache,
+    resolveGameProfileStaticSceneCacheOcclusionFixture,
     resolveGameProfileWeatherSurface,
 } from './profileFlags.ts';
 
@@ -53,32 +55,71 @@ describe('resolveGameProfileOperationVisuals', () => {
 describe('resolveGameProfileFlags', () => {
     it('defaults production-profile weather surfaces to the integrated path', () => {
         assert.deepEqual(
-            resolveGameProfileFlags(undefined, undefined, undefined),
+            resolveGameProfileFlags(undefined, undefined, undefined, undefined),
             {
                 enableAdaptiveHighQualityFlag: false,
                 enableBlockGeometryMergingFlag: false,
                 enableDebugHudFlag: true,
                 enableIntegratedWeatherSurfacesFlag: true,
                 enableRainWetOverlayFlag: true,
+                enableStaticOpaqueSceneCacheFlag: true,
             },
         );
-        assert.deepEqual(resolveGameProfileFlags('0', '1', 'integrated'), {
-            enableAdaptiveHighQualityFlag: true,
-            enableBlockGeometryMergingFlag: false,
-            enableDebugHudFlag: true,
-            enableIntegratedWeatherSurfacesFlag: true,
-            enableRainWetOverlayFlag: true,
-        });
+        assert.deepEqual(
+            resolveGameProfileFlags('0', '1', 'integrated', 'cache'),
+            {
+                enableAdaptiveHighQualityFlag: true,
+                enableBlockGeometryMergingFlag: false,
+                enableDebugHudFlag: true,
+                enableIntegratedWeatherSurfacesFlag: true,
+                enableRainWetOverlayFlag: true,
+                enableStaticOpaqueSceneCacheFlag: true,
+            },
+        );
     });
 
-    it('allows an explicit legacy weather-surface comparison', () => {
-        assert.deepEqual(resolveGameProfileFlags('1', '0', 'legacy'), {
-            enableAdaptiveHighQualityFlag: false,
-            enableBlockGeometryMergingFlag: true,
-            enableDebugHudFlag: true,
-            enableIntegratedWeatherSurfacesFlag: false,
-            enableRainWetOverlayFlag: true,
-        });
+    it('allows explicit legacy weather-surface and scene-cache comparisons', () => {
+        assert.deepEqual(
+            resolveGameProfileFlags('1', '0', 'legacy', 'legacy'),
+            {
+                enableAdaptiveHighQualityFlag: false,
+                enableBlockGeometryMergingFlag: true,
+                enableDebugHudFlag: true,
+                enableIntegratedWeatherSurfacesFlag: false,
+                enableRainWetOverlayFlag: true,
+                enableStaticOpaqueSceneCacheFlag: false,
+            },
+        );
+    });
+});
+
+describe('resolveGameProfileStaticSceneCache', () => {
+    it('accepts only the exact legacy override', () => {
+        assert.equal(resolveGameProfileStaticSceneCache('legacy'), 'legacy');
+        assert.equal(resolveGameProfileStaticSceneCache('cache'), 'cache');
+        assert.equal(resolveGameProfileStaticSceneCache(undefined), 'cache');
+        assert.equal(resolveGameProfileStaticSceneCache('unexpected'), 'cache');
+    });
+});
+
+describe('resolveGameProfileStaticSceneCacheOcclusionFixture', () => {
+    it('keeps the depth fixture behind an exact profiler opt-in', () => {
+        assert.equal(
+            resolveGameProfileStaticSceneCacheOcclusionFixture(undefined),
+            false,
+        );
+        assert.equal(
+            resolveGameProfileStaticSceneCacheOcclusionFixture('0'),
+            false,
+        );
+        assert.equal(
+            resolveGameProfileStaticSceneCacheOcclusionFixture('unexpected'),
+            false,
+        );
+        assert.equal(
+            resolveGameProfileStaticSceneCacheOcclusionFixture('1'),
+            true,
+        );
     });
 });
 

--- a/apps/garden/app/flags.ts
+++ b/apps/garden/app/flags.ts
@@ -39,6 +39,14 @@ export const adaptiveHighQualityFlag = flag<boolean>({
     options: booleanFlagOptions,
 });
 
+export const staticOpaqueSceneCacheFlag = flag<boolean>({
+    key: 'staticOpaqueSceneCache',
+    description:
+        'Cache stable opaque terrain while rendering the game at High quality.',
+    decide: () => true,
+    options: booleanFlagOptions,
+});
+
 export const enableDebugCloseupFlag = flag<boolean>({
     key: 'enableDebugCloseup',
     decide: () => false,

--- a/apps/garden/app/page.tsx
+++ b/apps/garden/app/page.tsx
@@ -11,6 +11,7 @@ import {
     enableSuncokretChatFlag,
     enableSuncokretDebugFlag,
     rainWetOverlayFlag,
+    staticOpaqueSceneCacheFlag,
 } from './flags';
 
 const impersonationFlagCookieName = 'gredice_impersonating';
@@ -35,6 +36,7 @@ export default async function Home() {
         enableBlockGeometryMergingFlag: await blockGeometryMergingFlag(),
         enableDebugHudFlag: await enableDebugHudFlag(),
         enableRainWetOverlayFlag: await rainWetOverlayFlag(),
+        enableStaticOpaqueSceneCacheFlag: await staticOpaqueSceneCacheFlag(),
         enableSuncokretChatFlag: await enableSuncokretChatFlag(),
         enableSuncokretDebugFlag: await enableSuncokretDebugFlag(),
     };

--- a/apps/garden/package.json
+++ b/apps/garden/package.json
@@ -17,6 +17,7 @@
         "profile:game:dense-mobile": "GAME_PROFILE_SCENARIO_SET=dense-mobile pnpm run profile:game",
         "profile:game:high-target": "GAME_PROFILE_SCENARIO_SET=high-target pnpm run profile:game",
         "profile:game:high-target-operation-visuals": "GAME_PROFILE_SCENARIO_SET=high-target-operation-visuals pnpm run profile:game",
+        "profile:game:high-target-static-scene-cache": "GAME_PROFILE_SCENARIO_SET=high-target-static-scene-cache GAME_PROFILE_FAIL_ON_BUDGET=1 GAME_PROFILE_SCREENSHOTS=1 pnpm run profile:game",
         "profile:game:existing": "node scripts/profile-game-scene.mjs",
         "profile:game:start": "GAME_PROFILE_BASE_URL=http://localhost:3101 GAME_PROFILE_START_SERVER=1 node scripts/profile-game-scene.mjs",
         "profile:game:ci": "GAME_PROFILE_FAIL_ON_BUDGET=1 pnpm run profile:game",

--- a/apps/garden/scripts/profile-game-scene.mjs
+++ b/apps/garden/scripts/profile-game-scene.mjs
@@ -1,8 +1,9 @@
 import { spawn } from 'node:child_process';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { chromium } from '@playwright/test';
+import sharp from 'sharp';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const appRoot = resolve(__dirname, '..');
@@ -63,6 +64,26 @@ const highTargetWeatherSurfaceMaximumGpuMedianRatio = 0.98;
 const highTargetWeatherSurfaceMaximumGpuRunRatio = 1.05;
 const highTargetWeatherSurfaceMaximumProgramIncrease = 1;
 const highTargetWeatherSurfacePairedRunCount = 5;
+const highTargetStaticSceneCacheMaximumCpuMedianRatio = 1.05;
+const highTargetStaticSceneCacheMaximumDrawCallRatio = 0.9;
+const highTargetStaticSceneCacheMaximumGpuMedianRatio = 0.95;
+const highTargetStaticSceneCacheMaximumGpuRunRatio = 1.05;
+const highTargetStaticSceneCacheMaximumProgramIncrease = 1;
+const highTargetStaticSceneCacheMaximumTextureIncrease = 4;
+const highTargetStaticSceneCacheMaximumTotalEstimatedBytes = 160 * 1024 * 1024;
+const highTargetStaticSceneCacheMaximumTriangleRatio = 0.9;
+const highTargetStaticSceneCacheMaximumVisualMismatchRatio = 0.01;
+const highTargetStaticSceneCacheMaximumVisualP99ByteError = 8;
+const highTargetStaticSceneCacheOcclusionMaximumLeakRatio = 0.04;
+const highTargetStaticSceneCacheOcclusionMinimumMatchRatio = 0.96;
+const highTargetStaticSceneCacheOcclusionVerifiedHitCount = 3;
+const highTargetStaticSceneCachePairedRunCount = 5;
+const highTargetStaticSceneCacheComparisonPairs = new Set([
+    'static-opaque-scene-cache',
+    'static-opaque-scene-cache-cloudy',
+]);
+const staticSceneCacheVisualComparisonUnavailableReason =
+    'The scenario has no deterministic scene-time screenshot contract';
 const highTargetWeatherSurfaceOnsetExpectation = {
     avoidedOverlaySubmissionCount: 0,
     avoidedOverlayTriangleCount: 0,
@@ -363,6 +384,74 @@ const highTargetWeatherMaterialScenarios = [
         comparisonPair: 'snow-weather-surfaces',
         comparisonRole: 'integrated',
         repeat: 5,
+    },
+];
+
+const highTargetStaticSceneCacheScenarios = [
+    {
+        name: 'game-high-target-static-scene-cache-legacy-desktop',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=0&details=1&hud=0&debugHud=0&blockGeometryMerging=1&staticSceneCache=legacy',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        comparisonPair: 'static-opaque-scene-cache',
+        comparisonRole: 'legacy',
+        repeat: 5,
+        staticSceneCacheBenchmark: true,
+        staticSceneCacheVisualDeterministic: true,
+    },
+    {
+        name: 'game-high-target-static-scene-cache-cached-desktop',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=0&details=1&hud=0&debugHud=0&blockGeometryMerging=1&staticSceneCache=cache',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        comparisonPair: 'static-opaque-scene-cache',
+        comparisonRole: 'cache',
+        repeat: 5,
+        staticSceneCacheBenchmark: true,
+        staticSceneCacheVisualDeterministic: true,
+    },
+    {
+        name: 'game-high-target-static-scene-cache-cloudy-legacy-desktop',
+        path: '/debug/profile/game?mode=cloudy&profile=high-target&quality=high&controls=0&details=1&hud=0&debugHud=0&blockGeometryMerging=1&staticSceneCache=legacy&fixedTimeSeconds=12',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        comparisonPair: 'static-opaque-scene-cache-cloudy',
+        comparisonRole: 'legacy',
+        repeat: 5,
+        staticSceneCacheBenchmark: true,
+        staticSceneCacheVisualDeterministic: true,
+        fixedTimeSeconds: 12,
+    },
+    {
+        name: 'game-high-target-static-scene-cache-cloudy-cached-desktop',
+        path: '/debug/profile/game?mode=cloudy&profile=high-target&quality=high&controls=0&details=1&hud=0&debugHud=0&blockGeometryMerging=1&staticSceneCache=cache&fixedTimeSeconds=12',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        comparisonPair: 'static-opaque-scene-cache-cloudy',
+        comparisonRole: 'cache',
+        repeat: 5,
+        staticSceneCacheBenchmark: true,
+        staticSceneCacheVisualDeterministic: true,
+        fixedTimeSeconds: 12,
+    },
+    {
+        name: 'game-high-target-static-scene-cache-occlusion-fixture-desktop',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=0&details=1&hud=0&debugHud=0&blockGeometryMerging=1&staticSceneCache=cache&staticSceneCacheOcclusionFixture=1',
+        viewport: { width: 1280, height: 720 },
+        dpr: 2,
+        isMobile: false,
+        budget: 'gameHighTarget',
+        repeat: 1,
+        staticSceneCacheBenchmark: true,
+        staticSceneCacheOcclusionFixture: true,
     },
 ];
 
@@ -777,6 +866,7 @@ const scenarioSets = {
     'high-target': highTargetScenarios,
     'high-target-foliage-budget': highTargetFoliageBudgetScenarios,
     'high-target-operation-visuals': highTargetOperationVisualScenarios,
+    'high-target-static-scene-cache': highTargetStaticSceneCacheScenarios,
     'high-target-weather-materials': highTargetWeatherMaterialScenarios,
     'high-target-weather-onset': highTargetWeatherOnsetScenarios,
     outline: outlineScenarios,
@@ -1074,7 +1164,7 @@ function printHelp(options) {
             '  --warmup-ms <ms>       Warmup wait after canvas appears. Default: 5000',
             '  --soak-ms <ms>         Run the scene before sampling. Default: 0',
             '  --sample-ms <ms>       requestAnimationFrame sample window. Default: 5000',
-            `  --scenario-set <set>    core, dense, dense-mobile, high-target, high-target-foliage-budget, high-target-operation-visuals, high-target-weather-materials, high-target-weather-onset, adaptive-high, outline, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or comma-separated names. Current: ${options.scenarioSet}`,
+            `  --scenario-set <set>    core, dense, dense-mobile, high-target, high-target-foliage-budget, high-target-operation-visuals, high-target-static-scene-cache, high-target-weather-materials, high-target-weather-onset, adaptive-high, outline, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or comma-separated names. Current: ${options.scenarioSet}`,
             '  --scenario <name>       Profile exact scenario name(s). Repeat or use commas.',
             '  --screenshots           Save a PNG screenshot for each scenario.',
             '  --fail-on-budget       Exit non-zero when a budget check fails.',
@@ -1105,6 +1195,7 @@ function allScenarios() {
         ...highTargetScenarios,
         ...highTargetFoliageBudgetScenarios,
         ...highTargetOperationVisualScenarios,
+        ...highTargetStaticSceneCacheScenarios,
         ...highTargetWeatherMaterialScenarios,
         ...highTargetWeatherOnsetScenarios,
         ...outlineScenarios,
@@ -1140,7 +1231,7 @@ function resolveScenarios(scenarioSet, scenarioNames = []) {
 
         if (!candidates.length) {
             throw new Error(
-                `Unknown scenario set or scenario: ${token}. Use core, dense, dense-mobile, high-target, high-target-foliage-budget, high-target-operation-visuals, high-target-weather-materials, high-target-weather-onset, adaptive-high, outline, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or one of: ${knownScenarios.map((scenario) => scenario.name).join(', ')}.`,
+                `Unknown scenario set or scenario: ${token}. Use core, dense, dense-mobile, high-target, high-target-foliage-budget, high-target-operation-visuals, high-target-static-scene-cache, high-target-weather-materials, high-target-weather-onset, adaptive-high, outline, placement, plant-closeup, auto-quality, rewards, weather-transitions, all, or one of: ${knownScenarios.map((scenario) => scenario.name).join(', ')}.`,
             );
         }
 
@@ -1189,19 +1280,22 @@ function buildScenarioRunQueue(scenarios, { closeupRepeat = null } = {}) {
                           candidate.comparisonPair ===
                               scenario.comparisonPair &&
                           (candidate.comparisonRole === 'legacy' ||
-                              candidate.comparisonRole === 'integrated'),
+                              candidate.comparisonRole === 'integrated' ||
+                              candidate.comparisonRole === 'cache'),
                   )
                 : [];
         const legacy = paired.find(
             (candidate) => candidate.comparisonRole === 'legacy',
         );
-        const integrated = paired.find(
-            (candidate) => candidate.comparisonRole === 'integrated',
+        const optimized = paired.find(
+            (candidate) =>
+                candidate.comparisonRole === 'integrated' ||
+                candidate.comparisonRole === 'cache',
         );
-        if (legacy && integrated) {
+        if (legacy && optimized) {
             const legacyRepeat = repeatFor(legacy);
-            const integratedRepeat = repeatFor(integrated);
-            if (legacyRepeat === integratedRepeat) {
+            const optimizedRepeat = repeatFor(optimized);
+            if (legacyRepeat === optimizedRepeat) {
                 for (
                     let runIndex = 1;
                     runIndex <= legacyRepeat;
@@ -1209,14 +1303,14 @@ function buildScenarioRunQueue(scenarios, { closeupRepeat = null } = {}) {
                 ) {
                     const ordered =
                         runIndex % 2 === 1
-                            ? [legacy, integrated]
-                            : [integrated, legacy];
+                            ? [legacy, optimized]
+                            : [optimized, legacy];
                     for (const candidate of ordered) {
                         enqueue(candidate, runIndex, legacyRepeat);
                     }
                 }
                 scheduled.add(legacy.name);
-                scheduled.add(integrated.name);
+                scheduled.add(optimized.name);
                 continue;
             }
         }
@@ -1253,6 +1347,14 @@ function getScenarioRequest(path) {
         outline: url.searchParams.get('outline') ?? '0',
         placement: url.searchParams.get('placement') ?? '0',
         quality: url.searchParams.get('quality') ?? 'auto',
+        staticSceneCache:
+            url.searchParams.get('staticSceneCache') === 'legacy'
+                ? 'legacy'
+                : 'cache',
+        staticSceneCacheOcclusionFixture:
+            url.searchParams.get('staticSceneCacheOcclusionFixture') === '1'
+                ? '1'
+                : '0',
         weatherSurface:
             url.searchParams.get('weatherSurface') === 'legacy'
                 ? 'legacy'
@@ -1284,6 +1386,7 @@ function installBrowserMetrics({ externalGpuTimer = true } = {}) {
         lastRenderedRafTick: -1,
         renderedFrames: 0,
         rendererShaders: 0,
+        rendererTextures: 0,
         submittedTriangles: 0,
     };
     globalThis.__gameProfileLongTasks = [];
@@ -1578,8 +1681,12 @@ function installBrowserMetrics({ externalGpuTimer = true } = {}) {
         prototype[name].__gameProfilePatched = true;
     };
     const livePrograms = new Set();
+    const liveTextures = new Set();
     const updateRendererShaderCount = () => {
         globalThis.__gameProfileMetrics.rendererShaders = livePrograms.size;
+    };
+    const updateRendererTextureCount = () => {
+        globalThis.__gameProfileMetrics.rendererTextures = liveTextures.size;
     };
     const patchProgramLifecycle = (Context) => {
         const prototype = Context?.prototype;
@@ -1611,6 +1718,37 @@ function installBrowserMetrics({ externalGpuTimer = true } = {}) {
             return result;
         };
         prototype.deleteProgram.__gameProfilePatched = true;
+    };
+    const patchTextureLifecycle = (Context) => {
+        const prototype = Context?.prototype;
+        if (
+            !prototype?.createTexture ||
+            prototype.createTexture.__gameProfilePatched
+        ) {
+            return;
+        }
+
+        const originalCreateTexture = prototype.createTexture;
+        prototype.createTexture = function patchedCreateTexture(...args) {
+            const texture = originalCreateTexture.apply(this, args);
+            if (texture) {
+                liveTextures.add(texture);
+                updateRendererTextureCount();
+            }
+            return texture;
+        };
+        prototype.createTexture.__gameProfilePatched = true;
+
+        const originalDeleteTexture = prototype.deleteTexture;
+        prototype.deleteTexture = function patchedDeleteTexture(...args) {
+            const result = originalDeleteTexture.apply(this, args);
+            if (args[0]) {
+                liveTextures.delete(args[0]);
+                updateRendererTextureCount();
+            }
+            return result;
+        };
+        prototype.deleteTexture.__gameProfilePatched = true;
     };
 
     const patchContext = (Context) => {
@@ -1649,6 +1787,8 @@ function installBrowserMetrics({ externalGpuTimer = true } = {}) {
 
     patchProgramLifecycle(globalThis.WebGLRenderingContext);
     patchProgramLifecycle(globalThis.WebGL2RenderingContext);
+    patchTextureLifecycle(globalThis.WebGLRenderingContext);
+    patchTextureLifecycle(globalThis.WebGL2RenderingContext);
     patchContext(globalThis.WebGLRenderingContext);
     patchContext(globalThis.WebGL2RenderingContext);
 }
@@ -1745,6 +1885,7 @@ async function finishInteractiveProfileSample() {
         renderedFps: renderedFrames / safeElapsedSeconds,
         renderedFrames,
         rendererShaders: metrics?.rendererShaders ?? null,
+        rendererTextures: metrics?.rendererTextures ?? null,
         submittedTriangles,
         trianglesPerFrame: submittedTriangles / safeRafFrames,
         trianglesPerRafFrame: submittedTriangles / safeRafFrames,
@@ -2557,6 +2698,37 @@ async function measureScenario(browser, baseUrl, scenario, options) {
             new Promise((resolveWarmup) => setTimeout(resolveWarmup, warmupMs)),
         options.warmupMs,
     );
+    if (
+        scenario.staticSceneCacheBenchmark === true &&
+        request.staticSceneCache === 'cache'
+    ) {
+        await page.waitForFunction(
+            () => {
+                const profile = globalThis.__grediceGameProfile;
+                return (
+                    profile?.staticOpaqueSceneCacheSupported === true &&
+                    profile.staticOpaqueSceneCacheState === 'ready' &&
+                    profile.staticOpaqueSceneCacheReplayStatus === 'ready' &&
+                    (profile.staticOpaqueSceneCacheCaptureCount ?? 0) >= 1 &&
+                    (profile.staticOpaqueSceneCacheHitFrameCount ?? 0) >= 3
+                );
+            },
+            undefined,
+            { timeout: 60_000 },
+        );
+    }
+    if (request.staticSceneCacheOcclusionFixture === '1') {
+        await page.waitForFunction(
+            () => {
+                const state =
+                    globalThis.__grediceGameProfile
+                        ?.staticOpaqueSceneCacheOcclusionFixtureState;
+                return state === 'passed' || state === 'failed';
+            },
+            undefined,
+            { timeout: 60_000 },
+        );
+    }
     if (options.soakMs > 0) {
         await wait(options.soakMs);
     }
@@ -2638,6 +2810,15 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 ) || null,
             details: element.dataset.gameProfileDetails ?? null,
             debugHud: element.dataset.gameProfileDebugHud ?? null,
+            fixedTimeSeconds: Number.isFinite(
+                Number.parseFloat(
+                    element.dataset.gameProfileFixedTimeSeconds ?? '',
+                ),
+            )
+                ? Number.parseFloat(
+                      element.dataset.gameProfileFixedTimeSeconds ?? '',
+                  )
+                : null,
             gardenProfile: element.dataset.gameProfileGardenProfile ?? null,
             hud: element.dataset.gameProfileHud ?? null,
             mode: element.dataset.gameProfileMode ?? null,
@@ -2645,6 +2826,11 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 element.dataset.gameProfileOperationVisuals ?? null,
             outline: element.dataset.gameProfileOutline ?? null,
             quality: element.dataset.gameProfileQuality ?? null,
+            staticSceneCache:
+                element.dataset.gameProfileStaticSceneCache ?? null,
+            staticSceneCacheOcclusionFixture:
+                element.dataset.gameProfileStaticSceneCacheOcclusionFixture ??
+                null,
             weatherSurface: element.dataset.gameProfileWeatherSurface ?? null,
         };
     });
@@ -2724,6 +2910,9 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 outline: profileMetadata?.outline ?? request.outline,
                 outlineProfile: 'none',
                 quality: profileMetadata?.quality ?? request.quality,
+                staticSceneCache:
+                    profileMetadata?.staticSceneCache ??
+                    request.staticSceneCache,
                 viewport: scenario.viewport,
                 weatherTransition: 'none',
             },
@@ -2787,6 +2976,18 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 const value = globalThis.__grediceGameProfile?.[field];
                 return typeof value === 'number' ? value : null;
             };
+            const readProfileBoolean = (field) => {
+                const value = globalThis.__grediceGameProfile?.[field];
+                return typeof value === 'boolean' ? value : null;
+            };
+            const readProfileString = (field) => {
+                const value = globalThis.__grediceGameProfile?.[field];
+                return typeof value === 'string' ? value : null;
+            };
+            const counterDelta = (startValue, endValue) =>
+                startValue === null || endValue === null
+                    ? null
+                    : endValue - startValue;
             const readEffectiveDpr = () => {
                 if (
                     !canvas ||
@@ -2858,6 +3059,32 @@ async function measureScenario(browser, baseUrl, scenario, options) {
             );
             const cloudAttenuationUpdateCountAtStart = readProfileNumber(
                 'cloudAttenuationUpdateCount',
+            );
+            const staticOpaqueSceneCacheBypassFrameCountAtStart =
+                readProfileNumber('staticOpaqueSceneCacheBypassFrameCount');
+            const staticOpaqueSceneCacheCaptureCountAtStart = readProfileNumber(
+                'staticOpaqueSceneCacheCaptureCount',
+            );
+            const staticOpaqueSceneCacheCompositePassCountAtStart =
+                readProfileNumber('staticOpaqueSceneCacheCompositePassCount');
+            const staticOpaqueSceneCacheHitFrameCountAtStart =
+                readProfileNumber('staticOpaqueSceneCacheHitFrameCount');
+            const staticOpaqueSceneCacheInvalidationCountAtStart =
+                readProfileNumber('staticOpaqueSceneCacheInvalidationCount');
+            const staticOpaqueSceneCacheLiveFrameCountAtStart =
+                readProfileNumber('staticOpaqueSceneCacheLiveFrameCount');
+            const staticOpaqueSceneCacheSavedSubmissionCountAtStart =
+                readProfileNumber('staticOpaqueSceneCacheSavedSubmissionCount');
+            const staticOpaqueSceneCacheSavedTriangleCountAtStart =
+                readProfileNumber('staticOpaqueSceneCacheSavedTriangleCount');
+            const staticOpaqueSceneCacheReplayStatusAtStart = readProfileString(
+                'staticOpaqueSceneCacheReplayStatus',
+            );
+            const staticOpaqueSceneCacheStateAtStart = readProfileString(
+                'staticOpaqueSceneCacheState',
+            );
+            const staticOpaqueSceneCacheSupportedAtStart = readProfileBoolean(
+                'staticOpaqueSceneCacheSupported',
             );
             const interactionResolvedTargetCountAtStart =
                 typeof globalThis.__grediceGameProfile
@@ -3267,6 +3494,55 @@ async function measureScenario(browser, baseUrl, scenario, options) {
             const cloudAttenuationUpdateCountAtEnd = readProfileNumber(
                 'cloudAttenuationUpdateCount',
             );
+            const staticOpaqueSceneCacheBypassFrameCountAtEnd =
+                readProfileNumber('staticOpaqueSceneCacheBypassFrameCount');
+            const staticOpaqueSceneCacheCaptureCountAtEnd = readProfileNumber(
+                'staticOpaqueSceneCacheCaptureCount',
+            );
+            const staticOpaqueSceneCacheCompositePassCountAtEnd =
+                readProfileNumber('staticOpaqueSceneCacheCompositePassCount');
+            const staticOpaqueSceneCacheHitFrameCountAtEnd = readProfileNumber(
+                'staticOpaqueSceneCacheHitFrameCount',
+            );
+            const staticOpaqueSceneCacheInvalidationCountAtEnd =
+                readProfileNumber('staticOpaqueSceneCacheInvalidationCount');
+            const staticOpaqueSceneCacheLiveFrameCountAtEnd = readProfileNumber(
+                'staticOpaqueSceneCacheLiveFrameCount',
+            );
+            const staticOpaqueSceneCacheSavedSubmissionCountAtEnd =
+                readProfileNumber('staticOpaqueSceneCacheSavedSubmissionCount');
+            const staticOpaqueSceneCacheSavedTriangleCountAtEnd =
+                readProfileNumber('staticOpaqueSceneCacheSavedTriangleCount');
+            const staticOpaqueSceneCacheUnexpectedStaticSubmissionCountAtEnd =
+                readProfileNumber(
+                    'staticOpaqueSceneCacheUnexpectedStaticSubmissionCount',
+                );
+            const staticOpaqueSceneCacheHitFrameCountDelta = counterDelta(
+                staticOpaqueSceneCacheHitFrameCountAtStart,
+                staticOpaqueSceneCacheHitFrameCountAtEnd,
+            );
+            const staticOpaqueSceneCacheLiveFrameCountDelta = counterDelta(
+                staticOpaqueSceneCacheLiveFrameCountAtStart,
+                staticOpaqueSceneCacheLiveFrameCountAtEnd,
+            );
+            const staticOpaqueSceneCacheBypassFrameCountDelta = counterDelta(
+                staticOpaqueSceneCacheBypassFrameCountAtStart,
+                staticOpaqueSceneCacheBypassFrameCountAtEnd,
+            );
+            const staticOpaqueSceneCacheCaptureCountDelta = counterDelta(
+                staticOpaqueSceneCacheCaptureCountAtStart,
+                staticOpaqueSceneCacheCaptureCountAtEnd,
+            );
+            const staticOpaqueSceneCacheMeasuredFrameCount = [
+                staticOpaqueSceneCacheHitFrameCountDelta,
+                staticOpaqueSceneCacheLiveFrameCountDelta,
+                staticOpaqueSceneCacheBypassFrameCountDelta,
+                staticOpaqueSceneCacheCaptureCountDelta,
+            ].reduce(
+                (total, value) =>
+                    total + (typeof value === 'number' ? value : 0),
+                0,
+            );
             const nonGpuSample = {
                 adaptiveHighDeclineCountDelta:
                     adaptiveHighDeclineCountAtStart === null ||
@@ -3398,6 +3674,39 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 renderedFps: renderedFrames / safeElapsedSeconds,
                 renderedFrames,
                 rendererShaders: metrics?.rendererShaders ?? null,
+                rendererTextures: metrics?.rendererTextures ?? null,
+                staticOpaqueSceneCacheBypassFrameCountDelta,
+                staticOpaqueSceneCacheCaptureCountAtStart,
+                staticOpaqueSceneCacheCaptureCountDelta,
+                staticOpaqueSceneCacheCompositePassCountDelta: counterDelta(
+                    staticOpaqueSceneCacheCompositePassCountAtStart,
+                    staticOpaqueSceneCacheCompositePassCountAtEnd,
+                ),
+                staticOpaqueSceneCacheHitFrameCountAtStart,
+                staticOpaqueSceneCacheHitFrameCountDelta,
+                staticOpaqueSceneCacheHitRatio:
+                    staticOpaqueSceneCacheMeasuredFrameCount > 0 &&
+                    staticOpaqueSceneCacheHitFrameCountDelta !== null
+                        ? staticOpaqueSceneCacheHitFrameCountDelta /
+                          staticOpaqueSceneCacheMeasuredFrameCount
+                        : null,
+                staticOpaqueSceneCacheInvalidationCountDelta: counterDelta(
+                    staticOpaqueSceneCacheInvalidationCountAtStart,
+                    staticOpaqueSceneCacheInvalidationCountAtEnd,
+                ),
+                staticOpaqueSceneCacheLiveFrameCountDelta,
+                staticOpaqueSceneCacheSavedSubmissionCountDelta: counterDelta(
+                    staticOpaqueSceneCacheSavedSubmissionCountAtStart,
+                    staticOpaqueSceneCacheSavedSubmissionCountAtEnd,
+                ),
+                staticOpaqueSceneCacheSavedTriangleCountDelta: counterDelta(
+                    staticOpaqueSceneCacheSavedTriangleCountAtStart,
+                    staticOpaqueSceneCacheSavedTriangleCountAtEnd,
+                ),
+                staticOpaqueSceneCacheReplayStatusAtStart,
+                staticOpaqueSceneCacheStateAtStart,
+                staticOpaqueSceneCacheSupportedAtStart,
+                staticOpaqueSceneCacheUnexpectedStaticSubmissionCountAtEnd,
                 submittedTriangles,
                 trianglesPerFrame: submittedTriangles / safeRafFrames,
                 trianglesPerRafFrame: submittedTriangles / safeRafFrames,
@@ -3460,7 +3769,11 @@ async function measureScenario(browser, baseUrl, scenario, options) {
         ]),
     );
 
-    const runtime = await page.evaluate((instrumentedRendererShaders) => {
+    const instrumentedRendererResources = {
+        rendererShaders: sample.rendererShaders,
+        rendererTextures: sample.rendererTextures,
+    };
+    const runtime = await page.evaluate((resources) => {
         const metadata = globalThis.__grediceGameProfile;
         if (!metadata || typeof metadata !== 'object') {
             return null;
@@ -3967,7 +4280,10 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                     : null,
             rendererShaders:
                 numberOrNull(metadata.rendererShaders) ??
-                numberOrNull(instrumentedRendererShaders),
+                numberOrNull(resources.rendererShaders),
+            rendererTextures:
+                numberOrNull(metadata.rendererTextures) ??
+                numberOrNull(resources.rendererTextures),
             shadowMapAutoUpdate:
                 typeof metadata.shadowMapAutoUpdate === 'boolean'
                     ? metadata.shadowMapAutoUpdate
@@ -4008,6 +4324,132 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 typeof metadata.snowParticleGeometryBuildCount === 'number'
                     ? metadata.snowParticleGeometryBuildCount
                     : null,
+            staticOpaqueSceneCacheBoundaryCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheBoundaryCount,
+            ),
+            staticOpaqueSceneCacheBypassFrameCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheBypassFrameCount,
+            ),
+            staticOpaqueSceneCacheCaptureCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheCaptureCount,
+            ),
+            staticOpaqueSceneCacheCaptureSubmissionCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheCaptureSubmissionCount,
+            ),
+            staticOpaqueSceneCacheCaptureTriangleCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheCaptureTriangleCount,
+            ),
+            staticOpaqueSceneCacheCompositePassCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheCompositePassCount,
+            ),
+            staticOpaqueSceneCacheReplayEstimatedBytes: numberOrNull(
+                metadata.staticOpaqueSceneCacheReplayEstimatedBytes,
+            ),
+            staticOpaqueSceneCacheReplayStatus: stringOrNull(
+                metadata.staticOpaqueSceneCacheReplayStatus,
+            ),
+            staticOpaqueSceneCacheReplaySubmissionCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheReplaySubmissionCount,
+            ),
+            staticOpaqueSceneCacheReplayTriangleCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheReplayTriangleCount,
+            ),
+            staticOpaqueSceneCacheEnabled: booleanOrNull(
+                metadata.staticOpaqueSceneCacheEnabled,
+            ),
+            staticOpaqueSceneCacheHitFrameCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheHitFrameCount,
+            ),
+            staticOpaqueSceneCacheIneligibleBoundaryCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheIneligibleBoundaryCount,
+            ),
+            staticOpaqueSceneCacheInvalidationCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheInvalidationCount,
+            ),
+            staticOpaqueSceneCacheLastInvalidationReason: stringOrNull(
+                metadata.staticOpaqueSceneCacheLastInvalidationReason,
+            ),
+            staticOpaqueSceneCacheLiveFrameCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheLiveFrameCount,
+            ),
+            staticOpaqueSceneCacheMeshCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheMeshCount,
+            ),
+            staticOpaqueSceneCacheOcclusionBackgroundWitnessMinimumMatchRatio:
+                numberOrNull(
+                    metadata.staticOpaqueSceneCacheOcclusionBackgroundWitnessMinimumMatchRatio,
+                ),
+            staticOpaqueSceneCacheOcclusionCaptureCountAtTransition:
+                numberOrNull(
+                    metadata.staticOpaqueSceneCacheOcclusionCaptureCountAtTransition,
+                ),
+            staticOpaqueSceneCacheOcclusionFixtureEnabled: booleanOrNull(
+                metadata.staticOpaqueSceneCacheOcclusionFixtureEnabled,
+            ),
+            staticOpaqueSceneCacheOcclusionFixturePass: booleanOrNull(
+                metadata.staticOpaqueSceneCacheOcclusionFixturePass,
+            ),
+            staticOpaqueSceneCacheOcclusionFixtureState: stringOrNull(
+                metadata.staticOpaqueSceneCacheOcclusionFixtureState,
+            ),
+            staticOpaqueSceneCacheOcclusionForegroundMinimumMatchRatio:
+                numberOrNull(
+                    metadata.staticOpaqueSceneCacheOcclusionForegroundMinimumMatchRatio,
+                ),
+            staticOpaqueSceneCacheOcclusionHitFrameCountAtTransition:
+                numberOrNull(
+                    metadata.staticOpaqueSceneCacheOcclusionHitFrameCountAtTransition,
+                ),
+            staticOpaqueSceneCacheOcclusionOccludedBackgroundLeakMaximumRatio:
+                numberOrNull(
+                    metadata.staticOpaqueSceneCacheOcclusionOccludedBackgroundLeakMaximumRatio,
+                ),
+            staticOpaqueSceneCacheOcclusionOccluderMinimumMatchRatio:
+                numberOrNull(
+                    metadata.staticOpaqueSceneCacheOcclusionOccluderMinimumMatchRatio,
+                ),
+            staticOpaqueSceneCacheOcclusionTransitionCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheOcclusionTransitionCount,
+            ),
+            staticOpaqueSceneCacheOcclusionVerifiedHitFrameCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheOcclusionVerifiedHitFrameCount,
+            ),
+            staticOpaqueSceneCacheReason: stringOrNull(
+                metadata.staticOpaqueSceneCacheReason,
+            ),
+            staticOpaqueSceneCacheSavedSubmissionCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheSavedSubmissionCount,
+            ),
+            staticOpaqueSceneCacheSavedTriangleCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheSavedTriangleCount,
+            ),
+            staticOpaqueSceneCacheState: stringOrNull(
+                metadata.staticOpaqueSceneCacheState,
+            ),
+            staticOpaqueSceneCacheSupported: booleanOrNull(
+                metadata.staticOpaqueSceneCacheSupported,
+            ),
+            staticOpaqueSceneCacheTargetEstimatedBytes: numberOrNull(
+                metadata.staticOpaqueSceneCacheTargetEstimatedBytes,
+            ),
+            staticOpaqueSceneCacheTotalEstimatedBytes: numberOrNull(
+                metadata.staticOpaqueSceneCacheTargetEstimatedBytes,
+            ),
+            staticOpaqueSceneCacheTargetHeight: numberOrNull(
+                metadata.staticOpaqueSceneCacheTargetHeight,
+            ),
+            staticOpaqueSceneCacheTargetSampleCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheTargetSampleCount,
+            ),
+            staticOpaqueSceneCacheTargetWidth: numberOrNull(
+                metadata.staticOpaqueSceneCacheTargetWidth,
+            ),
+            staticOpaqueSceneCacheTriangleCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheTriangleCount,
+            ),
+            staticOpaqueSceneCacheUnexpectedStaticSubmissionCount: numberOrNull(
+                metadata.staticOpaqueSceneCacheUnexpectedStaticSubmissionCount,
+            ),
             weatherSurfaceAvoidedOverlaySubmissionCount: numberOrNull(
                 metadata.weatherSurfaceAvoidedOverlaySubmissionCount,
             ),
@@ -4044,11 +4486,14 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                     ? metadata.weatherDisabled
                     : null,
         };
-    }, sample.rendererShaders);
+    }, instrumentedRendererResources);
 
-    const screenshotPath = options.screenshots
-        ? resolve(options.outDir, 'screenshots', `${scenario.name}.png`)
-        : null;
+    const screenshotPath =
+        options.screenshots ||
+        (scenario.staticSceneCacheBenchmark === true &&
+            scenario.staticSceneCacheVisualDeterministic !== false)
+            ? resolve(options.outDir, 'screenshots', `${scenario.name}.png`)
+            : null;
     if (screenshotPath) {
         await mkdir(dirname(screenshotPath), { recursive: true });
         await page.screenshot({
@@ -4076,6 +4521,10 @@ async function measureScenario(browser, baseUrl, scenario, options) {
         debugHud: profileMetadata?.debugHud ?? request.debugHud,
         dpr: scenario.dpr,
         foliageBudget: request.foliageBudget,
+        fixedTimeSeconds:
+            profileMetadata?.fixedTimeSeconds ??
+            scenario.fixedTimeSeconds ??
+            null,
         gardenProfile: profileMetadata?.gardenProfile ?? request.gardenProfile,
         graphicsBackend: options.graphicsBackend,
         hud: profileMetadata?.hud ?? request.hud,
@@ -4096,6 +4545,13 @@ async function measureScenario(browser, baseUrl, scenario, options) {
         quality: profileMetadata?.quality ?? request.quality,
         runtimeGpuSource: scenario.runtimeGpuSource === true,
         sampleMs,
+        staticSceneCache:
+            profileMetadata?.staticSceneCache ?? request.staticSceneCache,
+        staticSceneCacheVisualDeterministic:
+            scenario.staticSceneCacheVisualDeterministic !== false,
+        staticSceneCacheOcclusionFixture:
+            profileMetadata?.staticSceneCacheOcclusionFixture ??
+            request.staticSceneCacheOcclusionFixture,
         viewport: scenario.viewport,
         weatherSurface:
             profileMetadata?.weatherSurface ?? request.weatherSurface,
@@ -4212,6 +4668,10 @@ function roundSample(sample) {
         p99FrameMs: round(sample.p99FrameMs),
         rainUnmountMs: round(sample.rainUnmountMs),
         renderedFps: round(sample.renderedFps, 1),
+        staticOpaqueSceneCacheHitRatio: round(
+            sample.staticOpaqueSceneCacheHitRatio,
+            4,
+        ),
         trianglesPerFrame: Math.round(sample.trianglesPerFrame),
         trianglesPerRafFrame: Math.round(sample.trianglesPerRafFrame),
         trianglesPerRenderedFrame: Math.round(sample.trianglesPerRenderedFrame),
@@ -4263,6 +4723,28 @@ function evaluateBudget(sample, budget) {
         checks,
         pass: checks.every((check) => check.pass),
     };
+}
+
+function isIgnoredLocalProfilerConsoleError(message) {
+    if (
+        message?.type !== 'error' ||
+        typeof message.text !== 'string' ||
+        typeof message.url !== 'string' ||
+        !message.text.startsWith('Failed to load resource:') ||
+        !message.text.includes('404')
+    ) {
+        return false;
+    }
+
+    try {
+        const url = new URL(message.url);
+        return (
+            ['localhost', '127.0.0.1', '::1'].includes(url.hostname) &&
+            url.pathname === '/_vercel/insights/script.js'
+        );
+    } catch {
+        return false;
+    }
 }
 
 function evaluateHighTargetAcceptance({
@@ -4347,6 +4829,30 @@ function evaluateHighTargetAcceptance({
         : null;
     const operationVisualsRequested = requested.operationVisuals === '1';
     const foliageBudgetRequested = requested.foliageBudget === '1';
+    const staticSceneCacheBenchmarkRequested =
+        highTargetStaticSceneCacheComparisonPairs.has(requested.comparisonPair);
+    const staticSceneCacheCloudyBenchmarkRequested =
+        staticSceneCacheBenchmarkRequested && requested.mode === 'cloudy';
+    const staticSceneCacheExpectedCloudAttenuationUpdates =
+        staticSceneCacheCloudyBenchmarkRequested &&
+        typeof sample.elapsedMs === 'number' &&
+        typeof runtime?.cloudAttenuationUpdateMs === 'number' &&
+        runtime.cloudAttenuationUpdateMs > 0
+            ? sample.elapsedMs / runtime.cloudAttenuationUpdateMs
+            : null;
+    const staticSceneCacheOcclusionFixtureRequested =
+        requested.staticSceneCacheOcclusionFixture === '1';
+    const staticSceneCacheCachedRunRequested =
+        (staticSceneCacheBenchmarkRequested &&
+            requested.comparisonRole === 'cache') ||
+        staticSceneCacheOcclusionFixtureRequested;
+    const staticSceneCacheOcclusionPostTransitionHitCount =
+        typeof runtime?.staticOpaqueSceneCacheHitFrameCount === 'number' &&
+        typeof runtime?.staticOpaqueSceneCacheOcclusionHitFrameCountAtTransition ===
+            'number'
+            ? runtime.staticOpaqueSceneCacheHitFrameCount -
+              runtime.staticOpaqueSceneCacheOcclusionHitFrameCountAtTransition
+            : null;
     const weatherSurfaceRequested =
         requested.weatherSurface === 'integrated' ||
         requested.weatherSurface === 'legacy'
@@ -4608,12 +5114,299 @@ function evaluateHighTargetAcceptance({
         exact('highTargetApiErrors', apiErrors.length, 0),
         exact(
             'highTargetConsoleErrors',
-            consoleMessages.filter((message) => message.type === 'error')
-                .length,
+            consoleMessages.filter(
+                (message) =>
+                    message.type === 'error' &&
+                    !isIgnoredLocalProfilerConsoleError(message),
+            ).length,
             0,
         ),
         exact('highTargetPageErrors', pageErrors.length, 0),
     ];
+    if (staticSceneCacheCachedRunRequested) {
+        checks.push(
+            exact(
+                'highTargetStaticSceneCacheRequestedMode',
+                requested.staticSceneCache,
+                'cache',
+            ),
+            exact(
+                'highTargetStaticSceneCacheEnabled',
+                runtime?.staticOpaqueSceneCacheEnabled,
+                true,
+            ),
+            exact(
+                'highTargetStaticSceneCacheSupported',
+                runtime?.staticOpaqueSceneCacheSupported,
+                true,
+            ),
+            exact(
+                'highTargetStaticSceneCacheWarmState',
+                sample.staticOpaqueSceneCacheStateAtStart,
+                'ready',
+            ),
+            exact(
+                'highTargetStaticSceneCacheWarmReplayStatus',
+                sample.staticOpaqueSceneCacheReplayStatusAtStart,
+                'ready',
+            ),
+            exact(
+                'highTargetStaticSceneCacheWarmSupported',
+                sample.staticOpaqueSceneCacheSupportedAtStart,
+                true,
+            ),
+            exact(
+                'highTargetStaticSceneCacheFinalState',
+                runtime?.staticOpaqueSceneCacheState,
+                'ready',
+            ),
+            exact(
+                'highTargetStaticSceneCacheFinalReplayStatus',
+                runtime?.staticOpaqueSceneCacheReplayStatus,
+                'ready',
+            ),
+            minimum(
+                'highTargetStaticSceneCacheWarmCaptures',
+                sample.staticOpaqueSceneCacheCaptureCountAtStart,
+                1,
+            ),
+            minimum(
+                'highTargetStaticSceneCacheWarmHits',
+                sample.staticOpaqueSceneCacheHitFrameCountAtStart,
+                3,
+            ),
+            minimum(
+                'highTargetStaticSceneCacheBoundaries',
+                runtime?.staticOpaqueSceneCacheBoundaryCount,
+                1,
+            ),
+            minimum(
+                'highTargetStaticSceneCacheMeshes',
+                runtime?.staticOpaqueSceneCacheMeshCount,
+                1,
+            ),
+            minimum(
+                'highTargetStaticSceneCacheTriangles',
+                runtime?.staticOpaqueSceneCacheTriangleCount,
+                1,
+            ),
+            minimum(
+                'highTargetStaticSceneCacheCaptureSubmissions',
+                runtime?.staticOpaqueSceneCacheCaptureSubmissionCount,
+                1,
+            ),
+            minimum(
+                'highTargetStaticSceneCacheCaptureTriangles',
+                runtime?.staticOpaqueSceneCacheCaptureTriangleCount,
+                1,
+            ),
+            finiteMinimum(
+                'highTargetStaticSceneCacheReplayEstimatedBytes',
+                runtime?.staticOpaqueSceneCacheReplayEstimatedBytes,
+                1,
+            ),
+            exact(
+                'highTargetStaticSceneCacheReplaySubmissions',
+                runtime?.staticOpaqueSceneCacheReplaySubmissionCount,
+                1,
+            ),
+            exact(
+                'highTargetStaticSceneCacheReplayTriangles',
+                runtime?.staticOpaqueSceneCacheReplayTriangleCount,
+                1,
+            ),
+            exact(
+                'highTargetStaticSceneCacheTargetWidth',
+                runtime?.staticOpaqueSceneCacheTargetWidth,
+                sample.canvas?.width,
+            ),
+            exact(
+                'highTargetStaticSceneCacheTargetHeight',
+                runtime?.staticOpaqueSceneCacheTargetHeight,
+                sample.canvas?.height,
+            ),
+            exact(
+                'highTargetStaticSceneCacheTargetSampleCount',
+                runtime?.staticOpaqueSceneCacheTargetSampleCount,
+                4,
+            ),
+            range(
+                'highTargetStaticSceneCacheTotalEstimatedBytes',
+                runtime?.staticOpaqueSceneCacheTotalEstimatedBytes,
+                1,
+                highTargetStaticSceneCacheMaximumTotalEstimatedBytes,
+            ),
+            exact(
+                'highTargetStaticSceneCacheTimedCaptures',
+                sample.staticOpaqueSceneCacheCaptureCountDelta,
+                0,
+            ),
+            exact(
+                'highTargetStaticSceneCacheTimedInvalidations',
+                sample.staticOpaqueSceneCacheInvalidationCountDelta,
+                0,
+            ),
+            exact(
+                'highTargetStaticSceneCacheTimedBypasses',
+                sample.staticOpaqueSceneCacheBypassFrameCountDelta,
+                0,
+            ),
+            exact(
+                'highTargetStaticSceneCacheTimedLiveFrames',
+                sample.staticOpaqueSceneCacheLiveFrameCountDelta,
+                0,
+            ),
+            exact(
+                'highTargetStaticSceneCacheTimedHitRatio',
+                sample.staticOpaqueSceneCacheHitRatio,
+                1,
+            ),
+            exact(
+                'highTargetStaticSceneCacheTimedCompositePasses',
+                sample.staticOpaqueSceneCacheCompositePassCountDelta,
+                sample.staticOpaqueSceneCacheHitFrameCountDelta,
+            ),
+            minimum(
+                'highTargetStaticSceneCacheSavedSubmissions',
+                sample.staticOpaqueSceneCacheSavedSubmissionCountDelta,
+                1,
+            ),
+            minimum(
+                'highTargetStaticSceneCacheSavedTriangles',
+                sample.staticOpaqueSceneCacheSavedTriangleCountDelta,
+                1,
+            ),
+            exact(
+                'highTargetStaticSceneCacheIneligibleBoundaries',
+                runtime?.staticOpaqueSceneCacheIneligibleBoundaryCount,
+                0,
+            ),
+            exact(
+                'highTargetStaticSceneCacheUnexpectedSubmissions',
+                sample.staticOpaqueSceneCacheUnexpectedStaticSubmissionCountAtEnd,
+                0,
+            ),
+        );
+    }
+    if (staticSceneCacheCloudyBenchmarkRequested) {
+        checks.push(
+            exact(
+                'highTargetStaticSceneCacheCloudFixedTimeSeconds',
+                requested.fixedTimeSeconds,
+                12,
+            ),
+            exact(
+                'highTargetStaticSceneCacheCloudVisuals',
+                runtime?.cloudVisualCount,
+                8,
+            ),
+            exact(
+                'highTargetStaticSceneCacheCloudProjectedShadows',
+                runtime?.cloudProjectedShadowCount,
+                8,
+            ),
+            exact(
+                'highTargetStaticSceneCacheCloudRealShadowCasters',
+                runtime?.cloudRealShadowCasterCount,
+                0,
+            ),
+            exact(
+                'highTargetStaticSceneCacheCloudAttenuationResolution',
+                runtime?.cloudAttenuationMaskResolution,
+                192,
+            ),
+            exact(
+                'highTargetStaticSceneCacheCloudAttenuationCadence',
+                runtime?.cloudAttenuationUpdateMs,
+                96,
+            ),
+            minimum(
+                'highTargetStaticSceneCacheCloudAttenuationMaterials',
+                runtime?.cloudAttenuationMaterialCount,
+                1,
+            ),
+            range(
+                'highTargetStaticSceneCacheCloudAttenuationUpdates',
+                sample.cloudAttenuationUpdateCountDelta,
+                Math.max(
+                    2,
+                    Math.floor(
+                        (staticSceneCacheExpectedCloudAttenuationUpdates ?? 0) *
+                            0.65,
+                    ),
+                ),
+                Math.ceil(
+                    (staticSceneCacheExpectedCloudAttenuationUpdates ?? 0) *
+                        1.35,
+                ),
+            ),
+            exact(
+                'highTargetStaticSceneCacheCloudPrimaryShadowRefreshes',
+                sample.primaryShadowRefreshCountDelta,
+                0,
+            ),
+        );
+    }
+    if (staticSceneCacheOcclusionFixtureRequested) {
+        checks.push(
+            exact(
+                'highTargetStaticSceneCacheOcclusionFixtureEnabled',
+                runtime?.staticOpaqueSceneCacheOcclusionFixtureEnabled,
+                true,
+            ),
+            exact(
+                'highTargetStaticSceneCacheOcclusionFixtureState',
+                runtime?.staticOpaqueSceneCacheOcclusionFixtureState,
+                'passed',
+            ),
+            exact(
+                'highTargetStaticSceneCacheOcclusionFixturePass',
+                runtime?.staticOpaqueSceneCacheOcclusionFixturePass,
+                true,
+            ),
+            exact(
+                'highTargetStaticSceneCacheOcclusionTransitions',
+                runtime?.staticOpaqueSceneCacheOcclusionTransitionCount,
+                1,
+            ),
+            exact(
+                'highTargetStaticSceneCacheOcclusionRecaptures',
+                runtime?.staticOpaqueSceneCacheCaptureCount,
+                runtime?.staticOpaqueSceneCacheOcclusionCaptureCountAtTransition,
+            ),
+            minimum(
+                'highTargetStaticSceneCacheOcclusionPostTransitionHits',
+                staticSceneCacheOcclusionPostTransitionHitCount,
+                highTargetStaticSceneCacheOcclusionVerifiedHitCount + 1,
+            ),
+            exact(
+                'highTargetStaticSceneCacheOcclusionVerifiedHits',
+                runtime?.staticOpaqueSceneCacheOcclusionVerifiedHitFrameCount,
+                highTargetStaticSceneCacheOcclusionVerifiedHitCount,
+            ),
+            minimum(
+                'highTargetStaticSceneCacheOcclusionBackgroundWitness',
+                runtime?.staticOpaqueSceneCacheOcclusionBackgroundWitnessMinimumMatchRatio,
+                highTargetStaticSceneCacheOcclusionMinimumMatchRatio,
+            ),
+            minimum(
+                'highTargetStaticSceneCacheOcclusionCachedOccluder',
+                runtime?.staticOpaqueSceneCacheOcclusionOccluderMinimumMatchRatio,
+                highTargetStaticSceneCacheOcclusionMinimumMatchRatio,
+            ),
+            minimum(
+                'highTargetStaticSceneCacheOcclusionLiveForeground',
+                runtime?.staticOpaqueSceneCacheOcclusionForegroundMinimumMatchRatio,
+                highTargetStaticSceneCacheOcclusionMinimumMatchRatio,
+            ),
+            range(
+                'highTargetStaticSceneCacheOcclusionBackgroundLeak',
+                runtime?.staticOpaqueSceneCacheOcclusionOccludedBackgroundLeakMaximumRatio,
+                0,
+                highTargetStaticSceneCacheOcclusionMaximumLeakRatio,
+            ),
+        );
+    }
     if (operationVisualsRequested) {
         checks.push(
             exact(
@@ -5659,6 +6452,69 @@ function buildHighTargetMedians(scenarios) {
                     value: valid ? value : null,
                 };
             });
+            const rendererTextures = metric(
+                runs,
+                (run) => run.runtime?.rendererTextures,
+            );
+            const rendererTexturesRuns = runs.map((run, index) => {
+                const value = run.runtime?.rendererTextures ?? null;
+                const valid = Number.isFinite(value) && value >= 0;
+                return {
+                    profileRun: run.profileRun ?? index + 1,
+                    valid,
+                    value: valid ? value : null,
+                };
+            });
+            const staticOpaqueSceneCacheHitRatio = metric(
+                runs,
+                (run) => run.sample.staticOpaqueSceneCacheHitRatio,
+            );
+            const staticOpaqueSceneCacheCaptureSubmissionCount = metric(
+                runs,
+                (run) =>
+                    run.runtime?.staticOpaqueSceneCacheCaptureSubmissionCount,
+            );
+            const staticOpaqueSceneCacheCaptureTriangleCount = metric(
+                runs,
+                (run) =>
+                    run.runtime?.staticOpaqueSceneCacheCaptureTriangleCount,
+            );
+            const staticOpaqueSceneCacheReplayEstimatedBytes = metric(
+                runs,
+                (run) =>
+                    run.runtime?.staticOpaqueSceneCacheReplayEstimatedBytes,
+            );
+            const staticOpaqueSceneCacheReplayReadyRunCount = runs.filter(
+                (run) =>
+                    run.runtime?.staticOpaqueSceneCacheReplayStatus === 'ready',
+            ).length;
+            const staticOpaqueSceneCacheReplaySubmissionCount = metric(
+                runs,
+                (run) =>
+                    run.runtime?.staticOpaqueSceneCacheReplaySubmissionCount,
+            );
+            const staticOpaqueSceneCacheReplayTriangleCount = metric(
+                runs,
+                (run) => run.runtime?.staticOpaqueSceneCacheReplayTriangleCount,
+            );
+            const staticOpaqueSceneCacheSavedSubmissionCountDelta = metric(
+                runs,
+                (run) =>
+                    run.sample.staticOpaqueSceneCacheSavedSubmissionCountDelta,
+            );
+            const staticOpaqueSceneCacheSavedTriangleCountDelta = metric(
+                runs,
+                (run) =>
+                    run.sample.staticOpaqueSceneCacheSavedTriangleCountDelta,
+            );
+            const staticOpaqueSceneCacheTargetSampleCount = metric(
+                runs,
+                (run) => run.runtime?.staticOpaqueSceneCacheTargetSampleCount,
+            );
+            const staticOpaqueSceneCacheTotalEstimatedBytes = metric(
+                runs,
+                (run) => run.runtime?.staticOpaqueSceneCacheTotalEstimatedBytes,
+            );
             const trianglesPerFrame = metric(
                 runs,
                 (run) => run.sample.trianglesPerFrame,
@@ -5749,7 +6605,20 @@ function buildHighTargetMedians(scenarios) {
                     renderedFps,
                     rendererShaders,
                     rendererShadersRuns,
+                    rendererTextures,
+                    rendererTexturesRuns,
                     runCount: runs.length,
+                    staticOpaqueSceneCacheCaptureSubmissionCount,
+                    staticOpaqueSceneCacheCaptureTriangleCount,
+                    staticOpaqueSceneCacheHitRatio,
+                    staticOpaqueSceneCacheReplayEstimatedBytes,
+                    staticOpaqueSceneCacheReplayReadyRunCount,
+                    staticOpaqueSceneCacheReplaySubmissionCount,
+                    staticOpaqueSceneCacheReplayTriangleCount,
+                    staticOpaqueSceneCacheSavedSubmissionCountDelta,
+                    staticOpaqueSceneCacheSavedTriangleCountDelta,
+                    staticOpaqueSceneCacheTargetSampleCount,
+                    staticOpaqueSceneCacheTotalEstimatedBytes,
                     trianglesPerRenderedFrame,
                     weatherSurfaceAvoidedOverlaySubmissionCount,
                     weatherSurfaceAvoidedOverlayTriangleCount,
@@ -6244,7 +7113,559 @@ function buildWeatherSurfaceComparisons(highTargetMedians) {
     );
 }
 
-function buildProfileSummary(scenarios, highTargetMedians) {
+function measureStaticSceneCacheImageParity(legacy, cached) {
+    if (
+        legacy.info.width !== cached.info.width ||
+        legacy.info.height !== cached.info.height ||
+        legacy.info.channels !== 4 ||
+        cached.info.channels !== 4
+    ) {
+        return {
+            reason: 'Screenshot dimensions or channels do not match',
+            valid: false,
+        };
+    }
+
+    const histogram = new Uint32Array(256);
+    const pixelCount = legacy.info.width * legacy.info.height;
+    let mismatchCount = 0;
+    let totalByteError = 0;
+    let maximumByteError = 0;
+    for (let offset = 0; offset < legacy.data.length; offset += 4) {
+        const byteError = Math.max(
+            Math.abs(legacy.data[offset] - cached.data[offset]),
+            Math.abs(legacy.data[offset + 1] - cached.data[offset + 1]),
+            Math.abs(legacy.data[offset + 2] - cached.data[offset + 2]),
+        );
+        histogram[byteError] += 1;
+        totalByteError += byteError;
+        maximumByteError = Math.max(maximumByteError, byteError);
+        if (byteError > highTargetStaticSceneCacheMaximumVisualP99ByteError) {
+            mismatchCount += 1;
+        }
+    }
+
+    const percentileTarget = Math.ceil(pixelCount * 0.99);
+    let cumulativePixels = 0;
+    let p99ByteError = 0;
+    for (; p99ByteError < histogram.length; p99ByteError += 1) {
+        cumulativePixels += histogram[p99ByteError];
+        if (cumulativePixels >= percentileTarget) {
+            break;
+        }
+    }
+
+    return {
+        height: legacy.info.height,
+        maximumByteError,
+        meanByteError: round(totalByteError / pixelCount, 4),
+        mismatchRatio: round(mismatchCount / pixelCount, 6),
+        p99ByteError,
+        valid: true,
+        width: legacy.info.width,
+    };
+}
+
+async function readStaticSceneCacheParityImage(path) {
+    const { data, info } = await sharp(await readFile(path))
+        .ensureAlpha()
+        .raw()
+        .toBuffer({ resolveWithObject: true });
+    return { data, info };
+}
+
+async function buildStaticSceneCacheVisualComparisons(scenarios) {
+    const candidates = scenarios.filter(
+        (scenario) =>
+            highTargetStaticSceneCacheComparisonPairs.has(
+                scenario.requested?.comparisonPair,
+            ) &&
+            (scenario.requested?.comparisonRole === 'legacy' ||
+                scenario.requested?.comparisonRole === 'cache'),
+    );
+    const grouped = Map.groupBy(
+        candidates,
+        (scenario) => scenario.requested.comparisonPair,
+    );
+    const entries = await Promise.all(
+        Array.from(grouped, async ([pairName, runs]) => {
+            if (
+                runs.some(
+                    (run) =>
+                        run.requested?.staticSceneCacheVisualDeterministic ===
+                        false,
+                )
+            ) {
+                return [
+                    pairName,
+                    {
+                        maximumMismatchRatio: null,
+                        maximumP99ByteError: null,
+                        pairedRuns: [],
+                        pass: false,
+                        reason: staticSceneCacheVisualComparisonUnavailableReason,
+                        status: 'unavailable',
+                        validRunCount: 0,
+                    },
+                ];
+            }
+
+            const pairedRuns = await Promise.all(
+                Array.from(
+                    { length: highTargetStaticSceneCachePairedRunCount },
+                    async (_, index) => {
+                        const profileRun = index + 1;
+                        const legacy = runs.find(
+                            (run) =>
+                                run.profileRun === profileRun &&
+                                run.requested.comparisonRole === 'legacy',
+                        );
+                        const cached = runs.find(
+                            (run) =>
+                                run.profileRun === profileRun &&
+                                run.requested.comparisonRole === 'cache',
+                        );
+                        if (
+                            !legacy?.screenshotPath ||
+                            !cached?.screenshotPath
+                        ) {
+                            return {
+                                profileRun,
+                                reason: 'Paired screenshots are unavailable',
+                                valid: false,
+                            };
+                        }
+
+                        try {
+                            const [legacyImage, cachedImage] =
+                                await Promise.all([
+                                    readStaticSceneCacheParityImage(
+                                        legacy.screenshotPath,
+                                    ),
+                                    readStaticSceneCacheParityImage(
+                                        cached.screenshotPath,
+                                    ),
+                                ]);
+                            return {
+                                profileRun,
+                                ...measureStaticSceneCacheImageParity(
+                                    legacyImage,
+                                    cachedImage,
+                                ),
+                            };
+                        } catch (error) {
+                            return {
+                                profileRun,
+                                reason: String(error),
+                                valid: false,
+                            };
+                        }
+                    },
+                ),
+            );
+            const validRuns = pairedRuns.filter((run) => run.valid);
+            const maximumMismatchRatio =
+                validRuns.length > 0
+                    ? Math.max(...validRuns.map((run) => run.mismatchRatio))
+                    : null;
+            const maximumP99ByteError =
+                validRuns.length > 0
+                    ? Math.max(...validRuns.map((run) => run.p99ByteError))
+                    : null;
+            return [
+                pairName,
+                {
+                    maximumMismatchRatio,
+                    maximumP99ByteError,
+                    pairedRuns,
+                    pass:
+                        validRuns.length ===
+                            highTargetStaticSceneCachePairedRunCount &&
+                        maximumMismatchRatio <=
+                            highTargetStaticSceneCacheMaximumVisualMismatchRatio &&
+                        maximumP99ByteError <=
+                            highTargetStaticSceneCacheMaximumVisualP99ByteError,
+                    reason: null,
+                    status: 'measured',
+                    validRunCount: validRuns.length,
+                },
+            ];
+        }),
+    );
+    return Object.fromEntries(entries);
+}
+
+function buildStaticSceneCacheComparisons(
+    highTargetMedians,
+    visualComparisons = {},
+) {
+    const pairedSummaries = Object.entries(highTargetMedians).filter(
+        ([, summary]) =>
+            highTargetStaticSceneCacheComparisonPairs.has(
+                summary.comparisonPair,
+            ) &&
+            (summary.comparisonRole === 'legacy' ||
+                summary.comparisonRole === 'cache'),
+    );
+    const grouped = Map.groupBy(
+        pairedSummaries,
+        ([, summary]) => summary.comparisonPair,
+    );
+    const metricComparison = (legacy, cached, metricName) => {
+        const legacyValue = legacy[metricName]?.median ?? null;
+        const cachedValue = cached[metricName]?.median ?? null;
+        return {
+            cached: cachedValue,
+            delta:
+                Number.isFinite(legacyValue) && Number.isFinite(cachedValue)
+                    ? round(cachedValue - legacyValue)
+                    : null,
+            legacy: legacyValue,
+            percentDelta:
+                Number.isFinite(legacyValue) &&
+                legacyValue !== 0 &&
+                Number.isFinite(cachedValue)
+                    ? round(
+                          ((cachedValue - legacyValue) / legacyValue) * 100,
+                          1,
+                      )
+                    : null,
+        };
+    };
+    const passRate = (summary, passedField) =>
+        summary.runCount > 0
+            ? round((summary[passedField] / summary.runCount) * 100, 1)
+            : null;
+
+    return Object.fromEntries(
+        Array.from(grouped, ([pairName, entries]) => {
+            const legacyEntry = entries.find(
+                ([, summary]) => summary.comparisonRole === 'legacy',
+            );
+            const cachedEntry = entries.find(
+                ([, summary]) => summary.comparisonRole === 'cache',
+            );
+            if (!legacyEntry || !cachedEntry) {
+                return null;
+            }
+
+            const [legacyName, legacy] = legacyEntry;
+            const [cachedName, cached] = cachedEntry;
+            const drawCallsPerRenderedFrame = metricComparison(
+                legacy,
+                cached,
+                'drawCallsPerRenderedFrame',
+            );
+            const trianglesPerRenderedFrame = metricComparison(
+                legacy,
+                cached,
+                'trianglesPerRenderedFrame',
+            );
+            const p95FrameMs = metricComparison(legacy, cached, 'p95FrameMs');
+            const gpuElapsedP95Ms = metricComparison(
+                legacy,
+                cached,
+                'gpuElapsedP95Ms',
+            );
+            const rendererShaders = metricComparison(
+                legacy,
+                cached,
+                'rendererShaders',
+            );
+            const rendererTextures = metricComparison(
+                legacy,
+                cached,
+                'rendererTextures',
+            );
+            const ratio = (comparison) =>
+                Number.isFinite(comparison.legacy) &&
+                comparison.legacy > 0 &&
+                Number.isFinite(comparison.cached)
+                    ? comparison.cached / comparison.legacy
+                    : null;
+            const drawCallRatio = ratio(drawCallsPerRenderedFrame);
+            const triangleRatio = ratio(trianglesPerRenderedFrame);
+            const cpuMedianRatio = ratio(p95FrameMs);
+            const runsByIndex = (runs) =>
+                new Map((runs ?? []).map((run) => [run.profileRun, run]));
+            const legacyGpuRuns = runsByIndex(legacy.gpuElapsedP95MsRuns);
+            const cachedGpuRuns = runsByIndex(cached.gpuElapsedP95MsRuns);
+            const pairedGpuRuns = Array.from(
+                { length: highTargetStaticSceneCachePairedRunCount },
+                (_, index) => {
+                    const profileRun = index + 1;
+                    const legacyRun = legacyGpuRuns.get(profileRun);
+                    const cachedRun = cachedGpuRuns.get(profileRun);
+                    const valid =
+                        legacyRun?.valid === true &&
+                        cachedRun?.valid === true &&
+                        Number.isFinite(legacyRun.value) &&
+                        legacyRun.value > 0 &&
+                        Number.isFinite(cachedRun.value);
+                    return {
+                        cachedMs: cachedRun?.value ?? null,
+                        cachedReason: cachedRun?.reason ?? null,
+                        legacyMs: legacyRun?.value ?? null,
+                        legacyReason: legacyRun?.reason ?? null,
+                        profileRun,
+                        ratio: valid
+                            ? round(cachedRun.value / legacyRun.value, 4)
+                            : null,
+                        valid,
+                    };
+                },
+            );
+            const validGpuRatios = pairedGpuRuns
+                .filter((run) => run.valid)
+                .map((run) => run.cachedMs / run.legacyMs);
+            const gpuTimingStatus =
+                legacy.runCount === highTargetStaticSceneCachePairedRunCount &&
+                cached.runCount === highTargetStaticSceneCachePairedRunCount &&
+                validGpuRatios.length ===
+                    highTargetStaticSceneCachePairedRunCount
+                    ? 'valid'
+                    : 'inconclusive';
+            const rawGpuMedianRatio =
+                gpuTimingStatus === 'valid' ? median(validGpuRatios) : null;
+            const rawGpuMaximumRunRatio =
+                gpuTimingStatus === 'valid'
+                    ? Math.max(...validGpuRatios)
+                    : null;
+            const gpuMedianRatio = round(rawGpuMedianRatio, 4);
+            const gpuMaximumRunRatio = round(rawGpuMaximumRunRatio, 4);
+            const buildResourcePairs = (legacyRuns, cachedRuns) => {
+                const legacyByRun = runsByIndex(legacyRuns);
+                const cachedByRun = runsByIndex(cachedRuns);
+                return Array.from(
+                    { length: highTargetStaticSceneCachePairedRunCount },
+                    (_, index) => {
+                        const profileRun = index + 1;
+                        const legacyRun = legacyByRun.get(profileRun);
+                        const cachedRun = cachedByRun.get(profileRun);
+                        const valid =
+                            legacyRun?.valid === true &&
+                            cachedRun?.valid === true &&
+                            Number.isFinite(legacyRun.value) &&
+                            Number.isFinite(cachedRun.value);
+                        return {
+                            cached: cachedRun?.value ?? null,
+                            increase: valid
+                                ? cachedRun.value - legacyRun.value
+                                : null,
+                            legacy: legacyRun?.value ?? null,
+                            profileRun,
+                            valid,
+                        };
+                    },
+                );
+            };
+            const pairedRendererProgramRuns = buildResourcePairs(
+                legacy.rendererShadersRuns,
+                cached.rendererShadersRuns,
+            );
+            const pairedRendererTextureRuns = buildResourcePairs(
+                legacy.rendererTexturesRuns,
+                cached.rendererTexturesRuns,
+            );
+            const maximumIncrease = (pairs) => {
+                const increases = pairs
+                    .filter((run) => run.valid)
+                    .map((run) => run.increase);
+                return increases.length ===
+                    highTargetStaticSceneCachePairedRunCount
+                    ? Math.max(...increases)
+                    : null;
+            };
+            const rendererProgramMaximumIncrease = maximumIncrease(
+                pairedRendererProgramRuns,
+            );
+            const rendererTextureMaximumIncrease = maximumIncrease(
+                pairedRendererTextureRuns,
+            );
+            const visualComparison = visualComparisons[pairName] ?? {
+                maximumMismatchRatio: null,
+                maximumP99ByteError: null,
+                pairedRuns: [],
+                pass: false,
+                reason: 'Paired visual comparison is unavailable',
+                status: 'unavailable',
+                validRunCount: 0,
+            };
+            const maximumRatioCheck = (name, actual, limit) => ({
+                actual: round(actual, 4),
+                comparison: 'maximum-ratio',
+                limit,
+                name,
+                pass: Number.isFinite(actual) && actual <= limit,
+            });
+            const relativePerformanceChecks = [
+                {
+                    actual: {
+                        cached: cached.runCount,
+                        legacy: legacy.runCount,
+                    },
+                    comparison: 'paired-run-count',
+                    limit: highTargetStaticSceneCachePairedRunCount,
+                    name: 'staticSceneCachePairedRunCount',
+                    pass:
+                        legacy.runCount ===
+                            highTargetStaticSceneCachePairedRunCount &&
+                        cached.runCount ===
+                            highTargetStaticSceneCachePairedRunCount,
+                },
+                maximumRatioCheck(
+                    'staticSceneCacheDrawCallRatio',
+                    drawCallRatio,
+                    highTargetStaticSceneCacheMaximumDrawCallRatio,
+                ),
+                maximumRatioCheck(
+                    'staticSceneCacheTriangleRatio',
+                    triangleRatio,
+                    highTargetStaticSceneCacheMaximumTriangleRatio,
+                ),
+                maximumRatioCheck(
+                    'staticSceneCacheCpuMedianRatio',
+                    cpuMedianRatio,
+                    highTargetStaticSceneCacheMaximumCpuMedianRatio,
+                ),
+                {
+                    actual: validGpuRatios.length,
+                    comparison: 'equal',
+                    limit: highTargetStaticSceneCachePairedRunCount,
+                    name: 'staticSceneCacheGpuPairCompleteness',
+                    pass: gpuTimingStatus === 'valid',
+                },
+                maximumRatioCheck(
+                    'staticSceneCacheGpuMedianRatio',
+                    rawGpuMedianRatio,
+                    highTargetStaticSceneCacheMaximumGpuMedianRatio,
+                ),
+                maximumRatioCheck(
+                    'staticSceneCacheGpuMaximumRunRatio',
+                    rawGpuMaximumRunRatio,
+                    highTargetStaticSceneCacheMaximumGpuRunRatio,
+                ),
+                {
+                    actual: rendererProgramMaximumIncrease,
+                    comparison: 'maximum-increase',
+                    limit: highTargetStaticSceneCacheMaximumProgramIncrease,
+                    name: 'staticSceneCacheRendererProgramBound',
+                    pass:
+                        Number.isFinite(rendererProgramMaximumIncrease) &&
+                        rendererProgramMaximumIncrease <=
+                            highTargetStaticSceneCacheMaximumProgramIncrease,
+                },
+                {
+                    actual: rendererTextureMaximumIncrease,
+                    comparison: 'maximum-increase',
+                    limit: highTargetStaticSceneCacheMaximumTextureIncrease,
+                    name: 'staticSceneCacheRendererTextureBound',
+                    pass:
+                        Number.isFinite(rendererTextureMaximumIncrease) &&
+                        rendererTextureMaximumIncrease <=
+                            highTargetStaticSceneCacheMaximumTextureIncrease,
+                },
+                {
+                    actual: visualComparison.validRunCount,
+                    comparison: 'equal',
+                    limit: highTargetStaticSceneCachePairedRunCount,
+                    name: 'staticSceneCacheVisualPairCompleteness',
+                    pass:
+                        visualComparison.validRunCount ===
+                        highTargetStaticSceneCachePairedRunCount,
+                },
+                maximumRatioCheck(
+                    'staticSceneCacheVisualMismatchRatio',
+                    visualComparison.maximumMismatchRatio,
+                    highTargetStaticSceneCacheMaximumVisualMismatchRatio,
+                ),
+                {
+                    actual: visualComparison.maximumP99ByteError,
+                    comparison: 'maximum',
+                    limit: highTargetStaticSceneCacheMaximumVisualP99ByteError,
+                    name: 'staticSceneCacheVisualP99ByteError',
+                    pass:
+                        Number.isFinite(visualComparison.maximumP99ByteError) &&
+                        visualComparison.maximumP99ByteError <=
+                            highTargetStaticSceneCacheMaximumVisualP99ByteError,
+                },
+            ];
+            const relativePerformancePass = relativePerformanceChecks.every(
+                (check) => check.pass,
+            );
+
+            return [
+                pairName,
+                {
+                    acceptancePassRate: {
+                        cached: passRate(cached, 'acceptedRunCount'),
+                        legacy: passRate(legacy, 'acceptedRunCount'),
+                    },
+                    aggregatePass: {
+                        cached: cached.pass && relativePerformancePass,
+                        legacy: legacy.pass,
+                    },
+                    cachedName,
+                    cpuMedianRatio: round(cpuMedianRatio, 4),
+                    drawCallRatio: round(drawCallRatio, 4),
+                    drawCallsPerRenderedFrame,
+                    gpuElapsedP95Ms,
+                    gpuMaximumRunRatio,
+                    gpuMedianRatio,
+                    gpuTimingStatus,
+                    legacyName,
+                    p95FrameMs,
+                    pairedGpuRuns,
+                    pairedRendererProgramRuns,
+                    pairedRendererTextureRuns,
+                    performancePassRate: {
+                        cached: passRate(cached, 'performancePassedRunCount'),
+                        legacy: passRate(legacy, 'performancePassedRunCount'),
+                    },
+                    relativePerformanceChecks,
+                    relativePerformancePass,
+                    rendererProgramMaximumIncrease,
+                    rendererShaders,
+                    rendererTextureMaximumIncrease,
+                    rendererTextures,
+                    staticOpaqueSceneCacheCaptureSubmissionCount:
+                        cached.staticOpaqueSceneCacheCaptureSubmissionCount,
+                    staticOpaqueSceneCacheCaptureTriangleCount:
+                        cached.staticOpaqueSceneCacheCaptureTriangleCount,
+                    staticOpaqueSceneCacheHitRatio:
+                        cached.staticOpaqueSceneCacheHitRatio,
+                    staticOpaqueSceneCacheReplayEstimatedBytes:
+                        cached.staticOpaqueSceneCacheReplayEstimatedBytes,
+                    staticOpaqueSceneCacheReplayReadyRunCount:
+                        cached.staticOpaqueSceneCacheReplayReadyRunCount,
+                    staticOpaqueSceneCacheReplaySubmissionCount:
+                        cached.staticOpaqueSceneCacheReplaySubmissionCount,
+                    staticOpaqueSceneCacheReplayTriangleCount:
+                        cached.staticOpaqueSceneCacheReplayTriangleCount,
+                    staticOpaqueSceneCacheSavedSubmissionCountDelta:
+                        cached.staticOpaqueSceneCacheSavedSubmissionCountDelta,
+                    staticOpaqueSceneCacheSavedTriangleCountDelta:
+                        cached.staticOpaqueSceneCacheSavedTriangleCountDelta,
+                    staticOpaqueSceneCacheTargetSampleCount:
+                        cached.staticOpaqueSceneCacheTargetSampleCount,
+                    staticOpaqueSceneCacheTotalEstimatedBytes:
+                        cached.staticOpaqueSceneCacheTotalEstimatedBytes,
+                    triangleRatio: round(triangleRatio, 4),
+                    trianglesPerRenderedFrame,
+                    visualComparison,
+                },
+            ];
+        }).filter(Boolean),
+    );
+}
+
+function buildProfileSummary(
+    scenarios,
+    highTargetMedians,
+    staticSceneCacheComparisons = buildStaticSceneCacheComparisons(
+        highTargetMedians,
+    ),
+) {
     const nonHighTargetScenarios = scenarios.filter(
         (scenario) => scenario.requested?.gardenProfile !== 'high-target',
     );
@@ -6259,6 +7680,11 @@ function buildProfileSummary(scenarios, highTargetMedians) {
     )
         .filter((comparison) => !comparison.pairedPass)
         .map((comparison) => comparison.integratedName);
+    const staticSceneCacheFailureNames = Object.values(
+        staticSceneCacheComparisons,
+    )
+        .filter((comparison) => !comparison.relativePerformancePass)
+        .map((comparison) => comparison.cachedName);
     const failedScenarioNames = [
         ...new Set([
             ...nonHighTargetScenarios
@@ -6268,6 +7694,7 @@ function buildProfileSummary(scenarios, highTargetMedians) {
                 .filter(([, result]) => !result.pass)
                 .map(([name]) => name),
             ...comparativeFailureNames,
+            ...staticSceneCacheFailureNames,
             ...weatherSurfaceFailureNames,
         ]),
     ];
@@ -7032,6 +8459,66 @@ function buildMarkdown(report) {
         }
     }
 
+    const staticSceneCacheComparisons = Object.entries(
+        report.staticSceneCacheComparisons ??
+            buildStaticSceneCacheComparisons(report.highTargetMedians ?? {}),
+    );
+    if (staticSceneCacheComparisons.length > 0) {
+        lines.push(
+            '',
+            '## Static opaque scene-cache paired comparison',
+            '',
+            '| Pair | Legacy / Cached | Acceptance pass rate | Performance pass rate | Draw/render legacy → cached | Triangles/render legacy → cached | CPU p95 legacy → cached | GPU p95 legacy → cached | Draw/Triangle/CPU ratios | Paired GPU median/max | Programs legacy → cached (max increase) | Textures legacy → cached (max increase) | Visual parity status / pairs / max p99 / max >8 ratio | Cache hit ratio | Replay ready / capture→replay submissions / triangles | Cache total MiB median/max @ samples | Saved submissions/triangles | Relative gate | Aggregate |',
+            '| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |',
+        );
+        const formatComparison = (comparison, suffix = '') =>
+            `${comparison.legacy ?? 'n/a'} → ${comparison.cached ?? 'n/a'}${suffix} (${comparison.percentDelta ?? 'n/a'}%)`;
+        for (const [pairName, comparison] of staticSceneCacheComparisons) {
+            const visualComparison = comparison.visualComparison;
+            const visualSummary =
+                visualComparison.status === 'unavailable'
+                    ? `unavailable: ${visualComparison.reason ?? 'deterministic screenshots are unavailable'}`
+                    : `${visualComparison.status ?? 'measured'} / ${visualComparison.validRunCount}/${highTargetStaticSceneCachePairedRunCount} / ${visualComparison.maximumP99ByteError ?? 'n/a'} / ${visualComparison.maximumMismatchRatio ?? 'n/a'}`;
+            const totalMemory =
+                comparison.staticOpaqueSceneCacheTotalEstimatedBytes;
+            const formatMib = (value) =>
+                Number.isFinite(value)
+                    ? round(value / (1024 * 1024), 2)
+                    : 'n/a';
+            lines.push(
+                `| ${pairName} | ${comparison.legacyName} / ${comparison.cachedName} | ${comparison.acceptancePassRate.legacy ?? 'n/a'}% → ${comparison.acceptancePassRate.cached ?? 'n/a'}% | ${comparison.performancePassRate.legacy ?? 'n/a'}% → ${comparison.performancePassRate.cached ?? 'n/a'}% | ${formatComparison(comparison.drawCallsPerRenderedFrame)} | ${formatComparison(comparison.trianglesPerRenderedFrame)} | ${formatComparison(comparison.p95FrameMs, ' ms')} | ${formatComparison(comparison.gpuElapsedP95Ms, ' ms')} | ${comparison.drawCallRatio ?? 'n/a'}/${comparison.triangleRatio ?? 'n/a'}/${comparison.cpuMedianRatio ?? 'n/a'} | ${comparison.gpuTimingStatus === 'valid' ? `${comparison.gpuMedianRatio}/${comparison.gpuMaximumRunRatio}` : 'inconclusive'} | ${formatComparison(comparison.rendererShaders)} (${comparison.rendererProgramMaximumIncrease ?? 'n/a'}) | ${formatComparison(comparison.rendererTextures)} (${comparison.rendererTextureMaximumIncrease ?? 'n/a'}) | ${visualSummary} | ${comparison.staticOpaqueSceneCacheHitRatio.median ?? 'n/a'} | ${comparison.staticOpaqueSceneCacheReplayReadyRunCount}/${highTargetStaticSceneCachePairedRunCount} / ${comparison.staticOpaqueSceneCacheCaptureSubmissionCount.median ?? 'n/a'}→${comparison.staticOpaqueSceneCacheReplaySubmissionCount.median ?? 'n/a'} / ${comparison.staticOpaqueSceneCacheCaptureTriangleCount.median ?? 'n/a'}→${comparison.staticOpaqueSceneCacheReplayTriangleCount.median ?? 'n/a'} | ${formatMib(totalMemory.median)}/${formatMib(totalMemory.max)} MiB @ ${comparison.staticOpaqueSceneCacheTargetSampleCount.median ?? 'n/a'}x | ${comparison.staticOpaqueSceneCacheSavedSubmissionCountDelta.median ?? 'n/a'}/${comparison.staticOpaqueSceneCacheSavedTriangleCountDelta.median ?? 'n/a'} | ${comparison.relativePerformancePass ? 'pass' : 'fail'} | ${comparison.aggregatePass.legacy ? 'pass' : 'fail'} → ${comparison.aggregatePass.cached ? 'pass' : 'fail'} |`,
+            );
+        }
+    }
+
+    const staticSceneCacheOcclusionFixtures = report.scenarios.filter(
+        (scenario) =>
+            scenario.requested.staticSceneCacheOcclusionFixture === '1',
+    );
+    if (staticSceneCacheOcclusionFixtures.length > 0) {
+        lines.push(
+            '',
+            '## Static opaque scene-cache occlusion fixture',
+            '',
+            '| Scenario | State | Transition | Captures at transition/final | Hits after transition/verified | Background witness min | Cached occluder min | Live foreground min | Occluded background leak max | Result |',
+            '| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
+        );
+        for (const scenario of staticSceneCacheOcclusionFixtures) {
+            const runtime = scenario.runtime;
+            const hitsAfterTransition =
+                typeof runtime?.staticOpaqueSceneCacheHitFrameCount ===
+                    'number' &&
+                typeof runtime?.staticOpaqueSceneCacheOcclusionHitFrameCountAtTransition ===
+                    'number'
+                    ? runtime.staticOpaqueSceneCacheHitFrameCount -
+                      runtime.staticOpaqueSceneCacheOcclusionHitFrameCountAtTransition
+                    : null;
+            lines.push(
+                `| ${scenario.name} | ${runtime?.staticOpaqueSceneCacheOcclusionFixtureState ?? 'n/a'} | ${runtime?.staticOpaqueSceneCacheOcclusionTransitionCount ?? 'n/a'} | ${runtime?.staticOpaqueSceneCacheOcclusionCaptureCountAtTransition ?? 'n/a'}/${runtime?.staticOpaqueSceneCacheCaptureCount ?? 'n/a'} | ${hitsAfterTransition ?? 'n/a'}/${runtime?.staticOpaqueSceneCacheOcclusionVerifiedHitFrameCount ?? 'n/a'} | ${runtime?.staticOpaqueSceneCacheOcclusionBackgroundWitnessMinimumMatchRatio ?? 'n/a'} | ${runtime?.staticOpaqueSceneCacheOcclusionOccluderMinimumMatchRatio ?? 'n/a'} | ${runtime?.staticOpaqueSceneCacheOcclusionForegroundMinimumMatchRatio ?? 'n/a'} | ${runtime?.staticOpaqueSceneCacheOcclusionOccludedBackgroundLeakMaximumRatio ?? 'n/a'} | ${runtime?.staticOpaqueSceneCacheOcclusionFixturePass ? 'pass' : 'fail'} |`,
+            );
+        }
+    }
+
     const adaptiveHighComparisons = Object.entries(
         report.adaptiveHighComparisons ??
             buildAdaptiveHighComparisons(report.highTargetMedians ?? {}),
@@ -7149,6 +8636,14 @@ function buildMarkdown(report) {
                 .map(
                     (check) =>
                         `- ${pairName} relative: ${check.name} ${check.actual} missed ${check.limit}`,
+                ),
+        ),
+        ...staticSceneCacheComparisons.flatMap(([pairName, comparison]) =>
+            comparison.relativePerformanceChecks
+                .filter((check) => !check.pass)
+                .map(
+                    (check) =>
+                        `- ${pairName} relative: ${check.name} ${JSON.stringify(check.actual)} missed ${check.limit}`,
                 ),
         ),
         ...weatherSurfaceComparisons.flatMap(([pairName, comparison]) =>
@@ -7504,11 +8999,18 @@ async function main() {
         const highTargetMedians = buildHighTargetMedians(scenarios);
         const adaptiveHighComparisons =
             buildAdaptiveHighComparisons(highTargetMedians);
+        const staticSceneCacheVisualComparisons =
+            await buildStaticSceneCacheVisualComparisons(scenarios);
+        const staticSceneCacheComparisons = buildStaticSceneCacheComparisons(
+            highTargetMedians,
+            staticSceneCacheVisualComparisons,
+        );
         const weatherSurfaceComparisons =
             buildWeatherSurfaceComparisons(highTargetMedians);
         const profileSummary = buildProfileSummary(
             scenarios,
             highTargetMedians,
+            staticSceneCacheComparisons,
         );
         const report = {
             baseUrl: options.baseUrl,
@@ -7536,6 +9038,8 @@ async function main() {
             scenarios,
             highTargetMedians,
             plantCloseupMedians: buildPlantCloseupMedians(scenarios),
+            staticSceneCacheComparisons,
+            staticSceneCacheVisualComparisons,
             summary: {
                 durationMs: Date.now() - startedAt,
                 ...profileSummary,
@@ -7569,6 +9073,8 @@ export {
     buildPlantCloseupMedians,
     buildProfileSummary,
     buildScenarioRunQueue,
+    buildStaticSceneCacheComparisons,
+    buildStaticSceneCacheVisualComparisons,
     buildWeatherSurfaceComparisons,
     drainProfileSample,
     evaluateBudget,
@@ -7577,7 +9083,9 @@ export {
     finishInteractiveProfileSample,
     getScenarioRequest,
     installBrowserMetrics,
+    isIgnoredLocalProfilerConsoleError,
     isOutlineProfileTelemetryReady,
+    measureStaticSceneCacheImageParity,
     mergeProfileSampleDrain,
     normalizeRenderWork,
     parseArgs,

--- a/apps/garden/scripts/profile-game-scene.unit.mjs
+++ b/apps/garden/scripts/profile-game-scene.unit.mjs
@@ -8,6 +8,8 @@ import {
     buildPlantCloseupMedians,
     buildProfileSummary,
     buildScenarioRunQueue,
+    buildStaticSceneCacheComparisons,
+    buildStaticSceneCacheVisualComparisons,
     buildWeatherSurfaceComparisons,
     drainProfileSample,
     evaluateBudget,
@@ -16,7 +18,9 @@ import {
     finishInteractiveProfileSample,
     getScenarioRequest,
     installBrowserMetrics,
+    isIgnoredLocalProfilerConsoleError,
     isOutlineProfileTelemetryReady,
+    measureStaticSceneCacheImageParity,
     mergeProfileSampleDrain,
     normalizeRenderWork,
     parseArgs,
@@ -198,6 +202,8 @@ test('operation-visual High scenario is isolated behind its own opt-in set', () 
         outline: '0',
         placement: '0',
         quality: 'high',
+        staticSceneCache: 'cache',
+        staticSceneCacheOcclusionFixture: '0',
         weatherSurface: 'integrated',
     });
     assert.equal(
@@ -322,6 +328,111 @@ test('weather-material runs interleave five legacy and integrated samples per pa
     );
 });
 
+test('static scene-cache High scenarios use deterministic five-run ABBA pairs', () => {
+    const scenarios = resolveScenarios('high-target-static-scene-cache');
+
+    assert.deepEqual(
+        scenarios.map((scenario) => scenario.name),
+        [
+            'game-high-target-static-scene-cache-legacy-desktop',
+            'game-high-target-static-scene-cache-cached-desktop',
+            'game-high-target-static-scene-cache-cloudy-legacy-desktop',
+            'game-high-target-static-scene-cache-cloudy-cached-desktop',
+            'game-high-target-static-scene-cache-occlusion-fixture-desktop',
+        ],
+    );
+    assert.deepEqual(
+        scenarios.map((scenario) => scenario.comparisonRole),
+        ['legacy', 'cache', 'legacy', 'cache', undefined],
+    );
+    for (const scenario of scenarios.slice(0, 4)) {
+        const request = getScenarioRequest(scenario.path);
+        assert.equal(scenario.budget, 'gameHighTarget');
+        assert.equal(
+            scenario.comparisonPair,
+            request.mode === 'cloudy'
+                ? 'static-opaque-scene-cache-cloudy'
+                : 'static-opaque-scene-cache',
+        );
+        assert.equal(scenario.dpr, 2);
+        assert.equal(scenario.isMobile, false);
+        assert.equal(scenario.repeat, 5);
+        assert.equal(scenario.staticSceneCacheBenchmark, true);
+        assert.equal(request.blockGeometryMerging, '1');
+        assert.equal(request.controls, '0');
+        assert.equal(request.details, '1');
+        assert.equal(request.gardenProfile, 'high-target');
+        assert.equal(scenario.staticSceneCacheVisualDeterministic, true);
+        assert.equal(
+            new URL(scenario.path, 'http://profile.local').searchParams.get(
+                'fixedTimeSeconds',
+            ),
+            request.mode === 'cloudy' ? '12' : null,
+        );
+        assert.equal(
+            scenario.fixedTimeSeconds,
+            request.mode === 'cloudy' ? 12 : undefined,
+        );
+        assert.equal(request.quality, 'high');
+    }
+    assert.deepEqual(
+        scenarios.slice(0, 4).map((scenario) => {
+            return getScenarioRequest(scenario.path).mode;
+        }),
+        ['details', 'details', 'cloudy', 'cloudy'],
+    );
+    assert.deepEqual(
+        scenarios.map(
+            (scenario) => getScenarioRequest(scenario.path).staticSceneCache,
+        ),
+        ['legacy', 'cache', 'legacy', 'cache', 'cache'],
+    );
+    const fixture = scenarios[4];
+    assert.equal(fixture.repeat, 1);
+    assert.equal(fixture.staticSceneCacheBenchmark, true);
+    assert.equal(fixture.staticSceneCacheOcclusionFixture, true);
+    assert.equal(fixture.comparisonPair, undefined);
+    assert.equal(
+        getScenarioRequest(fixture.path).staticSceneCacheOcclusionFixture,
+        '1',
+    );
+
+    const queue = buildScenarioRunQueue(scenarios);
+    assert.deepEqual(
+        queue.map(
+            ({ baseScenario, runIndex }) =>
+                `${
+                    baseScenario.staticSceneCacheOcclusionFixture
+                        ? 'fixture'
+                        : `${baseScenario.comparisonPair}:${baseScenario.comparisonRole}`
+                }:${runIndex}`,
+        ),
+        [
+            'static-opaque-scene-cache:legacy:1',
+            'static-opaque-scene-cache:cache:1',
+            'static-opaque-scene-cache:cache:2',
+            'static-opaque-scene-cache:legacy:2',
+            'static-opaque-scene-cache:legacy:3',
+            'static-opaque-scene-cache:cache:3',
+            'static-opaque-scene-cache:cache:4',
+            'static-opaque-scene-cache:legacy:4',
+            'static-opaque-scene-cache:legacy:5',
+            'static-opaque-scene-cache:cache:5',
+            'static-opaque-scene-cache-cloudy:legacy:1',
+            'static-opaque-scene-cache-cloudy:cache:1',
+            'static-opaque-scene-cache-cloudy:cache:2',
+            'static-opaque-scene-cache-cloudy:legacy:2',
+            'static-opaque-scene-cache-cloudy:legacy:3',
+            'static-opaque-scene-cache-cloudy:cache:3',
+            'static-opaque-scene-cache-cloudy:cache:4',
+            'static-opaque-scene-cache-cloudy:legacy:4',
+            'static-opaque-scene-cache-cloudy:legacy:5',
+            'static-opaque-scene-cache-cloudy:cache:5',
+            'fixture:1',
+        ],
+    );
+});
+
 test('snow-onset High scenarios provide deterministic visual legacy and integrated cases', () => {
     const scenarios = resolveScenarios('high-target-weather-onset');
 
@@ -375,6 +486,43 @@ test('profile request defaults invalid weather-surface values to integrated', ()
         getScenarioRequest('/debug/profile/game?weatherSurface=unexpected')
             .weatherSurface,
         'integrated',
+    );
+});
+
+test('profile request defaults invalid static scene-cache values to cache', () => {
+    assert.equal(
+        getScenarioRequest('/debug/profile/game').staticSceneCache,
+        'cache',
+    );
+    assert.equal(
+        getScenarioRequest('/debug/profile/game?staticSceneCache=unexpected')
+            .staticSceneCache,
+        'cache',
+    );
+    assert.equal(
+        getScenarioRequest('/debug/profile/game?staticSceneCache=legacy')
+            .staticSceneCache,
+        'legacy',
+    );
+});
+
+test('profile request enables the static scene-cache occlusion fixture only for an exact opt-in', () => {
+    assert.equal(
+        getScenarioRequest('/debug/profile/game')
+            .staticSceneCacheOcclusionFixture,
+        '0',
+    );
+    assert.equal(
+        getScenarioRequest(
+            '/debug/profile/game?staticSceneCacheOcclusionFixture=unexpected',
+        ).staticSceneCacheOcclusionFixture,
+        '0',
+    );
+    assert.equal(
+        getScenarioRequest(
+            '/debug/profile/game?staticSceneCacheOcclusionFixture=1',
+        ).staticSceneCacheOcclusionFixture,
+        '1',
     );
 });
 
@@ -562,6 +710,8 @@ test('profile request parses the High target fixture contract', () => {
         outline: '0',
         placement: '0',
         quality: 'high',
+        staticSceneCache: 'cache',
+        staticSceneCacheOcclusionFixture: '0',
         weatherSurface: 'integrated',
     });
 });
@@ -584,7 +734,10 @@ test('runtime GPU-source scenario disables only the external profiler timer', ()
     assert.match(source, /__gameProfileMetrics =/);
     assert.match(source, /patchedCreateProgram/);
     assert.match(source, /patchedDeleteProgram/);
+    assert.match(source, /patchedCreateTexture/);
+    assert.match(source, /patchedDeleteTexture/);
     assert.match(source, /rendererShaders: 0/);
+    assert.match(source, /rendererTextures: 0/);
 });
 
 test('render budgets gate calls and triangles per rendered frame', () => {
@@ -833,6 +986,8 @@ test('interactive sampling stops at the endpoint and drains bounded long tasks l
         drawCalls: 120,
         instancedDrawCalls: 30,
         renderedFrames: 12,
+        rendererShaders: 18,
+        rendererTextures: 27,
         submittedTriangles: 900_000,
     };
     const startedAt = performance.now() - 1_000;
@@ -890,6 +1045,8 @@ test('interactive sampling stops at the endpoint and drains bounded long tasks l
         assert.equal(sampleAtEndpoint.frames, 2);
         assert.equal(sampleAtEndpoint.instancedDrawCalls, 30);
         assert.equal(sampleAtEndpoint.renderedFrames, 12);
+        assert.equal(sampleAtEndpoint.rendererShaders, 18);
+        assert.equal(sampleAtEndpoint.rendererTextures, 27);
         assert.equal(sampleAtEndpoint.submittedTriangles, 900_000);
 
         const drainedSample = await drainProfileSample(
@@ -904,6 +1061,8 @@ test('interactive sampling stops at the endpoint and drains bounded long tasks l
         assert.equal(result.longTaskCount, 1);
         assert.equal(result.longTaskMaxMs, 55);
         assert.equal(result.renderedFrames, 12);
+        assert.equal(result.rendererShaders, 18);
+        assert.equal(result.rendererTextures, 27);
         assert.equal(result.submittedTriangles, 900_000);
         assert.deepEqual(result.gpu, {
             elapsedP95Ms: 7,
@@ -1170,6 +1329,50 @@ test('high target acceptance proves the intended workload rendered', () => {
         )?.pass,
         false,
     );
+
+    const localInsightsAssetResult = evaluateHighTargetAcceptance({
+        ...input,
+        consoleMessages: [
+            {
+                type: 'error',
+                text: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
+                url: 'http://localhost:3101/_vercel/insights/script.js',
+            },
+        ],
+    });
+    assert.equal(localInsightsAssetResult.pass, true);
+    assert.equal(
+        localInsightsAssetResult.checks.find(
+            (check) => check.name === 'highTargetConsoleErrors',
+        )?.actual,
+        0,
+    );
+});
+
+test('local profiler console filtering only ignores the known missing analytics asset', () => {
+    const knownLocalAnalyticsError = {
+        type: 'error',
+        text: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
+        url: 'http://127.0.0.1:3101/_vercel/insights/script.js',
+    };
+
+    assert.equal(
+        isIgnoredLocalProfilerConsoleError(knownLocalAnalyticsError),
+        true,
+    );
+    for (const message of [
+        { ...knownLocalAnalyticsError, text: 'application crashed' },
+        {
+            ...knownLocalAnalyticsError,
+            url: 'http://localhost:3101/_vercel/speed-insights/script.js',
+        },
+        {
+            ...knownLocalAnalyticsError,
+            url: 'https://garden.example.com/_vercel/insights/script.js',
+        },
+    ]) {
+        assert.equal(isIgnoredLocalProfilerConsoleError(message), false);
+    }
 });
 
 test('operation-visual High acceptance gates batching, uploads, mulch, and highlight identity', () => {
@@ -2779,6 +2982,420 @@ test('high target acceptance rejects failed API requests', () => {
     );
 });
 
+test('static scene-cache acceptance requires a warm, stable timed window', () => {
+    const requested = {
+        blockGeometryMerging: '1',
+        comparisonPair: 'static-opaque-scene-cache',
+        comparisonRole: 'cache',
+        gardenProfile: 'high-target',
+        mode: 'details',
+        quality: 'high',
+        staticSceneCache: 'cache',
+    };
+    const runtime = {
+        staticOpaqueSceneCacheBoundaryCount: 19,
+        staticOpaqueSceneCacheCaptureSubmissionCount: 19,
+        staticOpaqueSceneCacheCaptureTriangleCount: 12_000,
+        staticOpaqueSceneCacheEnabled: true,
+        staticOpaqueSceneCacheIneligibleBoundaryCount: 0,
+        staticOpaqueSceneCacheMeshCount: 19,
+        staticOpaqueSceneCacheReplayEstimatedBytes: 36,
+        staticOpaqueSceneCacheReplayStatus: 'ready',
+        staticOpaqueSceneCacheReplaySubmissionCount: 1,
+        staticOpaqueSceneCacheReplayTriangleCount: 1,
+        staticOpaqueSceneCacheState: 'ready',
+        staticOpaqueSceneCacheSupported: true,
+        staticOpaqueSceneCacheTargetHeight: 1440,
+        staticOpaqueSceneCacheTargetSampleCount: 4,
+        staticOpaqueSceneCacheTargetWidth: 2560,
+        staticOpaqueSceneCacheTotalEstimatedBytes: 162_201_636,
+        staticOpaqueSceneCacheTriangleCount: 12_000,
+    };
+    const sample = {
+        canvas: {
+            clientHeight: 720,
+            clientWidth: 1280,
+            height: 1440,
+            width: 2560,
+        },
+        drawCalls: 100,
+        elapsedMs: 5_000,
+        renderedFps: 60,
+        renderedFrames: 300,
+        reportedDpr: 2,
+        staticOpaqueSceneCacheBypassFrameCountDelta: 0,
+        staticOpaqueSceneCacheCaptureCountAtStart: 1,
+        staticOpaqueSceneCacheCaptureCountDelta: 0,
+        staticOpaqueSceneCacheCompositePassCountDelta: 300,
+        staticOpaqueSceneCacheHitFrameCountAtStart: 3,
+        staticOpaqueSceneCacheHitFrameCountDelta: 300,
+        staticOpaqueSceneCacheHitRatio: 1,
+        staticOpaqueSceneCacheInvalidationCountDelta: 0,
+        staticOpaqueSceneCacheLiveFrameCountDelta: 0,
+        staticOpaqueSceneCacheReplayStatusAtStart: 'ready',
+        staticOpaqueSceneCacheSavedSubmissionCountDelta: 5_700,
+        staticOpaqueSceneCacheSavedTriangleCountDelta: 3_600_000,
+        staticOpaqueSceneCacheStateAtStart: 'ready',
+        staticOpaqueSceneCacheSupportedAtStart: true,
+        staticOpaqueSceneCacheUnexpectedStaticSubmissionCountAtEnd: 0,
+        submittedTriangles: 1_000_000,
+    };
+    const evaluate = ({ runtimeOverride = {}, sampleOverride = {} } = {}) =>
+        evaluateHighTargetAcceptance({
+            apiErrors: [],
+            consoleMessages: [],
+            pageErrors: [],
+            requested,
+            runtime: { ...runtime, ...runtimeOverride },
+            sample: { ...sample, ...sampleOverride },
+        });
+    const checks = evaluate().checks.filter((check) =>
+        check.name.startsWith('highTargetStaticSceneCache'),
+    );
+
+    assert.equal(checks.length, 32);
+    assert.equal(
+        checks.every((check) => check.pass),
+        true,
+    );
+    assert.deepEqual(
+        evaluate({
+            sampleOverride: {
+                staticOpaqueSceneCacheCaptureCountDelta: 1,
+            },
+        }).checks.find(
+            (check) => check.name === 'highTargetStaticSceneCacheTimedCaptures',
+        ),
+        {
+            actual: 1,
+            comparison: 'equal',
+            limit: 0,
+            name: 'highTargetStaticSceneCacheTimedCaptures',
+            pass: false,
+        },
+    );
+    assert.equal(
+        evaluate({
+            runtimeOverride: {
+                staticOpaqueSceneCacheReplayStatus: 'pending',
+            },
+        }).checks.find(
+            (check) =>
+                check.name === 'highTargetStaticSceneCacheFinalReplayStatus',
+        )?.pass,
+        false,
+    );
+    assert.equal(
+        evaluate({
+            runtimeOverride: {
+                staticOpaqueSceneCacheReplaySubmissionCount: 2,
+            },
+        }).checks.find(
+            (check) =>
+                check.name === 'highTargetStaticSceneCacheReplaySubmissions',
+        )?.pass,
+        false,
+    );
+    assert.equal(
+        evaluate({
+            runtimeOverride: {
+                staticOpaqueSceneCacheTargetSampleCount: 2,
+            },
+        }).checks.find(
+            (check) =>
+                check.name === 'highTargetStaticSceneCacheTargetSampleCount',
+        )?.pass,
+        false,
+    );
+    assert.equal(
+        evaluate({
+            runtimeOverride: {
+                staticOpaqueSceneCacheTotalEstimatedBytes:
+                    160 * 1024 * 1024 + 1,
+            },
+        }).checks.find(
+            (check) =>
+                check.name === 'highTargetStaticSceneCacheTotalEstimatedBytes',
+        )?.pass,
+        false,
+    );
+    assert.equal(
+        evaluate({
+            sampleOverride: {
+                staticOpaqueSceneCacheHitRatio: 0.99,
+            },
+        }).checks.find(
+            (check) => check.name === 'highTargetStaticSceneCacheTimedHitRatio',
+        )?.pass,
+        false,
+    );
+});
+
+test('cloudy static scene-cache acceptance proves live cloud attenuation without shadow recaptures', () => {
+    const input = {
+        apiErrors: [],
+        consoleMessages: [],
+        pageErrors: [],
+        requested: {
+            blockGeometryMerging: '1',
+            comparisonPair: 'static-opaque-scene-cache-cloudy',
+            comparisonRole: 'cache',
+            fixedTimeSeconds: 12,
+            gardenProfile: 'high-target',
+            mode: 'cloudy',
+            quality: 'high',
+            staticSceneCache: 'cache',
+        },
+        runtime: {
+            cloudAttenuationMaskResolution: 192,
+            cloudAttenuationMaterialCount: 19,
+            cloudAttenuationUpdateMs: 96,
+            cloudProjectedShadowCount: 8,
+            cloudRealShadowCasterCount: 0,
+            cloudVisualCount: 8,
+            staticOpaqueSceneCacheBoundaryCount: 19,
+            staticOpaqueSceneCacheCaptureSubmissionCount: 19,
+            staticOpaqueSceneCacheCaptureTriangleCount: 12_000,
+            staticOpaqueSceneCacheEnabled: true,
+            staticOpaqueSceneCacheIneligibleBoundaryCount: 0,
+            staticOpaqueSceneCacheMeshCount: 19,
+            staticOpaqueSceneCacheReplayEstimatedBytes: 36,
+            staticOpaqueSceneCacheReplayStatus: 'ready',
+            staticOpaqueSceneCacheReplaySubmissionCount: 1,
+            staticOpaqueSceneCacheReplayTriangleCount: 1,
+            staticOpaqueSceneCacheState: 'ready',
+            staticOpaqueSceneCacheSupported: true,
+            staticOpaqueSceneCacheTargetHeight: 1440,
+            staticOpaqueSceneCacheTargetSampleCount: 4,
+            staticOpaqueSceneCacheTargetWidth: 2560,
+            staticOpaqueSceneCacheTotalEstimatedBytes: 162_201_636,
+            staticOpaqueSceneCacheTriangleCount: 12_000,
+        },
+        sample: {
+            canvas: {
+                clientHeight: 720,
+                clientWidth: 1280,
+                height: 1440,
+                width: 2560,
+            },
+            cloudAttenuationUpdateCountDelta: 52,
+            drawCalls: 100,
+            elapsedMs: 5_000,
+            primaryShadowRefreshCountDelta: 0,
+            renderedFps: 60,
+            renderedFrames: 300,
+            reportedDpr: 2,
+            staticOpaqueSceneCacheBypassFrameCountDelta: 0,
+            staticOpaqueSceneCacheCaptureCountAtStart: 1,
+            staticOpaqueSceneCacheCaptureCountDelta: 0,
+            staticOpaqueSceneCacheCompositePassCountDelta: 300,
+            staticOpaqueSceneCacheHitFrameCountAtStart: 3,
+            staticOpaqueSceneCacheHitFrameCountDelta: 300,
+            staticOpaqueSceneCacheHitRatio: 1,
+            staticOpaqueSceneCacheInvalidationCountDelta: 0,
+            staticOpaqueSceneCacheLiveFrameCountDelta: 0,
+            staticOpaqueSceneCacheReplayStatusAtStart: 'ready',
+            staticOpaqueSceneCacheSavedSubmissionCountDelta: 5_700,
+            staticOpaqueSceneCacheSavedTriangleCountDelta: 3_600_000,
+            staticOpaqueSceneCacheStateAtStart: 'ready',
+            staticOpaqueSceneCacheSupportedAtStart: true,
+            staticOpaqueSceneCacheUnexpectedStaticSubmissionCountAtEnd: 0,
+            submittedTriangles: 1_000_000,
+        },
+    };
+    const result = evaluateHighTargetAcceptance(input);
+    const checks = result.checks.filter((check) =>
+        check.name.startsWith('highTargetStaticSceneCacheCloud'),
+    );
+
+    assert.equal(checks.length, 9);
+    assert.equal(
+        checks.every((check) => check.pass),
+        true,
+    );
+    assert.equal(
+        evaluateHighTargetAcceptance({
+            ...input,
+            sample: {
+                ...input.sample,
+                cloudAttenuationUpdateCountDelta: 1,
+            },
+        }).checks.find(
+            (check) =>
+                check.name ===
+                'highTargetStaticSceneCacheCloudAttenuationUpdates',
+        )?.pass,
+        false,
+    );
+});
+
+test('static scene-cache occlusion acceptance requires cached depth and live layers on verified hits', () => {
+    const requested = {
+        blockGeometryMerging: '1',
+        gardenProfile: 'high-target',
+        mode: 'details',
+        quality: 'high',
+        staticSceneCache: 'cache',
+        staticSceneCacheOcclusionFixture: '1',
+    };
+    const runtime = {
+        staticOpaqueSceneCacheBoundaryCount: 20,
+        staticOpaqueSceneCacheCaptureCount: 1,
+        staticOpaqueSceneCacheCaptureSubmissionCount: 20,
+        staticOpaqueSceneCacheCaptureTriangleCount: 12_002,
+        staticOpaqueSceneCacheEnabled: true,
+        staticOpaqueSceneCacheHitFrameCount: 7,
+        staticOpaqueSceneCacheIneligibleBoundaryCount: 0,
+        staticOpaqueSceneCacheMeshCount: 20,
+        staticOpaqueSceneCacheOcclusionBackgroundWitnessMinimumMatchRatio: 1,
+        staticOpaqueSceneCacheOcclusionCaptureCountAtTransition: 1,
+        staticOpaqueSceneCacheOcclusionFixtureEnabled: true,
+        staticOpaqueSceneCacheOcclusionFixturePass: true,
+        staticOpaqueSceneCacheOcclusionFixtureState: 'passed',
+        staticOpaqueSceneCacheOcclusionForegroundMinimumMatchRatio: 1,
+        staticOpaqueSceneCacheOcclusionHitFrameCountAtTransition: 3,
+        staticOpaqueSceneCacheOcclusionOccludedBackgroundLeakMaximumRatio: 0,
+        staticOpaqueSceneCacheOcclusionOccluderMinimumMatchRatio: 1,
+        staticOpaqueSceneCacheOcclusionTransitionCount: 1,
+        staticOpaqueSceneCacheOcclusionVerifiedHitFrameCount: 3,
+        staticOpaqueSceneCacheReplayEstimatedBytes: 36,
+        staticOpaqueSceneCacheReplayStatus: 'ready',
+        staticOpaqueSceneCacheReplaySubmissionCount: 1,
+        staticOpaqueSceneCacheReplayTriangleCount: 1,
+        staticOpaqueSceneCacheState: 'ready',
+        staticOpaqueSceneCacheSupported: true,
+        staticOpaqueSceneCacheTargetHeight: 1440,
+        staticOpaqueSceneCacheTargetSampleCount: 4,
+        staticOpaqueSceneCacheTargetWidth: 2560,
+        staticOpaqueSceneCacheTotalEstimatedBytes: 162_201_636,
+        staticOpaqueSceneCacheTriangleCount: 12_002,
+    };
+    const sample = {
+        canvas: {
+            clientHeight: 720,
+            clientWidth: 1280,
+            height: 1440,
+            width: 2560,
+        },
+        drawCalls: 100,
+        elapsedMs: 5_000,
+        renderedFps: 60,
+        renderedFrames: 300,
+        reportedDpr: 2,
+        staticOpaqueSceneCacheBypassFrameCountDelta: 0,
+        staticOpaqueSceneCacheCaptureCountAtStart: 1,
+        staticOpaqueSceneCacheCaptureCountDelta: 0,
+        staticOpaqueSceneCacheCompositePassCountDelta: 300,
+        staticOpaqueSceneCacheHitFrameCountAtStart: 7,
+        staticOpaqueSceneCacheHitFrameCountDelta: 300,
+        staticOpaqueSceneCacheHitRatio: 1,
+        staticOpaqueSceneCacheInvalidationCountDelta: 0,
+        staticOpaqueSceneCacheLiveFrameCountDelta: 0,
+        staticOpaqueSceneCacheReplayStatusAtStart: 'ready',
+        staticOpaqueSceneCacheSavedSubmissionCountDelta: 6_000,
+        staticOpaqueSceneCacheSavedTriangleCountDelta: 3_600_600,
+        staticOpaqueSceneCacheStateAtStart: 'ready',
+        staticOpaqueSceneCacheSupportedAtStart: true,
+        staticOpaqueSceneCacheUnexpectedStaticSubmissionCountAtEnd: 0,
+        submittedTriangles: 1_000_000,
+    };
+    const evaluate = (runtimeOverride = {}) =>
+        evaluateHighTargetAcceptance({
+            apiErrors: [],
+            consoleMessages: [],
+            pageErrors: [],
+            requested,
+            runtime: { ...runtime, ...runtimeOverride },
+            sample,
+        });
+    const checks = evaluate().checks.filter((check) =>
+        check.name.startsWith('highTargetStaticSceneCacheOcclusion'),
+    );
+
+    assert.equal(checks.length, 11);
+    assert.equal(
+        checks.every((check) => check.pass),
+        true,
+    );
+    assert.equal(
+        evaluate({
+            staticOpaqueSceneCacheCaptureCount: 2,
+        }).checks.find(
+            (check) =>
+                check.name === 'highTargetStaticSceneCacheOcclusionRecaptures',
+        )?.pass,
+        false,
+    );
+    assert.equal(
+        evaluate({
+            staticOpaqueSceneCacheOcclusionOccludedBackgroundLeakMaximumRatio: 0.08,
+        }).checks.find(
+            (check) =>
+                check.name ===
+                'highTargetStaticSceneCacheOcclusionBackgroundLeak',
+        )?.pass,
+        false,
+    );
+
+    const markdown = buildMarkdown({
+        adaptiveHighComparisons: {},
+        baseUrl: 'http://profile.local',
+        generatedAt: '2026-07-27T00:00:00.000Z',
+        highTargetMedians: {},
+        options: {
+            build: false,
+            managedServer: false,
+            sampleMs: 5_000,
+            scenarios: [],
+            scenarioSet: 'high-target-static-scene-cache',
+            soakMs: 0,
+            warmupMs: 0,
+        },
+        plantCloseupMedians: {},
+        scenarios: [
+            {
+                budget: { checks, pass: true },
+                consoleMessages: [],
+                environment: null,
+                name: 'game-high-target-static-scene-cache-occlusion-fixture-desktop',
+                pageErrors: [],
+                requested: {
+                    controls: '0',
+                    debugHud: '0',
+                    details: '1',
+                    hud: '0',
+                    motion: 'none',
+                    ...requested,
+                },
+                runtime,
+                sample: {
+                    drawCallsPerFrame: 2,
+                    drawCallsPerRenderedFrame: 20,
+                    fps: 60,
+                    jsHeapMb: 100,
+                    longTaskCount: 0,
+                    maxFrameMs: 20,
+                    p95FrameMs: 16,
+                    rainUnmountMs: null,
+                    trianglesPerFrame: 15_000,
+                    trianglesPerRenderedFrame: 300_000,
+                    ...sample,
+                },
+                screenshotPath: null,
+            },
+        ],
+        schemaVersion: 2,
+        sourceCommit: null,
+        staticSceneCacheComparisons: {},
+        summary: { failedScenarios: 0 },
+        weatherSurfaceComparisons: {},
+    });
+    assert.match(
+        markdown,
+        /Static opaque scene-cache occlusion fixture[\s\S]*passed \| 1 \| 1\/1 \| 4\/3 \| 1 \| 1 \| 1 \| 0 \| pass/,
+    );
+});
+
 test('high target acceptance rejects a demand-render scene with one frame', () => {
     const result = evaluateHighTargetAcceptance({
         apiErrors: [],
@@ -3107,6 +3724,289 @@ test('adaptive High comparison reports paired pass rates and frame/GPU deltas', 
             .failedScenarioNames,
         ['game-high-target-adaptive-camera-motion-desktop'],
     );
+});
+
+test('static scene-cache comparison gates paired render work, GPU, and resources', () => {
+    const visualComparisons = {
+        'static-opaque-scene-cache': {
+            maximumMismatchRatio: 0.001,
+            maximumP99ByteError: 1,
+            pairedRuns: Array.from({ length: 5 }, (_, index) => ({
+                mismatchRatio: 0.001,
+                p99ByteError: 1,
+                profileRun: index + 1,
+                valid: true,
+            })),
+            pass: true,
+            validRunCount: 5,
+        },
+    };
+    const pairedRun = ({ comparisonRole, index }) => {
+        const cached = comparisonRole === 'cache';
+        const baseName = `game-high-target-static-scene-cache-${cached ? 'cached' : 'legacy'}-desktop`;
+        const run = highTargetRun(cached ? 21 : 20, index);
+        return {
+            ...run,
+            baseName,
+            name: `${baseName}-run-${index + 1}`,
+            requested: {
+                ...run.requested,
+                comparisonPair: 'static-opaque-scene-cache',
+                comparisonRole,
+            },
+            runtime: {
+                rendererShaders: cached ? 31 : 30,
+                rendererTextures: cached ? 24 : 20,
+                ...(cached
+                    ? {
+                          staticOpaqueSceneCacheCaptureSubmissionCount: 19,
+                          staticOpaqueSceneCacheCaptureTriangleCount: 12_000,
+                          staticOpaqueSceneCacheReplayEstimatedBytes: 36,
+                          staticOpaqueSceneCacheReplayStatus: 'ready',
+                          staticOpaqueSceneCacheReplaySubmissionCount: 1,
+                          staticOpaqueSceneCacheReplayTriangleCount: 1,
+                          staticOpaqueSceneCacheTargetSampleCount: 4,
+                          staticOpaqueSceneCacheTotalEstimatedBytes: 162_201_636,
+                      }
+                    : {}),
+            },
+            sample: {
+                ...run.sample,
+                drawCallsPerRenderedFrame: cached ? 180 : 200,
+                gpu: {
+                    elapsedP95Ms: cached ? 9.5 : 10,
+                    valid: true,
+                },
+                staticOpaqueSceneCacheHitRatio: cached ? 1 : null,
+                staticOpaqueSceneCacheSavedSubmissionCountDelta: cached
+                    ? 5_700
+                    : null,
+                staticOpaqueSceneCacheSavedTriangleCountDelta: cached
+                    ? 3_600_000
+                    : null,
+                trianglesPerRenderedFrame: cached ? 900_000 : 1_000_000,
+            },
+        };
+    };
+    const runs = [
+        ...[0, 1, 2, 3, 4].map((index) =>
+            pairedRun({ comparisonRole: 'legacy', index }),
+        ),
+        ...[0, 1, 2, 3, 4].map((index) =>
+            pairedRun({ comparisonRole: 'cache', index }),
+        ),
+    ];
+    const medians = buildHighTargetMedians(runs);
+    const comparisons = buildStaticSceneCacheComparisons(
+        medians,
+        visualComparisons,
+    );
+    const comparison = comparisons['static-opaque-scene-cache'];
+
+    assert.deepEqual(comparison.acceptancePassRate, {
+        cached: 100,
+        legacy: 100,
+    });
+    assert.equal(comparison.drawCallRatio, 0.9);
+    assert.equal(comparison.triangleRatio, 0.9);
+    assert.equal(comparison.cpuMedianRatio, 1.05);
+    assert.equal(comparison.gpuTimingStatus, 'valid');
+    assert.equal(comparison.gpuMedianRatio, 0.95);
+    assert.equal(comparison.gpuMaximumRunRatio, 0.95);
+    assert.equal(comparison.rendererProgramMaximumIncrease, 1);
+    assert.equal(comparison.rendererTextureMaximumIncrease, 4);
+    assert.equal(comparison.visualComparison.pass, true);
+    assert.equal(comparison.staticOpaqueSceneCacheHitRatio.median, 1);
+    assert.equal(comparison.staticOpaqueSceneCacheReplayReadyRunCount, 5);
+    assert.equal(
+        comparison.staticOpaqueSceneCacheReplaySubmissionCount.median,
+        1,
+    );
+    assert.equal(
+        comparison.staticOpaqueSceneCacheReplayTriangleCount.median,
+        1,
+    );
+    assert.equal(
+        comparison.staticOpaqueSceneCacheTotalEstimatedBytes.max,
+        162_201_636,
+    );
+    assert.equal(
+        comparison.staticOpaqueSceneCacheSavedSubmissionCountDelta.median,
+        5_700,
+    );
+    assert.equal(comparison.relativePerformancePass, true);
+    assert.equal(comparison.aggregatePass.cached, true);
+    assert.equal(
+        buildProfileSummary(runs, medians, comparisons).failedScenarios,
+        0,
+    );
+    assert.match(
+        buildMarkdown({
+            adaptiveHighComparisons: {},
+            baseUrl: 'http://profile.local',
+            generatedAt: '2026-07-27T00:00:00.000Z',
+            highTargetMedians: medians,
+            options: {
+                build: false,
+                managedServer: false,
+                sampleMs: 5_000,
+                scenarios: [],
+                scenarioSet: 'high-target-static-scene-cache',
+                soakMs: 0,
+                warmupMs: 0,
+            },
+            plantCloseupMedians: {},
+            scenarios: [],
+            schemaVersion: 2,
+            sourceCommit: null,
+            staticSceneCacheComparisons: comparisons,
+            summary: { failedScenarios: 0 },
+            weatherSurfaceComparisons: {},
+        }),
+        /Static opaque scene-cache paired comparison[\s\S]*0\.9\/0\.9\/1\.05[\s\S]*0\.95\/0\.95[\s\S]*30 → 31 \(3\.3%\) \(1\)[\s\S]*20 → 24 \(20%\) \(4\)[\s\S]*5\/5 \/ 19→1 \/ 12000→1[\s\S]*154\.69\/154\.69 MiB @ 4x[\s\S]*5700\/3600000/,
+    );
+
+    const gpuOutlierRuns = runs.map((run) =>
+        run.requested.comparisonRole === 'cache' && run.profileRun === 1
+            ? {
+                  ...run,
+                  sample: {
+                      ...run.sample,
+                      gpu: {
+                          elapsedP95Ms: 10.6,
+                          valid: true,
+                      },
+                  },
+              }
+            : run,
+    );
+    const gpuOutlierMedians = buildHighTargetMedians(gpuOutlierRuns);
+    const gpuOutlierComparison = buildStaticSceneCacheComparisons(
+        gpuOutlierMedians,
+        visualComparisons,
+    )['static-opaque-scene-cache'];
+    assert.equal(gpuOutlierComparison.gpuMedianRatio, 0.95);
+    assert.equal(gpuOutlierComparison.gpuMaximumRunRatio, 1.06);
+    assert.equal(gpuOutlierComparison.relativePerformancePass, false);
+    assert.deepEqual(
+        buildProfileSummary(
+            gpuOutlierRuns,
+            gpuOutlierMedians,
+            buildStaticSceneCacheComparisons(
+                gpuOutlierMedians,
+                visualComparisons,
+            ),
+        ).failedScenarioNames,
+        ['game-high-target-static-scene-cache-cached-desktop'],
+    );
+
+    const incompleteTextureRuns = runs.map((run) =>
+        run.requested.comparisonRole === 'cache' && run.profileRun === 1
+            ? {
+                  ...run,
+                  runtime: {
+                      ...run.runtime,
+                      rendererTextures: null,
+                  },
+              }
+            : run,
+    );
+    const incompleteTextureMedians = buildHighTargetMedians(
+        incompleteTextureRuns,
+    );
+    const incompleteTextureComparison = buildStaticSceneCacheComparisons(
+        incompleteTextureMedians,
+        visualComparisons,
+    )['static-opaque-scene-cache'];
+    assert.equal(
+        incompleteTextureComparison.rendererTextureMaximumIncrease,
+        null,
+    );
+    assert.equal(incompleteTextureComparison.relativePerformancePass, false);
+    assert.deepEqual(
+        buildProfileSummary(
+            incompleteTextureRuns,
+            incompleteTextureMedians,
+            buildStaticSceneCacheComparisons(
+                incompleteTextureMedians,
+                visualComparisons,
+            ),
+        ).failedScenarioNames,
+        ['game-high-target-static-scene-cache-cached-desktop'],
+    );
+
+    const visualRegression = {
+        'static-opaque-scene-cache': {
+            ...visualComparisons['static-opaque-scene-cache'],
+            maximumMismatchRatio: 0.02,
+            pass: false,
+        },
+    };
+    const visualRegressionComparison = buildStaticSceneCacheComparisons(
+        medians,
+        visualRegression,
+    )['static-opaque-scene-cache'];
+    assert.equal(visualRegressionComparison.relativePerformancePass, false);
+});
+
+test('static scene-cache image parity measures RGB errors per pixel', () => {
+    const legacy = new Uint8Array(100 * 4);
+    const cached = new Uint8Array(100 * 4);
+    cached[0] = 10;
+    const withinBudget = measureStaticSceneCacheImageParity(
+        {
+            data: legacy,
+            info: { channels: 4, height: 10, width: 10 },
+        },
+        {
+            data: cached,
+            info: { channels: 4, height: 10, width: 10 },
+        },
+    );
+    assert.equal(withinBudget.valid, true);
+    assert.equal(withinBudget.mismatchRatio, 0.01);
+    assert.equal(withinBudget.p99ByteError, 0);
+
+    cached[4] = 10;
+    const regressed = measureStaticSceneCacheImageParity(
+        {
+            data: legacy,
+            info: { channels: 4, height: 10, width: 10 },
+        },
+        {
+            data: cached,
+            info: { channels: 4, height: 10, width: 10 },
+        },
+    );
+    assert.equal(regressed.mismatchRatio, 0.02);
+    assert.equal(regressed.p99ByteError, 10);
+});
+
+test('static scene-cache visual comparison fails closed without a deterministic clock contract', async () => {
+    const visualComparisons = await buildStaticSceneCacheVisualComparisons([
+        {
+            profileRun: 1,
+            requested: {
+                comparisonPair: 'static-opaque-scene-cache-cloudy',
+                comparisonRole: 'legacy',
+                staticSceneCacheVisualDeterministic: false,
+            },
+        },
+        {
+            profileRun: 1,
+            requested: {
+                comparisonPair: 'static-opaque-scene-cache-cloudy',
+                comparisonRole: 'cache',
+                staticSceneCacheVisualDeterministic: false,
+            },
+        },
+    ]);
+    const comparison = visualComparisons['static-opaque-scene-cache-cloudy'];
+
+    assert.equal(comparison.status, 'unavailable');
+    assert.equal(comparison.pass, false);
+    assert.equal(comparison.validRunCount, 0);
+    assert.match(comparison.reason, /no deterministic scene-time/);
 });
 
 test('weather-surface comparison gates render work, GPU time, and renderer programs', () => {

--- a/packages/game/src/GameFlagsContext.tsx
+++ b/packages/game/src/GameFlagsContext.tsx
@@ -14,6 +14,7 @@ export interface GameFeatureFlags {
     enableBlockGeometryMergingFlag?: boolean;
     enableIntegratedWeatherSurfacesFlag?: boolean;
     enableRainWetOverlayFlag?: boolean;
+    enableStaticOpaqueSceneCacheFlag?: boolean;
     enableSuncokretChatFlag?: boolean;
     enableSuncokretDebugFlag?: boolean;
 }

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -65,6 +65,7 @@ import {
     resolveGameQualityProfile,
 } from './scene/gameQuality';
 import { Scene } from './scene/Scene';
+import { StaticOpaqueSceneCacheOcclusionFixture } from './scene/StaticOpaqueSceneCacheOcclusionFixture';
 import type { Block } from './types/Block';
 import type { Stack } from './types/Stack';
 import {
@@ -86,6 +87,7 @@ export type GameSceneProps = HTMLAttributes<HTMLDivElement> & {
 
     // Demo purposes only
     freezeTime?: Date;
+    fixedTimeSeconds?: number;
     dayNightCycleDisabled?: boolean;
     noBackground?: boolean;
     noControls?: boolean;
@@ -107,6 +109,7 @@ export type GameSceneProps = HTMLAttributes<HTMLDivElement> & {
 
     // Development purposes
     enableGameProfileController?: boolean;
+    enableStaticOpaqueSceneCacheOcclusionFixture?: boolean;
     flags?: GameFeatureFlags;
 };
 
@@ -296,6 +299,8 @@ export function GameScene({
     deferDetails,
     renderDetails: renderDetailsOverride,
     enableGameProfileController,
+    enableStaticOpaqueSceneCacheOcclusionFixture,
+    fixedTimeSeconds,
     ...rest
 }: GameSceneInnerProps) {
     useFocusPlacedBlock();
@@ -346,8 +351,13 @@ export function GameScene({
             (quality === 'high' ||
                 (quality === undefined && gameQualitySetting === 'high')),
     );
-    const adaptiveHighInteractionActive =
-        useAdaptiveHighInteractionActivity(adaptiveHighEnabled);
+    const staticOpaqueCacheEnabled = Boolean(
+        flags?.enableStaticOpaqueSceneCacheFlag &&
+            qualityProfile.tier === 'high',
+    );
+    const adaptiveHighInteractionActive = useAdaptiveHighInteractionActivity(
+        adaptiveHighEnabled || staticOpaqueCacheEnabled,
+    );
     const [adaptiveHighProfile, setAdaptiveHighProfile] =
         useState<AdaptiveHighQualityLevelProfile>(adaptiveHighQualityLevels.L0);
 
@@ -437,8 +447,10 @@ export function GameScene({
                     adaptiveHighProfile={adaptiveHighProfile}
                     onAdaptiveHighProfileChange={setAdaptiveHighProfile}
                     debugStats={showDebugHud}
+                    fixedTimeSeconds={fixedTimeSeconds}
                     position={sceneCameraPosition}
                     quality={qualityProfile}
+                    staticOpaqueCacheEnabled={staticOpaqueCacheEnabled}
                     zoom={sceneCameraZoom}
                     className="!absolute"
                 >
@@ -458,6 +470,10 @@ export function GameScene({
                                 quality={qualityProfile}
                                 weather={weather}
                             />
+                            {enableStaticOpaqueSceneCacheOcclusionFixture &&
+                            staticOpaqueCacheEnabled ? (
+                                <StaticOpaqueSceneCacheOcclusionFixture />
+                            ) : null}
                             <PlacementGroundingShadows
                                 stacks={garden?.stacks}
                             />

--- a/packages/game/src/entities/AdditionalEntityInstances.tsx
+++ b/packages/game/src/entities/AdditionalEntityInstances.tsx
@@ -394,6 +394,7 @@ function BlockGroundInstances({
             <EntityInstancesGeometry
                 instanceKey="Block_Ground_1"
                 instances={oddVariantInstances}
+                staticOpaqueCacheGroup="base-terrain"
                 geometry={nodes.Block_Ground_1.geometry}
                 material={groundMaterial11}
                 snow={{
@@ -407,6 +408,7 @@ function BlockGroundInstances({
             <EntityInstancesGeometry
                 instanceKey="Block_Ground_2"
                 instances={evenVariantInstances}
+                staticOpaqueCacheGroup="base-terrain"
                 geometry={nodes.Block_Ground_2.geometry}
                 material={groundMaterial21}
                 snow={{
@@ -899,6 +901,11 @@ function RaisedBedInstances({
                             instances={shapeInstances}
                             geometry={nodes[shape1].geometry}
                             material={shape1Material}
+                            staticOpaqueCacheGroup={
+                                shape1 === 'Raised_Bed_O_1'
+                                    ? 'static-props'
+                                    : undefined
+                            }
                             renderRainWetOverlay
                             snow={{
                                 maxThickness: 0.16,
@@ -913,6 +920,11 @@ function RaisedBedInstances({
                             instances={shapeInstances}
                             geometry={nodes[shape2].geometry}
                             material={shape2Material}
+                            staticOpaqueCacheGroup={
+                                shape2 === 'Raised_Bed_O_2'
+                                    ? undefined
+                                    : 'static-props'
+                            }
                             renderRainWetOverlay
                             snow={{
                                 maxThickness: 0.16,
@@ -1280,6 +1292,7 @@ function FenceInstances({
                         .map(({ instance }) => instance)}
                     geometry={nodes[key].geometry}
                     material={materials[planksMaterialName]}
+                    staticOpaqueCacheGroup="static-props"
                     renderRainWetOverlay
                     snow={{
                         maxThickness: 0.09,
@@ -1340,6 +1353,7 @@ function GardenBoxInstances({
                 instances={bodyInstances}
                 geometry={nodes.GardenBox_Body_Planks.geometry}
                 material={materials[planksMaterialName]}
+                staticOpaqueCacheGroup="static-props"
                 renderRainWetOverlay
                 snow={snowPresets.giftBox}
                 {...commonSnowProps}
@@ -2021,6 +2035,28 @@ function CatPillowInstances({
     const seam = transformNode(nodes.CatPillow_Seam, 0.62);
     const names = ['CatPillow', 'Cat_Pillow'];
     const instances = useEntityBlockInstances({ names, stacks });
+    const cushionMaterial = useMemo(
+        () => (
+            <meshStandardMaterial
+                color="#b80718"
+                metalness={0}
+                roughness={0.94}
+                side={DoubleSide}
+            />
+        ),
+        [],
+    );
+    const seamMaterial = useMemo(
+        () => (
+            <meshStandardMaterial
+                color="#6b0610"
+                metalness={0}
+                roughness={0.92}
+                side={DoubleSide}
+            />
+        ),
+        [],
+    );
 
     return (
         <>
@@ -2028,14 +2064,8 @@ function CatPillowInstances({
                 instanceKey="CatPillow_Cushion"
                 instances={instances}
                 geometry={nodes.CatPillow_Cushion.geometry}
-                materialNode={
-                    <meshStandardMaterial
-                        color="#b80718"
-                        metalness={0}
-                        roughness={0.94}
-                        side={DoubleSide}
-                    />
-                }
+                materialNode={cushionMaterial}
+                staticOpaqueCacheGroup="static-props"
                 renderRainWetOverlay
                 snow={{
                     maxThickness: 0.045,
@@ -2050,14 +2080,8 @@ function CatPillowInstances({
                 instanceKey="CatPillow_Seam"
                 instances={instances}
                 geometry={nodes.CatPillow_Seam.geometry}
-                materialNode={
-                    <meshStandardMaterial
-                        color="#6b0610"
-                        metalness={0}
-                        roughness={0.92}
-                        side={DoubleSide}
-                    />
-                }
+                materialNode={seamMaterial}
+                staticOpaqueCacheGroup="static-props"
                 renderRainWetOverlay
                 snow={{
                     maxThickness: 0.025,
@@ -2236,6 +2260,7 @@ function WaterWellInstances({
                     name="WaterWell"
                     geometry={nodes[nodeName].geometry}
                     material={nodes[nodeName].material}
+                    staticOpaqueCacheGroup="static-props"
                     renderRainWetOverlay
                     snow={snowPresets.stone}
                     {...transformNode(nodes[nodeName], groupScale)}
@@ -2249,6 +2274,7 @@ function WaterWellInstances({
                     name="WaterWell"
                     geometry={nodes[nodeName].geometry}
                     material={nodes[nodeName].material}
+                    staticOpaqueCacheGroup="static-props"
                     renderRainWetOverlay
                     snow={{
                         maxThickness: 0.08,
@@ -2265,6 +2291,7 @@ function WaterWellInstances({
                 name="WaterWell"
                 geometry={nodes.WaterWell_Rope.geometry}
                 material={nodes.WaterWell_Rope.material}
+                staticOpaqueCacheGroup="static-props"
                 renderRainWetOverlay
                 {...transformNode(nodes.WaterWell_Rope, groupScale)}
                 {...commonSnowProps}
@@ -2301,21 +2328,27 @@ function BirdHouseInstances({
         name: 'BirdHouse',
         stacks,
     })?.map((instance) => mapInstanceRotation(instance, instance.rotation + 2));
-    const woodMaterial = (
-        <meshStandardMaterial
-            color="#956247"
-            metalness={0}
-            roughness={0.9}
-            side={DoubleSide}
-        />
+    const woodMaterial = useMemo(
+        () => (
+            <meshStandardMaterial
+                color="#956247"
+                metalness={0}
+                roughness={0.9}
+                side={DoubleSide}
+            />
+        ),
+        [],
     );
-    const roofMaterial = (
-        <meshStandardMaterial
-            color="#2f3437"
-            metalness={0}
-            roughness={0.62}
-            side={DoubleSide}
-        />
+    const roofMaterial = useMemo(
+        () => (
+            <meshStandardMaterial
+                color="#2f3437"
+                metalness={0}
+                roughness={0.62}
+                side={DoubleSide}
+            />
+        ),
+        [],
     );
 
     return (
@@ -2327,6 +2360,7 @@ function BirdHouseInstances({
                     instances={instances}
                     geometry={nodes[nodeName].geometry}
                     materialNode={woodMaterial}
+                    staticOpaqueCacheGroup="static-props"
                     renderRainWetOverlay
                     snow={{
                         maxThickness:
@@ -2354,6 +2388,7 @@ function BirdHouseInstances({
                     instances={instances}
                     geometry={nodes[nodeName].geometry}
                     materialNode={roofMaterial}
+                    staticOpaqueCacheGroup="static-props"
                     renderRainWetOverlay
                     snow={{
                         maxThickness:
@@ -2404,6 +2439,7 @@ function SimpleAdditionalInstances({
                 assetName="BlockGroundAngle"
                 stacks={stacks}
                 name="Block_Ground_Angle"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="dirt"
                 yOffset={1}
                 geometry={(gltf) => gltf.nodes.Block_Ground_Angle_1.geometry}
@@ -2420,6 +2456,7 @@ function SimpleAdditionalInstances({
                 assetName="BlockTerrainCorner"
                 stacks={stacks}
                 name="Block_Ground_Corner"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="dirt"
                 yOffset={1}
                 geometry={(gltf) => gltf.nodes.Block_Ground_Corner_1.geometry}
@@ -2436,6 +2473,7 @@ function SimpleAdditionalInstances({
                 assetName="BlockTerrainReverseCorner"
                 stacks={stacks}
                 name="Block_Ground_Reverse_Corner"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="dirt"
                 yOffset={1}
                 geometry={(gltf) =>
@@ -2456,6 +2494,7 @@ function SimpleAdditionalInstances({
                 assetName="Composter"
                 stacks={stacks}
                 name="Composter"
+                staticOpaqueCacheGroup="static-props"
                 geometry={(gltf) => gltf.nodes.Composter_1.geometry}
                 material={(gltf) => gltf.materials[dirtMaterialName]}
                 snow={{
@@ -2469,6 +2508,7 @@ function SimpleAdditionalInstances({
                 assetName="Composter"
                 stacks={stacks}
                 name="Composter"
+                staticOpaqueCacheGroup="static-props"
                 geometry={(gltf) => gltf.nodes.Composter_2.geometry}
                 material={(gltf) => gltf.materials[planksMaterialName]}
                 snow={{

--- a/packages/game/src/entities/EntityInstances.tsx
+++ b/packages/game/src/entities/EntityInstances.tsx
@@ -323,6 +323,7 @@ export function EntityInstances({
                 assetName="BlockGrass"
                 stacks={stacks}
                 name="Block_Grass"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="grass"
                 renderRainWetOverlay
                 weatherSurface="base-ground"
@@ -338,6 +339,7 @@ export function EntityInstances({
                 assetName="BlockGrassAngle"
                 stacks={stacks}
                 name="Block_Grass_Angle"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="grass"
                 renderRainWetOverlay
                 yOffset={0.2}
@@ -352,6 +354,7 @@ export function EntityInstances({
                 assetName="BlockTerrainCorner"
                 stacks={stacks}
                 name="Block_Grass_Corner"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="grass"
                 yOffset={0.2}
                 geometry={(gltf) => gltf.nodes.Block_Grass_Corner_1_1.geometry}
@@ -363,6 +366,7 @@ export function EntityInstances({
                 assetName="BlockTerrainCorner"
                 stacks={stacks}
                 name="Block_Grass_Corner"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="grass"
                 renderRainWetOverlay
                 yOffset={0.2}
@@ -377,6 +381,7 @@ export function EntityInstances({
                 assetName="BlockTerrainReverseCorner"
                 stacks={stacks}
                 name="Block_Grass_Reverse_Corner"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="grass"
                 yOffset={0.2}
                 geometry={(gltf) =>
@@ -392,6 +397,7 @@ export function EntityInstances({
                 assetName="BlockTerrainReverseCorner"
                 stacks={stacks}
                 name="Block_Grass_Reverse_Corner"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="grass"
                 renderRainWetOverlay
                 yOffset={0.2}
@@ -410,6 +416,7 @@ export function EntityInstances({
                 assetName="BlockSand"
                 stacks={stacks}
                 name="Block_Sand"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="sand"
                 renderRainWetOverlay
                 weatherSurface="base-ground"
@@ -425,6 +432,7 @@ export function EntityInstances({
                 assetName="BlockSandAngle"
                 stacks={stacks}
                 name="Block_Sand_Angle"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="sand"
                 renderRainWetOverlay
                 yOffset={0.2}
@@ -439,6 +447,7 @@ export function EntityInstances({
                 assetName="BlockTerrainCorner"
                 stacks={stacks}
                 name="Block_Sand_Corner"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="sand"
                 renderRainWetOverlay
                 yOffset={0.2}
@@ -453,6 +462,7 @@ export function EntityInstances({
                 assetName="BlockTerrainReverseCorner"
                 stacks={stacks}
                 name="Block_Sand_Reverse_Corner"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="sand"
                 renderRainWetOverlay
                 yOffset={0.2}
@@ -471,6 +481,7 @@ export function EntityInstances({
                 assetName="BlockSand"
                 stacks={stacks}
                 name="Block_Snow"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="snow"
                 weatherSurface="base-ground"
                 yOffset={0.2}
@@ -485,6 +496,7 @@ export function EntityInstances({
                 assetName="BlockSandAngle"
                 stacks={stacks}
                 name="Block_Snow_Angle"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="snow"
                 yOffset={0.2}
                 geometry={(gltf) => gltf.nodes.Block_Sand_Angle_1.geometry}
@@ -498,6 +510,7 @@ export function EntityInstances({
                 assetName="BlockTerrainCorner"
                 stacks={stacks}
                 name="Block_Snow_Corner"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="snow"
                 yOffset={0.2}
                 geometry={(gltf) => gltf.nodes.Block_Sand_Corner_1.geometry}
@@ -511,6 +524,7 @@ export function EntityInstances({
                 assetName="BlockTerrainReverseCorner"
                 stacks={stacks}
                 name="Block_Snow_Reverse_Corner"
+                staticOpaqueCacheGroup="base-terrain"
                 groundPatch="snow"
                 yOffset={0.2}
                 geometry={(gltf) =>
@@ -534,6 +548,7 @@ export function EntityInstances({
                 assetName="Tree"
                 stacks={stacks}
                 name="Tree"
+                staticOpaqueCacheGroup="static-props"
                 yOffset={0.5}
                 scale={[0.125, 0.5, 0.125]}
                 geometry={(gltf) => gltf.nodes.Tree_1_1.geometry}
@@ -544,6 +559,7 @@ export function EntityInstances({
                 assetName="Tree"
                 stacks={stacks}
                 name="Tree"
+                staticOpaqueCacheGroup="static-props"
                 yOffset={0.5}
                 scale={[0.125, 0.5, 0.125]}
                 geometry={(gltf) => gltf.nodes.Tree_1_2.geometry}
@@ -556,6 +572,7 @@ export function EntityInstances({
                 assetName="Tree"
                 stacks={stacks}
                 name="Tree"
+                staticOpaqueCacheGroup="static-props"
                 yOffset={0.5}
                 scale={[0.125, 0.5, 0.125]}
                 geometry={(gltf) => gltf.nodes.Tree_1_3.geometry}
@@ -592,6 +609,7 @@ export function EntityInstances({
                     assetName="Tulip"
                     stacks={stacks}
                     name="Tulip"
+                    staticOpaqueCacheGroup="static-props"
                     localPosition={stem.position}
                     localRotation={stem.rotation}
                     scale={stem.scale}
@@ -608,6 +626,7 @@ export function EntityInstances({
                     assetName="Tulip"
                     stacks={stacks}
                     name="Tulip"
+                    staticOpaqueCacheGroup="static-props"
                     localPosition={stem.position}
                     localRotation={stem.rotation}
                     scale={stem.scale}
@@ -622,6 +641,7 @@ export function EntityInstances({
                 assetName="Bush"
                 stacks={stacks}
                 name="Bush"
+                staticOpaqueCacheGroup="static-props"
                 geometry={(gltf) => gltf.nodes.Bush_1_1.geometry}
                 material={(gltf) => gltf.nodes.Bush_1_1.material}
                 scale={[0.5, 0.5, 0.5]}
@@ -633,6 +653,7 @@ export function EntityInstances({
                 assetName="Bush"
                 stacks={stacks}
                 name="Bush"
+                staticOpaqueCacheGroup="static-props"
                 geometry={(gltf) => gltf.nodes.Bush_1_2.geometry}
                 material={(gltf) => gltf.nodes.Bush_1_2.material}
                 scale={[0.5, 0.5, 0.5]}
@@ -665,6 +686,7 @@ export function EntityInstances({
                 assetName="StoneMedium"
                 stacks={stacks}
                 name="StoneMedium"
+                staticOpaqueCacheGroup="static-props"
                 geometry={(gltf) => gltf.nodes.Stone_Medium.geometry}
                 material={(gltf) => gltf.nodes.Stone_Medium.material}
                 scale={[0.236, 0.269, 0.205]}

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -25,6 +25,10 @@ import {
 } from '../rain/RainWetOverlay';
 import { registerCloudShadowAttenuationMaterialCandidate } from '../scene/cloudShadowAttenuation';
 import {
+    StaticOpaqueSceneCacheBoundary,
+    type StaticOpaqueSceneCacheGroup,
+} from '../scene/StaticOpaqueSceneCache';
+import {
     useRainSurfacePuddleStrengthUniform,
     useRainSurfaceWetnessActive,
     useRainSurfaceWetnessUniform,
@@ -103,6 +107,7 @@ export type EntityInstancesBlockBaseProps = {
     snow?: SnowMaterialOptions;
     renderRainWetOverlay?: boolean;
     renderStableChunksAsMergedGeometry?: boolean;
+    staticOpaqueCacheGroup?: StaticOpaqueSceneCacheGroup;
     weatherSurface?: 'base-ground';
     castShadow?: boolean;
     receiveShadow?: boolean;
@@ -383,6 +388,7 @@ export function EntityInstancesBlock(
         snow,
         renderRainWetOverlay = false,
         renderStableChunksAsMergedGeometry,
+        staticOpaqueCacheGroup,
         weatherSurface,
         castShadow = true,
         receiveShadow = true,
@@ -410,6 +416,7 @@ export function EntityInstancesBlock(
         snow,
         snowLift,
         snowOverlayMinCoverage,
+        staticOpaqueCacheGroup,
         weatherSurface,
     };
 
@@ -657,6 +664,7 @@ function EntityInstancesGeometryRenderer(
         snowOverlayMinCoverage,
         renderRainWetOverlay = false,
         renderStableChunksAsMergedGeometry = false,
+        staticOpaqueCacheGroup,
         integratedStableWeather,
         weatherSurfaceMode,
         castShadow = true,
@@ -760,6 +768,34 @@ function EntityInstancesGeometryRenderer(
     const stableMaterialNode = integratedStableWeather
         ? undefined
         : materialNode;
+    const staticOpaqueCacheContentKey = useMemo(
+        () => ({
+            castShadow,
+            localTransform,
+            placementSignatureByChunkKey,
+            receiveShadow,
+            renderOrder,
+            renderStableChunksAsMergedGeometry,
+            stableChunks,
+            stableGeometry,
+            stableMaterial,
+            stableMaterialNode,
+            stableScale,
+        }),
+        [
+            castShadow,
+            localTransform,
+            placementSignatureByChunkKey,
+            receiveShadow,
+            renderOrder,
+            renderStableChunksAsMergedGeometry,
+            stableChunks,
+            stableGeometry,
+            stableMaterial,
+            stableMaterialNode,
+            stableScale,
+        ],
+    );
     const weatherRegistryId = useId();
     const rainOverlayVisible = useRainWetOverlayVisible();
     const rainOverlayEnabled =
@@ -813,6 +849,10 @@ function EntityInstancesGeometryRenderer(
                 0,
             ),
         [stableChunks],
+    );
+    const stableTriangleCount = useMemo(
+        () => stableInstanceCount * countGeometryTriangles(stableGeometry),
+        [stableGeometry, stableInstanceCount],
     );
     const stableRainOverlaySubmissionCount = activeRainOverlay
         ? stableChunks.length
@@ -991,42 +1031,50 @@ function EntityInstancesGeometryRenderer(
 
     return (
         <>
-            {stableChunks.map((chunk) => {
-                const placementSignature =
-                    placementSignatureByChunkKey.get(chunk.key) ?? '';
+            <StaticOpaqueSceneCacheBoundary
+                contentKey={staticOpaqueCacheContentKey}
+                group={staticOpaqueCacheGroup}
+                instanceCount={stableInstanceCount}
+                submissionCount={stableChunks.length}
+                triangleCount={stableTriangleCount}
+            >
+                {stableChunks.map((chunk) => {
+                    const placementSignature =
+                        placementSignatureByChunkKey.get(chunk.key) ?? '';
 
-                return renderStableChunksAsMergedGeometry ? (
-                    <ChunkedMergedMesh
-                        key={`${instanceKey}:${chunk.key}`}
-                        castShadow={castShadow}
-                        chunk={chunk}
-                        debugName={`MergedBlockChunk:${instanceKey}:chunk:${chunk.key}:count:${chunk.instances.length}`}
-                        geometry={stableGeometry}
-                        localTransform={localTransform}
-                        material={stableMaterial}
-                        materialNode={stableMaterialNode}
-                        placementSignature={placementSignature}
-                        receiveShadow={receiveShadow}
-                        renderOrder={renderOrder}
-                        scale={stableScale}
-                    />
-                ) : (
-                    <ChunkedInstancedMesh
-                        key={`${instanceKey}:${chunk.key}`}
-                        castShadow={castShadow}
-                        chunk={chunk}
-                        debugName={`BlockInstances:${instanceKey}:chunk:${chunk.key}:count:${chunk.instances.length}`}
-                        geometry={stableGeometry}
-                        localTransform={localTransform}
-                        material={stableMaterial}
-                        materialNode={stableMaterialNode}
-                        placementSignature={placementSignature}
-                        receiveShadow={receiveShadow}
-                        renderOrder={renderOrder}
-                        scale={stableScale}
-                    />
-                );
-            })}
+                    return renderStableChunksAsMergedGeometry ? (
+                        <ChunkedMergedMesh
+                            key={`${instanceKey}:${chunk.key}`}
+                            castShadow={castShadow}
+                            chunk={chunk}
+                            debugName={`MergedBlockChunk:${instanceKey}:chunk:${chunk.key}:count:${chunk.instances.length}`}
+                            geometry={stableGeometry}
+                            localTransform={localTransform}
+                            material={stableMaterial}
+                            materialNode={stableMaterialNode}
+                            placementSignature={placementSignature}
+                            receiveShadow={receiveShadow}
+                            renderOrder={renderOrder}
+                            scale={stableScale}
+                        />
+                    ) : (
+                        <ChunkedInstancedMesh
+                            key={`${instanceKey}:${chunk.key}`}
+                            castShadow={castShadow}
+                            chunk={chunk}
+                            debugName={`BlockInstances:${instanceKey}:chunk:${chunk.key}:count:${chunk.instances.length}`}
+                            geometry={stableGeometry}
+                            localTransform={localTransform}
+                            material={stableMaterial}
+                            materialNode={stableMaterialNode}
+                            placementSignature={placementSignature}
+                            receiveShadow={receiveShadow}
+                            renderOrder={renderOrder}
+                            scale={stableScale}
+                        />
+                    );
+                })}
+            </StaticOpaqueSceneCacheBoundary>
             {renderAnimatedInstances('base')}
             {(instances ?? []).map((data) =>
                 data.pickupOutlineVisible ? (

--- a/packages/game/src/entities/helpers/groundPatchMaterial.ts
+++ b/packages/game/src/entities/helpers/groundPatchMaterial.ts
@@ -68,6 +68,20 @@ const groundPatchPresets = {
 
 const maxWetPatchCount = 48;
 const emptyWetPatches: readonly GroundPatchWetPatch[] = [];
+const staticGroundPatchShaderHookPairs = new WeakMap<
+    Material['onBeforeCompile'],
+    Material['customProgramCacheKey']
+>();
+
+export function hasStaticGroundPatchMaterialShaderHooks({
+    customProgramCacheKey,
+    onBeforeCompile,
+}: Pick<Material, 'customProgramCacheKey' | 'onBeforeCompile'>) {
+    return (
+        staticGroundPatchShaderHookPairs.get(onBeforeCompile) ===
+        customProgramCacheKey
+    );
+}
 
 const groundPatchVertexParameters = `
 varying vec3 vGroundPatchWorldPosition;
@@ -339,7 +353,7 @@ export function applyGroundPatchMaterial(
     const originalCustomProgramCacheKey =
         material.customProgramCacheKey.bind(material);
 
-    material.onBeforeCompile = (shader, renderer) => {
+    const onBeforeCompile: Material['onBeforeCompile'] = (shader, renderer) => {
         originalOnBeforeCompile(shader, renderer);
         const weatherWorldPositionAvailable =
             shader.vertexShader.includes(
@@ -410,8 +424,14 @@ export function applyGroundPatchMaterial(
             `#include <color_fragment>\n${colorFragment}`,
         );
     };
-    material.customProgramCacheKey = () =>
+    const customProgramCacheKey: Material['customProgramCacheKey'] = () =>
         `${originalCustomProgramCacheKey()}:ground-patch:${surface}`;
+    material.onBeforeCompile = onBeforeCompile;
+    material.customProgramCacheKey = customProgramCacheKey;
+    staticGroundPatchShaderHookPairs.set(
+        onBeforeCompile,
+        customProgramCacheKey,
+    );
     material.needsUpdate = true;
 
     return material;

--- a/packages/game/src/scene/CloudLayer.tsx
+++ b/packages/game/src/scene/CloudLayer.tsx
@@ -24,13 +24,20 @@ import type { Stack } from '../types/Stack';
 import { useGameState } from '../useGameState';
 import { CloudShadowAttenuation } from './CloudShadowAttenuationLayer';
 import {
+    resolveDeterministicCloudSpawn,
+    seededCloudRandom,
+} from './cloudDeterministicLayout';
+import {
     type CloudShadowSample,
     resolveCloudShadowAttenuationConfig,
     resolveCloudShadowProjection,
 } from './cloudShadowAttenuation';
 import { updateGameProfileMetadata } from './gameProfileMetadata';
 import type { GameQualityProfile } from './gameQuality';
-import { useSceneTimeInvalidation } from './SceneTime';
+import {
+    useSceneFixedTimeSeconds,
+    useSceneTimeInvalidation,
+} from './SceneTime';
 import { getVisualDaylightAmount, smoothstep } from './visualDayNight';
 
 const MAX_CLOUDS = 8;
@@ -52,11 +59,6 @@ const CLOUD_BASE_DRIFT_SPEED = 0.35;
 const CLOUD_WIND_DRIFT_SPEED = 0.5;
 const CLOUD_RENDER_ORDER = 30;
 const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
-
-function seededRandom(seed: number) {
-    const value = Math.sin(seed * 12.9898) * 43758.5453;
-    return value - Math.floor(value);
-}
 
 function wrapValue(value: number, min: number, max: number) {
     const range = max - min;
@@ -83,9 +85,9 @@ function createCloudAlphaAsset(): CloudAlphaAsset | null {
 
     for (let index = 0; index < 8; index += 1) {
         const seed = 11.7 + index * 23.1;
-        const x = MathUtils.lerp(54, 202, seededRandom(seed));
-        const y = MathUtils.lerp(72, 184, seededRandom(seed + 1));
-        const radius = MathUtils.lerp(34, 72, seededRandom(seed + 2));
+        const x = MathUtils.lerp(54, 202, seededCloudRandom(seed));
+        const y = MathUtils.lerp(72, 184, seededCloudRandom(seed + 1));
+        const radius = MathUtils.lerp(34, 72, seededCloudRandom(seed + 2));
         const gradient = context.createRadialGradient(
             x,
             y,
@@ -170,6 +172,7 @@ type CloudDefinition = {
     laneZ: number;
     opacityScale: number;
     phase: number;
+    seed: number;
     sizeScale: number;
     tint: string;
     wanderScale: number;
@@ -313,6 +316,7 @@ export function CloudLayer({
         [],
     );
     const prefersReducedMotion = usePrefersReducedMotion();
+    const fixedTimeSeconds = useSceneFixedTimeSeconds();
     const attenuationConfig = useMemo(
         () =>
             resolveCloudShadowAttenuationConfig({
@@ -401,18 +405,31 @@ export function CloudLayer({
                 return {
                     altitude:
                         CLOUD_WORLD_ALTITUDE +
-                        (seededRandom(seed) - 0.5) * CLOUD_ALTITUDE_VARIATION,
-                    driftScale: 0.55 + seededRandom(seed + 1) * 0.45,
+                        (seededCloudRandom(seed) - 0.5) *
+                            CLOUD_ALTITUDE_VARIATION,
+                    driftScale: 0.55 + seededCloudRandom(seed + 1) * 0.45,
                     id: `cloud-slot-${index}-${seed.toFixed(3)}`,
-                    laneX: MathUtils.lerp(-0.72, 0.72, seededRandom(seed + 2)),
-                    laneZ: MathUtils.lerp(-0.68, 0.68, seededRandom(seed + 3)),
-                    opacityScale: 1.05 + seededRandom(seed + 4) * 0.4,
-                    phase: seededRandom(seed + 5) * Math.PI * 2,
-                    sizeScale: 0.78 + seededRandom(seed + 5.5) * 0.34,
-                    tint: seededRandom(seed + 6) > 0.5 ? '#edf2f7' : '#c9d5e0',
-                    wanderScale: 0.55 + seededRandom(seed + 7) * 0.7,
-                    width: 11 + seededRandom(seed + 8) * 9,
-                    height: 6.2 + seededRandom(seed + 9) * 4,
+                    laneX: MathUtils.lerp(
+                        -0.72,
+                        0.72,
+                        seededCloudRandom(seed + 2),
+                    ),
+                    laneZ: MathUtils.lerp(
+                        -0.68,
+                        0.68,
+                        seededCloudRandom(seed + 3),
+                    ),
+                    opacityScale: 1.05 + seededCloudRandom(seed + 4) * 0.4,
+                    phase: seededCloudRandom(seed + 5) * Math.PI * 2,
+                    seed,
+                    sizeScale: 0.78 + seededCloudRandom(seed + 5.5) * 0.34,
+                    tint:
+                        seededCloudRandom(seed + 6) > 0.5
+                            ? '#edf2f7'
+                            : '#c9d5e0',
+                    wanderScale: 0.55 + seededCloudRandom(seed + 7) * 0.7,
+                    width: 11 + seededCloudRandom(seed + 8) * 9,
+                    height: 6.2 + seededCloudRandom(seed + 9) * 4,
                 };
             }),
         [stacks],
@@ -487,7 +504,7 @@ export function CloudLayer({
             return;
         }
 
-        const elapsed = clock.elapsedTime;
+        const elapsed = fixedTimeSeconds ?? clock.elapsedTime;
         const {
             despawnHalfX,
             despawnHalfZ,
@@ -524,23 +541,53 @@ export function CloudLayer({
             const slot = cloudSlotsRef.current[index];
             const shadowSample = cloudShadowSamplesRef.current[index];
             const shouldBeVisible = index < visibleCloudCount;
-            if (
-                shouldBeVisible &&
-                !slot.active &&
-                elapsed >= slot.cooldownUntil
-            ) {
-                spawnCloud(slot, cloud, focusX, focusZ, spawnHalfX, spawnHalfZ);
-            }
+            if (fixedTimeSeconds !== undefined) {
+                if (shouldBeVisible) {
+                    const placement = resolveDeterministicCloudSpawn({
+                        focusX,
+                        focusZ,
+                        laneX: cloud.laneX,
+                        laneZ: cloud.laneZ,
+                        seed: cloud.seed,
+                        spawnHalfX,
+                        spawnHalfZ,
+                    });
+                    slot.active = true;
+                    slot.baseX = placement.x;
+                    slot.baseZ = placement.z;
+                    slot.targetVisibility = 1;
+                    slot.visibility = 1;
+                } else {
+                    slot.active = false;
+                    slot.targetVisibility = 0;
+                    slot.visibility = 0;
+                }
+            } else {
+                if (
+                    shouldBeVisible &&
+                    !slot.active &&
+                    elapsed >= slot.cooldownUntil
+                ) {
+                    spawnCloud(
+                        slot,
+                        cloud,
+                        focusX,
+                        focusZ,
+                        spawnHalfX,
+                        spawnHalfZ,
+                    );
+                }
 
-            if (
-                slot.active &&
-                shouldBeVisible &&
-                (Math.abs(slot.baseX - focusX) > despawnHalfX ||
-                    Math.abs(slot.baseZ - focusZ) > despawnHalfZ)
-            ) {
-                slot.targetVisibility = 0;
-            } else if (slot.active) {
-                slot.targetVisibility = shouldBeVisible ? 1 : 0;
+                if (
+                    slot.active &&
+                    shouldBeVisible &&
+                    (Math.abs(slot.baseX - focusX) > despawnHalfX ||
+                        Math.abs(slot.baseZ - focusZ) > despawnHalfZ)
+                ) {
+                    slot.targetVisibility = 0;
+                } else if (slot.active) {
+                    slot.targetVisibility = shouldBeVisible ? 1 : 0;
+                }
             }
 
             if (!slot.active) {
@@ -554,53 +601,63 @@ export function CloudLayer({
                 continue;
             }
 
-            const fadeDuration =
-                slot.targetVisibility > slot.visibility
-                    ? CLOUD_FADE_IN_DURATION
-                    : CLOUD_FADE_OUT_DURATION;
-            const fadeStep = fadeDuration > 0 ? 1 / fadeDuration : 1;
-            if (slot.targetVisibility > slot.visibility) {
-                slot.visibility = Math.min(
-                    1,
-                    slot.visibility + delta * fadeStep,
-                );
-            } else if (slot.targetVisibility < slot.visibility) {
-                slot.visibility = Math.max(
-                    0,
-                    slot.visibility - delta * fadeStep,
-                );
+            if (fixedTimeSeconds === undefined) {
+                const fadeDuration =
+                    slot.targetVisibility > slot.visibility
+                        ? CLOUD_FADE_IN_DURATION
+                        : CLOUD_FADE_OUT_DURATION;
+                const fadeStep = fadeDuration > 0 ? 1 / fadeDuration : 1;
+                if (slot.targetVisibility > slot.visibility) {
+                    slot.visibility = Math.min(
+                        1,
+                        slot.visibility + delta * fadeStep,
+                    );
+                } else if (slot.targetVisibility < slot.visibility) {
+                    slot.visibility = Math.max(
+                        0,
+                        slot.visibility - delta * fadeStep,
+                    );
+                }
+
+                if (slot.targetVisibility <= 0 && slot.visibility <= 0.001) {
+                    slot.active = false;
+                    slot.cooldownUntil = elapsed + 0.3 + Math.random() * 0.6;
+                    if (mesh) {
+                        mesh.visible = false;
+                    }
+                    if (material) {
+                        material.opacity = 0;
+                    }
+                    shadowSample.opacity = 0;
+                    continue;
+                }
             }
 
-            if (slot.targetVisibility <= 0 && slot.visibility <= 0.001) {
-                slot.active = false;
-                slot.cooldownUntil = elapsed + 0.3 + Math.random() * 0.6;
-                if (mesh) {
-                    mesh.visible = false;
-                }
-                if (material) {
-                    material.opacity = 0;
-                }
-                shadowSample.opacity = 0;
-                continue;
-            }
-
-            slot.baseX = wrapValue(
-                slot.baseX + windX * driftSpeed * cloud.driftScale * delta,
+            const driftSeconds =
+                fixedTimeSeconds === undefined ? delta : fixedTimeSeconds;
+            const driftBaseX = wrapValue(
+                slot.baseX +
+                    windX * driftSpeed * cloud.driftScale * driftSeconds,
                 wrapMinX,
                 wrapMaxX,
             );
-            slot.baseZ = wrapValue(
-                slot.baseZ + windZ * driftSpeed * cloud.driftScale * delta,
+            const driftBaseZ = wrapValue(
+                slot.baseZ +
+                    windZ * driftSpeed * cloud.driftScale * driftSeconds,
                 wrapMinZ,
                 wrapMaxZ,
             );
+            if (fixedTimeSeconds === undefined) {
+                slot.baseX = driftBaseX;
+                slot.baseZ = driftBaseZ;
+            }
             const wander =
                 Math.sin(elapsed * (0.06 + windStrength * 0.08) + cloud.phase) *
                 cloud.wanderScale *
                 (0.12 + windStrength * 0.22);
 
             const x = wrapValue(
-                slot.baseX +
+                driftBaseX +
                     crossX * wander +
                     Math.sin(elapsed * 0.035 + cloud.phase) *
                         cloud.wanderScale *
@@ -609,7 +666,7 @@ export function CloudLayer({
                 wrapMaxX,
             );
             const z = wrapValue(
-                slot.baseZ +
+                driftBaseZ +
                     crossZ * wander +
                     Math.cos(elapsed * 0.032 + cloud.phase) *
                         cloud.wanderScale *

--- a/packages/game/src/scene/Scene.tsx
+++ b/packages/game/src/scene/Scene.tsx
@@ -37,6 +37,7 @@ import {
     resolveGameQualityProfile,
 } from './gameQuality';
 import { SceneTimeProvider, sceneFrameRates } from './SceneTime';
+import { StaticOpaqueSceneCacheProvider } from './StaticOpaqueSceneCache';
 import { WeatherSurfaceUniformProvider } from './WeatherSurfaceUniformProvider';
 
 export type SceneProps = HTMLAttributes<HTMLDivElement> &
@@ -54,6 +55,7 @@ export type SceneProps = HTMLAttributes<HTMLDivElement> &
         position: FiberVector3;
         quality?: GameQualityProfile;
         rendererOptions?: WebGLRendererParameters;
+        staticOpaqueCacheEnabled?: boolean;
         suspendWhenOffscreen?: boolean;
         zoom: number;
     }>;
@@ -240,6 +242,7 @@ export function Scene({
     position,
     quality,
     rendererOptions,
+    staticOpaqueCacheEnabled = false,
     suspendWhenOffscreen,
     zoom,
     ...rest
@@ -257,6 +260,15 @@ export function Scene({
         (state) => state.wireframeDebugVisible,
         false,
     );
+    const staticOpaqueCacheActive =
+        staticOpaqueCacheEnabled && qualityProfile.tier === 'high';
+    const staticOpaqueCacheQualityKey = [
+        qualityProfile.cloudShadowMode,
+        qualityProfile.dpr,
+        qualityProfile.shadowMapSize,
+        qualityProfile.shadows ? 1 : 0,
+        qualityProfile.tier,
+    ].join('|');
 
     useEffect(() => {
         updateGameProfileMetadata({
@@ -308,22 +320,29 @@ export function Scene({
                     }
                 />
                 <WeatherSurfaceUniformProvider>
-                    <ActorGroundingShadowProvider
-                        enabled={qualityProfile.shadows}
+                    <StaticOpaqueSceneCacheProvider
+                        enabled={staticOpaqueCacheActive}
+                        interactionActive={adaptiveHighInteractionActive}
+                        qualityKey={staticOpaqueCacheQualityKey}
+                        wireframe={Boolean(debugStats && wireframeDebugVisible)}
                     >
-                        <HoverOutlineProvider>
-                            <SceneDebugName />
-                            <GeneratedLSystemCacheStatsReporter />
-                            {debugStats && <RendererStatsReporter />}
-                            <SceneWireframeMode
-                                enabled={Boolean(
-                                    debugStats && wireframeDebugVisible,
-                                )}
-                            />
-                            {children}
-                            <HoverOutlineEffect />
-                        </HoverOutlineProvider>
-                    </ActorGroundingShadowProvider>
+                        <ActorGroundingShadowProvider
+                            enabled={qualityProfile.shadows}
+                        >
+                            <HoverOutlineProvider>
+                                <SceneDebugName />
+                                <GeneratedLSystemCacheStatsReporter />
+                                {debugStats && <RendererStatsReporter />}
+                                <SceneWireframeMode
+                                    enabled={Boolean(
+                                        debugStats && wireframeDebugVisible,
+                                    )}
+                                />
+                                {children}
+                                <HoverOutlineEffect />
+                            </HoverOutlineProvider>
+                        </ActorGroundingShadowProvider>
+                    </StaticOpaqueSceneCacheProvider>
                 </WeatherSurfaceUniformProvider>
             </SceneTimeProvider>
         </Canvas>

--- a/packages/game/src/scene/SceneTime.tsx
+++ b/packages/game/src/scene/SceneTime.tsx
@@ -25,6 +25,7 @@ export const sceneFrameRates = {
 
 type SceneTimeContextValue = {
     acquireContinuousRender: (framesPerSecond?: number) => () => void;
+    fixedTimeSeconds: number | undefined;
     subscribeSceneResume: (listener: () => void) => () => void;
     timeUniform: IUniform<number>;
 };
@@ -297,10 +298,11 @@ export function SceneTimeProvider({
     const contextValue = useMemo(
         () => ({
             acquireContinuousRender,
+            fixedTimeSeconds: fixedTime,
             subscribeSceneResume,
             timeUniform,
         }),
-        [acquireContinuousRender, subscribeSceneResume, timeUniform],
+        [acquireContinuousRender, fixedTime, subscribeSceneResume, timeUniform],
     );
 
     return (
@@ -317,6 +319,15 @@ export function useSceneTimeUniform() {
     }
 
     return sceneTime.timeUniform;
+}
+
+export function useSceneFixedTimeSeconds() {
+    const sceneTime = useContext(SceneTimeContext);
+    if (!sceneTime) {
+        throw new Error('Missing SceneTimeProvider in the scene tree');
+    }
+
+    return sceneTime.fixedTimeSeconds;
 }
 
 export function useSceneTimeInvalidation(

--- a/packages/game/src/scene/StaticOpaqueSceneCache.tsx
+++ b/packages/game/src/scene/StaticOpaqueSceneCache.tsx
@@ -1,0 +1,1564 @@
+'use client';
+
+import { useFrame, useThree } from '@react-three/fiber';
+import {
+    createContext,
+    type PropsWithChildren,
+    type ReactNode,
+    useCallback,
+    useContext,
+    useEffect,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+    useSyncExternalStore,
+} from 'react';
+import {
+    ACESFilmicToneMapping,
+    AlwaysDepth,
+    type Camera,
+    Color,
+    DataTexture,
+    DepthFormat,
+    DepthTexture,
+    GLSL3,
+    type Group,
+    type Material,
+    Matrix4,
+    NearestFilter,
+    NoBlending,
+    NoColorSpace,
+    type Object3D,
+    RGBAFormat,
+    type Scene,
+    ShaderMaterial,
+    SRGBColorSpace,
+    type Texture,
+    UnsignedByteType,
+    UnsignedIntType,
+    Vector2,
+    type WebGLRenderer,
+    WebGLRenderTarget,
+} from 'three';
+import { useOptionalGameState } from '../useGameState';
+import {
+    type CloudShadowMaterialUniforms,
+    getCloudShadowAttenuationMaterialUniforms,
+} from './cloudShadowAttenuation';
+import { updateGameProfileMetadata } from './gameProfileMetadata';
+import { useSceneResume } from './SceneTime';
+import {
+    createStaticOpaqueSceneCacheReplay,
+    isStaticOpaqueSceneCacheReplayEligible,
+    type StaticOpaqueSceneCacheReplay,
+    staticOpaqueSceneCacheReplayVertexShader,
+} from './staticOpaqueSceneCacheReplay';
+import {
+    createStaticOpaqueSceneCacheRuntime,
+    isStaticOpaqueSceneCacheMaterialEligible,
+    resolveStaticOpaqueSceneCacheTarget,
+    type StaticOpaqueSceneCacheReason,
+    type StaticOpaqueSceneCacheRuntime,
+    transitionStaticOpaqueSceneCache,
+} from './staticOpaqueSceneCacheState';
+import { useWeatherSurfaceUniformActivitySnapshot } from './WeatherSurfaceUniformProvider';
+
+export type StaticOpaqueSceneCacheGroup = 'base-terrain' | 'static-props';
+
+type StaticOpaqueSceneCacheBoundaryEntry = {
+    contentKey: unknown;
+    group: StaticOpaqueSceneCacheGroup;
+    instanceCount: number;
+    root: Object3D;
+    submissionCount: number;
+    triangleCount: number;
+};
+
+type StaticOpaqueSceneCacheRegistrySnapshot = {
+    boundaries: readonly StaticOpaqueSceneCacheBoundaryEntry[];
+    boundarySignature: string;
+    ineligibleBoundaryCount: number;
+    instanceCount: number;
+    invalidationCount: number;
+    lastInvalidationReason: StaticOpaqueSceneCacheReason;
+    meshCount: number;
+    renderables: readonly Object3D[];
+    revision: number;
+    submissionCount: number;
+    triangleCount: number;
+};
+
+class StaticOpaqueSceneCacheRegistry {
+    private readonly boundaries = new Map<
+        symbol,
+        StaticOpaqueSceneCacheBoundaryEntry
+    >();
+    private readonly listeners = new Set<() => void>();
+    private snapshot: StaticOpaqueSceneCacheRegistrySnapshot = {
+        boundaries: [],
+        boundarySignature: '',
+        ineligibleBoundaryCount: 0,
+        instanceCount: 0,
+        invalidationCount: 0,
+        lastInvalidationReason: 'boundary-change',
+        meshCount: 0,
+        renderables: [],
+        revision: 0,
+        submissionCount: 0,
+        triangleCount: 0,
+    };
+
+    constructor(private readonly onInvalidate: () => void) {}
+
+    deleteBoundary = (id: symbol) => {
+        if (!this.boundaries.delete(id)) {
+            return;
+        }
+        this.bump('boundary-change');
+    };
+
+    getSnapshot = () => this.snapshot;
+
+    invalidate = (reason: StaticOpaqueSceneCacheReason) => {
+        this.bump(reason);
+    };
+
+    setBoundary = (
+        id: symbol,
+        boundary: StaticOpaqueSceneCacheBoundaryEntry,
+    ) => {
+        const previous = this.boundaries.get(id);
+        if (
+            previous &&
+            previous.contentKey === boundary.contentKey &&
+            previous.group === boundary.group &&
+            previous.instanceCount === boundary.instanceCount &&
+            previous.root === boundary.root &&
+            previous.submissionCount === boundary.submissionCount &&
+            previous.triangleCount === boundary.triangleCount
+        ) {
+            return;
+        }
+
+        this.boundaries.set(id, boundary);
+        this.bump('boundary-change');
+    };
+
+    subscribe = (listener: () => void) => {
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    };
+
+    private bump(reason: StaticOpaqueSceneCacheReason) {
+        const mountedBoundaries = [...this.boundaries.values()].filter(
+            (boundary) => boundary.root.parent !== null,
+        );
+        const boundaries: StaticOpaqueSceneCacheBoundaryEntry[] = [];
+        const renderables: Object3D[] = [];
+        let ineligibleBoundaryCount = 0;
+        let instanceCount = 0;
+        let meshCount = 0;
+        let submissionCount = 0;
+        let triangleCount = 0;
+        for (const boundary of mountedBoundaries) {
+            const boundaryRenderables: Object3D[] = [];
+            boundary.root.traverse((object) => {
+                if (isRenderable(object)) {
+                    boundaryRenderables.push(object);
+                }
+            });
+            if (
+                boundaryRenderables.length === 0 ||
+                boundaryRenderables.some(
+                    (object) => !isStaticOpaqueRenderableEligible(object),
+                )
+            ) {
+                ineligibleBoundaryCount += 1;
+                continue;
+            }
+
+            boundaries.push(boundary);
+            renderables.push(...boundaryRenderables);
+            instanceCount += boundary.instanceCount;
+            submissionCount += boundary.submissionCount;
+            triangleCount += boundary.triangleCount;
+            meshCount += boundaryRenderables.length;
+        }
+        this.snapshot = {
+            boundaries,
+            boundarySignature: buildBoundarySignature(boundaries),
+            ineligibleBoundaryCount,
+            instanceCount,
+            invalidationCount: this.snapshot.invalidationCount + 1,
+            lastInvalidationReason: reason,
+            meshCount,
+            renderables,
+            revision: this.snapshot.revision + 1,
+            submissionCount,
+            triangleCount,
+        };
+        for (const listener of this.listeners) {
+            listener();
+        }
+        this.onInvalidate();
+    }
+}
+
+const StaticOpaqueSceneCacheContext =
+    createContext<StaticOpaqueSceneCacheRegistry | null>(null);
+
+export function StaticOpaqueSceneCacheBoundary({
+    children,
+    contentKey,
+    group,
+    instanceCount,
+    submissionCount,
+    triangleCount,
+}: {
+    children: ReactNode;
+    contentKey: unknown;
+    group?: StaticOpaqueSceneCacheGroup;
+    instanceCount: number;
+    submissionCount: number;
+    triangleCount: number;
+}) {
+    const registry = useContext(StaticOpaqueSceneCacheContext);
+    const id = useMemo(() => Symbol(group ?? 'disabled'), [group]);
+    const rootRef = useRef<Group>(null);
+
+    useLayoutEffect(() => {
+        const root = rootRef.current;
+        if (!registry || !group || !root) {
+            return;
+        }
+
+        registry.setBoundary(id, {
+            contentKey,
+            group,
+            instanceCount,
+            root,
+            submissionCount,
+            triangleCount,
+        });
+    }, [
+        contentKey,
+        group,
+        id,
+        instanceCount,
+        registry,
+        submissionCount,
+        triangleCount,
+    ]);
+
+    useLayoutEffect(
+        () => () => {
+            registry?.deleteBoundary(id);
+        },
+        [id, registry],
+    );
+
+    if (!group || !registry) {
+        return children;
+    }
+
+    return (
+        <group ref={rootRef} name={`StaticOpaqueCache:${group}`}>
+            {children}
+        </group>
+    );
+}
+
+type StaticOpaqueSceneCacheCounters = {
+    bypassFrames: number;
+    captureSubmissions: number;
+    captureTriangles: number;
+    captures: number;
+    compositePasses: number;
+    replayEstimatedBytes: number;
+    replaySubmissions: number;
+    replayTriangles: number;
+    hitFrames: number;
+    invalidations: number;
+    lastInvalidationReason: StaticOpaqueSceneCacheReason;
+    liveFrames: number;
+    savedSubmissions: number;
+    savedTriangles: number;
+    unexpectedStaticSubmissions: number;
+};
+
+function createCounters(): StaticOpaqueSceneCacheCounters {
+    return {
+        bypassFrames: 0,
+        captureSubmissions: 0,
+        captureTriangles: 0,
+        captures: 0,
+        compositePasses: 0,
+        replayEstimatedBytes: 0,
+        replaySubmissions: 0,
+        replayTriangles: 0,
+        hitFrames: 0,
+        invalidations: 0,
+        lastInvalidationReason: 'boundary-change',
+        liveFrames: 0,
+        savedSubmissions: 0,
+        savedTriangles: 0,
+        unexpectedStaticSubmissions: 0,
+    };
+}
+
+function isRenderable(object: Object3D) {
+    return (
+        Reflect.get(object, 'isMesh') === true ||
+        Reflect.get(object, 'isLine') === true ||
+        Reflect.get(object, 'isPoints') === true ||
+        Reflect.get(object, 'isSprite') === true
+    );
+}
+
+function getMaterials(object: Object3D): Material[] {
+    const material = Reflect.get(object, 'material');
+    if (Array.isArray(material)) {
+        return material.filter(
+            (entry): entry is Material =>
+                typeof entry === 'object' &&
+                entry !== null &&
+                Reflect.get(entry, 'isMaterial') === true,
+        );
+    }
+
+    return typeof material === 'object' &&
+        material !== null &&
+        Reflect.get(material, 'isMaterial') === true
+        ? [material]
+        : [];
+}
+
+function isStaticOpaqueRenderableEligible(object: Object3D) {
+    if (Reflect.get(object, 'isMesh') !== true) {
+        return false;
+    }
+
+    const materials = getMaterials(object);
+    return (
+        materials.length > 0 &&
+        isStaticOpaqueSceneCacheReplayEligible(object) &&
+        materials.every((material) =>
+            isStaticOpaqueSceneCacheMaterialEligible(material),
+        )
+    );
+}
+
+function countIneligibleStaticOpaqueSceneCacheBoundaries(
+    boundaries: readonly StaticOpaqueSceneCacheBoundaryEntry[],
+) {
+    let count = 0;
+    for (const boundary of boundaries) {
+        let eligible = true;
+        boundary.root.traverse((object) => {
+            if (
+                eligible &&
+                isRenderable(object) &&
+                !isStaticOpaqueRenderableEligible(object)
+            ) {
+                eligible = false;
+            }
+        });
+        if (!eligible) {
+            count += 1;
+        }
+    }
+    return count;
+}
+
+function signatureNumbers(values: readonly number[]) {
+    return values
+        .map((value) => (Number.isFinite(value) ? value.toFixed(6) : '0'))
+        .join(',');
+}
+
+function mixRuntimeSignature(hash: number, value: number) {
+    const normalized = Number.isFinite(value)
+        ? Math.round(value * 1_000_000)
+        : 0;
+    return Math.imul(hash ^ normalized, 16_777_619) >>> 0;
+}
+
+function mixOptionalColorSignature(hash: number, value: unknown) {
+    if (typeof value !== 'object' || value === null) {
+        return mixRuntimeSignature(hash, 0);
+    }
+    const getHex = Reflect.get(value, 'getHex');
+    return mixRuntimeSignature(
+        hash,
+        typeof getHex === 'function' ? getHex.call(value) : 0,
+    );
+}
+
+function buildBoundaryRuntimeSignature(
+    boundaries: readonly StaticOpaqueSceneCacheBoundaryEntry[],
+    renderables: readonly Object3D[],
+) {
+    for (const boundary of boundaries) {
+        boundary.root.updateWorldMatrix(true, true);
+    }
+
+    let hash = 2_166_136_261;
+    for (const object of renderables) {
+        hash = mixRuntimeSignature(hash, isEffectivelyVisible(object) ? 1 : 0);
+        hash = mixRuntimeSignature(hash, object.layers.mask);
+        hash = mixRuntimeSignature(hash, object.renderOrder);
+        hash = mixRuntimeSignature(
+            hash,
+            Reflect.get(object, 'castShadow') === true ? 1 : 0,
+        );
+        hash = mixRuntimeSignature(
+            hash,
+            Reflect.get(object, 'receiveShadow') === true ? 1 : 0,
+        );
+        hash = mixRuntimeSignature(hash, object.frustumCulled ? 1 : 0);
+        for (const value of object.matrixWorld.elements) {
+            hash = mixRuntimeSignature(hash, value);
+        }
+
+        const geometry = Reflect.get(object, 'geometry');
+        hash = mixRuntimeSignature(hash, geometry?.version ?? 0);
+        hash = mixRuntimeSignature(hash, geometry?.drawRange?.start ?? 0);
+        hash = mixRuntimeSignature(hash, geometry?.drawRange?.count ?? 0);
+        hash = mixRuntimeSignature(hash, geometry?.index?.version ?? 0);
+        for (const attributeName of [
+            'color',
+            'normal',
+            'position',
+            'tangent',
+            'uv',
+            'uv1',
+        ]) {
+            hash = mixRuntimeSignature(
+                hash,
+                geometry?.getAttribute?.(attributeName)?.version ?? 0,
+            );
+        }
+
+        const instanceCount = Reflect.get(object, 'count');
+        hash = mixRuntimeSignature(
+            hash,
+            typeof instanceCount === 'number' ? instanceCount : 0,
+        );
+        hash = mixRuntimeSignature(
+            hash,
+            Reflect.get(object, 'instanceMatrix')?.version ?? 0,
+        );
+        hash = mixRuntimeSignature(
+            hash,
+            Reflect.get(object, 'instanceColor')?.version ?? 0,
+        );
+        const morphTargetInfluences = Reflect.get(
+            object,
+            'morphTargetInfluences',
+        );
+        if (Array.isArray(morphTargetInfluences)) {
+            for (const influence of morphTargetInfluences) {
+                hash = mixRuntimeSignature(hash, influence);
+            }
+        }
+
+        for (const material of getMaterials(object)) {
+            hash = mixRuntimeSignature(hash, material.version);
+            hash = mixRuntimeSignature(hash, material.visible ? 1 : 0);
+            hash = mixRuntimeSignature(hash, material.transparent ? 1 : 0);
+            hash = mixRuntimeSignature(hash, material.opacity);
+            hash = mixRuntimeSignature(hash, material.alphaTest);
+            hash = mixRuntimeSignature(hash, material.alphaToCoverage ? 1 : 0);
+            hash = mixRuntimeSignature(hash, material.depthTest ? 1 : 0);
+            hash = mixRuntimeSignature(hash, material.depthWrite ? 1 : 0);
+            hash = mixRuntimeSignature(hash, material.colorWrite ? 1 : 0);
+            hash = mixRuntimeSignature(hash, material.stencilWrite ? 1 : 0);
+            hash = mixRuntimeSignature(hash, material.toneMapped ? 1 : 0);
+            const transmission = Reflect.get(material, 'transmission');
+            hash = mixRuntimeSignature(
+                hash,
+                typeof transmission === 'number' ? transmission : 0,
+            );
+            hash = mixOptionalColorSignature(
+                hash,
+                Reflect.get(material, 'color'),
+            );
+            hash = mixOptionalColorSignature(
+                hash,
+                Reflect.get(material, 'emissive'),
+            );
+            for (const property of [
+                'aoMapIntensity',
+                'bumpScale',
+                'displacementBias',
+                'displacementScale',
+                'emissiveIntensity',
+                'envMapIntensity',
+                'lightMapIntensity',
+                'metalness',
+                'roughness',
+            ]) {
+                const value = Reflect.get(material, property);
+                hash = mixRuntimeSignature(
+                    hash,
+                    typeof value === 'number' ? value : 0,
+                );
+            }
+            for (const textureProperty of [
+                'alphaMap',
+                'aoMap',
+                'bumpMap',
+                'displacementMap',
+                'emissiveMap',
+                'envMap',
+                'lightMap',
+                'map',
+                'metalnessMap',
+                'normalMap',
+                'roughnessMap',
+            ]) {
+                const texture = Reflect.get(material, textureProperty);
+                hash = mixRuntimeSignature(hash, texture?.id ?? 0);
+                hash = mixRuntimeSignature(hash, texture?.version ?? 0);
+            }
+        }
+    }
+    return hash.toString(36);
+}
+
+function buildCameraSignature(camera: Camera) {
+    camera.updateWorldMatrix(true, false);
+    return [
+        camera.layers.mask,
+        signatureNumbers(camera.matrixWorld.elements),
+        signatureNumbers(camera.projectionMatrix.elements),
+    ].join('|');
+}
+
+function buildLightingSignature(scene: Object3D) {
+    const sceneEnvironment = Reflect.get(scene, 'environment');
+    const environmentRotation = Reflect.get(scene, 'environmentRotation');
+    const fog = Reflect.get(scene, 'fog');
+    const parts: string[] = [
+        [
+            'environment',
+            typeof sceneEnvironment?.uuid === 'string'
+                ? sceneEnvironment.uuid
+                : 'none',
+            typeof sceneEnvironment?.version === 'number'
+                ? sceneEnvironment.version
+                : 0,
+            typeof Reflect.get(scene, 'environmentIntensity') === 'number'
+                ? Reflect.get(scene, 'environmentIntensity').toFixed(6)
+                : 'none',
+            typeof environmentRotation?.x === 'number'
+                ? environmentRotation.x.toFixed(6)
+                : 'none',
+            typeof environmentRotation?.y === 'number'
+                ? environmentRotation.y.toFixed(6)
+                : 'none',
+            typeof environmentRotation?.z === 'number'
+                ? environmentRotation.z.toFixed(6)
+                : 'none',
+        ].join(':'),
+        [
+            'fog',
+            typeof fog?.uuid === 'string' ? fog.uuid : 'none',
+            typeof fog?.color?.getHexString === 'function'
+                ? fog.color.getHexString()
+                : 'none',
+            typeof fog?.near === 'number' ? fog.near.toFixed(6) : 'none',
+            typeof fog?.far === 'number' ? fog.far.toFixed(6) : 'none',
+            typeof fog?.density === 'number' ? fog.density.toFixed(6) : 'none',
+        ].join(':'),
+    ];
+    scene.traverse((object) => {
+        if (Reflect.get(object, 'isLight') !== true) {
+            return;
+        }
+
+        object.updateWorldMatrix(true, false);
+        const color = Reflect.get(object, 'color');
+        const groundColor = Reflect.get(object, 'groundColor');
+        const intensity = Reflect.get(object, 'intensity');
+        const shadow = Reflect.get(object, 'shadow');
+        const shadowCamera = shadow ? Reflect.get(shadow, 'camera') : undefined;
+        const shadowMapSize = shadow
+            ? Reflect.get(shadow, 'mapSize')
+            : undefined;
+        const target = Reflect.get(object, 'target');
+        if (target && typeof target.updateWorldMatrix === 'function') {
+            target.updateWorldMatrix(true, false);
+        }
+        parts.push(
+            [
+                object.uuid,
+                object.type,
+                isEffectivelyVisible(object) ? 1 : 0,
+                Reflect.get(object, 'castShadow') === true ? 1 : 0,
+                object.layers.mask,
+                typeof color?.getHexString === 'function'
+                    ? color.getHexString()
+                    : 'none',
+                typeof groundColor?.getHexString === 'function'
+                    ? groundColor.getHexString()
+                    : 'none',
+                typeof intensity === 'number' ? intensity.toFixed(6) : 'none',
+                signatureNumbers(object.matrixWorld.elements),
+                target?.matrixWorld?.elements
+                    ? signatureNumbers(target.matrixWorld.elements)
+                    : 'none',
+                typeof shadow?.intensity === 'number'
+                    ? shadow.intensity.toFixed(6)
+                    : 'none',
+                typeof shadow?.bias === 'number'
+                    ? shadow.bias.toFixed(6)
+                    : 'none',
+                typeof shadow?.normalBias === 'number'
+                    ? shadow.normalBias.toFixed(6)
+                    : 'none',
+                typeof shadow?.radius === 'number'
+                    ? shadow.radius.toFixed(6)
+                    : 'none',
+                typeof shadow?.blurSamples === 'number'
+                    ? shadow.blurSamples
+                    : 'none',
+                typeof shadowMapSize?.x === 'number' ? shadowMapSize.x : 'none',
+                typeof shadowMapSize?.y === 'number' ? shadowMapSize.y : 'none',
+                shadowCamera?.projectionMatrix?.elements
+                    ? signatureNumbers(shadowCamera.projectionMatrix.elements)
+                    : 'none',
+            ].join(':'),
+        );
+    });
+    return parts.sort().join('|');
+}
+
+function isEffectivelyVisible(object: Object3D) {
+    let current: Object3D | null = object;
+    while (current) {
+        if (!current.visible) {
+            return false;
+        }
+        current = current.parent;
+    }
+    return true;
+}
+
+function buildBoundarySignature(
+    boundaries: readonly StaticOpaqueSceneCacheBoundaryEntry[],
+) {
+    const parts: string[] = [];
+    for (const boundary of boundaries) {
+        boundary.root.updateWorldMatrix(true, true);
+        boundary.root.traverse((object) => {
+            if (!isRenderable(object)) {
+                return;
+            }
+            const geometry = Reflect.get(object, 'geometry');
+            const instanceMatrix = Reflect.get(object, 'instanceMatrix');
+            parts.push(
+                [
+                    object.uuid,
+                    isEffectivelyVisible(object) ? 1 : 0,
+                    object.layers.mask,
+                    object.renderOrder,
+                    typeof geometry?.uuid === 'string' ? geometry.uuid : 'none',
+                    typeof geometry?.version === 'number'
+                        ? geometry.version
+                        : 0,
+                    getMaterials(object)
+                        .map((material) =>
+                            [
+                                material.uuid,
+                                material.version,
+                                material.visible ? 1 : 0,
+                                material.transparent ? 1 : 0,
+                                material.opacity.toFixed(6),
+                                material.alphaTest.toFixed(6),
+                                material.depthTest ? 1 : 0,
+                                material.depthWrite ? 1 : 0,
+                                material.colorWrite ? 1 : 0,
+                            ].join(':'),
+                        )
+                        .join(','),
+                    typeof Reflect.get(object, 'count') === 'number'
+                        ? Reflect.get(object, 'count')
+                        : 'none',
+                    typeof instanceMatrix?.version === 'number'
+                        ? instanceMatrix.version
+                        : 'none',
+                    signatureNumbers(object.matrixWorld.elements),
+                ].join(':'),
+            );
+        });
+    }
+    return parts.sort().join('|');
+}
+
+function createOutputSpaceTarget({
+    depthTexture,
+    depthBuffer = depthTexture !== null,
+    name,
+    samples,
+}: {
+    depthBuffer?: boolean;
+    depthTexture: DepthTexture | null;
+    name: string;
+    samples: number;
+}) {
+    const target = new WebGLRenderTarget(1, 1, {
+        depthBuffer,
+        depthTexture,
+        format: RGBAFormat,
+        internalFormat: 'RGBA8',
+        magFilter: NearestFilter,
+        minFilter: NearestFilter,
+        resolveDepthBuffer: true,
+        samples,
+        stencilBuffer: false,
+        type: UnsignedByteType,
+    });
+    target.texture.colorSpace = SRGBColorSpace;
+    target.texture.generateMipmaps = false;
+    target.texture.name = `${name}.Color`;
+    target.viewport.set(0, 0, 1, 1);
+    target.scissor.set(0, 0, 1, 1);
+    target.scissorTest = false;
+
+    /*
+     * Three preserves the canvas tone-mapping/output pipeline for XR-style
+     * targets. Keeping the cache in the same encoded RGBA8 representation
+     * reuses the live material programs and avoids scene-linear variants that
+     * would exist only for a cold capture.
+     */
+    Reflect.set(target, 'isXRRenderTarget', true);
+    return target;
+}
+
+function createCloudResponseTarget() {
+    return createOutputSpaceTarget({
+        depthBuffer: false,
+        depthTexture: null,
+        name: 'StaticOpaqueSceneCache.CloudFullResponse',
+        samples: 0,
+    });
+}
+
+function createCloudResponseMaskTexture() {
+    const texture = new DataTexture(
+        new Uint8Array([255, 255, 255, 255]),
+        1,
+        1,
+        RGBAFormat,
+        UnsignedByteType,
+    );
+    texture.colorSpace = NoColorSpace;
+    texture.generateMipmaps = false;
+    texture.magFilter = NearestFilter;
+    texture.minFilter = NearestFilter;
+    texture.name = 'StaticOpaqueSceneCache.CloudFullResponseMask';
+    texture.needsUpdate = true;
+    return texture;
+}
+
+function createCacheTarget(samples: number) {
+    const depthTexture = new DepthTexture(1, 1, UnsignedIntType);
+    depthTexture.format = DepthFormat;
+    depthTexture.magFilter = NearestFilter;
+    depthTexture.minFilter = NearestFilter;
+    depthTexture.name = 'StaticOpaqueSceneCache.Depth';
+
+    return {
+        depthTexture,
+        target: createOutputSpaceTarget({
+            depthTexture,
+            name: 'StaticOpaqueSceneCache',
+            samples,
+        }),
+    };
+}
+
+function createCacheReplayMaterial({
+    baseColorTexture,
+    cloudUniforms,
+    depthTexture,
+    inverseViewProjection,
+    shadowColorTexture,
+}: {
+    baseColorTexture: Texture;
+    cloudUniforms: CloudShadowMaterialUniforms;
+    depthTexture: Texture;
+    inverseViewProjection: Matrix4;
+    shadowColorTexture: Texture;
+}) {
+    return new ShaderMaterial({
+        alphaToCoverage: true,
+        blending: NoBlending,
+        depthFunc: AlwaysDepth,
+        depthTest: true,
+        depthWrite: true,
+        fragmentShader: `
+            out vec4 cacheOutput;
+            #define gl_FragColor cacheOutput
+
+            uniform sampler2D cacheBaseColor;
+            uniform sampler2D cacheShadowColor;
+            uniform sampler2D cacheDepth;
+            uniform sampler2D cloudShadowMap;
+            uniform vec4 cloudShadowBounds;
+            uniform vec2 cloudShadowProjection;
+            uniform float cloudShadowStrength;
+            uniform float cloudShadowHardness;
+            uniform mat4 inverseViewProjection;
+
+            void main() {
+                ivec2 pixel = ivec2(gl_FragCoord.xy);
+                vec4 baseColor = texelFetch(cacheBaseColor, pixel, 0);
+                if (baseColor.a <= 0.000001) {
+                    discard;
+                }
+
+                float cloudResponse = 0.0;
+                float cachedDepth = texelFetch(cacheDepth, pixel, 0).r;
+                if (
+                    cloudShadowStrength > 0.001 &&
+                    cachedDepth < 0.9999999
+                ) {
+                    vec2 textureSizePixels =
+                        vec2(textureSize(cacheDepth, 0));
+                    vec2 cacheUv =
+                        (vec2(pixel) + vec2(0.5)) / textureSizePixels;
+                    vec4 worldPosition = inverseViewProjection * vec4(
+                        cacheUv * 2.0 - 1.0,
+                        cachedDepth * 2.0 - 1.0,
+                        1.0
+                    );
+                    vec3 world =
+                        worldPosition.xyz / max(worldPosition.w, 0.000001);
+                    vec2 groundPosition =
+                        world.xz - cloudShadowProjection * world.y;
+                    vec2 cloudUv =
+                        (groundPosition - cloudShadowBounds.xy) *
+                        cloudShadowBounds.zw;
+                    float inBounds =
+                        step(0.0, cloudUv.x) *
+                        step(0.0, cloudUv.y) *
+                        step(cloudUv.x, 1.0) *
+                        step(cloudUv.y, 1.0);
+                    float cloudMask =
+                        texture(cloudShadowMap, cloudUv).r * inBounds;
+                    float hardMask = smoothstep(0.08, 0.52, cloudMask);
+                    cloudResponse =
+                        mix(cloudMask, hardMask, cloudShadowHardness) *
+                        cloudShadowStrength;
+                }
+
+                vec3 normalizedBase =
+                    baseColor.rgb / max(baseColor.a, 0.000001);
+                float response = clamp(cloudResponse, 0.0, 1.0);
+                vec3 cachedColor = normalizedBase;
+                if (response > 0.000001) {
+                    vec4 shadowColor =
+                        texelFetch(cacheShadowColor, pixel, 0);
+                    vec3 normalizedShadow =
+                        shadowColor.rgb /
+                        max(shadowColor.a, 0.000001);
+                    cachedColor = mix(
+                        normalizedBase,
+                        normalizedShadow,
+                        response
+                    );
+                }
+                float coverage = clamp(baseColor.a, 0.0, 1.0);
+                gl_FragDepth = cachedDepth;
+                gl_FragColor = vec4(cachedColor, coverage);
+            }
+        `,
+        glslVersion: GLSL3,
+        toneMapped: false,
+        uniforms: {
+            cacheBaseColor: { value: baseColorTexture },
+            cacheShadowColor: { value: shadowColorTexture },
+            cacheDepth: { value: depthTexture },
+            cloudShadowBounds: cloudUniforms.bounds,
+            cloudShadowHardness: cloudUniforms.hardness,
+            cloudShadowMap: cloudUniforms.map,
+            cloudShadowProjection: cloudUniforms.projection,
+            cloudShadowStrength: cloudUniforms.strength,
+            inverseViewProjection: { value: inverseViewProjection },
+        },
+        vertexShader: staticOpaqueSceneCacheReplayVertexShader,
+    });
+}
+
+function restoreVisibility(
+    changedVisibility: readonly {
+        object: Object3D;
+        visible: boolean;
+    }[],
+) {
+    for (const { object, visible } of changedVisibility) {
+        object.visible = visible;
+    }
+}
+
+function captureStaticScene({
+    boundaries,
+    camera,
+    gl,
+    scene,
+    target,
+}: {
+    boundaries: readonly StaticOpaqueSceneCacheBoundaryEntry[];
+    camera: Parameters<WebGLRenderer['render']>[1];
+    gl: WebGLRenderer;
+    scene: Scene;
+    target: WebGLRenderTarget;
+}) {
+    const allowed = new Set<Object3D>();
+    for (const boundary of boundaries) {
+        boundary.root.traverse((object) => allowed.add(object));
+    }
+
+    const changedVisibility: { object: Object3D; visible: boolean }[] = [];
+    scene.traverse((object) => {
+        if (isRenderable(object) && !allowed.has(object) && object.visible) {
+            changedVisibility.push({ object, visible: true });
+            object.visible = false;
+        }
+    });
+
+    const previousAutoClear = gl.autoClear;
+    const previousBackground = scene.background;
+    const previousClearAlpha = gl.getClearAlpha();
+    const previousClearColor = gl.getClearColor(new Color());
+    const previousRenderTarget = gl.getRenderTarget();
+    const previousActiveCubeFace = gl.getActiveCubeFace();
+    const previousActiveMipmapLevel = gl.getActiveMipmapLevel();
+
+    try {
+        scene.background = null;
+        gl.autoClear = false;
+        target.viewport.set(0, 0, target.width, target.height);
+        target.scissor.set(0, 0, target.width, target.height);
+        target.scissorTest = false;
+        gl.setRenderTarget(target);
+        gl.setClearColor(0x000000, 0);
+        gl.clear(true, true, false);
+        gl.render(scene, camera);
+
+        const context = gl.getContext();
+        return (
+            context.checkFramebufferStatus(context.FRAMEBUFFER) ===
+            context.FRAMEBUFFER_COMPLETE
+        );
+    } finally {
+        gl.setRenderTarget(
+            previousRenderTarget,
+            previousActiveCubeFace,
+            previousActiveMipmapLevel,
+        );
+        gl.setClearColor(previousClearColor, previousClearAlpha);
+        gl.autoClear = previousAutoClear;
+        scene.background = previousBackground;
+        restoreVisibility(changedVisibility);
+    }
+}
+
+function captureStaticCloudResponse({
+    boundaries,
+    camera,
+    cloudUniforms,
+    fullResponseMask,
+    gl,
+    responseTarget,
+    scene,
+    target,
+}: {
+    boundaries: readonly StaticOpaqueSceneCacheBoundaryEntry[];
+    camera: Parameters<WebGLRenderer['render']>[1];
+    cloudUniforms: CloudShadowMaterialUniforms;
+    fullResponseMask: Texture;
+    gl: WebGLRenderer;
+    responseTarget: WebGLRenderTarget;
+    scene: Scene;
+    target: WebGLRenderTarget;
+}) {
+    const previousMap = cloudUniforms.map.value;
+    const previousStrength = cloudUniforms.strength.value;
+    try {
+        if (previousMap !== null) {
+            cloudUniforms.map.value = fullResponseMask;
+            cloudUniforms.strength.value = 1;
+            const responseCaptured = captureStaticScene({
+                boundaries,
+                camera,
+                gl,
+                scene,
+                target,
+            });
+            if (!responseCaptured) {
+                return {
+                    captured: false,
+                    submissions: 0,
+                    triangles: 0,
+                };
+            }
+
+            gl.initRenderTarget(responseTarget);
+            gl.copyTextureToTexture(target.texture, responseTarget.texture);
+        }
+
+        cloudUniforms.map.value = previousMap;
+        cloudUniforms.strength.value = 0;
+        const submissionsBefore = gl.info.render.calls;
+        const trianglesBefore = gl.info.render.triangles;
+        return {
+            captured: captureStaticScene({
+                boundaries,
+                camera,
+                gl,
+                scene,
+                target,
+            }),
+            submissions: gl.info.render.calls - submissionsBefore,
+            triangles: gl.info.render.triangles - trianglesBefore,
+        };
+    } finally {
+        cloudUniforms.map.value = previousMap;
+        cloudUniforms.strength.value = previousStrength;
+    }
+}
+
+function renderCachedScene({
+    boundaries,
+    camera,
+    gl,
+    replay,
+    scene,
+}: {
+    boundaries: readonly StaticOpaqueSceneCacheBoundaryEntry[];
+    camera: Parameters<WebGLRenderer['render']>[1];
+    gl: WebGLRenderer;
+    replay: StaticOpaqueSceneCacheReplay;
+    scene: Scene;
+}) {
+    const changedVisibility: { object: Object3D; visible: boolean }[] = [];
+    const previousAutoClear = gl.autoClear;
+    try {
+        for (const { root } of boundaries) {
+            if (root.visible) {
+                changedVisibility.push({ object: root, visible: true });
+                root.visible = false;
+            }
+        }
+        scene.add(replay.scene);
+        gl.setRenderTarget(null);
+        gl.autoClear = true;
+        gl.render(scene, camera);
+        return 'ready';
+    } finally {
+        scene.remove(replay.scene);
+        gl.autoClear = previousAutoClear;
+        restoreVisibility(changedVisibility);
+    }
+}
+
+function renderLiveScene({
+    camera,
+    gl,
+    scene,
+}: {
+    camera: Parameters<WebGLRenderer['render']>[1];
+    gl: WebGLRenderer;
+    scene: Scene;
+}) {
+    gl.setRenderTarget(null);
+    gl.render(scene, camera);
+}
+
+function getSignatureChangeReason(
+    previous: readonly string[] | null,
+    current: readonly string[],
+    registryReason: StaticOpaqueSceneCacheReason,
+): StaticOpaqueSceneCacheReason {
+    if (!previous) {
+        return 'boundary-change';
+    }
+    if (previous[0] !== current[0]) {
+        return 'target-resize';
+    }
+    if (previous[1] !== current[1]) {
+        return 'camera-change';
+    }
+    if (previous[2] !== current[2]) {
+        return 'lighting-change';
+    }
+    if (previous[3] !== current[3]) {
+        return registryReason;
+    }
+    return 'boundary-change';
+}
+
+function StaticOpaqueSceneCacheRenderer({
+    enabled,
+    interactionActive,
+    qualityKey,
+    registry,
+    wireframe,
+}: {
+    enabled: boolean;
+    interactionActive: boolean;
+    qualityKey: string;
+    registry: StaticOpaqueSceneCacheRegistry;
+    wireframe: boolean;
+}) {
+    const camera = useThree((state) => state.camera);
+    const gl = useThree((state) => state.gl);
+    const scene = useThree((state) => state.scene);
+    const drawingBufferSize = useMemo(() => new Vector2(), []);
+    const cacheSampleCount = useMemo(() => {
+        const context = gl.getContext();
+        const samples = context.getParameter(context.SAMPLES);
+        return typeof samples === 'number' && samples > 0
+            ? Math.min(samples, gl.capabilities.maxSamples)
+            : 0;
+    }, [gl]);
+    const cacheTarget = useMemo(() => {
+        return createCacheTarget(cacheSampleCount);
+    }, [cacheSampleCount]);
+    const { depthTexture, target } = cacheTarget;
+    const cloudUniforms = useMemo(
+        getCloudShadowAttenuationMaterialUniforms,
+        [],
+    );
+    const cloudFullResponseTarget = useMemo(createCloudResponseTarget, []);
+    const cloudFullResponseMask = useMemo(createCloudResponseMaskTexture, []);
+    const inverseViewProjection = useMemo(() => new Matrix4(), []);
+    const cacheReplayMaterial = useMemo(() => {
+        const material = createCacheReplayMaterial({
+            baseColorTexture: target.texture,
+            cloudUniforms,
+            depthTexture,
+            inverseViewProjection,
+            shadowColorTexture: cloudFullResponseTarget.texture,
+        });
+        material.name = 'StaticOpaqueSceneCache.ColorReplay';
+        return material;
+    }, [
+        cloudFullResponseTarget.texture,
+        cloudUniforms,
+        depthTexture,
+        inverseViewProjection,
+        target.texture,
+    ]);
+    const cacheReplay = useMemo(
+        () =>
+            createStaticOpaqueSceneCacheReplay({
+                material: cacheReplayMaterial,
+            }),
+        [cacheReplayMaterial],
+    );
+    const countersRef = useRef(createCounters());
+    const runtimeRef = useRef<StaticOpaqueSceneCacheRuntime>(
+        createStaticOpaqueSceneCacheRuntime(),
+    );
+    const signaturePartsRef = useRef<readonly string[] | null>(null);
+    const cachePathSupportedRef = useRef(true);
+    const replayStatusRef = useRef('pending');
+    const rainSurfaceIntensity = useOptionalGameState(
+        (state) => state.rainSurfaceIntensity,
+        0,
+    );
+    const snowCoverage = useOptionalGameState((state) => state.snowCoverage, 0);
+    const closeupView = useOptionalGameState(
+        (state) => state.view === 'closeup',
+        false,
+    );
+    const weatherSurfaceActivity = useWeatherSurfaceUniformActivitySnapshot();
+    const registrySnapshot = useSyncExternalStore(
+        registry.subscribe,
+        registry.getSnapshot,
+        registry.getSnapshot,
+    );
+
+    const invalidateForResume = useCallback(() => {
+        registry.invalidate('target-resize');
+    }, [registry]);
+    useSceneResume(invalidateForResume);
+
+    useEffect(() => {
+        const canvas = gl.domElement;
+        const handleContextRestored = () => {
+            cachePathSupportedRef.current = true;
+            registry.invalidate('unsupported');
+        };
+        canvas.addEventListener('webglcontextrestored', handleContextRestored);
+        return () =>
+            canvas.removeEventListener(
+                'webglcontextrestored',
+                handleContextRestored,
+            );
+    }, [gl.domElement, registry]);
+
+    useEffect(
+        () => () => {
+            cloudFullResponseTarget.dispose();
+            cloudFullResponseMask.dispose();
+            cacheReplay.dispose();
+            cacheReplayMaterial.dispose();
+            target.dispose();
+        },
+        [
+            cloudFullResponseTarget,
+            cloudFullResponseMask,
+            cacheReplay,
+            cacheReplayMaterial,
+            target,
+        ],
+    );
+
+    useFrame(() => {
+        gl.getDrawingBufferSize(drawingBufferSize);
+        const targetConfig = resolveStaticOpaqueSceneCacheTarget({
+            additionalBytes: cacheReplay.estimatedBytes,
+            height: drawingBufferSize.y,
+            sampleCount: cacheSampleCount,
+            width: drawingBufferSize.x,
+        });
+        const targetWidth = targetConfig.supported ? targetConfig.width : 1;
+        const targetHeight = targetConfig.supported ? targetConfig.height : 1;
+        if (target.width !== targetWidth || target.height !== targetHeight) {
+            target.setSize(targetWidth, targetHeight);
+        }
+        if (
+            cloudFullResponseTarget.width !== targetWidth ||
+            cloudFullResponseTarget.height !== targetHeight
+        ) {
+            cloudFullResponseTarget.setSize(targetWidth, targetHeight);
+        }
+
+        const boundaries = registrySnapshot.boundaries;
+        const runtimeIneligibleBoundaryCount =
+            countIneligibleStaticOpaqueSceneCacheBoundaries(boundaries);
+        const ineligibleBoundaryCount =
+            registrySnapshot.ineligibleBoundaryCount +
+            runtimeIneligibleBoundaryCount;
+        const boundaryMetrics = {
+            instances: registrySnapshot.instanceCount,
+            meshes: registrySnapshot.meshCount,
+            submissions: registrySnapshot.submissionCount,
+            triangles: registrySnapshot.triangleCount,
+        };
+        const context = gl.getContext();
+        const webGlSupported =
+            gl.capabilities.isWebGL2 &&
+            cacheSampleCount > 0 &&
+            gl.toneMapping === ACESFilmicToneMapping &&
+            gl.outputColorSpace === SRGBColorSpace &&
+            target.texture.colorSpace === SRGBColorSpace &&
+            cloudFullResponseTarget.texture.colorSpace === SRGBColorSpace &&
+            Reflect.get(target, 'isXRRenderTarget') === true &&
+            !context.isContextLost() &&
+            cachePathSupportedRef.current;
+        const supported =
+            targetConfig.supported &&
+            webGlSupported &&
+            boundaries.length > 0 &&
+            runtimeIneligibleBoundaryCount === 0;
+        const weatherActive =
+            rainSurfaceIntensity > 0.001 ||
+            snowCoverage > 0.001 ||
+            weatherSurfaceActivity.rainActive ||
+            weatherSurfaceActivity.rainSettling ||
+            weatherSurfaceActivity.snowActive ||
+            weatherSurfaceActivity.snowSettling;
+        let bypassReason: StaticOpaqueSceneCacheReason | undefined;
+        if (boundaries.length === 0) {
+            bypassReason = 'empty';
+        } else if (wireframe) {
+            bypassReason = 'wireframe';
+        } else if (interactionActive || closeupView) {
+            bypassReason = 'interaction';
+        } else if (weatherActive) {
+            bypassReason = 'weather';
+        } else if (
+            gl.xr.isPresenting ||
+            (gl.shadowMap.enabled && gl.shadowMap.autoUpdate) ||
+            scene.overrideMaterial !== null
+        ) {
+            bypassReason = 'unsupported';
+        } else if (gl.shadowMap.needsUpdate) {
+            bypassReason = 'shadow-update';
+        } else if (!targetConfig.supported) {
+            bypassReason = targetConfig.reason;
+        } else if (!webGlSupported) {
+            bypassReason = 'unsupported';
+        }
+
+        const signatureParts = [
+            [
+                drawingBufferSize.x,
+                drawingBufferSize.y,
+                gl.getPixelRatio(),
+                gl.outputColorSpace,
+                gl.toneMapping,
+                gl.toneMappingExposure,
+                qualityKey,
+                cloudUniforms.map.value?.uuid ?? 'no-cloud-response',
+            ].join(':'),
+            buildCameraSignature(camera),
+            buildLightingSignature(scene),
+            [
+                registrySnapshot.revision,
+                registrySnapshot.boundarySignature,
+            ].join(':'),
+            buildBoundaryRuntimeSignature(
+                boundaries,
+                registrySnapshot.renderables,
+            ),
+        ] as const;
+        const signatureChangeReason = getSignatureChangeReason(
+            signaturePartsRef.current,
+            signatureParts,
+            registrySnapshot.lastInvalidationReason,
+        );
+        signaturePartsRef.current = signatureParts;
+        const signature = signatureParts.join('||');
+        inverseViewProjection.multiplyMatrices(
+            camera.matrixWorld,
+            camera.projectionMatrixInverse,
+        );
+        const transition = transitionStaticOpaqueSceneCache(
+            runtimeRef.current,
+            {
+                bypassReason,
+                enabled,
+                signature,
+                signatureChangeReason,
+                supported,
+            },
+        );
+        runtimeRef.current = transition.runtime;
+        const counters = countersRef.current;
+        if (transition.invalidated) {
+            counters.invalidations += 1;
+            counters.lastInvalidationReason = transition.reason;
+        }
+        const renderLive = () => {
+            counters.liveFrames += 1;
+            if (
+                transition.state === 'bypass' ||
+                transition.state === 'unsupported'
+            ) {
+                counters.bypassFrames += 1;
+            }
+            renderLiveScene({
+                camera,
+                gl,
+                scene,
+            });
+        };
+
+        const previousInfoAutoReset = gl.info.autoReset;
+        gl.info.autoReset = false;
+        gl.info.reset();
+        try {
+            if (transition.action === 'capture') {
+                const capture = captureStaticCloudResponse({
+                    boundaries,
+                    camera,
+                    cloudUniforms,
+                    fullResponseMask: cloudFullResponseMask,
+                    gl,
+                    responseTarget: cloudFullResponseTarget,
+                    scene,
+                    target,
+                });
+                counters.replayEstimatedBytes = cacheReplay.estimatedBytes;
+                counters.replaySubmissions = cacheReplay.submissionCount;
+                counters.replayTriangles = cacheReplay.triangleCount;
+                counters.captureSubmissions = capture.submissions;
+                counters.captureTriangles = capture.triangles;
+                counters.unexpectedStaticSubmissions = Math.max(
+                    0,
+                    counters.captureSubmissions - boundaryMetrics.submissions,
+                );
+                const replayStatus = capture.captured
+                    ? renderCachedScene({
+                          boundaries,
+                          camera,
+                          gl,
+                          replay: cacheReplay,
+                          scene,
+                      })
+                    : 'capture-failed';
+                replayStatusRef.current = replayStatus;
+                if (capture.captured && replayStatus === 'ready') {
+                    counters.captures += 1;
+                    counters.compositePasses += 1;
+                } else {
+                    cachePathSupportedRef.current = false;
+                    runtimeRef.current = createStaticOpaqueSceneCacheRuntime();
+                    renderLive();
+                }
+            } else if (transition.action === 'hit') {
+                counters.hitFrames += 1;
+                counters.compositePasses += 1;
+                counters.savedSubmissions += Math.max(
+                    0,
+                    counters.captureSubmissions - counters.replaySubmissions,
+                );
+                counters.savedTriangles += Math.max(
+                    0,
+                    counters.captureTriangles - counters.replayTriangles,
+                );
+                const replayStatus = renderCachedScene({
+                    boundaries,
+                    camera,
+                    gl,
+                    replay: cacheReplay,
+                    scene,
+                });
+                replayStatusRef.current = replayStatus;
+                if (replayStatus !== 'ready') {
+                    cachePathSupportedRef.current = false;
+                    runtimeRef.current = createStaticOpaqueSceneCacheRuntime();
+                    renderLive();
+                }
+            } else {
+                renderLive();
+            }
+        } finally {
+            gl.info.autoReset = previousInfoAutoReset;
+        }
+
+        updateGameProfileMetadata({
+            staticOpaqueSceneCacheBoundaryCount: boundaries.length,
+            staticOpaqueSceneCacheBypassFrameCount: counters.bypassFrames,
+            staticOpaqueSceneCacheCaptureCount: counters.captures,
+            staticOpaqueSceneCacheCaptureSubmissionCount:
+                counters.captureSubmissions,
+            staticOpaqueSceneCacheCaptureTriangleCount:
+                counters.captureTriangles,
+            staticOpaqueSceneCacheCompositePassCount: counters.compositePasses,
+            staticOpaqueSceneCacheReplayEstimatedBytes:
+                counters.replayEstimatedBytes,
+            staticOpaqueSceneCacheReplayStatus: replayStatusRef.current,
+            staticOpaqueSceneCacheReplaySubmissionCount:
+                counters.replaySubmissions,
+            staticOpaqueSceneCacheReplayTriangleCount: counters.replayTriangles,
+            staticOpaqueSceneCacheEnabled: enabled,
+            staticOpaqueSceneCacheHitFrameCount: counters.hitFrames,
+            staticOpaqueSceneCacheIneligibleBoundaryCount:
+                ineligibleBoundaryCount,
+            staticOpaqueSceneCacheInvalidationCount: counters.invalidations,
+            staticOpaqueSceneCacheLastInvalidationReason:
+                counters.lastInvalidationReason,
+            staticOpaqueSceneCacheLiveFrameCount: counters.liveFrames,
+            staticOpaqueSceneCacheMeshCount: boundaryMetrics.meshes,
+            staticOpaqueSceneCacheReason: capturedStateReason(
+                transition.reason,
+                cachePathSupportedRef.current,
+            ),
+            staticOpaqueSceneCacheSavedSubmissionCount:
+                counters.savedSubmissions,
+            staticOpaqueSceneCacheSavedTriangleCount: counters.savedTriangles,
+            staticOpaqueSceneCacheState: !cachePathSupportedRef.current
+                ? 'unsupported'
+                : transition.action === 'capture'
+                  ? 'capturing'
+                  : transition.state,
+            staticOpaqueSceneCacheSupported:
+                supported && cachePathSupportedRef.current,
+            staticOpaqueSceneCacheTargetEstimatedBytes:
+                targetConfig.estimatedBytes,
+            staticOpaqueSceneCacheTargetHeight: targetConfig.height,
+            staticOpaqueSceneCacheTargetSampleCount: target.samples,
+            staticOpaqueSceneCacheTargetWidth: targetConfig.width,
+            staticOpaqueSceneCacheTriangleCount: boundaryMetrics.triangles,
+            staticOpaqueSceneCacheUnexpectedStaticSubmissionCount:
+                counters.unexpectedStaticSubmissions,
+        });
+    }, 1);
+
+    return null;
+}
+
+function capturedStateReason(
+    reason: StaticOpaqueSceneCacheReason,
+    framebufferSupported: boolean,
+) {
+    return framebufferSupported ? reason : 'unsupported';
+}
+
+export function StaticOpaqueSceneCacheProvider({
+    children,
+    enabled,
+    interactionActive,
+    qualityKey,
+    wireframe,
+}: PropsWithChildren<{
+    enabled: boolean;
+    interactionActive: boolean;
+    qualityKey: string;
+    wireframe: boolean;
+}>) {
+    const invalidate = useThree((state) => state.invalidate);
+    const registry = useMemo(
+        () => new StaticOpaqueSceneCacheRegistry(invalidate),
+        [invalidate],
+    );
+
+    useEffect(() => {
+        if (enabled) {
+            return;
+        }
+        updateGameProfileMetadata({
+            staticOpaqueSceneCacheBoundaryCount: 0,
+            staticOpaqueSceneCacheBypassFrameCount: 0,
+            staticOpaqueSceneCacheCaptureCount: 0,
+            staticOpaqueSceneCacheCaptureSubmissionCount: 0,
+            staticOpaqueSceneCacheCaptureTriangleCount: 0,
+            staticOpaqueSceneCacheCompositePassCount: 0,
+            staticOpaqueSceneCacheReplayEstimatedBytes: 0,
+            staticOpaqueSceneCacheReplayStatus: 'disabled',
+            staticOpaqueSceneCacheReplaySubmissionCount: 0,
+            staticOpaqueSceneCacheReplayTriangleCount: 0,
+            staticOpaqueSceneCacheEnabled: false,
+            staticOpaqueSceneCacheHitFrameCount: 0,
+            staticOpaqueSceneCacheIneligibleBoundaryCount: 0,
+            staticOpaqueSceneCacheInvalidationCount: 0,
+            staticOpaqueSceneCacheLastInvalidationReason: 'disabled',
+            staticOpaqueSceneCacheLiveFrameCount: 0,
+            staticOpaqueSceneCacheMeshCount: 0,
+            staticOpaqueSceneCacheReason: 'disabled',
+            staticOpaqueSceneCacheSavedSubmissionCount: 0,
+            staticOpaqueSceneCacheSavedTriangleCount: 0,
+            staticOpaqueSceneCacheState: 'disabled',
+            staticOpaqueSceneCacheSupported: false,
+            staticOpaqueSceneCacheTargetEstimatedBytes: 0,
+            staticOpaqueSceneCacheTargetHeight: 0,
+            staticOpaqueSceneCacheTargetSampleCount: 0,
+            staticOpaqueSceneCacheTargetWidth: 0,
+            staticOpaqueSceneCacheTriangleCount: 0,
+            staticOpaqueSceneCacheUnexpectedStaticSubmissionCount: 0,
+        });
+    }, [enabled]);
+
+    return (
+        <StaticOpaqueSceneCacheContext.Provider value={registry}>
+            {children}
+            {enabled && (
+                <StaticOpaqueSceneCacheRenderer
+                    enabled
+                    interactionActive={interactionActive}
+                    qualityKey={qualityKey}
+                    registry={registry}
+                    wireframe={wireframe}
+                />
+            )}
+        </StaticOpaqueSceneCacheContext.Provider>
+    );
+}

--- a/packages/game/src/scene/StaticOpaqueSceneCacheOcclusionFixture.tsx
+++ b/packages/game/src/scene/StaticOpaqueSceneCacheOcclusionFixture.tsx
@@ -1,0 +1,438 @@
+'use client';
+
+import { useFrame, useThree } from '@react-three/fiber';
+import { useEffect, useMemo, useRef } from 'react';
+import {
+    type Group,
+    type Mesh,
+    MeshBasicMaterial,
+    OrthographicCamera,
+    PlaneGeometry,
+    Vector3,
+} from 'three';
+import {
+    readGameProfileMetadata,
+    updateGameProfileMetadata,
+} from './gameProfileMetadata';
+import { StaticOpaqueSceneCacheBoundary } from './StaticOpaqueSceneCache';
+
+const backgroundColor = [255, 0, 0] as const;
+const occluderColor = [0, 0, 255] as const;
+const foregroundColor = [0, 255, 0] as const;
+const colorChannelTolerance = 8;
+const minimumMatchRatio = 0.96;
+const maximumLeakRatio = 0.04;
+const probeSize = 5;
+const stableArmingHitCount = 12;
+const settleHitCount = 1;
+const verifiedHitCount = 3;
+
+const anchorNdcX = 0.62;
+const anchorNdcY = 0.65;
+const backgroundProbeNdcX = 0.49;
+const occludedProbeNdcX = 0.57;
+const foregroundProbeNdcX = 0.68;
+const backgroundWidthNdc = 0.32;
+const occluderWidthNdc = 0.2;
+const foregroundWidthNdc = 0.07;
+const fixtureHeightNdc = 0.18;
+const foregroundHeightNdc = 0.12;
+
+type FixtureState = {
+    armingCaptureCount: number | null;
+    armingHitFrameCount: number | null;
+    armingStableHitCount: number;
+    backgroundWitnessMinimumMatchRatio: number;
+    captureCountAtTransition: number | null;
+    foregroundMinimumMatchRatio: number;
+    hitFrameCountAtTransition: number | null;
+    lastObservedHitFrameCount: number | null;
+    occludedBackgroundLeakMaximumRatio: number;
+    occluderMinimumMatchRatio: number;
+    pass: boolean;
+    phase: 'arming' | 'failed' | 'passed' | 'verifying';
+    transitionCount: number;
+    verifiedHitFrameCount: number;
+};
+
+function createFixtureState(): FixtureState {
+    return {
+        armingCaptureCount: null,
+        armingHitFrameCount: null,
+        armingStableHitCount: 0,
+        backgroundWitnessMinimumMatchRatio: 1,
+        captureCountAtTransition: null,
+        foregroundMinimumMatchRatio: 1,
+        hitFrameCountAtTransition: null,
+        lastObservedHitFrameCount: null,
+        occludedBackgroundLeakMaximumRatio: 0,
+        occluderMinimumMatchRatio: 1,
+        pass: false,
+        phase: 'arming',
+        transitionCount: 0,
+        verifiedHitFrameCount: 0,
+    };
+}
+
+function publishFixtureState(state: FixtureState) {
+    updateGameProfileMetadata({
+        staticOpaqueSceneCacheOcclusionBackgroundWitnessMinimumMatchRatio:
+            state.backgroundWitnessMinimumMatchRatio,
+        staticOpaqueSceneCacheOcclusionCaptureCountAtTransition:
+            state.captureCountAtTransition,
+        staticOpaqueSceneCacheOcclusionFixtureEnabled: true,
+        staticOpaqueSceneCacheOcclusionFixturePass: state.pass,
+        staticOpaqueSceneCacheOcclusionFixtureState: state.phase,
+        staticOpaqueSceneCacheOcclusionForegroundMinimumMatchRatio:
+            state.foregroundMinimumMatchRatio,
+        staticOpaqueSceneCacheOcclusionHitFrameCountAtTransition:
+            state.hitFrameCountAtTransition,
+        staticOpaqueSceneCacheOcclusionOccludedBackgroundLeakMaximumRatio:
+            state.occludedBackgroundLeakMaximumRatio,
+        staticOpaqueSceneCacheOcclusionOccluderMinimumMatchRatio:
+            state.occluderMinimumMatchRatio,
+        staticOpaqueSceneCacheOcclusionTransitionCount: state.transitionCount,
+        staticOpaqueSceneCacheOcclusionVerifiedHitFrameCount:
+            state.verifiedHitFrameCount,
+    });
+}
+
+function matchRatio(
+    pixels: Uint8Array,
+    expected: readonly [number, number, number],
+) {
+    let matches = 0;
+    const pixelCount = pixels.length / 4;
+    for (let offset = 0; offset < pixels.length; offset += 4) {
+        const error = Math.max(
+            Math.abs(pixels[offset] - expected[0]),
+            Math.abs(pixels[offset + 1] - expected[1]),
+            Math.abs(pixels[offset + 2] - expected[2]),
+        );
+        if (error <= colorChannelTolerance) {
+            matches += 1;
+        }
+    }
+    return matches / pixelCount;
+}
+
+function readProbe(
+    context: WebGLRenderingContext | WebGL2RenderingContext,
+    ndcX: number,
+    ndcY: number,
+) {
+    const radius = Math.floor(probeSize / 2);
+    const centerX = Math.round(
+        ((ndcX + 1) / 2) * (context.drawingBufferWidth - 1),
+    );
+    const centerY = Math.round(
+        ((ndcY + 1) / 2) * (context.drawingBufferHeight - 1),
+    );
+    const x = Math.max(
+        0,
+        Math.min(context.drawingBufferWidth - probeSize, centerX - radius),
+    );
+    const y = Math.max(
+        0,
+        Math.min(context.drawingBufferHeight - probeSize, centerY - radius),
+    );
+    const pixels = new Uint8Array(probeSize * probeSize * 4);
+    context.readPixels(
+        x,
+        y,
+        probeSize,
+        probeSize,
+        context.RGBA,
+        context.UNSIGNED_BYTE,
+        pixels,
+    );
+    return pixels;
+}
+
+function setTerminalState(state: FixtureState, pass: boolean) {
+    state.pass = pass;
+    state.phase = pass ? 'passed' : 'failed';
+    publishFixtureState(state);
+}
+
+export function StaticOpaqueSceneCacheOcclusionFixture() {
+    const camera = useThree((state) => state.camera);
+    const gl = useThree((state) => state.gl);
+    const invalidate = useThree((state) => state.invalidate);
+    const rootRef = useRef<Group>(null);
+    const dynamicGroupRef = useRef<Group>(null);
+    const backgroundRef = useRef<Mesh>(null);
+    const occluderRef = useRef<Mesh>(null);
+    const foregroundRef = useRef<Mesh>(null);
+    const cameraScaleRef = useRef(new Vector3());
+    const stateRef = useRef(createFixtureState());
+    const geometry = useMemo(() => new PlaneGeometry(1, 1), []);
+    const backgroundMaterial = useMemo(() => {
+        const material = new MeshBasicMaterial({ color: 0xff0000 });
+        material.fog = false;
+        material.toneMapped = false;
+        return material;
+    }, []);
+    const occluderMaterial = useMemo(() => {
+        const material = new MeshBasicMaterial({ color: 0x0000ff });
+        material.fog = false;
+        material.toneMapped = false;
+        return material;
+    }, []);
+    const foregroundMaterial = useMemo(() => {
+        const material = new MeshBasicMaterial({ color: 0x00ff00 });
+        material.fog = false;
+        material.toneMapped = false;
+        return material;
+    }, []);
+
+    useEffect(() => {
+        publishFixtureState(stateRef.current);
+        return () => {
+            geometry.dispose();
+            backgroundMaterial.dispose();
+            occluderMaterial.dispose();
+            foregroundMaterial.dispose();
+            updateGameProfileMetadata({
+                staticOpaqueSceneCacheOcclusionFixtureEnabled: false,
+            });
+        };
+    }, [backgroundMaterial, foregroundMaterial, geometry, occluderMaterial]);
+
+    useFrame(() => {
+        const root = rootRef.current;
+        const dynamicGroup = dynamicGroupRef.current;
+        const background = backgroundRef.current;
+        const occluder = occluderRef.current;
+        const foreground = foregroundRef.current;
+        if (!root || !dynamicGroup || !background || !occluder || !foreground) {
+            return;
+        }
+        if (!(camera instanceof OrthographicCamera)) {
+            setTerminalState(stateRef.current, false);
+            return;
+        }
+
+        camera.updateWorldMatrix(true, false);
+        camera.matrixWorld.decompose(
+            root.position,
+            root.quaternion,
+            cameraScaleRef.current,
+        );
+        root.scale.set(1, 1, 1);
+
+        const halfWidth = (camera.right - camera.left) / (2 * camera.zoom);
+        const halfHeight = (camera.top - camera.bottom) / (2 * camera.zoom);
+        const centerX = (camera.right + camera.left) / 2;
+        const centerY = (camera.top + camera.bottom) / 2;
+        const anchorX = centerX + anchorNdcX * halfWidth;
+        const anchorY = centerY + anchorNdcY * halfHeight;
+        background.position.set(anchorX, anchorY, -30);
+        background.scale.set(
+            backgroundWidthNdc * halfWidth,
+            fixtureHeightNdc * halfHeight,
+            1,
+        );
+        occluder.position.set(anchorX, anchorY, -20);
+        occluder.scale.set(
+            occluderWidthNdc * halfWidth,
+            fixtureHeightNdc * halfHeight,
+            1,
+        );
+        foreground.position.set(
+            centerX + foregroundProbeNdcX * halfWidth,
+            anchorY,
+            -10,
+        );
+        foreground.scale.set(
+            foregroundWidthNdc * halfWidth,
+            foregroundHeightNdc * halfHeight,
+            1,
+        );
+
+        const fixtureState = stateRef.current;
+        dynamicGroup.position.x =
+            fixtureState.phase === 'arming' ? halfWidth * 4 : 0;
+        const profile = readGameProfileMetadata();
+        if (fixtureState.phase !== 'arming') {
+            return;
+        }
+
+        const captureCount = profile?.staticOpaqueSceneCacheCaptureCount;
+        const hitFrameCount = profile?.staticOpaqueSceneCacheHitFrameCount;
+        if (
+            profile?.staticOpaqueSceneCacheSupported !== true ||
+            profile.staticOpaqueSceneCacheState !== 'ready' ||
+            typeof captureCount !== 'number' ||
+            captureCount < 1 ||
+            typeof hitFrameCount !== 'number'
+        ) {
+            fixtureState.armingCaptureCount = null;
+            fixtureState.armingHitFrameCount = null;
+            fixtureState.armingStableHitCount = 0;
+            return;
+        }
+
+        if (fixtureState.armingCaptureCount !== captureCount) {
+            fixtureState.armingCaptureCount = captureCount;
+            fixtureState.armingHitFrameCount = hitFrameCount;
+            fixtureState.armingStableHitCount = 0;
+            return;
+        }
+        if (
+            fixtureState.armingHitFrameCount === null ||
+            hitFrameCount <= fixtureState.armingHitFrameCount
+        ) {
+            return;
+        }
+
+        fixtureState.armingStableHitCount +=
+            hitFrameCount - fixtureState.armingHitFrameCount;
+        fixtureState.armingHitFrameCount = hitFrameCount;
+        if (fixtureState.armingStableHitCount >= stableArmingHitCount) {
+            fixtureState.captureCountAtTransition = captureCount;
+            fixtureState.hitFrameCountAtTransition = hitFrameCount;
+            fixtureState.lastObservedHitFrameCount = hitFrameCount;
+            fixtureState.phase = 'verifying';
+            fixtureState.transitionCount += 1;
+            dynamicGroup.position.x = 0;
+            dynamicGroup.updateWorldMatrix(true, true);
+            publishFixtureState(fixtureState);
+            invalidate();
+        }
+    }, 0.5);
+
+    useFrame(() => {
+        const fixtureState = stateRef.current;
+        if (fixtureState.phase !== 'verifying') {
+            return;
+        }
+
+        const profile = readGameProfileMetadata();
+        const captureCount = profile?.staticOpaqueSceneCacheCaptureCount;
+        const hitFrameCount = profile?.staticOpaqueSceneCacheHitFrameCount;
+        if (
+            profile?.staticOpaqueSceneCacheSupported !== true ||
+            profile.staticOpaqueSceneCacheState !== 'ready' ||
+            typeof captureCount !== 'number' ||
+            captureCount !== fixtureState.captureCountAtTransition
+        ) {
+            setTerminalState(fixtureState, false);
+            return;
+        }
+        if (
+            typeof hitFrameCount !== 'number' ||
+            hitFrameCount <=
+                (fixtureState.lastObservedHitFrameCount ??
+                    Number.NEGATIVE_INFINITY)
+        ) {
+            invalidate();
+            return;
+        }
+
+        fixtureState.lastObservedHitFrameCount = hitFrameCount;
+        const hitsAfterTransition =
+            hitFrameCount - (fixtureState.hitFrameCountAtTransition ?? 0);
+        if (hitsAfterTransition <= settleHitCount) {
+            invalidate();
+            return;
+        }
+
+        if (!gl.capabilities.isWebGL2) {
+            setTerminalState(fixtureState, false);
+            return;
+        }
+        const context = gl.getContext();
+        const backgroundPixels = readProbe(
+            context,
+            backgroundProbeNdcX,
+            anchorNdcY,
+        );
+        const occludedPixels = readProbe(
+            context,
+            occludedProbeNdcX,
+            anchorNdcY,
+        );
+        const foregroundPixels = readProbe(
+            context,
+            foregroundProbeNdcX,
+            anchorNdcY,
+        );
+        fixtureState.backgroundWitnessMinimumMatchRatio = Math.min(
+            fixtureState.backgroundWitnessMinimumMatchRatio,
+            matchRatio(backgroundPixels, backgroundColor),
+        );
+        fixtureState.occluderMinimumMatchRatio = Math.min(
+            fixtureState.occluderMinimumMatchRatio,
+            matchRatio(occludedPixels, occluderColor),
+        );
+        fixtureState.foregroundMinimumMatchRatio = Math.min(
+            fixtureState.foregroundMinimumMatchRatio,
+            matchRatio(foregroundPixels, foregroundColor),
+        );
+        fixtureState.occludedBackgroundLeakMaximumRatio = Math.max(
+            fixtureState.occludedBackgroundLeakMaximumRatio,
+            matchRatio(occludedPixels, backgroundColor),
+        );
+        fixtureState.verifiedHitFrameCount += 1;
+        publishFixtureState(fixtureState);
+
+        if (fixtureState.verifiedHitFrameCount >= verifiedHitCount) {
+            setTerminalState(
+                fixtureState,
+                fixtureState.backgroundWitnessMinimumMatchRatio >=
+                    minimumMatchRatio &&
+                    fixtureState.occluderMinimumMatchRatio >=
+                        minimumMatchRatio &&
+                    fixtureState.foregroundMinimumMatchRatio >=
+                        minimumMatchRatio &&
+                    fixtureState.occludedBackgroundLeakMaximumRatio <=
+                        maximumLeakRatio,
+            );
+            return;
+        }
+        invalidate();
+    }, 2);
+
+    return (
+        <group ref={rootRef} name="ProfileStaticCacheOcclusionFixture">
+            <StaticOpaqueSceneCacheBoundary
+                contentKey="profile-static-cache-occlusion-v1"
+                group="static-props"
+                instanceCount={1}
+                submissionCount={1}
+                triangleCount={2}
+            >
+                <mesh
+                    ref={occluderRef}
+                    frustumCulled={false}
+                    geometry={geometry}
+                    material={occluderMaterial}
+                    name="ProfileStaticCacheOccluder"
+                    raycast={() => null}
+                />
+            </StaticOpaqueSceneCacheBoundary>
+            <group
+                ref={dynamicGroupRef}
+                name="ProfileStaticCacheDynamicObjects"
+            >
+                <mesh
+                    ref={backgroundRef}
+                    frustumCulled={false}
+                    geometry={geometry}
+                    material={backgroundMaterial}
+                    name="ProfileStaticCacheDynamicBackground"
+                    raycast={() => null}
+                />
+                <mesh
+                    ref={foregroundRef}
+                    frustumCulled={false}
+                    geometry={geometry}
+                    material={foregroundMaterial}
+                    name="ProfileStaticCacheDynamicForeground"
+                    raycast={() => null}
+                />
+            </group>
+        </group>
+    );
+}

--- a/packages/game/src/scene/WeatherSurfaceUniformProvider.tsx
+++ b/packages/game/src/scene/WeatherSurfaceUniformProvider.tsx
@@ -17,6 +17,7 @@ import { updateGameProfileMetadata } from './gameProfileMetadata';
 import {
     type RainSurfaceUniformOptions,
     type SnowSurfaceUniformOptions,
+    type WeatherSurfaceUniformActivitySnapshot,
     WeatherSurfaceUniformRegistry,
     type WeatherSurfaceUniformStats,
 } from './weatherSurfaceUniforms';
@@ -264,4 +265,13 @@ export function useRainSurfaceWetnessActive({
 
 export function useRainSurfacePuddleStrengthUniform(): IUniform<number> {
     return useWeatherSurfaceUniformRegistry().rainPuddleStrengthUniform;
+}
+
+export function useWeatherSurfaceUniformActivitySnapshot(): WeatherSurfaceUniformActivitySnapshot {
+    const registry = useWeatherSurfaceUniformRegistry();
+    return useSyncExternalStore(
+        registry.subscribeActivity,
+        registry.getActivitySnapshot,
+        registry.getActivitySnapshot,
+    );
 }

--- a/packages/game/src/scene/cloudDeterministicLayout.ts
+++ b/packages/game/src/scene/cloudDeterministicLayout.ts
@@ -1,0 +1,56 @@
+type DeterministicCloudSpawnInput = {
+    focusX: number;
+    focusZ: number;
+    laneX: number;
+    laneZ: number;
+    seed: number;
+    spawnHalfX: number;
+    spawnHalfZ: number;
+};
+
+function clamp(value: number, minimum: number, maximum: number) {
+    return Math.min(maximum, Math.max(minimum, value));
+}
+
+function lerp(start: number, end: number, amount: number) {
+    return start + (end - start) * amount;
+}
+
+export function seededCloudRandom(seed: number) {
+    const value = Math.sin(seed * 12.9898) * 43758.5453;
+    return value - Math.floor(value);
+}
+
+export function resolveDeterministicCloudSpawn({
+    focusX,
+    focusZ,
+    laneX,
+    laneZ,
+    seed,
+    spawnHalfX,
+    spawnHalfZ,
+}: DeterministicCloudSpawnInput) {
+    const jitterX = lerp(
+        -spawnHalfX * 0.35,
+        spawnHalfX * 0.35,
+        seededCloudRandom(seed + 10),
+    );
+    const jitterZ = lerp(
+        -spawnHalfZ * 0.35,
+        spawnHalfZ * 0.35,
+        seededCloudRandom(seed + 11),
+    );
+
+    return {
+        x: clamp(
+            focusX + laneX * spawnHalfX * 0.65 + jitterX,
+            focusX - spawnHalfX,
+            focusX + spawnHalfX,
+        ),
+        z: clamp(
+            focusZ + laneZ * spawnHalfZ * 0.65 + jitterZ,
+            focusZ - spawnHalfZ,
+            focusZ + spawnHalfZ,
+        ),
+    };
+}

--- a/packages/game/src/scene/cloudDeterministicLayout.unit.ts
+++ b/packages/game/src/scene/cloudDeterministicLayout.unit.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    resolveDeterministicCloudSpawn,
+    seededCloudRandom,
+} from './cloudDeterministicLayout';
+
+describe('seededCloudRandom', () => {
+    it('returns a stable unit interval value for a scene seed', () => {
+        const value = seededCloudRandom(42.5);
+
+        assert.equal(value, seededCloudRandom(42.5));
+        assert.ok(value >= 0);
+        assert.ok(value < 1);
+    });
+});
+
+describe('resolveDeterministicCloudSpawn', () => {
+    const input = {
+        focusX: 4,
+        focusZ: -3,
+        laneX: 0.4,
+        laneZ: -0.2,
+        seed: 18.25,
+        spawnHalfX: 12,
+        spawnHalfZ: 9,
+    };
+
+    it('repeats the exact placement without runtime randomness', () => {
+        assert.deepEqual(
+            resolveDeterministicCloudSpawn(input),
+            resolveDeterministicCloudSpawn(input),
+        );
+    });
+
+    it('keeps seeded jitter inside the camera spawn frame', () => {
+        const placement = resolveDeterministicCloudSpawn(input);
+
+        assert.ok(placement.x >= input.focusX - input.spawnHalfX);
+        assert.ok(placement.x <= input.focusX + input.spawnHalfX);
+        assert.ok(placement.z >= input.focusZ - input.spawnHalfZ);
+        assert.ok(placement.z <= input.focusZ + input.spawnHalfZ);
+    });
+
+    it('produces a distinct layout for a distinct cloud seed', () => {
+        assert.notDeepEqual(
+            resolveDeterministicCloudSpawn(input),
+            resolveDeterministicCloudSpawn({
+                ...input,
+                seed: input.seed + 1,
+            }),
+        );
+    });
+});

--- a/packages/game/src/scene/gameProfileMetadata.ts
+++ b/packages/game/src/scene/gameProfileMetadata.ts
@@ -167,6 +167,20 @@ export type GeneratedPlantProfileSnapshot = {
     sessionId: number;
 };
 
+export type StaticOpaqueSceneCacheState =
+    | 'bypass'
+    | 'capturing'
+    | 'cold'
+    | 'disabled'
+    | 'ready'
+    | 'unsupported';
+
+export type StaticOpaqueSceneCacheOcclusionFixtureState =
+    | 'arming'
+    | 'failed'
+    | 'passed'
+    | 'verifying';
+
 export type GameProfileMetadata = {
     adaptiveHighAmbientFps?: number;
     adaptiveHighCloudUpdateMs?: number;
@@ -336,6 +350,45 @@ export type GameProfileMetadata = {
     snowParticleCapacity?: number;
     snowParticleCount?: number;
     snowParticleGeometryBuildCount?: number;
+    staticOpaqueSceneCacheBoundaryCount?: number;
+    staticOpaqueSceneCacheBypassFrameCount?: number;
+    staticOpaqueSceneCacheCaptureCount?: number;
+    staticOpaqueSceneCacheCaptureSubmissionCount?: number;
+    staticOpaqueSceneCacheCaptureTriangleCount?: number;
+    staticOpaqueSceneCacheCompositePassCount?: number;
+    staticOpaqueSceneCacheReplayEstimatedBytes?: number;
+    staticOpaqueSceneCacheReplayStatus?: string;
+    staticOpaqueSceneCacheReplaySubmissionCount?: number;
+    staticOpaqueSceneCacheReplayTriangleCount?: number;
+    staticOpaqueSceneCacheEnabled?: boolean;
+    staticOpaqueSceneCacheHitFrameCount?: number;
+    staticOpaqueSceneCacheIneligibleBoundaryCount?: number;
+    staticOpaqueSceneCacheInvalidationCount?: number;
+    staticOpaqueSceneCacheLastInvalidationReason?: string;
+    staticOpaqueSceneCacheLiveFrameCount?: number;
+    staticOpaqueSceneCacheMeshCount?: number;
+    staticOpaqueSceneCacheOcclusionBackgroundWitnessMinimumMatchRatio?: number;
+    staticOpaqueSceneCacheOcclusionCaptureCountAtTransition?: number | null;
+    staticOpaqueSceneCacheOcclusionFixtureEnabled?: boolean;
+    staticOpaqueSceneCacheOcclusionFixturePass?: boolean;
+    staticOpaqueSceneCacheOcclusionFixtureState?: StaticOpaqueSceneCacheOcclusionFixtureState;
+    staticOpaqueSceneCacheOcclusionForegroundMinimumMatchRatio?: number;
+    staticOpaqueSceneCacheOcclusionHitFrameCountAtTransition?: number | null;
+    staticOpaqueSceneCacheOcclusionOccludedBackgroundLeakMaximumRatio?: number;
+    staticOpaqueSceneCacheOcclusionOccluderMinimumMatchRatio?: number;
+    staticOpaqueSceneCacheOcclusionTransitionCount?: number;
+    staticOpaqueSceneCacheOcclusionVerifiedHitFrameCount?: number;
+    staticOpaqueSceneCacheReason?: string;
+    staticOpaqueSceneCacheSavedSubmissionCount?: number;
+    staticOpaqueSceneCacheSavedTriangleCount?: number;
+    staticOpaqueSceneCacheState?: StaticOpaqueSceneCacheState;
+    staticOpaqueSceneCacheSupported?: boolean;
+    staticOpaqueSceneCacheTargetEstimatedBytes?: number;
+    staticOpaqueSceneCacheTargetHeight?: number;
+    staticOpaqueSceneCacheTargetSampleCount?: number;
+    staticOpaqueSceneCacheTargetWidth?: number;
+    staticOpaqueSceneCacheTriangleCount?: number;
+    staticOpaqueSceneCacheUnexpectedStaticSubmissionCount?: number;
     weatherDisabled?: boolean;
     weatherSurfaceAvoidedOverlaySubmissionCount?: number;
     weatherSurfaceAvoidedOverlayTriangleCount?: number;

--- a/packages/game/src/scene/staticOpaqueSceneCache.unit.ts
+++ b/packages/game/src/scene/staticOpaqueSceneCache.unit.ts
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    createStaticOpaqueSceneCacheRuntime,
+    estimateStaticOpaqueSceneCacheBytes,
+    isStaticOpaqueSceneCacheMaterialEligible,
+    resolveStaticOpaqueSceneCacheTarget,
+    transitionStaticOpaqueSceneCache,
+} from './staticOpaqueSceneCacheState';
+
+describe('static opaque scene cache material eligibility', () => {
+    const opaqueMaterial = {
+        alphaToCoverage: false,
+        colorWrite: true,
+        depthTest: true,
+        depthWrite: true,
+        opacity: 1,
+        stencilWrite: false,
+        transparent: false,
+    };
+
+    it('accepts only ordinary opaque color and depth writers', () => {
+        assert.equal(
+            isStaticOpaqueSceneCacheMaterialEligible(opaqueMaterial),
+            true,
+        );
+        for (const material of [
+            { ...opaqueMaterial, alphaToCoverage: true },
+            { ...opaqueMaterial, colorWrite: false },
+            { ...opaqueMaterial, depthTest: false },
+            { ...opaqueMaterial, depthWrite: false },
+            { ...opaqueMaterial, opacity: 0.9 },
+            { ...opaqueMaterial, stencilWrite: true },
+            { ...opaqueMaterial, transmission: 0.1 },
+            { ...opaqueMaterial, transparent: true },
+        ]) {
+            assert.equal(
+                isStaticOpaqueSceneCacheMaterialEligible(material),
+                false,
+            );
+        }
+    });
+});
+
+describe('static opaque scene cache target', () => {
+    it('accounts for resolved and four-sample cache attachments', () => {
+        assert.equal(
+            estimateStaticOpaqueSceneCacheBytes(2560, 1440),
+            162_201_600,
+        );
+        assert.deepEqual(
+            resolveStaticOpaqueSceneCacheTarget({
+                height: 1440,
+                sampleCount: 4,
+                width: 2560,
+            }),
+            {
+                estimatedBytes: 162_201_600,
+                height: 1440,
+                reason: 'ready',
+                supported: true,
+                width: 2560,
+            },
+        );
+        assert.equal(
+            resolveStaticOpaqueSceneCacheTarget({
+                height: 1440,
+                sampleCount: 8,
+                width: 2560,
+            }).reason,
+            'target-budget',
+        );
+    });
+
+    it('rejects zero-sized and over-budget targets', () => {
+        assert.equal(
+            resolveStaticOpaqueSceneCacheTarget({
+                height: 0,
+                width: 2560,
+            }).reason,
+            'unsupported',
+        );
+        assert.equal(
+            resolveStaticOpaqueSceneCacheTarget({
+                height: 2160,
+                width: 3840,
+            }).reason,
+            'target-budget',
+        );
+        assert.equal(
+            resolveStaticOpaqueSceneCacheTarget({
+                additionalBytes: 6 * 1024 * 1024,
+                height: 1440,
+                width: 2560,
+            }).reason,
+            'target-budget',
+        );
+    });
+});
+
+describe('static opaque scene cache transitions', () => {
+    const enabledInput = {
+        enabled: true,
+        signature: 'camera-a',
+        signatureChangeReason: 'camera-change' as const,
+        supported: true,
+    };
+
+    it('warms a stable frame before capture and then serves hits', () => {
+        const initial = transitionStaticOpaqueSceneCache(
+            createStaticOpaqueSceneCacheRuntime(),
+            enabledInput,
+        );
+        assert.equal(initial.action, 'live');
+        assert.equal(initial.state, 'cold');
+
+        const warm = transitionStaticOpaqueSceneCache(
+            initial.runtime,
+            enabledInput,
+        );
+        assert.equal(warm.action, 'live');
+
+        const capture = transitionStaticOpaqueSceneCache(
+            warm.runtime,
+            enabledInput,
+        );
+        assert.equal(capture.action, 'capture');
+
+        const hit = transitionStaticOpaqueSceneCache(
+            capture.runtime,
+            enabledInput,
+        );
+        assert.equal(hit.action, 'hit');
+        assert.equal(hit.state, 'ready');
+    });
+
+    it('invalidates on signature changes and bypasses active interaction', () => {
+        const ready = {
+            cacheValid: true,
+            lastSignature: 'camera-a',
+            stableFrameCount: 1,
+        };
+        const changed = transitionStaticOpaqueSceneCache(ready, {
+            ...enabledInput,
+            signature: 'camera-b',
+        });
+        assert.equal(changed.invalidated, true);
+        assert.equal(changed.reason, 'camera-change');
+        assert.equal(changed.action, 'live');
+
+        const interaction = transitionStaticOpaqueSceneCache(ready, {
+            ...enabledInput,
+            bypassReason: 'interaction',
+        });
+        assert.equal(interaction.action, 'live');
+        assert.equal(interaction.state, 'bypass');
+        assert.equal(interaction.runtime.cacheValid, false);
+    });
+
+    it('allows capture immediately after a live shadow refresh', () => {
+        const ready = {
+            cacheValid: true,
+            lastSignature: 'camera-a',
+            stableFrameCount: 1,
+        };
+        const shadow = transitionStaticOpaqueSceneCache(ready, {
+            ...enabledInput,
+            bypassReason: 'shadow-update',
+        });
+        assert.equal(shadow.action, 'live');
+
+        const capture = transitionStaticOpaqueSceneCache(
+            shadow.runtime,
+            enabledInput,
+        );
+        assert.equal(capture.action, 'capture');
+    });
+
+    it('reports disabled and unsupported modes without stale validity', () => {
+        const ready = {
+            cacheValid: true,
+            lastSignature: 'camera-a',
+            stableFrameCount: 1,
+        };
+        assert.equal(
+            transitionStaticOpaqueSceneCache(ready, {
+                ...enabledInput,
+                enabled: false,
+            }).state,
+            'disabled',
+        );
+        assert.equal(
+            transitionStaticOpaqueSceneCache(ready, {
+                ...enabledInput,
+                supported: false,
+            }).state,
+            'unsupported',
+        );
+    });
+});

--- a/packages/game/src/scene/staticOpaqueSceneCacheReplay.ts
+++ b/packages/game/src/scene/staticOpaqueSceneCacheReplay.ts
@@ -1,0 +1,148 @@
+import {
+    BackSide,
+    BufferGeometry,
+    DoubleSide,
+    Float32BufferAttribute,
+    FrontSide,
+    Group,
+    LessEqualDepth,
+    Material,
+    Mesh,
+    NormalBlending,
+    Object3D,
+    type Side,
+} from 'three';
+import { hasStaticGroundPatchMaterialShaderHooks } from '../entities/helpers/groundPatchMaterial';
+import { getMaterialShaderHooksWithoutCloudShadowAttenuation } from './cloudShadowAttenuation';
+
+export type StaticOpaqueSceneCacheReplay = {
+    dispose: () => void;
+    estimatedBytes: number;
+    scene: Group;
+    submissionCount: number;
+    triangleCount: number;
+};
+
+function getMaterials(object: Object3D) {
+    const material = Reflect.get(object, 'material');
+    if (Array.isArray(material)) {
+        return material.filter(
+            (entry): entry is Material =>
+                typeof entry === 'object' &&
+                entry !== null &&
+                Reflect.get(entry, 'isMaterial') === true,
+        );
+    }
+
+    return typeof material === 'object' &&
+        material !== null &&
+        Reflect.get(material, 'isMaterial') === true
+        ? [material]
+        : [];
+}
+
+function isSupportedSide(side: number): side is Side {
+    return side === FrontSide || side === BackSide || side === DoubleSide;
+}
+
+// Ground patches only derive deterministic color from world position; they do
+// not move or discard geometry. Match their exact registered callback
+// identities so unrelated custom shaders still fail closed.
+function hasCacheStableShaderHooks(material: Material) {
+    const hooks = getMaterialShaderHooksWithoutCloudShadowAttenuation(material);
+    return (
+        (hooks.onBeforeCompile === Material.prototype.onBeforeCompile &&
+            hooks.customProgramCacheKey ===
+                Material.prototype.customProgramCacheKey) ||
+        hasStaticGroundPatchMaterialShaderHooks(hooks)
+    );
+}
+
+function isReplayMaterialEligible(material: Material) {
+    const clippingPlanes = material.clippingPlanes;
+    const supportedBuiltInMaterial =
+        Reflect.get(material, 'isMeshBasicMaterial') === true ||
+        Reflect.get(material, 'isMeshLambertMaterial') === true ||
+        Reflect.get(material, 'isMeshPhongMaterial') === true ||
+        Reflect.get(material, 'isMeshStandardMaterial') === true ||
+        Reflect.get(material, 'isMeshToonMaterial') === true;
+
+    return (
+        supportedBuiltInMaterial &&
+        material.alphaTest <= 0 &&
+        !Reflect.get(material, 'alphaHash') &&
+        material.blending === NormalBlending &&
+        (clippingPlanes === null || clippingPlanes.length === 0) &&
+        material.depthFunc === LessEqualDepth &&
+        !material.polygonOffset &&
+        !Reflect.get(material, 'displacementMap') &&
+        Reflect.get(material, 'wireframe') !== true &&
+        isSupportedSide(material.side) &&
+        hasCacheStableShaderHooks(material)
+    );
+}
+
+export function isStaticOpaqueSceneCacheReplayEligible(object: Object3D) {
+    if (
+        Reflect.get(object, 'isMesh') !== true ||
+        Reflect.get(object, 'isBatchedMesh') === true ||
+        Reflect.get(object, 'isSkinnedMesh') === true ||
+        Array.isArray(Reflect.get(object, 'morphTargetInfluences')) ||
+        object.onBeforeRender !== Object3D.prototype.onBeforeRender
+    ) {
+        return false;
+    }
+
+    const geometry = Reflect.get(object, 'geometry');
+    const position =
+        geometry instanceof BufferGeometry
+            ? geometry.getAttribute('position')
+            : undefined;
+    const materials = getMaterials(object);
+    return Boolean(
+        position &&
+            position.itemSize >= 3 &&
+            materials.length > 0 &&
+            materials.every(isReplayMaterialEligible),
+    );
+}
+
+export const staticOpaqueSceneCacheReplayVertexShader = `
+    void main() {
+        gl_Position = vec4(position.xy, 0.0, 1.0);
+    }
+`;
+
+export function createStaticOpaqueSceneCacheReplay({
+    material,
+}: {
+    material: Material;
+}): StaticOpaqueSceneCacheReplay {
+    const geometry = new BufferGeometry();
+    geometry.setAttribute(
+        'position',
+        new Float32BufferAttribute([-1, 3, 0, -1, -1, 0, 3, -1, 0], 3),
+    );
+
+    const scene = new Group();
+    scene.name = 'StaticOpaqueSceneCache.ReplayRoot';
+    const mesh = new Mesh(geometry, material);
+    mesh.frustumCulled = false;
+    mesh.name = 'StaticOpaqueSceneCache.Replay';
+    // SkyGradientBackground renders at -1000. Replay immediately after it so
+    // the sky cannot erase cached color, but before ordinary scene geometry.
+    mesh.renderOrder = -999;
+    scene.add(mesh);
+    scene.updateMatrixWorld(true);
+
+    return {
+        dispose: () => {
+            geometry.dispose();
+            scene.clear();
+        },
+        estimatedBytes: 9 * Float32Array.BYTES_PER_ELEMENT,
+        scene,
+        submissionCount: 1,
+        triangleCount: 1,
+    };
+}

--- a/packages/game/src/scene/staticOpaqueSceneCacheReplay.unit.ts
+++ b/packages/game/src/scene/staticOpaqueSceneCacheReplay.unit.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    BufferGeometry,
+    Float32BufferAttribute,
+    Mesh,
+    MeshBasicMaterial,
+    MeshStandardMaterial,
+    ShaderMaterial,
+    Vector2,
+    Vector4,
+} from 'three';
+import { applyGroundPatchMaterial } from '../entities/helpers/groundPatchMaterial';
+import { retainCloudShadowAttenuationMaterial } from './cloudShadowAttenuation';
+import {
+    createStaticOpaqueSceneCacheReplay,
+    isStaticOpaqueSceneCacheReplayEligible,
+} from './staticOpaqueSceneCacheReplay';
+
+function createTriangleGeometry() {
+    const geometry = new BufferGeometry();
+    geometry.setAttribute(
+        'position',
+        new Float32BufferAttribute([0, 0, 0, 1, 0, 0, 0, 1, 0], 3),
+    );
+    return geometry;
+}
+
+describe('static opaque scene cache replay', () => {
+    it('replays the cached color and depth with one fullscreen triangle', () => {
+        const material = new ShaderMaterial();
+        const replay = createStaticOpaqueSceneCacheReplay({ material });
+        const mesh = replay.scene.children[0];
+        const position = Reflect.get(mesh, 'geometry')?.getAttribute(
+            'position',
+        );
+
+        assert.equal(replay.estimatedBytes, 36);
+        assert.equal(replay.submissionCount, 1);
+        assert.equal(replay.triangleCount, 1);
+        assert.equal(mesh?.frustumCulled, false);
+        assert.equal(mesh?.renderOrder, -999);
+        assert.deepEqual(
+            Array.from(position.array),
+            [-1, 3, 0, -1, -1, 0, 3, -1, 0],
+        );
+
+        replay.dispose();
+        assert.equal(replay.scene.children.length, 0);
+        material.dispose();
+    });
+
+    it('accepts stable built-in opaque meshes', () => {
+        const geometry = createTriangleGeometry();
+        const material = new MeshBasicMaterial();
+        const mesh = new Mesh(geometry, material);
+
+        assert.equal(isStaticOpaqueSceneCacheReplayEligible(mesh), true);
+
+        geometry.dispose();
+        material.dispose();
+    });
+
+    it('accepts the known static ground-patch shader without accepting arbitrary hooks', () => {
+        const geometry = createTriangleGeometry();
+        const material = applyGroundPatchMaterial(
+            new MeshStandardMaterial(),
+            'grass',
+            {},
+        );
+        const mesh = new Mesh(geometry, material);
+
+        assert.equal(isStaticOpaqueSceneCacheReplayEligible(mesh), true);
+        const cloudLease = retainCloudShadowAttenuationMaterial(material, {
+            bounds: { value: new Vector4(-10, -10, 0.05, 0.05) },
+            hardness: { value: 0 },
+            map: { value: null },
+            projection: { value: new Vector2(0.5, -0.25) },
+            strength: { value: 0.8 },
+        });
+        assert.equal(isStaticOpaqueSceneCacheReplayEligible(mesh), true);
+        cloudLease.release();
+
+        const otherGroundPatchMaterial = applyGroundPatchMaterial(
+            new MeshStandardMaterial(),
+            'sand',
+            {},
+        );
+        material.customProgramCacheKey =
+            otherGroundPatchMaterial.customProgramCacheKey;
+        assert.equal(isStaticOpaqueSceneCacheReplayEligible(mesh), false);
+
+        material.onBeforeCompile = () => {};
+        assert.equal(isStaticOpaqueSceneCacheReplayEligible(mesh), false);
+
+        geometry.dispose();
+        material.dispose();
+        otherGroundPatchMaterial.dispose();
+    });
+
+    it('fails closed for silhouettes that need uncached shader behavior', () => {
+        const geometry = createTriangleGeometry();
+        const material = new MeshBasicMaterial({ alphaTest: 0.1 });
+        const mesh = new Mesh(geometry, material);
+
+        assert.equal(isStaticOpaqueSceneCacheReplayEligible(mesh), false);
+
+        geometry.dispose();
+        material.dispose();
+    });
+});

--- a/packages/game/src/scene/staticOpaqueSceneCacheState.ts
+++ b/packages/game/src/scene/staticOpaqueSceneCacheState.ts
@@ -1,0 +1,248 @@
+export const staticOpaqueSceneCacheMaximumBytes = 160 * 1024 * 1024;
+export const staticOpaqueSceneCacheRequiredStableFrames = 1;
+// RGBA8 cloud-response endpoint plus resolved RGBA8/D24 cache attachments.
+const staticOpaqueSceneCacheResolvedBytesPerPixel = 12;
+const staticOpaqueSceneCacheMultisampleBytesPerPixel = 8;
+
+type StaticOpaqueSceneCacheMaterialCandidate = {
+    alphaToCoverage: boolean;
+    colorWrite: boolean;
+    depthTest: boolean;
+    depthWrite: boolean;
+    opacity: number;
+    stencilWrite: boolean;
+    transmission?: number;
+    transparent: boolean;
+};
+
+export function isStaticOpaqueSceneCacheMaterialEligible(
+    material: StaticOpaqueSceneCacheMaterialCandidate,
+) {
+    return (
+        !material.transparent &&
+        material.opacity >= 1 &&
+        material.colorWrite &&
+        material.depthTest &&
+        material.depthWrite &&
+        !material.stencilWrite &&
+        !material.alphaToCoverage &&
+        (typeof material.transmission !== 'number' ||
+            material.transmission <= 0)
+    );
+}
+
+export type StaticOpaqueSceneCacheState =
+    | 'bypass'
+    | 'capturing'
+    | 'cold'
+    | 'disabled'
+    | 'ready'
+    | 'unsupported';
+
+export type StaticOpaqueSceneCacheReason =
+    | 'boundary-change'
+    | 'camera-change'
+    | 'disabled'
+    | 'empty'
+    | 'interaction'
+    | 'lighting-change'
+    | 'ready'
+    | 'shadow-update'
+    | 'target-budget'
+    | 'target-resize'
+    | 'unsupported'
+    | 'weather'
+    | 'wireframe';
+
+export type StaticOpaqueSceneCacheAction =
+    | 'capture'
+    | 'hit'
+    | 'live'
+    | 'unsupported';
+
+export type StaticOpaqueSceneCacheRuntime = {
+    cacheValid: boolean;
+    lastSignature: string | null;
+    stableFrameCount: number;
+};
+
+export type StaticOpaqueSceneCacheTransitionInput = {
+    bypassReason?: StaticOpaqueSceneCacheReason;
+    enabled: boolean;
+    signature: string;
+    signatureChangeReason: StaticOpaqueSceneCacheReason;
+    supported: boolean;
+};
+
+export type StaticOpaqueSceneCacheTransition = {
+    action: StaticOpaqueSceneCacheAction;
+    invalidated: boolean;
+    reason: StaticOpaqueSceneCacheReason;
+    runtime: StaticOpaqueSceneCacheRuntime;
+    state: StaticOpaqueSceneCacheState;
+};
+
+export function createStaticOpaqueSceneCacheRuntime(): StaticOpaqueSceneCacheRuntime {
+    return {
+        cacheValid: false,
+        lastSignature: null,
+        stableFrameCount: 0,
+    };
+}
+
+export function estimateStaticOpaqueSceneCacheBytes(
+    width: number,
+    height: number,
+    sampleCount = 4,
+) {
+    const safeWidth = Number.isFinite(width)
+        ? Math.max(0, Math.floor(width))
+        : 0;
+    const safeHeight = Number.isFinite(height)
+        ? Math.max(0, Math.floor(height))
+        : 0;
+    const safeSampleCount = Number.isFinite(sampleCount)
+        ? Math.max(0, Math.floor(sampleCount))
+        : 0;
+
+    return (
+        safeWidth *
+        safeHeight *
+        (staticOpaqueSceneCacheResolvedBytesPerPixel +
+            safeSampleCount * staticOpaqueSceneCacheMultisampleBytesPerPixel)
+    );
+}
+
+export function resolveStaticOpaqueSceneCacheTarget({
+    additionalBytes = 0,
+    height,
+    maximumBytes = staticOpaqueSceneCacheMaximumBytes,
+    sampleCount = 4,
+    width,
+}: {
+    additionalBytes?: number;
+    height: number;
+    maximumBytes?: number;
+    sampleCount?: number;
+    width: number;
+}) {
+    const safeAdditionalBytes = Number.isFinite(additionalBytes)
+        ? Math.max(0, Math.floor(additionalBytes))
+        : 0;
+    const estimatedBytes =
+        estimateStaticOpaqueSceneCacheBytes(width, height, sampleCount) +
+        safeAdditionalBytes;
+    const validSize =
+        Number.isFinite(width) &&
+        Number.isFinite(height) &&
+        width > 0 &&
+        height > 0;
+    const withinBudget =
+        validSize &&
+        Number.isFinite(maximumBytes) &&
+        maximumBytes > 0 &&
+        estimatedBytes <= maximumBytes;
+
+    return {
+        estimatedBytes,
+        height: validSize ? Math.floor(height) : 0,
+        reason: validSize
+            ? withinBudget
+                ? ('ready' as const)
+                : ('target-budget' as const)
+            : ('unsupported' as const),
+        supported: withinBudget,
+        width: validSize ? Math.floor(width) : 0,
+    };
+}
+
+export function transitionStaticOpaqueSceneCache(
+    runtime: StaticOpaqueSceneCacheRuntime,
+    input: StaticOpaqueSceneCacheTransitionInput,
+): StaticOpaqueSceneCacheTransition {
+    if (!input.enabled) {
+        return {
+            action: 'live',
+            invalidated: runtime.cacheValid,
+            reason: 'disabled',
+            runtime: createStaticOpaqueSceneCacheRuntime(),
+            state: 'disabled',
+        };
+    }
+
+    if (!input.supported) {
+        return {
+            action: 'unsupported',
+            invalidated: runtime.cacheValid,
+            reason: input.bypassReason ?? 'unsupported',
+            runtime: createStaticOpaqueSceneCacheRuntime(),
+            state: 'unsupported',
+        };
+    }
+
+    if (input.bypassReason) {
+        return {
+            action: 'live',
+            invalidated: runtime.cacheValid,
+            reason: input.bypassReason,
+            runtime: {
+                cacheValid: false,
+                lastSignature: input.signature,
+                stableFrameCount:
+                    input.bypassReason === 'shadow-update' ? 1 : 0,
+            },
+            state: 'bypass',
+        };
+    }
+
+    if (runtime.lastSignature !== input.signature) {
+        return {
+            action: 'live',
+            invalidated: runtime.cacheValid || runtime.lastSignature !== null,
+            reason: input.signatureChangeReason,
+            runtime: {
+                cacheValid: false,
+                lastSignature: input.signature,
+                stableFrameCount: 0,
+            },
+            state: 'cold',
+        };
+    }
+
+    if (!runtime.cacheValid) {
+        if (
+            runtime.stableFrameCount <
+            staticOpaqueSceneCacheRequiredStableFrames
+        ) {
+            return {
+                action: 'live',
+                invalidated: false,
+                reason: input.signatureChangeReason,
+                runtime: {
+                    ...runtime,
+                    stableFrameCount: runtime.stableFrameCount + 1,
+                },
+                state: 'cold',
+            };
+        }
+
+        return {
+            action: 'capture',
+            invalidated: false,
+            reason: 'ready',
+            runtime: {
+                ...runtime,
+                cacheValid: true,
+            },
+            state: 'capturing',
+        };
+    }
+
+    return {
+        action: 'hit',
+        invalidated: false,
+        reason: 'ready',
+        runtime,
+        state: 'ready',
+    };
+}

--- a/packages/game/src/scene/weatherSurfaceUniforms.ts
+++ b/packages/game/src/scene/weatherSurfaceUniforms.ts
@@ -21,6 +21,15 @@ export type WeatherSurfaceUniformStats = {
     snowIntegrationTransitionCount: number;
 };
 
+export type WeatherSurfaceUniformActivitySnapshot = {
+    rainActive: boolean;
+    rainDrying: boolean;
+    rainSettling: boolean;
+    snowActive: boolean;
+    snowMelting: boolean;
+    snowSettling: boolean;
+};
+
 export type SnowSurfaceUniformEntry = SnowSurfaceUniformOptions & {
     consumerCount: number;
     key: string;
@@ -62,6 +71,16 @@ type RainActivityTracker = BooleanTransitionTracker<RainSurfaceUniformEntry> & {
 const snowDampingSpeed = 6;
 const integratedSnowMinimumFragmentCoverage = 0.1;
 const integratedSnowActivationSafetyMargin = 0.02;
+const weatherSurfaceUniformVisualThreshold = 0.001;
+const inactiveWeatherSurfaceUniformActivitySnapshot: WeatherSurfaceUniformActivitySnapshot =
+    {
+        rainActive: false,
+        rainDrying: false,
+        rainSettling: false,
+        snowActive: false,
+        snowMelting: false,
+        snowSettling: false,
+    };
 
 function clampUnit(value: number) {
     return Math.min(1, Math.max(0, value));
@@ -143,6 +162,9 @@ export function resolveRainPuddleStrength(rainAmount: number) {
 export class WeatherSurfaceUniformRegistry {
     readonly rainPuddleStrengthUniform: IUniform<number> = { value: 0 };
 
+    private readonly activityListeners = new Set<() => void>();
+    private activitySnapshot = inactiveWeatherSurfaceUniformActivitySnapshot;
+    private rainAmount = 0;
     private readonly rainActivityTrackers = new Map<
         string,
         RainActivityTracker
@@ -153,6 +175,7 @@ export class WeatherSurfaceUniformRegistry {
         SnowIntegrationTracker
     >();
     private readonly snowEntries = new Map<string, SnowSurfaceUniformEntry>();
+    private snowCoverage = 0;
     private snowIntegrationTransitionCount = 0;
 
     constructor(
@@ -203,6 +226,7 @@ export class WeatherSurfaceUniformRegistry {
             this.refreshTransitionTrackers(entry);
         }
         entry.consumerCount += 1;
+        this.refreshActivitySnapshot();
         this.publishStats();
 
         let retained = true;
@@ -213,11 +237,14 @@ export class WeatherSurfaceUniformRegistry {
 
             retained = false;
             entry.consumerCount = Math.max(0, entry.consumerCount - 1);
+            this.refreshActivitySnapshot();
             this.publishStats();
         };
     }
 
     advance(values: WeatherSurfaceValues, delta: number) {
+        this.rainAmount = values.rainAmount;
+        this.snowCoverage = values.snowCoverage;
         this.rainPuddleStrengthUniform.value = resolveRainPuddleStrength(
             values.rainAmount,
         );
@@ -252,7 +279,18 @@ export class WeatherSurfaceUniformRegistry {
             );
             this.refreshRainActivityTrackers(entry);
         }
+
+        this.refreshActivitySnapshot();
     }
+
+    getActivitySnapshot = () => this.activitySnapshot;
+
+    subscribeActivity = (listener: () => void) => {
+        this.activityListeners.add(listener);
+        return () => {
+            this.activityListeners.delete(listener);
+        };
+    };
 
     getSnowIntegrationReady(
         entry: SnowSurfaceUniformEntry,
@@ -476,6 +514,71 @@ export class WeatherSurfaceUniformRegistry {
             for (const listener of tracker.listeners) {
                 listener();
             }
+        }
+    }
+
+    private refreshActivitySnapshot() {
+        let rainActive = false;
+        let rainDrying = false;
+        let rainSettling = false;
+        let snowActive = false;
+        let snowMelting = false;
+        let snowSettling = false;
+
+        for (const entry of this.rainEntries.values()) {
+            if (entry.consumerCount === 0) {
+                continue;
+            }
+
+            const target = resolveRainSurfaceTarget(this.rainAmount, entry);
+            const active =
+                entry.uniform.value > weatherSurfaceUniformVisualThreshold;
+            rainActive ||= active;
+            rainDrying ||=
+                active && target <= weatherSurfaceUniformVisualThreshold;
+            rainSettling ||=
+                Math.abs(entry.uniform.value - target) >
+                weatherSurfaceUniformVisualThreshold;
+        }
+
+        for (const entry of this.snowEntries.values()) {
+            if (entry.consumerCount === 0) {
+                continue;
+            }
+
+            const target = resolveSnowSurfaceTarget(this.snowCoverage, entry);
+            const active =
+                entry.uniform.value > weatherSurfaceUniformVisualThreshold;
+            snowActive ||= active;
+            snowMelting ||=
+                active && target <= weatherSurfaceUniformVisualThreshold;
+            snowSettling ||=
+                Math.abs(entry.uniform.value - target) >
+                weatherSurfaceUniformVisualThreshold;
+        }
+
+        const previous = this.activitySnapshot;
+        if (
+            previous.rainActive === rainActive &&
+            previous.rainDrying === rainDrying &&
+            previous.rainSettling === rainSettling &&
+            previous.snowActive === snowActive &&
+            previous.snowMelting === snowMelting &&
+            previous.snowSettling === snowSettling
+        ) {
+            return;
+        }
+
+        this.activitySnapshot = {
+            rainActive,
+            rainDrying,
+            rainSettling,
+            snowActive,
+            snowMelting,
+            snowSettling,
+        };
+        for (const listener of this.activityListeners) {
+            listener();
         }
     }
 }

--- a/packages/game/src/scene/weatherSurfaceUniforms.unit.ts
+++ b/packages/game/src/scene/weatherSurfaceUniforms.unit.ts
@@ -365,4 +365,118 @@ describe('WeatherSurfaceUniformRegistry', () => {
 
         unsubscribe();
     });
+
+    it('reports retained rain as drying until its rendered wetness is inactive', () => {
+        const registry = new WeatherSurfaceUniformRegistry();
+        const entry = registry.getRainEntry({
+            drySpeed: 1.8,
+            intensityMultiplier: 1,
+            wetSpeed: 5,
+        });
+        registry.retain(entry);
+        let notificationCount = 0;
+        registry.subscribeActivity(() => {
+            notificationCount += 1;
+        });
+
+        registry.advance({ rainAmount: 1, snowCoverage: 0 }, 10);
+        assert.deepEqual(registry.getActivitySnapshot(), {
+            rainActive: true,
+            rainDrying: false,
+            rainSettling: false,
+            snowActive: false,
+            snowMelting: false,
+            snowSettling: false,
+        });
+
+        registry.advance({ rainAmount: 0, snowCoverage: 0 }, 0.1);
+        const dryingSnapshot = registry.getActivitySnapshot();
+        assert.deepEqual(dryingSnapshot, {
+            rainActive: true,
+            rainDrying: true,
+            rainSettling: true,
+            snowActive: false,
+            snowMelting: false,
+            snowSettling: false,
+        });
+        assert.equal(notificationCount, 2);
+
+        registry.advance({ rainAmount: 0, snowCoverage: 0 }, 0.1);
+        assert.equal(
+            registry.getActivitySnapshot(),
+            dryingSnapshot,
+            'unchanged aggregate activity keeps a stable snapshot',
+        );
+        assert.equal(notificationCount, 2);
+
+        registry.advance({ rainAmount: 0, snowCoverage: 0 }, 10);
+        assert.deepEqual(registry.getActivitySnapshot(), {
+            rainActive: false,
+            rainDrying: false,
+            rainSettling: false,
+            snowActive: false,
+            snowMelting: false,
+            snowSettling: false,
+        });
+        assert.equal(notificationCount, 3);
+    });
+
+    it('reports retained snow as melting until its rendered coverage is inactive', () => {
+        const registry = new WeatherSurfaceUniformRegistry();
+        const entry = registry.getSnowEntry({
+            coverageMultiplier: 1,
+            overrideSnow: undefined,
+        });
+        registry.retain(entry);
+
+        registry.advance({ rainAmount: 0, snowCoverage: 1 }, 10);
+        assert.deepEqual(registry.getActivitySnapshot(), {
+            rainActive: false,
+            rainDrying: false,
+            rainSettling: false,
+            snowActive: true,
+            snowMelting: false,
+            snowSettling: false,
+        });
+
+        registry.advance({ rainAmount: 0, snowCoverage: 0 }, 0.1);
+        assert.deepEqual(registry.getActivitySnapshot(), {
+            rainActive: false,
+            rainDrying: false,
+            rainSettling: false,
+            snowActive: true,
+            snowMelting: true,
+            snowSettling: true,
+        });
+
+        registry.advance({ rainAmount: 0, snowCoverage: 0 }, 10);
+        assert.deepEqual(registry.getActivitySnapshot(), {
+            rainActive: false,
+            rainDrying: false,
+            rainSettling: false,
+            snowActive: false,
+            snowMelting: false,
+            snowSettling: false,
+        });
+    });
+
+    it('does not classify a retained snow override as game-weather melting', () => {
+        const registry = new WeatherSurfaceUniformRegistry();
+        const entry = registry.getSnowEntry({
+            coverageMultiplier: 1,
+            overrideSnow: 0.4,
+        });
+        registry.retain(entry);
+
+        registry.advance({ rainAmount: 0, snowCoverage: 0 }, 10);
+
+        assert.deepEqual(registry.getActivitySnapshot(), {
+            rainActive: false,
+            rainDrying: false,
+            rainSettling: false,
+            snowActive: true,
+            snowMelting: false,
+            snowSettling: false,
+        });
+    });
 });


### PR DESCRIPTION
## Summary

- cache stable opaque garden color and depth at High quality, then replay it with one fullscreen triangle while dynamic actors, plants, atmosphere, precipitation, and controls remain live
- preserve depth occlusion and cloud attenuation through cached depth reconstruction and deterministic cloud endpoints
- fail closed for unsupported geometry, materials, interaction, camera, lighting, weather-surface, shadow, and layout states
- add explicit cache telemetry, strict five-pair ABBA profiler gates, screenshot parity checks, and a semantic occlusion fixture

## Representative benchmark

Production build, 2560x1440 canvas, DPR 2, High target fixture, five legacy/cache ABBA pairs:

| Condition | GPU p95 | Draws/render | Triangles/render | CPU p95 |
| --- | ---: | ---: | ---: | ---: |
| Clear | 17.95 -> 6.65 ms (-63.0%) | 196 -> 143 (-27.0%) | 25,046 -> 11,397 (-54.5%) | 26.9 -> 26.5 ms (-1.5%) |
| Cloudy | 18.01 -> 10.61 ms (-41.1%) | 185 -> 132 (-28.6%) | 23,474 -> 9,825 (-58.1%) | 26.8 -> 26.1 ms (-2.6%) |

- paired GPU median/max ratios: clear 0.3856/0.3873; cloudy 0.5435/0.6285
- cache hit ratio: 100%; cached static work: 54 submissions / 13,650 triangles -> 1 submission / 1 triangle
- visual parity: maximum mismatched-pixel ratio 0.2334% clear and 0.3256% cloudy; maximum p99 byte error 0 clear and 1 cloudy
- semantic depth fixture: background, cached occluder, and live foreground all visible; zero leaked occluded-background pixels
- cache memory: 154.69 MiB at QHD DPR 2 with 4x MSAA, under the 160 MiB gate
- all aggregate and per-run diagnostic gates passed

## Validation

- `pnpm --filter @gredice/game test` — 765/765 passed
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden test:profile` — 72/72 passed
- `pnpm --filter garden typecheck`
- `pnpm --filter garden build`
- `git diff --check`
- two independent read-only correctness/performance reviews: no blockers

No schema changes, migrations, generated assets, or environment changes.

Closes #4326
