### PR TITLE
fix(game): default cart items to sunflowers

### DIFF
--- a/apps/api/app/api/[...route]/shoppingCartRoutes.ts
+++ b/apps/api/app/api/[...route]/shoppingCartRoutes.ts
@@ -25,6 +25,7 @@ import { Hono } from 'hono';
 import { describeRoute, validator as zValidator } from 'hono-openapi';
 import { z } from 'zod';
 import { getCartInfo } from '../../../lib/checkout/cartInfo';
+import { getDefaultCartItemCurrency } from '../../../lib/checkout/sunflowerCalculations';
 import {
     type AuthVariables,
     authValidator,
@@ -163,7 +164,8 @@ const app = new Hono<{ Variables: AuthVariables }>()
     .post(
         '/',
         describeRoute({
-            description: 'Add or update an item in the shopping cart',
+            description:
+                'Add or update an item in the shopping cart. New items without an explicit currency use sunflowers when the current balance covers all sunflower commitments in the cart.',
         }),
         authValidator(['user', 'admin']),
         zValidator(
@@ -267,25 +269,28 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     );
                 }
             }
+            let appliedCurrency = currency ?? undefined;
             try {
+                let cartItemId: number | null = null;
                 if (outletOfferId && amount > 0) {
-                    await upsertOrRemoveCartItemWithOutletReservation({
-                        id,
-                        cartId,
-                        entityId,
-                        entityTypeName,
-                        amount,
-                        gardenId,
-                        raisedBedId,
-                        positionIndex,
-                        additionalData,
-                        currency,
-                        forceCreate,
-                        outletOfferId,
-                        accountId,
-                    });
+                    cartItemId =
+                        await upsertOrRemoveCartItemWithOutletReservation({
+                            id,
+                            cartId,
+                            entityId,
+                            entityTypeName,
+                            amount,
+                            gardenId,
+                            raisedBedId,
+                            positionIndex,
+                            additionalData,
+                            currency,
+                            forceCreate,
+                            outletOfferId,
+                            accountId,
+                        });
                 } else {
-                    const cartItemId = await upsertOrRemoveCartItem(
+                    cartItemId = await upsertOrRemoveCartItem(
                         id,
                         cartId,
                         entityId,
@@ -300,6 +305,44 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     );
                     if (amount > 0 && cartItemId) {
                         await releaseOutletReservationForCartItem(cartItemId);
+                    }
+                }
+
+                const isNewCartItem =
+                    cartItemId !== null &&
+                    !cart.items.some((item) => item.id === cartItemId);
+                if (
+                    amount > 0 &&
+                    cartItemId !== null &&
+                    currency == null &&
+                    isNewCartItem
+                ) {
+                    const updatedCart = await getShoppingCart(cartId);
+                    if (updatedCart) {
+                        const cartInfo = await getCartInfo(
+                            updatedCart.items,
+                            accountId,
+                        );
+                        appliedCurrency = getDefaultCartItemCurrency({
+                            availableSunflowers: await getSunflowers(accountId),
+                            items: cartInfo.items,
+                            newCartItemId: cartItemId,
+                        });
+
+                        if (appliedCurrency === 'sunflower') {
+                            await upsertOrRemoveCartItem(
+                                cartItemId,
+                                cartId,
+                                entityId,
+                                entityTypeName,
+                                amount,
+                                gardenId,
+                                raisedBedId,
+                                positionIndex,
+                                additionalData,
+                                appliedCurrency,
+                            );
+                        }
                     }
                 }
             } catch (error) {
@@ -333,7 +376,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     entity_id: entityId,
                     entity_type: entityTypeName,
                     amount,
-                    currency: currency ?? undefined,
+                    currency: appliedCurrency,
                     outlet_offer_id: outletOfferId,
                 },
             });

