### PR TITLE
feat(game): use calendar pickers for dates

### DIFF
--- a/apps/garden/tests/calendarDatePickerTestUtils.ts
+++ b/apps/garden/tests/calendarDatePickerTestUtils.ts
@@ -1,0 +1,42 @@
+import type { Locator, Page } from '@playwright/test';
+
+export function calendarMonthOffset(from: Date, to: Date) {
+    return (
+        (to.getFullYear() - from.getFullYear()) * 12 +
+        to.getMonth() -
+        from.getMonth()
+    );
+}
+
+export function formatTestCalendarDate(date: Date) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+export async function selectCalendarDate({
+    date,
+    monthOffset = 0,
+    page,
+    trigger,
+}: {
+    date: string;
+    monthOffset?: number;
+    page: Page;
+    trigger: Locator;
+}) {
+    await trigger.click();
+
+    const calendar = page.getByRole('group', { name: 'Kalendar' }).last();
+    await calendar.waitFor();
+
+    const navigationButton = calendar.getByRole('button', {
+        name: monthOffset < 0 ? 'Prethodni mjesec' : 'Sljedeći mjesec',
+    });
+    for (let index = 0; index < Math.abs(monthOffset); index += 1) {
+        await navigationButton.click();
+    }
+
+    await calendar.locator(`[data-calendar-date="${date}"]`).click();
+}

