### PR TITLE
feat(garden): add React-only 2D overview

### DIFF
--- a/apps/garden/app/getGardenGameFlags.ts
+++ b/apps/garden/app/getGardenGameFlags.ts
@@ -1,0 +1,40 @@
+import type { GameFeatureFlags } from '@gredice/game';
+import {
+    adaptiveHighQualityFlag,
+    blockGeometryMergingFlag,
+    enableDebugHudFlag,
+    enableSuncokretChatFlag,
+    enableSuncokretDebugFlag,
+    rainWetOverlayFlag,
+    staticOpaqueSceneCacheFlag,
+} from './flags';
+
+export async function getGardenGameFlags(): Promise<GameFeatureFlags> {
+    const [
+        enableAdaptiveHighQualityFlag,
+        enableBlockGeometryMergingFlag,
+        enableDebugHud,
+        enableRainWetOverlayFlag,
+        enableStaticOpaqueSceneCacheFlag,
+        enableSuncokretChat,
+        enableSuncokretDebug,
+    ] = await Promise.all([
+        adaptiveHighQualityFlag(),
+        blockGeometryMergingFlag(),
+        enableDebugHudFlag(),
+        rainWetOverlayFlag(),
+        staticOpaqueSceneCacheFlag(),
+        enableSuncokretChatFlag(),
+        enableSuncokretDebugFlag(),
+    ]);
+
+    return {
+        enableAdaptiveHighQualityFlag,
+        enableBlockGeometryMergingFlag,
+        enableDebugHudFlag: enableDebugHud,
+        enableRainWetOverlayFlag,
+        enableStaticOpaqueSceneCacheFlag,
+        enableSuncokretChatFlag: enableSuncokretChat,
+        enableSuncokretDebugFlag: enableSuncokretDebug,
+    };
+}

--- a/apps/garden/app/pregled-vrta/page.tsx
+++ b/apps/garden/app/pregled-vrta/page.tsx
@@ -1,14 +1,18 @@
 import { SignedIn, SignedOut } from '@gredice/ui/auth';
-import type { Viewport } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { cookies } from 'next/headers';
-import LoginModal from '../components/auth/LoginModal';
-import { GameSceneWithAnalytics } from '../components/game/GameSceneWithAnalytics';
-import { getGardenGameFlags } from './getGardenGameFlags';
+import LoginModal from '../../components/auth/LoginModal';
+import { GardenOverview2DWithAnalytics } from '../../components/game/GardenOverview2DWithAnalytics';
+import { getGardenGameFlags } from '../getGardenGameFlags';
 
 const impersonationFlagCookieName = 'gredice_impersonating';
 
