### PR TITLE
fix(farm): retain explicit harvest labels

### DIFF
--- a/apps/farm/app/schedule/FieldOperationPrintModal.spec.tsx
+++ b/apps/farm/app/schedule/FieldOperationPrintModal.spec.tsx
@@ -1,0 +1,135 @@
+import type { FieldOperationLabelData } from '@gredice/label-printer';
+import { expect, test } from '@playwright/experimental-ct-react';
+import '../globals.css';
+import { FieldOperationPrintModal } from './FieldOperationPrintModal';
+
+const firstLabel: FieldOperationLabelData = {
+    raisedBedPhysicalId: 'A12',
+    fieldLabel: '1',
+    detailLabel: 'Berba',
+    plantSortName: 'Salata',
+    dateLabel: '02.08.2026.',
+};
+
+const labels: FieldOperationLabelData[] = [
+    firstLabel,
+    {
+        raisedBedPhysicalId: 'A12',
+        fieldLabel: '2',
+        detailLabel: 'Berba',
+        plantSortName: 'Rajčica',
+        dateLabel: '02.08.2026.',
+    },
+    {
+        raisedBedPhysicalId: 'A12',
+        fieldLabel: '3',
+        detailLabel: 'Berba',
+        plantSortName: 'Paprika',
+        dateLabel: '02.08.2026.',
+    },
+];
+
+test('lets farmers exclude labels and restore the full print selection', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <FieldOperationPrintModal
+            title="Ispis dnevnih etiketa"
+            description="Odaberite etikete za ispis."
+            labelData={labels}
+            triggerLabel="Otvori etikete"
+            printButtonLabel="Ispiši odabrane etikete"
+        />,
+    );
+
+    await page.getByRole('button', { name: 'Otvori etikete' }).click();
+    const dialog = page.getByRole('dialog', {
+        name: 'Ispis dnevnih etiketa',
+    });
+
+    await expect(dialog.getByText('Odabrano: 3 od 3 etiketa')).toBeVisible();
+    const secondLabel = dialog.getByRole('checkbox', {
+        name: 'Uključi etiketu #2',
+    });
+    await expect(secondLabel).toBeChecked();
+
+    await secondLabel.click();
+
+    await expect(secondLabel).not.toBeChecked();
+    await expect(dialog.getByText('Odabrano: 2 od 3 etiketa')).toBeVisible();
+    await expect(
+        dialog.getByRole('checkbox', { name: 'Odaberi sve' }),
+    ).toHaveAttribute('data-state', 'indeterminate');
+
+    await dialog.getByRole('checkbox', { name: 'Odaberi sve' }).click();
+
+    await expect(secondLabel).toBeChecked();
+    await expect(dialog.getByText('Odabrano: 3 od 3 etiketa')).toBeVisible();
+});
+
+test('supports clearing every label before choosing a retry subset', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <FieldOperationPrintModal
+            title="Ponovni ispis etiketa"
+            description="Odaberite etikete za ponovni ispis."
+            labelData={labels}
+            triggerLabel="Ponovi ispis"
+            printButtonLabel="Ispiši odabrane etikete"
+        />,
+    );
+
+    await page.getByRole('button', { name: 'Ponovi ispis' }).click();
+    const dialog = page.getByRole('dialog', {
+        name: 'Ponovni ispis etiketa',
+    });
+
+    await dialog.getByRole('checkbox', { name: 'Poništi odabir svih' }).click();
+
+    await expect(dialog.getByText('Odabrano: 0 od 3 etiketa')).toBeVisible();
+    for (const position of [1, 2, 3]) {
+        await expect(
+            dialog.getByRole('checkbox', {
+                name: `Uključi etiketu #${position}`,
+            }),
+        ).not.toBeChecked();
+    }
+
+    await dialog.getByRole('checkbox', { name: 'Uključi etiketu #3' }).click();
+
+    await expect(dialog.getByText('Odabrano: 1 od 3 etiketa')).toBeVisible();
+});
+
+test('keeps identical duplicate labels independently selectable', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <FieldOperationPrintModal
+            title="Odabir duplih etiketa"
+            description="Odaberite primjerke za ispis."
+            labelData={[firstLabel, firstLabel]}
+            triggerLabel="Otvori duple etikete"
+        />,
+    );
+
+    await page.getByRole('button', { name: 'Otvori duple etikete' }).click();
+    const dialog = page.getByRole('dialog', {
+        name: 'Odabir duplih etiketa',
+    });
+    const firstCheckbox = dialog.getByRole('checkbox', {
+        name: 'Uključi etiketu #1',
+    });
+    const secondCheckbox = dialog.getByRole('checkbox', {
+        name: 'Uključi etiketu #2',
+    });
+
+    await secondCheckbox.click();
+
+    await expect(firstCheckbox).toBeChecked();
+    await expect(secondCheckbox).not.toBeChecked();
+    await expect(dialog.getByText('Odabrano: 1 od 2 etiketa')).toBeVisible();
+});

