### PR TITLE
Fix animal water movement and collision pathing

### DIFF
--- a/packages/game/src/entities/animals/animalMovementTerrain.ts
+++ b/packages/game/src/entities/animals/animalMovementTerrain.ts
@@ -1,0 +1,185 @@
+import type { BlockData } from '@gredice/client';
+import type { Stack } from '../../types/Stack';
+import { getStackHeight } from '../../utils/getStackHeight';
+import { getWaterBlockColumnSurfaceY } from '../waterBlockDepth';
+import { waterBlockName } from '../waterBlockFoam';
+
+export type AnimalMovementCell = {
+    x: number;
+    z: number;
+};
+
+export type AnimalMovementSurface = AnimalMovementCell & {
+    kind: 'ground' | 'water';
+    y: number;
+};
+
+const movementSurfaceHalfSize = 0.5;
+const movementSurfaceEpsilon = 0.001;
+
+const groundBlockNames = new Set([
+    'Block_Ground',
+    'Block_Ground_Angle',
+    'Block_Ground_Corner',
+    'Block_Ground_Reverse_Corner',
+    'Block_Grass',
+    'Block_Grass_Angle',
+    'Block_Grass_Corner',
+    'Block_Grass_Reverse_Corner',
+    'Block_Sand',
+    'Block_Sand_Angle',
+    'Block_Sand_Corner',
+    'Block_Sand_Reverse_Corner',
+    'Block_Snow',
+    'Block_Snow_Angle',
+    'Block_Snow_Corner',
+    'Block_Snow_Reverse_Corner',
+    'Block_Snow_Falling',
+]);
+
+export function isAnimalGroundBlockName(name: string) {
+    return groundBlockNames.has(name);
+}
+
+export function isAnimalWaterBlockName(name: string) {
+    return name === waterBlockName;
+}
+
+function getGroundSurfaceY({
+    blockData,
+    groundLift,
+    stack,
+}: {
+    blockData: BlockData[] | null | undefined;
+    groundLift: number;
+    stack: Stack;
+}) {
+    const firstNonGroundBlock = stack.blocks.find(
+        (block) => !isAnimalGroundBlockName(block.name),
+    );
+    const firstBlock = stack.blocks[0];
+
+    if (!firstBlock || !isAnimalGroundBlockName(firstBlock.name)) {
+        return null;
+    }
+
+    const height = getStackHeight(blockData, stack, firstNonGroundBlock);
+    return height > 0 ? height + groundLift : 0;
+}
+
+export function createAnimalMovementSurfaces({
+    blockData,
+    groundLift,
+    stacks,
+    swimDepth,
+}: {
+    blockData: BlockData[] | null | undefined;
+    groundLift: number;
+    stacks: Stack[] | undefined;
+    swimDepth: number;
+}) {
+    const surfaces: AnimalMovementSurface[] = [];
+
+    for (const stack of stacks ?? []) {
+        const topBlock = stack.blocks.at(-1);
+        if (!topBlock) {
+            continue;
+        }
+
+        if (isAnimalWaterBlockName(topBlock.name)) {
+            surfaces.push({
+                kind: 'water',
+                x: stack.position.x,
+                y: Math.max(
+                    0,
+                    getWaterBlockColumnSurfaceY({
+                        block: topBlock,
+                        blockData,
+                        stack,
+                    }) - swimDepth,
+                ),
+                z: stack.position.z,
+            });
+            continue;
+        }
+
+        const y = getGroundSurfaceY({ blockData, groundLift, stack });
+        if (y !== null) {
+            surfaces.push({
+                kind: 'ground',
+                x: stack.position.x,
+                y,
+                z: stack.position.z,
+            });
+        }
+    }
+
+    return surfaces;
+}
+
+export function createAnimalBlockedCells(stacks: Stack[] | undefined) {
+    const blockedCells: AnimalMovementCell[] = [];
+
+    for (const stack of stacks ?? []) {
+        const topBlock = stack.blocks.at(-1);
+        if (
+            !topBlock ||
+            isAnimalGroundBlockName(topBlock.name) ||
+            isAnimalWaterBlockName(topBlock.name)
+        ) {
+            continue;
+        }
+
+        blockedCells.push({
+            x: Math.round(stack.position.x),
+            z: Math.round(stack.position.z),
+        });
+    }
+
+    return blockedCells;
+}
+
+export function getAnimalMovementSurfaceAt(
+    position: AnimalMovementCell,
+    surfaces: AnimalMovementSurface[],
+) {
+    let selectedSurface: AnimalMovementSurface | null = null;
+
+    for (const surface of surfaces) {
+        const insideSurface =
+            Math.abs(position.x - surface.x) <=
+                movementSurfaceHalfSize + movementSurfaceEpsilon &&
+            Math.abs(position.z - surface.z) <=
+                movementSurfaceHalfSize + movementSurfaceEpsilon;
+
+        if (
+            insideSurface &&
+            (!selectedSurface || surface.y > selectedSurface.y)
+        ) {
+            selectedSurface = surface;
+        }
+    }
+
+    return selectedSurface;
+}
+
+export function getAnimalMovementYAt(
+    position: AnimalMovementCell,
+    surfaces: AnimalMovementSurface[],
+) {
+    return getAnimalMovementSurfaceAt(position, surfaces)?.y ?? 0;
+}
+
+export function canAnimalSettleAt(
+    position: AnimalMovementCell,
+    surfaces: AnimalMovementSurface[],
+) {
+    return getAnimalMovementSurfaceAt(position, surfaces)?.kind !== 'water';
+}
+
+export function isAnimalSwimmingAt(
+    position: AnimalMovementCell,
+    surfaces: AnimalMovementSurface[],
+) {
+    return getAnimalMovementSurfaceAt(position, surfaces)?.kind === 'water';
+}

