### PR TITLE
fix(checkout): sync sunflower package balance

### DIFF
--- a/apps/app/app/admin/accounts/[accountId]/AccountSunflowersCard.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/AccountSunflowersCard.tsx
@@ -224,6 +224,15 @@ function getSunflowerReasonSummary(event: SunflowerHistoryEvent) {
         };
     }
 
+    if (reasonPrefix === 'sunflowerPackage') {
+        return {
+            icon: iconFrame(<Wallet className="size-5" aria-hidden />, tone),
+            label: 'Kupnja paketa suncokreta',
+            description: 'Suncokreti dodijeljeni iz plaćenog paketa.',
+            reason,
+        };
+    }
+
     if (
         reasonPrefix === 'shoppingCart' ||
         reasonPrefix === 'shoppingCartItem'

--- a/packages/game/src/shared-ui/sunflowers/SunflowersList.tsx
+++ b/packages/game/src/shared-ui/sunflowers/SunflowersList.tsx
@@ -113,6 +113,20 @@ function sunflowerReasonToDescription(reason: string) {
             label: 'Plaćanje',
         };
     }
+    if (reason.startsWith('sunflowerPackage:')) {
+        return {
+            icon: (
+                <Image
+                    src="https://cdn.gredice.com/sunflower-large.svg"
+                    alt="Suncokret"
+                    width={40}
+                    height={40}
+                    className="size-10"
+                />
+            ),
+            label: 'Kupnja paketa suncokreta',
+        };
+    }
     if (
         reason.startsWith('shoppingCart:') ||
         reason.startsWith('shoppingCartItem:')

--- a/packages/storage/src/repositories/events/types.ts
+++ b/packages/storage/src/repositories/events/types.ts
@@ -9,6 +9,7 @@ export type AccountAssignUserPayload = {
 
 export type AccountSunflowersPayload = {
     amount: number;
+    idempotencyKey?: string;
     reason: string;
 };
 

--- a/packages/storage/src/repositories/sunflowerLedgerRepo.ts
+++ b/packages/storage/src/repositories/sunflowerLedgerRepo.ts
@@ -1,6 +1,9 @@
 import 'server-only';
 import { and, asc, desc, eq, sql } from 'drizzle-orm';
 import {
+    createEvent,
+    events,
+    knownEvents,
     type SelectSunflowerLedgerEntry,
     storage,
     sunflowerLedgerEntries,
@@ -356,12 +359,47 @@ export async function topUpSunflowerPackage(input: SunflowerPackageTopUpInput) {
             tx,
         );
 
+        const recordVisibleBalanceIfMissing = async (
+            amount: number,
+            reason: string,
+        ) => {
+            const visibleBalanceEvent = knownEvents.accounts.sunflowersEarnedV1(
+                input.accountId,
+                {
+                    amount,
+                    idempotencyKey: input.idempotencyKey,
+                    reason,
+                },
+            );
+            const existingEvent = await tx.query.events.findFirst({
+                columns: { id: true },
+                where: and(
+                    eq(events.type, visibleBalanceEvent.type),
+                    eq(events.version, visibleBalanceEvent.version),
+                    eq(events.aggregateId, visibleBalanceEvent.aggregateId),
+                    eq(
+                        sql<string>`${events.data}->>'idempotencyKey'`,
+                        input.idempotencyKey,
+                    ),
+                ),
+            });
+            if (!existingEvent) {
+                await createEvent(visibleBalanceEvent, tx);
+            }
+        };
+
         if (existingTopUp) {
             if (bonusSunflowers > 0 && !existingBonus) {
                 throw new Error(
                     'Sunflower package top-up already exists without a matching bonus entry.',
                 );
             }
+            await recordVisibleBalanceIfMissing(
+                existingTopUp.amount + (existingBonus?.amount ?? 0),
+                existingTopUp.reason ??
+                    input.reason ??
+                    `sunflowerPackage:${input.packageCode}`,
+            );
             return {
                 topUp: { status: 'existing' as const, entry: existingTopUp },
                 bonus: existingBonus
@@ -410,6 +448,10 @@ export async function topUpSunflowerPackage(input: SunflowerPackageTopUpInput) {
         };
 
         if (bonusSunflowers === 0) {
+            await recordVisibleBalanceIfMissing(
+                input.sunflowers,
+                input.reason ?? `sunflowerPackage:${input.packageCode}`,
+            );
             return { topUp, bonus: null };
         }
         assertPositiveInteger('bonusSunflowers', bonusSunflowers);
@@ -434,6 +476,11 @@ export async function topUpSunflowerPackage(input: SunflowerPackageTopUpInput) {
                       tx,
                   ),
               };
+
+        await recordVisibleBalanceIfMissing(
+            input.sunflowers,
+            input.reason ?? `sunflowerPackage:${input.packageCode}`,
+        );
 
         return { topUp, bonus };
     });

--- a/packages/storage/tests/sunflowerLedgerRepo.node.spec.ts
+++ b/packages/storage/tests/sunflowerLedgerRepo.node.spec.ts
@@ -3,9 +3,12 @@ import test from 'node:test';
 import {
     captureSunflowerReservation,
     correctSunflowerBalance,
+    deleteEventById,
     getSunflowerLedgerBalance,
     getSunflowerLedgerHistory,
     getSunflowerReservationEntries,
+    getSunflowers,
+    getSunflowersHistory,
     refundSunflowers,
     releaseSunflowerReservation,
     reserveSunflowers,
@@ -34,16 +37,49 @@ test('topUpSunflowerPackage credits purchased and bonus sunflowers idempotently'
         priceCents: 3999,
         idempotencyKey: 'checkout-session-ledger-topup',
     });
+    const initialPackageEvent = (
+        await getSunflowersHistory(accountId, 0, 100)
+    ).find((event) => event.reason === 'sunflowerPackage:vrtna_kosarica');
+    assert.ok(initialPackageEvent);
+    await deleteEventById(initialPackageEvent.id);
+    assert.equal(await getSunflowers(accountId), 1000);
+
+    const repairedReplay = await topUpSunflowerPackage({
+        accountId,
+        packageCode: 'vrtna_kosarica',
+        sunflowers: 42000,
+        bonusSunflowers: 2000,
+        priceCents: 3999,
+        idempotencyKey: 'checkout-session-ledger-topup',
+    });
+    const repeatedReplay = await topUpSunflowerPackage({
+        accountId,
+        packageCode: 'vrtna_kosarica',
+        sunflowers: 42000,
+        bonusSunflowers: 2000,
+        priceCents: 3999,
+        idempotencyKey: 'checkout-session-ledger-topup',
+    });
 
     assert.equal(first.topUp.status, 'created');
     assert.equal(first.bonus?.status, 'created');
     assert.equal(second.topUp.status, 'existing');
     assert.equal(second.bonus?.status, 'existing');
+    assert.equal(repairedReplay.topUp.status, 'existing');
+    assert.equal(repairedReplay.bonus?.status, 'existing');
+    assert.equal(repeatedReplay.topUp.status, 'existing');
+    assert.equal(repeatedReplay.bonus?.status, 'existing');
     assert.deepEqual(await getSunflowerLedgerBalance(accountId), {
         available: 42000,
         reserved: 0,
         total: 42000,
     });
+    assert.equal(await getSunflowers(accountId), 43000);
+    const packageEvents = (
+        await getSunflowersHistory(accountId, 0, 100)
+    ).filter((event) => event.reason === 'sunflowerPackage:vrtna_kosarica');
+    assert.equal(packageEvents.length, 1);
+    assert.equal(packageEvents[0]?.amount, 42000);
 });
 
 test('reserve, release, and capture move available and reserved balances safely', async () => {


### PR DESCRIPTION
## What changed

- atomically mirror each new sunflower package ledger top-up into the account event balance used by Garden and spending flows
- keep Stripe fulfillment replays idempotent so the customer-visible credit is not duplicated
- label package purchases clearly in Garden and admin sunflower history
- add regression coverage for visible balance credit and replay behavior

## Root cause

Sunflower package fulfillment credited the prepaid ledger used for package eligibility, while the live Garden balance and sunflower spending paths still derive their balance from account sunflower events. A paid package could therefore exist in the ledger without becoming visible or spendable.

## Validation

- `pnpm --filter @gredice/storage test -- sunflowerLedgerRepo.node.spec.ts` — 7 passed
- `pnpm --filter api test:node -- lib/stripe/processCheckoutSession.node.spec.ts` — 301 passed
- `pnpm typecheck --filter @gredice/game` — passed
- targeted Biome checks for all four changed files — passed
- `git diff --check` — passed

Standalone full `tsc` runs for storage and admin remain blocked by unrelated pre-existing errors elsewhere in those workspaces; neither reported an error in the changed files.