--- a/apps/farm/app/schedule/FieldOperationPrintModal.tsx
+++ b/apps/farm/app/schedule/FieldOperationPrintModal.tsx
@@ -8,6 +8,7 @@ import {
     type LabelPrinterSnapshot,
 } from '@gredice/label-printer';
 import { Button, type ButtonProps } from '@gredice/ui/Button';
+import { Checkbox } from '@gredice/ui/Checkbox';
 import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -128,6 +129,9 @@ export function FieldOperationPrintModal({
     const labels = Array.isArray(labelData) ? labelData : [labelData];
     const labelPreviewItems = getLabelPreviewItems(labels);
     const [isOpen, setIsOpen] = useState(false);
+    const [excludedLabelKeys, setExcludedLabelKeys] = useState<Set<string>>(
+        () => new Set(),
+    );
     const [snapshot, setSnapshot] = useState(() =>
         sharedLabelPrinter.getSnapshot(),
     );
@@ -135,6 +139,13 @@ export function FieldOperationPrintModal({
     const [isDisconnecting, setIsDisconnecting] = useState(false);
     const [actionError, setActionError] = useState<string | null>(null);
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
+    const selectedLabelPreviewItems = labelPreviewItems.filter(
+        (item) => !excludedLabelKeys.has(item.key),
+    );
+    const selectedLabels = selectedLabelPreviewItems.map((item) => item.label);
+    const allLabelsSelected =
+        selectedLabels.length > 0 && selectedLabels.length === labels.length;
+    const someLabelsSelected = selectedLabels.length > 0 && !allLabelsSelected;
 
     useEffect(() => {
         return sharedLabelPrinter.subscribe(setSnapshot);
@@ -144,6 +155,10 @@ export function FieldOperationPrintModal({
         setIsOpen(open);
         setActionError(null);
         setSuccessMessage(null);
+
+        if (open) {
+            setExcludedLabelKeys(new Set());
+        }
 
         if (open && snapshot.isConnected) {
             void sharedLabelPrinter.refresh().catch(() => undefined);
@@ -189,18 +204,38 @@ export function FieldOperationPrintModal({
         }
     };
 
+    const handleToggleAllLabels = (checked: boolean) => {
+        setExcludedLabelKeys(
+            checked
+                ? new Set()
+                : new Set(labelPreviewItems.map((item) => item.key)),
+        );
+    };
+
+    const handleToggleLabel = (key: string, checked: boolean) => {
+        setExcludedLabelKeys((currentKeys) => {
+            const nextKeys = new Set(currentKeys);
+            if (checked) {
+                nextKeys.delete(key);
+            } else {
+                nextKeys.add(key);
+            }
+            return nextKeys;
+        });
+    };
+
     const handlePrint = async () => {
         setActionError(null);
         setSuccessMessage(null);
 
-        if (labels.length === 0) {
-            setActionError('Nema etiketa za ispis.');
+        if (selectedLabels.length === 0) {
+            setActionError('Odaberite barem jednu etiketu za ispis.');
             return;
         }
 
         try {
-            if (labels.length === 1) {
-                const firstLabel = labels.at(0);
+            if (selectedLabels.length === 1) {
+                const firstLabel = selectedLabels.at(0);
                 if (!firstLabel) {
                     setActionError('Nema etiketa za ispis.');
                     return;
@@ -210,12 +245,15 @@ export function FieldOperationPrintModal({
                     preset: DEFAULT_HARVEST_LABEL_PRESET,
                 });
             } else {
-                await sharedLabelPrinter.printFieldOperationLabels(labels, {
-                    preset: DEFAULT_HARVEST_LABEL_PRESET,
-                });
+                await sharedLabelPrinter.printFieldOperationLabels(
+                    selectedLabels,
+                    {
+                        preset: DEFAULT_HARVEST_LABEL_PRESET,
+                    },
+                );
             }
 
-            const traceLinkIds = getTraceLinkIds(labels);
+            const traceLinkIds = getTraceLinkIds(selectedLabels);
             if (traceLinkIds.length > 0 && onPrintSuccess) {
                 try {
                     await onPrintSuccess(traceLinkIds);
@@ -226,7 +264,7 @@ export function FieldOperationPrintModal({
                 }
             }
             setSuccessMessage(
-                labels.length === 1
+                selectedLabels.length === 1
                     ? 'Etiketa je poslana na pisač.'
                     : 'Etikete su poslane na pisač.',
             );
@@ -243,12 +281,16 @@ export function FieldOperationPrintModal({
         snapshot.isConnected &&
         !snapshot.isConnecting &&
         !snapshot.isPrinting &&
-        labels.length > 0 &&
+        selectedLabels.length > 0 &&
         snapshot.paperInserted !== false &&
         snapshot.lidClosed !== false;
     const resolvedPrintButtonLabel =
         printButtonLabel ??
-        (labels.length === 1 ? 'Ispiši etiketu' : 'Ispiši etikete');
+        (labels.length === 1 ? 'Ispiši etiketu' : 'Ispiši odabrane etikete');
+    const printButtonText =
+        labels.length > 1
+            ? `${resolvedPrintButtonLabel} (${selectedLabels.length})`
+            : resolvedPrintButtonLabel;
 
     return (
         <Modal
@@ -274,12 +316,33 @@ export function FieldOperationPrintModal({
                 <div className="rounded-lg border bg-muted/20 p-3">
                     <Stack spacing={2}>
                         {labels.length > 1 && (
-                            <Typography
-                                level="body2"
-                                className="text-muted-foreground"
-                            >
-                                Pregled: {labels.length} etiketa
-                            </Typography>
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                                <Typography
+                                    level="body2"
+                                    className="text-muted-foreground"
+                                >
+                                    Odabrano: {selectedLabels.length} od{' '}
+                                    {labels.length} etiketa
+                                </Typography>
+                                <Checkbox
+                                    checked={
+                                        allLabelsSelected
+                                            ? true
+                                            : someLabelsSelected
+                                              ? 'indeterminate'
+                                              : false
+                                    }
+                                    disabled={snapshot.isPrinting}
+                                    label={
+                                        allLabelsSelected
+                                            ? 'Poništi odabir svih'
+                                            : 'Odaberi sve'
+                                    }
+                                    onCheckedChange={(checked) =>
+                                        handleToggleAllLabels(checked === true)
+                                    }
+                                />
+                            </div>
                         )}
                         <div
                             className={
@@ -288,30 +351,59 @@ export function FieldOperationPrintModal({
                                     : ''
                             }
                         >
-                            {labelPreviewItems.map((item) => (
-                                <div key={item.key} className="min-w-0">
-                                    {labels.length > 1 && (
-                                        <Typography
-                                            level="body2"
-                                            className="mb-1 text-xs text-muted-foreground"
+                            {labelPreviewItems.map((item) => {
+                                const isSelected = !excludedLabelKeys.has(
+                                    item.key,
+                                );
+
+                                return (
+                                    <div key={item.key} className="min-w-0">
+                                        {labels.length > 1 && (
+                                            <div className="mb-2 flex min-h-11 items-center">
+                                                <Checkbox
+                                                    checked={isSelected}
+                                                    disabled={
+                                                        snapshot.isPrinting
+                                                    }
+                                                    label={`Uključi etiketu #${item.position}`}
+                                                    onCheckedChange={(
+                                                        checked,
+                                                    ) =>
+                                                        handleToggleLabel(
+                                                            item.key,
+                                                            checked === true,
+                                                        )
+                                                    }
+                                                />
+                                            </div>
+                                        )}
+                                        <div
+                                            className={
+                                                isSelected
+                                                    ? undefined
+                                                    : 'opacity-45 grayscale'
+                                            }
                                         >
-                                            #{item.position}
-                                        </Typography>
-                                    )}
-                                    <FieldOperationLabelPreviewCanvas
-                                        labelData={item.label}
-                                        className="mx-auto block w-full max-w-sm rounded border bg-white shadow-xs"
-                                    />
-                                    {getTraceStatusLabel(item.label) && (
-                                        <Typography
-                                            level="body2"
-                                            className="mt-1 text-center text-xs text-muted-foreground"
-                                        >
-                                            {getTraceStatusLabel(item.label)}
-                                        </Typography>
-                                    )}
-                                </div>
-                            ))}
+                                            <FieldOperationLabelPreviewCanvas
+                                                labelData={item.label}
+                                                className="mx-auto block w-full max-w-sm rounded border bg-white shadow-xs"
+                                            />
+                                            {getTraceStatusLabel(
+                                                item.label,
+                                            ) && (
+                                                <Typography
+                                                    level="body2"
+                                                    className="mt-1 text-center text-xs text-muted-foreground"
+                                                >
+                                                    {getTraceStatusLabel(
+                                                        item.label,
+                                                    )}
+                                                </Typography>
+                                            )}
+                                        </div>
+                                    </div>
+                                );
+                            })}
                         </div>
                     </Stack>
                 </div>
@@ -497,7 +589,7 @@ export function FieldOperationPrintModal({
                                 loading={snapshot.isPrinting}
                                 disabled={!canPrint}
                             >
-                                {resolvedPrintButtonLabel}
+                                {printButtonText}
                             </Button>
                         </div>
                     </Stack>

--- a/apps/farm/app/schedule/ScheduleLabelPrintSection.tsx
+++ b/apps/farm/app/schedule/ScheduleLabelPrintSection.tsx
@@ -85,12 +85,12 @@ export async function ScheduleLabelPrintSection({
             triggerVariant="solid"
             triggerSize="sm"
             triggerClassName="whitespace-nowrap"
-            printButtonLabel="Ispiši sve etikete"
+            printButtonLabel="Ispiši odabrane etikete"
             onPrintSuccess={markHarvestTraceLabelsPrintedAction}
             description={
                 <Stack spacing={1}>
                     <Typography>
-                        Ispis uključuje sve etikete za odabrani dan.
+                        Odaberite etikete koje želite ispisati za ovaj dan.
                     </Typography>
                     {labelSummary && (
                         <Typography

--- a/apps/farm/app/schedule/scheduleLabelEligibility.spec.ts
+++ b/apps/farm/app/schedule/scheduleLabelEligibility.spec.ts
@@ -1,13 +1,34 @@
 import { expect, test } from '@playwright/test';
 import { isHarvestLabelEligible } from './scheduleLabelEligibility';
 
-test('prints harvest labels only for plants ready for harvest', () => {
-    expect(isHarvestLabelEligible({ plantStatus: 'ready' })).toBe(true);
+test('prints an explicitly targeted field regardless of plant status', () => {
+    for (const plantStatus of [
+        'sprouted',
+        'firstFruitSet',
+        'ready',
+        'harvested',
+        null,
+        undefined,
+    ]) {
+        expect(isHarvestLabelEligible({ plantStatus }, 'explicitField')).toBe(
+            true,
+        );
+    }
+});
+
+test('prints only ready plants when harvesting a whole raised bed', () => {
+    expect(isHarvestLabelEligible({ plantStatus: 'ready' }, 'raisedBed')).toBe(
+        true,
+    );
 
     for (const plantStatus of ['sprouted', 'firstFruitSet', 'harvested']) {
-        expect(isHarvestLabelEligible({ plantStatus })).toBe(false);
+        expect(isHarvestLabelEligible({ plantStatus }, 'raisedBed')).toBe(
+            false,
+        );
     }
 
-    expect(isHarvestLabelEligible({ plantStatus: null })).toBe(false);
-    expect(isHarvestLabelEligible({})).toBe(false);
+    expect(isHarvestLabelEligible({ plantStatus: null }, 'raisedBed')).toBe(
+        false,
+    );
+    expect(isHarvestLabelEligible({}, 'raisedBed')).toBe(false);
 });

--- a/apps/farm/app/schedule/scheduleLabelEligibility.spec.ts
+++ b/apps/farm/app/schedule/scheduleLabelEligibility.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '@playwright/test';
-import { isHarvestLabelEligible } from './scheduleLabelEligibility';
+import {
+    findHarvestLabelPlantCycleAtDate,
+    isHarvestLabelEligible,
+} from './scheduleLabelEligibility';
 
 test('prints an explicitly targeted field regardless of plant status', () => {
     for (const plantStatus of [
@@ -31,4 +34,37 @@ test('prints only ready plants when harvesting a whole raised bed', () => {
         false,
     );
     expect(isHarvestLabelEligible({}, 'raisedBed')).toBe(false);
+});
+
+test('binds an explicit label to the plant cycle at the operation date', () => {
+    const firstCycle = {
+        plantPlaceEventId: 101,
+        plantSortId: 11,
+        startedAt: new Date('2026-05-01T08:00:00.000Z'),
+    };
+    const replacementCycle = {
+        plantPlaceEventId: 202,
+        plantSortId: 22,
+        startedAt: new Date('2026-07-01T08:00:00.000Z'),
+    };
+    const cycles = [replacementCycle, firstCycle];
+
+    expect(
+        findHarvestLabelPlantCycleAtDate(
+            cycles,
+            new Date('2026-06-15T08:00:00.000Z'),
+        ),
+    ).toBe(firstCycle);
+    expect(
+        findHarvestLabelPlantCycleAtDate(
+            cycles,
+            new Date('2026-07-15T08:00:00.000Z'),
+        ),
+    ).toBe(replacementCycle);
+    expect(
+        findHarvestLabelPlantCycleAtDate(
+            cycles,
+            new Date('2026-04-15T08:00:00.000Z'),
+        ),
+    ).toBeUndefined();
 });

--- a/apps/farm/app/schedule/scheduleLabelEligibility.ts
+++ b/apps/farm/app/schedule/scheduleLabelEligibility.ts
@@ -2,6 +2,11 @@ type HarvestLabelField = {
     plantStatus?: string | null;
 };
 
-export function isHarvestLabelEligible(field: HarvestLabelField) {
-    return field.plantStatus === 'ready';
+type HarvestLabelScope = 'explicitField' | 'raisedBed';
+
+export function isHarvestLabelEligible(
+    field: HarvestLabelField,
+    scope: HarvestLabelScope,
+) {
+    return scope === 'explicitField' || field.plantStatus === 'ready';
 }

--- a/apps/farm/app/schedule/scheduleLabelEligibility.ts
+++ b/apps/farm/app/schedule/scheduleLabelEligibility.ts
@@ -3,10 +3,25 @@ type HarvestLabelField = {
 };
 
 type HarvestLabelScope = 'explicitField' | 'raisedBed';
+type HarvestLabelPlantCycle = {
+    startedAt: Date;
+};
 
 export function isHarvestLabelEligible(
     field: HarvestLabelField,
     scope: HarvestLabelScope,
 ) {
     return scope === 'explicitField' || field.plantStatus === 'ready';
+}
+
+export function findHarvestLabelPlantCycleAtDate<
+    T extends HarvestLabelPlantCycle,
+>(plantCycles: readonly T[] | null | undefined, operationDate: Date) {
+    return plantCycles
+        ?.filter((plantCycle) => plantCycle.startedAt <= operationDate)
+        .toSorted(
+            (left, right) =>
+                left.startedAt.getTime() - right.startedAt.getTime(),
+        )
+        .at(-1);
 }

--- a/apps/farm/app/schedule/scheduleLabels.ts
+++ b/apps/farm/app/schedule/scheduleLabels.ts
@@ -7,7 +7,10 @@ import {
 } from '@gredice/storage';
 import type { FarmScheduleDayData } from './scheduleData';
 import { formatScheduleLabelDate } from './scheduleLabelDate';
-import { isHarvestLabelEligible } from './scheduleLabelEligibility';
+import {
+    findHarvestLabelPlantCycleAtDate,
+    isHarvestLabelEligible,
+} from './scheduleLabelEligibility';
 import {
     getFieldPhysicalPositionIndex,
     groupRaisedBedsForSchedule,
@@ -285,8 +288,30 @@ async function buildHarvestFieldLabel(
         return null;
     }
 
-    const plantSortName = field.plantSortId
-        ? plantSortById.get(field.plantSortId)?.information?.name
+    const sortedPlantCycles = field.plantCycles?.toSorted((left, right) => {
+        const startedAtDifference =
+            left.startedAt.getTime() - right.startedAt.getTime();
+        if (startedAtDifference !== 0) {
+            return startedAtDifference;
+        }
+
+        return left.plantPlaceEventId - right.plantPlaceEventId;
+    });
+    const explicitPlantCycle =
+        createTraceLink && labelScope === 'explicitField'
+            ? findHarvestLabelPlantCycleAtDate(
+                  sortedPlantCycles,
+                  operation.completedAt ??
+                      operation.verifiedAt ??
+                      operation.timestamp,
+              )
+            : undefined;
+    const plantSortId =
+        createTraceLink && labelScope === 'explicitField'
+            ? explicitPlantCycle?.plantSortId
+            : field.plantSortId;
+    const plantSortName = plantSortId
+        ? plantSortById.get(plantSortId)?.information?.name
         : undefined;
 
     if (!raisedBed.physicalId || !plantSortName) {
@@ -308,21 +333,13 @@ async function buildHarvestFieldLabel(
         return label;
     }
 
-    const sortedPlantCycles = field.plantCycles?.toSorted((left, right) => {
-        const startedAtDifference =
-            left.startedAt.getTime() - right.startedAt.getTime();
-        if (startedAtDifference !== 0) {
-            return startedAtDifference;
-        }
-
-        return left.plantPlaceEventId - right.plantPlaceEventId;
-    });
     const plantCycle =
+        explicitPlantCycle ??
         sortedPlantCycles?.findLast(
             (cycle) =>
-                cycle.plantSortId === field.plantSortId &&
-                cycle.active !== false,
-        ) ?? sortedPlantCycles?.at(-1);
+                cycle.plantSortId === plantSortId && cycle.active !== false,
+        ) ??
+        sortedPlantCycles?.at(-1);
     const accountId = operation.accountId ?? raisedBed.accountId;
     const gardenId = operation.gardenId ?? raisedBed.gardenId;
 
@@ -330,7 +347,7 @@ async function buildHarvestFieldLabel(
         !accountId ||
         !gardenId ||
         !plantCycle ||
-        typeof field.plantSortId !== 'number'
+        typeof plantSortId !== 'number'
     ) {
         return label;
     }
@@ -343,7 +360,7 @@ async function buildHarvestFieldLabel(
         fieldPositionIndex: field.positionIndex,
         fieldLabel,
         plantPlaceEventId: plantCycle.plantPlaceEventId,
-        plantSortId: field.plantSortId,
+        plantSortId,
         harvestOperationId: operation.id,
     });
 

--- a/apps/farm/app/schedule/scheduleLabels.ts
+++ b/apps/farm/app/schedule/scheduleLabels.ts
@@ -279,7 +279,9 @@ async function buildHarvestFieldLabel(
     dateLabel: string,
     createTraceLink: boolean,
 ): Promise<FieldOperationLabelData | null> {
-    if (createTraceLink && !isHarvestLabelEligible(field)) {
+    const labelScope =
+        operation.raisedBedFieldId === null ? 'raisedBed' : 'explicitField';
+    if (createTraceLink && !isHarvestLabelEligible(field, labelScope)) {
         return null;
     }
 


### PR DESCRIPTION
## What changed

- keep harvest labels for an explicitly targeted field regardless of its current plant status
- require `ready` only when a whole-raised-bed harvest operation expands into per-field labels
- bind historical explicit-field labels and trace links to the plant cycle active on the operation date
- let farmers include or skip each generated label before printing, including identical duplicates
- support select-all, clear-all, and retry subsets; only selected QR trace labels are marked printed

## Why

PR #4356 placed the readiness check in the shared field-label builder without distinguishing an explicitly selected field from whole-bed expansion. That incorrectly hid labels for explicit field operations when the plant was not currently `ready`. Historical explicit operations must also retain the crop cycle they originally targeted after a field is replanted.

A daily batch can also contain duplicates or partially print. Farmers need to retry only the missing labels instead of printing the entire batch again.

## Impact

Farmers can print the label for any explicitly selected field, with the correct historical crop and trace link. Whole-bed harvest printing still excludes empty fields and plants that are not marked **Spremna za berbu**. The preview starts with all eligible labels selected and supports skipping any individual label before printing.

## Validation

- `pnpm --filter farm exec playwright test app/schedule/FieldOperationPrintModal.spec.tsx app/schedule/scheduleLabelEligibility.spec.ts` (6 passed)
- `pnpm --filter farm exec biome check app/schedule/FieldOperationPrintModal.tsx app/schedule/FieldOperationPrintModal.spec.tsx app/schedule/ScheduleLabelPrintSection.tsx app/schedule/scheduleLabels.ts app/schedule/scheduleLabelEligibility.ts app/schedule/scheduleLabelEligibility.spec.ts`
- `pnpm typecheck --filter farm`
- `pnpm build --filter farm`
- `git diff --check`