--- a/apps/api/lib/checkout/sunflowerCalculations.node.spec.ts
+++ b/apps/api/lib/checkout/sunflowerCalculations.node.spec.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getDefaultCartItemCurrency } from './sunflowerCalculations';
+
+function cartItem({
+    currency = 'eur',
+    discountPrice,
+    id,
+    price,
+    status = 'new',
+}: {
+    currency?: string;
+    discountPrice?: number;
+    id: number;
+    price: number;
+    status?: string;
+}) {
+    return {
+        currency,
+        id,
+        shopData: {
+            discountPrice,
+            price,
+        },
+        status,
+    };
+}
+
+test('defaults a new item to sunflowers when the balance covers the committed cart and new item', () => {
+    assert.equal(
+        getDefaultCartItemCurrency({
+            availableSunflowers: 4_500,
+            items: [
+                cartItem({
+                    currency: 'sunflower',
+                    id: 1,
+                    price: 2.5,
+                }),
+                cartItem({ id: 2, price: 2 }),
+            ],
+            newCartItemId: 2,
+        }),
+        'sunflower',
+    );
+});
+
+test('defaults a new item to euros when it is affordable alone but not with sunflower cart commitments', () => {
+    assert.equal(
+        getDefaultCartItemCurrency({
+            availableSunflowers: 4_000,
+            items: [
+                cartItem({
+                    currency: 'sunflower',
+                    id: 1,
+                    price: 2.5,
+                }),
+                cartItem({ id: 2, price: 2 }),
+            ],
+            newCartItemId: 2,
+        }),
+        'eur',
+    );
+});
+
+test('does not reserve sunflowers for items explicitly kept in euros or already paid', () => {
+    assert.equal(
+        getDefaultCartItemCurrency({
+            availableSunflowers: 3_000,
+            items: [
+                cartItem({ id: 1, price: 4 }),
+                cartItem({
+                    currency: 'sunflower',
+                    id: 2,
+                    price: 5,
+                    status: 'paid',
+                }),
+                cartItem({ id: 3, price: 2 }),
+            ],
+            newCartItemId: 3,
+        }),
+        'sunflower',
+    );
+});
+
+test('uses the effective discounted price and requires a positive price', () => {
+    assert.equal(
+        getDefaultCartItemCurrency({
+            availableSunflowers: 1_200,
+            items: [cartItem({ discountPrice: 1.2, id: 1, price: 2 })],
+            newCartItemId: 1,
+        }),
+        'sunflower',
+    );
+    assert.equal(
+        getDefaultCartItemCurrency({
+            availableSunflowers: 1_200,
+            items: [cartItem({ id: 2, price: 0 })],
+            newCartItemId: 2,
+        }),
+        'eur',
+    );
+});

--- a/apps/api/lib/checkout/sunflowerCalculations.ts
+++ b/apps/api/lib/checkout/sunflowerCalculations.ts
@@ -1,15 +1,53 @@
 import type { ShoppingCartItemWithShopData } from './cartInfo';
 
+type ShoppingCartItemForSunflowerCalculation = Pick<
+    ShoppingCartItemWithShopData,
+    'currency' | 'id' | 'shopData' | 'status'
+>;
+
 /**
  * Calculate the sunflower amount for a cart item based on its shop data.
  * Returns the amount in sunflowers (multiplied by 1000 for precision).
  */
 export function calculateSunflowerAmount(
-    item: ShoppingCartItemWithShopData,
+    item: Pick<ShoppingCartItemWithShopData, 'shopData'>,
 ): number {
     const price =
         typeof item.shopData.discountPrice === 'number'
             ? item.shopData.discountPrice
             : (item.shopData.price ?? 0);
     return Math.round(price * 1000);
+}
+
+export function getDefaultCartItemCurrency({
+    availableSunflowers,
+    items,
+    newCartItemId,
+}: {
+    availableSunflowers: number;
+    items: readonly ShoppingCartItemForSunflowerCalculation[];
+    newCartItemId: number;
+}): 'eur' | 'sunflower' {
+    const newItem = items.find((item) => item.id === newCartItemId);
+    if (!newItem || newItem.status === 'paid') {
+        return 'eur';
+    }
+
+    const newItemSunflowers = calculateSunflowerAmount(newItem);
+    if (newItemSunflowers <= 0) {
+        return 'eur';
+    }
+
+    const committedSunflowers = items
+        .filter(
+            (item) =>
+                item.id !== newCartItemId &&
+                item.status !== 'paid' &&
+                item.currency === 'sunflower',
+        )
+        .reduce((total, item) => total + calculateSunflowerAmount(item), 0);
+
+    return committedSunflowers + newItemSunflowers <= availableSunflowers
+        ? 'sunflower'
+        : 'eur';
 }