--- a/apps/garden/tests/harvest-schedule-step.spec.tsx
+++ b/apps/garden/tests/harvest-schedule-step.spec.tsx
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/experimental-ct-react';
+import { selectCalendarDate } from './calendarDatePickerTestUtils';
 import { HarvestScheduleStepStory } from './HarvestScheduleStepStory';
 
 test('shows the summary and lets a valid flexible date be changed again', async ({
@@ -7,7 +8,9 @@ test('shows the summary and lets a valid flexible date be changed again', async 
 }) => {
     await mount(<HarvestScheduleStepStory />);
 
-    const carrotDate = page.getByLabel('Datum branja za Berba mrkve');
+    const carrotDate = page.getByRole('button', {
+        name: /^Datum branja za Berba mrkve:/u,
+    });
     const editDates = page.getByRole('button', { name: 'Uredi datume' });
 
     await expect(
@@ -20,11 +23,17 @@ test('shows the summary and lets a valid flexible date be changed again', async 
 
     await editDates.click();
 
-    await expect(carrotDate).toHaveValue('2026-07-22');
-    await expect(page.getByLabel('Datum branja za Berba salate')).toHaveCount(
-        0,
-    );
-    await carrotDate.fill('2026-07-23');
+    await expect(carrotDate).toContainText('22. 07. 2026.');
+    await expect(
+        page.getByRole('button', {
+            name: /^Datum branja za Berba salate:/u,
+        }),
+    ).toHaveCount(0);
+    await selectCalendarDate({
+        date: '2026-07-23',
+        page,
+        trigger: carrotDate,
+    });
     await page.getByRole('button', { name: 'Završi uređivanje' }).click();
 
     await expect(carrotDate).toHaveCount(0);
@@ -41,7 +50,9 @@ test('applies a suggested date and keeps it available for another manual edit', 
     await page.setViewportSize({ height: 844, width: 390 });
     await mount(<HarvestScheduleStepStory invalid />);
 
-    const carrotDate = page.getByLabel('Datum branja za Berba mrkve');
+    const carrotDate = page.getByRole('button', {
+        name: /^Datum branja za Berba mrkve:/u,
+    });
     const confirm = page.getByRole('button', { name: 'Potvrdi i plati' });
     const output = page.getByLabel('Odabrani datumi branja');
 
@@ -50,7 +61,7 @@ test('applies a suggested date and keeps it available for another manual edit', 
             exact: false,
         }),
     ).toBeVisible();
-    await expect(carrotDate).toHaveValue('2026-07-20');
+    await expect(carrotDate).toContainText('20. 07. 2026.');
     await expect(
         page.getByText('Predloženi datum branja: 21. srpnja 2026.'),
     ).toBeVisible();
@@ -61,9 +72,11 @@ test('applies a suggested date and keeps it available for another manual edit', 
     await expect(
         page.getByRole('button', { name: 'Uredi datume' }),
     ).toHaveCount(0);
-    await expect(page.getByLabel('Datum branja za Berba salate')).toHaveCount(
-        0,
-    );
+    await expect(
+        page.getByRole('button', {
+            name: /^Datum branja za Berba salate:/u,
+        }),
+    ).toHaveCount(0);
     await expect(output).toContainText(
         '"cartItemId":71,"scheduledDate":"2026-07-24"',
     );
@@ -87,18 +100,13 @@ test('applies a suggested date and keeps it available for another manual edit', 
 
     await page.getByRole('button', { name: 'Uredi datume' }).click();
 
-    await expect(carrotDate).toHaveValue('2026-07-21');
-    await carrotDate.fill('2026-07-20');
+    await expect(carrotDate).toContainText('21. 07. 2026.');
+    await carrotDate.click();
+    const calendar = page.getByRole('group', { name: 'Kalendar' });
     await expect(
-        page.getByRole('button', { name: 'Završi uređivanje' }),
+        calendar.locator('[data-calendar-date="2026-07-20"]'),
     ).toBeDisabled();
-    await page
-        .getByRole('button', {
-            name: 'Primijeni predloženi datum za Berba mrkve',
-        })
-        .click();
-    await expect(carrotDate).toHaveValue('2026-07-21');
-    await carrotDate.fill('2026-07-23');
+    await calendar.locator('[data-calendar-date="2026-07-23"]').click();
     await expect(output).toContainText(
         '"cartItemId":72,"scheduledDate":"2026-07-23"',
     );

--- a/apps/garden/tests/raised-bed-diary.spec.tsx
+++ b/apps/garden/tests/raised-bed-diary.spec.tsx
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import type { Locator, Page } from '@playwright/test';
-import { getMinimumDiaryRescheduleDateInput } from '../../../packages/game/src/hooks/useRescheduleDiaryEntry';
 import { RaisedBedDiaryOverflowStory } from './RaisedBedDiaryStory';
 
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
@@ -258,12 +257,14 @@ test('future planned diary entries expose the in-game reschedule action', async 
 
     await rescheduleButtons.first().click();
 
-    const dateInput = page.getByLabel('Novi datum');
-    await expect(dateInput).toBeVisible();
-    await expect(dateInput).toHaveAttribute(
-        'min',
-        getMinimumDiaryRescheduleDateInput(),
-    );
+    const dateButton = page.getByRole('button', { name: /Novi datum:/ });
+    await expect(dateButton).toBeVisible();
+    await dateButton.click();
+
+    const calendar = page.getByRole('group', { name: 'Kalendar' }).last();
+    await expect(
+        calendar.locator('[data-calendar-date][aria-pressed="true"]'),
+    ).toHaveCount(1);
 });
 
 test('future planned diary entries expose cancel confirmation', async ({

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -1359,7 +1359,6 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
             /opacity-100/,
         );
         await expect(healthContent).toHaveAttribute('aria-hidden', 'true');
-        await expect(healthContent).toHaveCount(0);
         await healthHeader.click();
         await expect
             .poll(() =>
@@ -2423,9 +2422,15 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         await expect(statusChangeDateButton).toBeVisible();
         await statusChangeDateButton.click();
 
+        const statusChangeCalendar = page
+            .getByRole('group', { name: 'Kalendar' })
+            .last();
+        await expect(statusChangeCalendar).toBeVisible();
         await expect(
-            page.getByRole('textbox', { name: 'Datum promjene' }),
-        ).toBeVisible();
+            statusChangeCalendar.locator(
+                '[data-calendar-date][aria-pressed="true"]',
+            ),
+        ).toHaveCount(1);
     });
 
     test('opening the plant history modal lists prior plants newest first', async ({

--- a/apps/garden/tests/raised-bed-plant-picker.spec.tsx
+++ b/apps/garden/tests/raised-bed-plant-picker.spec.tsx
@@ -1,6 +1,11 @@
 import type { FavoriteEntityType, FavoriteItem } from '@gredice/client';
 import { expect, test } from '@playwright/experimental-ct-react';
 import type { Page } from '@playwright/test';
+import {
+    calendarMonthOffset,
+    formatTestCalendarDate,
+    selectCalendarDate,
+} from './calendarDatePickerTestUtils';
 import { PlantPickerTestStory } from './PlantPickerTestStory';
 
 const favoriteTimestamp = '2026-06-01T00:00:00.000Z';
@@ -230,7 +235,7 @@ test('outlet sorts keep planned sowing selected by default', async ({
     await expect(sowingMode.getByText('Outlet sadnica')).toHaveCount(2);
     await expect(sowingMode.locator('svg').first()).toBeVisible();
     await expect(
-        page.getByRole('textbox', { name: 'Datum sijanja' }),
+        page.getByRole('button', { name: /Datum sijanja/u }),
     ).toBeVisible();
     await expect(
         page.getByRole('switch', { name: 'Sijanje u stakleniku' }),
@@ -308,7 +313,7 @@ test('outlet sowing sends the selected outlet offer', async ({
     await sowingMode.getByText('Preostalo 3').click();
     await expect(laterOutletOffer).toBeChecked();
     await expect(
-        page.getByRole('textbox', { name: 'Datum sijanja' }),
+        page.getByRole('button', { name: /Datum sijanja/u }),
     ).toHaveCount(0);
 
     await page.getByRole('button', { name: 'Dodaj u košaru' }).click();
@@ -342,7 +347,7 @@ test('outlet selection param opens the selected outlet offer', async ({
     });
     await expect(laterOutletOffer).toBeChecked();
     await expect(
-        page.getByRole('textbox', { name: 'Datum sijanja' }),
+        page.getByRole('button', { name: /Datum sijanja/u }),
     ).toHaveCount(0);
 
     await page.getByRole('button', { name: 'Dodaj u košaru' }).click();
@@ -418,7 +423,7 @@ test('scheduled greenhouse sowing sends date and sowing location together', asyn
     await page.getByRole('button', { name: /Rajčica/ }).click();
     await page.getByRole('button', { name: /Cherry rajčica/ }).click();
 
-    const dateInput = page.getByRole('textbox', { name: 'Datum sijanja' });
+    const dateInput = page.getByRole('button', { name: /Datum sijanja/u });
     const greenhouseSwitch = page.getByRole('switch', {
         name: 'Sijanje u stakleniku',
     });
@@ -431,7 +436,17 @@ test('scheduled greenhouse sowing sends date and sowing location together', asyn
     expect(switchBox).not.toBeNull();
     expect(Math.abs((dateBox?.y ?? 0) - (switchBox?.y ?? 0))).toBeLessThan(48);
 
-    await dateInput.fill('2026-07-01');
+    const initialDate = new Date();
+    initialDate.setDate(initialDate.getDate() + 1);
+    const selectedDate = new Date();
+    selectedDate.setDate(selectedDate.getDate() + 14);
+    const selectedDateKey = formatTestCalendarDate(selectedDate);
+    await selectCalendarDate({
+        date: selectedDateKey,
+        monthOffset: calendarMonthOffset(initialDate, selectedDate),
+        page,
+        trigger: dateInput,
+    });
     await greenhouseSwitch.click();
     await expect(greenhouseSwitch).toBeChecked();
     await page.getByRole('button', { name: 'Dodaj u košaru' }).click();
@@ -453,7 +468,9 @@ test('scheduled greenhouse sowing sends date and sowing location together', asyn
         return;
     }
     expect(additionalData.sowingLocation).toBe('greenhouse');
-    expect(additionalData.scheduledDate).toBe('2026-07-01T00:00:00.000Z');
+    expect(additionalData.scheduledDate).toBe(
+        `${selectedDateKey}T00:00:00.000Z`,
+    );
 });
 
 test('outlet refetch does not replace a missing selected offer', async ({
@@ -486,7 +503,7 @@ test('outlet refetch does not replace a missing selected offer', async ({
         sowingMode.getByRole('radio', { name: /Preostalo 2/ }),
     ).not.toBeChecked();
     await expect(
-        page.getByRole('textbox', { name: 'Datum sijanja' }),
+        page.getByRole('button', { name: /Datum sijanja/u }),
     ).toHaveCount(0);
     await expect(
         page.getByRole('button', { name: 'Dodaj u košaru' }),
@@ -545,7 +562,7 @@ test('mobile sort step scrolls the sowing date clear of sticky actions', async (
     await page.getByRole('button', { name: /Rajčica/ }).click();
     await page.getByRole('button', { name: /Cherry rajčica/ }).click();
 
-    const dateInput = page.getByRole('textbox', { name: 'Datum sijanja' });
+    const dateInput = page.getByRole('button', { name: /Datum sijanja/u });
     await dateInput.evaluate((element) => {
         let scrollParent = element.parentElement;
         while (scrollParent) {

--- a/apps/garden/tests/sandbox-environment-hud.spec.tsx
+++ b/apps/garden/tests/sandbox-environment-hud.spec.tsx
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/experimental-ct-react';
+import { selectCalendarDate } from './calendarDatePickerTestUtils';
 import {
     SandboxEnvironmentHudStory,
     SandboxEnvironmentResetStory,
@@ -55,8 +56,12 @@ test('sandbox environment HUD can scrub time and change date', async ({
         .poll(() => page.getByTestId('sandbox-timeofday-value').textContent())
         .not.toBe(initialTimeOfDay);
 
-    await page.getByTitle('Promijeni datum').click();
-    await page.getByRole('textbox', { name: 'Datum' }).fill('2026-12-21');
+    await selectCalendarDate({
+        date: '2026-12-21',
+        monthOffset: 6,
+        page,
+        trigger: page.getByTitle('Promijeni datum'),
+    });
     await expect(page.getByTestId('sandbox-date-value')).toHaveText(
         '2026-12-21',
     );

--- a/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
+++ b/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
@@ -1,6 +1,10 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import type { Locator } from '@playwright/test';
 import {
+    calendarMonthOffset,
+    selectCalendarDate,
+} from './calendarDatePickerTestUtils';
+import {
     ShoppingCartHudItemsPresenceStory,
     ShoppingCartItemsPresenceStory,
     ShoppingCartOptimisticToggleStory,
@@ -215,11 +219,16 @@ test('shopping cart date chip updates scheduled date metadata', async ({
 
     await mount(<ShoppingCartOptimisticToggleStory />);
 
-    const tomorrowLabel = formatCartDate(addDays(new Date(), 1));
-    await page.getByTitle(`Promijeni datum: ${tomorrowLabel}`).click();
-
-    const selectedDate = formatDateInput(addDays(new Date(), 7));
-    await page.getByLabel('Datum').fill(selectedDate);
+    const tomorrow = addDays(new Date(), 1);
+    const selected = addDays(new Date(), 7);
+    const tomorrowLabel = formatCartDate(tomorrow);
+    const selectedDate = formatDateInput(selected);
+    await selectCalendarDate({
+        date: selectedDate,
+        monthOffset: calendarMonthOffset(tomorrow, selected),
+        page,
+        trigger: page.getByTitle(`Promijeni datum: ${tomorrowLabel}`),
+    });
 
     const payload = await postedPayload;
     const additionalData =

--- a/apps/storybook/stories/packages/ui/CalendarDatePicker.stories.tsx
+++ b/apps/storybook/stories/packages/ui/CalendarDatePicker.stories.tsx
@@ -1,0 +1,70 @@
+import { CalendarDatePicker } from '@gredice/ui/CalendarDatePicker';
+import { Stack } from '@gredice/ui/Stack';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { type ComponentProps, useState } from 'react';
+
+function ControlledCalendarDatePicker(
+    args: ComponentProps<typeof CalendarDatePicker>,
+) {
+    const [value, setValue] = useState(args.value);
+
+    return (
+        <CalendarDatePicker {...args} onValueChange={setValue} value={value} />
+    );
+}
+
+const meta = {
+    title: 'packages/ui/Inputs/CalendarDatePicker',
+    component: CalendarDatePicker,
+    tags: ['autodocs'],
+    args: {
+        label: 'Datum sijanja',
+        onValueChange: () => undefined,
+        value: '2026-08-02',
+    },
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Localized calendar picker for date-only values, with keyboard navigation and optional minimum and maximum dates.',
+            },
+        },
+        layout: 'centered',
+    },
+    render: ControlledCalendarDatePicker,
+} satisfies Meta<typeof CalendarDatePicker>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const AllowedRange: Story = {
+    args: {
+        helperText: 'Odaberi datum unutar dostupnog termina.',
+        max: '2026-10-31',
+        min: '2026-08-02',
+    },
+};
+
+export const States: Story = {
+    render: () => (
+        <Stack spacing={4} className="w-72">
+            <ControlledCalendarDatePicker
+                aria-invalid
+                helperText="Odabrani datum više nije dostupan."
+                label="Datum branja"
+                min="2026-08-03"
+                onValueChange={() => undefined}
+                value="2026-08-02"
+            />
+            <ControlledCalendarDatePicker
+                disabled
+                label="Zaključani datum"
+                onValueChange={() => undefined}
+                value="2026-08-02"
+            />
+        </Stack>
+    ),
+};

--- a/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
@@ -16,6 +16,7 @@ import { BlockImage } from '@gredice/ui/BlockImage';
 import { BlurText } from '@gredice/ui/BlurText';
 import { Breadcrumbs } from '@gredice/ui/Breadcrumbs';
 import { Button } from '@gredice/ui/Button';
+import { CalendarDatePicker } from '@gredice/ui/CalendarDatePicker';
 import {
     Card,
     CardActions,
@@ -1342,6 +1343,7 @@ function PublicContentShowcase() {
 
 function GardenWorkspaceShowcase() {
     const [collapsed, setCollapsed] = useState(false);
+    const [scheduledDate, setScheduledDate] = useState('2026-06-20');
 
     return (
         <Container className="py-8" maxWidth="xl">
@@ -1516,6 +1518,15 @@ function GardenWorkspaceShowcase() {
                                     </Row>
                                 </CardContent>
                             </Card>
+
+                            <CalendarDatePicker
+                                fullWidth
+                                helperText="Kalendar zadržava datum kao lokalnu vrijednost bez vremenskog pomaka."
+                                label="Datum sljedeće radnje"
+                                min="2026-06-19"
+                                onValueChange={setScheduledDate}
+                                value={scheduledDate}
+                            />
 
                             <EventCalendar
                                 entries={gardenCalendarEntries}

--- a/packages/game/src/hud/SandboxEnvironmentHud.tsx
+++ b/packages/game/src/hud/SandboxEnvironmentHud.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { Button } from '@gredice/ui/Button';
+import { CalendarDatePicker } from '@gredice/ui/CalendarDatePicker';
 import { Divider } from '@gredice/ui/Divider';
-import { Input } from '@gredice/ui/Input';
 import {
     Calendar,
     Cloud,
@@ -651,11 +651,10 @@ export function SandboxEnvironmentHud() {
                                     )}
                                     {formatTime(currentTime)}
                                 </Typography>
-                                <Popper
+                                <CalendarDatePicker
                                     align="end"
-                                    className="w-56 p-3"
+                                    onValueChange={updateDate}
                                     side="bottom"
-                                    sideOffset={8}
                                     trigger={
                                         <Button
                                             aria-label={`Promijeni datum ${formatShortDate(currentTime)}`}
@@ -670,21 +669,8 @@ export function SandboxEnvironmentHud() {
                                             {formatShortDate(currentTime)}
                                         </Button>
                                     }
-                                >
-                                    <Input
-                                        fullWidth
-                                        label="Datum"
-                                        type="date"
-                                        value={formatDateInputValue(
-                                            currentTime,
-                                        )}
-                                        onChange={(event) =>
-                                            updateDate(
-                                                event.currentTarget.value,
-                                            )
-                                        }
-                                    />
-                                </Popper>
+                                    value={formatDateInputValue(currentTime)}
+                                />
                             </Row>
                         </Stack>
                     </Stack>

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
@@ -1,11 +1,10 @@
 import { BackpackIcon } from '@gredice/ui/BackpackIcon';
+import { CalendarDatePicker } from '@gredice/ui/CalendarDatePicker';
 import { Chip } from '@gredice/ui/Chip';
 import { IconButton } from '@gredice/ui/IconButton';
-import { Input } from '@gredice/ui/Input';
 import { Close, Delete, Navigate, Sprout, Timer } from '@gredice/ui/icons';
 import { ModalConfirm } from '@gredice/ui/ModalConfirm';
 import { OperationImage } from '@gredice/ui/OperationImage';
-import { Popper } from '@gredice/ui/Popper';
 import { PlantOrSortImage } from '@gredice/ui/plants';
 import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
 import { Row } from '@gredice/ui/Row';
@@ -439,7 +438,7 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
 
     function renderScheduledDateControl() {
         return canChangeScheduledDate ? (
-            <Popper
+            <CalendarDatePicker
                 open={datePickerOpen}
                 onOpenChange={(open) => {
                     setDatePickerOpen(open);
@@ -447,10 +446,15 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                         setDatePickerError(null);
                     }
                 }}
-                side="bottom"
                 align="start"
-                sideOffset={8}
-                className="w-72 p-3"
+                closeOnSelect={false}
+                disabled={changeScheduledDateShoppingCartItem.isPending}
+                min={formatDateInput(getTomorrowDate())}
+                name={`cartItemScheduledDate-${item.id}`}
+                onValueChange={(nextDate) => {
+                    void handleScheduledDateChange(nextDate);
+                }}
+                side="bottom"
                 trigger={
                     <Chip
                         startDecorator={<Timer className="size-4" />}
@@ -464,21 +468,9 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                         {scheduledDateLabel}
                     </Chip>
                 }
+                value={formatDateInput(scheduledDate)}
             >
                 <Stack spacing={2}>
-                    <Input
-                        type="date"
-                        label="Datum"
-                        name={`cartItemScheduledDate-${item.id}`}
-                        className="w-full bg-card"
-                        value={formatDateInput(scheduledDate)}
-                        min={formatDateInput(getTomorrowDate())}
-                        disabled={changeScheduledDateShoppingCartItem.isPending}
-                        onChange={(event) => {
-                            void handleScheduledDateChange(event.target.value);
-                        }}
-                        required
-                    />
                     {datePickerError ? (
                         <Typography level="body3" className="text-red-600">
                             {datePickerError}
@@ -495,7 +487,7 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                         />
                     ) : null}
                 </Stack>
-            </Popper>
+            </CalendarDatePicker>
         ) : (
             <Chip
                 startDecorator={<Timer className="size-4" />}

--- a/packages/game/src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx
@@ -1,6 +1,6 @@
 import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
-import { Input } from '@gredice/ui/Input';
+import { CalendarDatePicker } from '@gredice/ui/CalendarDatePicker';
 import { Calendar } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -37,6 +37,7 @@ export function RaisedBedDiaryRescheduleAction({
         ? formatDiaryRescheduleDateInput(new Date(target.scheduledDate))
         : minimumDate;
     const currentValue = defaultDate >= minimumDate ? defaultDate : minimumDate;
+    const [scheduledDate, setScheduledDate] = useState(currentValue);
     const actionLabel =
         triggerLabel ?? (hasScheduledDate ? 'Prerasporedi' : 'Zakaži');
     const modalActionLabel = hasScheduledDate ? 'Prerasporedi' : 'Zakaži';
@@ -84,9 +85,7 @@ export function RaisedBedDiaryRescheduleAction({
         event.preventDefault();
         setErrorMessage(null);
 
-        const formData = new FormData(event.currentTarget);
-        const scheduledDate = formData.get('scheduledDate');
-        if (typeof scheduledDate !== 'string' || !scheduledDate) {
+        if (!scheduledDate) {
             setErrorMessage('Odaberi novi datum.');
             return;
         }
@@ -111,6 +110,9 @@ export function RaisedBedDiaryRescheduleAction({
             title={`${modalActionLabel} ${entryName}`}
             open={open}
             onOpenChange={(nextOpen) => {
+                if (nextOpen) {
+                    setScheduledDate(currentValue);
+                }
                 setOpen(nextOpen);
                 if (!nextOpen) {
                     setErrorMessage(null);
@@ -136,15 +138,15 @@ export function RaisedBedDiaryRescheduleAction({
                         </Alert>
                     ) : null}
 
-                    <Input
-                        type="date"
-                        label="Novi datum"
-                        name="scheduledDate"
-                        defaultValue={currentValue}
-                        min={minimumDate}
+                    <CalendarDatePicker
                         disabled={mutation.isPending}
                         fullWidth
+                        label="Novi datum"
+                        min={minimumDate}
+                        name="scheduledDate"
+                        onValueChange={setScheduledDate}
                         required
+                        value={scheduledDate}
                     />
 
                     <Row spacing={2} className="justify-end">

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldStatusChange.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldStatusChange.tsx
@@ -2,7 +2,7 @@ import {
     plantFieldStatusLabel,
     userAllowedPlantStatusTransitions,
 } from '@gredice/js/plants';
-import { Input } from '@gredice/ui/Input';
+import { CalendarDatePicker } from '@gredice/ui/CalendarDatePicker';
 import { Calendar, Navigate } from '@gredice/ui/icons';
 import { List } from '@gredice/ui/List';
 import { ListItem } from '@gredice/ui/ListItem';
@@ -116,14 +116,15 @@ export function RaisedBedFieldStatusChange({
                             : 'Stanje biljke'}
                     </Typography>
                     {hasAllowedNextStatuses && (
-                        <Popper
+                        <CalendarDatePicker
                             open={datePickerOpen}
                             onOpenChange={setDatePickerOpen}
                             side="bottom"
                             align="end"
-                            sideOffset={8}
-                            container={datePickerContainer}
-                            className="w-72 p-3"
+                            max={formatLocalDate(new Date())}
+                            name="statusChangeDate"
+                            onValueChange={setSelectedDate}
+                            popoverContainer={datePickerContainer}
                             trigger={
                                 <button
                                     type="button"
@@ -138,21 +139,8 @@ export function RaisedBedFieldStatusChange({
                                     {formatStatusChangeDate(selectedDate)}
                                 </button>
                             }
-                        >
-                            <Input
-                                type="date"
-                                label="Datum promjene"
-                                name="statusChangeDate"
-                                className="w-full bg-card"
-                                value={selectedDate}
-                                onChange={(e) => {
-                                    setSelectedDate(e.target.value);
-                                    setDatePickerOpen(false);
-                                }}
-                                max={formatLocalDate(new Date())}
-                                required
-                            />
-                        </Popper>
+                            value={selectedDate}
+                        />
                     )}
                 </Row>
                 {hasAllowedNextStatuses ? (

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -1,5 +1,6 @@
 import type { PlantData, PlantSortData } from '@gredice/client';
 import { Button } from '@gredice/ui/Button';
+import { CalendarDatePicker } from '@gredice/ui/CalendarDatePicker';
 import { IconButton } from '@gredice/ui/IconButton';
 import { Input } from '@gredice/ui/Input';
 import {
@@ -263,7 +264,6 @@ export function PlantPicker({
     const searchInputId = useId();
     const sowingModeName = useId();
     const plantDateInputId = useId();
-    const plantDateLabelId = useId();
     const greenhouseSowingSwitchId = useId();
     const greenhouseSowingLabelId = useId();
     const shouldRestoreSearchFocusRef = useRef(false);
@@ -998,32 +998,26 @@ export function PlantPicker({
                                     ) : selectedOutletOfferUnavailable ? null : (
                                         <div className="grid grid-cols-[minmax(0,1fr)_minmax(6.75rem,auto)] items-end gap-2 rounded-lg border border-green-200 bg-green-50/70 p-3 dark:border-green-900 dark:bg-green-950/30">
                                             <div className="min-w-0 space-y-1.5">
-                                                <label
-                                                    className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground"
-                                                    htmlFor={plantDateInputId}
-                                                    id={plantDateLabelId}
-                                                >
-                                                    <Calendar className="size-4 shrink-0 text-green-700 dark:text-green-300" />
-                                                    <span className="min-w-0">
-                                                        Datum sijanja
-                                                    </span>
-                                                </label>
-                                                <Input
-                                                    aria-labelledby={
-                                                        plantDateLabelId
-                                                    }
+                                                <CalendarDatePicker
                                                     className="w-full border-green-200 bg-card dark:border-green-900"
                                                     fullWidth
                                                     id={plantDateInputId}
+                                                    label={
+                                                        <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                                            <Calendar className="size-4 shrink-0 text-green-700 dark:text-green-300" />
+                                                            <span className="min-w-0">
+                                                                Datum sijanja
+                                                            </span>
+                                                        </span>
+                                                    }
                                                     max={max}
                                                     min={min}
                                                     name="plantDate"
-                                                    onChange={(e) =>
+                                                    onValueChange={(date) =>
                                                         handlePlantDateChange(
-                                                            e.target.value,
+                                                            date,
                                                         )
                                                     }
-                                                    type="date"
                                                     value={plantDate}
                                                 />
                                             </div>

--- a/packages/game/src/shared-ui/delivery/HarvestScheduleStep.tsx
+++ b/packages/game/src/shared-ui/delivery/HarvestScheduleStep.tsx
@@ -2,8 +2,8 @@
 
 import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
+import { CalendarDatePicker } from '@gredice/ui/CalendarDatePicker';
 import { Chip } from '@gredice/ui/Chip';
-import { Input } from '@gredice/ui/Input';
 import { Check, Edit, Info, Navigate } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -436,7 +436,7 @@ export function HarvestScheduleStep({
                                                         </Button>
                                                     </Row>
                                                 ) : null}
-                                                <Input
+                                                <CalendarDatePicker
                                                     aria-describedby={helpId}
                                                     aria-invalid={
                                                         !selectedDateValid
@@ -449,12 +449,11 @@ export function HarvestScheduleStep({
                                                     min={
                                                         allowedFrom ?? undefined
                                                     }
-                                                    type="date"
                                                     value={selectedDate}
-                                                    onChange={(event) =>
+                                                    onValueChange={(date) =>
                                                         handleDateChange(
                                                             item,
-                                                            event.target.value,
+                                                            date,
                                                         )
                                                     }
                                                 />

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,7 +12,7 @@
         "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
-        "test": "node --import tsx --test src/cms/CmsOgImage.unit.ts",
+        "test": "node --import tsx --test src/cms/CmsOgImage.unit.ts src/CalendarDatePicker/calendarDateUtils.unit.ts",
         "typecheck": "tsc --noEmit --pretty false"
     },
     "devDependencies": {

--- a/packages/ui/src/CalendarDatePicker/Calendar.tsx
+++ b/packages/ui/src/CalendarDatePicker/Calendar.tsx
@@ -1,0 +1,298 @@
+'use client';
+
+import type { HTMLAttributes, KeyboardEvent } from 'react';
+import { useRef, useState } from 'react';
+import { IconButton } from '../IconButton';
+import { ArrowLeft, ArrowRight } from '../icons';
+import { cx } from '../utils';
+import {
+    addCalendarDays,
+    addCalendarMonths,
+    calendarDateIsInRange,
+    formatCalendarDateKey,
+    getCalendarMonthCells,
+    getInitialCalendarMonth,
+    parseCalendarDateKey,
+    startOfCalendarMonth,
+} from './calendarDateUtils';
+
+const weekDays = ['Pon', 'Uto', 'Sri', 'Čet', 'Pet', 'Sub', 'Ned'];
+const monthFormatter = new Intl.DateTimeFormat('hr-HR', {
+    month: 'long',
+    year: 'numeric',
+});
+const dayFormatter = new Intl.DateTimeFormat('hr-HR', {
+    dateStyle: 'full',
+});
+
+export type CalendarProps = Omit<
+    HTMLAttributes<HTMLFieldSetElement>,
+    'onChange'
+> & {
+    disabled?: boolean;
+    max?: string;
+    min?: string;
+    onValueChange: (value: string) => void;
+    referenceDate?: Date;
+    value: string;
+};
+
+export function Calendar({
+    className,
+    disabled = false,
+    max,
+    min,
+    onValueChange,
+    referenceDate,
+    value,
+    ...rest
+}: CalendarProps) {
+    const selectedDate = parseCalendarDateKey(value);
+    const minimumDate = parseCalendarDateKey(min);
+    const maximumDate = parseCalendarDateKey(max);
+    const today = referenceDate ?? new Date();
+    const [visibleMonth, setVisibleMonth] = useState(() =>
+        getInitialCalendarMonth({
+            maximumDate,
+            minimumDate,
+            referenceDate: today,
+            selectedDate,
+        }),
+    );
+    const pendingFocusDate = useRef<string | null>(null);
+    const dayButtons = useRef(new Map<string, HTMLButtonElement>());
+    const visibleMonthKey = `${visibleMonth.getFullYear()}-${visibleMonth.getMonth()}`;
+    const selectedMonthKey = selectedDate
+        ? `${selectedDate.getFullYear()}-${selectedDate.getMonth()}`
+        : null;
+    const selectedDateKey = selectedDate
+        ? formatCalendarDateKey(selectedDate)
+        : null;
+
+    const cells = getCalendarMonthCells(visibleMonth);
+    const previousMonth = addCalendarMonths(visibleMonth, -1);
+    const nextMonth = addCalendarMonths(visibleMonth, 1);
+    const previousMonthLastDay = new Date(
+        visibleMonth.getFullYear(),
+        visibleMonth.getMonth(),
+        0,
+        12,
+    );
+    const nextMonthFirstDay = nextMonth;
+    const canGoBack =
+        !disabled &&
+        (!minimumDate ||
+            calendarDateIsInRange(
+                previousMonthLastDay,
+                minimumDate,
+                maximumDate,
+            ));
+    const canGoForward =
+        !disabled &&
+        (!maximumDate ||
+            calendarDateIsInRange(nextMonthFirstDay, minimumDate, maximumDate));
+    const todayKey = formatCalendarDateKey(today);
+    const firstEnabledDate = cells.find(
+        (date) => date && calendarDateIsInRange(date, minimumDate, maximumDate),
+    );
+    const focusableDateKey =
+        selectedDate &&
+        selectedMonthKey === visibleMonthKey &&
+        calendarDateIsInRange(selectedDate, minimumDate, maximumDate)
+            ? selectedDateKey
+            : cells.some(
+                    (date) => date && formatCalendarDateKey(date) === todayKey,
+                ) && calendarDateIsInRange(today, minimumDate, maximumDate)
+              ? todayKey
+              : firstEnabledDate
+                ? formatCalendarDateKey(firstEnabledDate)
+                : null;
+
+    function moveDayFocus(event: KeyboardEvent<HTMLButtonElement>, date: Date) {
+        const dayOffset =
+            event.key === 'ArrowLeft'
+                ? -1
+                : event.key === 'ArrowRight'
+                  ? 1
+                  : event.key === 'ArrowUp'
+                    ? -7
+                    : event.key === 'ArrowDown'
+                      ? 7
+                      : null;
+
+        if (dayOffset === null) {
+            return;
+        }
+
+        event.preventDefault();
+        const nextDate = addCalendarDays(date, dayOffset);
+        if (
+            disabled ||
+            !calendarDateIsInRange(nextDate, minimumDate, maximumDate)
+        ) {
+            return;
+        }
+
+        const nextDateKey = formatCalendarDateKey(nextDate);
+        const nextButton = dayButtons.current.get(nextDateKey);
+        if (nextButton) {
+            nextButton.focus();
+            return;
+        }
+
+        pendingFocusDate.current = nextDateKey;
+        setVisibleMonth(startOfCalendarMonth(nextDate));
+    }
+
+    return (
+        <fieldset
+            aria-label="Kalendar"
+            className={cx('min-w-0 space-y-3 border-0 p-0', className)}
+            {...rest}
+        >
+            <div className="flex items-center justify-between gap-2">
+                <IconButton
+                    aria-label="Prethodni mjesec"
+                    disabled={!canGoBack}
+                    size="xs"
+                    title="Prethodni mjesec"
+                    type="button"
+                    variant="plain"
+                    onClick={() => setVisibleMonth(previousMonth)}
+                >
+                    <ArrowLeft aria-hidden className="size-4" />
+                </IconButton>
+                <div
+                    aria-live="polite"
+                    className="min-w-0 truncate text-sm font-semibold capitalize"
+                >
+                    {monthFormatter.format(visibleMonth)}
+                </div>
+                <IconButton
+                    aria-label="Sljedeći mjesec"
+                    disabled={!canGoForward}
+                    size="xs"
+                    title="Sljedeći mjesec"
+                    type="button"
+                    variant="plain"
+                    onClick={() => setVisibleMonth(nextMonth)}
+                >
+                    <ArrowRight aria-hidden className="size-4" />
+                </IconButton>
+            </div>
+            <table
+                aria-label="Dani u mjesecu"
+                className="w-full table-fixed border-separate border-spacing-1 text-center"
+            >
+                <thead>
+                    <tr>
+                        {weekDays.map((weekDay) => (
+                            <th
+                                className="h-7 text-[0.65rem] font-semibold uppercase text-muted-foreground"
+                                key={weekDay}
+                                scope="col"
+                            >
+                                {weekDay}
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {Array.from({ length: 6 }, (_, weekIndex) => (
+                        <tr key={`${visibleMonthKey}-${weekIndex.toString()}`}>
+                            {cells
+                                .slice(weekIndex * 7, weekIndex * 7 + 7)
+                                .map((date, dayIndex) => {
+                                    if (!date) {
+                                        return (
+                                            <td
+                                                aria-hidden
+                                                className="h-8 p-0"
+                                                key={`${visibleMonthKey}-${weekIndex.toString()}-${dayIndex.toString()}`}
+                                            />
+                                        );
+                                    }
+
+                                    const dateKey = formatCalendarDateKey(date);
+                                    const isSelected =
+                                        dateKey === selectedDateKey;
+                                    const isToday = dateKey === todayKey;
+                                    const isDisabled =
+                                        disabled ||
+                                        !calendarDateIsInRange(
+                                            date,
+                                            minimumDate,
+                                            maximumDate,
+                                        );
+
+                                    return (
+                                        <td className="h-8 p-0" key={dateKey}>
+                                            <button
+                                                aria-current={
+                                                    isToday ? 'date' : undefined
+                                                }
+                                                aria-label={dayFormatter.format(
+                                                    date,
+                                                )}
+                                                aria-pressed={isSelected}
+                                                className={cx(
+                                                    'mx-auto grid size-8 place-items-center rounded-full text-xs tabular-nums transition-colors',
+                                                    'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                                                    isSelected &&
+                                                        'bg-primary font-semibold text-primary-foreground ring-2 ring-primary ring-offset-2 ring-offset-popover',
+                                                    !isSelected &&
+                                                        !isDisabled &&
+                                                        'text-foreground hover:bg-muted',
+                                                    !isSelected &&
+                                                        isToday &&
+                                                        'bg-muted font-semibold',
+                                                    isDisabled &&
+                                                        'cursor-not-allowed text-muted-foreground/40',
+                                                )}
+                                                data-calendar-date={dateKey}
+                                                disabled={isDisabled}
+                                                ref={(node) => {
+                                                    if (node) {
+                                                        dayButtons.current.set(
+                                                            dateKey,
+                                                            node,
+                                                        );
+                                                        if (
+                                                            pendingFocusDate.current ===
+                                                            dateKey
+                                                        ) {
+                                                            pendingFocusDate.current =
+                                                                null;
+                                                            node.focus();
+                                                        }
+                                                    } else {
+                                                        dayButtons.current.delete(
+                                                            dateKey,
+                                                        );
+                                                    }
+                                                }}
+                                                tabIndex={
+                                                    dateKey === focusableDateKey
+                                                        ? 0
+                                                        : -1
+                                                }
+                                                type="button"
+                                                onClick={() =>
+                                                    onValueChange(dateKey)
+                                                }
+                                                onKeyDown={(event) =>
+                                                    moveDayFocus(event, date)
+                                                }
+                                            >
+                                                {date.getDate()}
+                                            </button>
+                                        </td>
+                                    );
+                                })}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </fieldset>
+    );
+}

--- a/packages/ui/src/CalendarDatePicker/CalendarDatePicker.tsx
+++ b/packages/ui/src/CalendarDatePicker/CalendarDatePicker.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import {
+    type ButtonHTMLAttributes,
+    type ReactElement,
+    type ReactNode,
+    useId,
+    useState,
+} from 'react';
+import { Calendar as CalendarIcon } from '../icons';
+import { Popper, type PopperProps } from '../Popper';
+import { cx } from '../utils';
+import { Calendar } from './Calendar';
+import { parseCalendarDateKey } from './calendarDateUtils';
+
+const displayDateFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+});
+
+const variantClassNames = {
+    outlined: 'border border-input bg-background',
+    soft: 'border border-transparent bg-muted',
+    plain: 'border border-transparent bg-transparent',
+};
+
+export type CalendarDatePickerProps = Omit<
+    ButtonHTMLAttributes<HTMLButtonElement>,
+    'children' | 'defaultValue' | 'onChange' | 'value'
+> & {
+    align?: PopperProps['align'];
+    calendarClassName?: string;
+    children?: ReactNode;
+    closeOnSelect?: boolean;
+    fullWidth?: boolean;
+    helperText?: ReactNode;
+    label?: ReactNode;
+    max?: string;
+    min?: string;
+    name?: string;
+    onOpenChange?: (open: boolean) => void;
+    onValueChange: (value: string) => void;
+    open?: boolean;
+    placeholder?: ReactNode;
+    popoverClassName?: string;
+    popoverContainer?: HTMLElement;
+    required?: boolean;
+    side?: PopperProps['side'];
+    trigger?: ReactElement;
+    value: string;
+    variant?: keyof typeof variantClassNames;
+};
+
+export function CalendarDatePicker({
+    align,
+    calendarClassName,
+    children,
+    className,
+    closeOnSelect = true,
+    disabled,
+    fullWidth,
+    helperText,
+    id,
+    label,
+    max,
+    min,
+    name,
+    onOpenChange,
+    onValueChange,
+    open,
+    placeholder = 'Odaberi datum',
+    popoverClassName,
+    popoverContainer,
+    required,
+    side,
+    trigger,
+    value,
+    variant = 'outlined',
+    ...buttonProps
+}: CalendarDatePickerProps) {
+    const generatedId = useId();
+    const inputId = id ?? name ?? generatedId;
+    const [internalOpen, setInternalOpen] = useState(false);
+    const resolvedOpen = open ?? internalOpen;
+    const selectedDate = parseCalendarDateKey(value);
+    const valueLabel = selectedDate
+        ? displayDateFormatter.format(selectedDate)
+        : placeholder;
+    const helperTextId = helperText ? `${inputId}-helper` : undefined;
+    const describedBy = [buttonProps['aria-describedby'], helperTextId]
+        .filter(Boolean)
+        .join(' ');
+    const accessibleLabel =
+        buttonProps['aria-label'] ??
+        (typeof label === 'string' ? `${label}: ${valueLabel}` : undefined);
+
+    function handleOpenChange(nextOpen: boolean) {
+        if (open === undefined) {
+            setInternalOpen(nextOpen);
+        }
+        onOpenChange?.(nextOpen);
+    }
+
+    const defaultTrigger = (
+        <button
+            {...buttonProps}
+            aria-describedby={describedBy || undefined}
+            aria-label={accessibleLabel}
+            className={cx(
+                'flex h-10 items-center justify-between gap-2 rounded-md px-3 py-2 text-left text-sm ring-offset-background transition-colors',
+                'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                'disabled:cursor-not-allowed disabled:opacity-50',
+                variantClassNames[variant],
+                fullWidth ? 'w-full' : 'w-fit',
+                !selectedDate && 'text-muted-foreground',
+                className,
+            )}
+            disabled={disabled}
+            id={inputId}
+            type="button"
+        >
+            <span className="min-w-0 truncate">{valueLabel}</span>
+            <CalendarIcon
+                aria-hidden
+                className="size-4 shrink-0 text-muted-foreground"
+            />
+        </button>
+    );
+
+    return (
+        <div className={cx('space-y-1', fullWidth && 'w-full')}>
+            {label ? (
+                <label
+                    className="block text-sm font-medium text-foreground"
+                    htmlFor={inputId}
+                >
+                    {label}
+                </label>
+            ) : null}
+            {name ? (
+                <input
+                    disabled={disabled}
+                    name={name}
+                    required={required}
+                    type="hidden"
+                    value={value}
+                />
+            ) : null}
+            <Popper
+                align={align}
+                className={cx('w-72 p-3', popoverClassName)}
+                container={popoverContainer}
+                onOpenChange={handleOpenChange}
+                open={resolvedOpen}
+                side={side}
+                sideOffset={8}
+                trigger={trigger ?? defaultTrigger}
+            >
+                <Calendar
+                    className={calendarClassName}
+                    disabled={disabled}
+                    max={max}
+                    min={min}
+                    onValueChange={(nextValue) => {
+                        onValueChange(nextValue);
+                        if (closeOnSelect) {
+                            handleOpenChange(false);
+                        }
+                    }}
+                    value={value}
+                />
+                {children ? <div className="mt-3">{children}</div> : null}
+            </Popper>
+            {helperText ? (
+                <div
+                    className="text-xs text-muted-foreground"
+                    id={helperTextId}
+                >
+                    {helperText}
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/packages/ui/src/CalendarDatePicker/calendarDateUtils.ts
+++ b/packages/ui/src/CalendarDatePicker/calendarDateUtils.ts
@@ -1,0 +1,124 @@
+const calendarDateKeyPattern = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+export function parseCalendarDateKey(value: string | null | undefined) {
+    if (!value) {
+        return null;
+    }
+
+    const match = calendarDateKeyPattern.exec(value);
+    if (!match) {
+        return null;
+    }
+
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const date = new Date(year, month - 1, day, 12);
+
+    if (
+        date.getFullYear() !== year ||
+        date.getMonth() !== month - 1 ||
+        date.getDate() !== day
+    ) {
+        return null;
+    }
+
+    return date;
+}
+
+export function formatCalendarDateKey(date: Date) {
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${date.getFullYear()}-${month}-${day}`;
+}
+
+export function startOfCalendarMonth(date: Date) {
+    return new Date(date.getFullYear(), date.getMonth(), 1, 12);
+}
+
+export function addCalendarMonths(date: Date, months: number) {
+    return new Date(date.getFullYear(), date.getMonth() + months, 1, 12);
+}
+
+export function addCalendarDays(date: Date, days: number) {
+    return new Date(
+        date.getFullYear(),
+        date.getMonth(),
+        date.getDate() + days,
+        12,
+    );
+}
+
+export function calendarDateIsInRange(
+    date: Date,
+    minimumDate: Date | null,
+    maximumDate: Date | null,
+) {
+    const dateKey = formatCalendarDateKey(date);
+    const minimumDateKey = minimumDate
+        ? formatCalendarDateKey(minimumDate)
+        : null;
+    const maximumDateKey = maximumDate
+        ? formatCalendarDateKey(maximumDate)
+        : null;
+
+    return (
+        (!minimumDateKey || dateKey >= minimumDateKey) &&
+        (!maximumDateKey || dateKey <= maximumDateKey)
+    );
+}
+
+export function getCalendarMonthCells(month: Date) {
+    const firstDay = startOfCalendarMonth(month);
+    const mondayOffset = (firstDay.getDay() + 6) % 7;
+    const daysInMonth = new Date(
+        firstDay.getFullYear(),
+        firstDay.getMonth() + 1,
+        0,
+        12,
+    ).getDate();
+
+    return Array.from({ length: 42 }, (_, index) => {
+        const dayOfMonth = index - mondayOffset + 1;
+        if (dayOfMonth < 1 || dayOfMonth > daysInMonth) {
+            return null;
+        }
+
+        return new Date(
+            firstDay.getFullYear(),
+            firstDay.getMonth(),
+            dayOfMonth,
+            12,
+        );
+    });
+}
+
+export function getInitialCalendarMonth({
+    maximumDate,
+    minimumDate,
+    referenceDate,
+    selectedDate,
+}: {
+    maximumDate: Date | null;
+    minimumDate: Date | null;
+    referenceDate: Date;
+    selectedDate: Date | null;
+}) {
+    let candidate = selectedDate ?? referenceDate;
+
+    if (
+        minimumDate &&
+        formatCalendarDateKey(candidate) < formatCalendarDateKey(minimumDate)
+    ) {
+        candidate = minimumDate;
+    }
+
+    if (
+        maximumDate &&
+        formatCalendarDateKey(candidate) > formatCalendarDateKey(maximumDate)
+    ) {
+        candidate = maximumDate;
+    }
+
+    return startOfCalendarMonth(candidate);
+}

--- a/packages/ui/src/CalendarDatePicker/calendarDateUtils.unit.ts
+++ b/packages/ui/src/CalendarDatePicker/calendarDateUtils.unit.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+    calendarDateIsInRange,
+    formatCalendarDateKey,
+    getCalendarMonthCells,
+    getInitialCalendarMonth,
+    parseCalendarDateKey,
+} from './calendarDateUtils';
+
+describe('calendar date utilities', () => {
+    test('parses and formats local calendar date keys without timezone shifts', () => {
+        const date = parseCalendarDateKey('2026-08-02');
+
+        assert.ok(date);
+        assert.equal(formatCalendarDateKey(date), '2026-08-02');
+        assert.equal(parseCalendarDateKey('2026-02-30'), null);
+        assert.equal(parseCalendarDateKey('02. 08. 2026.'), null);
+    });
+
+    test('builds a stable Monday-first six-week grid', () => {
+        const cells = getCalendarMonthCells(new Date(2026, 7, 1, 12));
+
+        assert.equal(cells.length, 42);
+        assert.equal(cells[0], null);
+        assert.equal(cells[5]?.getDate(), 1);
+        assert.equal(cells[35]?.getDate(), 31);
+        assert.equal(cells[36], null);
+    });
+
+    test('enforces inclusive date bounds', () => {
+        const minimumDate = parseCalendarDateKey('2026-08-02');
+        const maximumDate = parseCalendarDateKey('2026-08-05');
+
+        assert.ok(minimumDate);
+        assert.ok(maximumDate);
+        assert.equal(
+            calendarDateIsInRange(minimumDate, minimumDate, maximumDate),
+            true,
+        );
+        assert.equal(
+            calendarDateIsInRange(
+                new Date(2026, 7, 6, 12),
+                minimumDate,
+                maximumDate,
+            ),
+            false,
+        );
+    });
+
+    test('opens on the selected date or the nearest allowed month', () => {
+        const minimumDate = parseCalendarDateKey('2026-08-02');
+        const maximumDate = parseCalendarDateKey('2026-10-05');
+        const selectedDate = parseCalendarDateKey('2026-09-12');
+
+        assert.ok(minimumDate);
+        assert.ok(maximumDate);
+        assert.ok(selectedDate);
+        assert.equal(
+            formatCalendarDateKey(
+                getInitialCalendarMonth({
+                    maximumDate,
+                    minimumDate,
+                    referenceDate: new Date(2025, 0, 1, 12),
+                    selectedDate,
+                }),
+            ),
+            '2026-09-01',
+        );
+        assert.equal(
+            formatCalendarDateKey(
+                getInitialCalendarMonth({
+                    maximumDate,
+                    minimumDate,
+                    referenceDate: new Date(2025, 0, 1, 12),
+                    selectedDate: null,
+                }),
+            ),
+            '2026-08-01',
+        );
+    });
+});

--- a/packages/ui/src/CalendarDatePicker/index.ts
+++ b/packages/ui/src/CalendarDatePicker/index.ts
@@ -1,0 +1,10 @@
+export { Calendar, type CalendarProps } from './Calendar';
+export {
+    CalendarDatePicker,
+    type CalendarDatePickerProps,
+} from './CalendarDatePicker';
+export {
+    calendarDateIsInRange,
+    formatCalendarDateKey,
+    parseCalendarDateKey,
+} from './calendarDateUtils';

--- a/packages/ui/src/WeatherCharts/WeatherCharts.tsx
+++ b/packages/ui/src/WeatherCharts/WeatherCharts.tsx
@@ -37,7 +37,7 @@ import {
     ButtonGroup,
     buttonGroupItemClassName,
 } from '../ButtonGroup/ButtonGroup';
-import { Input } from '../Input/Input';
+import { CalendarDatePicker } from '../CalendarDatePicker/CalendarDatePicker';
 import { ArrowUp, Calendar, Droplets, ThermometerSun, Wind } from '../icons';
 import { Popper } from '../Popper/Popper';
 import { Row } from '../Row/Row';
@@ -942,25 +942,19 @@ export function WeatherCharts({
                         }
                     >
                         <Row spacing={1} className="items-end">
-                            <Input
-                                type="date"
+                            <CalendarDatePicker
                                 value={toDateInputValue(range.from)}
                                 min={minInput}
                                 max={maxInput}
-                                onChange={(event) =>
-                                    handleFromChange(event.target.value)
-                                }
+                                onValueChange={handleFromChange}
                                 label="Od"
                                 className="w-36"
                             />
-                            <Input
-                                type="date"
+                            <CalendarDatePicker
                                 value={toDateInputValue(range.to)}
                                 min={minInput}
                                 max={maxInput}
-                                onChange={(event) =>
-                                    handleToChange(event.target.value)
-                                }
+                                onValueChange={handleToChange}
                                 label="Do"
                                 className="w-36"
                             />


### PR DESCRIPTION
## What changed

- added a shared Croatian calendar date picker with keyboard navigation and inclusive min/max bounds
- replaced native date fields across the Garden cart, planting, diary rescheduling, plant status, harvest scheduling, sandbox time, and weather history
- preserved date-only values and existing async/error behavior
- added focused date utility tests plus Storybook stories and the Garden workspace showcase

## Why

Native browser date inputs are inconsistent across browsers and feel disconnected from the in-game HUD. A shared picker provides one predictable, touch-friendly experience everywhere dates are selected in Garden.

## Validation

- `pnpm lint --filter @gredice/ui --filter @gredice/game --filter garden --filter storybook`
- `pnpm typecheck --filter @gredice/ui --filter @gredice/game --filter garden --filter storybook`
- `pnpm test --filter @gredice/ui`
- `pnpm test --filter @gredice/game` (780 tests)
- Storybook browser verification: mouse and keyboard selection, bounds and month navigation, no runtime overlay/errors, zero WCAG A/AA violations