### PR TITLE
fix(game): identify operation plants in cart

### DIFF
--- a/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
+++ b/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
@@ -17,6 +17,7 @@ import {
     createGameState,
     GameStateContext,
 } from '../../../packages/game/src/useGameState';
+import { allSorts, testSorts } from './raisedBedFieldHudScenarios';
 
 const now = '2026-05-21T00:00:00.000Z';
 
@@ -137,6 +138,15 @@ function createPaidCartItem() {
     } as unknown as ShoppingCartItemData;
 }
 
+function createTargetedOperationCartItem() {
+    return {
+        ...cartItem,
+        gardenId: 1,
+        raisedBedId: 1,
+        positionIndex: 0,
+    } as ShoppingCartItemData;
+}
+
 function createPlantSortCartItem() {
     return {
         ...cartItem,
@@ -218,9 +228,17 @@ function createOptimisticToggleQueryClient(items = onePresenceItem) {
                 id: 1,
                 name: 'Mock gredica',
                 physicalId: '1',
+                fields: [
+                    {
+                        id: 1,
+                        positionIndex: 0,
+                        plantSortId: testSorts.tomato.id,
+                    },
+                ],
             },
         ],
     });
+    queryClient.setQueryData(['sorts'], allSorts);
     queryClient.setQueryData(['inventory'], { items: [] });
     queryClient.setQueryData(['shopping-cart'], {
         allowPurchase: true,
@@ -409,6 +427,16 @@ export function ShoppingCartOutletCountdownStory() {
 
 export function ShoppingCartPaidItemStory() {
     const item = useMemo(() => createPaidCartItem(), []);
+
+    return (
+        <ShoppingCartOptimisticToggleProviders item={item}>
+            <ShoppingCartOptimisticTogglePanel />
+        </ShoppingCartOptimisticToggleProviders>
+    );
+}
+
+export function ShoppingCartTargetedOperationStory() {
+    const item = useMemo(() => createTargetedOperationCartItem(), []);
 
     return (
         <ShoppingCartOptimisticToggleProviders item={item}>

--- a/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
+++ b/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
@@ -7,6 +7,7 @@ import {
     ShoppingCartOutletCountdownStory,
     ShoppingCartPaidItemStory,
     ShoppingCartPlantSortStory,
+    ShoppingCartTargetedOperationStory,
 } from './ShoppingCartOptimisticToggleStory';
 
 const shoppingCartServerItem = {
@@ -274,6 +275,24 @@ test('shopping cart greenhouse toggle updates sowing location metadata', async (
 
     expect(additionalData?.scheduledDate).toBe('2040-01-05T00:00:00.000Z');
     expect(additionalData?.sowingLocation).toBe('greenhouse');
+});
+
+test('shopping cart operation shows its target plant with an operation badge', async ({
+    mount,
+    page,
+}) => {
+    await mount(<ShoppingCartTargetedOperationStory />);
+
+    const media = page.locator('[data-shopping-cart-item-media="plant"]');
+    await expect(
+        media.getByRole('img', { name: 'Cherry rajčica' }),
+    ).toBeVisible();
+
+    const operationBadge = media.locator(
+        '[data-shopping-cart-item-operation-badge]',
+    );
+    await expect(operationBadge).toBeVisible();
+    await expect(operationBadge.locator('svg')).toBeVisible();
 });
 
 test('paid shopping cart item date is not editable', async ({

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
@@ -2,15 +2,9 @@ import { BackpackIcon } from '@gredice/ui/BackpackIcon';
 import { Chip } from '@gredice/ui/Chip';
 import { IconButton } from '@gredice/ui/IconButton';
 import { Input } from '@gredice/ui/Input';
-import {
-    Close,
-    Delete,
-    Hammer,
-    Navigate,
-    Sprout,
-    Timer,
-} from '@gredice/ui/icons';
+import { Close, Delete, Navigate, Sprout, Timer } from '@gredice/ui/icons';
 import { ModalConfirm } from '@gredice/ui/ModalConfirm';
+import { OperationImage } from '@gredice/ui/OperationImage';
 import { Popper } from '@gredice/ui/Popper';
 import { PlantOrSortImage } from '@gredice/ui/plants';
 import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
@@ -18,12 +12,13 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useQueryClient } from '@tanstack/react-query';
-import { type CSSProperties, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useGameAnalytics } from '../../../analytics/GameAnalyticsContext';
 import { getCartItemOutletOfferId } from '../../../hooks/shoppingCartPositionPayload';
 import { useCurrentAccount } from '../../../hooks/useCurrentAccount';
 import { useCurrentGarden } from '../../../hooks/useCurrentGarden';
 import { useInventory } from '../../../hooks/useInventory';
+import { usePlantSort } from '../../../hooks/usePlantSorts';
 import { useSetShoppingCartItem } from '../../../hooks/useSetShoppingCartItem';
 import {
     type ShoppingCartItemData,
@@ -166,6 +161,13 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
     const raisedBed = hasRaisedBed
         ? garden?.raisedBeds.find((rb) => rb.id === item.raisedBedId)
         : null;
+    const targetPlantSortId =
+        item.entityTypeName === 'operation' && hasPosition
+            ? raisedBed?.fields.find(
+                  (field) => field.positionIndex === item.positionIndex,
+              )?.plantSortId
+            : null;
+    const { data: targetPlantSort } = usePlantSort(targetPlantSortId);
     const additionalData = parseAdditionalData(item.additionalData);
     const scheduledDateInfo = getCartItemScheduledDateInfo(item);
     const scheduledDate = scheduledDateInfo.date;
@@ -406,9 +408,6 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
 
     const plantSort =
         item.entityTypeName === 'plantSort' ? item.entityData : null;
-    const hasShopImage = Boolean(item.shopData.image);
-    const shouldShowOperationFallback =
-        item.entityTypeName === 'operation' && !hasShopImage;
     function renderGreenhouseSowingControl() {
         if (canChangeGreenhouseSowing) {
             return (
@@ -544,18 +543,31 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                     alt={item.shopData.name ?? 'Nepoznato'}
                     plantSort={plantSort}
                 />
-            ) : shouldShowOperationFallback ? (
-                <div className="rounded-lg border overflow-hidden size-14 aspect-square shrink-0 flex items-center justify-center">
-                    <Hammer
-                        role="img"
-                        aria-label={item.shopData.name ?? 'Nepoznato'}
-                        style={
-                            {
-                                '--imageSize': '32px',
-                            } as CSSProperties
-                        }
-                        className="size-[--imageSize] shrink-0"
+            ) : item.entityTypeName === 'operation' && targetPlantSort ? (
+                <div
+                    className="relative size-14 shrink-0"
+                    data-shopping-cart-item-media="plant"
+                >
+                    <PlantOrSortImage
+                        className="rounded-lg border overflow-hidden size-14 aspect-square"
+                        width={56}
+                        height={56}
+                        alt={targetPlantSort.information.name}
+                        plantSort={targetPlantSort}
                     />
+                    <span
+                        className="-right-1 -top-1 absolute flex size-6 items-center justify-center rounded-full border bg-background text-foreground shadow-xs"
+                        data-shopping-cart-item-operation-badge
+                    >
+                        <OperationImage operation={item.entityData} size={18} />
+                    </span>
+                </div>
+            ) : item.entityTypeName === 'operation' ? (
+                <div
+                    className="rounded-lg border overflow-hidden size-14 aspect-square shrink-0 flex items-center justify-center"
+                    data-shopping-cart-item-media="operation"
+                >
+                    <OperationImage operation={item.entityData} size={56} />
                 </div>
             ) : (
                 <PlantOrSortImage


### PR DESCRIPTION
## Summary

- show the target plant thumbnail for field-scoped operation items in the shopping cart
- overlay the operation image/icon above the plant, matching the diary entry treatment
- keep the operation-only image/icon fallback when no planted field target can be resolved
- cover the layered cart media in the production component-test harness

## Why

Operation cart rows only exposed the raised-bed field position, so users could not see which plant the operation applied to.

## Validation

- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter @gredice/game test` (625 passed)
- `GREDICE_PLAYWRIGHT_REUSE_SERVER=true GREDICE_PORT_OFFSET=0 pnpm --filter garden exec playwright test tests/shopping-cart-optimistic-toggle.spec.tsx --project=chromium` (17 passed)
- focused Biome checks for all changed files
- `git diff --check`