-// Garden experience routes paint edge to edge. Other Garden routes keep the
-// root viewport behavior so their document UI remains safely contained.
+export const metadata: Metadata = {
+    title: '2D pregled vrta | Gredice',
+    description:
+        'Brzi top-down pregled vrta bez 3D iscrtavanja, uz sve alate za upravljanje vrtom.',
+};
+
 export const viewport: Viewport = {
     initialScale: 1,
     maximumScale: 1,
@@ -18,27 +22,25 @@ export const viewport: Viewport = {
     width: 'device-width',
 };
 
-export default async function Home() {
+export default async function GardenOverviewPage() {
     const cookieStore = await cookies();
     const suppressOpeningHud =
         cookieStore.get(impersonationFlagCookieName)?.value === '1';
     const flags = await getGardenGameFlags();
 
     return (
-        <div className="grid grid-cols-1 h-[100dvh] relative overflow-hidden">
+        <div className="relative grid h-[100dvh] grid-cols-1 overflow-hidden">
             <SignedIn>
-                <GameSceneWithAnalytics
+                <GardenOverview2DWithAnalytics
                     flags={flags}
-                    deferDetails
                     suppressOpeningHud={suppressOpeningHud}
                 />
             </SignedIn>
             <SignedOut>
-                <GameSceneWithAnalytics
+                <GardenOverview2DWithAnalytics
                     flags={flags}
                     mockGarden
                     hideHud
-                    deferDetails
                 />
             </SignedOut>
             <SignedOut>

--- a/apps/garden/components/game/GardenOverview2DWithAnalytics.tsx
+++ b/apps/garden/components/game/GardenOverview2DWithAnalytics.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { GameAnalyticsProvider } from '@gredice/game/analytics';
+import {
+    GardenOverview2DDynamic,
+    type GardenOverview2DProps,
+} from '@gredice/game/garden-2d';
+import { usePostHog } from '@posthog/next';
+
+export function GardenOverview2DWithAnalytics(props: GardenOverview2DProps) {
+    const posthog = usePostHog();
+
+    return (
+        <GameAnalyticsProvider
+            capture={(eventName, properties) => {
+                posthog?.capture(eventName, {
+                    surface: 'garden_2d',
+                    ...properties,
+                });
+            }}
+        >
+            <GardenOverview2DDynamic {...props} />
+        </GameAnalyticsProvider>
+    );
+}

--- a/apps/garden/components/providers/ClientAppProvider.tsx
+++ b/apps/garden/components/providers/ClientAppProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useThemeManager } from '@gredice/game';
+import { useThemeManager } from '@gredice/game/theme';
 import { AuthProvider } from '@gredice/ui/auth';
 import { NotificationsContainer } from '@gredice/ui/notifications';
 import { NuqsAdapter } from '@gredice/ui/nuqs';

--- a/apps/garden/tests/landing.spec.ts
+++ b/apps/garden/tests/landing.spec.ts
@@ -1,4 +1,9 @@
 import { type ConsoleMessage, expect, type Page, test } from '@playwright/test';
+import { getLocalSandboxBlockData } from '../../../packages/game/src/localSandboxBlockData';
+
+type GardenRenderProbeWindow = Window & {
+    __gardenWebglContextRequests?: number;
+};
 
 const currentUser = {
     avatarUrl: null,
@@ -37,6 +42,85 @@ const tutorialChecklist = {
     },
 };
 
+const gardenOverviewListItem = {
+    createdAt: '2026-07-01T00:00:00.000Z',
+    id: 1,
+    isSandbox: false,
+    name: 'Testni vrt',
+};
+
+const gardenOverviewDetail = {
+    ...gardenOverviewListItem,
+    backgroundPalette: 'current',
+    farmId: 1,
+    homeCamera: null,
+    isPublic: false,
+    latitude: 45.739,
+    longitude: 16.572,
+    previewImage: null,
+    previewSourceRevision: null,
+    raisedBeds: [
+        {
+            abandonReason: null,
+            appliedOperations: [],
+            blockId: 'raised-bed-primary',
+            createdAt: '2026-07-01T00:00:00.000Z',
+            fields: [],
+            id: 10,
+            isValid: true,
+            name: 'Testna gredica',
+            orientation: 'vertical',
+            physicalId: null,
+            status: 'active',
+            updatedAt: '2026-07-01T00:00:00.000Z',
+            weedState: null,
+        },
+    ],
+    stacks: {
+        '0': {
+            '0': [
+                {
+                    id: 'grass-0-0',
+                    name: 'Block_Grass',
+                    rotation: 0,
+                },
+                {
+                    id: 'raised-bed-primary',
+                    name: 'Raised_Bed',
+                    rotation: 0,
+                },
+            ],
+            '1': [
+                {
+                    id: 'grass-0-1',
+                    name: 'Block_Grass',
+                    rotation: 0,
+                },
+                {
+                    id: 'raised-bed-secondary',
+                    name: 'Raised_Bed',
+                    rotation: 0,
+                },
+            ],
+        },
+        '2': {
+            '-1': [
+                {
+                    id: 'grass-2--1',
+                    name: 'Block_Grass',
+                    rotation: 0,
+                },
+                {
+                    id: 'tree-2--1',
+                    name: 'Tree',
+                    rotation: 0,
+                },
+            ],
+        },
+    },
+    updatedAt: '2026-07-01T00:00:00.000Z',
+};
+
 const crashPatterns = [
     /Maximum update depth exceeded/u,
     /The result of getSnapshot should be cached/u,
@@ -65,7 +149,14 @@ function collectRuntimeFailures(page: Page) {
     return failures;
 }
 
-async function mockGardenApi(page: Page, signedIn: boolean) {
+async function mockGardenApi(
+    page: Page,
+    signedIn: boolean,
+    {
+        withBlockData = false,
+        withGarden = false,
+    }: { withBlockData?: boolean; withGarden?: boolean } = {},
+) {
     await page.route('**/api/gredice/**', async (route) => {
         const { pathname } = new URL(route.request().url());
         let body: unknown;
@@ -76,8 +167,58 @@ async function mockGardenApi(page: Page, signedIn: boolean) {
             body = {};
         } else if (pathname.endsWith('/api/users/current')) {
             body = signedIn ? currentUser : null;
+        } else if (
+            withGarden &&
+            pathname.endsWith('/api/gardens/1/operations')
+        ) {
+            body = { items: [], nextCursor: null, total: 0 };
+        } else if (
+            withGarden &&
+            pathname.endsWith('/api/gardens/1/visit-summary/seen')
+        ) {
+            body = {
+                state: {
+                    accountId: 'test-account',
+                    gardenId: 1,
+                    id: 1,
+                    lastOpenedAt: '2026-07-28T00:00:00.000Z',
+                    lastSummaryFactsHash: null,
+                    lastSummarySeenAt: '2026-07-28T00:00:00.000Z',
+                    userId: currentUser.id,
+                },
+            };
+        } else if (
+            withGarden &&
+            pathname.endsWith('/api/gardens/1/visit-summary')
+        ) {
+            body = {
+                facts: [],
+                factsHash: null,
+                state: null,
+                window: {
+                    firstVisit: false,
+                    since: '2026-07-01T00:00:00.000Z',
+                    until: '2026-07-28T00:00:00.000Z',
+                },
+            };
+        } else if (
+            withGarden &&
+            pathname.endsWith('/api/gardens/1/raised-beds/10/ai-history')
+        ) {
+            body = [];
+        } else if (
+            withGarden &&
+            pathname.endsWith('/api/gardens/1/raised-beds/10/sensors')
+        ) {
+            body = [];
+        } else if (withGarden && pathname.endsWith('/api/gardens/1')) {
+            body = gardenOverviewDetail;
         } else if (pathname.endsWith('/api/gardens')) {
-            body = signedIn ? [] : null;
+            body = signedIn
+                ? withGarden
+                    ? [gardenOverviewListItem]
+                    : []
+                : null;
         } else if (pathname.endsWith('/api/accounts/gardens')) {
             body = signedIn
                 ? [
@@ -85,12 +226,22 @@ async function mockGardenApi(page: Page, signedIn: boolean) {
                           accountId: 'test-account',
                           name: 'test@example.com račun',
                           isCurrent: true,
-                          gardens: [],
+                          gardens: withGarden
+                              ? [
+                                    {
+                                        ...gardenOverviewListItem,
+                                        isDefault: true,
+                                    },
+                                ]
+                              : [],
                       },
                   ]
                 : null;
         } else if (pathname.includes('/api/directories/entities/')) {
-            body = [];
+            body =
+                withBlockData && pathname.endsWith('/entities/block')
+                    ? getLocalSandboxBlockData()
+                    : [];
         } else if (pathname.endsWith('/api/data/weather/now')) {
             body = {
                 cloudy: 0,
@@ -245,6 +396,195 @@ test('loads signed-in landing page HUD without immediate runtime failures', asyn
     await expectNoImmediateRuntimeFailures(page, failures);
 });
 
+test('loads the signed-out React-only garden page behind the login prompt', async ({
+    page,
+}) => {
+    const failures = collectRuntimeFailures(page);
+    await mockGardenApi(page, false, { withBlockData: true });
+
+    const response = await page.goto('/pregled-vrta');
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('[data-garden-renderer="2d"]')).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Prijava' }).first(),
+    ).toBeVisible();
+    await expect(page.locator('canvas')).toHaveCount(0);
+    await expectNoImmediateRuntimeFailures(page, failures);
+});
+
+test('opens the React-only garden page from the existing HUD', async ({
+    context,
+    page,
+}) => {
+    test.setTimeout(20_000);
+    await context.addCookies([
+        {
+            domain: '127.0.0.1',
+            name: 'gredice_impersonating',
+            path: '/',
+            value: '1',
+        },
+    ]);
+    await mockGardenApi(page, true);
+
+    const response = await page.goto('/?vrt=1');
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.getByTitle('Profil')).toBeVisible({ timeout: 15_000 });
+    await page.getByTitle('Profil').click();
+    const overviewLink = page.getByRole('menuitem', {
+        name: '2D prikaz vrta',
+    });
+    await expect(overviewLink).toHaveAttribute('href', '/pregled-vrta?vrt=1');
+    await overviewLink.click();
+    await expect(page).toHaveURL(/\/pregled-vrta\?vrt=1$/u);
+    await expect(page.locator('[data-garden-renderer="2d"]')).toBeVisible();
+    await expect(page.locator('canvas')).toHaveCount(0);
+});
+
+test('renders the shared HUD over a React-only 2D garden overview', async ({
+    context,
+    page,
+}) => {
+    test.setTimeout(20_000);
+    const failures = collectRuntimeFailures(page);
+    const modelRequests: string[] = [];
+    await page.setViewportSize({ height: 844, width: 390 });
+    await page.addInitScript(() => {
+        const probeWindow = window as GardenRenderProbeWindow;
+        probeWindow.__gardenWebglContextRequests = 0;
+        const originalGetContext = HTMLCanvasElement.prototype.getContext;
+        const instrumentedGetContext = function (
+            this: HTMLCanvasElement,
+            contextId: string,
+            ...args: unknown[]
+        ) {
+            if (contextId === 'webgl' || contextId === 'webgl2') {
+                probeWindow.__gardenWebglContextRequests =
+                    (probeWindow.__gardenWebglContextRequests ?? 0) + 1;
+            }
+            return Reflect.apply(originalGetContext, this, [
+                contextId,
+                ...args,
+            ]);
+        };
+        HTMLCanvasElement.prototype.getContext =
+            instrumentedGetContext as typeof originalGetContext;
+    });
+    page.on('request', (request) => {
+        if (new URL(request.url()).pathname.endsWith('.glb')) {
+            modelRequests.push(request.url());
+        }
+    });
+    await context.addCookies([
+        {
+            domain: '127.0.0.1',
+            name: 'gredice_impersonating',
+            path: '/',
+            value: '1',
+        },
+    ]);
+    await mockGardenApi(page, true, {
+        withBlockData: true,
+        withGarden: true,
+    });
+
+    const response = await page.goto('/pregled-vrta?vrt=1');
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('[data-garden-renderer="2d"]')).toBeVisible();
+    await expect(
+        page.getByRole('region', { name: 'Tlocrt vrta Testni vrt' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: /Otvori gredicu Testna gredica/u }),
+    ).toBeVisible();
+    await expect(page.getByTitle('Profil')).toBeVisible();
+    await expect(page.locator('canvas')).toHaveCount(0);
+    await expect(page.getByTitle(/zvuk/u)).toHaveCount(0);
+    expect(modelRequests).toEqual([]);
+    await expect
+        .poll(() =>
+            page.evaluate(
+                () =>
+                    (window as GardenRenderProbeWindow)
+                        .__gardenWebglContextRequests ?? 0,
+            ),
+        )
+        .toBe(0);
+
+    const overview = page.getByRole('region', {
+        name: 'Tlocrt vrta Testni vrt',
+    });
+    const overviewScrollport = page.locator('[data-garden-overview-2d]');
+    await expect(overview).toHaveAttribute('data-preview-track-padding', '2');
+    const initialScrollBounds = await overviewScrollport.boundingBox();
+    const initialOverviewBounds = await overview.boundingBox();
+    expect(initialScrollBounds).not.toBeNull();
+    expect(initialOverviewBounds).not.toBeNull();
+    expect(initialOverviewBounds?.x).toBeGreaterThanOrEqual(
+        initialScrollBounds?.x ?? 0,
+    );
+    const horizontalScrollRange = await overviewScrollport.evaluate(
+        (element) => {
+            element.scrollLeft = element.scrollWidth - element.clientWidth;
+            return element.scrollWidth - element.clientWidth;
+        },
+    );
+    expect(horizontalScrollRange).toBeGreaterThan(0);
+    const finalScrollBounds = await overviewScrollport.boundingBox();
+    const finalOverviewBounds = await overview.boundingBox();
+    expect(finalScrollBounds).not.toBeNull();
+    expect(finalOverviewBounds).not.toBeNull();
+    expect(
+        (finalOverviewBounds?.x ?? 0) + (finalOverviewBounds?.width ?? 0),
+    ).toBeLessThanOrEqual(
+        (finalScrollBounds?.x ?? 0) + (finalScrollBounds?.width ?? 0) + 1,
+    );
+
+    await expect(overview).toHaveAttribute('data-world-rotation', '0');
+    await expect(
+        overview.locator('img[src*="Raised_Bed_1"]').first(),
+    ).toBeVisible();
+    await page.getByTitle('Okreni desno').click();
+    await expect(overview).toHaveAttribute('data-world-rotation', '1');
+    await expect(
+        overview.locator('img[src*="Raised_Bed_2"]').first(),
+    ).toBeVisible();
+
+    await page.getByTitle('Profil').click();
+    await expect(
+        page.getByRole('menuitem', { name: '3D prikaz vrta' }),
+    ).toHaveAttribute('href', '/?vrt=1');
+
+    await page.keyboard.press('Escape');
+    await page
+        .getByRole('button', { name: /Otvori gredicu Testna gredica/u })
+        .click();
+    await expect(page).toHaveURL(/gredica=Testna\+gredica/u);
+    await expect(page.locator('[data-garden-overview-2d]')).toHaveClass(
+        /opacity-0/u,
+    );
+    await expect(
+        page.getByRole('button', {
+            name: 'Podignuta gredica Testna gredica',
+        }),
+    ).toBeVisible();
+    await expectNoImmediateRuntimeFailures(page, failures);
+    await expect(page.locator('canvas')).toHaveCount(0);
+    expect(modelRequests).toEqual([]);
+    await expect
+        .poll(() =>
+            page.evaluate(
+                () =>
+                    (window as GardenRenderProbeWindow)
+                        .__gardenWebglContextRequests ?? 0,
+            ),
+        )
+        .toBe(0);
+});
+
 test('renders the whole game edge to edge while keeping HUD controls safe', async ({
     context,
     page,
@@ -379,20 +719,25 @@ test('keeps landscape game dialogs inside the safe area', async ({ page }) => {
     ).toBeLessThanOrEqual(844 - landscapeSafeArea.right);
 });
 
-test('keeps edge-to-edge viewport behavior scoped to the game route', async ({
+test('keeps edge-to-edge viewport behavior scoped to garden experience routes', async ({
     request,
 }) => {
     const gameResponse = await request.get('/');
+    const overviewResponse = await request.get('/pregled-vrta');
     const documentResponse = await request.get('/pozivnica');
 
     expect(gameResponse.ok()).toBe(true);
+    expect(overviewResponse.ok()).toBe(true);
     expect(documentResponse.ok()).toBe(true);
 
     const gameHtml = await gameResponse.text();
+    const overviewHtml = await overviewResponse.text();
     const documentHtml = await documentResponse.text();
 
     expect(gameHtml.match(/name="viewport"/gu)).toHaveLength(1);
     expect(gameHtml).toContain('viewport-fit=cover');
+    expect(overviewHtml.match(/name="viewport"/gu)).toHaveLength(1);
+    expect(overviewHtml).toContain('viewport-fit=cover');
     expect(documentHtml).not.toContain('viewport-fit=cover');
 });
 

--- a/apps/garden/tests/landing.spec.ts
+++ b/apps/garden/tests/landing.spec.ts
@@ -553,6 +553,11 @@ test('renders the shared HUD over a React-only 2D garden overview', async ({
         overview.locator('img[src*="Raised_Bed_2"]').first(),
     ).toBeVisible();
 
+    await page
+        .getByRole('button', {
+            name: 'Privremeno sakrij banner impersonacije',
+        })
+        .click();
     await page.getByTitle('Profil').click();
     await expect(
         page.getByRole('menuitem', { name: '3D prikaz vrta' }),

--- a/packages/game/package.json
+++ b/packages/game/package.json
@@ -8,7 +8,10 @@
     "type": "module",
     "license": "MIT",
     "exports": {
-        ".": "./src/index.ts"
+        ".": "./src/index.ts",
+        "./analytics": "./src/analytics/GameAnalyticsContext.tsx",
+        "./garden-2d": "./src/GardenOverview2DDynamic.tsx",
+        "./theme": "./src/hooks/useThemeManager.ts"
     },
     "scripts": {
         "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -4,6 +4,7 @@ import { IconButton } from '@gredice/ui/IconButton';
 import { Megaphone } from '@gredice/ui/icons';
 import { cx } from '@gredice/ui/utils';
 import { useState } from 'react';
+import type { GardenViewMode } from './gardenViewMode';
 import { useCurrentGarden } from './hooks/useCurrentGarden';
 import { useMarkTutorialChecklistTaskReady } from './hooks/useTutorialChecklist';
 import { AccountHud } from './hud/AccountHud';
@@ -11,7 +12,7 @@ import { AdventHud } from './hud/AdventHud';
 import { AudioHud } from './hud/AudioHud';
 import { CameraHud } from './hud/CameraHud';
 import { ControlsTooltipHud } from './hud/ControlsTooltipHud';
-import { DebugHud } from './hud/DebugHud';
+import { DebugHudDynamic } from './hud/DebugHudDynamic';
 import { GardenVisitSummaryHighlightHud } from './hud/GardenVisitSummaryHighlightHud';
 import { GardenVisitSummaryModal } from './hud/GardenVisitSummaryModal';
 import { InventoryHud } from './hud/InventoryHud';
@@ -61,10 +62,12 @@ export function GameHud({
     debugHud,
     noWeather,
     suppressOpeningHud,
+    viewMode = '3d',
 }: {
     debugHud?: boolean;
     noWeather?: boolean;
     suppressOpeningHud?: boolean;
+    viewMode?: GardenViewMode;
 }) {
     const [welcomeConfirmed, setWelcomeConfirmed] = useState(false);
     const [whatsNewOpenRequestId, setWhatsNewOpenRequestId] = useState(0);
@@ -129,7 +132,7 @@ export function GameHud({
                     'motion-safe:slide-in-from-left-4',
                 )}
             >
-                {!isLocalSandbox && <AccountHud />}
+                {!isLocalSandbox && <AccountHud viewMode={viewMode} />}
                 {!isLocalSandbox && raisedBedOnboardingAvailable && (
                     <RaisedBedOnboardingModal
                         autoOpen={raisedBedOnboardingEnabled}
@@ -194,8 +197,8 @@ export function GameHud({
                     )}
                 >
                     <CameraHud />
-                    <AudioHud />
-                    <ControlsTooltipHud />
+                    {viewMode === '3d' ? <AudioHud /> : null}
+                    {viewMode === '3d' ? <ControlsTooltipHud /> : null}
                     {whatsNewHudEnabled && (
                         <IconButton
                             title="Što je novo"
@@ -223,7 +226,9 @@ export function GameHud({
                     <ItemsHud />
                 </div>
             </div>
-            {!isLocalSandbox && <RaisedBedFieldHud />}
+            {!isLocalSandbox && (
+                <RaisedBedFieldHud instantTransition={viewMode === '2d'} />
+            )}
             {!isLocalSandbox && <OverviewModal />}
             {!isLocalSandbox && <AdventModal />}
             {!isLocalSandbox && <GiftBoxModal />}
@@ -249,7 +254,7 @@ export function GameHud({
                 </>
             )}
             {!isLocalSandbox && <PaymentSuccessfulMessage />}
-            {debugHud && <DebugHud />}
+            {debugHud && viewMode === '3d' ? <DebugHudDynamic /> : null}
         </SuncokretChatProvider>
     );
 }

--- a/packages/game/src/GameRuntimeProvider.tsx
+++ b/packages/game/src/GameRuntimeProvider.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { type PropsWithChildren, useEffect, useRef } from 'react';
+import { type GameFeatureFlags, GameFlagsContext } from './GameFlagsContext';
+import type { GameSceneProps } from './GameScene';
+import { GardenSelectionGate } from './GardenSelectionGate';
+import {
+    createGameState,
+    GameStateContext,
+    type GameStateStore,
+    useDisposeGameStateStore,
+} from './useGameState';
+
+export type GameRuntimeProviderProps = PropsWithChildren<
+    Pick<
+        GameSceneProps,
+        | 'appBaseUrl'
+        | 'dayNightCycleDisabled'
+        | 'flags'
+        | 'freezeTime'
+        | 'initialQualitySetting'
+        | 'localSandboxInitialStacks'
+        | 'localSandboxStorageKey'
+        | 'mockGarden'
+        | 'mockGardenProfile'
+        | 'spriteBaseUrl'
+        | 'winterMode'
+    > & {
+        visualPlacementEffectsEnabled?: boolean;
+    }
+>;
+
+export function GameRuntimeProvider({
+    appBaseUrl,
+    children,
+    dayNightCycleDisabled,
+    flags,
+    freezeTime,
+    initialQualitySetting,
+    localSandboxInitialStacks,
+    localSandboxStorageKey,
+    mockGarden,
+    mockGardenProfile,
+    spriteBaseUrl,
+    visualPlacementEffectsEnabled,
+    winterMode,
+}: GameRuntimeProviderProps) {
+    const storeRef = useRef<GameStateStore>(null);
+    if (!storeRef.current) {
+        storeRef.current = createGameState({
+            appBaseUrl: appBaseUrl || '',
+            spriteBaseUrl,
+            dayNightCycleDisabled,
+            freezeTime: freezeTime || null,
+            initialQualitySetting,
+            isMock: mockGarden || false,
+            localSandboxStorageKey,
+            localSandboxInitialStacks,
+            mockGardenProfile,
+            visualPlacementEffectsEnabled,
+            winterMode: winterMode ?? 'summer',
+        });
+    }
+    useDisposeGameStateStore(storeRef.current);
+
+    useEffect(() => {
+        storeRef.current?.getState().setWinterMode(winterMode ?? 'summer');
+    }, [winterMode]);
+
+    useEffect(() => {
+        storeRef.current?.getState().setFreezeTime(freezeTime ?? null);
+    }, [freezeTime]);
+
+    useEffect(() => {
+        if (initialQualitySetting) {
+            storeRef.current?.setState({
+                gameQualitySetting: initialQualitySetting,
+            });
+        }
+    }, [initialQualitySetting]);
+
+    return (
+        <GameStateContext.Provider value={storeRef.current}>
+            <GameFlagsContext.Provider
+                value={(flags ?? {}) satisfies GameFeatureFlags}
+            >
+                <GardenSelectionGate
+                    disabled={Boolean(mockGarden || localSandboxStorageKey)}
+                >
+                    {children}
+                </GardenSelectionGate>
+            </GameFlagsContext.Provider>
+        </GameStateContext.Provider>
+    );
+}

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -46,6 +46,8 @@ import { useClearSandboxEnvironmentOverrides } from './hooks/useClearSandboxEnvi
 import { type CurrentGarden, useCurrentGarden } from './hooks/useCurrentGarden';
 import { useDeferredSceneDetails } from './hooks/useDeferredSceneDetails';
 import { useFocusPlacedBlock } from './hooks/useFocusPlacedBlock';
+import { useSceneCurrentGarden } from './hooks/useSceneCurrentGarden';
+import { useSyncGardenBackgroundPalette } from './hooks/useSyncGardenBackgroundPalette';
 import { useWeatherNow } from './hooks/useWeatherNow';
 import { DebugHud } from './hud/DebugHud';
 import { GardenLoadingIndicator } from './indicators/GardenLoadingIndicator';
@@ -363,7 +365,8 @@ export function GameScene({
 
     // Start non-critical metadata early, but don't block the first scene frame.
     useBlockData();
-    const { data: garden, isLoading: gardenLoading } = useCurrentGarden();
+    const { data: gardenData, isLoading: gardenLoading } = useCurrentGarden();
+    const garden = useSceneCurrentGarden(gardenData);
     const gardenInitialViewKey = garden?.id ?? 'default';
     const gardenInitialHomeCameraRef = useRef<{
         key: string | number;
@@ -391,24 +394,14 @@ export function GameScene({
     const sceneCameraZoom =
         gardenHomeCamera?.zoom ??
         (zoom === 'far' ? farGameCameraZoom : defaultGameCameraZoom);
-    const setBackgroundPaletteKey = useGameState(
-        (state) => state.setBackgroundPaletteKey,
-    );
     const gardenBackgroundPalette = garden?.backgroundPalette;
     useClearSandboxEnvironmentOverrides(garden);
+    useSyncGardenBackgroundPalette(gardenBackgroundPalette);
     useWeatherNow(
         !isLocalSandbox && !weatherDisabled && !weather && garden !== undefined,
         garden?.farmId,
     );
     const isLoading = gardenLoading;
-
-    useEffect(() => {
-        if (!gardenBackgroundPalette) {
-            return;
-        }
-
-        setBackgroundPaletteKey(gardenBackgroundPalette);
-    }, [gardenBackgroundPalette, setBackgroundPaletteKey]);
 
     const loadingContext = useGameLoading();
     useEffect(() => {

--- a/packages/game/src/GameSceneWrapper.tsx
+++ b/packages/game/src/GameSceneWrapper.tsx
@@ -1,18 +1,11 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { groundGameAssetNames, primaryGameAssetNames } from './data/models';
 import { resetPlacementAnimationProfileMetrics } from './entities/placementAnimationProfileMetrics';
-import { GameFlagsContext } from './GameFlagsContext';
+import { GameRuntimeProvider } from './GameRuntimeProvider';
 import { GameScene, type GameSceneProps } from './GameScene';
-import { GardenSelectionGate } from './GardenSelectionGate';
 import { GameProfileController } from './scene/GameProfileController';
-import {
-    createGameState,
-    GameStateContext,
-    type GameStateStore,
-    useDisposeGameStateStore,
-} from './useGameState';
 import { preloadGameAssetModels } from './utils/useGameGLTF';
 
 export function GameSceneWrapper({
@@ -30,48 +23,9 @@ export function GameSceneWrapper({
     winterMode,
     ...rest
 }: GameSceneProps) {
-    const storeRef = useRef<GameStateStore>(null);
-    if (!storeRef.current) {
-        storeRef.current = createGameState({
-            appBaseUrl: appBaseUrl || '',
-            spriteBaseUrl,
-            dayNightCycleDisabled,
-            freezeTime: freezeTime || null,
-            initialQualitySetting,
-            isMock: mockGarden || false,
-            localSandboxStorageKey,
-            localSandboxInitialStacks,
-            mockGardenProfile,
-            winterMode: winterMode ?? 'summer',
-        });
-    }
-    useDisposeGameStateStore(storeRef.current);
-
     useEffect(() => {
         resetPlacementAnimationProfileMetrics();
     }, []);
-
-    // Sync winterMode prop changes to the store
-    useEffect(() => {
-        if (storeRef.current) {
-            storeRef.current.getState().setWinterMode(winterMode ?? 'summer');
-        }
-    }, [winterMode]);
-
-    // Sync freezeTime prop changes to the store
-    useEffect(() => {
-        if (storeRef.current) {
-            storeRef.current.getState().setFreezeTime(freezeTime ?? null);
-        }
-    }, [freezeTime]);
-
-    useEffect(() => {
-        if (initialQualitySetting && storeRef.current) {
-            storeRef.current.setState({
-                gameQualitySetting: initialQualitySetting,
-            });
-        }
-    }, [initialQualitySetting]);
 
     const resolvedAppBaseUrl = appBaseUrl ?? '';
     preloadGameAssetModels(resolvedAppBaseUrl, groundGameAssetNames);
@@ -86,23 +40,25 @@ export function GameSceneWrapper({
     }, [resolvedAppBaseUrl]);
 
     return (
-        <GameStateContext.Provider value={storeRef.current}>
-            <GameFlagsContext.Provider value={flags ?? {}}>
-                <GardenSelectionGate
-                    disabled={Boolean(mockGarden || localSandboxStorageKey)}
-                >
-                    <GameScene
-                        enableGameProfileController={
-                            enableGameProfileController
-                        }
-                        flags={flags}
-                        {...rest}
-                    />
-                    {enableGameProfileController ? (
-                        <GameProfileController />
-                    ) : null}
-                </GardenSelectionGate>
-            </GameFlagsContext.Provider>
-        </GameStateContext.Provider>
+        <GameRuntimeProvider
+            appBaseUrl={appBaseUrl}
+            dayNightCycleDisabled={dayNightCycleDisabled}
+            flags={flags}
+            freezeTime={freezeTime}
+            initialQualitySetting={initialQualitySetting}
+            localSandboxInitialStacks={localSandboxInitialStacks}
+            localSandboxStorageKey={localSandboxStorageKey}
+            mockGarden={mockGarden}
+            mockGardenProfile={mockGardenProfile}
+            spriteBaseUrl={spriteBaseUrl}
+            winterMode={winterMode}
+        >
+            <GameScene
+                enableGameProfileController={enableGameProfileController}
+                flags={flags}
+                {...rest}
+            />
+            {enableGameProfileController ? <GameProfileController /> : null}
+        </GameRuntimeProvider>
     );
 }

--- a/packages/game/src/GardenOverview2DContent.tsx
+++ b/packages/game/src/GardenOverview2DContent.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { cx } from '@gredice/ui/utils';
+import { useMemo } from 'react';
+import { useGameFlags } from './GameFlagsContext';
+import { GameHud } from './GameHud';
+import styles from './GameScene.module.css';
+import { GardenOverview2DMap } from './GardenOverview2DMap';
+import { useBlockData } from './hooks/useBlockData';
+import { useClearSandboxEnvironmentOverrides } from './hooks/useClearSandboxEnvironmentOverrides';
+import { useCurrentGarden } from './hooks/useCurrentGarden';
+import { useSyncGameTime } from './hooks/useSyncGameTime';
+import { useSyncGardenBackgroundPalette } from './hooks/useSyncGardenBackgroundPalette';
+import { GardenLoadingIndicator } from './indicators/GardenLoadingIndicator';
+import { useGameState } from './useGameState';
+import { useRaisedBedCloseup } from './useRaisedBedCloseup';
+import { defaultGameLocation } from './utils/timeOfDay';
+
+export function GardenOverview2DContent({
+    className,
+    debugHud,
+    hideHud,
+    noWeather,
+    suppressOpeningHud,
+}: {
+    className?: string;
+    debugHud?: boolean;
+    hideHud?: boolean;
+    noWeather?: boolean;
+    suppressOpeningHud?: boolean;
+}) {
+    useRaisedBedCloseup();
+    const flags = useGameFlags();
+    const isLocalSandbox = useGameState(
+        (state) => state.localSandboxStorageKey !== null,
+    );
+    const {
+        data: blockData,
+        isError: blockDataError,
+        isLoading: blockDataLoading,
+    } = useBlockData();
+    const {
+        data: garden,
+        isError: gardenError,
+        isLoading: gardenLoading,
+    } = useCurrentGarden();
+    const gardenLatitude = garden?.location.lat;
+    const gardenLongitude = garden?.location.lon;
+    const location = useMemo(
+        () => ({
+            lat: gardenLatitude ?? defaultGameLocation.lat,
+            lon: gardenLongitude ?? defaultGameLocation.lon,
+        }),
+        [gardenLatitude, gardenLongitude],
+    );
+    useSyncGameTime(location);
+    useClearSandboxEnvironmentOverrides(garden);
+    useSyncGardenBackgroundPalette(garden?.backgroundPalette);
+
+    const isLoading = gardenLoading || blockDataLoading;
+    const showDebugHud = debugHud ?? Boolean(flags.enableDebugHudFlag);
+    const hud = !hideHud ? (
+        <GameHud
+            debugHud={showDebugHud}
+            noWeather={noWeather}
+            suppressOpeningHud={suppressOpeningHud}
+            viewMode="2d"
+        />
+    ) : null;
+
+    if (gardenError || blockDataError || (!isLoading && !blockData)) {
+        return (
+            <div
+                data-garden-renderer="2d"
+                className={cx(
+                    styles.interactionSurface,
+                    'relative flex h-full w-full items-center justify-center bg-lime-100 p-6 text-center dark:bg-emerald-950',
+                    className,
+                )}
+            >
+                <div
+                    role="alert"
+                    className="max-w-md rounded-2xl border border-red-900/15 bg-background/90 p-5 text-sm shadow-xl"
+                >
+                    2D pregled vrta trenutačno nije moguće učitati. Pokušajte
+                    ponovno.
+                </div>
+                {hud}
+            </div>
+        );
+    }
+
+    if (isLoading || garden === undefined || !blockData) {
+        return (
+            <div
+                data-garden-renderer="2d"
+                className={cx(
+                    styles.interactionSurface,
+                    'relative h-full w-full bg-lime-100 dark:bg-emerald-950',
+                    className,
+                )}
+            >
+                <GardenLoadingIndicator />
+            </div>
+        );
+    }
+
+    if (garden === null) {
+        return (
+            <div
+                data-garden-renderer="2d"
+                className={cx(
+                    styles.interactionSurface,
+                    'relative flex h-full w-full items-center justify-center bg-lime-100 p-6 text-center dark:bg-emerald-950',
+                    className,
+                )}
+            >
+                <div className="max-w-md rounded-2xl border border-foreground/10 bg-background/90 p-5 text-sm shadow-xl">
+                    Odaberite ili izradite vrt kako biste otvorili 2D pregled.
+                </div>
+                {hud}
+            </div>
+        );
+    }
+
+    return (
+        <div
+            data-garden-renderer="2d"
+            className={cx(
+                styles.interactionSurface,
+                'relative h-full w-full animate-in overflow-hidden fade-in duration-500',
+                className,
+            )}
+        >
+            <GardenOverview2DMap blockData={blockData} garden={garden} />
+            {hud}
+            {isLocalSandbox ? null : (
+                <span className="sr-only">
+                    2D prikaz ne koristi 3D iscrtavanje.
+                </span>
+            )}
+        </div>
+    );
+}

--- a/packages/game/src/GardenOverview2DDynamic.tsx
+++ b/packages/game/src/GardenOverview2DDynamic.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import type { GardenOverview2DProps } from './GardenOverview2DWrapper';
+import { GardenLoadingIndicator } from './indicators/GardenLoadingIndicator';
+
+export type { GardenOverview2DProps } from './GardenOverview2DWrapper';
+
+const GardenOverview2DInner = dynamic(
+    () =>
+        import('./GardenOverview2DWrapper').then(
+            (module) => module.GardenOverview2DWrapper,
+        ),
+    {
+        loading: () => <GardenLoadingIndicator />,
+        ssr: false,
+    },
+);
+
+export function GardenOverview2DDynamic(props: GardenOverview2DProps) {
+    return <GardenOverview2DInner {...props} />;
+}

--- a/packages/game/src/GardenOverview2DMap.tsx
+++ b/packages/game/src/GardenOverview2DMap.tsx
@@ -1,0 +1,308 @@
+'use client';
+
+import type { BlockData } from '@gredice/client';
+import { BlockImage } from '@gredice/ui/BlockImage';
+import { cx } from '@gredice/ui/utils';
+import { type CSSProperties, useMemo, useRef } from 'react';
+import { useHudPlacementPreview } from './controls/useHudPlacementPreview';
+import {
+    createGardenOverview2DLayout,
+    type GardenOverview2DGridArea,
+    getGardenOverview2DGridArea,
+    getGardenOverview2DImageRotationSuffix,
+    getGardenOverview2DPreviewTrackPadding,
+} from './gardenOverview2DLayout';
+import type { CurrentGarden } from './hooks/useCurrentGarden';
+import { useGameState } from './useGameState';
+import { useSetRaisedBedCloseupParam } from './useRaisedBedCloseup';
+import { getRaisedBedBlockIds } from './utils/raisedBedBlocks';
+
+const gridPositionSelector = '[data-garden-grid-position="true"]';
+
+function gridAreaStyle(
+    area: GardenOverview2DGridArea,
+    trackPadding: number,
+): CSSProperties {
+    return {
+        gridColumnEnd: `span ${area.gridColumnSpan}`,
+        gridColumnStart: area.gridColumnStart + trackPadding,
+        gridRowEnd: `span ${area.gridRowSpan}`,
+        gridRowStart: area.gridRowStart + trackPadding,
+    };
+}
+
+function isGroundBlock(blockName: string) {
+    return blockName.startsWith('Block_');
+}
+
+export function GardenOverview2DMap({
+    blockData,
+    garden,
+}: {
+    blockData: BlockData[];
+    garden: CurrentGarden;
+}) {
+    const gridRef = useRef<HTMLElement>(null);
+    const worldRotation = useGameState((state) => state.worldRotation);
+    const activeView = useGameState((state) => state.view);
+    const hudPlacementDrag = useGameState((state) => state.hudPlacementDrag);
+    const { mutate: openRaisedBed } = useSetRaisedBedCloseupParam();
+    const layout = useMemo(
+        () =>
+            createGardenOverview2DLayout({
+                blockData,
+                stacks: garden.stacks,
+                worldRotation,
+            }),
+        [blockData, garden.stacks, worldRotation],
+    );
+    const blockDataByName = useMemo(
+        () =>
+            new Map(blockData.map((block) => [block.information.name, block])),
+        [blockData],
+    );
+    const previewTrackPadding = useMemo(
+        () => getGardenOverview2DPreviewTrackPadding(blockData),
+        [blockData],
+    );
+    const layoutItemByBlockId = useMemo(
+        () =>
+            new Map(layout.items.map((item) => [String(item.block.id), item])),
+        [layout.items],
+    );
+    const raisedBedTargets = useMemo(
+        () =>
+            garden.raisedBeds.flatMap((raisedBed) => {
+                const items = getRaisedBedBlockIds(garden, raisedBed.id)
+                    .map((blockId) => layoutItemByBlockId.get(String(blockId)))
+                    .filter((item) => item !== undefined);
+                if (!items.length || !raisedBed.name) {
+                    return [];
+                }
+
+                const gridColumnStart = Math.min(
+                    ...items.map((item) => item.gridColumnStart),
+                );
+                const gridRowStart = Math.min(
+                    ...items.map((item) => item.gridRowStart),
+                );
+                const gridColumnEnd = Math.max(
+                    ...items.map(
+                        (item) =>
+                            item.gridColumnStart + item.gridColumnSpan - 1,
+                    ),
+                );
+                const gridRowEnd = Math.max(
+                    ...items.map(
+                        (item) => item.gridRowStart + item.gridRowSpan - 1,
+                    ),
+                );
+                const plantedFieldCount = raisedBed.fields.filter(
+                    (field) => field.active && field.plantSortId != null,
+                ).length;
+
+                return [
+                    {
+                        area: {
+                            gridColumnSpan: gridColumnEnd - gridColumnStart + 1,
+                            gridColumnStart,
+                            gridRowSpan: gridRowEnd - gridRowStart + 1,
+                            gridRowStart,
+                        },
+                        plantedFieldCount,
+                        raisedBed,
+                    },
+                ];
+            }),
+        [garden, layoutItemByBlockId],
+    );
+    const pointerPosition = useMemo(() => {
+        if (!hudPlacementDrag || typeof document === 'undefined') {
+            return null;
+        }
+
+        const target = document
+            .elementFromPoint(
+                hudPlacementDrag.clientX,
+                hudPlacementDrag.clientY,
+            )
+            ?.closest<HTMLElement>(gridPositionSelector);
+        if (!target || !gridRef.current?.contains(target)) {
+            return null;
+        }
+
+        const x = Number(target.dataset.gardenX);
+        const z = Number(target.dataset.gardenZ);
+        return Number.isFinite(x) && Number.isFinite(z) ? { x, z } : null;
+    }, [hudPlacementDrag]);
+    const {
+        hudPlacementDrag: activeHudPlacementDrag,
+        isBlocked,
+        placementPreview,
+    } = useHudPlacementPreview(pointerPosition);
+    const placementArea =
+        placementPreview && activeHudPlacementDrag
+            ? getGardenOverview2DGridArea({
+                  block: {
+                      name: activeHudPlacementDrag.blockName,
+                      rotation: 0,
+                  },
+                  blockDataByName,
+                  position: placementPreview.position,
+                  projection: layout.projection,
+                  worldRotation,
+              })
+            : null;
+    const isCloseup = activeView === 'closeup';
+    const gridColumnCount = layout.columnCount + previewTrackPadding * 2;
+    const gridRowCount = layout.rowCount + previewTrackPadding * 2;
+    const gridStyle: CSSProperties = {
+        gridTemplateColumns: `repeat(${gridColumnCount}, clamp(2.75rem, 7vw, 4.5rem))`,
+        gridTemplateRows: `repeat(${gridRowCount}, clamp(2.75rem, 7vw, 4.5rem))`,
+    };
+
+    return (
+        <div
+            data-garden-overview-2d
+            className={cx(
+                'absolute inset-0 overflow-auto overscroll-contain bg-[radial-gradient(circle_at_top,#dcfce7_0%,#bbf7d0_38%,#86efac_100%)] transition-[opacity,transform] duration-300 dark:bg-[radial-gradient(circle_at_top,#163522_0%,#10271a_45%,#07150d_100%)]',
+                isCloseup && 'pointer-events-none scale-95 opacity-0',
+            )}
+            aria-hidden={isCloseup ? 'true' : 'false'}
+            inert={isCloseup ? true : undefined}
+        >
+            <div
+                className="flex min-h-full min-w-full items-center justify-start"
+                style={{
+                    paddingBottom:
+                        'calc(var(--game-safe-area-bottom, 0px) + 7rem)',
+                    paddingLeft: 'calc(var(--game-safe-area-left, 0px) + 1rem)',
+                    paddingRight:
+                        'calc(var(--game-safe-area-right, 0px) + 1rem)',
+                    paddingTop: 'calc(var(--game-safe-area-top, 0px) + 5rem)',
+                }}
+            >
+                <section
+                    ref={gridRef}
+                    aria-label={`Tlocrt vrta ${garden.name}`}
+                    data-layout-mode={layout.isSparse ? 'sparse' : 'dense'}
+                    data-preview-track-padding={previewTrackPadding}
+                    data-world-rotation={worldRotation}
+                    className="relative isolate mx-auto grid shrink-0 gap-1 rounded-3xl border border-green-950/15 bg-lime-50/65 p-3 shadow-[0_24px_70px_rgb(20_83_45_/_0.22)] ring-1 ring-white/60 backdrop-blur-sm dark:border-lime-100/15 dark:bg-emerald-950/65 dark:ring-lime-100/10"
+                    style={gridStyle}
+                >
+                    {garden.stacks.every(
+                        (stack) => stack.blocks.length === 0,
+                    ) ? (
+                        <p className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center p-6 text-center text-sm font-semibold text-green-950/75 dark:text-lime-50/75">
+                            Vrt je prazan. Dodajte prvi element iz alatne trake.
+                        </p>
+                    ) : null}
+                    {layout.cells.map((cell) => (
+                        <div
+                            key={`${cell.worldX}:${cell.worldZ}`}
+                            aria-hidden="true"
+                            data-garden-grid-position="true"
+                            data-garden-x={cell.worldX}
+                            data-garden-z={cell.worldZ}
+                            className="relative z-0 rounded-lg border border-green-950/10 bg-lime-100/45 shadow-inner dark:border-lime-100/10 dark:bg-emerald-900/35"
+                            style={{
+                                gridColumnStart:
+                                    cell.gridColumnStart + previewTrackPadding,
+                                gridRowStart:
+                                    cell.gridRowStart + previewTrackPadding,
+                            }}
+                        />
+                    ))}
+                    {layout.items.map((item) => {
+                        const block = blockDataByName.get(item.block.name);
+                        const ground = isGroundBlock(item.block.name);
+
+                        return (
+                            <div
+                                key={`${item.stackIndex}:${item.block.id}`}
+                                aria-hidden="true"
+                                className={cx(
+                                    'pointer-events-none relative min-h-0 min-w-0',
+                                    ground ? 'z-10' : 'z-20',
+                                )}
+                                style={gridAreaStyle(item, previewTrackPadding)}
+                            >
+                                <BlockImage
+                                    blockName={item.block.name}
+                                    alt={
+                                        block?.information.label ??
+                                        item.block.name
+                                    }
+                                    draggable={false}
+                                    fill
+                                    rotationSuffix={getGardenOverview2DImageRotationSuffix(
+                                        item.block.rotation,
+                                        worldRotation,
+                                    )}
+                                    sizes="(max-width: 640px) 44px, 72px"
+                                    className={cx(
+                                        'object-contain',
+                                        ground
+                                            ? 'scale-110 opacity-85'
+                                            : 'drop-shadow-[0_6px_5px_rgb(20_83_45_/_0.28)]',
+                                    )}
+                                />
+                            </div>
+                        );
+                    })}
+                    {raisedBedTargets.map(
+                        ({ area, plantedFieldCount, raisedBed }) => (
+                            <button
+                                key={raisedBed.id}
+                                type="button"
+                                aria-label={`Otvori gredicu ${raisedBed.name}, ${plantedFieldCount} posađenih polja`}
+                                data-raised-bed-name={raisedBed.name}
+                                className={cx(
+                                    'relative z-30 rounded-xl bg-lime-300/5 outline-none ring-lime-600/70 transition hover:bg-lime-300/15 hover:ring-2 focus-visible:ring-4 dark:ring-lime-300/80',
+                                    activeHudPlacementDrag &&
+                                        'pointer-events-none',
+                                )}
+                                style={gridAreaStyle(area, previewTrackPadding)}
+                                onClick={() => openRaisedBed(raisedBed.name)}
+                            >
+                                <span className="absolute inset-x-1 bottom-1 hidden truncate rounded-full bg-green-950/75 px-2 py-0.5 text-center text-[0.65rem] font-semibold text-white shadow-sm sm:block">
+                                    {raisedBed.name}
+                                </span>
+                            </button>
+                        ),
+                    )}
+                    {placementArea && activeHudPlacementDrag ? (
+                        <div
+                            aria-hidden="true"
+                            data-placement-blocked={isBlocked}
+                            className={cx(
+                                'pointer-events-none relative z-40 min-h-0 min-w-0 rounded-xl border-2 border-dashed bg-white/55 shadow-lg',
+                                isBlocked
+                                    ? 'border-red-600 ring-4 ring-red-500/20'
+                                    : 'border-lime-600 ring-4 ring-lime-400/30',
+                            )}
+                            style={gridAreaStyle(
+                                placementArea,
+                                previewTrackPadding,
+                            )}
+                        >
+                            <BlockImage
+                                blockName={activeHudPlacementDrag.blockName}
+                                alt={activeHudPlacementDrag.blockName}
+                                draggable={false}
+                                fill
+                                rotationSuffix={getGardenOverview2DImageRotationSuffix(
+                                    0,
+                                    worldRotation,
+                                )}
+                                sizes="(max-width: 640px) 44px, 72px"
+                                className="object-contain opacity-80"
+                            />
+                        </div>
+                    ) : null}
+                </section>
+            </div>
+        </div>
+    );
+}

--- a/packages/game/src/GardenOverview2DWrapper.tsx
+++ b/packages/game/src/GardenOverview2DWrapper.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { GameRuntimeProvider } from './GameRuntimeProvider';
+import type { GameSceneProps } from './GameScene';
+import { GardenOverview2DContent } from './GardenOverview2DContent';
+
+export type GardenOverview2DProps = Pick<
+    GameSceneProps,
+    | 'appBaseUrl'
+    | 'className'
+    | 'dayNightCycleDisabled'
+    | 'debugHud'
+    | 'flags'
+    | 'freezeTime'
+    | 'hideHud'
+    | 'initialQualitySetting'
+    | 'localSandboxInitialStacks'
+    | 'localSandboxStorageKey'
+    | 'mockGarden'
+    | 'mockGardenProfile'
+    | 'noWeather'
+    | 'spriteBaseUrl'
+    | 'suppressOpeningHud'
+    | 'winterMode'
+>;
+
+export function GardenOverview2DWrapper({
+    appBaseUrl,
+    dayNightCycleDisabled,
+    flags,
+    freezeTime,
+    initialQualitySetting,
+    localSandboxInitialStacks,
+    localSandboxStorageKey,
+    mockGarden,
+    mockGardenProfile,
+    spriteBaseUrl,
+    winterMode,
+    ...contentProps
+}: GardenOverview2DProps) {
+    return (
+        <GameRuntimeProvider
+            appBaseUrl={appBaseUrl}
+            dayNightCycleDisabled={dayNightCycleDisabled}
+            flags={flags}
+            freezeTime={freezeTime}
+            initialQualitySetting={initialQualitySetting}
+            localSandboxInitialStacks={localSandboxInitialStacks}
+            localSandboxStorageKey={localSandboxStorageKey}
+            mockGarden={mockGarden}
+            mockGardenProfile={mockGardenProfile}
+            spriteBaseUrl={spriteBaseUrl}
+            visualPlacementEffectsEnabled={false}
+            winterMode={winterMode}
+        >
+            <GardenOverview2DContent {...contentProps} />
+        </GameRuntimeProvider>
+    );
+}

--- a/packages/game/src/controls/GameCameraRig.tsx
+++ b/packages/game/src/controls/GameCameraRig.tsx
@@ -4,6 +4,7 @@ import { useFrame, useThree } from '@react-three/fiber';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { MathUtils, OrthographicCamera, Vector2, Vector3 } from 'three';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import { useSceneCurrentGarden } from '../hooks/useSceneCurrentGarden';
 import { sceneFrameRates, useSceneTimeInvalidation } from '../scene/SceneTime';
 import { useGameState } from '../useGameState';
 import {
@@ -195,7 +196,8 @@ export function GameCameraRig({
         (state) =>
             Boolean(state.pickupBlock) || Boolean(state.hudPlacementDrag),
     );
-    const { data: garden } = useCurrentGarden();
+    const { data: gardenData } = useCurrentGarden();
+    const garden = useSceneCurrentGarden(gardenData);
     useSceneTimeInvalidation(
         isAnimating || isDragging || isKeyboardPanning,
         sceneFrameRates.interactive,

--- a/packages/game/src/controls/HudPlacementDragPreview.tsx
+++ b/packages/game/src/controls/HudPlacementDragPreview.tsx
@@ -2,23 +2,16 @@
 
 import { Shadow } from '@react-three/drei';
 import { useThree } from '@react-three/fiber';
-import { Suspense, useEffect, useMemo, useRef } from 'react';
+import { Suspense, useMemo, useRef } from 'react';
 import { Plane, Raycaster, Vector2, Vector3 } from 'three';
 import { EntityFactory } from '../entities/EntityFactory';
 import { blockPickupOutlineStyle } from '../entities/helpers/blockPickupOutlineStyle';
 import { HoverOutline } from '../entities/helpers/HoverOutline';
-import { useBlockData } from '../hooks/useBlockData';
-import { useBlockPlace } from '../hooks/useBlockPlace';
-import { useCurrentAccount } from '../hooks/useCurrentAccount';
-import { useCurrentGarden } from '../hooks/useCurrentGarden';
-import { getHudEntityPlacementAvailability } from '../hud/itemPlacementAvailability';
 import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
 import { useGameState } from '../useGameState';
-import {
-    type HudPlacementGridPosition,
-    resolveHudPlacementPreview,
-} from './hudPlacement';
+import type { HudPlacementGridPosition } from './hudPlacement';
+import { useHudPlacementPreview } from './useHudPlacementPreview';
 
 const groundPlane = new Plane(new Vector3(0, 1, 0), 0);
 const previewLift = 0.1;
@@ -53,15 +46,7 @@ export function HudPlacementDragPreview() {
     const raycaster = useRef(new Raycaster());
     const pointerVector = useRef(new Vector2());
     const intersectionPoint = useRef(new Vector3());
-    const { data: blockData } = useBlockData();
-    const { data: garden } = useCurrentGarden();
-    const { data: account, isLoading: isAccountLoading } = useCurrentAccount();
-    const { mutate: placeBlock } = useBlockPlace();
     const hudPlacementDrag = useGameState((state) => state.hudPlacementDrag);
-    const clearHudPlacementDrag = useGameState(
-        (state) => state.clearHudPlacementDrag,
-    );
-    const timeOfDay = useGameState((state) => state.timeOfDay);
 
     const pointerPosition = useMemo<HudPlacementGridPosition | null>(() => {
         if (!hudPlacementDrag) {
@@ -105,31 +90,23 @@ export function HudPlacementDragPreview() {
             z: Math.round(intersectionPoint.current.z),
         };
     }, [camera, domElement, hudPlacementDrag]);
-
-    const placementPreview = useMemo(() => {
-        if (!hudPlacementDrag || !pointerPosition) {
-            return null;
-        }
-
-        return resolveHudPlacementPreview({
-            blockData,
-            blockName: hudPlacementDrag.blockName,
-            garden,
-            position: pointerPosition,
-        });
-    }, [blockData, garden, hudPlacementDrag, pointerPosition]);
+    const {
+        hudPlacementDrag: activeHudPlacementDrag,
+        isBlocked,
+        placementPreview,
+    } = useHudPlacementPreview(pointerPosition);
 
     const block = useMemo<Block | null>(() => {
-        if (!hudPlacementDrag || !placementPreview) {
+        if (!activeHudPlacementDrag || !placementPreview) {
             return null;
         }
 
         return {
-            id: `hud-placement-preview:${hudPlacementDrag.blockName}`,
-            name: hudPlacementDrag.blockName,
+            id: `hud-placement-preview:${activeHudPlacementDrag.blockName}`,
+            name: activeHudPlacementDrag.blockName,
             rotation: 0,
         };
-    }, [hudPlacementDrag, placementPreview]);
+    }, [activeHudPlacementDrag, placementPreview]);
 
     const stack = useMemo<Stack | null>(() => {
         if (!block || !placementPreview) {
@@ -146,53 +123,7 @@ export function HudPlacementDragPreview() {
         };
     }, [block, placementPreview]);
 
-    const blockEntity = blockData?.find(
-        (candidate) =>
-            candidate.information.name === hudPlacementDrag?.blockName,
-    );
-    const availability =
-        blockEntity && garden
-            ? getHudEntityPlacementAvailability({
-                  accountSunflowers: account?.sunflowers.amount,
-                  block: blockEntity,
-                  isAccountLoading,
-                  isSandbox: garden.isSandbox,
-                  timeOfDay,
-              })
-            : null;
-    const isBlocked =
-        !availability?.canPlace || (placementPreview?.isBlocked ?? true);
-    const dropRequestSequence = hudPlacementDrag?.dropRequest?.sequence ?? null;
-
-    useEffect(() => {
-        if (!hudPlacementDrag?.dropRequest || dropRequestSequence === null) {
-            return;
-        }
-
-        if (!placementPreview || isBlocked || !availability?.canPlace) {
-            clearHudPlacementDrag();
-            return;
-        }
-
-        placeBlock({
-            blockName: hudPlacementDrag.blockName,
-            position: {
-                x: placementPreview.position.x,
-                y: placementPreview.position.z,
-            },
-        });
-        clearHudPlacementDrag();
-    }, [
-        availability?.canPlace,
-        clearHudPlacementDrag,
-        dropRequestSequence,
-        hudPlacementDrag,
-        isBlocked,
-        placeBlock,
-        placementPreview,
-    ]);
-
-    if (!hudPlacementDrag || !placementPreview || !block || !stack) {
+    if (!activeHudPlacementDrag || !placementPreview || !block || !stack) {
         return null;
     }
 

--- a/packages/game/src/controls/PickupPlacementResolver.ts
+++ b/packages/game/src/controls/PickupPlacementResolver.ts
@@ -3,13 +3,12 @@ import {
     canStackBlockOnBlock,
     getGardenBlockFootprintOffsets,
 } from '@gredice/js/gardenBlocks';
-import type { Vector3 } from 'three';
 import {
     type ActiveDragPreviewTargetOffset,
     createActiveDragPreviewTarget,
 } from '../dragPreviewIdentity';
 import type { Block } from '../types/Block';
-import type { Stack } from '../types/Stack';
+import type { GardenStack } from '../types/Stack';
 import {
     getBlockDataByName,
     getStackBlockHeight,
@@ -18,11 +17,17 @@ import {
 import { isRecyclerPlacementTarget } from './recyclerPlacement';
 
 export type MovingSegment = {
-    sourceStack: Stack;
+    sourceStack: GardenStack;
     sourceStartIndex: number;
-    blocks: Stack['blocks'];
+    blocks: GardenStack['blocks'];
     baseHeight: number;
     canRecycle: boolean;
+};
+
+export type PickupPlacementRelative = {
+    x: number;
+    y: number;
+    z: number;
 };
 
 type PlacementPreview = {
@@ -40,7 +45,7 @@ type PlacementPreview = {
 };
 
 export type ResolvedPlacementPreview = {
-    relative: Vector3;
+    relative: PickupPlacementRelative;
     previewHoverHeight: number;
     hoveredGardenBoxBlockId: string | null;
     canStoreInGardenBox: boolean;
@@ -50,11 +55,13 @@ export type ResolvedPlacementPreview = {
 };
 
 export type PickupPlacementPreviewResolver = {
-    resolveForRelative: (relative: Vector3) => ResolvedPlacementPreview | null;
+    resolveForRelative: (
+        relative: PickupPlacementRelative,
+    ) => ResolvedPlacementPreview | null;
 };
 
 function getStack(
-    stacks: Stack[] | undefined,
+    stacks: GardenStack[] | undefined,
     destination: { x: number; z: number },
 ) {
     return stacks?.find(
@@ -67,7 +74,7 @@ function getStack(
 type OccupiedCell = {
     block: Block;
     blockIndex: number;
-    stack: Stack;
+    stack: GardenStack;
     stackable: boolean;
     topHeight: number;
 };
@@ -83,7 +90,7 @@ function createOccupiedCells({
 }: {
     blockData: BlockData[] | null | undefined;
     movingBlockIds: Set<string>;
-    stacks: Stack[] | undefined;
+    stacks: GardenStack[] | undefined;
 }) {
     const occupiedCells = new Map<string, OccupiedCell[]>();
 
@@ -193,7 +200,7 @@ function getExternalRaisedBedBlockAtPosition({
     z,
 }: {
     movingBlockIds: Set<string>;
-    stacks: Stack[] | undefined;
+    stacks: GardenStack[] | undefined;
     x: number;
     z: number;
 }): Block | null {
@@ -226,7 +233,7 @@ function hasExternalRaisedBedNeighbor({
 }: {
     excludedPositions: Set<string>;
     movingBlockIds: Set<string>;
-    stacks: Stack[] | undefined;
+    stacks: GardenStack[] | undefined;
     x: number;
     z: number;
 }) {
@@ -260,7 +267,7 @@ function isRaisedBedPlacementBlocked({
 }: {
     movingBlockIds: Set<string>;
     movedRaisedBedPreviews: PlacementPreview[];
-    stacks: Stack[] | undefined;
+    stacks: GardenStack[] | undefined;
 }) {
     const movedRaisedBedPreviewByPosition = new Map(
         movedRaisedBedPreviews.map((preview) => [
@@ -347,8 +354,8 @@ export function resolvePickupPlacementPreviewForRelative({
     gardenIsSandbox: boolean;
     localSandboxStorageKey: string | null;
     movingSegments: MovingSegment[];
-    relative: Vector3;
-    stacks: Stack[] | undefined;
+    relative: PickupPlacementRelative;
+    stacks: GardenStack[] | undefined;
 }): ResolvedPlacementPreview | null {
     return (
         createPickupPlacementPreviewResolver({
@@ -372,7 +379,7 @@ export function createPickupPlacementPreviewResolver({
     gardenIsSandbox: boolean;
     localSandboxStorageKey: string | null;
     movingSegments: MovingSegment[];
-    stacks: Stack[] | undefined;
+    stacks: GardenStack[] | undefined;
 }): PickupPlacementPreviewResolver | null {
     if (!blockData || movingSegments.length === 0) {
         return null;
@@ -426,8 +433,8 @@ function resolvePickupPlacementPreviewFromPreparedState({
     movingBlockIds: Set<string>;
     occupiedCells: Map<string, OccupiedCell[]>;
     preparedMovingSegments: PreparedMovingSegment[];
-    relative: Vector3;
-    stacks: Stack[] | undefined;
+    relative: PickupPlacementRelative;
+    stacks: GardenStack[] | undefined;
 }): ResolvedPlacementPreview | null {
     const placementPreviews: PlacementPreview[] =
         preparedMovingSegments.flatMap(({ footprintOffsets, segment }) => {
@@ -575,7 +582,11 @@ function resolvePickupPlacementPreviewFromPreparedState({
             raisedBedPlacementBlocked;
 
     return {
-        relative: relative.clone(),
+        relative: {
+            x: relative.x,
+            y: relative.y,
+            z: relative.z,
+        },
         previewHoverHeight,
         hoveredGardenBoxBlockId,
         canStoreInGardenBox,

--- a/packages/game/src/controls/hudPlacement.ts
+++ b/packages/game/src/controls/hudPlacement.ts
@@ -2,7 +2,7 @@ import type { BlockData } from '@gredice/client';
 import { getGardenBlockFootprintOffsets } from '@gredice/js/gardenBlocks';
 import { resolveBlockPlacement } from '../hooks/optimisticBlockPlacement';
 import type { Block } from '../types/Block';
-import type { Stack } from '../types/Stack';
+import type { GardenStack } from '../types/Stack';
 import { getStackHeight } from '../utils/stackHeightCore';
 
 export type HudPlacementGridPosition = {
@@ -19,11 +19,11 @@ export type HudPlacementPreview = {
 };
 
 type GardenWithStacks = {
-    stacks: Stack[];
+    stacks: GardenStack[];
 };
 
 function getStackAtPosition(
-    stacks: Stack[] | undefined,
+    stacks: GardenStack[] | undefined,
     position: HudPlacementGridPosition,
 ) {
     return stacks?.find(
@@ -41,7 +41,7 @@ function getHudPlacementSupport({
     blockData: BlockData[];
     blockName: string;
     position: HudPlacementGridPosition;
-    stacks: Stack[] | undefined;
+    stacks: GardenStack[] | undefined;
 }) {
     const blockEntity = blockData.find(
         (block) => block.information.name === blockName,

--- a/packages/game/src/controls/pickupSelection.ts
+++ b/packages/game/src/controls/pickupSelection.ts
@@ -4,12 +4,12 @@ import {
     activeDragPreviewTargetMatches,
 } from '../dragPreviewIdentity';
 import type { Block } from '../types/Block';
-import type { Stack } from '../types/Stack';
+import type { GardenStack } from '../types/Stack';
 import { getStackHeight } from '../utils/stackHeightCore';
 import type { MovingSegment } from './PickupPlacementResolver';
 
 export type AttachedPickupSegment = {
-    sourceStack: Stack;
+    sourceStack: GardenStack;
     sourceStartIndex: number;
     blocks: Block[];
     baseHeight: number;
@@ -24,24 +24,27 @@ export type PickupSelectionMoveRequest = {
 
 type SelectedSegmentCandidate = {
     target: ActiveDragPreviewTarget;
-    sourceStack: Stack;
+    sourceStack: GardenStack;
     sourceStartIndex: number;
     block: Block;
 };
 
-function stackPositionMatches(stack: Stack, target: ActiveDragPreviewTarget) {
+function stackPositionMatches(
+    stack: GardenStack,
+    target: ActiveDragPreviewTarget,
+) {
     return (
         stack.position.x === target.stackPosition.x &&
         stack.position.z === target.stackPosition.z
     );
 }
 
-function stackKey(stack: Stack) {
+function stackKey(stack: GardenStack) {
     return `${stack.position.x}|${stack.position.z}`;
 }
 
 function findSelectedSegmentCandidate(
-    stacks: Stack[] | undefined,
+    stacks: GardenStack[] | undefined,
     target: ActiveDragPreviewTarget,
 ): SelectedSegmentCandidate | null {
     const sourceStack = stacks?.find((stack) =>
@@ -83,7 +86,7 @@ function getSelectedSegmentCandidates({
 }: {
     primaryTarget: ActiveDragPreviewTarget;
     selectedTargets: ActiveDragPreviewTarget[];
-    stacks: Stack[] | undefined;
+    stacks: GardenStack[] | undefined;
 }) {
     const targets = selectionTargetsInclude(selectedTargets, primaryTarget)
         ? selectedTargets
@@ -133,7 +136,7 @@ export function createPickupSelectionMovingSegments({
     canRecyclePrimarySegment: boolean;
     primaryTarget: ActiveDragPreviewTarget;
     selectedTargets: ActiveDragPreviewTarget[];
-    stacks: Stack[] | undefined;
+    stacks: GardenStack[] | undefined;
 }): MovingSegment[] {
     const selectedCandidates = getSelectedSegmentCandidates({
         primaryTarget,

--- a/packages/game/src/controls/useHudPlacementPreview.ts
+++ b/packages/game/src/controls/useHudPlacementPreview.ts
@@ -1,0 +1,101 @@
+'use client';
+
+import { useEffect, useMemo } from 'react';
+import { useBlockData } from '../hooks/useBlockData';
+import { useBlockPlace } from '../hooks/useBlockPlace';
+import { useCurrentAccount } from '../hooks/useCurrentAccount';
+import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import { getHudEntityPlacementAvailability } from '../hud/itemPlacementAvailability';
+import { useGameState } from '../useGameState';
+import {
+    type HudPlacementGridPosition,
+    resolveHudPlacementPreview,
+} from './hudPlacement';
+
+export function useHudPlacementPreview(
+    pointerPosition: HudPlacementGridPosition | null,
+) {
+    const { data: blockData } = useBlockData();
+    const { data: garden } = useCurrentGarden();
+    const { data: account, isLoading: isAccountLoading } = useCurrentAccount();
+    const { mutate: placeBlock } = useBlockPlace();
+    const hudPlacementDrag = useGameState((state) => state.hudPlacementDrag);
+    const clearHudPlacementDrag = useGameState(
+        (state) => state.clearHudPlacementDrag,
+    );
+    const timeOfDay = useGameState((state) => state.timeOfDay);
+    const blockName = hudPlacementDrag?.blockName;
+    const pointerX = pointerPosition?.x;
+    const pointerZ = pointerPosition?.z;
+
+    const placementPreview = useMemo(() => {
+        if (!blockName || pointerX === undefined || pointerZ === undefined) {
+            return null;
+        }
+
+        return resolveHudPlacementPreview({
+            blockData,
+            blockName,
+            garden,
+            position: {
+                x: pointerX,
+                z: pointerZ,
+            },
+        });
+    }, [blockData, blockName, garden, pointerX, pointerZ]);
+
+    const blockEntity = useMemo(
+        () =>
+            blockData?.find(
+                (candidate) => candidate.information.name === blockName,
+            ),
+        [blockData, blockName],
+    );
+    const availability =
+        blockEntity && garden
+            ? getHudEntityPlacementAvailability({
+                  accountSunflowers: account?.sunflowers.amount,
+                  block: blockEntity,
+                  isAccountLoading,
+                  isSandbox: garden.isSandbox,
+                  timeOfDay,
+              })
+            : null;
+    const isBlocked =
+        !availability?.canPlace || (placementPreview?.isBlocked ?? true);
+    const dropRequestSequence = hudPlacementDrag?.dropRequest?.sequence ?? null;
+
+    useEffect(() => {
+        if (!blockName || dropRequestSequence === null) {
+            return;
+        }
+
+        if (!placementPreview || isBlocked || !availability?.canPlace) {
+            clearHudPlacementDrag();
+            return;
+        }
+
+        placeBlock({
+            blockName,
+            position: {
+                x: placementPreview.position.x,
+                y: placementPreview.position.z,
+            },
+        });
+        clearHudPlacementDrag();
+    }, [
+        availability?.canPlace,
+        blockName,
+        clearHudPlacementDrag,
+        dropRequestSequence,
+        isBlocked,
+        placeBlock,
+        placementPreview,
+    ]);
+
+    return {
+        hudPlacementDrag,
+        isBlocked,
+        placementPreview,
+    };
+}

--- a/packages/game/src/entities/helpers/useEntityNeighbors.ts
+++ b/packages/game/src/entities/helpers/useEntityNeighbors.ts
@@ -1,10 +1,10 @@
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import type { Block } from '../../types/Block';
-import type { Stack } from '../../types/Stack';
+import type { GardenStack } from '../../types/Stack';
 
 export function resolveEntityNeighbors(
-    stacks: Stack[] | undefined,
-    stack: Stack,
+    stacks: GardenStack[] | undefined,
+    stack: GardenStack,
     block: Block,
 ) {
     function getStack({ x, z }: { x: number; z: number }) {
@@ -66,7 +66,7 @@ export function resolveEntityNeighbors(
     };
 }
 
-export function useEntityNeighbors(stack: Stack, block: Block) {
+export function useEntityNeighbors(stack: GardenStack, block: Block) {
     const { data: garden } = useCurrentGarden();
 
     return resolveEntityNeighbors(garden?.stacks, stack, block);

--- a/packages/game/src/entities/raisedBed/RaisedBedMulchOverlays.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedMulchOverlays.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
-import type { BufferGeometry } from 'three';
+import { type BufferGeometry, Vector3 } from 'three';
 import {
     type ActiveDragPreviewTarget,
     createActiveDragPreviewTarget,
@@ -16,7 +16,7 @@ import {
 } from '../../scene/gameQuality';
 import { snowPresets } from '../../snow/snowPresets';
 import type { Block } from '../../types/Block';
-import type { Stack } from '../../types/Stack';
+import type { GardenStack } from '../../types/Stack';
 import { type ActiveDragPreview, useGameState } from '../../useGameState';
 import { getStackHeight } from '../../utils/getStackHeight';
 import { getRaisedBedBlockIds } from '../../utils/raisedBedBlocks';
@@ -80,7 +80,7 @@ type RaisedBedPlacement = {
     dirtGeometryName: RaisedBedDirtGeometryName;
     origin: [number, number, number];
     rotationQuarterTurns: number;
-    stack: Stack;
+    stack: GardenStack;
     stackBlockIndex: number;
 };
 
@@ -190,7 +190,7 @@ function activeDragPreviewTouchesRaisedBed(
 
 function getRaisedBedNeighbors(
     garden: CurrentGardenData,
-    stack: Stack,
+    stack: GardenStack,
     block: Block,
 ) {
     function getStackAt(x: number, z: number) {
@@ -225,7 +225,7 @@ function getRaisedBedNeighbors(
 
 function getRaisedBedOrigin(
     blockData: ReturnType<typeof useBlockData>['data'],
-    stack: Stack,
+    stack: GardenStack,
     block: Block,
     neighbors: ReturnType<typeof getRaisedBedNeighbors>,
 ): [number, number, number] {
@@ -504,7 +504,14 @@ function createMulchRenderInstance({
         rotation: 0,
         // The synthetic block ID intentionally opts mulch overlays out of block
         // placement animations; retain a stable stack identity for comparisons.
-        stack: cached?.stack ?? placement.stack,
+        stack: cached?.stack ?? {
+            ...placement.stack,
+            position: new Vector3(
+                placement.stack.position.x,
+                placement.stack.position.y,
+                placement.stack.position.z,
+            ),
+        },
         stackHeight: position[1],
     } satisfies EntityBlockInstance;
     cache.set(key, instance);

--- a/packages/game/src/entities/raisedBed/raisedBedHarvestRewards.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedHarvestRewards.ts
@@ -1,6 +1,6 @@
 import type { BlockData } from '@gredice/client';
 import type { OperationVisualReward } from '../../operationVisualRewards';
-import type { Stack } from '../../types/Stack';
+import type { GardenStack } from '../../types/Stack';
 import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
 import {
     getBlockDataByName,
@@ -32,7 +32,7 @@ type ResolveRaisedBedHarvestBasketPlacementInput = {
     blockData: BlockData[] | null | undefined;
     blockIds: string[];
     reservedPositionKeys?: ReadonlySet<string>;
-    stacks: Stack[];
+    stacks: GardenStack[];
 };
 
 type ResolveRaisedBedHarvestBasketPlacementsInput = {
@@ -41,7 +41,7 @@ type ResolveRaisedBedHarvestBasketPlacementsInput = {
         blockIds: string[];
         raisedBedId: number;
     }[];
-    stacks: Stack[];
+    stacks: GardenStack[];
 };
 
 export type RaisedBedHarvestBasketFillLevel = 'empty' | 'full' | 'partial';
@@ -176,7 +176,7 @@ function stackPositionKey(position: { x: number; z: number }) {
 }
 
 function findStackAtPosition(
-    stacks: Stack[],
+    stacks: GardenStack[],
     position: { x: number; z: number },
 ) {
     return stacks.find(
@@ -187,7 +187,7 @@ function findStackAtPosition(
 
 function isFreeStackableStack(
     blockData: BlockData[] | null | undefined,
-    stack: Stack | undefined,
+    stack: GardenStack | undefined,
 ) {
     const topBlock = stack?.blocks.at(-1);
     if (

--- a/packages/game/src/gardenOverview2DBundleBoundary.unit.ts
+++ b/packages/game/src/gardenOverview2DBundleBoundary.unit.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, extname, join, relative, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const sourceRoot = dirname(fileURLToPath(import.meta.url));
+const entryPath = join(sourceRoot, 'GardenOverview2DWrapper.tsx');
+const sourceExtensions = ['.ts', '.tsx'];
+const prohibitedRuntimePackages = [
+    '@react-spring/three',
+    '@react-three/drei',
+    '@react-three/fiber',
+    'three',
+    'three-custom-shader-material',
+    'three-stdlib',
+];
+
+function resolveSourceImport(fromPath: string, specifier: string) {
+    if (!specifier.startsWith('.')) {
+        return null;
+    }
+
+    const unresolvedPath = resolve(dirname(fromPath), specifier);
+    const candidates = extname(unresolvedPath)
+        ? [unresolvedPath]
+        : [
+              ...sourceExtensions.map(
+                  (extension) => unresolvedPath + extension,
+              ),
+              ...sourceExtensions.map((extension) =>
+                  join(unresolvedPath, `index${extension}`),
+              ),
+          ];
+
+    return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+function getStaticRuntimeImports(source: string) {
+    const imports: string[] = [];
+    const statementPattern =
+        /(?:import|export)\s+([\s\S]*?)\s+from\s+['"]([^'"]+)['"]\s*;/g;
+
+    for (const match of source.matchAll(statementPattern)) {
+        const clause = match[1]?.trimStart();
+        const specifier = match[2];
+        if (clause?.startsWith('type ') || !specifier) {
+            continue;
+        }
+        imports.push(specifier);
+    }
+
+    return imports;
+}
+
+function isProhibitedRuntimeImport(specifier: string) {
+    return prohibitedRuntimePackages.some(
+        (packageName) =>
+            specifier === packageName ||
+            specifier.startsWith(`${packageName}/`),
+    );
+}
+
+test('keeps the React-only garden entry free of 3D runtime imports', () => {
+    const pending = [entryPath];
+    const visited = new Set<string>();
+
+    while (pending.length > 0) {
+        const sourcePath = pending.pop();
+        if (!sourcePath || visited.has(sourcePath)) {
+            continue;
+        }
+        visited.add(sourcePath);
+
+        const imports = getStaticRuntimeImports(
+            readFileSync(sourcePath, 'utf8'),
+        );
+        for (const specifier of imports) {
+            assert.equal(
+                isProhibitedRuntimeImport(specifier),
+                false,
+                `${relative(sourceRoot, sourcePath)} statically imports ${specifier}`,
+            );
+
+            const importedSource = resolveSourceImport(sourcePath, specifier);
+            if (importedSource) {
+                pending.push(importedSource);
+            }
+        }
+    }
+
+    assert.ok(visited.size > 10, 'expected to inspect the shared HUD graph');
+});

--- a/packages/game/src/gardenOverview2DLayout.ts
+++ b/packages/game/src/gardenOverview2DLayout.ts
@@ -1,0 +1,486 @@
+import {
+    type GardenBlockDataLike,
+    getGardenBlockFootprintOffsets,
+    getGardenBlockSpan,
+} from '@gredice/js/gardenBlocks';
+
+export type GardenOverview2DBlockData = GardenBlockDataLike & {
+    information: {
+        name: string;
+    };
+};
+
+type GardenOverview2DBlock = {
+    id: string;
+    name: string;
+    rotation: number;
+};
+
+type GardenOverview2DStack = {
+    blocks: readonly GardenOverview2DBlock[];
+    position: {
+        x: number;
+        z: number;
+    };
+};
+
+export type GardenOverview2DBounds = {
+    maxX: number;
+    maxZ: number;
+    minX: number;
+    minZ: number;
+};
+
+export type GardenOverview2DGridArea = {
+    gridColumnSpan: number;
+    gridColumnStart: number;
+    gridRowSpan: number;
+    gridRowStart: number;
+};
+
+export type GardenOverview2DLayoutItem = GardenOverview2DGridArea & {
+    block: GardenOverview2DBlock;
+    blockIndex: number;
+    stackIndex: number;
+    worldX: number;
+    worldZ: number;
+};
+
+export type GardenOverview2DLayoutCell = {
+    gridColumnStart: number;
+    gridRowStart: number;
+    worldX: number;
+    worldZ: number;
+};
+
+type GardenOverview2DAxisProjection = {
+    coordinates: readonly number[];
+    trackByCoordinate: ReadonlyMap<number, number>;
+    trackCount: number;
+};
+
+export type GardenOverview2DGridProjection = {
+    columns: GardenOverview2DAxisProjection;
+    rows: GardenOverview2DAxisProjection;
+};
+
+export type GardenOverview2DLayout = {
+    bounds: GardenOverview2DBounds;
+    cells: GardenOverview2DLayoutCell[];
+    columnCount: number;
+    isSparse: boolean;
+    items: GardenOverview2DLayoutItem[];
+    projection: GardenOverview2DGridProjection;
+    rowCount: number;
+};
+
+type RenderedArea = {
+    maxX: number;
+    maxZ: number;
+    minX: number;
+    minZ: number;
+};
+
+export const gardenOverview2DGridPadding = 2;
+export const gardenOverview2DMaxRenderedCells = 2_500;
+
+export function normalizeGardenOverview2DRotation(rotation: number) {
+    return ((Math.round(rotation) % 4) + 4) % 4;
+}
+
+export function getGardenOverview2DImageRotationSuffix(
+    blockRotation: number,
+    worldRotation: number,
+) {
+    return normalizeGardenOverview2DRotation(blockRotation + worldRotation) + 1;
+}
+
+export function getGardenOverview2DPreviewTrackPadding(
+    blockData: readonly GardenOverview2DBlockData[],
+) {
+    return blockData.reduce((padding, block) => {
+        const span = getGardenBlockSpan(block);
+
+        return Math.max(padding, span.width - 1, span.depth - 1);
+    }, 0);
+}
+
+export function rotateGardenOverview2DPosition(
+    position: { x: number; z: number },
+    rotation: number,
+) {
+    switch (normalizeGardenOverview2DRotation(rotation)) {
+        case 1:
+            return { x: position.z, z: -position.x };
+        case 2:
+            return { x: -position.x, z: -position.z };
+        case 3:
+            return { x: -position.z, z: position.x };
+        default:
+            return position;
+    }
+}
+
+function getRenderedArea({
+    block,
+    blockDataByName,
+    position,
+    worldRotation,
+}: {
+    block: Pick<GardenOverview2DBlock, 'name' | 'rotation'>;
+    blockDataByName: ReadonlyMap<string, GardenOverview2DBlockData>;
+    position: { x: number; z: number };
+    worldRotation: number;
+}): RenderedArea {
+    const blockData = blockDataByName.get(block.name);
+    const renderedPositions = getGardenBlockFootprintOffsets(
+        blockData,
+        block.rotation,
+    ).map((offset) =>
+        rotateGardenOverview2DPosition(
+            {
+                x: position.x + offset.x,
+                z: position.z + offset.y,
+            },
+            worldRotation,
+        ),
+    );
+    const xs = renderedPositions.map(({ x }) => x);
+    const zs = renderedPositions.map(({ z }) => z);
+
+    return {
+        maxX: Math.max(...xs),
+        maxZ: Math.max(...zs),
+        minX: Math.min(...xs),
+        minZ: Math.min(...zs),
+    };
+}
+
+function createAxisProjection(
+    coordinateValues: ReadonlySet<number>,
+): GardenOverview2DAxisProjection {
+    const coordinates = [...coordinateValues].sort(
+        (left, right) => left - right,
+    );
+    const trackByCoordinate = new Map<number, number>();
+    let nextTrack = 1;
+    let previousCoordinate: number | undefined;
+
+    for (const coordinate of coordinates) {
+        if (
+            previousCoordinate !== undefined &&
+            coordinate - previousCoordinate > 1
+        ) {
+            nextTrack += 1;
+        }
+
+        trackByCoordinate.set(coordinate, nextTrack);
+        nextTrack += 1;
+        previousCoordinate = coordinate;
+    }
+
+    return {
+        coordinates,
+        trackByCoordinate,
+        trackCount: nextTrack - 1,
+    };
+}
+
+function getAxisTrack(
+    projection: GardenOverview2DAxisProjection,
+    coordinate: number,
+) {
+    const exactTrack = projection.trackByCoordinate.get(coordinate);
+    if (exactTrack !== undefined) {
+        return exactTrack;
+    }
+
+    const firstCoordinate = projection.coordinates[0];
+    const lastCoordinate = projection.coordinates.at(-1);
+    if (firstCoordinate === undefined || lastCoordinate === undefined) {
+        return 1;
+    }
+    if (coordinate < firstCoordinate) {
+        return coordinate - firstCoordinate + 1;
+    }
+    if (coordinate > lastCoordinate) {
+        return projection.trackCount + coordinate - lastCoordinate;
+    }
+
+    let lowerIndex = 0;
+    let upperIndex = projection.coordinates.length;
+
+    while (lowerIndex < upperIndex) {
+        const middleIndex = Math.floor((lowerIndex + upperIndex) / 2);
+        const middleCoordinate = projection.coordinates[middleIndex];
+        if (middleCoordinate !== undefined && middleCoordinate < coordinate) {
+            lowerIndex = middleIndex + 1;
+        } else {
+            upperIndex = middleIndex;
+        }
+    }
+
+    const nextCoordinate = projection.coordinates[lowerIndex];
+    return nextCoordinate === undefined
+        ? projection.trackCount
+        : (projection.trackByCoordinate.get(nextCoordinate) ?? 2) - 1;
+}
+
+function renderedAreaToGridArea(
+    area: RenderedArea,
+    projection: GardenOverview2DGridProjection,
+): GardenOverview2DGridArea {
+    const gridColumnStart = getAxisTrack(projection.columns, area.minX);
+    const gridColumnEnd = getAxisTrack(projection.columns, area.maxX);
+    const gridRowStart = getAxisTrack(projection.rows, area.minZ);
+    const gridRowEnd = getAxisTrack(projection.rows, area.maxZ);
+
+    return {
+        gridColumnSpan: Math.max(1, gridColumnEnd - gridColumnStart + 1),
+        gridColumnStart,
+        gridRowSpan: Math.max(1, gridRowEnd - gridRowStart + 1),
+        gridRowStart,
+    };
+}
+
+export function getGardenOverview2DGridArea({
+    block,
+    blockDataByName,
+    position,
+    projection,
+    worldRotation,
+}: {
+    block: Pick<GardenOverview2DBlock, 'name' | 'rotation'>;
+    blockDataByName: ReadonlyMap<string, GardenOverview2DBlockData>;
+    position: { x: number; z: number };
+    projection: GardenOverview2DGridProjection;
+    worldRotation: number;
+}) {
+    return renderedAreaToGridArea(
+        getRenderedArea({
+            block,
+            blockDataByName,
+            position,
+            worldRotation,
+        }),
+        projection,
+    );
+}
+
+export function createGardenOverview2DLayout({
+    blockData,
+    padding = gardenOverview2DGridPadding,
+    stacks,
+    worldRotation,
+}: {
+    blockData: readonly GardenOverview2DBlockData[];
+    padding?: number;
+    stacks: readonly GardenOverview2DStack[];
+    worldRotation: number;
+}): GardenOverview2DLayout {
+    const blockDataByName = new Map(
+        blockData.map((candidate) => [candidate.information.name, candidate]),
+    );
+    const renderedItems: Array<{
+        area: RenderedArea;
+        block: GardenOverview2DBlock;
+        blockIndex: number;
+        stackIndex: number;
+        worldX: number;
+        worldZ: number;
+    }> = [];
+    const renderedStackPositions: Array<{ x: number; z: number }> = [];
+    const renderedStackAreas = stacks.map((stack, stackIndex) => {
+        const renderedPosition = rotateGardenOverview2DPosition(
+            stack.position,
+            worldRotation,
+        );
+        const stackArea = {
+            maxX: renderedPosition.x,
+            maxZ: renderedPosition.z,
+            minX: renderedPosition.x,
+            minZ: renderedPosition.z,
+        };
+        renderedStackPositions.push(renderedPosition);
+
+        stack.blocks.forEach((block, blockIndex) => {
+            const area = getRenderedArea({
+                block,
+                blockDataByName,
+                position: stack.position,
+                worldRotation,
+            });
+            stackArea.maxX = Math.max(stackArea.maxX, area.maxX);
+            stackArea.maxZ = Math.max(stackArea.maxZ, area.maxZ);
+            stackArea.minX = Math.min(stackArea.minX, area.minX);
+            stackArea.minZ = Math.min(stackArea.minZ, area.minZ);
+            renderedItems.push({
+                area,
+                block,
+                blockIndex,
+                stackIndex,
+                worldX: stack.position.x,
+                worldZ: stack.position.z,
+            });
+        });
+
+        return stackArea;
+    });
+    const allXs = [
+        ...renderedStackAreas.flatMap(({ minX, maxX }) => [minX, maxX]),
+    ];
+    const allZs = [
+        ...renderedStackAreas.flatMap(({ minZ, maxZ }) => [minZ, maxZ]),
+    ];
+    const minX = allXs.length ? Math.min(...allXs) : 0;
+    const maxX = allXs.length ? Math.max(...allXs) : 0;
+    const minZ = allZs.length ? Math.min(...allZs) : 0;
+    const maxZ = allZs.length ? Math.max(...allZs) : 0;
+    const normalizedPadding = Math.max(0, Math.round(padding));
+    const bounds = {
+        maxX: maxX + normalizedPadding,
+        maxZ: maxZ + normalizedPadding,
+        minX: minX - normalizedPadding,
+        minZ: minZ - normalizedPadding,
+    };
+    const denseColumnCount = bounds.maxX - bounds.minX + 1;
+    const denseRowCount = bounds.maxZ - bounds.minZ + 1;
+    const renderDenseGrid =
+        Number.isSafeInteger(denseColumnCount) &&
+        Number.isSafeInteger(denseRowCount) &&
+        denseColumnCount > 0 &&
+        denseRowCount > 0 &&
+        denseColumnCount <= gardenOverview2DMaxRenderedCells &&
+        denseRowCount <=
+            Math.floor(gardenOverview2DMaxRenderedCells / denseColumnCount);
+    const renderedCellByCoordinate = new Map<
+        string,
+        { x: number; z: number }
+    >();
+    const addRenderedCell = (x: number, z: number) => {
+        if (renderedCellByCoordinate.size >= gardenOverview2DMaxRenderedCells) {
+            return;
+        }
+
+        renderedCellByCoordinate.set(`${x}:${z}`, { x, z });
+    };
+
+    if (renderDenseGrid) {
+        for (let gridZ = bounds.minZ; gridZ <= bounds.maxZ; gridZ += 1) {
+            for (let gridX = bounds.minX; gridX <= bounds.maxX; gridX += 1) {
+                addRenderedCell(gridX, gridZ);
+            }
+        }
+    } else {
+        for (const position of renderedStackPositions) {
+            addRenderedCell(position.x, position.z);
+        }
+
+        for (const { area } of renderedItems) {
+            for (
+                let gridZ = area.minZ;
+                gridZ <= area.maxZ &&
+                renderedCellByCoordinate.size <
+                    gardenOverview2DMaxRenderedCells;
+                gridZ += 1
+            ) {
+                for (
+                    let gridX = area.minX;
+                    gridX <= area.maxX &&
+                    renderedCellByCoordinate.size <
+                        gardenOverview2DMaxRenderedCells;
+                    gridX += 1
+                ) {
+                    addRenderedCell(gridX, gridZ);
+                }
+            }
+        }
+
+        for (const area of renderedStackAreas) {
+            for (
+                let gridZ = area.minZ - normalizedPadding;
+                gridZ <= area.maxZ + normalizedPadding &&
+                renderedCellByCoordinate.size <
+                    gardenOverview2DMaxRenderedCells;
+                gridZ += 1
+            ) {
+                for (
+                    let gridX = area.minX - normalizedPadding;
+                    gridX <= area.maxX + normalizedPadding &&
+                    renderedCellByCoordinate.size <
+                        gardenOverview2DMaxRenderedCells;
+                    gridX += 1
+                ) {
+                    addRenderedCell(gridX, gridZ);
+                }
+            }
+        }
+    }
+
+    const columnCoordinates = new Set<number>();
+    const rowCoordinates = new Set<number>();
+    for (const { area } of renderedItems) {
+        for (let gridX = area.minX; gridX <= area.maxX; gridX += 1) {
+            columnCoordinates.add(gridX);
+        }
+        for (let gridZ = area.minZ; gridZ <= area.maxZ; gridZ += 1) {
+            rowCoordinates.add(gridZ);
+        }
+    }
+    for (const position of renderedStackPositions) {
+        columnCoordinates.add(position.x);
+        rowCoordinates.add(position.z);
+    }
+
+    const previewTrackPadding =
+        getGardenOverview2DPreviewTrackPadding(blockData);
+    for (const { x, z } of renderedCellByCoordinate.values()) {
+        for (
+            let offset = -previewTrackPadding;
+            offset <= previewTrackPadding;
+            offset += 1
+        ) {
+            const bufferedX = x + offset;
+            const bufferedZ = z + offset;
+            if (bufferedX >= bounds.minX && bufferedX <= bounds.maxX) {
+                columnCoordinates.add(bufferedX);
+            }
+            if (bufferedZ >= bounds.minZ && bufferedZ <= bounds.maxZ) {
+                rowCoordinates.add(bufferedZ);
+            }
+        }
+        columnCoordinates.add(x);
+        rowCoordinates.add(z);
+    }
+
+    const projection = {
+        columns: createAxisProjection(columnCoordinates),
+        rows: createAxisProjection(rowCoordinates),
+    };
+    const cells = [...renderedCellByCoordinate.values()].map(({ x, z }) => {
+        const worldPosition = rotateGardenOverview2DPosition(
+            { x, z },
+            -worldRotation,
+        );
+
+        return {
+            gridColumnStart: getAxisTrack(projection.columns, x),
+            gridRowStart: getAxisTrack(projection.rows, z),
+            worldX: worldPosition.x,
+            worldZ: worldPosition.z,
+        };
+    });
+
+    return {
+        bounds,
+        cells,
+        columnCount: projection.columns.trackCount,
+        isSparse: !renderDenseGrid,
+        items: renderedItems.map(({ area, ...item }) => ({
+            ...item,
+            ...renderedAreaToGridArea(area, projection),
+        })),
+        projection,
+        rowCount: projection.rows.trackCount,
+    };
+}

--- a/packages/game/src/gardenOverview2DLayout.unit.ts
+++ b/packages/game/src/gardenOverview2DLayout.unit.ts
@@ -1,0 +1,245 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    createGardenOverview2DLayout,
+    gardenOverview2DMaxRenderedCells,
+    getGardenOverview2DGridArea,
+    getGardenOverview2DImageRotationSuffix,
+    getGardenOverview2DPreviewTrackPadding,
+    rotateGardenOverview2DPosition,
+} from './gardenOverview2DLayout';
+
+const blockData = [
+    {
+        attributes: {
+            spanDepth: 2,
+            spanWidth: 3,
+        },
+        information: {
+            name: 'Shade',
+        },
+    },
+    {
+        attributes: {},
+        information: {
+            name: 'Block_Grass',
+        },
+    },
+];
+const blockDataByName = new Map(
+    blockData.map((block) => [block.information.name, block]),
+);
+
+test('lays out negative garden coordinates with padding and reversible rotation', () => {
+    const layout = createGardenOverview2DLayout({
+        blockData,
+        padding: 1,
+        stacks: [
+            {
+                blocks: [
+                    {
+                        id: 'ground',
+                        name: 'Block_Grass',
+                        rotation: 0,
+                    },
+                ],
+                position: { x: -2, z: 1 },
+            },
+            {
+                blocks: [
+                    {
+                        id: 'shade',
+                        name: 'Shade',
+                        rotation: 0,
+                    },
+                ],
+                position: { x: 1, z: -1 },
+            },
+        ],
+        worldRotation: 1,
+    });
+
+    assert.deepEqual(rotateGardenOverview2DPosition({ x: -2, z: 1 }, 1), {
+        x: 1,
+        z: 2,
+    });
+    assert.equal(layout.isSparse, false);
+    assert.equal(layout.cells.length, layout.columnCount * layout.rowCount);
+    assert.ok(
+        layout.cells.some((cell) => cell.worldX === -2 && cell.worldZ === 1),
+    );
+    assert.equal(
+        layout.items.find((item) => item.block.id === 'shade')?.gridColumnSpan,
+        2,
+    );
+    assert.equal(
+        layout.items.find((item) => item.block.id === 'shade')?.gridRowSpan,
+        3,
+    );
+});
+
+test('computes a preview grid area from the same footprint rules as existing blocks', () => {
+    const layout = createGardenOverview2DLayout({
+        blockData,
+        padding: 2,
+        stacks: [],
+        worldRotation: 3,
+    });
+    const area = getGardenOverview2DGridArea({
+        block: {
+            name: 'Shade',
+            rotation: 0,
+        },
+        blockDataByName,
+        position: { x: 0, z: 0 },
+        projection: layout.projection,
+        worldRotation: 3,
+    });
+
+    assert.deepEqual(area, {
+        gridColumnSpan: 2,
+        gridColumnStart: 2,
+        gridRowSpan: 3,
+        gridRowStart: 3,
+    });
+});
+
+test('combines block and world rotation for directional image assets', () => {
+    assert.equal(getGardenOverview2DImageRotationSuffix(0, 0), 1);
+    assert.equal(getGardenOverview2DImageRotationSuffix(1, 0), 2);
+    assert.equal(getGardenOverview2DImageRotationSuffix(3, 1), 1);
+    assert.equal(getGardenOverview2DImageRotationSuffix(-1, 0), 4);
+});
+
+test('keeps edge previews within explicit non-targetable tracks at every rotation', () => {
+    const previewTrackPadding =
+        getGardenOverview2DPreviewTrackPadding(blockData);
+
+    assert.equal(previewTrackPadding, 2);
+
+    for (let worldRotation = 0; worldRotation < 4; worldRotation += 1) {
+        const layout = createGardenOverview2DLayout({
+            blockData,
+            padding: 2,
+            stacks: [],
+            worldRotation,
+        });
+        const explicitColumnCount =
+            layout.columnCount + previewTrackPadding * 2;
+        const explicitRowCount = layout.rowCount + previewTrackPadding * 2;
+        const renderedCorners = [
+            { x: layout.bounds.minX, z: layout.bounds.minZ },
+            { x: layout.bounds.maxX, z: layout.bounds.minZ },
+            { x: layout.bounds.minX, z: layout.bounds.maxZ },
+            { x: layout.bounds.maxX, z: layout.bounds.maxZ },
+        ];
+
+        for (const renderedPosition of renderedCorners) {
+            const position = rotateGardenOverview2DPosition(
+                renderedPosition,
+                -worldRotation,
+            );
+            const area = getGardenOverview2DGridArea({
+                block: {
+                    name: 'Shade',
+                    rotation: 0,
+                },
+                blockDataByName,
+                position,
+                projection: layout.projection,
+                worldRotation,
+            });
+            const shiftedColumnStart =
+                area.gridColumnStart + previewTrackPadding;
+            const shiftedRowStart = area.gridRowStart + previewTrackPadding;
+
+            assert.ok(shiftedColumnStart >= 1);
+            assert.ok(shiftedRowStart >= 1);
+            assert.ok(
+                shiftedColumnStart + area.gridColumnSpan - 1 <=
+                    explicitColumnCount,
+            );
+            assert.ok(
+                shiftedRowStart + area.gridRowSpan - 1 <= explicitRowCount,
+            );
+        }
+    }
+});
+
+test('compresses sparse coordinates without enumerating the empty rectangle', () => {
+    const farPosition = { x: 1_000_000, z: -1_000_000 };
+    const layout = createGardenOverview2DLayout({
+        blockData,
+        padding: 2,
+        stacks: [
+            {
+                blocks: [
+                    {
+                        id: 'near',
+                        name: 'Block_Grass',
+                        rotation: 0,
+                    },
+                ],
+                position: { x: 0, z: 0 },
+            },
+            {
+                blocks: [
+                    {
+                        id: 'far',
+                        name: 'Shade',
+                        rotation: 0,
+                    },
+                ],
+                position: farPosition,
+            },
+        ],
+        worldRotation: 0,
+    });
+
+    assert.equal(layout.isSparse, true);
+    assert.ok(layout.cells.length <= gardenOverview2DMaxRenderedCells);
+    assert.ok(layout.cells.length < 100);
+    assert.ok(layout.columnCount < 25);
+    assert.ok(layout.rowCount < 25);
+    assert.ok(
+        layout.cells.some(
+            (cell) =>
+                cell.worldX === farPosition.x && cell.worldZ === farPosition.z,
+        ),
+    );
+    assert.ok(
+        !layout.cells.some(
+            (cell) => cell.worldX === 500_000 && cell.worldZ === -500_000,
+        ),
+    );
+
+    const placementArea = getGardenOverview2DGridArea({
+        block: {
+            name: 'Shade',
+            rotation: 0,
+        },
+        blockDataByName,
+        position: { x: 2, z: 0 },
+        projection: layout.projection,
+        worldRotation: 0,
+    });
+    const previewTrackPadding =
+        getGardenOverview2DPreviewTrackPadding(blockData);
+
+    assert.equal(placementArea.gridColumnSpan, 3);
+    assert.equal(placementArea.gridRowSpan, 2);
+    assert.ok(
+        placementArea.gridColumnStart +
+            previewTrackPadding +
+            placementArea.gridColumnSpan -
+            1 <=
+            layout.columnCount + previewTrackPadding * 2,
+    );
+    assert.ok(
+        placementArea.gridRowStart +
+            previewTrackPadding +
+            placementArea.gridRowSpan -
+            1 <=
+            layout.rowCount + previewTrackPadding * 2,
+    );
+});

--- a/packages/game/src/gardenViewMode.ts
+++ b/packages/game/src/gardenViewMode.ts
@@ -1,0 +1,13 @@
+export const gardenOverview2DPath = '/pregled-vrta';
+
+export type GardenViewMode = '2d' | '3d';
+
+export function getGardenViewModeHref(
+    currentMode: GardenViewMode,
+    searchParams: Iterable<[string, string]>,
+) {
+    const targetPath = currentMode === '2d' ? '/' : gardenOverview2DPath;
+    const query = new URLSearchParams(Array.from(searchParams)).toString();
+
+    return `${targetPath}${query ? `?${query}` : ''}`;
+}

--- a/packages/game/src/gardenViewMode.unit.ts
+++ b/packages/game/src/gardenViewMode.unit.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getGardenViewModeHref } from './gardenViewMode';
+
+test('switches between garden renderers while preserving the complete query', () => {
+    const query = [
+        ['vrt', '42'],
+        ['gredica', '7'],
+        ['filter', 'active'],
+        ['filter', 'planned'],
+    ] satisfies Array<[string, string]>;
+
+    assert.equal(
+        getGardenViewModeHref('3d', query),
+        '/pregled-vrta?vrt=42&gredica=7&filter=active&filter=planned',
+    );
+    assert.equal(
+        getGardenViewModeHref('2d', query),
+        '/?vrt=42&gredica=7&filter=active&filter=planned',
+    );
+});
+
+test('does not add an empty query separator', () => {
+    assert.equal(getGardenViewModeHref('3d', []), '/pregled-vrta');
+    assert.equal(getGardenViewModeHref('2d', []), '/');
+});

--- a/packages/game/src/hooks/currentGardenStructuralSharing.ts
+++ b/packages/game/src/hooks/currentGardenStructuralSharing.ts
@@ -1,5 +1,5 @@
 import type { Block } from '../types/Block';
-import type { Stack } from '../types/Stack';
+import type { GardenStack } from '../types/Stack';
 import type { CurrentGarden } from './useCurrentGarden';
 
 function blockVariantsEqual(left: Block, right: Block) {
@@ -16,7 +16,7 @@ function blocksEqual(left: Block, right: Block) {
     );
 }
 
-function stackPositionsEqual(left: Stack, right: Stack) {
+function stackPositionsEqual(left: GardenStack, right: GardenStack) {
     return (
         left.position === right.position ||
         (left.position.x === right.position.x &&
@@ -25,7 +25,7 @@ function stackPositionsEqual(left: Stack, right: Stack) {
     );
 }
 
-function stackKey(stack: Stack) {
+function stackKey(stack: GardenStack) {
     return `${stack.position.x}|${stack.position.y}|${stack.position.z}`;
 }
 
@@ -48,7 +48,10 @@ function shareBlocks(previousBlocks: Block[], nextBlocks: Block[]) {
     return changed ? blocks : previousBlocks;
 }
 
-function shareStack(previousStack: Stack | undefined, nextStack: Stack) {
+function shareStack(
+    previousStack: GardenStack | undefined,
+    nextStack: GardenStack,
+) {
     if (!previousStack || !stackPositionsEqual(previousStack, nextStack)) {
         return nextStack;
     }
@@ -65,7 +68,7 @@ function shareStack(previousStack: Stack | undefined, nextStack: Stack) {
     };
 }
 
-function shareStacks(previousStacks: Stack[], nextStacks: Stack[]) {
+function shareStacks(previousStacks: GardenStack[], nextStacks: GardenStack[]) {
     if (previousStacks === nextStacks) {
         return previousStacks;
     }

--- a/packages/game/src/hooks/currentGardenStructuralSharing.unit.ts
+++ b/packages/game/src/hooks/currentGardenStructuralSharing.unit.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { Vector3 } from 'three';
 import type { Block } from '../types/Block';
-import type { Stack } from '../types/Stack';
+import { createGardenPosition, type GardenStack } from '../types/Stack';
 import { shareCurrentGardenData } from './currentGardenStructuralSharing';
 import type { CurrentGarden } from './useCurrentGarden';
 
@@ -19,9 +18,9 @@ function createStack(
     x: number,
     z: number,
     blocks: Block[] = [createBlock()],
-): Stack {
+): GardenStack {
     return {
-        position: new Vector3(x, 0, z),
+        position: createGardenPosition(x, 0, z),
         blocks,
     };
 }

--- a/packages/game/src/hooks/optimisticBlockPlacement.ts
+++ b/packages/game/src/hooks/optimisticBlockPlacement.ts
@@ -3,8 +3,7 @@ import {
     type GardenBlockStack,
     resolveGardenBlockPlacement,
 } from '@gredice/js/gardenBlocks';
-import { Vector3 } from 'three';
-import type { Stack } from '../types/Stack';
+import { createGardenPosition, type GardenStack } from '../types/Stack';
 
 export type PlacementBlockData = GardenBlockDataLike & {
     information?: {
@@ -13,7 +12,7 @@ export type PlacementBlockData = GardenBlockDataLike & {
 };
 
 type GardenWithStacks = {
-    stacks: Stack[];
+    stacks: GardenStack[];
 };
 
 export type BlockPlacementPosition = {
@@ -51,7 +50,7 @@ function createBlockDataByName(blockData: PlacementBlockData[]) {
     return blockDataByName;
 }
 
-function createBlockNameById(stacks: Stack[]) {
+function createBlockNameById(stacks: GardenStack[]) {
     const blockNameById = new Map<string, string>();
     for (const stack of stacks) {
         for (const block of stack.blocks) {
@@ -61,7 +60,7 @@ function createBlockNameById(stacks: Stack[]) {
     return blockNameById;
 }
 
-function createBlockRotationById(stacks: Stack[]) {
+function createBlockRotationById(stacks: GardenStack[]) {
     const blockRotationById = new Map<string, number>();
     for (const stack of stacks) {
         for (const block of stack.blocks) {
@@ -71,7 +70,7 @@ function createBlockRotationById(stacks: Stack[]) {
     return blockRotationById;
 }
 
-function createPlacementStacks(stacks: Stack[]): GardenBlockStack[] {
+function createPlacementStacks(stacks: GardenStack[]): GardenBlockStack[] {
     return stacks.map((stack) => ({
         positionX: stack.position.x,
         positionY: stack.position.z,
@@ -144,7 +143,7 @@ export function createOptimisticBlockPlacement<
 
     if (!hasTargetStack) {
         stacks.push({
-            position: new Vector3(x, 0, y),
+            position: createGardenPosition(x, 0, y),
             blocks: [optimisticBlock],
         });
     }
@@ -152,7 +151,7 @@ export function createOptimisticBlockPlacement<
     return {
         blockId,
         existingBlocks,
-        position: new Vector3(x, 0, y),
+        position: createGardenPosition(x, 0, y),
         stacks,
     };
 }

--- a/packages/game/src/hooks/optimisticBlockPlacement.unit.ts
+++ b/packages/game/src/hooks/optimisticBlockPlacement.unit.ts
@@ -123,9 +123,9 @@ describe('createOptimisticBlockPlacement', () => {
         );
 
         assert.ok(placement);
-        assert.deepStrictEqual(placement.position, new Vector3(-1, 0, 1));
+        assert.deepStrictEqual(placement.position, { x: -1, y: 0, z: 1 });
         assert.deepStrictEqual(placement.stacks.at(-1), {
-            position: new Vector3(-1, 0, 1),
+            position: { x: -1, y: 0, z: 1 },
             blocks: [
                 {
                     id: 'optimistic-bed',
@@ -158,9 +158,9 @@ describe('createOptimisticBlockPlacement', () => {
         );
 
         assert.ok(placement);
-        assert.deepStrictEqual(placement.position, new Vector3(0, 0, -1));
+        assert.deepStrictEqual(placement.position, { x: 0, y: 0, z: -1 });
         assert.deepStrictEqual(placement.stacks.at(-1), {
-            position: new Vector3(0, 0, -1),
+            position: { x: 0, y: 0, z: -1 },
             blocks: [
                 {
                     id: 'optimistic-shade',
@@ -191,7 +191,7 @@ describe('createOptimisticBlockPlacement', () => {
         );
 
         assert.ok(placement);
-        assert.deepStrictEqual(placement.position, new Vector3(0, 0, 0));
+        assert.deepStrictEqual(placement.position, { x: 0, y: 0, z: 0 });
         assert.deepStrictEqual(placement.stacks[0], {
             position: new Vector3(0, 0, 0),
             blocks: [
@@ -225,10 +225,10 @@ describe('createOptimisticBlockPlacement', () => {
         );
 
         assert.ok(placement);
-        assert.deepStrictEqual(placement.position, new Vector3(12, 0, -8));
+        assert.deepStrictEqual(placement.position, { x: 12, y: 0, z: -8 });
         assert.deepStrictEqual(placement.stacks, [
             {
-                position: new Vector3(12, 0, -8),
+                position: { x: 12, y: 0, z: -8 },
                 blocks: [
                     {
                         id: 'optimistic-shade',
@@ -254,10 +254,10 @@ describe('createOptimisticBlockPlacement', () => {
         );
 
         assert.ok(placement);
-        assert.deepStrictEqual(placement.position, new Vector3(4, 0, -2));
+        assert.deepStrictEqual(placement.position, { x: 4, y: 0, z: -2 });
         assert.deepStrictEqual(placement.stacks, [
             {
-                position: new Vector3(4, 0, -2),
+                position: { x: 4, y: 0, z: -2 },
                 blocks: [
                     {
                         id: 'optimistic-shade',

--- a/packages/game/src/hooks/optimisticStackUpdates.ts
+++ b/packages/game/src/hooks/optimisticStackUpdates.ts
@@ -1,4 +1,4 @@
-import type { Stack } from '../types/Stack';
+import type { GardenStack } from '../types/Stack';
 
 export function rotateBlocksInStacks({
     blockIds,
@@ -7,7 +7,7 @@ export function rotateBlocksInStacks({
 }: {
     blockIds: Iterable<string>;
     rotation: number;
-    stacks: Stack[];
+    stacks: GardenStack[];
 }) {
     const blockIdSet = new Set(blockIds);
     if (blockIdSet.size === 0) {

--- a/packages/game/src/hooks/useBlockMove.ts
+++ b/packages/game/src/hooks/useBlockMove.ts
@@ -1,9 +1,8 @@
 import { clientAuthenticated } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Vector3 } from 'three';
 import { handleOptimisticUpdate } from '../helpers/queryHelpers';
 import { persistLocalSandboxGarden } from '../localSandboxGarden';
-import type { Stack } from '../types/Stack';
+import { createGardenPosition, type GardenStack } from '../types/Stack';
 import { useGameState } from '../useGameState';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
 
@@ -42,7 +41,7 @@ function getMoveBlocks(args: MoveArgs): MoveBlockArgs[] {
 }
 
 function moveBlockOptimistically(
-    stacks: Stack[],
+    stacks: GardenStack[],
     sourcePosition: { x: number; z: number },
     destinationPosition: { x: number; z: number },
     blockIndex: number,
@@ -80,7 +79,7 @@ function moveBlockOptimistically(
         : [
               ...stacks,
               {
-                  position: new Vector3(
+                  position: createGardenPosition(
                       destinationPosition.x,
                       0,
                       destinationPosition.z,

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -10,7 +10,6 @@ import {
     useQueryClient,
 } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
-import { Vector3 } from 'three';
 import type { GardenPreviewImage } from '../gardenPreview';
 import {
     loadLocalSandboxGarden,
@@ -27,7 +26,7 @@ import {
     operationVisualRewardDebugScenarios,
     operationVisualRewardDebugTimestamp,
 } from '../operationVisualRewardDebugProfile';
-import type { Stack } from '../types/Stack';
+import { createGardenPosition, type GardenStack } from '../types/Stack';
 import {
     type MockGardenProfile,
     useGameState,
@@ -85,7 +84,7 @@ type useCurrentGardenResponse = Omit<
     farmId?: number | null;
     previewImage?: GardenPreviewImage | null;
     previewSourceRevision?: string | null;
-    stacks: Stack[];
+    stacks: GardenStack[];
     location: {
         lat: number;
         lon: number;
@@ -256,11 +255,11 @@ function getDenseMockDetailBlockName(x: number, z: number) {
 }
 
 function createDenseMockStacks(winterMode: WinterMode): {
-    stackByPosition: Map<string, Stack>;
-    stacks: Stack[];
+    stackByPosition: Map<string, GardenStack>;
+    stacks: GardenStack[];
 } {
-    const stackByPosition = new Map<string, Stack>();
-    const stacks: Stack[] = [];
+    const stackByPosition = new Map<string, GardenStack>();
+    const stacks: GardenStack[] = [];
 
     for (
         let x = denseMockGardenBounds.min;
@@ -273,8 +272,8 @@ function createDenseMockStacks(winterMode: WinterMode): {
             z += 1
         ) {
             const groundName = getDenseMockGroundBlockName(x, z, winterMode);
-            const stack: Stack = {
-                position: new Vector3(x, 0, z),
+            const stack: GardenStack = {
+                position: createGardenPosition(x, 0, z),
                 blocks: [
                     {
                         id: `profile-ground:${x}:${z}`,
@@ -301,10 +300,10 @@ function createDenseMockStacks(winterMode: WinterMode): {
 }
 
 function createHighTargetMockStacks(winterMode: WinterMode): {
-    stackByPosition: Map<string, Stack>;
-    stacks: Stack[];
+    stackByPosition: Map<string, GardenStack>;
+    stacks: GardenStack[];
 } {
-    const stackByPosition = new Map<string, Stack>();
+    const stackByPosition = new Map<string, GardenStack>();
     const detailByPosition = new Map(
         highTargetMockGardenDetailFixtures.map((fixture) => [
             mockGardenStackPositionKey(fixture.x, fixture.z),
@@ -316,8 +315,8 @@ function createHighTargetMockStacks(winterMode: WinterMode): {
             const detail = detailByPosition.get(
                 mockGardenStackPositionKey(x, z),
             );
-            const stack: Stack = {
-                position: new Vector3(x, 0, z),
+            const stack: GardenStack = {
+                position: createGardenPosition(x, 0, z),
                 blocks: [
                     {
                         id: `high-target-ground:${x}:${z}`,
@@ -347,11 +346,11 @@ function createHighTargetMockStacks(winterMode: WinterMode): {
 }
 
 function createOperationRewardDebugStacks(winterMode: WinterMode): {
-    stackByPosition: Map<string, Stack>;
-    stacks: Stack[];
+    stackByPosition: Map<string, GardenStack>;
+    stacks: GardenStack[];
 } {
-    const stackByPosition = new Map<string, Stack>();
-    const stacks: Stack[] = [];
+    const stackByPosition = new Map<string, GardenStack>();
+    const stacks: GardenStack[] = [];
 
     for (
         let x = operationRewardDebugGardenBounds.minX;
@@ -369,8 +368,8 @@ function createOperationRewardDebugStacks(winterMode: WinterMode): {
                     : Math.abs(x * 5 + z * 3) % 6 === 0
                       ? 'Block_Ground'
                       : 'Block_Grass';
-            const stack: Stack = {
-                position: new Vector3(x, 0, z),
+            const stack: GardenStack = {
+                position: createGardenPosition(x, 0, z),
                 blocks: [
                     {
                         id: `operation-reward-ground:${x}:${z}`,
@@ -424,7 +423,7 @@ function addProfileRaisedBedPair({
     id: number;
     now: string;
     raisedBeds: useCurrentGardenResponse['raisedBeds'];
-    stackByPosition: Map<string, Stack>;
+    stackByPosition: Map<string, GardenStack>;
     x: number;
     z: number;
 }): MockRaisedBed | null {
@@ -715,7 +714,7 @@ function addOperationRewardDebugRaisedBed({
     fieldOffset: number;
     now: string;
     raisedBeds: useCurrentGardenResponse['raisedBeds'];
-    stackByPosition: Map<string, Stack>;
+    stackByPosition: Map<string, GardenStack>;
     state: OperationVisualRewardDebugBedState;
     scenario: OperationVisualRewardDebugScenario;
     x: number;
@@ -1040,7 +1039,7 @@ function mockGarden(
         homeCamera: null,
         stacks: [
             {
-                position: new Vector3(
+                position: createGardenPosition(
                     0 + GARDEN_POSITION_X_OFFSET,
                     0,
                     0 + GARDEN_POSITION_Z_OFFSET,
@@ -1059,7 +1058,7 @@ function mockGarden(
                 ],
             },
             {
-                position: new Vector3(
+                position: createGardenPosition(
                     -1 + GARDEN_POSITION_X_OFFSET,
                     0,
                     2 + GARDEN_POSITION_Z_OFFSET,
@@ -1079,7 +1078,7 @@ function mockGarden(
                 ],
             },
             {
-                position: new Vector3(
+                position: createGardenPosition(
                     1 + GARDEN_POSITION_X_OFFSET,
                     0,
                     2 + GARDEN_POSITION_Z_OFFSET,
@@ -1098,7 +1097,7 @@ function mockGarden(
                 ],
             },
             {
-                position: new Vector3(
+                position: createGardenPosition(
                     0 + GARDEN_POSITION_X_OFFSET,
                     0,
                     2 + GARDEN_POSITION_Z_OFFSET,
@@ -1121,7 +1120,7 @@ function mockGarden(
                 ],
             },
             {
-                position: new Vector3(
+                position: createGardenPosition(
                     1 + GARDEN_POSITION_X_OFFSET,
                     0,
                     0 + GARDEN_POSITION_Z_OFFSET,
@@ -1135,7 +1134,7 @@ function mockGarden(
                 ],
             },
             {
-                position: new Vector3(
+                position: createGardenPosition(
                     0 + GARDEN_POSITION_X_OFFSET,
                     0,
                     1 + GARDEN_POSITION_Z_OFFSET,
@@ -1154,7 +1153,7 @@ function mockGarden(
                 ],
             },
             {
-                position: new Vector3(
+                position: createGardenPosition(
                     1 + GARDEN_POSITION_X_OFFSET,
                     0,
                     1 + GARDEN_POSITION_Z_OFFSET,
@@ -1168,7 +1167,7 @@ function mockGarden(
                 ],
             },
             {
-                position: new Vector3(
+                position: createGardenPosition(
                     -1 + GARDEN_POSITION_X_OFFSET,
                     0,
                     1 + GARDEN_POSITION_Z_OFFSET,
@@ -1182,7 +1181,7 @@ function mockGarden(
                 ],
             },
             {
-                position: new Vector3(
+                position: createGardenPosition(
                     1 + GARDEN_POSITION_X_OFFSET,
                     0,
                     -1 + GARDEN_POSITION_Z_OFFSET,
@@ -1196,7 +1195,7 @@ function mockGarden(
                 ],
             },
             {
-                position: new Vector3(
+                position: createGardenPosition(
                     -1 + GARDEN_POSITION_X_OFFSET,
                     0,
                     0 + GARDEN_POSITION_Z_OFFSET,
@@ -1210,7 +1209,7 @@ function mockGarden(
                 ],
             },
             {
-                position: new Vector3(
+                position: createGardenPosition(
                     0 + GARDEN_POSITION_X_OFFSET,
                     0,
                     -1 + GARDEN_POSITION_Z_OFFSET,
@@ -1224,7 +1223,7 @@ function mockGarden(
                 ],
             },
             {
-                position: new Vector3(
+                position: createGardenPosition(
                     -1 + GARDEN_POSITION_X_OFFSET,
                     0,
                     -1 + GARDEN_POSITION_Z_OFFSET,
@@ -1347,7 +1346,7 @@ export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | nu
 
             // Transform garden stacks from flat list to nested
             const rootStacks = garden.stacks ?? [];
-            const stacks: Stack[] = [];
+            const stacks: GardenStack[] = [];
 
             const xPositions = Object.keys(rootStacks);
             for (const x of xPositions) {
@@ -1355,7 +1354,7 @@ export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | nu
                 for (const y of yPositions) {
                     const blocks = rootStacks[x][y];
                     stacks.push({
-                        position: new Vector3(Number(x), 0, Number(y)),
+                        position: createGardenPosition(Number(x), 0, Number(y)),
                         blocks: blocks
                             ? blocks.map((block) => {
                                   return {

--- a/packages/game/src/hooks/useFocusPlacedBlock.ts
+++ b/packages/game/src/hooks/useFocusPlacedBlock.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { Vector3 } from 'three';
 import { animateSunflowerHudToPoint } from '../indicators/SunflowerTransfer/useSunflowerTransferAnimation';
 import { useGameState } from '../useGameState';
 import { useCurrentGarden } from './useCurrentGarden';
@@ -40,7 +41,11 @@ export function useFocusPlacedBlock() {
             stack.blocks.map((block) => ({
                 key: block.id,
                 block,
-                position: stack.position,
+                position: new Vector3(
+                    stack.position.x,
+                    stack.position.y,
+                    stack.position.z,
+                ),
             })),
         );
 

--- a/packages/game/src/hooks/useSceneCurrentGarden.ts
+++ b/packages/game/src/hooks/useSceneCurrentGarden.ts
@@ -1,0 +1,72 @@
+import { useMemo, useRef } from 'react';
+import { Vector3 } from 'three';
+import type { GardenStack, Stack } from '../types/Stack';
+import type { CurrentGarden } from './useCurrentGarden';
+
+export type SceneCurrentGarden = Omit<CurrentGarden, 'stacks'> & {
+    stacks: Stack[];
+};
+
+type SceneCurrentGardenAdapter = (
+    garden: CurrentGarden | null | undefined,
+) => SceneCurrentGarden | null | undefined;
+
+function sceneStackMatchesGardenStack(
+    sceneStack: Stack,
+    gardenStack: GardenStack,
+) {
+    return (
+        sceneStack.blocks === gardenStack.blocks &&
+        sceneStack.position.x === gardenStack.position.x &&
+        sceneStack.position.y === gardenStack.position.y &&
+        sceneStack.position.z === gardenStack.position.z
+    );
+}
+
+export function createSceneCurrentGardenAdapter(): SceneCurrentGardenAdapter {
+    const sceneStackByGardenStack = new WeakMap<GardenStack, Stack>();
+
+    return (garden) => {
+        if (!garden) {
+            return garden;
+        }
+
+        const stacks = garden.stacks.map((gardenStack) => {
+            const cachedSceneStack = sceneStackByGardenStack.get(gardenStack);
+            if (
+                cachedSceneStack &&
+                sceneStackMatchesGardenStack(cachedSceneStack, gardenStack)
+            ) {
+                return cachedSceneStack;
+            }
+
+            const sceneStack: Stack = {
+                blocks: gardenStack.blocks,
+                position: new Vector3(
+                    gardenStack.position.x,
+                    gardenStack.position.y,
+                    gardenStack.position.z,
+                ),
+            };
+            sceneStackByGardenStack.set(gardenStack, sceneStack);
+            return sceneStack;
+        });
+
+        return {
+            ...garden,
+            stacks,
+        };
+    };
+}
+
+export function useSceneCurrentGarden(
+    garden: CurrentGarden | null | undefined,
+) {
+    const adapterRef = useRef<SceneCurrentGardenAdapter | null>(null);
+    if (!adapterRef.current) {
+        adapterRef.current = createSceneCurrentGardenAdapter();
+    }
+    const adapter = adapterRef.current;
+
+    return useMemo(() => adapter(garden), [adapter, garden]);
+}

--- a/packages/game/src/hooks/useSceneCurrentGarden.unit.ts
+++ b/packages/game/src/hooks/useSceneCurrentGarden.unit.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Vector3 } from 'three';
+import type { GardenStack } from '../types/Stack';
+import type { CurrentGarden } from './useCurrentGarden';
+import { createSceneCurrentGardenAdapter } from './useSceneCurrentGarden';
+
+function createGarden(stacks: GardenStack[]): CurrentGarden {
+    return {
+        id: 1,
+        name: 'Garden',
+        isSandbox: false,
+        isPublic: false,
+        backgroundPalette: 'current',
+        homeCamera: null,
+        stacks,
+        location: {
+            lat: 45,
+            lon: 16,
+        },
+        raisedBeds: [],
+    };
+}
+
+describe('createSceneCurrentGardenAdapter', () => {
+    it('converts plain garden coordinates into scene Vector3 values', () => {
+        const gardenStack: GardenStack = {
+            position: { x: 4, y: 0, z: -2 },
+            blocks: [],
+        };
+        const sceneGarden = createSceneCurrentGardenAdapter()(
+            createGarden([gardenStack]),
+        );
+
+        assert.ok(sceneGarden);
+        assert.ok(sceneGarden.stacks[0]?.position instanceof Vector3);
+        assert.deepStrictEqual(
+            sceneGarden.stacks[0]?.position.toArray(),
+            [4, 0, -2],
+        );
+        assert.deepStrictEqual(gardenStack.position, { x: 4, y: 0, z: -2 });
+    });
+
+    it('reuses scene stack identities for structurally shared garden stacks', () => {
+        const gardenStack: GardenStack = {
+            position: { x: 1, y: 0, z: 3 },
+            blocks: [],
+        };
+        const garden = createGarden([gardenStack]);
+        const adaptGarden = createSceneCurrentGardenAdapter();
+        const firstSceneGarden = adaptGarden(garden);
+        const nextSceneGarden = adaptGarden({ ...garden });
+
+        assert.ok(firstSceneGarden);
+        assert.ok(nextSceneGarden);
+        assert.equal(nextSceneGarden.stacks[0], firstSceneGarden.stacks[0]);
+    });
+});

--- a/packages/game/src/hooks/useSyncGameTime.ts
+++ b/packages/game/src/hooks/useSyncGameTime.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useGameState } from '../useGameState';
+import type { GameLocation } from '../utils/timeOfDay';
+import { useLiveTime } from './useLiveTime';
+
+export function useSyncGameTime(location: GameLocation) {
+    const currentTime = useLiveTime();
+    const syncTimeOfDay = useGameState((state) => state.syncTimeOfDay);
+
+    useEffect(() => {
+        syncTimeOfDay(location, currentTime);
+    }, [currentTime, location, syncTimeOfDay]);
+
+    return currentTime;
+}

--- a/packages/game/src/hooks/useSyncGardenBackgroundPalette.ts
+++ b/packages/game/src/hooks/useSyncGardenBackgroundPalette.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import type { GameBackgroundPaletteKey } from '../scene/backgroundPalettes';
+import { useGameState } from '../useGameState';
+
+export function useSyncGardenBackgroundPalette(
+    backgroundPalette: GameBackgroundPaletteKey | null | undefined,
+) {
+    const setBackgroundPaletteKey = useGameState(
+        (state) => state.setBackgroundPaletteKey,
+    );
+
+    useEffect(() => {
+        if (backgroundPalette) {
+            setBackgroundPaletteKey(backgroundPalette);
+        }
+    }, [backgroundPalette, setBackgroundPaletteKey]);
+}

--- a/packages/game/src/hud/AccountHud.tsx
+++ b/packages/game/src/hud/AccountHud.tsx
@@ -9,6 +9,8 @@ import {
     Configuration,
     ExternalLink,
     Inbox,
+    Joystick,
+    LayoutGrid,
     LogOut,
     Sprout,
     User,
@@ -28,6 +30,7 @@ import { Typography } from '@gredice/ui/Typography';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
+import { type GardenViewMode, getGardenViewModeHref } from '../gardenViewMode';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useCurrentUser } from '../hooks/useCurrentUser';
 import { useMarkAllNotificationsRead } from '../hooks/useMarkAllNotificationsRead';
@@ -160,14 +163,20 @@ function NotificationsCard({
     );
 }
 
-function ProfileCard() {
+function ProfileCard({ viewMode }: { viewMode: GardenViewMode }) {
     const [, setProfileModalOpen] = useSearchParam('pregled');
     const openNotificationsOverview = useOpenNotificationsOverview();
     const { track } = useGameAnalytics();
+    const searchParams = useSearchParams();
     const { data: currentUser } = useCurrentUser();
     const { data: notifications } = useNotifications(currentUser?.id, false);
     const hasUnreadNotifications = notifications?.some(
         (notification) => !notification.readAt,
+    );
+    const nextViewMode = viewMode === '2d' ? '3d' : '2d';
+    const viewModeHref = getGardenViewModeHref(
+        viewMode,
+        searchParams.entries(),
     );
 
     return (
@@ -177,6 +186,24 @@ function ProfileCard() {
             <GardenAccountMenuItems
                 onGardenOverviewOpen={() => setProfileModalOpen('vrt')}
             />
+            <DropdownMenuItem
+                className="gap-3"
+                href={viewModeHref}
+                onClick={() =>
+                    track('game_view_mode_changed', {
+                        from: viewMode,
+                        source: 'profile_menu',
+                        to: nextViewMode,
+                    })
+                }
+            >
+                {nextViewMode === '2d' ? (
+                    <LayoutGrid className="size-4" />
+                ) : (
+                    <Joystick className="size-4" />
+                )}
+                <span>{nextViewMode.toUpperCase()} prikaz vrta</span>
+            </DropdownMenuItem>
             <DropdownMenuSeparator className="my-4" />
             <DropdownMenuItem
                 className="gap-3"
@@ -244,7 +271,7 @@ function ProfileCard() {
     );
 }
 
-export function AccountHud() {
+export function AccountHud({ viewMode = '3d' }: { viewMode?: GardenViewMode }) {
     const { track } = useGameAnalytics();
     const [isNotificationsOpen, setNotificationsOpen] = useState(false);
     const { data: currentUser } = useCurrentUser();
@@ -268,7 +295,7 @@ export function AccountHud() {
                             <ProfileAvatar variant="transparentOnMobile" />
                         </IconButton>
                     </DropdownMenuTrigger>
-                    <ProfileCard />
+                    <ProfileCard viewMode={viewMode} />
                 </DropdownMenu>
                 <div className="hidden md:block md:order-1">
                     {isLoading ? (

--- a/packages/game/src/hud/DebugHudDynamic.tsx
+++ b/packages/game/src/hud/DebugHudDynamic.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const DebugHud = dynamic(
+    () => import('./DebugHud').then((module) => module.DebugHud),
+    {
+        ssr: false,
+    },
+);
+
+export function DebugHudDynamic() {
+    return <DebugHud />;
+}

--- a/packages/game/src/hud/RaisedBedFieldHud.tsx
+++ b/packages/game/src/hud/RaisedBedFieldHud.tsx
@@ -41,7 +41,11 @@ function centerOffset(offset: number) {
     return `calc(50% ${operator} ${Math.abs(offset)}px)`;
 }
 
-export function RaisedBedFieldHud() {
+export function RaisedBedFieldHud({
+    instantTransition = false,
+}: {
+    instantTransition?: boolean;
+}) {
     const { data: currentGarden } = useCurrentGarden();
     const isSandbox = useIsSandboxGarden();
     const { track } = useGameAnalytics();
@@ -84,7 +88,10 @@ export function RaisedBedFieldHud() {
             className={cx(
                 'opacity-0 transition-opacity pointer-events-none duration-300',
                 view === 'closeup' &&
-                    'opacity-100 [transition-delay:950ms] pointer-events-auto',
+                    cx(
+                        'opacity-100 pointer-events-auto',
+                        !instantTransition && '[transition-delay:950ms]',
+                    ),
             )}
             style={hudStyles}
         >

--- a/packages/game/src/hud/raisedBed/plantPickerNavigation.ts
+++ b/packages/game/src/hud/raisedBed/plantPickerNavigation.ts
@@ -1,5 +1,5 @@
 import { isRaisedBedAbandoned } from '../../raisedBedConstants';
-import type { Stack } from '../../types/Stack';
+import type { GardenStack } from '../../types/Stack';
 import { getRaisedBedBlockIds } from '../../utils/raisedBedBlocks';
 import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
 
@@ -23,7 +23,7 @@ export type RaisedBedFieldTargetGarden = {
     id: number;
     isSandbox?: boolean | null;
     raisedBeds: RaisedBedTarget[];
-    stacks: Stack[];
+    stacks: GardenStack[];
 };
 
 export type RaisedBedFieldTargetCartItem = {

--- a/packages/game/src/hud/specialEntityDebug.ts
+++ b/packages/game/src/hud/specialEntityDebug.ts
@@ -1,4 +1,4 @@
-import type { Stack } from '../types/Stack';
+import type { GardenStack } from '../types/Stack';
 
 export const SUNFLOWER_SPECIAL_ENTITY_REWARD_AMOUNT = 1000;
 
@@ -77,7 +77,7 @@ function resolveSpecialEntityPositionY({
 }: {
     blockDataByName: Map<string, SpecialEntityBlockData>;
     blockIndex: number;
-    stack: Stack;
+    stack: GardenStack;
 }) {
     let y = 0;
 
@@ -102,7 +102,7 @@ export function getSpecialEntityDebugEntries({
     stacks,
 }: {
     blockData?: SpecialEntityBlockData[] | null;
-    stacks: Stack[] | undefined;
+    stacks: GardenStack[] | undefined;
 }) {
     const blockDataByName = resolveBlockDataByName(blockData ?? null);
     const entries: SpecialEntityDebugEntry[] = [];

--- a/packages/game/src/index.ts
+++ b/packages/game/src/index.ts
@@ -2,6 +2,7 @@ export {
     GameAnalyticsProvider,
     useGameAnalytics,
 } from './analytics/GameAnalyticsContext';
+export type { GameFeatureFlags } from './GameFlagsContext';
 export type { GameSceneProps } from './GameScene';
 export { GameSceneDynamic as GameScene } from './GameSceneDynamic';
 export { PlantEditor } from './generators/plant/editor/PlantEditor';

--- a/packages/game/src/localSandboxGarden.ts
+++ b/packages/game/src/localSandboxGarden.ts
@@ -3,9 +3,8 @@ import {
     type GameBackgroundPaletteKey,
     isGameBackgroundPaletteKey,
 } from '@gredice/js/gameBackground';
-import { Vector3 } from 'three';
 import type { Block } from './types/Block';
-import type { Stack } from './types/Stack';
+import { createGardenPosition, type GardenStack } from './types/Stack';
 
 export const localSandboxGardenId = 0;
 export const defaultLocalSandboxStorageKey = 'gredice.debug.sandbox.garden.v1';
@@ -17,7 +16,7 @@ export type LocalSandboxGarden = {
     isPublic: false;
     backgroundPalette: GameBackgroundPaletteKey;
     homeCamera: null;
-    stacks: Stack[];
+    stacks: GardenStack[];
     location: {
         lat: number;
         lon: number;
@@ -39,16 +38,16 @@ type StoredLocalSandboxGarden = {
 type LocalSandboxGardenOptions = {
     backgroundPalette?: GameBackgroundPaletteKey;
     name?: string;
-    stacks?: Stack[];
+    stacks?: GardenStack[];
 };
 
-function createDefaultLocalSandboxStacks(): Stack[] {
-    const stacks: Stack[] = [];
+function createDefaultLocalSandboxStacks(): GardenStack[] {
+    const stacks: GardenStack[] = [];
 
     for (let x = -2; x <= 2; x += 1) {
         for (let z = -2; z <= 2; z += 1) {
             stacks.push({
-                position: new Vector3(x, 0, z),
+                position: createGardenPosition(x, 0, z),
                 blocks: [
                     {
                         id: `local-ground:${x}:${z}`,
@@ -63,14 +62,18 @@ function createDefaultLocalSandboxStacks(): Stack[] {
     return stacks;
 }
 
-function cloneSandboxStacks(stacks: Stack[]): Stack[] {
+function cloneSandboxStacks(stacks: GardenStack[]): GardenStack[] {
     return stacks.map((stack) => ({
-        position: stack.position.clone(),
+        position: createGardenPosition(
+            stack.position.x,
+            stack.position.y,
+            stack.position.z,
+        ),
         blocks: stack.blocks.map((block) => ({ ...block })),
     }));
 }
 
-function resolveDefaultLocalSandboxStacks(stacks: Stack[] | undefined) {
+function resolveDefaultLocalSandboxStacks(stacks: GardenStack[] | undefined) {
     return stacks?.length
         ? cloneSandboxStacks(stacks)
         : createDefaultLocalSandboxStacks();
@@ -146,7 +149,7 @@ function normalizeStoredGarden(
 
             return [
                 {
-                    position: new Vector3(x, 0, z),
+                    position: createGardenPosition(x, 0, z),
                     blocks: normalizeStoredBlocks(stack.blocks),
                 },
             ];

--- a/packages/game/src/scene/CloudLayer.tsx
+++ b/packages/game/src/scene/CloudLayer.tsx
@@ -20,7 +20,7 @@ import {
     type OrthographicCamera,
     type Vector3,
 } from 'three';
-import type { Stack } from '../types/Stack';
+import type { GardenStack } from '../types/Stack';
 import { useGameState } from '../useGameState';
 import { CloudShadowAttenuation } from './CloudShadowAttenuationLayer';
 import {
@@ -118,7 +118,7 @@ function createCloudAlphaAsset(): CloudAlphaAsset | null {
     return { canvas, texture };
 }
 
-function getCloudBounds(stacks: Stack[] | undefined) {
+function getCloudBounds(stacks: GardenStack[] | undefined) {
     if (!stacks?.length) {
         return {
             centerX: 0,
@@ -157,7 +157,7 @@ type CloudLayerProps = {
     quality: GameQualityProfile;
     shadowUpdateMs?: number;
     shadowStrength: number;
-    stacks: Stack[] | undefined;
+    stacks: GardenStack[] | undefined;
     sunPosition: Vector3;
     timeOfDay: number;
     windDirection: number;

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -14,8 +14,8 @@ import * as SunCalc from 'suncalc';
 import { Color, type DirectionalLight } from 'three';
 import { PlantShaderPrewarm } from '../generators/plant/PlantShaderPrewarm';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
-import { useLiveTime } from '../hooks/useLiveTime';
 import { useSnapshotTime } from '../hooks/useSnapshotTime';
+import { useSyncGameTime } from '../hooks/useSyncGameTime';
 import { useWeatherNow } from '../hooks/useWeatherNow';
 import { type GameState, useGameState } from '../useGameState';
 import { defaultGameBackgroundPaletteIndex } from './backgroundPalettes';
@@ -579,9 +579,7 @@ export function Environment({
     const qualityProfile = quality ?? resolveGameQualityProfile();
     const directionalLightRef = useRef<DirectionalLight | null>(null);
 
-    const currentTime = useLiveTime();
     const timeOfDay = useGameState((state) => state.timeOfDay);
-    const syncTimeOfDay = useGameState((state) => state.syncTimeOfDay);
     const backgroundPaletteIndex = useGameState(
         (state) => state.backgroundPaletteIndex,
     );
@@ -618,9 +616,7 @@ export function Environment({
         }),
         [garden?.location.lat, garden?.location.lon],
     );
-    useEffect(() => {
-        syncTimeOfDay(location, currentTime);
-    }, [currentTime, location, syncTimeOfDay]);
+    const currentTime = useSyncGameTime(location);
     const shadowCameraSize = useMemo(() => {
         const stacks = garden?.stacks;
         if (!stacks?.length) {

--- a/packages/game/src/scene/shadowMapScheduling.ts
+++ b/packages/game/src/scene/shadowMapScheduling.ts
@@ -1,4 +1,4 @@
-import type { Stack } from '../types/Stack';
+import type { GardenStack } from '../types/Stack';
 
 type ShadowLightPosition = {
     x: number;
@@ -30,7 +30,7 @@ function formatShadowSignatureValue(value: number) {
 }
 
 export function buildGardenShadowGeometrySignature(
-    stacks: Stack[] | undefined,
+    stacks: GardenStack[] | undefined,
 ) {
     return (stacks ?? [])
         .map((stack) => {

--- a/packages/game/src/scene/waterColorState.ts
+++ b/packages/game/src/scene/waterColorState.ts
@@ -1,0 +1,11 @@
+export type WaterColors = {
+    deep: string;
+    shallow: string;
+    foam: string;
+};
+
+export const defaultWaterColors: WaterColors = {
+    deep: '#1f6ea7',
+    shallow: '#8eddd3',
+    foam: '#fbfffb',
+};

--- a/packages/game/src/scene/waterColors.ts
+++ b/packages/game/src/scene/waterColors.ts
@@ -1,23 +1,14 @@
 import { Color } from 'three';
 import { getNightAmount } from './moonlight';
+import { defaultWaterColors, type WaterColors } from './waterColorState';
+
+export { defaultWaterColors, type WaterColors } from './waterColorState';
 
 export type WaterEnvironmentWeather = {
     cloudy?: number;
     foggy?: number;
     rainy?: number;
     snowy?: number;
-};
-
-export type WaterColors = {
-    deep: string;
-    shallow: string;
-    foam: string;
-};
-
-export const defaultWaterColors: WaterColors = {
-    deep: '#1f6ea7',
-    shallow: '#8eddd3',
-    foam: '#fbfffb',
 };
 
 function clamp01(value: number) {

--- a/packages/game/src/types/Stack.ts
+++ b/packages/game/src/types/Stack.ts
@@ -1,7 +1,26 @@
 import type { Vector3 } from 'three';
 import type { Block } from './Block';
 
+export type GardenPosition = {
+    x: number;
+    y: number;
+    z: number;
+};
+
+export type GardenStack = {
+    position: GardenPosition;
+    blocks: Block[];
+};
+
 export type Stack = {
     position: Vector3;
     blocks: Block[];
 };
+
+export function createGardenPosition(
+    x: number,
+    y: number,
+    z: number,
+): GardenPosition {
+    return { x, y, z };
+}

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -30,7 +30,7 @@ import {
     setGameQualityCustomProfile as persistGameQualityCustomProfile,
     setGameQualitySetting as persistGameQualitySetting,
 } from './scene/gameQuality';
-import { defaultWaterColors, type WaterColors } from './scene/waterColors';
+import { defaultWaterColors, type WaterColors } from './scene/waterColorState';
 import type { Block } from './types/Block';
 import type { Stack } from './types/Stack';
 import { getAudioConfig } from './utils/audioConfig';
@@ -495,6 +495,7 @@ export function createGameState({
     localSandboxInitialStacks,
     mockGardenProfile,
     timeLocation: initialTimeLocation,
+    visualPlacementEffectsEnabled = true,
     winterMode,
 }: {
     appBaseUrl: string;
@@ -508,6 +509,7 @@ export function createGameState({
     localSandboxInitialStacks?: Stack[];
     mockGardenProfile?: MockGardenProfile;
     timeLocation?: GameLocation;
+    visualPlacementEffectsEnabled?: boolean;
     winterMode?: WinterMode;
 }) {
     const dayNightCycleDisabled =
@@ -766,13 +768,18 @@ export function createGameState({
             })),
         clearGardenBoxTooltip: () => set({ gardenBoxTooltip: null }),
         placedBlockEffects: {},
-        queuePlacedBlockEffect: (blockId, effect) =>
+        queuePlacedBlockEffect: (blockId, effect) => {
+            if (!visualPlacementEffectsEnabled) {
+                return;
+            }
+
             set((state) => ({
                 placedBlockEffects: {
                     ...state.placedBlockEffects,
                     [blockId]: effect,
                 },
-            })),
+            }));
+        },
         consumePlacedBlockEffect: (blockId) => {
             const effect = get().placedBlockEffects[blockId] ?? null;
             if (!effect) {
@@ -787,7 +794,11 @@ export function createGameState({
             return effect;
         },
         blockPlacementDropAnimations: {},
-        queueBlockPlacementDropAnimation: (blockId, options) =>
+        queueBlockPlacementDropAnimation: (blockId, options) => {
+            if (!visualPlacementEffectsEnabled) {
+                return;
+            }
+
             set((state) => {
                 nextBlockPlacementDropAnimationRenderId += 1;
                 return {
@@ -808,7 +819,8 @@ export function createGameState({
                         },
                     },
                 };
-            }),
+            });
+        },
         confirmBlockPlacementDropAnimation: (sourceBlockId, targetBlockId) =>
             set((state) => {
                 const animation = getBlockPlacementDropAnimationForBlockId(

--- a/packages/game/src/useGameState.unit.ts
+++ b/packages/game/src/useGameState.unit.ts
@@ -298,6 +298,28 @@ test('placement animation keeps render and completion identity through confirmed
     }
 });
 
+test('renderer-free state does not retain visual placement effects', () => {
+    const store = createGameState({
+        appBaseUrl: '',
+        freezeTime: new Date('2026-01-01T12:00:00.000Z'),
+        isMock: true,
+        visualPlacementEffectsEnabled: false,
+    });
+
+    try {
+        store.getState().queuePlacedBlockEffect('optimistic', {
+            kind: 'sunflowers',
+            amount: 25,
+        });
+        store.getState().queueBlockPlacementDropAnimation('optimistic');
+
+        assert.deepEqual(store.getState().placedBlockEffects, {});
+        assert.deepEqual(store.getState().blockPlacementDropAnimations, {});
+    } finally {
+        store.getState().audio.dispose();
+    }
+});
+
 test('placement animation waits for mutation confirmation after visual completion', () => {
     const store = createGameState({
         appBaseUrl: '',

--- a/packages/game/src/utils/raisedBedBlocks.ts
+++ b/packages/game/src/utils/raisedBedBlocks.ts
@@ -1,5 +1,5 @@
 import type { Block } from '../types/Block';
-import type { Stack } from '../types/Stack';
+import type { GardenStack } from '../types/Stack';
 
 type RaisedBedWithBlockId = {
     id: number;
@@ -10,18 +10,18 @@ type RaisedBedWithBlockId = {
 type GardenLike<
     TRaisedBed extends RaisedBedWithBlockId = RaisedBedWithBlockId,
 > = {
-    stacks: Stack[];
+    stacks: GardenStack[];
     raisedBeds: TRaisedBed[];
 };
 
 type BlockPlacement = {
     block: Block;
-    stack: Stack;
+    stack: GardenStack;
     index: number;
 };
 
 function getBlockPlacement(
-    stacks: Stack[],
+    stacks: GardenStack[],
     blockId: string,
 ): BlockPlacement | null {
     for (const stack of stacks) {
@@ -40,7 +40,7 @@ function getBlockPlacement(
 }
 
 function getAdjacentRaisedBedIds(
-    stacks: Stack[],
+    stacks: GardenStack[],
     blockId: string,
     placement: BlockPlacement,
 ): string[] {
@@ -73,7 +73,7 @@ function getAdjacentRaisedBedIds(
 }
 
 function sortBlockIdsByOrientation(
-    stacks: Stack[],
+    stacks: GardenStack[],
     blockIds: string[],
     orientation: 'vertical' | 'horizontal' = 'vertical',
 ): string[] {
@@ -95,7 +95,7 @@ function sortBlockIdsByOrientation(
 }
 
 export function getConnectedRaisedBedBlockIds(
-    stacks: Stack[],
+    stacks: GardenStack[],
     blockId: string,
 ): string[] {
     const startPlacement = getBlockPlacement(stacks, blockId);
@@ -135,7 +135,7 @@ export function getConnectedRaisedBedBlockIds(
 }
 
 export function findAttachedRaisedBedBlockId(
-    stacks: Stack[],
+    stacks: GardenStack[],
     blockId: string,
 ): string | null {
     const placement = getBlockPlacement(stacks, blockId);

--- a/packages/game/src/utils/stackHeightCore.ts
+++ b/packages/game/src/utils/stackHeightCore.ts
@@ -1,6 +1,6 @@
 import type { BlockData } from '@gredice/client';
 import type { Block } from '../types/Block';
-import type { Stack } from '../types/Stack';
+import type { GardenStack } from '../types/Stack';
 
 const waterBlockName = 'Block_Water';
 
@@ -23,7 +23,7 @@ export function getBlockDataByName(
 }
 
 function isWaterBlockCollapsedIntoSupport(
-    stack: Stack,
+    stack: GardenStack,
     block: Block,
     blockIndex: number,
 ) {
@@ -39,7 +39,7 @@ function isWaterBlockCollapsedIntoSupport(
 
 export function getStackBlockHeight(
     blockData: BlockData[] | null | undefined,
-    stack: Stack,
+    stack: GardenStack,
     block: Block,
     blockIndex = stack.blocks.indexOf(block),
 ) {
@@ -52,7 +52,7 @@ export function getStackBlockHeight(
 
 export function getStackHeight(
     blockData: BlockData[] | null | undefined,
-    stack: Stack | undefined,
+    stack: GardenStack | undefined,
     stopBlock?: Block,
 ) {
     if (!blockData || !stack || stack.blocks.length <= 0) {

--- a/packages/ui/src/BlockImage/BlockImage.tsx
+++ b/packages/ui/src/BlockImage/BlockImage.tsx
@@ -4,10 +4,16 @@ import { getBlockImageUrl } from './blockImageUrl';
 type BlockImageProps = Omit<ImageProps, 'src' | 'alt'> & {
     blockName: string;
     alt?: string;
+    rotationSuffix?: number | string;
 };
 
-export function BlockImage({ alt, blockName, ...rest }: BlockImageProps) {
-    const src = getBlockImageUrl(blockName) ?? '';
+export function BlockImage({
+    alt,
+    blockName,
+    rotationSuffix,
+    ...rest
+}: BlockImageProps) {
+    const src = getBlockImageUrl(blockName, { rotationSuffix }) ?? '';
 
     return <Image src={src} alt={alt || blockName} {...rest} />;
 }


### PR DESCRIPTION
## What changed

- adds `/pregled-vrta`, a React-only top-down garden overview for devices where 3D rendering is unavailable or too expensive
- reuses the existing `GameHud`, account menu, raised-bed detail flow, item placement rules, game state, and garden queries instead of creating a second UI mode
- adds a 2D/3D switch to the existing account HUD while preserving query parameters
- keeps Three.js, React Three Fiber, WebGL, GLB preloads, audio controls, and 3D debug/profile code outside the 2D client boundary
- supports negative coordinates, rotation, multi-cell footprints, drag placement, mobile safe areas, and raised-bed selection
- caps pathological sparse coordinate layouts at 2,500 background cells while retaining real world coordinates
- disables 3D-only placement presentation queues in the renderer-free mode

## Why

The Garden app needs a functional low-performance fallback that still exposes the same garden workflows and HUD without requiring a WebGL-capable device or maintaining duplicate product UI.

## Validation

- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game test` — 780 passed
- `pnpm --filter garden lint`
- `pnpm --filter garden typecheck`
- `pnpm --filter @gredice/ui typecheck`
- `pnpm --filter www typecheck`
- route-scoped production compile for `/pregled-vrta`
- focused production Playwright coverage for signed-out and full signed-in 2D flows — 2 passed
- full Garden landing regression suite — 9 passed
- production client-chunk audit — 16 route chunks, zero WebGL renderer, React Three Fiber, or GLB references
- `git diff --check`