--- a/apps/garden/tests/raised-bed-diary.spec.tsx
+++ b/apps/garden/tests/raised-bed-diary.spec.tsx
@@ -102,12 +102,12 @@ function expectBaseSchedulingPayload(
     expect(payload).toMatchObject({
         amount: 1,
         cartId: 1,
-        currency: 'eur',
         entityId,
         entityTypeName: 'operation',
         gardenId: TEST_GARDEN_ID,
         raisedBedId: TEST_RAISED_BED_ID,
     });
+    expect(payload.currency).toBeUndefined();
     expect(parseScheduledDate(payload)).toBe(
         new Date(selectedDate).toISOString(),
     );

--- a/apps/garden/tests/raised-bed-onboarding-modal.spec.tsx
+++ b/apps/garden/tests/raised-bed-onboarding-modal.spec.tsx
@@ -652,13 +652,20 @@ test('raised-bed onboarding applies twelve suggested cart plants', async ({
         expect.arrayContaining([
             expect.objectContaining({
                 amount: 1,
-                currency: 'eur',
                 entityTypeName: 'plantSort',
                 gardenId,
                 raisedBedId,
             }),
         ]),
     );
+    expect(
+        posts.every(
+            (post) =>
+                typeof post === 'object' &&
+                post !== null &&
+                Reflect.get(post, 'currency') === undefined,
+        ),
+    ).toBe(true);
     expect(
         new Set(
             posts

--- a/packages/game/src/hud/RaisedBedOnboardingModal.tsx
+++ b/packages/game/src/hud/RaisedBedOnboardingModal.tsx
@@ -958,7 +958,6 @@ export function RaisedBedOnboardingModal({
                     raisedBedId: targetRaisedBed.id,
                     positionIndex: placement.positionIndex,
                     additionalData: JSON.stringify({ scheduledDate }),
-                    currency: 'eur',
                 });
             }
 

--- a/packages/game/src/hud/raisedBed/RaisedBedAiOperationMarkdown.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedAiOperationMarkdown.tsx
@@ -183,7 +183,6 @@ function RaisedBedAiOperationChip({
                     additionalData: JSON.stringify({
                         scheduledDate: scheduledDate.toISOString(),
                     }),
-                    currency: 'eur',
                 });
             }}
             positionIndex={targetPositionIndex}

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -458,7 +458,7 @@ export function PlantPicker({
                                   : {}),
                           }),
                 }),
-                currency: useInventoryItem ? 'inventory' : 'eur',
+                currency: useInventoryItem ? 'inventory' : undefined,
                 outletOfferId:
                     useOutletOffer && selectedOutletOffer
                         ? selectedOutletOffer.id

--- a/packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx
@@ -73,7 +73,7 @@ export function OperationsListItem({
                       scheduledDate: scheduledDate.toISOString(),
                   })
                 : null,
-            currency: useInventoryItem ? 'inventory' : 'eur',
+            currency: useInventoryItem ? 'inventory' : undefined,
         });
         animateFlyToShoppingCart.run();
     }


### PR DESCRIPTION
## Summary

- default genuinely new cart items to sunflower payment when the account balance covers the existing sunflower commitments plus the new item
- preserve explicit EUR choices, inventory use, and existing-item currency updates
- let Garden planting and operation add flows delegate their default currency to the cart API
- cover cumulative affordability, discounts, paid/EUR exclusions, and zero-price fallback

## Why

Garden add-to-cart paths either hard-coded EUR or relied on the storage default, so users with enough sunflowers had to switch payment manually. Checking only the new item would also allow cumulative sunflower commitments to exceed the available balance.

## Validation

- `corepack pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/checkout/sunflowerCalculations.node.spec.ts` (4 passed)
- `corepack pnpm --filter api exec tsc --noEmit --pretty false`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter garden typecheck`
- `corepack pnpm --filter @gredice/game test` (769 passed)
- targeted Biome checks
- `git diff --check`