--- a/packages/game/src/entities/animals/animalMovementTerrain.unit.ts
+++ b/packages/game/src/entities/animals/animalMovementTerrain.unit.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Vector3 } from 'three';
+import { getLocalSandboxBlockData } from '../../localSandboxBlockData';
+import type { Block } from '../../types/Block';
+import type { Stack } from '../../types/Stack';
+import {
+    canAnimalSettleAt,
+    createAnimalBlockedCells,
+    createAnimalMovementSurfaces,
+    isAnimalGroundBlockName,
+    isAnimalSwimmingAt,
+} from './animalMovementTerrain';
+
+function block(id: string, name: string): Block {
+    return { id, name, rotation: 0 };
+}
+
+function stack(x: number, z: number, blocks: Block[]): Stack {
+    return {
+        blocks,
+        position: new Vector3(x, 0, z),
+    };
+}
+
+describe('animal movement terrain', () => {
+    it('treats every ground shape as traversable terrain', () => {
+        assert.equal(isAnimalGroundBlockName('Block_Grass'), true);
+        assert.equal(isAnimalGroundBlockName('Block_Sand_Angle'), true);
+        assert.equal(isAnimalGroundBlockName('Block_Snow_Corner'), true);
+        assert.equal(
+            isAnimalGroundBlockName('Block_Ground_Reverse_Corner'),
+            true,
+        );
+        assert.equal(isAnimalGroundBlockName('Raised_Bed'), false);
+    });
+
+    it('keeps water traversable at swimming depth but never settleable', () => {
+        const waterStack = stack(1, 2, [
+            block('grass', 'Block_Grass'),
+            block('water', 'Block_Water'),
+        ]);
+        const surfaces = createAnimalMovementSurfaces({
+            blockData: getLocalSandboxBlockData(),
+            groundLift: 0.02,
+            stacks: [waterStack],
+            swimDepth: 0.12,
+        });
+
+        assert.equal(createAnimalBlockedCells([waterStack]).length, 0);
+        assert.deepEqual(surfaces, [
+            {
+                kind: 'water',
+                x: 1,
+                y: 0.62,
+                z: 2,
+            },
+        ]);
+        assert.equal(isAnimalSwimmingAt({ x: 1, z: 2 }, surfaces), true);
+        assert.equal(canAnimalSettleAt({ x: 1, z: 2 }, surfaces), false);
+    });
+
+    it('blocks occupied cells while preserving the ground below them', () => {
+        const occupiedStack = stack(3, 4, [
+            block('sand', 'Block_Sand'),
+            block('raised-bed', 'Raised_Bed'),
+        ]);
+        const surfaces = createAnimalMovementSurfaces({
+            blockData: getLocalSandboxBlockData(),
+            groundLift: 0.02,
+            stacks: [occupiedStack],
+            swimDepth: 0.12,
+        });
+
+        assert.deepEqual(createAnimalBlockedCells([occupiedStack]), [
+            { x: 3, z: 4 },
+        ]);
+        assert.equal(surfaces.length, 1);
+        assert.equal(surfaces[0]?.kind, 'ground');
+        assert.equal(surfaces[0]?.x, 3);
+        assert.equal(Number(surfaces[0]?.y.toFixed(6)), 0.42);
+        assert.equal(surfaces[0]?.z, 4);
+    });
+});

