### PR TITLE
perf(checkout): add phase latency telemetry

### DIFF
--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -36,6 +36,11 @@ import { describeRoute, resolver, validator as zValidator } from 'hono-openapi';
 import { z } from 'zod';
 import { getCartInfo } from '../../../lib/checkout/cartInfo';
 import {
+    type CheckoutPaymentKind,
+    type CheckoutTimingVariables,
+    checkoutTimingMiddleware,
+} from '../../../lib/checkout/checkoutTiming';
+import {
     CheckoutDeliverySelectionError,
     validateCheckoutDeliverySelection,
 } from '../../../lib/checkout/deliverySelection';
@@ -80,7 +85,9 @@ function addMinutes(date: Date, minutes: number) {
     return new Date(date.getTime() + minutes * 60 * 1000);
 }
 
-const app = new Hono<{ Variables: AuthVariables }>()
+type CheckoutVariables = AuthVariables & CheckoutTimingVariables;
+
+const app = new Hono<{ Variables: CheckoutVariables }>()
     .get(
         '/sunflower-packages',
         describeRoute({
@@ -113,6 +120,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
         describeRoute({
             description: 'Create a Stripe checkout session for the given cart',
         }),
+        checkoutTimingMiddleware<{ Variables: CheckoutVariables }>(),
         authValidator(['user', 'admin']),
         zValidator(
             'json',
@@ -141,16 +149,21 @@ const app = new Hono<{ Variables: AuthVariables }>()
             }),
         ),
         async (context) => {
+            const checkoutTiming = context.get('checkoutTiming');
             const { accountId, userId } = context.get('authContext');
             const { cartId, deliveryInfo, harvestDates } =
                 context.req.valid('json');
 
             // Retrieve data
-            const [account, user, initialCart] = await Promise.all([
-                getAccount(accountId),
-                getUser(userId),
-                getShoppingCart(cartId),
-            ]);
+            const [account, user, initialCart] = await checkoutTiming.measure(
+                'account_cart_load',
+                () =>
+                    Promise.all([
+                        getAccount(accountId),
+                        getUser(userId),
+                        getShoppingCart(cartId),
+                    ]),
+            );
             if (!account) {
                 return context.json({ error: 'Account not found' }, 404);
             }
@@ -171,36 +184,45 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 return context.json({ error: 'Cart already paid' }, 400);
             }
 
-            const inventoryNormalizedCart =
-                (await normalizeShoppingCartInventoryUsage(cartId)) ??
-                initialCart;
-            const cart =
-                (await normalizeShoppingCartScheduledDates(
-                    inventoryNormalizedCart.id,
-                    {
-                        defaultMissingScheduledDates: true,
-                    },
-                )) ?? inventoryNormalizedCart;
-            const requiresDelivery = await cartContainsDeliverableItems(
-                cart.id,
+            const cart = await checkoutTiming.measure(
+                'cart_normalization',
+                async () => {
+                    const inventoryNormalizedCart =
+                        (await normalizeShoppingCartInventoryUsage(cartId)) ??
+                        initialCart;
+                    return (
+                        (await normalizeShoppingCartScheduledDates(
+                            inventoryNormalizedCart.id,
+                            {
+                                defaultMissingScheduledDates: true,
+                            },
+                        )) ?? inventoryNormalizedCart
+                    );
+                },
             );
-            const [slot, address, location] = await Promise.all([
-                deliveryInfo
-                    ? getTimeSlot(deliveryInfo.slotId)
-                    : Promise.resolve(undefined),
-                deliveryInfo?.mode === 'delivery' && deliveryInfo.addressId
-                    ? getDeliveryAddress(deliveryInfo.addressId, accountId)
-                    : Promise.resolve(undefined),
-                deliveryInfo?.mode === 'pickup' && deliveryInfo.locationId
-                    ? getPickupLocation(deliveryInfo.locationId)
-                    : Promise.resolve(undefined),
-            ]);
+            const endDeliveryValidation = checkoutTiming.startPhase(
+                'delivery_validation',
+            );
             let canonicalHarvestDates: Array<{
                 cartItemId: number;
                 scheduledDate: string;
             }> = [];
 
             try {
+                const requiresDelivery = await cartContainsDeliverableItems(
+                    cart.id,
+                );
+                const [slot, address, location] = await Promise.all([
+                    deliveryInfo
+                        ? getTimeSlot(deliveryInfo.slotId)
+                        : Promise.resolve(undefined),
+                    deliveryInfo?.mode === 'delivery' && deliveryInfo.addressId
+                        ? getDeliveryAddress(deliveryInfo.addressId, accountId)
+                        : Promise.resolve(undefined),
+                    deliveryInfo?.mode === 'pickup' && deliveryInfo.locationId
+                        ? getPickupLocation(deliveryInfo.locationId)
+                        : Promise.resolve(undefined),
+                ]);
                 validateCheckoutDeliverySelection({
                     address,
                     location,
@@ -255,6 +277,8 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 }
 
                 throw error;
+            } finally {
+                endDeliveryValidation();
             }
 
             const harvestDateByCartItemId = new Map(
@@ -264,7 +288,10 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 ]),
             );
             // Retrieve entities data
-            const cartInfo = await getCartInfo(cart.items, accountId);
+            const cartInfo = await checkoutTiming.measure(
+                'cart_enrichment',
+                () => getCartInfo(cart.items, accountId),
+            );
             if (!cartInfo.allowPurchase) {
                 return context.json({ error: 'Cart in invalid state' }, 400);
             }
@@ -321,45 +348,132 @@ const app = new Hono<{ Variables: AuthVariables }>()
                         ? [item.id]
                         : [],
             );
