### PR TITLE
fix(garden): hide completed operation badges

### DIFF
--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -334,6 +334,39 @@ function plantedGrowingWithRecommendedOperationsScenario(): RaisedBedScenario {
                     },
                 ],
             },
+            {
+                id: 802,
+                entityId: 202,
+                taskVersionEventId: 802,
+                entityTypeName: 'operation',
+                raisedBedId: 1,
+                raisedBedFieldId: 1,
+                status: 'planned',
+                createdAt: '2026-05-11T00:00:00.000Z',
+                scheduledDate: '2026-05-12T00:00:00.000Z',
+                scheduledAt: '2026-05-11T00:00:00.000Z',
+                completedAt: null,
+                verifiedAt: null,
+                canceledAt: null,
+                cancellationReason: null,
+                blockedAt: null,
+                blockReasonLabel: null,
+                blockNote: null,
+                blockImageUrls: [],
+                imageUrls: [],
+                completionNotes: null,
+                targetLabel: 'Raised Bed 1 › Polje 1',
+                statusHistory: [
+                    {
+                        status: 'new',
+                        changedAt: '2026-05-11T00:00:00.000Z',
+                    },
+                    {
+                        status: 'planned',
+                        changedAt: '2026-05-11T00:00:00.000Z',
+                    },
+                ],
+            },
         ],
     };
 }
@@ -1208,10 +1241,10 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         await expect(recommendationsList).toContainText('Uklanjanje korova');
         await expect(
             recommendationsList.locator('[data-operation-id="201"]'),
-        ).toContainText('Zakazano');
+        ).not.toContainText('Zakazano');
         await expect(
             recommendationsList.locator('[data-operation-id="202"]'),
-        ).not.toContainText('Zakazano');
+        ).toContainText('Zakazano');
 
         await operationsHeader.click();
         await expect(operationsSection.getByTitle('2 preporuka')).toHaveClass(
@@ -1250,6 +1283,11 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
             dialog
                 .getByRole('tabpanel', { name: 'Radnje' })
                 .locator('[data-operation-id="201"]'),
+        ).not.toContainText('Zakazano');
+        await expect(
+            dialog
+                .getByRole('tabpanel', { name: 'Radnje' })
+                .locator('[data-operation-id="202"]'),
         ).toContainText('Zakazano');
     });
 

--- a/packages/game/src/hud/raisedBed/shared/useOperationContextIndicators.ts
+++ b/packages/game/src/hud/raisedBed/shared/useOperationContextIndicators.ts
@@ -1,5 +1,8 @@
 import { useEffect, useMemo } from 'react';
-import { useGardenOperations } from '../../../hooks/useGardenOperations';
+import {
+    type GardenOperationItem,
+    useGardenOperations,
+} from '../../../hooks/useGardenOperations';
 import {
     type ShoppingCartItemData,
     useShoppingCart,
@@ -10,6 +13,13 @@ type OperationContextTarget = {
     raisedBedId?: number;
     positionIndex?: number;
 };
+
+const scheduledOperationStatuses = new Set<GardenOperationItem['status']>([
+    'new',
+    'planned',
+    'assigned',
+    'confirmed',
+]);
 
 function isOperationInCurrentContext(
     {
@@ -77,7 +87,8 @@ export function useOperationContextIndicators({
             new Set(
                 (scheduledOperationPages ?? []).flatMap((page) =>
                     page.items.flatMap((operation) =>
-                        operation.entityTypeName === 'operation'
+                        operation.entityTypeName === 'operation' &&
+                        scheduledOperationStatuses.has(operation.status)
                             ? [operation.entityId]
                             : [],
                     ),


### PR DESCRIPTION
## What changed

- mark action-list operations as scheduled only while their lifecycle is active
- stop completed, blocked, failed, and canceled operation history from producing a `Zakazano` badge
- cover both a completed operation and a genuinely planned operation in the raised-bed component regression

## Root cause

The raised-bed action indicator loaded operation history with completed entries and collected every matching operation definition ID without checking its current status. Once an action had ever been scheduled for that raised bed or field, its definition remained marked as scheduled after completion.

## User impact

Completed actions such as watering, weeding, or photography no longer appear as currently scheduled in the raised-bed **Radnje** list. Active scheduled instances continue to show the badge.

## Validation

- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter @gredice/game test` (780 passed)
- focused Biome checks for both changed files
- focused Chromium component test for the raised-bed recommended/all-actions flow