--- a/packages/game/src/entities/cats/Cats.tsx
+++ b/packages/game/src/entities/cats/Cats.tsx
@@ -25,6 +25,16 @@ import {
 } from '../animals/AnimalDebugIndicators';
 import { configureActorMeshShadows } from '../animals/actorMeshShadows';
 import {
+    type AnimalMovementSurface,
+    canAnimalSettleAt,
+    createAnimalBlockedCells,
+    createAnimalMovementSurfaces,
+    getAnimalMovementYAt,
+    isAnimalGroundBlockName,
+    isAnimalSwimmingAt,
+    isAnimalWaterBlockName,
+} from '../animals/animalMovementTerrain';
+import {
     animalPresencePosition,
     animalPresenceUpdateIntervalSeconds,
     freshAnimalPresences,
@@ -56,7 +66,7 @@ type CatTarget = {
     walkPosition?: Vector3;
 };
 
-type CatGroundSurface = CatPathSurface;
+type CatGroundSurface = AnimalMovementSurface;
 
 type CatHabitat = {
     id: string;
@@ -117,8 +127,7 @@ const clearCatWeather = {
 const catScale = 0.42;
 const catGroundLift = 0.02;
 const catPillowSurfaceYOffset = 0.24;
-const catGroundSurfaceHalfSize = 0.5;
-const catGroundSurfaceEpsilon = 0.001;
+const catSwimDepth = 0.12;
 const catWalkSpeedBlocksPerSecond = 0.75;
 const catWalkCycleDistance = 0.9;
 const catWalkAnimationFallbackDuration = 4 / 3;
@@ -133,17 +142,6 @@ const catDarkFurColor = '#2f3437';
 const catSoftDarkFurColor = '#3b4144';
 
 const catPillowBlockNames = new Set(['CatPillow', 'Cat_Pillow']);
-const groundBlockNames = new Set([
-    'Block_Ground',
-    'Block_Ground_Angle',
-    'Block_Grass',
-    'Block_Grass_Angle',
-    'Block_Sand',
-    'Block_Sand_Angle',
-    'Block_Snow',
-    'Block_Snow_Angle',
-    'Block_Snow_Falling',
-]);
 const treeBlockNames = new Set(['Tree', 'Pine', 'PineAdvent']);
 
 const lowEntityYOffsets: Record<string, number> = {
@@ -200,21 +198,7 @@ function getCatWalkYAt(
     position: Pick<Vector3, 'x' | 'z'>,
     groundSurfaces: CatGroundSurface[],
 ) {
-    let surfaceY: number | null = null;
-
-    for (const surface of groundSurfaces) {
-        const insideSurface =
-            Math.abs(position.x - surface.x) <=
-                catGroundSurfaceHalfSize + catGroundSurfaceEpsilon &&
-            Math.abs(position.z - surface.z) <=
-                catGroundSurfaceHalfSize + catGroundSurfaceEpsilon;
-
-        if (insideSurface && (surfaceY === null || surface.y > surfaceY)) {
-            surfaceY = surface.y;
-        }
-    }
-
-    return surfaceY ?? 0;
+    return getAnimalMovementYAt(position, groundSurfaces);
 }
 
 function getTargetWalkPosition(target: CatTarget) {
@@ -248,10 +232,6 @@ function isCatPillowBlockName(name: string) {
     return catPillowBlockNames.has(name);
 }
 
-function isGroundBlockName(name: string) {
-    return groundBlockNames.has(name);
-}
-
 function isTreeBlockName(name: string) {
     return treeBlockNames.has(name);
 }
@@ -281,65 +261,6 @@ function getLowEntityYOffset(
     }
 
     return null;
-}
-
-function getGroundSurfaceY(
-    blockData: BlockData[] | null | undefined,
-    stack: Stack,
-) {
-    let height = 0;
-    let hasGroundBlock = false;
-
-    for (const block of stack.blocks) {
-        if (!isGroundBlockName(block.name)) {
-            break;
-        }
-
-        hasGroundBlock = true;
-        height += getBlockHeight(blockData, block.name) ?? 0;
-    }
-
-    return hasGroundBlock ? getCatGroundYFromHeight(height) : null;
-}
-
-function createCatGroundSurfaces(
-    stacks: Stack[] | undefined,
-    blockData: BlockData[] | null | undefined,
-) {
-    const surfaces: CatGroundSurface[] = [];
-
-    for (const stack of stacks ?? []) {
-        const y = getGroundSurfaceY(blockData, stack);
-        if (y === null) {
-            continue;
-        }
-
-        surfaces.push({
-            x: stack.position.x,
-            y,
-            z: stack.position.z,
-        });
-    }
-
-    return surfaces;
-}
-
-function createCatBlockedCells(stacks: Stack[] | undefined) {
-    const blockedCells: CatPathCell[] = [];
-
-    for (const stack of stacks ?? []) {
-        const topBlock = stack.blocks.at(-1);
-        if (!topBlock || isGroundBlockName(topBlock.name)) {
-            continue;
-        }
-
-        blockedCells.push({
-            x: Math.round(stack.position.x),
-            z: Math.round(stack.position.z),
-        });
-    }
-
-    return blockedCells;
 }
 
 function targetForPillowBlock({
@@ -452,8 +373,13 @@ function createCatHabitats(
     stacks: Stack[] | undefined,
     blockData: BlockData[] | null | undefined,
 ) {
-    const blockedCells = createCatBlockedCells(stacks);
-    const groundSurfaces = createCatGroundSurfaces(stacks, blockData);
+    const blockedCells = createAnimalBlockedCells(stacks);
+    const groundSurfaces = createAnimalMovementSurfaces({
+        blockData,
+        groundLift: catGroundLift,
+        stacks,
+        swimDepth: catSwimDepth,
+    });
     const pillows: CatTarget[] = [];
     const covers: CatTarget[] = [];
     const lowEntities: CatTarget[] = [];
@@ -478,14 +404,18 @@ function createCatHabitats(
             continue;
         }
 
-        if (stack.blocks.length === 1 && isGroundBlockName(topBlock.name)) {
+        if (
+            stack.blocks.length === 1 &&
+            isAnimalGroundBlockName(topBlock.name)
+        ) {
             roamAnchors.push(targetForGroundStack(stack, blockData));
             continue;
         }
 
         if (
             !isCatPillowBlockName(topBlock.name) &&
-            !isGroundBlockName(topBlock.name)
+            !isAnimalGroundBlockName(topBlock.name) &&
+            !isAnimalWaterBlockName(topBlock.name)
         ) {
             const yOffset = getLowEntityYOffset(blockData, topBlock.name);
             if (yOffset !== null) {
@@ -651,6 +581,9 @@ function createRoamTarget({
         anchorWalkPosition.y,
         anchorWalkPosition.z + Math.sin(angle) * radius,
     );
+    if (!canAnimalSettleAt(position, habitat.groundSurfaces)) {
+        position.copy(anchorWalkPosition);
+    }
 
     return {
         behavior: 'roam',
@@ -709,6 +642,9 @@ function createStalkBirdTarget({
 
     const position = birdPosition.clone().add(approach);
     position.y = getCatWalkYAt(position, habitat.groundSurfaces);
+    if (!canAnimalSettleAt(position, habitat.groundSurfaces)) {
+        return null;
+    }
 
     return {
         behavior: 'stalk-bird',
@@ -772,6 +708,9 @@ function createInteractDogTarget({
 
     const position = dogPosition.clone().add(approach);
     position.y = getCatWalkYAt(position, habitat.groundSurfaces);
+    if (!canAnimalSettleAt(position, habitat.groundSurfaces)) {
+        return null;
+    }
 
     return {
         behavior: 'interact-dog',
@@ -1086,6 +1025,10 @@ function makeMovingState({
         surfaces: resolvedGroundSurfaces,
         to: walkTo,
     });
+    if (pathfinding.status === 'unreachable') {
+        return null;
+    }
+
     const path = vectorPathFromResult(pathfinding);
     const pathDistance = Math.max(
         pathfinding.distance,
@@ -1163,8 +1106,12 @@ function getCatAnimationName(runtime: CatRuntimeState): CatAnimationName {
     return 'Cat_Idle';
 }
 
-function getCatDebugActivity(runtime: CatRuntimeState) {
+function getCatDebugActivity(runtime: CatRuntimeState, swimming: boolean) {
     if (runtime.phase === 'moving') {
+        if (swimming) {
+            return `swimming to ${runtime.target.behavior}`;
+        }
+
         return `walking to ${runtime.target.behavior}`;
     }
 
@@ -1240,7 +1187,10 @@ function createCatDebugEntry({
         label: habitat.pillow.id.replace(/^pillow-/, ''),
         phase: runtime.phase,
         behavior: runtime.target.behavior,
-        activity: getCatDebugActivity(runtime),
+        activity: getCatDebugActivity(
+            runtime,
+            isAnimalSwimmingAt(group.position, habitat.groundSurfaces),
+        ),
         targetId: runtime.target.id,
         debugBehaviors: catDebugBehaviors,
         pathfinding:
@@ -1477,7 +1427,7 @@ function Cat({
             return;
         }
 
-        runtimeRef.current = makeMovingState({
+        const movingState = makeMovingState({
             blockedCells: habitat.blockedCells,
             from: group.position.clone(),
             fromTarget:
@@ -1486,6 +1436,9 @@ function Cat({
             now,
             target,
         });
+        if (movingState) {
+            runtimeRef.current = movingState;
+        }
     }
 
     useFrame(({ clock }, delta) => {
@@ -1554,26 +1507,30 @@ function Cat({
                 });
 
                 if (target) {
-                    runtime =
-                        group.position.distanceTo(target.position) < 0.08
-                            ? makeSettledState({
-                                  now,
-                                  random,
-                                  target,
-                                  timeOfDay,
-                                  weather,
-                              })
-                            : makeMovingState({
-                                  blockedCells: habitat.blockedCells,
-                                  from: group.position.clone(),
-                                  fromTarget:
-                                      runtime.phase === 'settled'
-                                          ? runtime.target
-                                          : undefined,
-                                  groundSurfaces: habitat.groundSurfaces,
-                                  now,
-                                  target,
-                              });
+                    if (group.position.distanceTo(target.position) < 0.08) {
+                        runtime = makeSettledState({
+                            now,
+                            random,
+                            target,
+                            timeOfDay,
+                            weather,
+                        });
+                    } else {
+                        const movingState = makeMovingState({
+                            blockedCells: habitat.blockedCells,
+                            from: group.position.clone(),
+                            fromTarget:
+                                runtime.phase === 'settled'
+                                    ? runtime.target
+                                    : undefined,
+                            groundSurfaces: habitat.groundSurfaces,
+                            now,
+                            target,
+                        });
+                        if (movingState) {
+                            runtime = movingState;
+                        }
+                    }
                     runtimeRef.current = runtime;
                 }
             }
@@ -1675,14 +1632,22 @@ function Cat({
             return;
         }
 
-        runtimeRef.current = makeMovingState({
-            blockedCells: habitat.blockedCells,
-            from: group.position.clone(),
-            fromTarget: runtime.target,
-            groundSurfaces: habitat.groundSurfaces,
-            now,
-            target,
-        });
+        runtimeRef.current =
+            makeMovingState({
+                blockedCells: habitat.blockedCells,
+                from: group.position.clone(),
+                fromTarget: runtime.target,
+                groundSurfaces: habitat.groundSurfaces,
+                now,
+                target,
+            }) ??
+            makeSettledState({
+                now,
+                random,
+                target: runtime.target,
+                timeOfDay,
+                weather,
+            });
     });
 
     useFrame(({ clock }) => {

--- a/packages/game/src/entities/cats/catPathfinding.ts
+++ b/packages/game/src/entities/cats/catPathfinding.ts
@@ -9,7 +9,7 @@ export type CatPathPoint = CatPathCell & {
 
 export type CatPathSurface = CatPathPoint;
 
-export type CatPathStatus = 'direct' | 'path' | 'fallback';
+export type CatPathStatus = 'direct' | 'path' | 'unreachable';
 
 export type CatPathResult = {
     blockedCellCount: number;
@@ -28,8 +28,16 @@ type SearchNode = {
     previousKey: string | null;
 };
 
+type SearchBounds = {
+    maxX: number;
+    maxZ: number;
+    minX: number;
+    minZ: number;
+};
+
 const diagonalCost = Math.SQRT2;
 const directPathSampleStep = 0.18;
+const searchBoundsPadding = 2;
 const cardinalDirections = [
     { x: 1, z: 0, cost: 1 },
     { x: -1, z: 0, cost: 1 },
@@ -53,6 +61,32 @@ function roundCell(point: Pick<CatPathPoint, 'x' | 'z'>): CatPathCell {
         x: Math.round(point.x),
         z: Math.round(point.z),
     };
+}
+
+function createSearchBounds(
+    blockedCells: CatPathCell[],
+    startCell: CatPathCell,
+    targetCell: CatPathCell,
+): SearchBounds {
+    const cells = [startCell, targetCell, ...blockedCells];
+    const xs = cells.map((cell) => cell.x);
+    const zs = cells.map((cell) => cell.z);
+
+    return {
+        maxX: Math.max(...xs) + searchBoundsPadding,
+        maxZ: Math.max(...zs) + searchBoundsPadding,
+        minX: Math.min(...xs) - searchBoundsPadding,
+        minZ: Math.min(...zs) - searchBoundsPadding,
+    };
+}
+
+function isCellInsideBounds(cell: CatPathCell, bounds: SearchBounds) {
+    return (
+        cell.x >= bounds.minX &&
+        cell.x <= bounds.maxX &&
+        cell.z >= bounds.minZ &&
+        cell.z <= bounds.maxZ
+    );
 }
 
 function horizontalDistance(
@@ -124,24 +158,23 @@ function isTemporarilyAllowedCell(
 
 function canWalkCell({
     blockedKeys,
+    bounds,
     cell,
     startCell,
-    surfaceByKey,
     targetCell,
 }: {
     blockedKeys: Set<string>;
+    bounds: SearchBounds;
     cell: CatPathCell;
     startCell: CatPathCell;
-    surfaceByKey: Map<string, CatPathSurface>;
     targetCell: CatPathCell;
 }) {
-    const key = cellKey(cell);
-    if (!surfaceByKey.has(key)) {
+    if (!isCellInsideBounds(cell, bounds)) {
         return false;
     }
 
     return (
-        !blockedKeys.has(key) ||
+        !blockedKeys.has(cellKey(cell)) ||
         isTemporarilyAllowedCell(cell, startCell, targetCell)
     );
 }
@@ -190,17 +223,17 @@ function heuristic(left: CatPathCell, right: CatPathCell) {
 
 function canWalkDiagonal({
     blockedKeys,
+    bounds,
     cell,
     direction,
     startCell,
-    surfaceByKey,
     targetCell,
 }: {
     blockedKeys: Set<string>;
+    bounds: SearchBounds;
     cell: CatPathCell;
     direction: CatPathCell;
     startCell: CatPathCell;
-    surfaceByKey: Map<string, CatPathSurface>;
     targetCell: CatPathCell;
 }) {
     if (direction.x === 0 || direction.z === 0) {
@@ -210,16 +243,16 @@ function canWalkDiagonal({
     return (
         canWalkCell({
             blockedKeys,
+            bounds,
             cell: { x: cell.x + direction.x, z: cell.z },
             startCell,
-            surfaceByKey,
             targetCell,
         }) &&
         canWalkCell({
             blockedKeys,
+            bounds,
             cell: { x: cell.x, z: cell.z + direction.z },
             startCell,
-            surfaceByKey,
             targetCell,
         })
     );
@@ -276,13 +309,13 @@ function reconstructPath(
 
 function findCellPath({
     blockedKeys,
+    bounds,
     startCell,
-    surfaceByKey,
     targetCell,
 }: {
     blockedKeys: Set<string>;
+    bounds: SearchBounds;
     startCell: CatPathCell;
-    surfaceByKey: Map<string, CatPathSurface>;
     targetCell: CatPathCell;
 }) {
     const startKey = cellKey(startCell);
@@ -331,17 +364,17 @@ function findCellPath({
             if (
                 !canWalkCell({
                     blockedKeys,
+                    bounds,
                     cell: neighborCell,
                     startCell,
-                    surfaceByKey,
                     targetCell,
                 }) ||
                 !canWalkDiagonal({
                     blockedKeys,
+                    bounds,
                     cell: current.node.cell,
                     direction,
                     startCell,
-                    surfaceByKey,
                     targetCell,
                 })
             ) {
@@ -469,6 +502,7 @@ export function findCatPath({
     const blockedKeys = new Set(blockedCells.map(cellKey));
     const blockedCellCount = blockedKeys.size;
     const directPoints = [from, to];
+    const bounds = createSearchBounds(blockedCells, startCell, targetCell);
 
     if (
         isSameCell(startCell, targetCell) ||
@@ -493,17 +527,17 @@ export function findCatPath({
 
     const cellPath = findCellPath({
         blockedKeys,
+        bounds,
         startCell,
-        surfaceByKey,
         targetCell,
     });
     if (!cellPath.cells) {
         return {
             blockedCellCount,
-            distance: pathDistance(directPoints),
-            points: directPoints,
+            distance: 0,
+            points: [from],
             startCell,
-            status: 'fallback',
+            status: 'unreachable',
             targetCell,
             visitedCellCount: cellPath.visitedCellCount,
         };

--- a/packages/game/src/entities/cats/catPathfinding.unit.ts
+++ b/packages/game/src/entities/cats/catPathfinding.unit.ts
@@ -86,7 +86,7 @@ test('allows the cat to start or finish on an occupied target cell', () => {
     assert.deepEqual(path.targetCell, { x: 2, z: 0 });
 });
 
-test('falls back to direct movement when no walkable passage exists', () => {
+test('routes through implicit open terrain when listed surfaces are sparse', () => {
     const path = findCatPath({
         blockedCells: [
             { x: -1, z: -1 },
@@ -100,10 +100,37 @@ test('falls back to direct movement when no walkable passage exists', () => {
             { x: 1, z: 1 },
         ],
         from: { x: -2, y: 0.42, z: 0 },
-        surfaces: createSurfaces({ minX: -2, maxX: 2, minZ: -1, maxZ: 1 }),
+        surfaces: [
+            { x: -2, y: 0.42, z: 0 },
+            { x: 2, y: 0.42, z: 0 },
+        ],
         to: { x: 2, y: 0.42, z: 0 },
     });
 
-    assert.equal(path.status, 'fallback');
-    assert.equal(path.points.length, 2);
+    assert.equal(path.status, 'path');
+    assert.ok(path.points.length > 2);
+    assert.ok(path.points.some((point) => Math.abs(point.z) >= 2));
+});
+
+test('reports an unreachable target without crossing its blocked enclosure', () => {
+    const from = { x: -3, y: 0.42, z: 0 };
+    const path = findCatPath({
+        blockedCells: [
+            { x: -1, z: -1 },
+            { x: -1, z: 0 },
+            { x: -1, z: 1 },
+            { x: 0, z: -1 },
+            { x: 0, z: 1 },
+            { x: 1, z: -1 },
+            { x: 1, z: 0 },
+            { x: 1, z: 1 },
+        ],
+        from,
+        surfaces: [from, { x: 0, y: 0.42, z: 0 }],
+        to: { x: 0, y: 0.42, z: 0 },
+    });
+
+    assert.equal(path.status, 'unreachable');
+    assert.deepEqual(path.points, [from]);
+    assert.equal(path.distance, 0);
 });

--- a/packages/game/src/entities/dogs/Dogs.tsx
+++ b/packages/game/src/entities/dogs/Dogs.tsx
@@ -25,6 +25,16 @@ import {
 } from '../animals/AnimalDebugIndicators';
 import { configureActorMeshShadows } from '../animals/actorMeshShadows';
 import {
+    type AnimalMovementSurface,
+    canAnimalSettleAt,
+    createAnimalBlockedCells,
+    createAnimalMovementSurfaces,
+    getAnimalMovementYAt,
+    isAnimalGroundBlockName,
+    isAnimalSwimmingAt,
+    isAnimalWaterBlockName,
+} from '../animals/animalMovementTerrain';
+import {
     animalPresencePosition,
     animalPresenceUpdateIntervalSeconds,
     freshAnimalPresences,
@@ -56,7 +66,7 @@ type DogTarget = {
     walkPosition?: Vector3;
 };
 
-type DogGroundSurface = DogPathSurface;
+type DogGroundSurface = AnimalMovementSurface;
 
 type DogHabitat = {
     id: string;
@@ -139,8 +149,7 @@ const dogScale = 0.46;
 const dogGroundLift = 0.02;
 const dogHouseDoorOffset = 0.46;
 const dogHouseNightRestInset = 0.42;
-const dogGroundSurfaceHalfSize = 0.5;
-const dogGroundSurfaceEpsilon = 0.001;
+const dogSwimDepth = 0.16;
 const dogWalkSpeedBlocksPerSecond = 0.9;
 const dogWalkCycleDistance = 0.82;
 const dogWalkAnimationFallbackDuration = 32 / 24;
@@ -160,17 +169,6 @@ const dogDarkFurColor = '#3c2115';
 const dogSoftDarkFurColor = '#7b4d2c';
 
 const dogHouseBlockNames = new Set(['DogHouse']);
-const groundBlockNames = new Set([
-    'Block_Ground',
-    'Block_Ground_Angle',
-    'Block_Grass',
-    'Block_Grass_Angle',
-    'Block_Sand',
-    'Block_Sand_Angle',
-    'Block_Snow',
-    'Block_Snow_Angle',
-    'Block_Snow_Falling',
-]);
 const treeBlockNames = new Set(['Tree', 'Pine', 'PineAdvent']);
 
 const lowEntityYOffsets: Record<string, number> = {
@@ -227,21 +225,7 @@ function getDogWalkYAt(
     position: Pick<Vector3, 'x' | 'z'>,
     groundSurfaces: DogGroundSurface[],
 ) {
-    let surfaceY: number | null = null;
-
-    for (const surface of groundSurfaces) {
-        const insideSurface =
-            Math.abs(position.x - surface.x) <=
-                dogGroundSurfaceHalfSize + dogGroundSurfaceEpsilon &&
-            Math.abs(position.z - surface.z) <=
-                dogGroundSurfaceHalfSize + dogGroundSurfaceEpsilon;
-
-        if (insideSurface && (surfaceY === null || surface.y > surfaceY)) {
-            surfaceY = surface.y;
-        }
-    }
-
-    return surfaceY ?? 0;
+    return getAnimalMovementYAt(position, groundSurfaces);
 }
 
 function getTargetWalkPosition(target: DogTarget) {
@@ -308,10 +292,6 @@ function isDogHouseBlockName(name: string) {
     return dogHouseBlockNames.has(name);
 }
 
-function isGroundBlockName(name: string) {
-    return groundBlockNames.has(name);
-}
-
 function isTreeBlockName(name: string) {
     return treeBlockNames.has(name);
 }
@@ -341,65 +321,6 @@ function getLowEntityYOffset(
     }
 
     return null;
-}
-
-function getGroundSurfaceY(
-    blockData: BlockData[] | null | undefined,
-    stack: Stack,
-) {
-    let height = 0;
-    let hasGroundBlock = false;
-
-    for (const block of stack.blocks) {
-        if (!isGroundBlockName(block.name)) {
-            break;
-        }
-
-        hasGroundBlock = true;
-        height += getBlockHeight(blockData, block.name) ?? 0;
-    }
-
-    return hasGroundBlock ? getDogGroundYFromHeight(height) : null;
-}
-
-function createDogGroundSurfaces(
-    stacks: Stack[] | undefined,
-    blockData: BlockData[] | null | undefined,
-) {
-    const surfaces: DogGroundSurface[] = [];
-
-    for (const stack of stacks ?? []) {
-        const y = getGroundSurfaceY(blockData, stack);
-        if (y === null) {
-            continue;
-        }
-
-        surfaces.push({
-            x: stack.position.x,
-            y,
-            z: stack.position.z,
-        });
-    }
-
-    return surfaces;
-}
-
-function createDogBlockedCells(stacks: Stack[] | undefined) {
-    const blockedCells: DogPathCell[] = [];
-
-    for (const stack of stacks ?? []) {
-        const topBlock = stack.blocks.at(-1);
-        if (!topBlock || isGroundBlockName(topBlock.name)) {
-            continue;
-        }
-
-        blockedCells.push({
-            x: Math.round(stack.position.x),
-            z: Math.round(stack.position.z),
-        });
-    }
-
-    return blockedCells;
 }
 
 function targetForDogHouseBlock({
@@ -515,8 +436,13 @@ function createDogHabitats(
     stacks: Stack[] | undefined,
     blockData: BlockData[] | null | undefined,
 ) {
-    const blockedCells = createDogBlockedCells(stacks);
-    const groundSurfaces = createDogGroundSurfaces(stacks, blockData);
+    const blockedCells = createAnimalBlockedCells(stacks);
+    const groundSurfaces = createAnimalMovementSurfaces({
+        blockData,
+        groundLift: dogGroundLift,
+        stacks,
+        swimDepth: dogSwimDepth,
+    });
     const dogHouses: DogTarget[] = [];
     const covers: DogTarget[] = [];
     const lowEntities: DogTarget[] = [];
@@ -543,14 +469,18 @@ function createDogHabitats(
             continue;
         }
 
-        if (stack.blocks.length === 1 && isGroundBlockName(topBlock.name)) {
+        if (
+            stack.blocks.length === 1 &&
+            isAnimalGroundBlockName(topBlock.name)
+        ) {
             roamAnchors.push(targetForGroundStack(stack, blockData));
             continue;
         }
 
         if (
             !isDogHouseBlockName(topBlock.name) &&
-            !isGroundBlockName(topBlock.name)
+            !isAnimalGroundBlockName(topBlock.name) &&
+            !isAnimalWaterBlockName(topBlock.name)
         ) {
             const yOffset = getLowEntityYOffset(blockData, topBlock.name);
             if (yOffset !== null) {
@@ -716,6 +646,9 @@ function createRoamTarget({
         anchorWalkPosition.y,
         anchorWalkPosition.z + Math.sin(angle) * radius,
     );
+    if (!canAnimalSettleAt(position, habitat.groundSurfaces)) {
+        position.copy(anchorWalkPosition);
+    }
 
     return {
         behavior: 'roam',
@@ -774,6 +707,9 @@ function createChaseBirdTarget({
 
     const position = birdPosition.clone().add(approach);
     position.y = getDogWalkYAt(position, habitat.groundSurfaces);
+    if (!canAnimalSettleAt(position, habitat.groundSurfaces)) {
+        return null;
+    }
 
     return {
         behavior: 'chase-bird',
@@ -837,6 +773,9 @@ function createInteractCatTarget({
 
     const position = catPosition.clone().add(approach);
     position.y = getDogWalkYAt(position, habitat.groundSurfaces);
+    if (!canAnimalSettleAt(position, habitat.groundSurfaces)) {
+        return null;
+    }
 
     return {
         behavior: 'interact-cat',
@@ -1151,6 +1090,10 @@ function makeMovingState({
         surfaces: resolvedGroundSurfaces,
         to: walkTo,
     });
+    if (pathfinding.status === 'unreachable') {
+        return null;
+    }
+
     const path = vectorPathFromResult(pathfinding);
     const pathDistance = Math.max(
         pathfinding.distance,
@@ -1229,8 +1172,12 @@ function getDogAnimationName(runtime: DogRuntimeState): DogAnimationName {
     return 'Dog_Idle';
 }
 
-function getDogDebugActivity(runtime: DogRuntimeState) {
+function getDogDebugActivity(runtime: DogRuntimeState, swimming: boolean) {
     if (runtime.phase === 'moving') {
+        if (swimming) {
+            return `swimming to ${runtime.target.behavior}`;
+        }
+
         return `walking to ${runtime.target.behavior}`;
     }
 
@@ -1306,7 +1253,10 @@ function createDogDebugEntry({
         label: habitat.dogHouse.id.replace(/^doghouse-/, ''),
         phase: runtime.phase,
         behavior: runtime.target.behavior,
-        activity: getDogDebugActivity(runtime),
+        activity: getDogDebugActivity(
+            runtime,
+            isAnimalSwimmingAt(group.position, habitat.groundSurfaces),
+        ),
         targetId: runtime.target.id,
         debugBehaviors: dogDebugBehaviors,
         pathfinding:
@@ -1653,7 +1603,7 @@ function Dog({
             return;
         }
 
-        runtimeRef.current = makeMovingState({
+        const movingState = makeMovingState({
             blockedCells: habitat.blockedCells,
             from: group.position.clone(),
             fromTarget:
@@ -1662,6 +1612,9 @@ function Dog({
             now,
             target,
         });
+        if (movingState) {
+            runtimeRef.current = movingState;
+        }
     }
 
     useFrame(({ clock }, delta) => {
@@ -1730,30 +1683,37 @@ function Dog({
                 });
 
                 if (target) {
-                    runtime =
+                    if (
                         isDogSettledAtNightDogHouse(
                             runtime,
                             target,
                             timeOfDay,
-                        ) || group.position.distanceTo(target.position) < 0.08
-                            ? makeSettledState({
-                                  now,
-                                  random,
-                                  target,
-                                  timeOfDay,
-                                  weather,
-                              })
-                            : makeMovingState({
-                                  blockedCells: habitat.blockedCells,
-                                  from: group.position.clone(),
-                                  fromTarget:
-                                      runtime.phase === 'settled'
-                                          ? runtime.target
-                                          : undefined,
-                                  groundSurfaces: habitat.groundSurfaces,
-                                  now,
-                                  target,
-                              });
+                        ) ||
+                        group.position.distanceTo(target.position) < 0.08
+                    ) {
+                        runtime = makeSettledState({
+                            now,
+                            random,
+                            target,
+                            timeOfDay,
+                            weather,
+                        });
+                    } else {
+                        const movingState = makeMovingState({
+                            blockedCells: habitat.blockedCells,
+                            from: group.position.clone(),
+                            fromTarget:
+                                runtime.phase === 'settled'
+                                    ? runtime.target
+                                    : undefined,
+                            groundSurfaces: habitat.groundSurfaces,
+                            now,
+                            target,
+                        });
+                        if (movingState) {
+                            runtime = movingState;
+                        }
+                    }
                     runtimeRef.current = runtime;
                 }
             }
@@ -1866,14 +1826,22 @@ function Dog({
             return;
         }
 
-        runtimeRef.current = makeMovingState({
-            blockedCells: habitat.blockedCells,
-            from: group.position.clone(),
-            fromTarget: runtime.target,
-            groundSurfaces: habitat.groundSurfaces,
-            now,
-            target,
-        });
+        runtimeRef.current =
+            makeMovingState({
+                blockedCells: habitat.blockedCells,
+                from: group.position.clone(),
+                fromTarget: runtime.target,
+                groundSurfaces: habitat.groundSurfaces,
+                now,
+                target,
+            }) ??
+            makeSettledState({
+                now,
+                random,
+                target: runtime.target,
+                timeOfDay,
+                weather,
+            });
     });
 
     useFrame(({ clock }) => {


### PR DESCRIPTION
## Summary

- share water and ground movement-surface classification between cats and dogs
- keep animals at a species-appropriate swimming depth while crossing water, without allowing water as a resting or interaction target
- route around occupied cells through implicit open terrain instead of falling back to a straight line through blocks
- leave animals at their current valid target when a destination is genuinely unreachable
- recognize angled, corner, and reverse-corner terrain consistently

## Root cause

Water was treated as a generic low entity, which made it eligible as a perch target while movement height still came from the submerged ground below it. Separately, pathfinding only searched explicitly listed raised terrain cells; when no such detour existed it returned a direct fallback path through blocked cells.

## Impact

Cats and dogs now swim across water at the visible surface, never stop on water, and detour around placed entities and blocks. Enclosed destinations no longer cause obstacle-crossing movement.

## Validation

- `pnpm --filter @gredice/game test` (769 passed)
- `pnpm lint --filter @gredice/game`
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter garden --filter www`
- `git diff --check`