### PR TITLE
fix(game): keep controls toggle visible when guide opens

### DIFF
--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -211,8 +211,11 @@ test('controls instructions clear the item picker on tablet layouts', async ({
 
     const picker = page.locator('[data-items-hud]');
     const guide = page.locator('[data-controls-tooltip-hud="open"]');
+    const toggle = page.getByTitle('Sakrij kontrole');
     await expect(picker).toBeVisible();
     await expect(guide).toBeVisible();
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
     await expect(page.getByText('Pokupi / spusti')).toBeVisible();
 
     const pickerBox = await picker.boundingBox();
@@ -222,6 +225,13 @@ test('controls instructions clear the item picker on tablet layouts', async ({
 
     expect((guideBox?.y ?? 0) + (guideBox?.height ?? 0)).toBeLessThanOrEqual(
         (pickerBox?.y ?? 0) - 8,
+    );
+
+    await toggle.click();
+    await expect(guide).toHaveCount(0);
+    await expect(page.getByTitle('Prikaži kontrole')).toHaveAttribute(
+        'aria-expanded',
+        'false',
     );
 });
 

--- a/packages/game/src/hud/ControlsTooltipHud.tsx
+++ b/packages/game/src/hud/ControlsTooltipHud.tsx
@@ -93,36 +93,41 @@ export function ControlsTooltipHud() {
         writeStorage(map);
     };
 
-    if (!open) {
-        return (
+    return (
+        <>
+            {open ? (
+                <div
+                    id="game-controls-tooltip"
+                    data-controls-tooltip-hud="open"
+                    className="pointer-events-auto relative p-2 sm:p-3 md:mb-24"
+                >
+                    <ControlsVisualization
+                        deviceType={deviceType}
+                        phase={phase}
+                    />
+                    <ButtonGreen
+                        title="Zatvori"
+                        variant="soft"
+                        size="sm"
+                        onClick={dismiss}
+                        className="absolute top-4 right-4 z-10 shrink-0 size-7 min-h-0 p-0 rounded-full"
+                    >
+                        <Check className="size-4 shrink-0" />
+                    </ButtonGreen>
+                </div>
+            ) : null}
             <div className="pointer-events-auto">
                 <IconButton
-                    title="Prikaži kontrole"
+                    title={open ? 'Sakrij kontrole' : 'Prikaži kontrole'}
+                    aria-controls="game-controls-tooltip"
+                    aria-expanded={open}
                     variant="plain"
-                    onClick={() => setOpen(true)}
+                    onClick={open ? dismiss : () => setOpen(true)}
                     className="hover:bg-muted"
                 >
                     <GamepadDirectional className="size-5" />
                 </IconButton>
             </div>
-        );
-    }
-
-    return (
-        <div
-            data-controls-tooltip-hud="open"
-            className="pointer-events-auto relative p-2 sm:p-3 md:mb-24"
-        >
-            <ControlsVisualization deviceType={deviceType} phase={phase} />
-            <ButtonGreen
-                title="Zatvori"
-                variant="soft"
-                size="sm"
-                onClick={dismiss}
-                className="absolute top-4 right-4 z-10 shrink-0 size-7 min-h-0 p-0 rounded-full"
-            >
-                <Check className="size-4 shrink-0" />
-            </ButtonGreen>
-        </div>
+        </>
     );
 }


### PR DESCRIPTION
## Summary

- keep the bottom gamepad control visible while the controls guide is open
- let the persistent button close the guide as an alternative to the check button
- expose the open state through `aria-expanded` and connect the trigger to the guide
- extend the Garden component test to cover the visible open-state trigger and toggle behavior

## Root cause

`ControlsTooltipHud` returned either the guide or the bottom trigger, so opening the guide removed the original toggle from the HUD.

## User impact

Players can now close the controls guide from the same bottom control they used to open it, while the existing check button remains available.

## Validation

- `pnpm --filter @gredice/game exec biome check src/hud/ControlsTooltipHud.tsx`
- `pnpm --filter garden exec biome check tests/items-hud.spec.tsx`
- `pnpm typecheck --filter @gredice/game --filter garden --filter www`
- `GREDICE_PLAYWRIGHT_REUSE_SERVER=true pnpm --filter garden exec playwright test tests/items-hud.spec.tsx --grep "controls instructions clear" --project chromium`
- `git diff --check`