### PR TITLE
fix(farm): print labels only for harvest-ready plants

### DIFF
--- a/apps/farm/app/schedule/scheduleLabelEligibility.spec.ts
+++ b/apps/farm/app/schedule/scheduleLabelEligibility.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test';
+import { isHarvestLabelEligible } from './scheduleLabelEligibility';
+
+test('prints harvest labels only for plants ready for harvest', () => {
+    expect(isHarvestLabelEligible({ plantStatus: 'ready' })).toBe(true);
+
+    for (const plantStatus of ['sprouted', 'firstFruitSet', 'harvested']) {
+        expect(isHarvestLabelEligible({ plantStatus })).toBe(false);
+    }
+
+    expect(isHarvestLabelEligible({ plantStatus: null })).toBe(false);
+    expect(isHarvestLabelEligible({})).toBe(false);
+});

--- a/apps/farm/app/schedule/scheduleLabelEligibility.ts
+++ b/apps/farm/app/schedule/scheduleLabelEligibility.ts
@@ -1,0 +1,7 @@
+type HarvestLabelField = {
+    plantStatus?: string | null;
+};
+
+export function isHarvestLabelEligible(field: HarvestLabelField) {
+    return field.plantStatus === 'ready';
+}

--- a/apps/farm/app/schedule/scheduleLabels.ts
+++ b/apps/farm/app/schedule/scheduleLabels.ts
@@ -7,6 +7,7 @@ import {
 } from '@gredice/storage';
 import type { FarmScheduleDayData } from './scheduleData';
 import { formatScheduleLabelDate } from './scheduleLabelDate';
+import { isHarvestLabelEligible } from './scheduleLabelEligibility';
 import {
     getFieldPhysicalPositionIndex,
     groupRaisedBedsForSchedule,
@@ -278,6 +279,10 @@ async function buildHarvestFieldLabel(
     dateLabel: string,
     createTraceLink: boolean,
 ): Promise<FieldOperationLabelData | null> {
+    if (createTraceLink && !isHarvestLabelEligible(field)) {
+        return null;
+    }
+
     const plantSortName = field.plantSortId
         ? plantSortById.get(field.plantSortId)?.information?.name
         : undefined;


### PR DESCRIPTION
## What changed

- require the current plant status to be `ready` before generating a harvest label
- apply the guard before creating a harvest trace link, covering field-targeted and full-bed harvest operations
- add focused eligibility coverage for ready, growing, harvested, and missing statuses

## Why

Full-bed harvest label generation iterated every field in the bed, and field-targeted harvest operations also did not validate the plant status. That allowed labels and QR traces to be created for plants that were not ready for harvest.

## Impact

Farm daily label printing now includes harvest labels only for plants marked **Spremna za berbu**. Other printable operation labels are unchanged.

## Validation

- `pnpm --filter farm exec playwright test app/schedule/scheduleLabelEligibility.spec.ts`
- `pnpm --filter farm exec biome check app/schedule/scheduleLabels.ts app/schedule/scheduleLabelEligibility.ts app/schedule/scheduleLabelEligibility.spec.ts`
- `pnpm typecheck --filter farm`
- `pnpm build --filter farm`
- `git diff --check`