### PR TITLE
fix(game): keep sunflower checkout in app

### DIFF
--- a/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
+++ b/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
@@ -9,6 +9,7 @@ import {
     useShoppingCartQueryKey,
 } from '../../../packages/game/src/hooks/useShoppingCart';
 import { ShoppingCartItem } from '../../../packages/game/src/hud/components/shopping-cart/ShoppingCartItem';
+import { PaymentSuccessfulMessage } from '../../../packages/game/src/hud/PaymentSuccessfulMessage';
 import {
     ShoppingCart,
     ShoppingCartHud,
@@ -99,6 +100,10 @@ const onePresenceItem = [cartItem];
 const twoPresenceItems = [cartItem, basilCartItem];
 const basilAndMintPresenceItems = [basilCartItem, mintCartItem];
 const noPresenceItems: ShoppingCartItemData[] = [];
+const sunflowerCartItem: ShoppingCartItemData = {
+    ...cartItem,
+    currency: 'sunflower',
+};
 
 function createOutletCartItem() {
     const plantSortItem = createPlantSortCartItem();
@@ -201,7 +206,10 @@ function cartTotal(items: ShoppingCartItemData[]) {
     );
 }
 
-function createOptimisticToggleQueryClient(items = onePresenceItem) {
+function createOptimisticToggleQueryClient(
+    items = onePresenceItem,
+    totalSunflowers = 0,
+) {
     const queryClient = new ReactQuery.QueryClient({
         defaultOptions: {
             queries: { retry: false, staleTime: Infinity },
@@ -246,8 +254,10 @@ function createOptimisticToggleQueryClient(items = onePresenceItem) {
         id: 1,
         items,
         notes: [],
-        total: cartTotal(items),
-        totalSunflowers: 0,
+        total: items.some((item) => item.currency === 'eur')
+            ? cartTotal(items)
+            : 0,
+        totalSunflowers,
     });
 
     return queryClient;
@@ -258,18 +268,20 @@ function ShoppingCartOptimisticToggleProviders({
     hasMemory = false,
     item,
     items,
+    totalSunflowers,
 }: PropsWithChildren<{
     hasMemory?: boolean;
     item?: ShoppingCartItemData;
     items?: ShoppingCartItemData[];
+    totalSunflowers?: number;
 }>) {
     const initialItems = useMemo(
         () => items ?? (item ? [item] : onePresenceItem),
         [item, items],
     );
     const queryClient = useMemo(
-        () => createOptimisticToggleQueryClient(initialItems),
-        [initialItems],
+        () => createOptimisticToggleQueryClient(initialItems, totalSunflowers),
+        [initialItems, totalSunflowers],
     );
     const gameStore = useMemo(
         () =>
@@ -481,6 +493,19 @@ export function ShoppingCartHudItemsPresenceStory() {
             items={onePresenceItem}
         >
             <ShoppingCartItemsPresencePanel useProductionHud />
+        </ShoppingCartOptimisticToggleProviders>
+    );
+}
+
+export function ShoppingCartSunflowerCheckoutStory() {
+    return (
+        <ShoppingCartOptimisticToggleProviders
+            hasMemory
+            items={[sunflowerCartItem]}
+            totalSunflowers={2500}
+        >
+            <ShoppingCartItemsPresencePanel useProductionHud />
+            <PaymentSuccessfulMessage />
         </ShoppingCartOptimisticToggleProviders>
     );
 }

--- a/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
+++ b/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
@@ -7,6 +7,7 @@ import {
     ShoppingCartOutletCountdownStory,
     ShoppingCartPaidItemStory,
     ShoppingCartPlantSortStory,
+    ShoppingCartSunflowerCheckoutStory,
     ShoppingCartTargetedOperationStory,
 } from './ShoppingCartOptimisticToggleStory';
 
@@ -792,6 +793,106 @@ test.describe('shopping cart item presence', () => {
         await expect(
             page.getByRole('dialog', { name: 'Košara' }),
         ).toContainText('Košara je prazna');
+    });
+
+    test('shows checkout success in place for a sunflower-only cart', async ({
+        mount,
+        page,
+    }) => {
+        let checkoutCompleted = false;
+        await page.route(
+            '**/api/gredice/api/checkout/checkout',
+            async (route) => {
+                checkoutCompleted = true;
+                await route.fulfill({
+                    body: JSON.stringify({ success: true }),
+                    contentType: 'application/json',
+                    status: 200,
+                });
+            },
+        );
+        await page.route('**/api/gredice/**/shopping-cart', async (route) => {
+            if (route.request().method() !== 'GET') {
+                await route.fallback();
+                return;
+            }
+
+            await route.fulfill({
+                body: JSON.stringify(
+                    checkoutCompleted
+                        ? createShoppingCartServerData([])
+                        : {
+                              ...createShoppingCartServerData(),
+                              items: [
+                                  {
+                                      ...shoppingCartServerItem,
+                                      currency: 'sunflower',
+                                  },
+                              ],
+                              total: 0,
+                              totalSunflowers: 2500,
+                          },
+                ),
+                contentType: 'application/json',
+                status: 200,
+            });
+        });
+
+        await mount(<ShoppingCartSunflowerCheckoutStory />);
+        const initialUrl = page.url();
+
+        await page.getByTitle('Košara').click();
+        await page.getByRole('button', { name: 'Potvrdi i plati' }).click();
+        await page
+            .getByRole('alertdialog')
+            .getByRole('button', { name: 'Potvrdi' })
+            .click();
+
+        await expect(
+            page.getByRole('dialog', { name: 'Plaćanje uspješno' }),
+        ).toBeVisible();
+        await expect(page.getByRole('dialog', { name: 'Košara' })).toHaveCount(
+            0,
+        );
+        await expect(page).toHaveURL(initialUrl);
+    });
+
+    test('redirects when checkout returns a Stripe URL', async ({
+        mount,
+        page,
+    }) => {
+        await page.route(
+            '**/api/gredice/api/checkout/checkout',
+            async (route) => {
+                await route.fulfill({
+                    body: JSON.stringify({
+                        sessionId: 'cs_test',
+                        url: '/stripe-checkout',
+                    }),
+                    contentType: 'application/json',
+                    status: 200,
+                });
+            },
+        );
+        await page.route('**/api/gredice/**/shopping-cart', async (route) => {
+            if (route.request().method() !== 'GET') {
+                await route.fallback();
+                return;
+            }
+
+            await route.fulfill({
+                body: JSON.stringify(createShoppingCartServerData()),
+                contentType: 'application/json',
+                status: 200,
+            });
+        });
+
+        await mount(<ShoppingCartHudItemsPresenceStory />);
+
+        await page.getByTitle('Košara').click();
+        await page.getByRole('button', { name: 'Plati' }).click();
+
+        await expect(page).toHaveURL(/\/stripe-checkout$/u);
     });
 
     test('keeps cached cart items visible when the modal refresh fails', async ({

--- a/packages/game/src/hooks/useCheckout.ts
+++ b/packages/game/src/hooks/useCheckout.ts
@@ -1,5 +1,9 @@
 import { clientAuthenticated } from '@gredice/client';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+    usePaymentStatusParam,
+    useShoppingCartOpenParam,
+} from '../useUrlState';
 
 export interface CheckoutData {
     cartId: number;
@@ -15,6 +19,10 @@ export interface CheckoutData {
         scheduledDate: string;
     }>;
 }
+
+type CheckoutResult =
+    | { kind: 'completed-in-app' }
+    | { kind: 'stripe'; url: string };
 
 // Type guard to check if delivery selection is complete
 export function isCompleteDeliverySelection(
@@ -36,8 +44,12 @@ export function isCompleteDeliverySelection(
 }
 
 export function useCheckout() {
+    const queryClient = useQueryClient();
+    const [, setShoppingCartOpen] = useShoppingCartOpenParam();
+    const [, setPaymentStatus] = usePaymentStatusParam();
+
     return useMutation({
-        mutationFn: async (data: CheckoutData) => {
+        mutationFn: async (data: CheckoutData): Promise<CheckoutResult> => {
             const response =
                 await clientAuthenticated().api.checkout.checkout.$post({
                     json: data,
@@ -57,8 +69,7 @@ export function useCheckout() {
             }
 
             if ('success' in responseData) {
-                window.location.href = '/?placanje=uspjesno';
-                return;
+                return { kind: 'completed-in-app' };
             }
 
             const { url } = responseData;
@@ -68,8 +79,17 @@ export function useCheckout() {
                 );
             }
 
-            // If a URL is provided, redirect the user to that URL
-            window.location.href = url;
+            return { kind: 'stripe', url };
+        },
+        onSuccess: (result) => {
+            if (result.kind === 'stripe') {
+                window.location.href = result.url;
+                return;
+            }
+
+            setShoppingCartOpen(false);
+            setPaymentStatus('uspjesno');
+            void queryClient.invalidateQueries();
         },
         // Prevent the mutation from being run in parallel
         scope: {

--- a/packages/game/src/hud/PaymentSuccessfulMessage.tsx
+++ b/packages/game/src/hud/PaymentSuccessfulMessage.tsx
@@ -1,28 +1,27 @@
 'use client';
 
 import { Button } from '@gredice/ui/Button';
-import { useSearchParam } from '@gredice/ui/hooks';
 import { Navigate } from '@gredice/ui/icons';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import Image from 'next/image';
-import { useState } from 'react';
 import Confetti from 'react-confetti-boom';
 import { useGameAudio } from '../hooks/useGameAudio';
 import { GameModal } from '../shared-ui/game-modal';
+import { usePaymentStatusParam } from '../useUrlState';
 
 export function PaymentSuccessfulMessage() {
-    const [showSuccessMessage, setShowSuccessMessage] =
-        useSearchParam('placanje');
+    const [showSuccessMessage, setShowSuccessMessage] = usePaymentStatusParam();
     // Accept the legacy spelling for checkouts started before this deployment.
     const isSuccess =
         showSuccessMessage === 'uspjesno' || showSuccessMessage === 'uspijesno';
 
-    const [open, setOpen] = useState(isSuccess);
     const { resumeIfNeeded } = useGameAudio();
     function handleOpenChange(newOpen: boolean) {
-        setOpen(newOpen);
-        setShowSuccessMessage(undefined);
+        if (newOpen) {
+            return;
+        }
+        setShowSuccessMessage(null);
         resumeIfNeeded();
     }
 
@@ -39,7 +38,7 @@ export function PaymentSuccessfulMessage() {
     return (
         <GameModal
             title={title}
-            open={open}
+            open={isSuccess}
             onOpenChange={handleOpenChange}
             className="max-w-screen-md"
         >

--- a/packages/game/src/useUrlState.tsx
+++ b/packages/game/src/useUrlState.tsx
@@ -12,6 +12,10 @@ export function useShoppingCartOpenParam() {
     return useQueryState('kosarica', parseAsBoolean.withDefault(false));
 }
 
+export function usePaymentStatusParam() {
+    return useQueryState('placanje', parseAsString);
+}
+
 export function useOutletOpenParam() {
     return useQueryState('outlet', parseAsString);
 }
@@ -86,6 +90,7 @@ export function useOverviewSectionParam() {
 // Serializer for building URLs with query params
 export const urlStateSerializer = createSerializer({
     kosarica: parseAsBoolean,
+    placanje: parseAsString,
     outlet: parseAsString,
     'outlet-ponuda': parseAsInteger,
     ruksak: parseAsBoolean,


### PR DESCRIPTION
## Summary

- keep sunflower-only checkout inside the Garden app and show the existing success modal without reloading the document
- redirect only when the checkout API returns a Stripe session URL
- close the cart and refresh cached app data after an in-app completion
- cover both the in-app success path and the Stripe redirect path through the production cart HUD

## Root cause

The checkout hook treated a successful in-app checkout like a Stripe return by assigning `window.location.href`, even though the user had never left the Garden app.

## Validation

- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter @gredice/game test` — 769 passed
- `pnpm --filter garden test:prepare`
- shopping-cart Playwright component suite — 19 passed
- focused Biome checks
- `git diff --check`