+            const hasSunflowerItems = cartInfo.items.some(
+                (item) =>
+                    item.status !== 'paid' && item.currency === 'sunflower',
+            );
+            const hasInventoryItems = cartInfo.items.some(
+                (item) =>
+                    item.status !== 'paid' &&
+                    (item.currency === 'inventory' || item.usesInventory),
+            );
+            let paymentKind: CheckoutPaymentKind = 'unknown';
+            if (requiresStripePayment) {
+                paymentKind = 'stripe';
+            } else if (hasSunflowerItems && hasInventoryItems) {
+                paymentKind = 'mixed_non_stripe';
+            } else if (hasSunflowerItems) {
+                paymentKind = 'sunflower';
+            } else if (hasInventoryItems) {
+                paymentKind = 'inventory';
+            }
+            checkoutTiming.setContext({
+                itemCount: cartInfo.items.filter(
+                    (item) => item.status !== 'paid',
+                ).length,
+                paymentKind,
+            });
 
             // Handle sunflower items
             if (!requiresStripePayment) {
-                const scheduledDeliveryEmailKeys = new Set<string>();
-                const sunflowerCartItemsWithShopData = cartInfo.items.filter(
-                    (item) =>
-                        item.status !== 'paid' && item.currency === 'sunflower',
+                let completedCart: Awaited<ReturnType<typeof getShoppingCart>>;
+                const endNonStripeFulfillment = checkoutTiming.startPhase(
+                    'non_stripe_fulfillment',
                 );
-                if (sunflowerCartItemsWithShopData.length > 0) {
-                    // Check if there are enough sunflowers in the account
-                    for (const item of sunflowerCartItemsWithShopData) {
-                        const scheduledHarvestDate =
-                            harvestDateByCartItemId.get(item.id);
-                        const sunflowerAmount = calculateSunflowerAmount(item);
-                        let didPaySunflowers = false;
-                        try {
-                            await spendSunflowers(
-                                accountId,
-                                sunflowerAmount,
-                                `shoppingCartItem:${item.id}`,
-                            );
-                            didPaySunflowers = true;
-                        } catch (error) {
-                            console.error('Error spending sunflowers', {
-                                error,
-                                accountId,
-                                sunflowerAmount,
-                                item,
-                            });
+                try {
+                    const scheduledDeliveryEmailKeys = new Set<string>();
+                    const sunflowerCartItemsWithShopData =
+                        cartInfo.items.filter(
+                            (item) =>
+                                item.status !== 'paid' &&
+                                item.currency === 'sunflower',
+                        );
+                    if (sunflowerCartItemsWithShopData.length > 0) {
+                        // Check if there are enough sunflowers in the account
+                        for (const item of sunflowerCartItemsWithShopData) {
+                            const scheduledHarvestDate =
+                                harvestDateByCartItemId.get(item.id);
+                            const sunflowerAmount =
+                                calculateSunflowerAmount(item);
+                            let didPaySunflowers = false;
+                            try {
+                                await spendSunflowers(
+                                    accountId,
+                                    sunflowerAmount,
+                                    `shoppingCartItem:${item.id}`,
+                                );
+                                didPaySunflowers = true;
+                            } catch (error) {
+                                checkoutTiming.setErrorCategory(
+                                    'sunflower_spend_failed',
+                                );
+                                console.error('Error spending sunflowers', {
+                                    error,
+                                    accountId,
+                                    sunflowerAmount,
+                                    item,
+                                });
+                            }
+
+                            if (didPaySunflowers) {
+                                await Promise.all([
+                                    setCartItemPaid(item.id),
+                                    processItem({
+                                        accountId,
+                                        cartItemId: item.id,
+                                        ...item,
+                                        amount_total: sunflowerAmount,
+                                        scheduledDeliveryEmailKeys,
+                                        additionalData:
+                                            buildCheckoutAdditionalData({
+                                                additionalData:
+                                                    item.additionalData,
+                                                deliveryInfo,
+                                                scheduledHarvestDate,
+                                            }),
+                                    }),
+                                ]);
+                            }
                         }
 
-                        if (didPaySunflowers) {
+                        // After processing sunflower items, check if all items are paid
+                        await markCartPaidIfAllItemsPaid(cart.id);
+                    }
+
+                    // Handle inventory items
+                    const inventoryCartItems = cartInfo.items.filter(
+                        (item) =>
+                            item.status !== 'paid' &&
+                            (item.currency === 'inventory' ||
+                                item.usesInventory),
+                    );
+
+                    if (inventoryCartItems.length > 0) {
+                        for (const item of inventoryCartItems) {
+                            const scheduledHarvestDate =
+                                harvestDateByCartItemId.get(item.id);
+                            if ((item.inventoryAvailable ?? 0) < item.amount) {
+                                return context.json(
+                                    {
+                                        error: 'Nema dovoljno predmeta u ruksaku',
+                                    },
+                                    400,
+                                );
+                            }
+
                             await Promise.all([
+                                consumeInventoryItem(accountId, {
+                                    entityTypeName: item.entityTypeName,
+                                    entityId: item.entityId,
+                                    amount: item.amount,
+                                    source: `shoppingCartItem:${item.id}`,
+                                }),
                                 setCartItemPaid(item.id),
                                 processItem({
                                     accountId,
                                     cartItemId: item.id,
                                     ...item,
-                                    amount_total: sunflowerAmount,
+                                    amount_total: 0,
                                     scheduledDeliveryEmailKeys,
                                     additionalData: buildCheckoutAdditionalData(
                                         {
@@ -371,68 +485,29 @@ const app = new Hono<{ Variables: AuthVariables }>()
                                 }),
                             ]);
                         }
+
+                        await markCartPaidIfAllItemsPaid(cart.id);
                     }
 
-                    // After processing sunflower items, check if all items are paid
-                    await markCartPaidIfAllItemsPaid(cart.id);
+                    completedCart = await getShoppingCart(cart.id);
+                } finally {
+                    endNonStripeFulfillment();
                 }
-
-                // Handle inventory items
-                const inventoryCartItems = cartInfo.items.filter(
-                    (item) =>
-                        item.status !== 'paid' &&
-                        (item.currency === 'inventory' || item.usesInventory),
-                );
-
-                if (inventoryCartItems.length > 0) {
-                    for (const item of inventoryCartItems) {
-                        const scheduledHarvestDate =
-                            harvestDateByCartItemId.get(item.id);
-                        if ((item.inventoryAvailable ?? 0) < item.amount) {
-                            return context.json(
-                                { error: 'Nema dovoljno predmeta u ruksaku' },
-                                400,
-                            );
-                        }
-
-                        await Promise.all([
-                            consumeInventoryItem(accountId, {
-                                entityTypeName: item.entityTypeName,
-                                entityId: item.entityId,
-                                amount: item.amount,
-                                source: `shoppingCartItem:${item.id}`,
-                            }),
-                            setCartItemPaid(item.id),
-                            processItem({
-                                accountId,
-                                cartItemId: item.id,
-                                ...item,
-                                amount_total: 0,
-                                scheduledDeliveryEmailKeys,
-                                additionalData: buildCheckoutAdditionalData({
-                                    additionalData: item.additionalData,
-                                    deliveryInfo,
-                                    scheduledHarvestDate,
-                                }),
-                            }),
-                        ]);
-                    }
-
-                    await markCartPaidIfAllItemsPaid(cart.id);
-                }
-
-                const completedCart = await getShoppingCart(cart.id);
                 if (completedCart?.status === 'paid') {
-                    await notifyOrderConfirmationEmail({
-                        to: user.userName,
-                        cartId: cart.id,
-                        items: buildOrderConfirmationItems(
-                            cartInfo.items,
-                            calculateSunflowerAmount,
-                        ),
-                        totalAmountCents: null,
-                        currency: null,
-                    });
+                    await checkoutTiming.measure(
+                        'confirmation_side_effects',
+                        () =>
+                            notifyOrderConfirmationEmail({
+                                to: user.userName,
+                                cartId: cart.id,
+                                items: buildOrderConfirmationItems(
+                                    cartInfo.items,
+                                    calculateSunflowerAmount,
+                                ),
+                                totalAmountCents: null,
+                                currency: null,
+                            }),
+                    );
                 }
             }
 
@@ -534,54 +609,62 @@ const app = new Hono<{ Variables: AuthVariables }>()
             }
 
             if (stripeCartItemsWithShopData.length) {
-                const { customerId, sessionId, url } = await stripeCheckout(
-                    {
-                        id: account.id,
-                        email: user.userName,
-                        name: user.userName,
-                        stripeCustomerId: account.stripeCustomerId ?? undefined,
-                    },
-                    {
-                        items: stripeItems,
-                        expiresAt: hasOutletStripeItems
-                            ? outletCheckoutExpiresAt
-                            : undefined,
-                        metadata: encodeHarvestDatesMetadata(
-                            canonicalHarvestDates,
-                            expectedNonStripeCartItemIds,
+                const { customerId, sessionId, url } =
+                    await checkoutTiming.measure('stripe_session', () =>
+                        stripeCheckout(
+                            {
+                                id: account.id,
+                                email: user.userName,
+                                name: user.userName,
+                                stripeCustomerId:
+                                    account.stripeCustomerId ?? undefined,
+                            },
+                            {
+                                items: stripeItems,
+                                expiresAt: hasOutletStripeItems
+                                    ? outletCheckoutExpiresAt
+                                    : undefined,
+                                metadata: encodeHarvestDatesMetadata(
+                                    canonicalHarvestDates,
+                                    expectedNonStripeCartItemIds,
+                                ),
+                            },
                         ),
-                    },
-                );
+                    );
 
                 if (account.stripeCustomerId !== customerId) {
                     await assignStripeCustomerId(account.id, customerId);
                 }
 
-                (await getPostHogClient()).capture({
-                    distinctId: accountId,
-                    event: 'checkout_initiated',
-                    properties: {
-                        cart_id: cartId,
-                        payment_method: 'stripe',
-                        item_count: stripeItems.length,
-                    },
+                await checkoutTiming.measure('analytics', async () => {
+                    (await getPostHogClient()).capture({
+                        distinctId: accountId,
+                        event: 'checkout_initiated',
+                        properties: {
+                            cart_id: cartId,
+                            payment_method: 'stripe',
+                            item_count: stripeItems.length,
+                        },
+                    });
                 });
 
                 return context.json({ sessionId, url });
             }
 
-            (await getPostHogClient()).capture({
-                distinctId: accountId,
-                event: 'checkout_initiated',
-                properties: {
-                    cart_id: cartId,
-                    payment_method: cartInfo.items.some(
-                        (i) => i.currency === 'sunflower',
-                    )
-                        ? 'sunflower'
-                        : 'inventory',
-                    item_count: cartInfo.items.length,
-                },
+            await checkoutTiming.measure('analytics', async () => {
+                (await getPostHogClient()).capture({
+                    distinctId: accountId,
+                    event: 'checkout_initiated',
+                    properties: {
+                        cart_id: cartId,
+                        payment_method: cartInfo.items.some(
+                            (i) => i.currency === 'sunflower',
+                        )
+                            ? 'sunflower'
+                            : 'inventory',
+                        item_count: cartInfo.items.length,
+                    },
+                });
             });
 
             return context.json({ success: true });

--- a/apps/api/lib/checkout/checkoutTiming.node.spec.ts
+++ b/apps/api/lib/checkout/checkoutTiming.node.spec.ts
@@ -1,0 +1,186 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { Hono } from 'hono';
+import {
+    CheckoutTiming,
+    type CheckoutTimingVariables,
+    checkoutItemCountBucket,
+    checkoutOutcomeFromStatus,
+    checkoutTimingMiddleware,
+} from './checkoutTiming';
+
+test('checkout timing records monotonic phase and total durations', async () => {
+    let currentTime = 100;
+    const records: Array<{
+        attributes: Record<string, unknown>;
+        event: string;
+        level: string;
+    }> = [];
+    const timing = new CheckoutTiming({
+        now: () => currentTime,
+        write: (level, event, attributes) => {
+            records.push({ attributes, event, level });
+        },
+    });
+
+    timing.setContext({ itemCount: 5, paymentKind: 'sunflower' });
+    await timing.measure('account_cart_load', async () => {
+        currentTime += 12.34;
+    });
+    const endFulfillment = timing.startPhase('non_stripe_fulfillment');
+    currentTime += 8.01;
+    endFulfillment();
+    currentTime += 1.05;
+
+    assert.equal(timing.finish({ status: 200 }), true);
+    assert.deepEqual(records, [
+        {
+            attributes: {
+                accountCartLoadDurationMs: 12.3,
+                itemCountBucket: '4-10',
+                nonStripeFulfillmentDurationMs: 8,
+                outcome: 'success',
+                paymentKind: 'sunflower',
+                route: '/api/checkout/checkout',
+                statusCode: 200,
+                totalDurationMs: 21.4,
+            },
+            event: 'checkout.request.complete',
+            level: 'info',
+        },
+    ]);
+});
+
+test('checkout timing emits one privacy-safe unexpected failure record', () => {
+    let currentTime = 20;
+    const records: Array<Record<string, unknown>> = [];
+    const timing = new CheckoutTiming({
+        now: () => currentTime,
+        write: (level, event, attributes) => {
+            records.push({ level, event, ...attributes });
+        },
+    });
+
+    timing.setErrorCategory('unexpected');
+    currentTime = 10;
+
+    assert.equal(
+        timing.finish({ outcome: 'unexpected_failure', status: 500 }),
+        true,
+    );
+    assert.equal(timing.finish({ status: 200 }), false);
+    assert.deepEqual(records, [
+        {
+            errorCategory: 'unexpected',
+            event: 'checkout.request.complete',
+            itemCountBucket: 'unknown',
+            level: 'error',
+            outcome: 'unexpected_failure',
+            paymentKind: 'unknown',
+            route: '/api/checkout/checkout',
+            statusCode: 500,
+            totalDurationMs: 0,
+        },
+    ]);
+});
+
+test('checkout timing accumulates repeated phases and ends each phase once', () => {
+    let currentTime = 0;
+    let record: Record<string, unknown> | undefined;
+    const timing = new CheckoutTiming({
+        now: () => currentTime,
+        write: (_level, _event, attributes) => {
+            record = attributes;
+        },
+    });
+
+    const endFirst = timing.startPhase('analytics');
+    currentTime = 2;
+    endFirst();
+    endFirst();
+    const endSecond = timing.startPhase('analytics');
+    currentTime = 5;
+    endSecond();
+    timing.finish({ status: 204 });
+
+    assert.equal(record?.analyticsDurationMs, 5);
+});
+
+test('checkout item count and response status use bounded categories', () => {
+    assert.deepEqual([-1, 1, 2, 4, 11].map(checkoutItemCountBucket), [
+        '0',
+        '1',
+        '2-3',
+        '4-10',
+        '11+',
+    ]);
+    assert.equal(checkoutOutcomeFromStatus(200), 'success');
+    assert.equal(checkoutOutcomeFromStatus(409), 'rejected');
+    assert.equal(checkoutOutcomeFromStatus(503), 'failed');
+});
+
+test('checkout timing middleware emits one record for every response path', async () => {
+    let currentTime = 0;
+    const records: Array<Record<string, unknown>> = [];
+    const app = new Hono<{ Variables: CheckoutTimingVariables }>();
+    app.use(
+        checkoutTimingMiddleware({
+            now: () => currentTime,
+            write: (level, event, attributes) => {
+                records.push({ level, event, ...attributes });
+            },
+        }),
+    );
+    app.get('/auth-rejection', (context) => context.json({}, 401));
+    app.get('/schema-rejection', (context) => context.json({}, 400));
+    app.get('/success', (context) => context.json({ ok: true }));
+    app.get('/unexpected', () => {
+        throw new Error('private failure details');
+    });
+    app.onError((_error, context) => context.json({}, 500));
+
+    for (const path of [
+        '/auth-rejection',
+        '/schema-rejection',
+        '/success',
+        '/unexpected',
+    ]) {
+        currentTime += 5;
+        await app.request(path);
+    }
+
+    assert.equal(records.length, 4);
+    assert.deepEqual(
+        records.map(({ errorCategory, outcome, statusCode }) => ({
+            errorCategory,
+            outcome,
+            statusCode,
+        })),
+        [
+            {
+                errorCategory: undefined,
+                outcome: 'rejected',
+                statusCode: 401,
+            },
+            {
+                errorCategory: undefined,
+                outcome: 'rejected',
+                statusCode: 400,
+            },
+            {
+                errorCategory: undefined,
+                outcome: 'success',
+                statusCode: 200,
+            },
+            {
+                errorCategory: 'unexpected',
+                outcome: 'unexpected_failure',
+                statusCode: 500,
+            },
+        ],
+    );
+    assert.equal(
+        JSON.stringify(records).includes('private failure details'),
+        false,
+    );
+});

--- a/apps/api/lib/checkout/checkoutTiming.ts
+++ b/apps/api/lib/checkout/checkoutTiming.ts
@@ -1,0 +1,264 @@
+import type { Env, MiddlewareHandler } from 'hono';
+
+export type CheckoutTimingPhase =
+    | 'account_cart_load'
+    | 'analytics'
+    | 'cart_enrichment'
+    | 'cart_normalization'
+    | 'confirmation_side_effects'
+    | 'delivery_validation'
+    | 'non_stripe_fulfillment'
+    | 'stripe_session';
+
+export type CheckoutPaymentKind =
+    | 'inventory'
+    | 'mixed_non_stripe'
+    | 'stripe'
+    | 'sunflower'
+    | 'unknown';
+
+export type CheckoutTimingOutcome =
+    | 'failed'
+    | 'rejected'
+    | 'success'
+    | 'unexpected_failure';
+
+export type CheckoutTimingErrorCategory =
+    | 'sunflower_spend_failed'
+    | 'unexpected';
+
+type CheckoutTimingLevel = 'error' | 'info';
+
+type CheckoutTimingAttributes = {
+    accountCartLoadDurationMs?: number;
+    analyticsDurationMs?: number;
+    cartEnrichmentDurationMs?: number;
+    cartNormalizationDurationMs?: number;
+    confirmationSideEffectsDurationMs?: number;
+    deliveryValidationDurationMs?: number;
+    errorCategory?: CheckoutTimingErrorCategory;
+    itemCountBucket: string;
+    nonStripeFulfillmentDurationMs?: number;
+    outcome: CheckoutTimingOutcome;
+    paymentKind: CheckoutPaymentKind;
+    route: '/api/checkout/checkout';
+    statusCode: number;
+    stripeSessionDurationMs?: number;
+    totalDurationMs: number;
+};
+
+type CheckoutDurationAttributeName =
+    | 'accountCartLoadDurationMs'
+    | 'analyticsDurationMs'
+    | 'cartEnrichmentDurationMs'
+    | 'cartNormalizationDurationMs'
+    | 'confirmationSideEffectsDurationMs'
+    | 'deliveryValidationDurationMs'
+    | 'nonStripeFulfillmentDurationMs'
+    | 'stripeSessionDurationMs';
+
+type CheckoutTimingWriter = (
+    level: CheckoutTimingLevel,
+    event: string,
+    attributes: CheckoutTimingAttributes,
+) => void;
+
+export type CheckoutTimingOptions = {
+    now?: () => number;
+    write?: CheckoutTimingWriter;
+};
+
+export type CheckoutTimingVariables = {
+    checkoutTiming: CheckoutTiming;
+};
+
+const checkoutTimingEvent = 'checkout.request.complete';
+
+const checkoutTimingPhases: CheckoutTimingPhase[] = [
+    'account_cart_load',
+    'analytics',
+    'cart_enrichment',
+    'cart_normalization',
+    'confirmation_side_effects',
+    'delivery_validation',
+    'non_stripe_fulfillment',
+    'stripe_session',
+];
+
+const phaseAttributeNames: Record<
+    CheckoutTimingPhase,
+    CheckoutDurationAttributeName
+> = {
+    account_cart_load: 'accountCartLoadDurationMs',
+    analytics: 'analyticsDurationMs',
+    cart_enrichment: 'cartEnrichmentDurationMs',
+    cart_normalization: 'cartNormalizationDurationMs',
+    confirmation_side_effects: 'confirmationSideEffectsDurationMs',
+    delivery_validation: 'deliveryValidationDurationMs',
+    non_stripe_fulfillment: 'nonStripeFulfillmentDurationMs',
+    stripe_session: 'stripeSessionDurationMs',
+};
+
+function roundedDuration(value: number) {
+    return Math.round(Math.max(0, value) * 10) / 10;
+}
+
+function defaultWriter(
+    level: CheckoutTimingLevel,
+    event: string,
+    attributes: CheckoutTimingAttributes,
+) {
+    if (level === 'error') {
+        console.error(event, attributes);
+        return;
+    }
+
+    console.info(event, attributes);
+}
+
+export function checkoutItemCountBucket(itemCount: number) {
+    if (itemCount <= 0) return '0';
+    if (itemCount === 1) return '1';
+    if (itemCount <= 3) return '2-3';
+    if (itemCount <= 10) return '4-10';
+    return '11+';
+}
+
+export function checkoutOutcomeFromStatus(
+    status: number,
+): CheckoutTimingOutcome {
+    if (status >= 500) return 'failed';
+    if (status >= 400) return 'rejected';
+    return 'success';
+}
+
+export class CheckoutTiming {
+    private errorCategory: CheckoutTimingErrorCategory | undefined;
+    private finished = false;
+    private itemCountBucket = 'unknown';
+    private readonly now: () => number;
+    private paymentKind: CheckoutPaymentKind = 'unknown';
+    private readonly phaseDurationsMs: Partial<
+        Record<CheckoutTimingPhase, number>
+    > = {};
+    private readonly startedAtMs: number;
+    private readonly write: CheckoutTimingWriter;
+
+    constructor({
+        now = performance.now.bind(performance),
+        write,
+    }: CheckoutTimingOptions = {}) {
+        this.now = now;
+        this.write = write ?? defaultWriter;
+        this.startedAtMs = this.now();
+    }
+
+    setContext({
+        itemCount,
+        paymentKind,
+    }: {
+        itemCount?: number;
+        paymentKind?: CheckoutPaymentKind;
+    }) {
+        if (typeof itemCount === 'number') {
+            this.itemCountBucket = checkoutItemCountBucket(itemCount);
+        }
+        if (paymentKind) {
+            this.paymentKind = paymentKind;
+        }
+    }
+
+    setErrorCategory(errorCategory: CheckoutTimingErrorCategory) {
+        this.errorCategory = errorCategory;
+    }
+
+    startPhase(phase: CheckoutTimingPhase) {
+        const startedAtMs = this.now();
+        let ended = false;
+
+        return () => {
+            if (ended) return;
+            ended = true;
+            const durationMs = roundedDuration(this.now() - startedAtMs);
+            this.phaseDurationsMs[phase] = roundedDuration(
+                (this.phaseDurationsMs[phase] ?? 0) + durationMs,
+            );
+        };
+    }
+
+    async measure<T>(phase: CheckoutTimingPhase, action: () => Promise<T>) {
+        const end = this.startPhase(phase);
+        try {
+            return await action();
+        } finally {
+            end();
+        }
+    }
+
+    finish({
+        outcome,
+        status,
+    }: {
+        outcome?: CheckoutTimingOutcome;
+        status: number;
+    }) {
+        if (this.finished) return false;
+        this.finished = true;
+
+        const finalOutcome = outcome ?? checkoutOutcomeFromStatus(status);
+        const attributes: CheckoutTimingAttributes = {
+            itemCountBucket: this.itemCountBucket,
+            outcome: finalOutcome,
+            paymentKind: this.paymentKind,
+            route: '/api/checkout/checkout',
+            statusCode: status,
+            totalDurationMs: roundedDuration(this.now() - this.startedAtMs),
+            ...(this.errorCategory
+                ? { errorCategory: this.errorCategory }
+                : {}),
+        };
+        for (const phase of checkoutTimingPhases) {
+            const durationMs = this.phaseDurationsMs[phase];
+            if (durationMs !== undefined) {
+                attributes[phaseAttributeNames[phase]] = durationMs;
+            }
+        }
+        this.write(
+            finalOutcome === 'unexpected_failure' || finalOutcome === 'failed'
+                ? 'error'
+                : 'info',
+            checkoutTimingEvent,
+            attributes,
+        );
+        return true;
+    }
+}
+
+export function checkoutTimingMiddleware<
+    E extends Env & { Variables: CheckoutTimingVariables },
+>(options?: CheckoutTimingOptions): MiddlewareHandler<E> {
+    return async (context, next) => {
+        const checkoutTiming = new CheckoutTiming(options);
+        context.set('checkoutTiming', checkoutTiming);
+
+        try {
+            await next();
+            if (context.error) {
+                checkoutTiming.setErrorCategory('unexpected');
+                checkoutTiming.finish({
+                    outcome: 'unexpected_failure',
+                    status: context.res.status,
+                });
+                return;
+            }
+            checkoutTiming.finish({ status: context.res.status });
+        } catch (error) {
+            checkoutTiming.setErrorCategory('unexpected');
+            checkoutTiming.finish({
+                outcome: 'unexpected_failure',
+                status: 500,
+            });
+            throw error;
+        }
+    };
+}

--- a/docs/checkout-performance.md
+++ b/docs/checkout-performance.md
@@ -1,0 +1,42 @@
+# Checkout performance
+
+The cart checkout route emits one `checkout.request.complete` record after each
+request that reaches `/api/checkout/checkout`. The record is intended for
+aggregate latency analysis, not customer or order debugging.
+
+## Fields
+
+- `route`: stable route name.
+- `statusCode`: final HTTP status, or `500` for an unhandled exception.
+- `outcome`: `success`, `rejected`, `failed`, or `unexpected_failure`.
+- `paymentKind`: `sunflower`, `inventory`, `mixed_non_stripe`, `stripe`, or
+  `unknown` when auth or validation ends the request before the cart is loaded.
+- `itemCountBucket`: pending-item count as `0`, `1`, `2-3`, `4-10`, `11+`, or
+  `unknown`.
+- `totalDurationMs`: monotonic time from checkout middleware entry through the
+  final response.
+- Optional monotonic phase fields: `accountCartLoadDurationMs`,
+  `cartNormalizationDurationMs`, `deliveryValidationDurationMs`,
+  `cartEnrichmentDurationMs`, `nonStripeFulfillmentDurationMs`,
+  `confirmationSideEffectsDurationMs`, `stripeSessionDurationMs`, and
+  `analyticsDurationMs`.
+- `errorCategory`: a bounded internal category when the route recovers from a
+  known failure before producing a response.
+
+The record never includes recipient, user, account, cart, address, delivery
+notes, cart contents, entity data, price, balance, Stripe identifiers, token,
+cookie, header, or arbitrary error values.
+
+## Production readback
+
+1. Filter API logs to the exact `checkout.request.complete` event.
+2. Select a release-bounded time window and record the deployed commit.
+3. Group by `paymentKind`, `itemCountBucket`, `outcome`, and `statusCode`.
+4. Report sample count plus p50, p90, and p95 for `totalDurationMs` and each
+   applicable phase. Omitted phases are not zero-duration samples.
+5. Compare equivalent windows before and after a checkout change. Keep cold
+   starts and unexpected failures visible rather than removing outliers.
+
+The optimization target for sunflower-only carts containing up to ten items is
+p50 below 500 ms and p95 below 1 second. A release is not verified by CI alone:
+the target requires production readback with a representative sample.


### PR DESCRIPTION
## What changed

- adds monotonic checkout phase timing for account/cart loading, normalization, delivery validation, cart enrichment, non-Stripe fulfilment, confirmation side effects, Stripe session creation, analytics, and total response time
- emits one stable `checkout.request.complete` record for successful, rejected, failed, and unexpected requests
- limits context to bounded payment-kind, pending-item-count, status, outcome, and error categories; no customer, cart, address, token, price, or arbitrary error content is emitted
- documents the aggregate production readback and the sunflower checkout target
- covers deterministic clock behavior and Hono auth/schema/success/exception response paths

## Why

Sunflower-only checkout latency was not attributable by phase, making it unsafe to optimize or verify from production behavior. This establishes the baseline and regression signal required by the subsequent email and debit changes.

## Impact

No checkout response, payment, fulfilment, or analytics behavior changes. The API emits one additional structured log record per checkout request.

No schema, migration, environment-variable, or deployment configuration changes.

## Validation

- `pnpm --filter api exec node --import tsx --test --conditions=react-server lib/checkout/checkoutTiming.node.spec.ts` — 5 passed
- `pnpm --filter api test:node` — 306 passed
- `pnpm --filter api exec tsc --noEmit --pretty false` — passed
- `pnpm lint --filter api` — passed
- `pnpm build --filter api` — passed
- `git diff --check` — passed

Closes #4367