### PR TITLE
perf(checkout): queue order confirmations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,14 @@ jobs:
               - pnpm-lock.yaml
               - pnpm-workspace.yaml
               - turbo.json
+            packages_email:
+              - packages/email/**
+              - packages/storage/**
+              - .github/workflows/**
+              - package.json
+              - pnpm-lock.yaml
+              - pnpm-workspace.yaml
+              - turbo.json
             packages_game:
               - packages/client/**
               - packages/game/**
@@ -186,6 +194,7 @@ jobs:
       app_storybook: ${{ steps.filter.outputs.app_storybook }}
       app_status: ${{ steps.filter.outputs.app_status }}
       packages_storage: ${{ steps.filter.outputs.packages_storage }}
+      packages_email: ${{ steps.filter.outputs.packages_email }}
       packages_game: ${{ steps.filter.outputs.packages_game }}
 
   ci_www:
@@ -364,6 +373,48 @@ jobs:
       - name: ⚒️ Test package
         run: pnpm test --filter=@gredice/game
 
+  test_email_package:
+    name: "CI - test @gredice/email"
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs: changes
+    if: success() && github.event_name == 'pull_request' &&
+      needs.changes.outputs.packages_email == 'true'
+    steps:
+      - uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 2
+
+      - uses: pnpm/action-setup@v6.0.8
+        name: ✨ Install pnpm
+
+      - name: ✨ Setup Node
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24.15.0"
+
+      - name: ✨ Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v5.0.5
+        name: ✨ Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: 📦️ Install dependencies
+        run: pnpm install --frozen-lockfile --filter @gredice/email... --filter .
+
+      - name: ⚒️ Test package
+        run: pnpm --filter @gredice/email test
+
+      - name: 🔎 Typecheck package
+        run: pnpm --filter @gredice/email typecheck
+
   ci_filter_check:
     name: "CI - verify app package filters"
     runs-on: ubuntu-latest
@@ -392,6 +443,7 @@ jobs:
         ci_status,
         test_packages,
         test_game_package,
+        test_email_package,
         ci_filter_check,
       ]
     if: ${{ always() }}

--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -12,7 +12,7 @@ import {
     getTimeSlotEffectiveClosesAt,
     getUser,
     HarvestScheduleConflictError,
-    markCartPaidIfAllItemsPaid,
+    markCartPaidAndEnqueueOrderConfirmation,
     normalizeShoppingCartInventoryUsage,
     normalizeShoppingCartScheduledDates,
     OUTLET_RESERVATION_HOLD_MINUTES,
@@ -50,7 +50,7 @@ import {
 } from '../../../lib/checkout/harvestCheckout';
 import {
     buildOrderConfirmationItems,
-    notifyOrderConfirmationEmail,
+    ORDER_CONFIRMATION_MANAGE_URL,
 } from '../../../lib/checkout/orderConfirmationEmail';
 import { calculateSunflowerAmount } from '../../../lib/checkout/sunflowerCalculations';
 import { authSecurity } from '../../../lib/docs/security';
@@ -376,7 +376,6 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
 
             // Handle sunflower items
             if (!requiresStripePayment) {
-                let completedCart: Awaited<ReturnType<typeof getShoppingCart>>;
                 const endNonStripeFulfillment = checkoutTiming.startPhase(
                     'non_stripe_fulfillment',
                 );
@@ -435,9 +434,6 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                                 ]);
                             }
                         }
-
-                        // After processing sunflower items, check if all items are paid
-                        await markCartPaidIfAllItemsPaid(cart.id);
                     }
 
                     // Handle inventory items
@@ -485,28 +481,41 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                                 }),
                             ]);
                         }
-
-                        await markCartPaidIfAllItemsPaid(cart.id);
                     }
-
-                    completedCart = await getShoppingCart(cart.id);
                 } finally {
                     endNonStripeFulfillment();
                 }
-                if (completedCart?.status === 'paid') {
-                    await checkoutTiming.measure(
-                        'confirmation_side_effects',
-                        () =>
-                            notifyOrderConfirmationEmail({
-                                to: user.userName,
+
+                const confirmationIntent = await checkoutTiming.measure(
+                    'confirmation_side_effects',
+                    () =>
+                        markCartPaidAndEnqueueOrderConfirmation({
+                            cartId: cart.id,
+                            payload: {
                                 cartId: cart.id,
+                                currency: null,
                                 items: buildOrderConfirmationItems(
                                     cartInfo.items,
                                     calculateSunflowerAmount,
                                 ),
+                                manageUrl: ORDER_CONFIRMATION_MANAGE_URL,
+                                to: user.userName,
                                 totalAmountCents: null,
-                                currency: null,
-                            }),
+                            },
+                        }),
+                );
+                if (
+                    confirmationIntent.status !== 'enqueued' &&
+                    !(
+                        confirmationIntent.status === 'already_paid' &&
+                        confirmationIntent.emailMessageId !== null
+                    )
+                ) {
+                    return context.json(
+                        {
+                            error: 'Narudžbu nije moguće dovršiti. Pokušaj ponovno.',
+                        },
+                        409,
                     );
                 }
             }

--- a/apps/api/app/api/internal/cron/order-confirmation-emails/route.ts
+++ b/apps/api/app/api/internal/cron/order-confirmation-emails/route.ts
@@ -1,0 +1,9 @@
+import type { NextRequest } from 'next/server';
+import { handleOrderConfirmationEmailCron } from '../../../../../lib/checkout/orderConfirmationEmailCron';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+export async function GET(request: NextRequest) {
+    return await handleOrderConfirmationEmailCron(request);
+}

--- a/apps/api/lib/checkout/orderConfirmationEmail.ts
+++ b/apps/api/lib/checkout/orderConfirmationEmail.ts
@@ -2,7 +2,7 @@ import type { OrderConfirmationEmailItem } from '@gredice/transactional/emails/C
 import { sendOrderConfirmation } from '../email/transactional';
 import type { ShoppingCartItemWithShopData } from './cartInfo';
 
-const CUSTOMER_APP_URL =
+export const ORDER_CONFIRMATION_MANAGE_URL =
     process.env.GREDICE_GARDEN_APP_URL ?? 'https://vrt.gredice.com';
 
 export interface OrderConfirmationEmailParams {
@@ -79,7 +79,7 @@ export async function notifyOrderConfirmationEmail({
             orderReference: cartId ? `Narudžba #${cartId}` : null,
             totalAmountCents,
             currency,
-            manageUrl: CUSTOMER_APP_URL,
+            manageUrl: ORDER_CONFIRMATION_MANAGE_URL,
         });
         return true;
     } catch (error) {

--- a/apps/api/lib/checkout/orderConfirmationEmailCron.node.spec.ts
+++ b/apps/api/lib/checkout/orderConfirmationEmailCron.node.spec.ts
@@ -1,0 +1,261 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { OrderConfirmationOutboxHealthSnapshot } from '@gredice/storage';
+import { handleOrderConfirmationEmailCron } from './orderConfirmationEmailCron';
+import type { OrderConfirmationEmailWorkerResult } from './orderConfirmationEmailWorker';
+
+const successfulResult: OrderConfirmationEmailWorkerResult = {
+    claimFailures: 0,
+    claimed: 2,
+    durationMs: 12,
+    exhausted: 0,
+    failed: 0,
+    failureCategories: {
+        configuration_error: 0,
+        invalid_payload: 0,
+        provider_rejected_retryable: 0,
+        provider_rejected_terminal: 0,
+        provider_submission_uncertain: 0,
+        render_failed: 0,
+        transport_before_submission: 0,
+        worker_error_before_submission: 0,
+    },
+    finalizationFailures: 0,
+    invalid: 0,
+    oldestQueueAgeMs: 12_000,
+    queuedForRetry: 0,
+    reconciliation: {
+        claimFailures: 0,
+        claimed: 0,
+        finalizationFailures: 0,
+        lookupFailures: 0,
+        pending: 0,
+        sent: 0,
+        terminalFailures: 0,
+    },
+    sent: 2,
+    stoppedForTimeBudget: false,
+    terminalFailures: 0,
+    uncertain: 0,
+};
+
+const observedAt = new Date('2026-08-03T09:15:00.000Z');
+const healthyOutbox: OrderConfirmationOutboxHealthSnapshot = {
+    fencedSubmissions: {
+        count: 0,
+        oldestFencedAt: null,
+        oldestStaleAt: null,
+        staleCount: 0,
+    },
+    observedAt: observedAt.toISOString(),
+    pendingQueued: {
+        count: 0,
+        dueCount: 0,
+        oldestDueAt: null,
+        oldestQueuedAt: null,
+    },
+    preSubmissionClaims: {
+        expiredCount: 0,
+        inFlightCount: 0,
+        oldestExpiredClaimedAt: null,
+        oldestInFlightClaimedAt: null,
+    },
+    reconciliation: {
+        claimedCount: 0,
+        dueCount: 0,
+        expiredClaimCount: 0,
+        oldestClaimedAt: null,
+        oldestPendingAt: null,
+        oldestStaleAt: null,
+        pendingCount: 0,
+        staleCount: 0,
+    },
+    staleBefore: '2026-08-03T09:05:00.000Z',
+    staleSubmissionStarted: { count: 0, oldestStartedAt: null },
+    submissionUncertain: {
+        count: 0,
+        oldestStaleUncertainAt: null,
+        oldestUncertainAt: null,
+        staleCount: 0,
+    },
+    terminalFailures: {
+        count: 0,
+        oldestFailedAt: null,
+        retryExhaustedCount: 0,
+    },
+};
+
+function successfulDependencies(
+    run: () => Promise<OrderConfirmationEmailWorkerResult> = async () =>
+        successfulResult,
+) {
+    return {
+        health: async () => healthyOutbox,
+        now: () => observedAt,
+        run,
+    };
+}
+
+function request(authorization?: string) {
+    return new Request(
+        'https://api.gredice.com/api/internal/cron/order-confirmation-emails',
+        { headers: authorization ? { authorization } : undefined },
+    );
+}
+
+test('order confirmation email cron rejects missing configuration and invalid authorization', async (t) => {
+    const previousSecret = process.env.CRON_SECRET;
+    t.after(() => {
+        if (previousSecret === undefined) delete process.env.CRON_SECRET;
+        else process.env.CRON_SECRET = previousSecret;
+    });
+    let runs = 0;
+    const dependencies = {
+        run: async () => {
+            runs += 1;
+            return successfulResult;
+        },
+    };
+
+    delete process.env.CRON_SECRET;
+    const unconfigured = await handleOrderConfirmationEmailCron(
+        request('Bearer undefined'),
+        dependencies,
+    );
+    assert.equal(unconfigured.status, 401);
+    assert.equal(
+        unconfigured.headers.get('cache-control'),
+        'private, no-store',
+    );
+
+    process.env.CRON_SECRET = 'cron-secret';
+    const unauthorized = await handleOrderConfirmationEmailCron(
+        request('Bearer wrong'),
+        dependencies,
+    );
+    assert.equal(unauthorized.status, 401);
+    assert.equal(runs, 0);
+});
+
+test('order confirmation email cron returns bounded batch results', async (t) => {
+    const previousSecret = process.env.CRON_SECRET;
+    t.after(() => {
+        if (previousSecret === undefined) delete process.env.CRON_SECRET;
+        else process.env.CRON_SECRET = previousSecret;
+    });
+    process.env.CRON_SECRET = 'cron-secret';
+
+    const response = await handleOrderConfirmationEmailCron(
+        request('Bearer cron-secret'),
+        successfulDependencies(),
+    );
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+        success: true,
+        ...successfulResult,
+        outboxHealth: healthyOutbox,
+    });
+});
+
+test('order confirmation email cron surfaces retry, terminal, and fenced failures as unhealthy', async (t) => {
+    const previousSecret = process.env.CRON_SECRET;
+    t.after(() => {
+        if (previousSecret === undefined) delete process.env.CRON_SECRET;
+        else process.env.CRON_SECRET = previousSecret;
+    });
+    process.env.CRON_SECRET = 'cron-secret';
+
+    for (const unhealthyResult of [
+        { ...successfulResult, failed: 1, queuedForRetry: 1 },
+        { ...successfulResult, terminalFailures: 1 },
+        { ...successfulResult, uncertain: 1 },
+        { ...successfulResult, exhausted: 1 },
+        { ...successfulResult, invalid: 1 },
+    ]) {
+        const response = await handleOrderConfirmationEmailCron(
+            request('Bearer cron-secret'),
+            successfulDependencies(async () => unhealthyResult),
+        );
+        assert.equal(response.status, 503);
+        assert.equal((await response.json()).success, false);
+    }
+});
+
+test('order confirmation email cron stays unhealthy until stale fences and terminal failures are reconciled', async (t) => {
+    const previousSecret = process.env.CRON_SECRET;
+    t.after(() => {
+        if (previousSecret === undefined) delete process.env.CRON_SECRET;
+        else process.env.CRON_SECRET = previousSecret;
+    });
+    process.env.CRON_SECRET = 'cron-secret';
+
+    for (const unhealthyHealth of [
+        {
+            ...healthyOutbox,
+            staleSubmissionStarted: {
+                count: 1,
+                oldestStartedAt: '2026-08-03T09:00:00.000Z',
+            },
+        },
+        {
+            ...healthyOutbox,
+            submissionUncertain: {
+                count: 1,
+                oldestStaleUncertainAt: null,
+                oldestUncertainAt: '2026-08-03T09:14:00.000Z',
+                staleCount: 0,
+            },
+        },
+        {
+            ...healthyOutbox,
+            terminalFailures: {
+                count: 1,
+                oldestFailedAt: '2026-08-03T09:14:00.000Z',
+                retryExhaustedCount: 0,
+            },
+        },
+        {
+            ...healthyOutbox,
+            pendingQueued: {
+                count: 1,
+                dueCount: 1,
+                oldestDueAt: '2026-08-03T09:00:00.000Z',
+                oldestQueuedAt: '2026-08-03T09:00:00.000Z',
+            },
+        },
+    ]) {
+        const response = await handleOrderConfirmationEmailCron(
+            request('Bearer cron-secret'),
+            {
+                ...successfulDependencies(),
+                health: async () => unhealthyHealth,
+            },
+        );
+        assert.equal(response.status, 503);
+        assert.equal((await response.json()).success, false);
+    }
+});
+
+test('order confirmation email cron keeps internal failures private', async (t) => {
+    const previousSecret = process.env.CRON_SECRET;
+    t.after(() => {
+        if (previousSecret === undefined) delete process.env.CRON_SECRET;
+        else process.env.CRON_SECRET = previousSecret;
+    });
+    process.env.CRON_SECRET = 'cron-secret';
+    const privateSentinel = 'PRIVATE_ORDER_CONFIRMATION_CRON_SENTINEL';
+    const logged: unknown[] = [];
+    t.mock.method(console, 'error', (...args: unknown[]) => logged.push(args));
+
+    const response = await handleOrderConfirmationEmailCron(
+        request('Bearer cron-secret'),
+        {
+            run: async () => {
+                throw new Error(privateSentinel);
+            },
+        },
+    );
+    assert.equal(response.status, 500);
+    assert.deepEqual(await response.json(), { success: false });
+    assert.equal(JSON.stringify(logged).includes(privateSentinel), false);
+});

--- a/apps/api/lib/checkout/orderConfirmationEmailCron.ts
+++ b/apps/api/lib/checkout/orderConfirmationEmailCron.ts
@@ -1,0 +1,115 @@
+import {
+    getOrderConfirmationOutboxHealthSnapshot,
+    type OrderConfirmationOutboxHealthSnapshot,
+} from '@gredice/storage';
+import {
+    type OrderConfirmationEmailWorkerResult,
+    runOrderConfirmationEmailWorker,
+} from './orderConfirmationEmailWorker';
+
+const noStoreHeaders = { 'Cache-Control': 'private, no-store' };
+const staleOutboxThresholdMilliseconds = 10 * 60 * 1000;
+
+type OrderConfirmationEmailCronDependencies = {
+    health: typeof getOrderConfirmationOutboxHealthSnapshot;
+    now: () => Date;
+    run: () => Promise<OrderConfirmationEmailWorkerResult>;
+};
+
+const defaultDependencies: OrderConfirmationEmailCronDependencies = {
+    health: getOrderConfirmationOutboxHealthSnapshot,
+    now: () => new Date(),
+    run: runOrderConfirmationEmailWorker,
+};
+
+function workerRunIsHealthy(result: OrderConfirmationEmailWorkerResult) {
+    return (
+        result.claimFailures === 0 &&
+        result.exhausted === 0 &&
+        result.failed === 0 &&
+        result.finalizationFailures === 0 &&
+        result.invalid === 0 &&
+        result.reconciliation.claimFailures === 0 &&
+        result.reconciliation.finalizationFailures === 0 &&
+        result.reconciliation.lookupFailures === 0 &&
+        result.reconciliation.terminalFailures === 0 &&
+        result.terminalFailures === 0 &&
+        result.uncertain === 0
+    );
+}
+
+function outboxHealthIsHealthy(health: OrderConfirmationOutboxHealthSnapshot) {
+    const oldestDueIsStale =
+        health.pendingQueued.oldestDueAt !== null &&
+        health.pendingQueued.oldestDueAt <= health.staleBefore;
+    return (
+        !oldestDueIsStale &&
+        health.preSubmissionClaims.expiredCount === 0 &&
+        health.fencedSubmissions.count === 0 &&
+        health.reconciliation.expiredClaimCount === 0 &&
+        health.staleSubmissionStarted.count === 0 &&
+        health.submissionUncertain.count === 0 &&
+        health.terminalFailures.count === 0
+    );
+}
+
+function boundedErrorContext(error: unknown) {
+    const errorName =
+        error instanceof Error ? error.name.slice(0, 64) : 'Unknown';
+    const errorCode =
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        typeof error.code === 'string' &&
+        /^[A-Za-z0-9._:-]{1,64}$/u.test(error.code)
+            ? error.code
+            : undefined;
+    return { errorCode, errorName };
+}
+
+export async function handleOrderConfirmationEmailCron(
+    request: Request,
+    dependencies: Partial<OrderConfirmationEmailCronDependencies> = {},
+) {
+    const resolved = { ...defaultDependencies, ...dependencies };
+    const cronSecret = process.env.CRON_SECRET?.trim();
+    if (
+        !cronSecret ||
+        request.headers.get('authorization') !== `Bearer ${cronSecret}`
+    ) {
+        return new Response('Unauthorized', {
+            headers: noStoreHeaders,
+            status: 401,
+        });
+    }
+
+    try {
+        const result = await resolved.run();
+        const observedAt = resolved.now();
+        const outboxHealth = await resolved.health({
+            now: observedAt,
+            staleBefore: new Date(
+                observedAt.getTime() - staleOutboxThresholdMilliseconds,
+            ),
+        });
+        console.info('order_confirmation_email.outbox.health', outboxHealth);
+        const success =
+            workerRunIsHealthy(result) && outboxHealthIsHealthy(outboxHealth);
+        return Response.json(
+            {
+                success,
+                ...result,
+                outboxHealth,
+            },
+            { headers: noStoreHeaders, status: success ? 200 : 503 },
+        );
+    } catch (error) {
+        console.error('Order confirmation email cron failed', {
+            ...boundedErrorContext(error),
+        });
+        return Response.json(
+            { success: false },
+            { headers: noStoreHeaders, status: 500 },
+        );
+    }
+}

--- a/apps/api/lib/checkout/orderConfirmationEmailWorker.node.spec.ts
+++ b/apps/api/lib/checkout/orderConfirmationEmailWorker.node.spec.ts
@@ -1,0 +1,461 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    EmailProviderSubmissionRejectedError,
+    EmailProviderSubmissionUncertainError,
+} from '@gredice/email/acs';
+import type { OrderConfirmationEmailClaimResult } from '@gredice/storage';
+import { runOrderConfirmationEmailWorker } from './orderConfirmationEmailWorker';
+
+const operationId = '018f0d12-2ec4-7fab-9d91-91f890ad5d73';
+const queuedAt = new Date('2026-08-03T09:00:00.000Z');
+const now = new Date('2026-08-03T09:02:00.000Z');
+
+type FailureCategories = {
+    configuration_error: number;
+    invalid_payload: number;
+    provider_rejected_retryable: number;
+    provider_rejected_terminal: number;
+    provider_submission_uncertain: number;
+    render_failed: number;
+    transport_before_submission: number;
+    worker_error_before_submission: number;
+};
+
+function failureCategories(
+    overrides: Partial<FailureCategories> = {},
+): FailureCategories {
+    return {
+        configuration_error: 0,
+        invalid_payload: 0,
+        provider_rejected_retryable: 0,
+        provider_rejected_terminal: 0,
+        provider_submission_uncertain: 0,
+        render_failed: 0,
+        transport_before_submission: 0,
+        worker_error_before_submission: 0,
+        ...overrides,
+    };
+}
+
+function claim(): OrderConfirmationEmailClaimResult {
+    return {
+        claim: {
+            attempt: 1,
+            claimId: 'claim-1',
+            emailMessageId: 42,
+            maxAttempts: 3,
+            operationId,
+            payload: {
+                cartId: 91,
+                currency: null,
+                items: [
+                    {
+                        amountSubtotal: 12,
+                        currency: 'sunflower',
+                        name: 'Bosiljak',
+                        quantity: 1,
+                    },
+                ],
+                manageUrl: 'https://vrt.gredice.com',
+                to: 'customer@example.com',
+                totalAmountCents: null,
+            },
+            queuedAt,
+        },
+        status: 'claimed',
+    };
+}
+
+test('order confirmation worker starts, sends, and finalizes one claimed intent', async (t) => {
+    const logged: unknown[] = [];
+    t.mock.method(console, 'info', (...args: unknown[]) => logged.push(args));
+    const calls: string[] = [];
+    let claimCount = 0;
+
+    const result = await runOrderConfirmationEmailWorker({
+        reconciliationLimit: 0,
+        dependencies: {
+            abortSignal: (timeoutMilliseconds) => {
+                assert.equal(timeoutMilliseconds, 45_000);
+                return new AbortController().signal;
+            },
+            claim: async () => {
+                claimCount += 1;
+                return claimCount === 1 ? claim() : { status: 'empty' };
+            },
+            markSent: async () => {
+                calls.push('finalize');
+                return { status: 'sent' };
+            },
+            monotonicNow: () => 0,
+            now: () => now,
+            randomId: () => 'claim-1',
+            send: async (_to, _config, options) => {
+                if (!options) throw new Error('Expected send options.');
+                calls.push('render');
+                await options.beforeProviderSubmission?.();
+                calls.push('send');
+                return {
+                    id: operationId,
+                    status: 'Succeeded',
+                };
+            },
+            start: async () => {
+                calls.push('start');
+                return { operationId, status: 'started' };
+            },
+        },
+    });
+
+    assert.deepEqual(calls, ['render', 'start', 'send', 'finalize']);
+    assert.deepEqual(result, {
+        claimFailures: 0,
+        claimed: 1,
+        durationMs: 0,
+        exhausted: 0,
+        failed: 0,
+        failureCategories: failureCategories(),
+        finalizationFailures: 0,
+        invalid: 0,
+        oldestQueueAgeMs: 120_000,
+        queuedForRetry: 0,
+        reconciliation: {
+            claimFailures: 0,
+            claimed: 0,
+            finalizationFailures: 0,
+            lookupFailures: 0,
+            pending: 0,
+            sent: 0,
+            terminalFailures: 0,
+        },
+        sent: 1,
+        stoppedForTimeBudget: false,
+        terminalFailures: 0,
+        uncertain: 0,
+    });
+    assert.deepEqual(logged, [
+        ['order_confirmation_email.worker.complete', result],
+    ]);
+});
+
+test('order confirmation worker fences a provider success when sent finalization throws', async (t) => {
+    t.mock.method(console, 'info', () => undefined);
+    t.mock.method(console, 'error', () => undefined);
+    const calls: string[] = [];
+    let claimCount = 0;
+    let markFailedCalled = false;
+
+    const result = await runOrderConfirmationEmailWorker({
+        reconciliationLimit: 0,
+        dependencies: {
+            claim: async () => {
+                claimCount += 1;
+                return claimCount === 1 ? claim() : { status: 'empty' };
+            },
+            markFailed: async () => {
+                markFailedCalled = true;
+                return {
+                    attempt: 1,
+                    nextAttemptAt: new Date(now.getTime() + 60_000),
+                    status: 'retry_scheduled',
+                };
+            },
+            markSent: async () => {
+                calls.push('finalize');
+                throw new Error('database unavailable');
+            },
+            monotonicNow: () => 0,
+            now: () => now,
+            send: async (_to, _config, options) => {
+                if (!options) throw new Error('Expected send options.');
+                await options.beforeProviderSubmission?.();
+                calls.push('send');
+                return {
+                    id: operationId,
+                    status: 'Succeeded',
+                };
+            },
+            start: async () => {
+                calls.push('start');
+                return { operationId, status: 'started' };
+            },
+        },
+    });
+
+    assert.deepEqual(calls, ['start', 'send', 'finalize']);
+    assert.equal(markFailedCalled, false);
+    assert.equal(result.failed, 0);
+    assert.equal(result.finalizationFailures, 1);
+    assert.equal(result.queuedForRetry, 0);
+    assert.equal(result.sent, 0);
+});
+
+test('order confirmation worker retries a proven provider rejection', async (t) => {
+    t.mock.method(console, 'info', () => undefined);
+    let failure:
+        | {
+              failureCode: string;
+              failureKind: string;
+          }
+        | undefined;
+    let claimCount = 0;
+
+    const result = await runOrderConfirmationEmailWorker({
+        reconciliationLimit: 0,
+        dependencies: {
+            claim: async () => {
+                claimCount += 1;
+                return claimCount === 1 ? claim() : { status: 'empty' };
+            },
+            markFailed: async (input) => {
+                failure = input;
+                return {
+                    attempt: 1,
+                    nextAttemptAt: new Date(now.getTime() + 60_000),
+                    status: 'retry_scheduled',
+                };
+            },
+            now: () => now,
+            send: async (_to, _config, options) => {
+                if (!options) throw new Error('Expected send options.');
+                await options.beforeProviderSubmission?.();
+                throw new EmailProviderSubmissionRejectedError(429);
+            },
+            start: async () => ({ operationId, status: 'started' }),
+        },
+    });
+
+    assert.equal(result.queuedForRetry, 1);
+    assert.deepEqual(
+        result.failureCategories,
+        failureCategories({ provider_rejected_retryable: 1 }),
+    );
+    assert.deepEqual(failure, {
+        claimId: 'claim-1',
+        emailMessageId: 42,
+        failureCode: 'provider_rejected_retryable',
+        failureKind: 'definite',
+        now,
+    });
+});
+
+test('order confirmation worker fences an uncertain provider submission', async (t) => {
+    t.mock.method(console, 'info', () => undefined);
+    const privateSentinel = 'PRIVATE_PROVIDER_SENTINEL';
+    let claimCount = 0;
+
+    const result = await runOrderConfirmationEmailWorker({
+        reconciliationLimit: 0,
+        dependencies: {
+            claim: async () => {
+                claimCount += 1;
+                return claimCount === 1 ? claim() : { status: 'empty' };
+            },
+            markFailed: async ({ failureCode, failureKind }) => {
+                assert.equal(failureCode, 'provider_submission_uncertain');
+                assert.equal(failureKind, 'uncertain');
+                return { status: 'fenced' };
+            },
+            now: () => now,
+            send: async (_to, _config, options) => {
+                if (!options) throw new Error('Expected send options.');
+                await options.beforeProviderSubmission?.();
+                throw new EmailProviderSubmissionUncertainError(
+                    operationId,
+                    new Error(privateSentinel),
+                );
+            },
+            start: async () => ({ operationId, status: 'started' }),
+        },
+    });
+
+    assert.equal(result.uncertain, 1);
+    assert.deepEqual(
+        result.failureCategories,
+        failureCategories({ provider_submission_uncertain: 1 }),
+    );
+    assert.equal(JSON.stringify(result).includes(privateSentinel), false);
+});
+
+test('order confirmation worker safely retries missing provider configuration', async (t) => {
+    t.mock.method(console, 'info', () => undefined);
+    const previousConnectionString = process.env.ACS_CONNECTION_STRING;
+    t.after(() => {
+        if (previousConnectionString === undefined) {
+            delete process.env.ACS_CONNECTION_STRING;
+        } else {
+            process.env.ACS_CONNECTION_STRING = previousConnectionString;
+        }
+    });
+    delete process.env.ACS_CONNECTION_STRING;
+    let claimCount = 0;
+    let failureCode: string | undefined;
+
+    const result = await runOrderConfirmationEmailWorker({
+        reconciliationLimit: 0,
+        dependencies: {
+            claim: async () => {
+                claimCount += 1;
+                return claimCount === 1 ? claim() : { status: 'empty' };
+            },
+            markFailed: async (input) => {
+                failureCode = input.failureCode;
+                return {
+                    attempt: 1,
+                    nextAttemptAt: new Date(now.getTime() + 60_000),
+                    status: 'retry_scheduled',
+                };
+            },
+            now: () => now,
+            send: async () => {
+                throw new Error('ACS_CONNECTION_STRING is not set');
+            },
+        },
+    });
+
+    assert.equal(failureCode, 'configuration_error');
+    assert.equal(result.queuedForRetry, 1);
+    assert.deepEqual(
+        result.failureCategories,
+        failureCategories({ configuration_error: 1 }),
+    );
+});
+
+test('order confirmation worker bounds claim failures without leaking errors', async (t) => {
+    const privateSentinel = 'PRIVATE_CLAIM_SENTINEL';
+    const logged: unknown[] = [];
+    t.mock.method(console, 'error', (...args: unknown[]) => logged.push(args));
+    t.mock.method(console, 'info', () => undefined);
+
+    const result = await runOrderConfirmationEmailWorker({
+        reconciliationLimit: 0,
+        dependencies: {
+            claim: async () => {
+                throw new Error(privateSentinel);
+            },
+        },
+    });
+
+    assert.equal(result.claimFailures, 1);
+    assert.equal(JSON.stringify(logged).includes(privateSentinel), false);
+});
+
+test('order confirmation worker stops before claiming work without a safe provider budget', async (t) => {
+    t.mock.method(console, 'info', () => undefined);
+    let monotonicReads = 0;
+    let claims = 0;
+
+    const result = await runOrderConfirmationEmailWorker({
+        reconciliationLimit: 0,
+        dependencies: {
+            claim: async () => {
+                claims += 1;
+                return { status: 'empty' };
+            },
+            monotonicNow: () => {
+                monotonicReads += 1;
+                return monotonicReads === 1 ? 0 : 50_000;
+            },
+        },
+    });
+
+    assert.equal(claims, 0);
+    assert.equal(result.stoppedForTimeBudget, true);
+    assert.equal(result.durationMs, 50_000);
+});
+
+test('order confirmation worker reconciles a fenced provider operation with status GET only', async (t) => {
+    t.mock.method(console, 'info', () => undefined);
+    let reconciliationClaims = 0;
+    let freshClaims = 0;
+    let finalizedOutcome: unknown;
+
+    const result = await runOrderConfirmationEmailWorker({
+        dependencies: {
+            claim: async () => {
+                freshClaims += 1;
+                return { status: 'empty' };
+            },
+            claimReconciliation: async () => {
+                reconciliationClaims += 1;
+                return reconciliationClaims === 1
+                    ? {
+                          claim: {
+                              attempt: 1,
+                              claimId: 'reconciliation-claim',
+                              emailMessageId: 42,
+                              operationId,
+                          },
+                          status: 'claimed',
+                      }
+                    : { status: 'empty' };
+            },
+            finalizeReconciliation: async (input) => {
+                finalizedOutcome = input.outcome;
+                return { status: 'sent' };
+            },
+            getOperationStatus: async () => 'Succeeded',
+            now: () => now,
+            randomId: () => 'reconciliation-claim',
+        },
+        reconciliationLimit: 2,
+    });
+
+    assert.equal(freshClaims, 1);
+    assert.deepEqual(finalizedOutcome, {
+        kind: 'provider_status',
+        status: 'Succeeded',
+    });
+    assert.equal(result.reconciliation.claimed, 1);
+    assert.equal(result.reconciliation.sent, 1);
+    assert.equal(result.reconciliation.lookupFailures, 0);
+});
+
+test('order confirmation worker keeps unavailable provider status fenced without private errors', async (t) => {
+    t.mock.method(console, 'info', () => undefined);
+    const privateSentinel = 'PRIVATE_RECONCILIATION_LOOKUP_SENTINEL';
+    const logged: unknown[] = [];
+    t.mock.method(console, 'error', (...args: unknown[]) => logged.push(args));
+    let reconciliationClaims = 0;
+    let finalizedOutcome: unknown;
+
+    const result = await runOrderConfirmationEmailWorker({
+        dependencies: {
+            claim: async () => ({ status: 'empty' }),
+            claimReconciliation: async () => {
+                reconciliationClaims += 1;
+                return reconciliationClaims === 1
+                    ? {
+                          claim: {
+                              attempt: 2,
+                              claimId: 'reconciliation-claim',
+                              emailMessageId: 42,
+                              operationId,
+                          },
+                          status: 'claimed',
+                      }
+                    : { status: 'empty' };
+            },
+            finalizeReconciliation: async (input) => {
+                finalizedOutcome = input.outcome;
+                return {
+                    attempt: 2,
+                    nextCheckAt: new Date(now.getTime() + 60_000),
+                    status: 'pending',
+                };
+            },
+            getOperationStatus: async () => {
+                throw new Error(privateSentinel);
+            },
+            now: () => now,
+            randomId: () => 'reconciliation-claim',
+        },
+        reconciliationLimit: 2,
+    });
+
+    assert.deepEqual(finalizedOutcome, { kind: 'lookup_unavailable' });
+    assert.equal(result.reconciliation.lookupFailures, 1);
+    assert.equal(result.reconciliation.pending, 1);
+    assert.equal(JSON.stringify(logged).includes(privateSentinel), false);
+});

--- a/apps/api/lib/checkout/orderConfirmationEmailWorker.node.spec.ts
+++ b/apps/api/lib/checkout/orderConfirmationEmailWorker.node.spec.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
     EmailProviderSubmissionRejectedError,
     EmailProviderSubmissionUncertainError,
+    EmailProviderTerminalFailureError,
 } from '@gredice/email/acs';
 import type { OrderConfirmationEmailClaimResult } from '@gredice/storage';
 import { runOrderConfirmationEmailWorker } from './orderConfirmationEmailWorker';
@@ -235,6 +236,52 @@ test('order confirmation worker retries a proven provider rejection', async (t) 
         claimId: 'claim-1',
         emailMessageId: 42,
         failureCode: 'provider_rejected_retryable',
+        failureKind: 'definite',
+        now,
+    });
+});
+
+test('order confirmation worker records a terminal provider result without retrying', async (t) => {
+    t.mock.method(console, 'info', () => undefined);
+    let claimCount = 0;
+    let failure:
+        | {
+              failureCode: string;
+              failureKind: string;
+          }
+        | undefined;
+
+    const result = await runOrderConfirmationEmailWorker({
+        reconciliationLimit: 0,
+        dependencies: {
+            claim: async () => {
+                claimCount += 1;
+                return claimCount === 1 ? claim() : { status: 'empty' };
+            },
+            markFailed: async (input) => {
+                failure = input;
+                return { attempt: 1, status: 'failed' };
+            },
+            now: () => now,
+            send: async (_to, _config, options) => {
+                if (!options) throw new Error('Expected send options.');
+                await options.beforeProviderSubmission?.();
+                throw new EmailProviderTerminalFailureError('Failed');
+            },
+            start: async () => ({ operationId, status: 'started' }),
+        },
+    });
+
+    assert.equal(result.queuedForRetry, 0);
+    assert.equal(result.terminalFailures, 1);
+    assert.deepEqual(
+        result.failureCategories,
+        failureCategories({ provider_rejected_terminal: 1 }),
+    );
+    assert.deepEqual(failure, {
+        claimId: 'claim-1',
+        emailMessageId: 42,
+        failureCode: 'provider_rejected_terminal',
         failureKind: 'definite',
         now,
     });

--- a/apps/api/lib/checkout/orderConfirmationEmailWorker.ts
+++ b/apps/api/lib/checkout/orderConfirmationEmailWorker.ts
@@ -1,0 +1,488 @@
+import { randomUUID } from 'node:crypto';
+import {
+    isEmailProviderSubmissionRejectedError,
+    isEmailProviderSubmissionUncertainError,
+} from '@gredice/email/acs';
+import {
+    getAcsEmailOperationStatus,
+    isAcsEmailOperationStatusParseError,
+} from '@gredice/email/acs-operation-status';
+import {
+    claimOrderConfirmationEmail,
+    claimOrderConfirmationEmailReconciliation,
+    finalizeOrderConfirmationEmailReconciliation,
+    markOrderConfirmationEmailFailed,
+    markOrderConfirmationEmailSent,
+    type OrderConfirmationEmailDefiniteFailureCode,
+    startOrderConfirmationEmailSubmission,
+} from '@gredice/storage';
+import { sendOrderConfirmation } from '../email/transactional';
+
+const defaultBatchLimit = 20;
+const maximumBatchLimit = 100;
+const defaultReconciliationLimit = 3;
+const maximumReconciliationLimit = 20;
+const maximumReconciliationLookupMilliseconds = 5_000;
+const claimLeaseMilliseconds = 5 * 60 * 1000;
+const reconciliationStaleMilliseconds = claimLeaseMilliseconds;
+const defaultMaximumRunMilliseconds = 50_000;
+const maximumRunMilliseconds = 55_000;
+const minimumProviderStartBudgetMilliseconds = 10_000;
+const finalizationReserveMilliseconds = 5_000;
+
+class OrderConfirmationEmailClaimUnavailableError extends Error {
+    readonly code = 'order_confirmation_email_claim_unavailable';
+
+    constructor() {
+        super('Order confirmation email claim is no longer available.');
+        this.name = 'OrderConfirmationEmailClaimUnavailableError';
+    }
+}
+
+type OrderConfirmationEmailWorkerDependencies = {
+    abortSignal: (timeoutMilliseconds: number) => AbortSignal;
+    claim: typeof claimOrderConfirmationEmail;
+    claimReconciliation: typeof claimOrderConfirmationEmailReconciliation;
+    finalizeReconciliation: typeof finalizeOrderConfirmationEmailReconciliation;
+    getOperationStatus: typeof getAcsEmailOperationStatus;
+    markFailed: typeof markOrderConfirmationEmailFailed;
+    markSent: typeof markOrderConfirmationEmailSent;
+    monotonicNow: () => number;
+    now: () => Date;
+    randomId: () => string;
+    send: typeof sendOrderConfirmation;
+    start: typeof startOrderConfirmationEmailSubmission;
+};
+
+const defaultDependencies: OrderConfirmationEmailWorkerDependencies = {
+    abortSignal: (timeoutMilliseconds) =>
+        AbortSignal.timeout(timeoutMilliseconds),
+    claim: claimOrderConfirmationEmail,
+    claimReconciliation: claimOrderConfirmationEmailReconciliation,
+    finalizeReconciliation: finalizeOrderConfirmationEmailReconciliation,
+    getOperationStatus: getAcsEmailOperationStatus,
+    markFailed: markOrderConfirmationEmailFailed,
+    markSent: markOrderConfirmationEmailSent,
+    monotonicNow: () => performance.now(),
+    now: () => new Date(),
+    randomId: randomUUID,
+    send: sendOrderConfirmation,
+    start: startOrderConfirmationEmailSubmission,
+};
+
+export type OrderConfirmationEmailWorkerResult = {
+    claimFailures: number;
+    claimed: number;
+    exhausted: number;
+    failed: number;
+    finalizationFailures: number;
+    durationMs: number;
+    failureCategories: Record<
+        | OrderConfirmationEmailDefiniteFailureCode
+        | 'provider_submission_uncertain',
+        number
+    >;
+    invalid: number;
+    oldestQueueAgeMs: number | null;
+    queuedForRetry: number;
+    reconciliation: {
+        claimFailures: number;
+        claimed: number;
+        finalizationFailures: number;
+        lookupFailures: number;
+        pending: number;
+        sent: number;
+        terminalFailures: number;
+    };
+    sent: number;
+    stoppedForTimeBudget: boolean;
+    terminalFailures: number;
+    uncertain: number;
+};
+
+function emptyResult(): OrderConfirmationEmailWorkerResult {
+    return {
+        claimFailures: 0,
+        claimed: 0,
+        exhausted: 0,
+        failed: 0,
+        finalizationFailures: 0,
+        durationMs: 0,
+        failureCategories: {
+            configuration_error: 0,
+            invalid_payload: 0,
+            provider_rejected_retryable: 0,
+            provider_rejected_terminal: 0,
+            provider_submission_uncertain: 0,
+            render_failed: 0,
+            transport_before_submission: 0,
+            worker_error_before_submission: 0,
+        },
+        invalid: 0,
+        oldestQueueAgeMs: null,
+        queuedForRetry: 0,
+        reconciliation: {
+            claimFailures: 0,
+            claimed: 0,
+            finalizationFailures: 0,
+            lookupFailures: 0,
+            pending: 0,
+            sent: 0,
+            terminalFailures: 0,
+        },
+        sent: 0,
+        stoppedForTimeBudget: false,
+        terminalFailures: 0,
+        uncertain: 0,
+    };
+}
+
+function boundedBatchLimit(limit: number) {
+    if (!Number.isFinite(limit)) return defaultBatchLimit;
+    return Math.min(maximumBatchLimit, Math.max(1, Math.floor(limit)));
+}
+
+function boundedReconciliationLimit(limit: number) {
+    if (!Number.isFinite(limit)) return defaultReconciliationLimit;
+    return Math.min(maximumReconciliationLimit, Math.max(0, Math.floor(limit)));
+}
+
+function boundedMaximumRunMilliseconds(value: number) {
+    if (!Number.isFinite(value)) return defaultMaximumRunMilliseconds;
+    return Math.min(
+        maximumRunMilliseconds,
+        Math.max(minimumProviderStartBudgetMilliseconds, Math.floor(value)),
+    );
+}
+
+function retryCanBeProvenSafe(
+    failureCode: OrderConfirmationEmailDefiniteFailureCode,
+) {
+    return (
+        failureCode === 'configuration_error' ||
+        failureCode === 'provider_rejected_retryable' ||
+        failureCode === 'transport_before_submission' ||
+        failureCode === 'worker_error_before_submission'
+    );
+}
+
+function queueAgeMilliseconds(queuedAt: Date, now: Date) {
+    return Math.max(0, now.getTime() - queuedAt.getTime());
+}
+
+function boundedErrorContext(error: unknown) {
+    const errorName =
+        error instanceof Error ? error.name.slice(0, 64) : 'Unknown';
+    const errorCode =
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        typeof error.code === 'string' &&
+        /^[A-Za-z0-9._:-]{1,64}$/u.test(error.code)
+            ? error.code
+            : undefined;
+    return { errorCode, errorName };
+}
+
+export async function runOrderConfirmationEmailWorker({
+    dependencies = {},
+    limit = defaultBatchLimit,
+    maxRunMilliseconds = defaultMaximumRunMilliseconds,
+    reconciliationLimit = defaultReconciliationLimit,
+}: {
+    dependencies?: Partial<OrderConfirmationEmailWorkerDependencies>;
+    limit?: number;
+    maxRunMilliseconds?: number;
+    reconciliationLimit?: number;
+} = {}): Promise<OrderConfirmationEmailWorkerResult> {
+    const resolved = { ...defaultDependencies, ...dependencies };
+    const result = emptyResult();
+    const startedAt = resolved.monotonicNow();
+    const runBudget = boundedMaximumRunMilliseconds(maxRunMilliseconds);
+    const remainingRunMilliseconds = () =>
+        Math.max(0, runBudget - (resolved.monotonicNow() - startedAt));
+
+    for (
+        let index = 0;
+        index < boundedReconciliationLimit(reconciliationLimit);
+        index += 1
+    ) {
+        if (
+            remainingRunMilliseconds() < minimumProviderStartBudgetMilliseconds
+        ) {
+            result.stoppedForTimeBudget = true;
+            break;
+        }
+        const now = resolved.now();
+        let claimed: Awaited<
+            ReturnType<typeof claimOrderConfirmationEmailReconciliation>
+        >;
+        try {
+            claimed = await resolved.claimReconciliation({
+                claimExpiresAt: new Date(
+                    now.getTime() + claimLeaseMilliseconds,
+                ),
+                claimId: resolved.randomId(),
+                now,
+                staleBefore: new Date(
+                    now.getTime() - reconciliationStaleMilliseconds,
+                ),
+            });
+        } catch (error) {
+            result.reconciliation.claimFailures += 1;
+            console.error('Order confirmation reconciliation claim failed', {
+                ...boundedErrorContext(error),
+            });
+            break;
+        }
+
+        if (claimed.status === 'empty') break;
+        result.reconciliation.claimed += 1;
+        let outcome:
+            | {
+                  kind: 'provider_status';
+                  status:
+                      | 'Canceled'
+                      | 'Failed'
+                      | 'NotStarted'
+                      | 'Running'
+                      | 'Succeeded';
+              }
+            | { kind: 'lookup_unavailable' | 'unknown_status' };
+        try {
+            const providerTimeoutMilliseconds = Math.max(
+                1,
+                Math.min(
+                    maximumReconciliationLookupMilliseconds,
+                    Math.floor(
+                        remainingRunMilliseconds() -
+                            finalizationReserveMilliseconds,
+                    ),
+                ),
+            );
+            outcome = {
+                kind: 'provider_status',
+                status: await resolved.getOperationStatus(
+                    claimed.claim.operationId,
+                    {
+                        abortSignal: resolved.abortSignal(
+                            providerTimeoutMilliseconds,
+                        ),
+                    },
+                ),
+            };
+        } catch (error) {
+            result.reconciliation.lookupFailures += 1;
+            outcome = {
+                kind: isAcsEmailOperationStatusParseError(error)
+                    ? 'unknown_status'
+                    : 'lookup_unavailable',
+            };
+            console.error('Order confirmation reconciliation lookup failed', {
+                ...boundedErrorContext(error),
+            });
+        }
+
+        try {
+            const finalized = await resolved.finalizeReconciliation({
+                claimId: claimed.claim.claimId,
+                emailMessageId: claimed.claim.emailMessageId,
+                now: resolved.now(),
+                outcome,
+            });
+            if (
+                finalized.status === 'sent' ||
+                finalized.status === 'already_sent'
+            ) {
+                result.reconciliation.sent += 1;
+            } else if (
+                finalized.status === 'failed' ||
+                finalized.status === 'already_failed'
+            ) {
+                result.reconciliation.terminalFailures += 1;
+            } else if (finalized.status === 'pending') {
+                result.reconciliation.pending += 1;
+            } else {
+                result.reconciliation.finalizationFailures += 1;
+            }
+        } catch (error) {
+            result.reconciliation.finalizationFailures += 1;
+            console.error(
+                'Order confirmation reconciliation finalization failed',
+                { ...boundedErrorContext(error) },
+            );
+        }
+    }
+
+    for (let index = 0; index < boundedBatchLimit(limit); index += 1) {
+        if (
+            remainingRunMilliseconds() < minimumProviderStartBudgetMilliseconds
+        ) {
+            result.stoppedForTimeBudget = true;
+            break;
+        }
+        const now = resolved.now();
+        let claimed: Awaited<ReturnType<typeof claimOrderConfirmationEmail>>;
+        try {
+            claimed = await resolved.claim({
+                claimExpiresAt: new Date(
+                    now.getTime() + claimLeaseMilliseconds,
+                ),
+                claimId: resolved.randomId(),
+                now,
+            });
+        } catch (error) {
+            result.claimFailures += 1;
+            console.error('Order confirmation email claim failed', {
+                ...boundedErrorContext(error),
+            });
+            break;
+        }
+
+        if (claimed.status === 'empty') break;
+        if (claimed.status === 'attempts_exhausted') {
+            result.exhausted += 1;
+            continue;
+        }
+        if (claimed.status === 'invalid') {
+            result.invalid += 1;
+            result.failureCategories.invalid_payload += 1;
+            continue;
+        }
+        if (claimed.status !== 'claimed') continue;
+        result.claimed += 1;
+        result.oldestQueueAgeMs = Math.max(
+            result.oldestQueueAgeMs ?? 0,
+            queueAgeMilliseconds(claimed.claim.queuedAt, now),
+        );
+
+        let providerResponse: Awaited<ReturnType<typeof resolved.send>>;
+        try {
+            const providerTimeoutMilliseconds = Math.max(
+                1,
+                Math.floor(
+                    remainingRunMilliseconds() -
+                        finalizationReserveMilliseconds,
+                ),
+            );
+            providerResponse = await resolved.send(
+                claimed.claim.payload.to,
+                {
+                    currency: claimed.claim.payload.currency,
+                    email: claimed.claim.payload.to,
+                    items: claimed.claim.payload.items,
+                    manageUrl: claimed.claim.payload.manageUrl,
+                    orderReference: `Narudžba #${claimed.claim.payload.cartId}`,
+                    totalAmountCents: claimed.claim.payload.totalAmountCents,
+                },
+                {
+                    abortSignal: resolved.abortSignal(
+                        providerTimeoutMilliseconds,
+                    ),
+                    beforeProviderSubmission: async () => {
+                        const start = await resolved.start({
+                            claimId: claimed.claim.claimId,
+                            emailMessageId: claimed.claim.emailMessageId,
+                            now: resolved.now(),
+                        });
+                        if (start.status !== 'started') {
+                            throw new OrderConfirmationEmailClaimUnavailableError();
+                        }
+                    },
+                    existingEmailLogId: claimed.claim.emailMessageId,
+                    providerOperationId: claimed.claim.operationId,
+                },
+            );
+        } catch (error) {
+            result.failed += 1;
+            if (error instanceof OrderConfirmationEmailClaimUnavailableError) {
+                result.finalizationFailures += 1;
+                continue;
+            }
+
+            const uncertain = isEmailProviderSubmissionUncertainError(error);
+            let failureCode: OrderConfirmationEmailDefiniteFailureCode =
+                'worker_error_before_submission';
+            if (isEmailProviderSubmissionRejectedError(error)) {
+                failureCode = error.retryable
+                    ? 'provider_rejected_retryable'
+                    : 'provider_rejected_terminal';
+            } else if (!process.env.ACS_CONNECTION_STRING?.trim()) {
+                failureCode = 'configuration_error';
+            }
+            result.failureCategories[
+                uncertain ? 'provider_submission_uncertain' : failureCode
+            ] += 1;
+
+            try {
+                const finalized = uncertain
+                    ? await resolved.markFailed({
+                          claimId: claimed.claim.claimId,
+                          emailMessageId: claimed.claim.emailMessageId,
+                          failureCode: 'provider_submission_uncertain',
+                          failureKind: 'uncertain',
+                          now: resolved.now(),
+                      })
+                    : await resolved.markFailed({
+                          claimId: claimed.claim.claimId,
+                          emailMessageId: claimed.claim.emailMessageId,
+                          failureCode,
+                          failureKind: 'definite',
+                          now: resolved.now(),
+                      });
+                if (finalized.status === 'retry_scheduled') {
+                    result.queuedForRetry += 1;
+                } else if (finalized.status === 'fenced') {
+                    result.uncertain += 1;
+                } else if (finalized.status === 'failed') {
+                    if (
+                        retryCanBeProvenSafe(failureCode) &&
+                        claimed.claim.attempt >= claimed.claim.maxAttempts
+                    ) {
+                        result.exhausted += 1;
+                    } else {
+                        result.terminalFailures += 1;
+                    }
+                } else {
+                    result.finalizationFailures += 1;
+                }
+            } catch (finalizationError) {
+                result.finalizationFailures += 1;
+                console.error('Order confirmation email finalization failed', {
+                    ...boundedErrorContext(finalizationError),
+                });
+            }
+            continue;
+        }
+
+        try {
+            const finalized = await resolved.markSent({
+                claimId: claimed.claim.claimId,
+                emailMessageId: claimed.claim.emailMessageId,
+                now: resolved.now(),
+                providerMessageId: providerResponse.id ?? null,
+                providerStatus: providerResponse.status ?? null,
+            });
+            if (
+                finalized.status !== 'sent' &&
+                finalized.status !== 'already_sent'
+            ) {
+                result.finalizationFailures += 1;
+                continue;
+            }
+            result.sent += 1;
+        } catch (finalizationError) {
+            result.finalizationFailures += 1;
+            console.error('Order confirmation email finalization failed', {
+                ...boundedErrorContext(finalizationError),
+            });
+        }
+    }
+
+    result.durationMs = Math.max(
+        0,
+        Math.round(resolved.monotonicNow() - startedAt),
+    );
+    console.info('order_confirmation_email.worker.complete', result);
+    return result;
+}

--- a/apps/api/lib/checkout/orderConfirmationEmailWorker.ts
+++ b/apps/api/lib/checkout/orderConfirmationEmailWorker.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import {
     isEmailProviderSubmissionRejectedError,
     isEmailProviderSubmissionUncertainError,
+    isEmailProviderTerminalFailureError,
 } from '@gredice/email/acs';
 import {
     getAcsEmailOperationStatus,
@@ -403,7 +404,9 @@ export async function runOrderConfirmationEmailWorker({
             const uncertain = isEmailProviderSubmissionUncertainError(error);
             let failureCode: OrderConfirmationEmailDefiniteFailureCode =
                 'worker_error_before_submission';
-            if (isEmailProviderSubmissionRejectedError(error)) {
+            if (isEmailProviderTerminalFailureError(error)) {
+                failureCode = 'provider_rejected_terminal';
+            } else if (isEmailProviderSubmissionRejectedError(error)) {
                 failureCode = error.retryable
                     ? 'provider_rejected_retryable'
                     : 'provider_rejected_terminal';

--- a/apps/api/lib/email/transactional.ts
+++ b/apps/api/lib/email/transactional.ts
@@ -85,6 +85,12 @@ export async function sendWelcome(
 export async function sendOrderConfirmation(
     to: string,
     config: OrderConfirmationEmailTemplateProps,
+    options: {
+        abortSignal?: AbortSignal;
+        beforeProviderSubmission?: () => Promise<void>;
+        existingEmailLogId?: number;
+        providerOperationId?: string;
+    } = {},
 ) {
     return await sendEmail({
         from: 'suncokret@obavijesti.gredice.com',
@@ -96,6 +102,10 @@ export async function sendOrderConfirmation(
         metadata: {
             orderReference: config.orderReference ?? null,
         },
+        abortSignal: options.abortSignal,
+        beforeProviderSubmission: options.beforeProviderSubmission,
+        existingEmailLogId: options.existingEmailLogId,
+        operationId: options.providerOperationId,
     });
 }
 

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -31,6 +31,10 @@
             "schedule": "* * * * *"
         },
         {
+            "path": "/api/internal/cron/order-confirmation-emails",
+            "schedule": "* * * * *"
+        },
+        {
             "path": "/api/internal/cron/delivery-notification-health",
             "schedule": "*/5 * * * *"
         },

--- a/docs/checkout-order-confirmation-outbox.md
+++ b/docs/checkout-order-confirmation-outbox.md
@@ -1,0 +1,75 @@
+# Checkout order-confirmation outbox
+
+Direct non-Stripe checkout records an order-confirmation intent in the existing
+`email_messages` table when the cart makes its authoritative `new` to `paid`
+transition. The checkout response waits for that transaction, but it does not
+render the email, call the provider, or poll provider delivery.
+
+The API cron at `/api/internal/cron/order-confirmation-emails` runs every minute
+and requires `CRON_SECRET`. Workers claim a bounded batch with database row
+locking. A durable claim can be retried after its lease expires. Once a worker
+crosses the provider-submission fence, an ambiguous result remains in `sending`
+and is not automatically submitted again; ACS operation IDs are identifiers,
+not a repeatability guarantee.
+
+The route has a 60-second function limit. The worker stops claiming new work
+with less than ten seconds left, aborts provider work before the 50-second
+worker budget, and reserves five seconds to persist the final state. An abort
+that can occur after provider submission starts is fenced as uncertain rather
+than retried. Each run reconciles at most three old fences first, with a
+five-second GET budget each, so stale work cannot starve new confirmations.
+
+The worker logs aggregate counts, queue age, duration, bounded failure
+categories, and whether it stopped for its time budget. The cron also logs an
+aggregate health snapshot for queued work, expired pre-submission claims,
+stale submission fences, uncertain submissions, terminal failures, and retry
+exhaustion. Recipient addresses, cart and item content, rendered bodies, and
+raw provider errors must not be logged. The cron returns `503` while a current
+delivery attempt fails or any stale/terminal state still needs reconciliation;
+this is an operational alert, not a signal to replay checkout.
+
+## Reconciliation
+
+Expired `outbox_claimed` rows are safe to reclaim automatically because the
+provider boundary was not crossed. Missing provider configuration follows the
+same deferred retry path, does not consume delivery attempts, and does not
+change checkout success.
+
+Five minutes after `submission_started` or `submission_uncertain`, the worker
+claims a separate reconciliation lease and uses the row's
+`provider_message_id` as the ACS operation ID. Reconciliation calls only the
+official, read-only operation endpoint; it never re-enters the email send path:
+
+`GET {ACS endpoint}/emails/operations/{operationId}?api-version=2025-09-01`
+
+- `Succeeded`: the existing audit row becomes `sent`; no new submission occurs.
+- `Running` or `NotStarted`: the fence remains and another GET is scheduled
+  with capped backoff.
+- `Failed` or `Canceled`: the existing row records the terminal provider
+  result and remains an operator-visible failure.
+- A timeout, unavailable status API, 404, or unknown response is not proof of
+  non-delivery. The row remains fenced and another read-only GET is scheduled.
+
+Reconciliation claims use row locking and a five-minute lease, so a worker
+crash during the GET is recoverable without creating a send path. Health stays
+unhealthy while any reconciliation is pending, stale, terminal, or exhausted.
+For a persistent fence, operators can use the same GET manually; raw provider
+responses, recipient data, and operation-status errors must not be logged.
+
+For `retry_exhausted`, first correct the bounded failure category shown in the
+audit row. Requeue only failures proven to be before submission (for example,
+configuration or rendering) or an authoritative provider non-delivery. Every
+manual state transition must retain the prior operation ID, failure category,
+and reconciliation time in metadata so the customer email remains auditable.
+
+## Deployment and rollback
+
+No schema migration or new environment variable is required. Deploy the API
+code and cron together. Existing direct checkouts then begin writing intents,
+and the worker drains them using the already-configured email provider.
+
+For rollback, remove or disable the cron before reverting the enqueue code.
+Queued rows remain durable in `email_messages`; they can be drained by the
+forward version after it is restored. Do not reset `sending` rows without
+confirming provider disposition through the reconciliation workflow, because
+that could duplicate a customer email.

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -2,23 +2,32 @@
     "name": "@gredice/email",
     "version": "1.0.0",
     "private": true,
+    "type": "module",
     "exports": {
         "./*": "./src/*/index.ts"
     },
     "scripts": {
         "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
-        "lint:migrate": "biome migrate --write"
+        "lint:migrate": "biome migrate --write",
+        "test": "pnpm run /^test:.*/",
+        "test:existing-log": "node --experimental-test-module-mocks --experimental-strip-types --test ./src/acs/sendEmailExistingLog.node.spec.ts",
+        "test:operation-status": "node --import tsx --test ./src/acs-operation-status/index.node.spec.ts",
+        "test:provider-classification": "node --conditions=react-server --import tsx --test ./src/acs/index.node.spec.ts",
+        "typecheck": "tsc --noEmit --pretty false"
     },
     "devDependencies": {
         "@biomejs/biome": "2.5.3",
         "@types/node": "24.12.4",
         "@types/react": "19.2.17",
+        "tsx": "4.23.0",
         "typescript": "7.0.2"
     },
     "dependencies": {
+        "@azure/communication-common": "2.4.0",
         "@azure/communication-email": "1.1.0",
         "@azure/core-lro": "3.3.1",
+        "@azure/core-rest-pipeline": "1.22.2",
         "@gredice/storage": "workspace:*",
         "react": "19.2.7",
         "react-email": "6.6.9"

--- a/packages/email/src/acs-operation-status/index.node.spec.ts
+++ b/packages/email/src/acs-operation-status/index.node.spec.ts
@@ -1,0 +1,414 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    createHttpHeaders,
+    type HttpClient,
+    type PipelineRequest,
+    type PipelineResponse,
+} from '@azure/core-rest-pipeline';
+import {
+    AcsEmailOperationStatusAbortedError,
+    AcsEmailOperationStatusConfigError,
+    AcsEmailOperationStatusHttpError,
+    AcsEmailOperationStatusParseError,
+    getAcsEmailOperationStatus,
+    isAcsEmailOperationStatus,
+    isAcsEmailOperationStatusAbortedError,
+    isAcsEmailOperationStatusConfigError,
+    isAcsEmailOperationStatusHttpError,
+    isAcsEmailOperationStatusParseError,
+} from './index';
+
+const operationId = '018F0D12-2EC4-7FAB-9D91-91F890AD5D73';
+const normalizedOperationId = operationId.toLowerCase();
+const accessKey = Buffer.alloc(32, 7).toString('base64');
+const connectionString = `endpoint=https://email.example.test/;accesskey=${accessKey}`;
+
+function responseFor(
+    request: PipelineRequest,
+    {
+        bodyAsText,
+        status = 200,
+    }: { bodyAsText?: string | null; status?: number } = {},
+): PipelineResponse {
+    return {
+        bodyAsText,
+        headers: createHttpHeaders(),
+        request,
+        status,
+    };
+}
+
+function createFakeHttpClient(
+    sendRequest: HttpClient['sendRequest'],
+): HttpClient {
+    return { sendRequest };
+}
+
+function lookup(
+    httpClient: HttpClient,
+    overrides: {
+        abortSignal?: AbortSignal;
+        connectionString?: string;
+        operationId?: string;
+    } = {},
+) {
+    return getAcsEmailOperationStatus(overrides.operationId ?? operationId, {
+        abortSignal: overrides.abortSignal,
+        connectionString: overrides.connectionString ?? connectionString,
+        httpClient,
+    });
+}
+
+test('sends one authenticated GET to the canonical ACS operation endpoint', async () => {
+    const requests: PipelineRequest[] = [];
+    const httpClient = createFakeHttpClient(async (request) => {
+        requests.push(request);
+        return responseFor(request, {
+            bodyAsText: JSON.stringify({
+                id: normalizedOperationId,
+                status: 'Succeeded',
+            }),
+        });
+    });
+
+    assert.equal(await lookup(httpClient), 'Succeeded');
+    assert.equal(requests.length, 1);
+
+    const request = requests[0];
+    assert.ok(request);
+    assert.equal(request.method, 'GET');
+    assert.equal(request.body, undefined);
+    assert.equal(
+        request.url,
+        `https://email.example.test/emails/operations/${normalizedOperationId}?api-version=2025-09-01`,
+    );
+    assert.equal(request.timeout, 10_000);
+    assert.equal(request.headers.get('host'), 'email.example.test');
+    assert.match(request.headers.get('x-ms-date') ?? '', /GMT$/u);
+    assert.equal(
+        request.headers.get('x-ms-content-sha256'),
+        '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=',
+    );
+    assert.match(
+        request.headers.get('authorization') ?? '',
+        /^HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=[A-Za-z0-9+/=]+$/u,
+    );
+});
+
+test('accepts every documented bounded operation status', async (t) => {
+    for (const status of [
+        'Succeeded',
+        'Failed',
+        'Canceled',
+        'Running',
+        'NotStarted',
+    ] as const) {
+        await t.test(status, async () => {
+            let requests = 0;
+            const httpClient = createFakeHttpClient(async (request) => {
+                requests += 1;
+                return responseFor(request, {
+                    bodyAsText: JSON.stringify({
+                        id: normalizedOperationId,
+                        ignoredProviderData: 'must-not-escape',
+                        status,
+                    }),
+                });
+            });
+
+            assert.equal(await lookup(httpClient), status);
+            assert.equal(isAcsEmailOperationStatus(status), true);
+            assert.equal(requests, 1);
+        });
+    }
+    assert.equal(isAcsEmailOperationStatus('completed'), false);
+});
+
+test('classifies bounded HTTP failures without exposing response data or retrying', async (t) => {
+    for (const { retryable, statusCode } of [
+        { retryable: false, statusCode: 400 },
+        { retryable: false, statusCode: 401 },
+        { retryable: true, statusCode: 408 },
+        { retryable: true, statusCode: 429 },
+        { retryable: true, statusCode: 500 },
+        { retryable: true, statusCode: 599 },
+    ]) {
+        await t.test(String(statusCode), async () => {
+            let requests = 0;
+            const httpClient = createFakeHttpClient(async (request) => {
+                requests += 1;
+                return responseFor(request, {
+                    bodyAsText:
+                        '{"error":{"message":"sensitive provider data"}}',
+                    status: statusCode,
+                });
+            });
+
+            await assert.rejects(lookup(httpClient), (error: unknown) => {
+                assert.equal(isAcsEmailOperationStatusHttpError(error), true);
+                assert.ok(error instanceof AcsEmailOperationStatusHttpError);
+                assert.equal(error.reason, 'response');
+                assert.equal(error.retryable, retryable);
+                assert.equal(error.statusCode, statusCode);
+                assert.doesNotMatch(error.message, /sensitive|provider data/u);
+                return true;
+            });
+            assert.equal(requests, 1);
+        });
+    }
+});
+
+test('classifies invalid response status and transport failure without retrying', async () => {
+    let invalidStatusRequests = 0;
+    const invalidStatusClient = createFakeHttpClient(async (request) => {
+        invalidStatusRequests += 1;
+        return responseFor(request, { status: 0 });
+    });
+    await assert.rejects(lookup(invalidStatusClient), (error: unknown) => {
+        assert.equal(isAcsEmailOperationStatusHttpError(error), true);
+        assert.ok(error instanceof AcsEmailOperationStatusHttpError);
+        assert.equal(error.reason, 'invalid_response_status');
+        assert.equal(error.retryable, false);
+        assert.equal(error.statusCode, null);
+        return true;
+    });
+    assert.equal(invalidStatusRequests, 1);
+
+    let transportRequests = 0;
+    const transportClient = createFakeHttpClient(async () => {
+        transportRequests += 1;
+        throw new Error('sensitive socket address and provider response');
+    });
+    await assert.rejects(lookup(transportClient), (error: unknown) => {
+        assert.equal(isAcsEmailOperationStatusHttpError(error), true);
+        assert.ok(error instanceof AcsEmailOperationStatusHttpError);
+        assert.equal(error.reason, 'transport');
+        assert.equal(error.retryable, true);
+        assert.equal(error.statusCode, null);
+        assert.doesNotMatch(error.message, /sensitive|socket address/u);
+        return true;
+    });
+    assert.equal(transportRequests, 1);
+});
+
+test('classifies response parsing failures without exposing provider payloads', async (t) => {
+    const cases: Array<{
+        bodyAsText?: string | null;
+        reason:
+            | 'body_too_large'
+            | 'empty_body'
+            | 'invalid_json'
+            | 'invalid_payload'
+            | 'mismatched_operation_id'
+            | 'unknown_status';
+    }> = [
+        { bodyAsText: undefined, reason: 'empty_body' },
+        { bodyAsText: null, reason: 'empty_body' },
+        { bodyAsText: '', reason: 'empty_body' },
+        { bodyAsText: '{secret invalid json', reason: 'invalid_json' },
+        { bodyAsText: '[]', reason: 'invalid_payload' },
+        { bodyAsText: '{"status":7}', reason: 'invalid_payload' },
+        {
+            bodyAsText: '{"status":"Succeeded"}',
+            reason: 'invalid_payload',
+        },
+        {
+            bodyAsText: '{"id":"not-an-operation-id","status":"Succeeded"}',
+            reason: 'invalid_payload',
+        },
+        {
+            bodyAsText:
+                '{"id":"118f0d12-2ec4-7fab-9d91-91f890ad5d73","status":"Succeeded"}',
+            reason: 'mismatched_operation_id',
+        },
+        {
+            bodyAsText:
+                '{"id":"018f0d12-2ec4-7fab-9d91-91f890ad5d73","status":"Completed","secret":"provider detail"}',
+            reason: 'unknown_status',
+        },
+        { bodyAsText: 'x'.repeat(16_385), reason: 'body_too_large' },
+    ];
+
+    for (const { bodyAsText, reason } of cases) {
+        await t.test(reason, async () => {
+            const httpClient = createFakeHttpClient(async (request) =>
+                responseFor(request, { bodyAsText }),
+            );
+
+            await assert.rejects(lookup(httpClient), (error: unknown) => {
+                assert.equal(isAcsEmailOperationStatusParseError(error), true);
+                assert.ok(error instanceof AcsEmailOperationStatusParseError);
+                assert.equal(error.reason, reason);
+                assert.doesNotMatch(
+                    error.message,
+                    /provider detail|secret invalid/u,
+                );
+                return true;
+            });
+        });
+    }
+});
+
+test('classifies connection and operation configuration without leaking credentials', async (t) => {
+    const unusedClient = createFakeHttpClient(async (request) =>
+        responseFor(request),
+    );
+    const cases: Array<{
+        connectionString?: string;
+        operationId?: string;
+        reason:
+            | 'invalid_connection_string'
+            | 'invalid_endpoint'
+            | 'invalid_operation_id'
+            | 'missing_connection_string';
+    }> = [
+        { connectionString: '', reason: 'missing_connection_string' },
+        {
+            connectionString: 'secret-invalid-connection-string',
+            reason: 'invalid_connection_string',
+        },
+        {
+            connectionString:
+                'endpoint=https://email.example.test/;accesskey=not-base64!',
+            reason: 'invalid_connection_string',
+        },
+        {
+            connectionString: `endpoint=http://email.example.test/;accesskey=${accessKey}`,
+            reason: 'invalid_endpoint',
+        },
+        { operationId: '../not-a-uuid', reason: 'invalid_operation_id' },
+    ];
+
+    for (const {
+        connectionString: candidate,
+        operationId: id,
+        reason,
+    } of cases) {
+        await t.test(reason, async () => {
+            await assert.rejects(
+                getAcsEmailOperationStatus(id ?? operationId, {
+                    connectionString: candidate,
+                    httpClient: unusedClient,
+                }),
+                (error: unknown) => {
+                    assert.equal(
+                        isAcsEmailOperationStatusConfigError(error),
+                        true,
+                    );
+                    assert.ok(
+                        error instanceof AcsEmailOperationStatusConfigError,
+                    );
+                    assert.equal(error.reason, reason);
+                    assert.doesNotMatch(
+                        error.message,
+                        /secret-invalid|accesskey/u,
+                    );
+                    return true;
+                },
+            );
+        });
+    }
+});
+
+test('passes the AbortSignal to transport and returns a bounded abort error', async () => {
+    const abortController = new AbortController();
+    let releaseTransportStart: (() => void) | undefined;
+    const transportStarted = new Promise<void>((resolve) => {
+        releaseTransportStart = resolve;
+    });
+    let requests = 0;
+    const httpClient = createFakeHttpClient(async (request) => {
+        requests += 1;
+        assert.equal(request.abortSignal, abortController.signal);
+        releaseTransportStart?.();
+        return new Promise<PipelineResponse>((_resolve, reject) => {
+            request.abortSignal?.addEventListener(
+                'abort',
+                () => {
+                    reject(
+                        Object.assign(
+                            new Error('sensitive provider abort details'),
+                            { name: 'AbortError' },
+                        ),
+                    );
+                },
+                { once: true },
+            );
+        });
+    });
+
+    const result = lookup(httpClient, {
+        abortSignal: abortController.signal,
+    });
+    await transportStarted;
+    abortController.abort();
+
+    await assert.rejects(result, (error: unknown) => {
+        assert.equal(isAcsEmailOperationStatusAbortedError(error), true);
+        assert.ok(error instanceof AcsEmailOperationStatusAbortedError);
+        assert.doesNotMatch(error.message, /sensitive|provider abort/u);
+        return true;
+    });
+    assert.equal(requests, 1);
+});
+
+test('does not enter the HTTP pipeline when already aborted', async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+    let requests = 0;
+    const httpClient = createFakeHttpClient(async (request) => {
+        requests += 1;
+        return responseFor(request);
+    });
+
+    await assert.rejects(
+        lookup(httpClient, { abortSignal: abortController.signal }),
+        (error: unknown) => {
+            assert.equal(isAcsEmailOperationStatusAbortedError(error), true);
+            return true;
+        },
+    );
+    assert.equal(requests, 0);
+});
+
+test('typed guards accept bounded serialized errors and reject malformed ones', () => {
+    assert.equal(
+        isAcsEmailOperationStatusConfigError({
+            code: 'acs_email_operation_status_configuration_error',
+            reason: 'missing_connection_string',
+        }),
+        true,
+    );
+    assert.equal(
+        isAcsEmailOperationStatusHttpError({
+            code: 'acs_email_operation_status_http_error',
+            reason: 'response',
+            retryable: true,
+            statusCode: 429,
+        }),
+        true,
+    );
+    assert.equal(
+        isAcsEmailOperationStatusHttpError({
+            code: 'acs_email_operation_status_http_error',
+            reason: 'response',
+            retryable: true,
+            statusCode: 999,
+        }),
+        false,
+    );
+    assert.equal(
+        isAcsEmailOperationStatusParseError({
+            code: 'acs_email_operation_status_parse_error',
+            reason: 'unknown_status',
+        }),
+        true,
+    );
+    assert.equal(
+        isAcsEmailOperationStatusAbortedError({
+            code: 'acs_email_operation_status_aborted',
+        }),
+        true,
+    );
+});

--- a/packages/email/src/acs-operation-status/index.ts
+++ b/packages/email/src/acs-operation-status/index.ts
@@ -1,0 +1,378 @@
+import {
+    createCommunicationAuthPolicy,
+    parseConnectionString,
+} from '@azure/communication-common';
+import {
+    createDefaultHttpClient,
+    createEmptyPipeline,
+    createPipelineRequest,
+    type HttpClient,
+    type PipelineResponse,
+} from '@azure/core-rest-pipeline';
+
+const apiVersion = '2025-09-01';
+const maximumConnectionStringLength = 4_096;
+const maximumResponseBodyLength = 16_384;
+const requestTimeoutMs = 10_000;
+const canonicalUuidPattern =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+
+const acsEmailOperationStatuses = [
+    'Succeeded',
+    'Failed',
+    'Canceled',
+    'Running',
+    'NotStarted',
+] as const;
+
+export type AcsEmailOperationStatus =
+    (typeof acsEmailOperationStatuses)[number];
+
+export type AcsEmailOperationStatusConfigErrorReason =
+    | 'invalid_connection_string'
+    | 'invalid_endpoint'
+    | 'invalid_operation_id'
+    | 'missing_connection_string';
+
+export class AcsEmailOperationStatusConfigError extends Error {
+    readonly code = 'acs_email_operation_status_configuration_error';
+    readonly reason: AcsEmailOperationStatusConfigErrorReason;
+
+    constructor(reason: AcsEmailOperationStatusConfigErrorReason) {
+        super(`ACS email operation status configuration failed: ${reason}.`);
+        this.name = 'AcsEmailOperationStatusConfigError';
+        this.reason = reason;
+    }
+}
+
+export type AcsEmailOperationStatusHttpErrorReason =
+    | 'invalid_response_status'
+    | 'response'
+    | 'transport';
+
+export class AcsEmailOperationStatusHttpError extends Error {
+    readonly code = 'acs_email_operation_status_http_error';
+    readonly reason: AcsEmailOperationStatusHttpErrorReason;
+    readonly retryable: boolean;
+    readonly statusCode: number | null;
+
+    constructor({
+        reason,
+        retryable,
+        statusCode,
+    }: {
+        reason: AcsEmailOperationStatusHttpErrorReason;
+        retryable: boolean;
+        statusCode: number | null;
+    }) {
+        super(
+            statusCode === null
+                ? `ACS email operation status request failed: ${reason}.`
+                : `ACS email operation status request failed with HTTP status ${statusCode}.`,
+        );
+        this.name = 'AcsEmailOperationStatusHttpError';
+        this.reason = reason;
+        this.retryable = retryable;
+        this.statusCode = statusCode;
+    }
+}
+
+export type AcsEmailOperationStatusParseErrorReason =
+    | 'body_too_large'
+    | 'empty_body'
+    | 'invalid_json'
+    | 'invalid_payload'
+    | 'mismatched_operation_id'
+    | 'unknown_status';
+
+export class AcsEmailOperationStatusParseError extends Error {
+    readonly code = 'acs_email_operation_status_parse_error';
+    readonly reason: AcsEmailOperationStatusParseErrorReason;
+
+    constructor(reason: AcsEmailOperationStatusParseErrorReason) {
+        super(
+            `ACS email operation status response could not be parsed: ${reason}.`,
+        );
+        this.name = 'AcsEmailOperationStatusParseError';
+        this.reason = reason;
+    }
+}
+
+export class AcsEmailOperationStatusAbortedError extends Error {
+    readonly code = 'acs_email_operation_status_aborted';
+
+    constructor() {
+        super('ACS email operation status request was aborted.');
+        this.name = 'AcsEmailOperationStatusAbortedError';
+    }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isConfigErrorReason(
+    value: unknown,
+): value is AcsEmailOperationStatusConfigErrorReason {
+    return (
+        value === 'invalid_connection_string' ||
+        value === 'invalid_endpoint' ||
+        value === 'invalid_operation_id' ||
+        value === 'missing_connection_string'
+    );
+}
+
+function isHttpErrorReason(
+    value: unknown,
+): value is AcsEmailOperationStatusHttpErrorReason {
+    return (
+        value === 'invalid_response_status' ||
+        value === 'response' ||
+        value === 'transport'
+    );
+}
+
+function isParseErrorReason(
+    value: unknown,
+): value is AcsEmailOperationStatusParseErrorReason {
+    return (
+        value === 'body_too_large' ||
+        value === 'empty_body' ||
+        value === 'invalid_json' ||
+        value === 'invalid_payload' ||
+        value === 'mismatched_operation_id' ||
+        value === 'unknown_status'
+    );
+}
+
+function isBoundedHttpStatus(value: unknown): value is number {
+    return (
+        typeof value === 'number' &&
+        Number.isSafeInteger(value) &&
+        value >= 100 &&
+        value <= 599
+    );
+}
+
+export function isAcsEmailOperationStatusConfigError(
+    error: unknown,
+): error is AcsEmailOperationStatusConfigError {
+    return (
+        error instanceof AcsEmailOperationStatusConfigError ||
+        (isRecord(error) &&
+            error.code === 'acs_email_operation_status_configuration_error' &&
+            isConfigErrorReason(error.reason))
+    );
+}
+
+export function isAcsEmailOperationStatusHttpError(
+    error: unknown,
+): error is AcsEmailOperationStatusHttpError {
+    return (
+        error instanceof AcsEmailOperationStatusHttpError ||
+        (isRecord(error) &&
+            error.code === 'acs_email_operation_status_http_error' &&
+            isHttpErrorReason(error.reason) &&
+            typeof error.retryable === 'boolean' &&
+            (error.statusCode === null ||
+                isBoundedHttpStatus(error.statusCode)))
+    );
+}
+
+export function isAcsEmailOperationStatusParseError(
+    error: unknown,
+): error is AcsEmailOperationStatusParseError {
+    return (
+        error instanceof AcsEmailOperationStatusParseError ||
+        (isRecord(error) &&
+            error.code === 'acs_email_operation_status_parse_error' &&
+            isParseErrorReason(error.reason))
+    );
+}
+
+export function isAcsEmailOperationStatusAbortedError(
+    error: unknown,
+): error is AcsEmailOperationStatusAbortedError {
+    return (
+        error instanceof AcsEmailOperationStatusAbortedError ||
+        (isRecord(error) && error.code === 'acs_email_operation_status_aborted')
+    );
+}
+
+export function isAcsEmailOperationStatus(
+    status: unknown,
+): status is AcsEmailOperationStatus {
+    return acsEmailOperationStatuses.some((candidate) => candidate === status);
+}
+
+function parseEndpoint(connectionString: string) {
+    if (connectionString.length > maximumConnectionStringLength) {
+        throw new AcsEmailOperationStatusConfigError(
+            'invalid_connection_string',
+        );
+    }
+
+    let parsedConnectionString: ReturnType<typeof parseConnectionString>;
+    try {
+        parsedConnectionString = parseConnectionString(connectionString);
+    } catch {
+        throw new AcsEmailOperationStatusConfigError(
+            'invalid_connection_string',
+        );
+    }
+
+    let endpoint: URL;
+    try {
+        endpoint = new URL(parsedConnectionString.endpoint);
+    } catch {
+        throw new AcsEmailOperationStatusConfigError('invalid_endpoint');
+    }
+
+    if (
+        !/^[A-Za-z0-9+/]+={0,2}$/u.test(
+            parsedConnectionString.credential.key,
+        ) ||
+        parsedConnectionString.credential.key.length < 16 ||
+        parsedConnectionString.credential.key.length > 1_024 ||
+        parsedConnectionString.credential.key.length % 4 !== 0
+    ) {
+        throw new AcsEmailOperationStatusConfigError(
+            'invalid_connection_string',
+        );
+    }
+
+    if (
+        endpoint.protocol !== 'https:' ||
+        endpoint.username !== '' ||
+        endpoint.password !== '' ||
+        endpoint.port !== '' ||
+        endpoint.search !== '' ||
+        endpoint.hash !== '' ||
+        (endpoint.pathname !== '' && endpoint.pathname !== '/')
+    ) {
+        throw new AcsEmailOperationStatusConfigError('invalid_endpoint');
+    }
+
+    return {
+        credential: parsedConnectionString.credential,
+        origin: endpoint.origin,
+    };
+}
+
+function httpStatusIsRetryable(statusCode: number) {
+    return statusCode === 408 || statusCode === 429 || statusCode >= 500;
+}
+
+function parseOperationStatus(
+    bodyAsText: string | null | undefined,
+    operationId: string,
+) {
+    if (bodyAsText === undefined || bodyAsText === null || bodyAsText === '') {
+        throw new AcsEmailOperationStatusParseError('empty_body');
+    }
+    if (bodyAsText.length > maximumResponseBodyLength) {
+        throw new AcsEmailOperationStatusParseError('body_too_large');
+    }
+
+    let body: unknown;
+    try {
+        body = JSON.parse(bodyAsText);
+    } catch {
+        throw new AcsEmailOperationStatusParseError('invalid_json');
+    }
+
+    if (!isRecord(body) || typeof body.status !== 'string') {
+        throw new AcsEmailOperationStatusParseError('invalid_payload');
+    }
+    if (!isAcsEmailOperationStatus(body.status)) {
+        throw new AcsEmailOperationStatusParseError('unknown_status');
+    }
+    if (typeof body.id !== 'string' || !canonicalUuidPattern.test(body.id)) {
+        throw new AcsEmailOperationStatusParseError('invalid_payload');
+    }
+    if (body.id.toLowerCase() !== operationId.toLowerCase()) {
+        throw new AcsEmailOperationStatusParseError('mismatched_operation_id');
+    }
+
+    return body.status;
+}
+
+function errorLooksAborted(error: unknown, abortSignal?: AbortSignal) {
+    return (
+        abortSignal?.aborted === true ||
+        (isRecord(error) && error.name === 'AbortError')
+    );
+}
+
+export type GetAcsEmailOperationStatusOptions = {
+    abortSignal?: AbortSignal;
+    connectionString?: string;
+    httpClient?: HttpClient;
+};
+
+export async function getAcsEmailOperationStatus(
+    operationId: string,
+    options: GetAcsEmailOperationStatusOptions = {},
+): Promise<AcsEmailOperationStatus> {
+    if (!canonicalUuidPattern.test(operationId)) {
+        throw new AcsEmailOperationStatusConfigError('invalid_operation_id');
+    }
+
+    const connectionString =
+        options.connectionString ?? process.env.ACS_CONNECTION_STRING;
+    if (!connectionString?.trim()) {
+        throw new AcsEmailOperationStatusConfigError(
+            'missing_connection_string',
+        );
+    }
+    if (options.abortSignal?.aborted) {
+        throw new AcsEmailOperationStatusAbortedError();
+    }
+
+    const { credential, origin } = parseEndpoint(connectionString);
+    const pipeline = createEmptyPipeline();
+    pipeline.addPolicy(createCommunicationAuthPolicy(credential), {
+        phase: 'Sign',
+    });
+
+    const request = createPipelineRequest({
+        abortSignal: options.abortSignal,
+        method: 'GET',
+        timeout: requestTimeoutMs,
+        url: `${origin}/emails/operations/${operationId.toLowerCase()}?api-version=${apiVersion}`,
+    });
+
+    let response: PipelineResponse;
+    try {
+        response = await pipeline.sendRequest(
+            options.httpClient ?? createDefaultHttpClient(),
+            request,
+        );
+    } catch (error) {
+        if (errorLooksAborted(error, options.abortSignal)) {
+            throw new AcsEmailOperationStatusAbortedError();
+        }
+        throw new AcsEmailOperationStatusHttpError({
+            reason: 'transport',
+            retryable: true,
+            statusCode: null,
+        });
+    }
+
+    if (!isBoundedHttpStatus(response.status)) {
+        throw new AcsEmailOperationStatusHttpError({
+            reason: 'invalid_response_status',
+            retryable: false,
+            statusCode: null,
+        });
+    }
+    if (response.status < 200 || response.status >= 300) {
+        throw new AcsEmailOperationStatusHttpError({
+            reason: 'response',
+            retryable: httpStatusIsRetryable(response.status),
+            statusCode: response.status,
+        });
+    }
+
+    return parseOperationStatus(response.bodyAsText, operationId);
+}

--- a/packages/email/src/acs/index.node.spec.ts
+++ b/packages/email/src/acs/index.node.spec.ts
@@ -9,7 +9,9 @@ import {
     classifyEmailProviderSubmissionFailure,
     createAtMostOnceEmailClient,
     EmailProviderSubmissionRejectedError,
+    EmailProviderTerminalFailureError,
     isEmailProviderSubmissionRejectedError,
+    isEmailProviderTerminalFailureError,
 } from './index';
 
 const operationId = '018f0d12-2ec4-7fab-9d91-91f890ad5d73';
@@ -171,7 +173,26 @@ test('terminal poll results throw after the provider has completed the operation
                     error: { code: 'ProviderFailure', message: 'terminal' },
                     status,
                 }),
-            /terminal/u,
+            (error: unknown) => {
+                assert.equal(isEmailProviderTerminalFailureError(error), true);
+                assert.ok(error instanceof EmailProviderTerminalFailureError);
+                assert.equal(error.providerStatus, status);
+                return true;
+            },
         );
     }
+    assert.equal(
+        isEmailProviderTerminalFailureError({
+            code: 'email_provider_terminal_failure',
+            providerStatus: KnownEmailSendStatus.Failed,
+        }),
+        true,
+    );
+    assert.equal(
+        isEmailProviderTerminalFailureError({
+            code: 'email_provider_terminal_failure',
+            providerStatus: KnownEmailSendStatus.Succeeded,
+        }),
+        false,
+    );
 });

--- a/packages/email/src/acs/index.ts
+++ b/packages/email/src/acs/index.ts
@@ -12,6 +12,7 @@ import {
     type EmailLogRecipient,
     type EmailLogRecipients,
     type EmailStatus,
+    getEmailMessage,
     updateEmailMessageLog,
 } from '@gredice/storage';
 import type { ReactElement } from 'react';
@@ -187,6 +188,9 @@ export type SendEmailParams = {
     messageType?: string | null;
     metadata?: Record<string, unknown>;
     operationId?: string;
+    existingEmailLogId?: number;
+    beforeProviderSubmission?: () => Promise<void>;
+    abortSignal?: AbortSignal;
 };
 
 const providerOperationIdPattern =
@@ -385,8 +389,17 @@ export async function sendEmail({
     messageType,
     metadata,
     operationId,
+    existingEmailLogId,
+    beforeProviderSubmission,
+    abortSignal,
 }: SendEmailParams) {
     const providerOperationId = normalizedProviderOperationId(operationId);
+    if (
+        existingEmailLogId !== undefined &&
+        (!Number.isSafeInteger(existingEmailLogId) || existingEmailLogId < 1)
+    ) {
+        throw new Error('Existing email log ID must be a positive integer.');
+    }
     const toRecipients = normalizeRecipients(to);
     if (toRecipients.length === 0) {
         throw new Error(
@@ -401,24 +414,54 @@ export async function sendEmail({
     const emailHtml = await render(template);
     const emailPlaintext = await render(template, { plainText: true });
 
-    const emailLog = await createEmailMessageLog({
-        fromAddress: from,
-        providerMessageId: providerOperationId ?? null,
-        subject,
-        templateName: templateName ?? null,
-        messageType: messageType ?? null,
-        recipients: toLogRecipients({
-            to: toRecipients,
-            cc: ccRecipients,
-            bcc: bccRecipients,
-            replyTo: replyToRecipients,
-        }),
-        attachments: buildAttachmentMetadata(attachments),
-        metadata: metadata ?? {},
-        htmlBody: emailHtml,
-        textBody: emailPlaintext,
-        status: 'queued',
-    });
+    const emailLog =
+        existingEmailLogId !== undefined
+            ? await (async () => {
+                  const existing = await getEmailMessage(existingEmailLogId);
+                  if (!existing) {
+                      throw new Error(
+                          'Existing email log entry was not found.',
+                      );
+                  }
+                  const updated = await updateEmailMessageLog(
+                      existingEmailLogId,
+                      {
+                          attachments: buildAttachmentMetadata(attachments),
+                          htmlBody: emailHtml,
+                          messageType: messageType ?? null,
+                          providerMessageId:
+                              existing.providerMessageId ??
+                              providerOperationId ??
+                              null,
+                          templateName: templateName ?? null,
+                          textBody: emailPlaintext,
+                      },
+                  );
+                  if (!updated) {
+                      throw new Error(
+                          'Existing email log entry was not updated.',
+                      );
+                  }
+                  return updated;
+              })()
+            : await createEmailMessageLog({
+                  fromAddress: from,
+                  providerMessageId: providerOperationId ?? null,
+                  subject,
+                  templateName: templateName ?? null,
+                  messageType: messageType ?? null,
+                  recipients: toLogRecipients({
+                      to: toRecipients,
+                      cc: ccRecipients,
+                      bcc: bccRecipients,
+                      replyTo: replyToRecipients,
+                  }),
+                  attachments: buildAttachmentMetadata(attachments),
+                  metadata: metadata ?? {},
+                  htmlBody: emailHtml,
+                  textBody: emailPlaintext,
+                  status: 'queued',
+              });
 
     const client = emailClient(providerOperationId !== undefined);
 
@@ -458,6 +501,8 @@ export async function sendEmail({
     let providerSubmissionStarted = false;
     let terminalProviderStatus: string | undefined;
     try {
+        abortSignal?.throwIfAborted();
+        await beforeProviderSubmission?.();
         // ACS Operation-Id identifies the long-running operation, but it is not
         // a repeatability guarantee. Disable the SDK's internal POST retries for
         // this durable at-most-once path, and fence any response that does not
@@ -465,34 +510,39 @@ export async function sendEmail({
         providerSubmissionStarted = true;
         const poller = await client.beginSend(
             azureMessage,
-            providerOperationId
-                ? { operationId: providerOperationId }
+            providerOperationId || abortSignal
+                ? { abortSignal, operationId: providerOperationId }
                 : undefined,
         );
         providerSubmissionAccepted = true;
         const operationState = poller.getOperationState();
         const operationStateId = getOperationStateId(operationState);
 
-        await updateEmailMessageLog(emailLog.id, {
-            status: 'sending',
-            providerMessageId: operationStateId ?? providerOperationId ?? null,
-            providerStatus: operationState.status ?? null,
-            lastAttemptAt: new Date(),
-        });
+        if (existingEmailLogId === undefined) {
+            await updateEmailMessageLog(emailLog.id, {
+                status: 'sending',
+                providerMessageId:
+                    operationStateId ?? providerOperationId ?? null,
+                providerStatus: operationState.status ?? null,
+                lastAttemptAt: new Date(),
+            });
+        }
 
         const response = await poller.pollUntilDone();
         terminalProviderStatus = response.status;
         const finalStatus = mapProviderStatus(response.status);
 
-        await updateEmailMessageLog(emailLog.id, {
-            status: finalStatus,
-            providerStatus: response.status,
-            providerMessageId: response.id ?? operationStateId ?? null,
-            sentAt: finalStatus === 'sent' ? new Date() : null,
-            completedAt: new Date(),
-            errorCode: response.error?.code ?? null,
-            errorMessage: response.error?.message ?? null,
-        });
+        if (existingEmailLogId === undefined) {
+            await updateEmailMessageLog(emailLog.id, {
+                status: finalStatus,
+                providerStatus: response.status,
+                providerMessageId: response.id ?? operationStateId ?? null,
+                sentAt: finalStatus === 'sent' ? new Date() : null,
+                completedAt: new Date(),
+                errorCode: response.error?.code ?? null,
+                errorMessage: response.error?.message ?? null,
+            });
+        }
 
         assertEmailProviderSendSucceeded(response);
 
@@ -513,15 +563,17 @@ export async function sendEmail({
               : error instanceof Error
                 ? error.message
                 : 'Failed to send email';
-        try {
-            await updateEmailMessageLog(emailLog.id, {
-                status: submissionIsUncertain ? 'sending' : 'failed',
-                errorMessage,
-                completedAt: submissionIsUncertain ? null : new Date(),
-            });
-        } catch {
-            // Preserve the provider result classification when audit-log storage
-            // is unavailable after the provider boundary.
+        if (existingEmailLogId === undefined) {
+            try {
+                await updateEmailMessageLog(emailLog.id, {
+                    status: submissionIsUncertain ? 'sending' : 'failed',
+                    errorMessage,
+                    completedAt: submissionIsUncertain ? null : new Date(),
+                });
+            } catch {
+                // Preserve the provider result classification when audit-log
+                // storage is unavailable after the provider boundary.
+            }
         }
         if (submissionIsUncertain && providerOperationId) {
             throw new EmailProviderSubmissionUncertainError(

--- a/packages/email/src/acs/index.ts
+++ b/packages/email/src/acs/index.ts
@@ -266,6 +266,21 @@ export class EmailProviderSubmissionRejectedError extends Error {
     }
 }
 
+export type EmailProviderTerminalStatus = 'Canceled' | 'Failed';
+
+export class EmailProviderTerminalFailureError extends Error {
+    readonly code = 'email_provider_terminal_failure';
+    readonly providerStatus: EmailProviderTerminalStatus;
+
+    constructor(providerStatus: EmailProviderTerminalStatus) {
+        super(
+            `Email provider completed submission with terminal status ${providerStatus}.`,
+        );
+        this.name = 'EmailProviderTerminalFailureError';
+        this.providerStatus = providerStatus;
+    }
+}
+
 export function isEmailProviderSubmissionUncertainError(
     error: unknown,
 ): error is EmailProviderSubmissionUncertainError {
@@ -275,6 +290,18 @@ export function isEmailProviderSubmissionUncertainError(
             error !== null &&
             'code' in error &&
             error.code === 'email_provider_submission_uncertain')
+    );
+}
+
+export function isEmailProviderTerminalFailureError(
+    error: unknown,
+): error is EmailProviderTerminalFailureError {
+    return (
+        error instanceof EmailProviderTerminalFailureError ||
+        (isRecord(error) &&
+            error.code === 'email_provider_terminal_failure' &&
+            (error.providerStatus === KnownEmailSendStatus.Failed ||
+                error.providerStatus === KnownEmailSendStatus.Canceled))
     );
 }
 
@@ -360,9 +387,16 @@ export function emailProviderSubmissionIsUncertain({
 export function assertEmailProviderSendSucceeded(
     response: Pick<EmailSendResponse, 'error' | 'status'>,
 ) {
-    if (response.status !== KnownEmailSendStatus.Succeeded) {
-        throw new Error(response.error?.message ?? 'Failed to send email');
+    if (response.status === KnownEmailSendStatus.Succeeded) {
+        return;
     }
+    if (
+        response.status === KnownEmailSendStatus.Failed ||
+        response.status === KnownEmailSendStatus.Canceled
+    ) {
+        throw new EmailProviderTerminalFailureError(response.status);
+    }
+    throw new Error(response.error?.message ?? 'Failed to send email');
 }
 
 function normalizedProviderOperationId(value?: string) {

--- a/packages/email/src/acs/sendEmailExistingLog.node.spec.ts
+++ b/packages/email/src/acs/sendEmailExistingLog.node.spec.ts
@@ -1,0 +1,262 @@
+import assert from 'node:assert/strict';
+import test, { type TestContext } from 'node:test';
+import { createElement } from 'react';
+
+const operationId = '018f0d12-2ec4-7fab-9d91-91f890ad5d73';
+const existingEmailLogId = 42;
+
+type ProviderMode = 'failed' | 'succeeded';
+
+function mockModule(
+    t: TestContext,
+    specifier: string,
+    exports: Record<string, unknown>,
+) {
+    // Node 24 renamed `namedExports` to `exports` before @types/node exposed
+    // the new option. Reflect keeps this test on the runtime API without a
+    // stale type assertion or a deprecation warning.
+    Reflect.apply(t.mock.module, t.mock, [specifier, { exports }]);
+}
+
+test('existing email logs preserve durable outbox ownership at the provider boundary', async (t) => {
+    const events: string[] = [];
+    const updates: Array<{
+        id: number;
+        values: Record<string, unknown>;
+    }> = [];
+    let createCalls = 0;
+    let providerMode: ProviderMode = 'succeeded';
+    let providerOptions: unknown;
+
+    mockModule(t, 'react-email', {
+        render: async (
+            _template: unknown,
+            options?: { plainText?: boolean },
+        ) => {
+            if (options?.plainText) {
+                events.push('render-text');
+                return 'Rendered plain text';
+            }
+            events.push('render-html');
+            return '<p>Rendered HTML</p>';
+        },
+    });
+    mockModule(t, '@gredice/storage', {
+        createEmailMessageLog: async () => {
+            createCalls += 1;
+            throw new Error(
+                'The existing-log path must not create another email log.',
+            );
+        },
+        getEmailMessage: async (id: number) => {
+            events.push('get-log');
+            return id === existingEmailLogId
+                ? {
+                      id,
+                      providerMessageId: operationId,
+                  }
+                : null;
+        },
+        updateEmailMessageLog: async (
+            id: number,
+            values: Record<string, unknown>,
+        ) => {
+            events.push('update-log');
+            updates.push({ id, values });
+            return { id, ...values };
+        },
+    });
+    mockModule(t, '@azure/communication-email', {
+        EmailClient: class {
+            constructor() {
+                events.push('client-created');
+            }
+
+            async beginSend(_message: unknown, options: unknown) {
+                events.push('begin-send');
+                providerOptions = options;
+                return {
+                    getOperationState: () => {
+                        events.push('state-read');
+                        return {
+                            id: operationId,
+                            status: 'Running',
+                        };
+                    },
+                    pollUntilDone: async () => {
+                        events.push('poll');
+                        return providerMode === 'succeeded'
+                            ? {
+                                  id: operationId,
+                                  status: 'Succeeded',
+                              }
+                            : {
+                                  error: {
+                                      code: 'ProviderFailure',
+                                      message: 'Provider failed',
+                                  },
+                                  id: operationId,
+                                  status: 'Failed',
+                              };
+                    },
+                };
+            }
+        },
+        KnownEmailSendStatus: {
+            Canceled: 'Canceled',
+            Failed: 'Failed',
+            NotStarted: 'NotStarted',
+            Running: 'Running',
+            Succeeded: 'Succeeded',
+        },
+    });
+
+    const moduleUrl = new URL('./index.ts', import.meta.url);
+    moduleUrl.searchParams.set('test', 'existing-email-log');
+    const { sendEmail } = await import(moduleUrl.href);
+    const originalConnectionString = process.env.ACS_CONNECTION_STRING;
+    process.env.ACS_CONNECTION_STRING =
+        'endpoint=https://email.example.test/;accesskey=test';
+    t.after(() => {
+        if (originalConnectionString === undefined) {
+            delete process.env.ACS_CONNECTION_STRING;
+        } else {
+            process.env.ACS_CONNECTION_STRING = originalConnectionString;
+        }
+    });
+
+    function reset(mode: ProviderMode = 'succeeded') {
+        events.length = 0;
+        updates.length = 0;
+        createCalls = 0;
+        providerMode = mode;
+        providerOptions = undefined;
+    }
+
+    function sendExisting(options: {
+        abortSignal?: AbortSignal;
+        beforeProviderSubmission?: () => Promise<void>;
+    }) {
+        return sendEmail({
+            abortSignal: options.abortSignal,
+            beforeProviderSubmission: options.beforeProviderSubmission,
+            existingEmailLogId,
+            from: 'sender@example.test',
+            operationId,
+            subject: 'Order confirmation',
+            template: createElement('p', null, 'Order confirmed'),
+            templateName: 'OrderConfirmationEmail',
+            messageType: 'order_confirmation',
+            to: 'recipient@example.test',
+        });
+    }
+
+    function assertOnlyContentUpdate() {
+        assert.equal(createCalls, 0);
+        assert.equal(updates.length, 1);
+        assert.equal(updates[0]?.id, existingEmailLogId);
+        assert.deepEqual(Object.keys(updates[0]?.values ?? {}).sort(), [
+            'attachments',
+            'htmlBody',
+            'messageType',
+            'providerMessageId',
+            'templateName',
+            'textBody',
+        ]);
+    }
+
+    await t.test(
+        'renders and updates the existing log before fencing immediately before provider submission',
+        async () => {
+            reset();
+            const abortController = new AbortController();
+
+            const response = await sendExisting({
+                abortSignal: abortController.signal,
+                beforeProviderSubmission: async () => {
+                    events.push('before-provider-submission');
+                },
+            });
+
+            assert.equal(response.status, 'Succeeded');
+            assert.deepEqual(events, [
+                'render-html',
+                'render-text',
+                'get-log',
+                'update-log',
+                'client-created',
+                'before-provider-submission',
+                'begin-send',
+                'state-read',
+                'poll',
+            ]);
+            assertOnlyContentUpdate();
+            assert.equal(
+                Reflect.get(Object(providerOptions), 'abortSignal'),
+                abortController.signal,
+            );
+            assert.equal(
+                Reflect.get(Object(providerOptions), 'operationId'),
+                operationId,
+            );
+        },
+    );
+
+    await t.test(
+        'does not apply generic terminal status updates over the outbox state machine',
+        async () => {
+            reset('failed');
+
+            await assert.rejects(
+                sendExisting({
+                    beforeProviderSubmission: async () => {
+                        events.push('before-provider-submission');
+                    },
+                }),
+                /Provider failed/u,
+            );
+
+            assertOnlyContentUpdate();
+            assert.deepEqual(events, [
+                'render-html',
+                'render-text',
+                'get-log',
+                'update-log',
+                'client-created',
+                'before-provider-submission',
+                'begin-send',
+                'state-read',
+                'poll',
+            ]);
+        },
+    );
+
+    await t.test(
+        'checks an expired budget before the submission fence and provider request',
+        async () => {
+            reset();
+            const abortController = new AbortController();
+            abortController.abort(new Error('Worker budget exhausted'));
+
+            await assert.rejects(
+                sendExisting({
+                    abortSignal: abortController.signal,
+                    beforeProviderSubmission: async () => {
+                        events.push('before-provider-submission');
+                    },
+                }),
+                /Worker budget exhausted/u,
+            );
+
+            assertOnlyContentUpdate();
+            assert.deepEqual(events, [
+                'render-html',
+                'render-text',
+                'get-log',
+                'update-log',
+                'client-created',
+            ]);
+            assert.equal(providerOptions, undefined);
+        },
+    );
+});

--- a/packages/email/src/acs/sendEmailExistingLog.node.spec.ts
+++ b/packages/email/src/acs/sendEmailExistingLog.node.spec.ts
@@ -113,7 +113,9 @@ test('existing email logs preserve durable outbox ownership at the provider boun
 
     const moduleUrl = new URL('./index.ts', import.meta.url);
     moduleUrl.searchParams.set('test', 'existing-email-log');
-    const { sendEmail } = await import(moduleUrl.href);
+    const { isEmailProviderTerminalFailureError, sendEmail } = await import(
+        moduleUrl.href
+    );
     const originalConnectionString = process.env.ACS_CONNECTION_STRING;
     process.env.ACS_CONNECTION_STRING =
         'endpoint=https://email.example.test/;accesskey=test';
@@ -213,7 +215,13 @@ test('existing email logs preserve durable outbox ownership at the provider boun
                         events.push('before-provider-submission');
                     },
                 }),
-                /Provider failed/u,
+                (error: unknown) => {
+                    assert.equal(
+                        isEmailProviderTerminalFailureError(error),
+                        true,
+                    );
+                    return true;
+                },
             );
 
             assertOnlyContentUpdate();

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -72,6 +72,7 @@ export * from './repositories/notificationSettingsRepo';
 export * from './repositories/notificationsRepo';
 export * from './repositories/occasionsRepo';
 export * from './repositories/operationsRepo';
+export * from './repositories/orderConfirmationOutboxRepo';
 export * from './repositories/outletOffersRepo';
 export * from './repositories/payoutsRepo';
 export * from './repositories/pickupLocationsRepo';

--- a/packages/storage/src/repositories/orderConfirmationOutboxRepo.ts
+++ b/packages/storage/src/repositories/orderConfirmationOutboxRepo.ts
@@ -1,0 +1,1571 @@
+import 'server-only';
+
+import { randomUUID } from 'node:crypto';
+import { and, asc, eq, or, sql } from 'drizzle-orm';
+import { emailMessages, shoppingCartItems, shoppingCarts } from '../schema';
+import { storage } from '../storage';
+
+const orderConfirmationOutboxKind = 'order_confirmation';
+const orderConfirmationTemplateName = 'commerce-order-confirmation';
+const orderConfirmationMessageType = 'commerce';
+const orderConfirmationFromAddress = 'suncokret@obavijesti.gredice.com';
+const orderConfirmationSubject = 'Gredice - potvrda narudžbe';
+const providerOperationIdPattern =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+
+export const orderConfirmationEmailMaxAttempts = 3;
+export const orderConfirmationEmailReconciliationMaxClaimLeaseMs = 5 * 60_000;
+
+const retryDelayMsByCompletedAttempt = [60_000, 5 * 60_000] as const;
+const configurationRetryDelayMs = 60_000;
+const reconciliationDelayMsByCompletedCheck = [
+    60_000,
+    5 * 60_000,
+    15 * 60_000,
+    60 * 60_000,
+    6 * 60 * 60_000,
+] as const;
+
+export type OrderConfirmationEmailItemPayload = {
+    amountSubtotal?: number | null;
+    currency?: string | null;
+    name?: string | null;
+    quantity?: number | null;
+};
+
+export type OrderConfirmationEmailPayload = {
+    cartId: number;
+    currency: string | null;
+    items: OrderConfirmationEmailItemPayload[];
+    manageUrl: string;
+    to: string;
+    totalAmountCents: number | null;
+};
+
+export type MarkCartPaidAndEnqueueOrderConfirmationResult =
+    | {
+          emailMessageId: number;
+          operationId: string;
+          status: 'enqueued';
+      }
+    | {
+          emailMessageId: number | null;
+          operationId: string | null;
+          status: 'already_paid';
+      }
+    | {
+          status: 'cart_not_found' | 'cart_not_ready';
+      };
+
+export type OrderConfirmationEmailClaim = {
+    attempt: number;
+    claimId: string;
+    emailMessageId: number;
+    maxAttempts: number;
+    operationId: string;
+    payload: OrderConfirmationEmailPayload;
+    queuedAt: Date;
+};
+
+export type OrderConfirmationEmailClaimResult =
+    | {
+          claim: OrderConfirmationEmailClaim;
+          status: 'claimed';
+      }
+    | {
+          status: 'empty';
+      }
+    | {
+          emailMessageId: number;
+          status: 'attempts_exhausted' | 'invalid';
+      };
+
+export type OrderConfirmationEmailSubmissionStartResult =
+    | {
+          operationId: string;
+          status: 'started';
+      }
+    | {
+          reason:
+              | 'claim_expired'
+              | 'claim_mismatch'
+              | 'email_not_found'
+              | 'not_claimed';
+          status: 'unavailable';
+      };
+
+export type OrderConfirmationEmailSentResult =
+    | {
+          status: 'already_sent' | 'sent';
+      }
+    | {
+          reason:
+              | 'claim_mismatch'
+              | 'email_not_found'
+              | 'submission_not_started';
+          status: 'unavailable';
+      };
+
+export type OrderConfirmationEmailFailureCode =
+    | 'configuration_error'
+    | 'invalid_payload'
+    | 'provider_rejected_retryable'
+    | 'provider_rejected_terminal'
+    | 'provider_submission_uncertain'
+    | 'render_failed'
+    | 'transport_before_submission'
+    | 'worker_error_before_submission';
+
+export type OrderConfirmationEmailDefiniteFailureCode = Exclude<
+    OrderConfirmationEmailFailureCode,
+    'provider_submission_uncertain'
+>;
+
+export type OrderConfirmationEmailFailureResult =
+    | {
+          attempt: number;
+          nextAttemptAt: Date;
+          status: 'retry_scheduled';
+      }
+    | {
+          attempt: number;
+          status: 'failed';
+      }
+    | {
+          status: 'fenced';
+      }
+    | {
+          reason:
+              | 'claim_mismatch'
+              | 'email_not_found'
+              | 'submission_not_started';
+          status: 'unavailable';
+      };
+
+export type OrderConfirmationEmailReconciliationClaim = {
+    attempt: number;
+    claimId: string;
+    emailMessageId: number;
+    operationId: string;
+};
+
+export type OrderConfirmationEmailReconciliationClaimResult =
+    | {
+          claim: OrderConfirmationEmailReconciliationClaim;
+          status: 'claimed';
+      }
+    | {
+          status: 'empty';
+      };
+
+export type OrderConfirmationEmailReconciliationProviderStatus =
+    | 'Canceled'
+    | 'Failed'
+    | 'NotStarted'
+    | 'Running'
+    | 'Succeeded';
+
+export type OrderConfirmationEmailReconciliationOutcome =
+    | {
+          kind: 'provider_status';
+          status: OrderConfirmationEmailReconciliationProviderStatus;
+      }
+    | {
+          kind: 'lookup_unavailable' | 'unknown_status';
+      };
+
+export type OrderConfirmationEmailReconciliationResult =
+    | {
+          status: 'already_sent' | 'sent';
+      }
+    | {
+          providerStatus: 'Canceled' | 'Failed' | null;
+          status: 'already_failed' | 'failed';
+      }
+    | {
+          attempt: number;
+          nextCheckAt: Date;
+          status: 'pending';
+      }
+    | {
+          reason:
+              | 'claim_expired'
+              | 'claim_mismatch'
+              | 'email_not_found'
+              | 'not_claimed';
+          status: 'unavailable';
+      };
+
+export type OrderConfirmationOutboxHealthSnapshot = {
+    fencedSubmissions: {
+        count: number;
+        oldestFencedAt: string | null;
+        oldestStaleAt: string | null;
+        staleCount: number;
+    };
+    observedAt: string;
+    pendingQueued: {
+        count: number;
+        dueCount: number;
+        oldestDueAt: string | null;
+        oldestQueuedAt: string | null;
+    };
+    preSubmissionClaims: {
+        expiredCount: number;
+        inFlightCount: number;
+        oldestExpiredClaimedAt: string | null;
+        oldestInFlightClaimedAt: string | null;
+    };
+    reconciliation: {
+        claimedCount: number;
+        dueCount: number;
+        expiredClaimCount: number;
+        oldestClaimedAt: string | null;
+        oldestPendingAt: string | null;
+        oldestStaleAt: string | null;
+        pendingCount: number;
+        staleCount: number;
+    };
+    staleBefore: string;
+    staleSubmissionStarted: {
+        count: number;
+        oldestStartedAt: string | null;
+    };
+    submissionUncertain: {
+        count: number;
+        oldestUncertainAt: string | null;
+        oldestStaleUncertainAt: string | null;
+        staleCount: number;
+    };
+    terminalFailures: {
+        count: number;
+        oldestFailedAt: string | null;
+        retryExhaustedCount: number;
+    };
+};
+
+function isRetryableDefiniteFailure(
+    failureCode: OrderConfirmationEmailDefiniteFailureCode,
+) {
+    return (
+        failureCode === 'provider_rejected_retryable' ||
+        failureCode === 'transport_before_submission' ||
+        failureCode === 'worker_error_before_submission'
+    );
+}
+
+type OrderConfirmationOutboxMetadata = Record<string, unknown>;
+
+function requirePositiveInteger(value: number, label: string) {
+    if (!Number.isInteger(value) || value <= 0) {
+        throw new RangeError(`${label} must be a positive integer`);
+    }
+}
+
+function normalizeOperationId(operationId?: string) {
+    const normalized = (operationId ?? randomUUID()).trim().toLowerCase();
+    if (!providerOperationIdPattern.test(normalized)) {
+        throw new TypeError(
+            'Order confirmation operation ID must be a canonical UUID',
+        );
+    }
+    return normalized;
+}
+
+function normalizeClaimId(claimId: string) {
+    const normalized = claimId.trim();
+    if (!normalized || normalized.length > 128) {
+        throw new TypeError(
+            'Order confirmation claim ID must contain 1 to 128 characters',
+        );
+    }
+    return normalized;
+}
+
+function normalizePayload(
+    cartId: number,
+    payload: OrderConfirmationEmailPayload,
+): OrderConfirmationEmailPayload {
+    requirePositiveInteger(cartId, 'Cart ID');
+    if (payload.cartId !== cartId) {
+        throw new TypeError('Order confirmation cart ID does not match');
+    }
+
+    const to = payload.to.trim();
+    if (!to || to.length > 320 || !to.includes('@')) {
+        throw new TypeError('Order confirmation recipient is invalid');
+    }
+    if (!Array.isArray(payload.items)) {
+        throw new TypeError('Order confirmation items must be an array');
+    }
+    if (
+        payload.totalAmountCents !== null &&
+        (!Number.isInteger(payload.totalAmountCents) ||
+            payload.totalAmountCents < 0)
+    ) {
+        throw new TypeError(
+            'Order confirmation total amount must be a non-negative integer or null',
+        );
+    }
+
+    const manageUrl = payload.manageUrl.trim();
+    const parsedManageUrl = new URL(manageUrl);
+    if (!['http:', 'https:'].includes(parsedManageUrl.protocol)) {
+        throw new TypeError('Order confirmation manage URL must use HTTP(S)');
+    }
+
+    return {
+        cartId,
+        currency: payload.currency?.trim().toLowerCase() || null,
+        items: payload.items.map((item) => ({ ...item })),
+        manageUrl,
+        to,
+        totalAmountCents: payload.totalAmountCents,
+    };
+}
+
+function buildInitialMetadata(
+    payload: OrderConfirmationEmailPayload,
+): OrderConfirmationOutboxMetadata {
+    return {
+        attemptCount: 0,
+        cartId: payload.cartId,
+        currency: payload.currency,
+        items: payload.items,
+        manageUrl: payload.manageUrl,
+        maxAttempts: orderConfirmationEmailMaxAttempts,
+        nextAttemptAt: null,
+        outboxKind: orderConfirmationOutboxKind,
+        outboxVersion: 1,
+        totalAmountCents: payload.totalAmountCents,
+    };
+}
+
+function readInteger(value: unknown) {
+    return typeof value === 'number' && Number.isInteger(value) ? value : null;
+}
+
+function readNullableString(value: unknown) {
+    return value === null || typeof value === 'string' ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseStoredItem(
+    value: unknown,
+): OrderConfirmationEmailItemPayload | null {
+    if (!isRecord(value)) {
+        return null;
+    }
+
+    const amountSubtotal = value.amountSubtotal;
+    const currency = value.currency;
+    const name = value.name;
+    const quantity = value.quantity;
+    if (
+        !(
+            amountSubtotal === undefined ||
+            amountSubtotal === null ||
+            typeof amountSubtotal === 'number'
+        ) ||
+        !(
+            currency === undefined ||
+            currency === null ||
+            typeof currency === 'string'
+        ) ||
+        !(name === undefined || name === null || typeof name === 'string') ||
+        !(
+            quantity === undefined ||
+            quantity === null ||
+            typeof quantity === 'number'
+        )
+    ) {
+        return null;
+    }
+
+    return { amountSubtotal, currency, name, quantity };
+}
+
+function parseStoredPayload({
+    metadata,
+    recipient,
+}: {
+    metadata: OrderConfirmationOutboxMetadata;
+    recipient: string | undefined;
+}): OrderConfirmationEmailPayload | null {
+    const cartId = readInteger(metadata.cartId);
+    const items = metadata.items;
+    const manageUrl = metadata.manageUrl;
+    const totalAmountCents = metadata.totalAmountCents;
+    const currency = readNullableString(metadata.currency);
+    const to = recipient?.trim();
+    if (
+        !cartId ||
+        !to ||
+        !Array.isArray(items) ||
+        typeof manageUrl !== 'string' ||
+        !(
+            totalAmountCents === null ||
+            (typeof totalAmountCents === 'number' &&
+                Number.isInteger(totalAmountCents) &&
+                totalAmountCents >= 0)
+        )
+    ) {
+        return null;
+    }
+
+    const parsedItems = items.map(parseStoredItem);
+    if (parsedItems.some((item) => item === null)) {
+        return null;
+    }
+
+    return {
+        cartId,
+        currency,
+        items: parsedItems.flatMap((item) => (item ? [item] : [])),
+        manageUrl,
+        to,
+        totalAmountCents,
+    };
+}
+
+function readAttemptCount(metadata: OrderConfirmationOutboxMetadata) {
+    const count = readInteger(metadata.attemptCount);
+    return count !== null && count >= 0 ? count : 0;
+}
+
+function metadataClaimMatches(
+    metadata: OrderConfirmationOutboxMetadata,
+    claimId: string,
+) {
+    return metadata.claimId === claimId;
+}
+
+function requireValidDate(value: Date, label: string) {
+    if (Number.isNaN(value.getTime())) {
+        throw new TypeError(`${label} must be a valid date`);
+    }
+}
+
+function aggregateTimestampToIso(value: Date | string | null) {
+    if (value === null) {
+        return null;
+    }
+
+    const parsed = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+/**
+ * Returns aggregate-only operational health for the confirmation outbox.
+ * Recipient, body, item, and cart data are neither selected nor returned.
+ */
+export async function getOrderConfirmationOutboxHealthSnapshot({
+    staleBefore,
+    now = new Date(),
+}: {
+    staleBefore: Date;
+    now?: Date;
+}): Promise<OrderConfirmationOutboxHealthSnapshot> {
+    requireValidDate(staleBefore, 'Order confirmation stale cutoff');
+    requireValidDate(now, 'Order confirmation observation time');
+    if (staleBefore.getTime() > now.getTime()) {
+        throw new RangeError(
+            'Order confirmation stale cutoff cannot be after the observation time',
+        );
+    }
+
+    const nowIso = now.toISOString();
+    const staleBeforeIso = staleBefore.toISOString();
+    const pendingQueuedWhere = eq(emailMessages.status, 'queued');
+    const dueQueuedWhere = and(
+        pendingQueuedWhere,
+        sql<boolean>`coalesce(${emailMessages.metadata}->>'nextAttemptAt', '') <= ${nowIso}`,
+    );
+    const preSubmissionClaimWhere = and(
+        eq(emailMessages.status, 'sending'),
+        eq(emailMessages.providerStatus, 'outbox_claimed'),
+    );
+    const inFlightPreSubmissionClaimWhere = and(
+        preSubmissionClaimWhere,
+        sql<boolean>`${emailMessages.metadata}->>'claimExpiresAt' > ${nowIso}`,
+    );
+    const expiredPreSubmissionClaimWhere = and(
+        preSubmissionClaimWhere,
+        sql<boolean>`coalesce(${emailMessages.metadata}->>'claimExpiresAt', '') <= ${nowIso}`,
+    );
+    const submissionStartedWhere = and(
+        eq(emailMessages.status, 'sending'),
+        eq(emailMessages.providerStatus, 'submission_started'),
+    );
+    const staleSubmissionStartedWhere = and(
+        submissionStartedWhere,
+        sql<boolean>`coalesce(${emailMessages.metadata}->>'submissionStartedAt', '') <= ${staleBeforeIso}`,
+    );
+    const submissionUncertainWhere = and(
+        eq(emailMessages.status, 'sending'),
+        eq(emailMessages.providerStatus, 'submission_uncertain'),
+    );
+    const staleSubmissionUncertainWhere = and(
+        submissionUncertainWhere,
+        sql<boolean>`coalesce(${emailMessages.metadata}->>'submissionUncertainAt', '') <= ${staleBeforeIso}`,
+    );
+    const reconciliationPendingWhere = and(
+        eq(emailMessages.status, 'sending'),
+        eq(emailMessages.providerStatus, 'reconciliation_pending'),
+    );
+    const dueReconciliationPendingWhere = and(
+        reconciliationPendingWhere,
+        sql<boolean>`coalesce(${emailMessages.metadata}->>'nextReconciliationAt', '') <= ${nowIso}`,
+    );
+    const staleReconciliationPendingWhere = and(
+        reconciliationPendingWhere,
+        sql<boolean>`coalesce(${emailMessages.metadata}->>'nextReconciliationAt', '') <= ${staleBeforeIso}`,
+    );
+    const reconciliationClaimedWhere = and(
+        eq(emailMessages.status, 'sending'),
+        eq(emailMessages.providerStatus, 'reconciliation_claimed'),
+    );
+    const expiredReconciliationClaimWhere = and(
+        reconciliationClaimedWhere,
+        sql<boolean>`coalesce(${emailMessages.metadata}->>'reconciliationClaimExpiresAt', '') <= ${nowIso}`,
+    );
+    const staleReconciliationClaimWhere = and(
+        reconciliationClaimedWhere,
+        sql<boolean>`coalesce(${emailMessages.metadata}->>'reconciliationClaimExpiresAt', '') <= ${staleBeforeIso}`,
+    );
+    const staleReconciliationWhere = or(
+        staleReconciliationPendingWhere,
+        staleReconciliationClaimWhere,
+    );
+    const fencedSubmissionWhere = or(
+        submissionStartedWhere,
+        submissionUncertainWhere,
+        reconciliationPendingWhere,
+        reconciliationClaimedWhere,
+    );
+    const staleFencedSubmissionWhere = or(
+        staleSubmissionStartedWhere,
+        staleSubmissionUncertainWhere,
+        staleReconciliationPendingWhere,
+        staleReconciliationClaimWhere,
+    );
+    const terminalFailureWhere = eq(emailMessages.status, 'failed');
+    const retryExhaustedWhere = and(
+        terminalFailureWhere,
+        eq(emailMessages.providerStatus, 'retry_exhausted'),
+        or(
+            eq(emailMessages.errorCode, 'attempts_exhausted'),
+            sql<boolean>`${emailMessages.metadata}->>'attemptCount' = ${emailMessages.metadata}->>'maxAttempts'`,
+        ),
+    );
+
+    const [aggregate] = await storage()
+        .select({
+            dueQueuedCount: sql<number>`count(*) filter (where ${dueQueuedWhere})::integer`,
+            dueReconciliationCount: sql<number>`count(*) filter (where ${dueReconciliationPendingWhere})::integer`,
+            expiredPreSubmissionClaimCount: sql<number>`count(*) filter (where ${expiredPreSubmissionClaimWhere})::integer`,
+            expiredReconciliationClaimCount: sql<number>`count(*) filter (where ${expiredReconciliationClaimWhere})::integer`,
+            fencedSubmissionCount: sql<number>`count(*) filter (where ${fencedSubmissionWhere})::integer`,
+            inFlightPreSubmissionClaimCount: sql<number>`count(*) filter (where ${inFlightPreSubmissionClaimWhere})::integer`,
+            oldestDueAt:
+                sql<Date | null>`min(${emailMessages.queuedAt}) filter (where ${dueQueuedWhere})`.mapWith(
+                    emailMessages.queuedAt,
+                ),
+            oldestExpiredClaimedAt:
+                sql<Date | null>`min(${emailMessages.lastAttemptAt}) filter (where ${expiredPreSubmissionClaimWhere})`.mapWith(
+                    emailMessages.lastAttemptAt,
+                ),
+            oldestFailedAt:
+                sql<Date | null>`min(${emailMessages.completedAt}) filter (where ${terminalFailureWhere})`.mapWith(
+                    emailMessages.completedAt,
+                ),
+            oldestInFlightClaimedAt:
+                sql<Date | null>`min(${emailMessages.lastAttemptAt}) filter (where ${inFlightPreSubmissionClaimWhere})`.mapWith(
+                    emailMessages.lastAttemptAt,
+                ),
+            oldestFencedAt: sql<
+                string | null
+            >`min(coalesce(${emailMessages.metadata}->>'reconciliationFencedAt', ${emailMessages.metadata}->>'submissionUncertainAt', ${emailMessages.metadata}->>'submissionStartedAt')) filter (where ${fencedSubmissionWhere})`,
+            oldestQueuedAt:
+                sql<Date | null>`min(${emailMessages.queuedAt}) filter (where ${pendingQueuedWhere})`.mapWith(
+                    emailMessages.queuedAt,
+                ),
+            oldestReconciliationClaimedAt: sql<
+                string | null
+            >`min(${emailMessages.metadata}->>'reconciliationClaimedAt') filter (where ${reconciliationClaimedWhere})`,
+            oldestReconciliationPendingAt: sql<
+                string | null
+            >`min(${emailMessages.metadata}->>'nextReconciliationAt') filter (where ${reconciliationPendingWhere})`,
+            oldestReconciliationStaleAt: sql<
+                string | null
+            >`min(coalesce(${emailMessages.metadata}->>'nextReconciliationAt', ${emailMessages.metadata}->>'reconciliationClaimExpiresAt')) filter (where ${staleReconciliationWhere})`,
+            oldestStaleFencedAt: sql<
+                string | null
+            >`min(coalesce(${emailMessages.metadata}->>'reconciliationFencedAt', ${emailMessages.metadata}->>'submissionUncertainAt', ${emailMessages.metadata}->>'submissionStartedAt')) filter (where ${staleFencedSubmissionWhere})`,
+            oldestStaleSubmissionStartedAt: sql<
+                string | null
+            >`min(${emailMessages.metadata}->>'submissionStartedAt') filter (where ${staleSubmissionStartedWhere})`,
+            oldestStaleSubmissionUncertainAt: sql<
+                string | null
+            >`min(${emailMessages.metadata}->>'submissionUncertainAt') filter (where ${staleSubmissionUncertainWhere})`,
+            oldestSubmissionUncertainAt: sql<
+                string | null
+            >`min(${emailMessages.metadata}->>'submissionUncertainAt') filter (where ${submissionUncertainWhere})`,
+            pendingQueuedCount: sql<number>`count(*) filter (where ${pendingQueuedWhere})::integer`,
+            reconciliationClaimedCount: sql<number>`count(*) filter (where ${reconciliationClaimedWhere})::integer`,
+            reconciliationPendingCount: sql<number>`count(*) filter (where ${reconciliationPendingWhere})::integer`,
+            reconciliationStaleCount: sql<number>`count(*) filter (where ${staleReconciliationWhere})::integer`,
+            retryExhaustedCount: sql<number>`count(*) filter (where ${retryExhaustedWhere})::integer`,
+            staleFencedSubmissionCount: sql<number>`count(*) filter (where ${staleFencedSubmissionWhere})::integer`,
+            staleSubmissionStartedCount: sql<number>`count(*) filter (where ${staleSubmissionStartedWhere})::integer`,
+            staleSubmissionUncertainCount: sql<number>`count(*) filter (where ${staleSubmissionUncertainWhere})::integer`,
+            submissionUncertainCount: sql<number>`count(*) filter (where ${submissionUncertainWhere})::integer`,
+            terminalFailureCount: sql<number>`count(*) filter (where ${terminalFailureWhere})::integer`,
+        })
+        .from(emailMessages)
+        .where(
+            and(
+                eq(emailMessages.templateName, orderConfirmationTemplateName),
+                sql<boolean>`${emailMessages.metadata}->>'outboxKind' = ${orderConfirmationOutboxKind}`,
+                or(
+                    eq(emailMessages.status, 'failed'),
+                    eq(emailMessages.status, 'queued'),
+                    eq(emailMessages.status, 'sending'),
+                ),
+            ),
+        );
+
+    if (!aggregate) {
+        throw new Error('Failed to read order confirmation outbox health');
+    }
+
+    return {
+        fencedSubmissions: {
+            count: aggregate.fencedSubmissionCount,
+            oldestFencedAt: aggregateTimestampToIso(aggregate.oldestFencedAt),
+            oldestStaleAt: aggregateTimestampToIso(
+                aggregate.oldestStaleFencedAt,
+            ),
+            staleCount: aggregate.staleFencedSubmissionCount,
+        },
+        observedAt: nowIso,
+        pendingQueued: {
+            count: aggregate.pendingQueuedCount,
+            dueCount: aggregate.dueQueuedCount,
+            oldestDueAt: aggregateTimestampToIso(aggregate.oldestDueAt),
+            oldestQueuedAt: aggregateTimestampToIso(aggregate.oldestQueuedAt),
+        },
+        preSubmissionClaims: {
+            expiredCount: aggregate.expiredPreSubmissionClaimCount,
+            inFlightCount: aggregate.inFlightPreSubmissionClaimCount,
+            oldestExpiredClaimedAt: aggregateTimestampToIso(
+                aggregate.oldestExpiredClaimedAt,
+            ),
+            oldestInFlightClaimedAt: aggregateTimestampToIso(
+                aggregate.oldestInFlightClaimedAt,
+            ),
+        },
+        reconciliation: {
+            claimedCount: aggregate.reconciliationClaimedCount,
+            dueCount: aggregate.dueReconciliationCount,
+            expiredClaimCount: aggregate.expiredReconciliationClaimCount,
+            oldestClaimedAt: aggregateTimestampToIso(
+                aggregate.oldestReconciliationClaimedAt,
+            ),
+            oldestPendingAt: aggregateTimestampToIso(
+                aggregate.oldestReconciliationPendingAt,
+            ),
+            oldestStaleAt: aggregateTimestampToIso(
+                aggregate.oldestReconciliationStaleAt,
+            ),
+            pendingCount: aggregate.reconciliationPendingCount,
+            staleCount: aggregate.reconciliationStaleCount,
+        },
+        staleBefore: staleBeforeIso,
+        staleSubmissionStarted: {
+            count: aggregate.staleSubmissionStartedCount,
+            oldestStartedAt: aggregateTimestampToIso(
+                aggregate.oldestStaleSubmissionStartedAt,
+            ),
+        },
+        submissionUncertain: {
+            count: aggregate.submissionUncertainCount,
+            oldestUncertainAt: aggregateTimestampToIso(
+                aggregate.oldestSubmissionUncertainAt,
+            ),
+            oldestStaleUncertainAt: aggregateTimestampToIso(
+                aggregate.oldestStaleSubmissionUncertainAt,
+            ),
+            staleCount: aggregate.staleSubmissionUncertainCount,
+        },
+        terminalFailures: {
+            count: aggregate.terminalFailureCount,
+            oldestFailedAt: aggregateTimestampToIso(aggregate.oldestFailedAt),
+            retryExhaustedCount: aggregate.retryExhaustedCount,
+        },
+    };
+}
+
+function findOrderConfirmationForCart(
+    cartId: number,
+    db: Parameters<Parameters<ReturnType<typeof storage>['transaction']>[0]>[0],
+) {
+    return db.query.emailMessages.findFirst({
+        where: and(
+            eq(emailMessages.templateName, orderConfirmationTemplateName),
+            sql<boolean>`${emailMessages.metadata}->>'outboxKind' = ${orderConfirmationOutboxKind}`,
+            sql<boolean>`${emailMessages.metadata}->>'cartId' = ${cartId.toString()}`,
+        ),
+        orderBy: [asc(emailMessages.id)],
+    });
+}
+
+/**
+ * Marks a ready cart paid and writes its confirmation-email intent in the same
+ * transaction. The cart status transition is the idempotency fence: replays of
+ * an already-paid cart never enqueue a second message.
+ */
+export async function markCartPaidAndEnqueueOrderConfirmation({
+    cartId,
+    payload,
+    operationId,
+    now = new Date(),
+}: {
+    cartId: number;
+    payload: OrderConfirmationEmailPayload;
+    operationId?: string;
+    now?: Date;
+}): Promise<MarkCartPaidAndEnqueueOrderConfirmationResult> {
+    const normalizedPayload = normalizePayload(cartId, payload);
+    const normalizedOperationId = normalizeOperationId(operationId);
+
+    return storage().transaction(async (tx) => {
+        await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtext(${`shopping-cart-checkout:${cartId.toString()}`}));`,
+        );
+
+        const [cart] = await tx
+            .select({ id: shoppingCarts.id, status: shoppingCarts.status })
+            .from(shoppingCarts)
+            .where(
+                and(
+                    eq(shoppingCarts.id, cartId),
+                    eq(shoppingCarts.isDeleted, false),
+                ),
+            )
+            .for('update')
+            .limit(1);
+        if (!cart) {
+            return { status: 'cart_not_found' };
+        }
+        if (cart.status === 'paid') {
+            const existing = await findOrderConfirmationForCart(cartId, tx);
+            return {
+                emailMessageId: existing?.id ?? null,
+                operationId: existing?.providerMessageId ?? null,
+                status: 'already_paid',
+            };
+        }
+        if (cart.status !== 'new') {
+            return { status: 'cart_not_ready' };
+        }
+
+        const items = await tx
+            .select({ status: shoppingCartItems.status })
+            .from(shoppingCartItems)
+            .where(
+                and(
+                    eq(shoppingCartItems.cartId, cartId),
+                    eq(shoppingCartItems.isDeleted, false),
+                ),
+            );
+        if (
+            items.length === 0 ||
+            items.some((item) => item.status !== 'paid')
+        ) {
+            return { status: 'cart_not_ready' };
+        }
+
+        const [transitioned] = await tx
+            .update(shoppingCarts)
+            .set({ status: 'paid', updatedAt: now })
+            .where(
+                and(
+                    eq(shoppingCarts.id, cartId),
+                    eq(shoppingCarts.status, 'new'),
+                    eq(shoppingCarts.isDeleted, false),
+                ),
+            )
+            .returning({ id: shoppingCarts.id });
+        if (!transitioned) {
+            return { status: 'cart_not_ready' };
+        }
+
+        const [emailMessage] = await tx
+            .insert(emailMessages)
+            .values({
+                attachments: [],
+                createdAt: now,
+                fromAddress: orderConfirmationFromAddress,
+                metadata: buildInitialMetadata(normalizedPayload),
+                messageType: orderConfirmationMessageType,
+                provider: 'acs',
+                providerMessageId: normalizedOperationId,
+                providerStatus: 'outbox_ready',
+                queuedAt: now,
+                recipients: {
+                    to: [{ address: normalizedPayload.to }],
+                },
+                status: 'queued',
+                subject: orderConfirmationSubject,
+                templateName: orderConfirmationTemplateName,
+                updatedAt: now,
+            })
+            .returning({ id: emailMessages.id });
+        if (!emailMessage) {
+            throw new Error('Failed to enqueue order confirmation email');
+        }
+
+        return {
+            emailMessageId: emailMessage.id,
+            operationId: normalizedOperationId,
+            status: 'enqueued',
+        };
+    });
+}
+
+function dueOrderConfirmationWhere(now: Date) {
+    const nowIso = now.toISOString();
+    return and(
+        eq(emailMessages.templateName, orderConfirmationTemplateName),
+        sql<boolean>`${emailMessages.metadata}->>'outboxKind' = ${orderConfirmationOutboxKind}`,
+        or(
+            and(
+                eq(emailMessages.status, 'queued'),
+                sql<boolean>`coalesce(${emailMessages.metadata}->>'nextAttemptAt', '') <= ${nowIso}`,
+            ),
+            and(
+                eq(emailMessages.status, 'sending'),
+                eq(emailMessages.providerStatus, 'outbox_claimed'),
+                sql<boolean>`${emailMessages.metadata}->>'claimExpiresAt' <= ${nowIso}`,
+            ),
+        ),
+    );
+}
+
+/** Claims one due intent without waiting for rows held by another worker. */
+export async function claimOrderConfirmationEmail({
+    claimId,
+    claimExpiresAt,
+    now = new Date(),
+}: {
+    claimId: string;
+    claimExpiresAt: Date;
+    now?: Date;
+}): Promise<OrderConfirmationEmailClaimResult> {
+    const normalizedClaimId = normalizeClaimId(claimId);
+    if (claimExpiresAt.getTime() <= now.getTime()) {
+        throw new RangeError(
+            'Order confirmation claim expiration must be in the future',
+        );
+    }
+
+    return storage().transaction(async (tx) => {
+        const [candidate] = await tx
+            .select()
+            .from(emailMessages)
+            .where(dueOrderConfirmationWhere(now))
+            .orderBy(asc(emailMessages.queuedAt), asc(emailMessages.id))
+            .for('update', { skipLocked: true })
+            .limit(1);
+        if (!candidate) {
+            return { status: 'empty' };
+        }
+
+        const attemptCount = readAttemptCount(candidate.metadata);
+        if (attemptCount >= orderConfirmationEmailMaxAttempts) {
+            await tx
+                .update(emailMessages)
+                .set({
+                    completedAt: now,
+                    errorCode: 'attempts_exhausted',
+                    errorMessage:
+                        'Order confirmation delivery attempts were exhausted before provider submission.',
+                    providerStatus: 'retry_exhausted',
+                    status: 'failed',
+                    updatedAt: now,
+                })
+                .where(eq(emailMessages.id, candidate.id));
+            return {
+                emailMessageId: candidate.id,
+                status: 'attempts_exhausted',
+            };
+        }
+
+        const payload = parseStoredPayload({
+            metadata: candidate.metadata,
+            recipient: candidate.recipients.to[0]?.address,
+        });
+        const operationId = candidate.providerMessageId?.trim().toLowerCase();
+        if (
+            !payload ||
+            !operationId ||
+            !providerOperationIdPattern.test(operationId)
+        ) {
+            await tx
+                .update(emailMessages)
+                .set({
+                    completedAt: now,
+                    errorCode: 'invalid_payload',
+                    errorMessage:
+                        'Order confirmation outbox payload is invalid.',
+                    providerStatus: 'outbox_invalid',
+                    status: 'failed',
+                    updatedAt: now,
+                })
+                .where(eq(emailMessages.id, candidate.id));
+            return { emailMessageId: candidate.id, status: 'invalid' };
+        }
+
+        const attempt = attemptCount + 1;
+        await tx
+            .update(emailMessages)
+            .set({
+                completedAt: null,
+                errorCode: null,
+                errorMessage: null,
+                lastAttemptAt: now,
+                metadata: {
+                    ...candidate.metadata,
+                    attemptCount: attempt,
+                    claimExpiresAt: claimExpiresAt.toISOString(),
+                    claimId: normalizedClaimId,
+                    claimedAt: now.toISOString(),
+                    nextAttemptAt: null,
+                },
+                providerStatus: 'outbox_claimed',
+                status: 'sending',
+                updatedAt: now,
+            })
+            .where(eq(emailMessages.id, candidate.id));
+
+        return {
+            claim: {
+                attempt,
+                claimId: normalizedClaimId,
+                emailMessageId: candidate.id,
+                maxAttempts: orderConfirmationEmailMaxAttempts,
+                operationId,
+                payload,
+                queuedAt: candidate.queuedAt,
+            },
+            status: 'claimed',
+        };
+    });
+}
+
+export async function startOrderConfirmationEmailSubmission({
+    emailMessageId,
+    claimId,
+    now = new Date(),
+}: {
+    emailMessageId: number;
+    claimId: string;
+    now?: Date;
+}): Promise<OrderConfirmationEmailSubmissionStartResult> {
+    requirePositiveInteger(emailMessageId, 'Email message ID');
+    const normalizedClaimId = normalizeClaimId(claimId);
+
+    return storage().transaction(async (tx) => {
+        const [message] = await tx
+            .select()
+            .from(emailMessages)
+            .where(eq(emailMessages.id, emailMessageId))
+            .for('update')
+            .limit(1);
+        if (!message) {
+            return { reason: 'email_not_found', status: 'unavailable' };
+        }
+        if (
+            message.status !== 'sending' ||
+            message.providerStatus !== 'outbox_claimed'
+        ) {
+            return { reason: 'not_claimed', status: 'unavailable' };
+        }
+        if (!metadataClaimMatches(message.metadata, normalizedClaimId)) {
+            return { reason: 'claim_mismatch', status: 'unavailable' };
+        }
+        const claimExpiresAt = message.metadata.claimExpiresAt;
+        if (
+            typeof claimExpiresAt !== 'string' ||
+            claimExpiresAt <= now.toISOString()
+        ) {
+            return { reason: 'claim_expired', status: 'unavailable' };
+        }
+
+        const operationId = message.providerMessageId?.trim().toLowerCase();
+        if (!operationId || !providerOperationIdPattern.test(operationId)) {
+            return { reason: 'not_claimed', status: 'unavailable' };
+        }
+
+        await tx
+            .update(emailMessages)
+            .set({
+                metadata: {
+                    ...message.metadata,
+                    submissionStartedAt: now.toISOString(),
+                },
+                providerStatus: 'submission_started',
+                updatedAt: now,
+            })
+            .where(eq(emailMessages.id, emailMessageId));
+
+        return { operationId, status: 'started' };
+    });
+}
+
+export async function markOrderConfirmationEmailSent({
+    emailMessageId,
+    claimId,
+    providerMessageId,
+    providerStatus,
+    now = new Date(),
+}: {
+    emailMessageId: number;
+    claimId: string;
+    providerMessageId?: string | null;
+    providerStatus?: string | null;
+    now?: Date;
+}): Promise<OrderConfirmationEmailSentResult> {
+    requirePositiveInteger(emailMessageId, 'Email message ID');
+    const normalizedClaimId = normalizeClaimId(claimId);
+
+    return storage().transaction(async (tx) => {
+        const [message] = await tx
+            .select()
+            .from(emailMessages)
+            .where(eq(emailMessages.id, emailMessageId))
+            .for('update')
+            .limit(1);
+        if (!message) {
+            return { reason: 'email_not_found', status: 'unavailable' };
+        }
+        if (message.status === 'sent') {
+            return { status: 'already_sent' };
+        }
+        if (!metadataClaimMatches(message.metadata, normalizedClaimId)) {
+            return { reason: 'claim_mismatch', status: 'unavailable' };
+        }
+        if (
+            message.status !== 'sending' ||
+            message.providerStatus !== 'submission_started'
+        ) {
+            return {
+                reason: 'submission_not_started',
+                status: 'unavailable',
+            };
+        }
+
+        await tx
+            .update(emailMessages)
+            .set({
+                completedAt: now,
+                errorCode: null,
+                errorMessage: null,
+                metadata: {
+                    ...message.metadata,
+                    deliveryCompletedAt: now.toISOString(),
+                },
+                providerMessageId:
+                    providerMessageId?.trim() || message.providerMessageId,
+                providerStatus: providerStatus?.trim() || 'succeeded',
+                sentAt: now,
+                status: 'sent',
+                updatedAt: now,
+            })
+            .where(eq(emailMessages.id, emailMessageId));
+
+        return { status: 'sent' };
+    });
+}
+
+export async function markOrderConfirmationEmailFailed({
+    emailMessageId,
+    claimId,
+    failureKind,
+    failureCode,
+    now = new Date(),
+}: {
+    emailMessageId: number;
+    claimId: string;
+    now?: Date;
+} & (
+    | {
+          failureKind: 'definite';
+          failureCode: OrderConfirmationEmailDefiniteFailureCode;
+      }
+    | {
+          failureKind: 'uncertain';
+          failureCode: 'provider_submission_uncertain';
+      }
+)): Promise<OrderConfirmationEmailFailureResult> {
+    requirePositiveInteger(emailMessageId, 'Email message ID');
+    const normalizedClaimId = normalizeClaimId(claimId);
+
+    return storage().transaction(async (tx) => {
+        const [message] = await tx
+            .select()
+            .from(emailMessages)
+            .where(eq(emailMessages.id, emailMessageId))
+            .for('update')
+            .limit(1);
+        if (!message) {
+            return { reason: 'email_not_found', status: 'unavailable' };
+        }
+
+        const attempt = readAttemptCount(message.metadata);
+        if (message.status === 'failed') {
+            return { attempt, status: 'failed' };
+        }
+        if (
+            failureKind === 'uncertain' &&
+            message.status === 'sending' &&
+            message.providerStatus === 'submission_uncertain'
+        ) {
+            return { status: 'fenced' };
+        }
+        if (!metadataClaimMatches(message.metadata, normalizedClaimId)) {
+            return { reason: 'claim_mismatch', status: 'unavailable' };
+        }
+
+        const submissionStarted =
+            message.status === 'sending' &&
+            message.providerStatus === 'submission_started';
+        const claimedBeforeSubmission =
+            message.status === 'sending' &&
+            message.providerStatus === 'outbox_claimed';
+        if (
+            (!submissionStarted && !claimedBeforeSubmission) ||
+            (failureKind === 'uncertain' && !submissionStarted)
+        ) {
+            return {
+                reason: 'submission_not_started',
+                status: 'unavailable',
+            };
+        }
+
+        if (failureKind === 'uncertain') {
+            await tx
+                .update(emailMessages)
+                .set({
+                    errorCode: failureCode,
+                    errorMessage:
+                        'Order confirmation provider submission outcome is uncertain; automatic retry is fenced.',
+                    metadata: {
+                        ...message.metadata,
+                        submissionUncertainAt: now.toISOString(),
+                    },
+                    providerStatus: 'submission_uncertain',
+                    status: 'sending',
+                    updatedAt: now,
+                })
+                .where(eq(emailMessages.id, emailMessageId));
+            return { status: 'fenced' };
+        }
+
+        if (failureCode === 'configuration_error' && claimedBeforeSubmission) {
+            const nextAttemptAt = new Date(
+                now.getTime() + configurationRetryDelayMs,
+            );
+            await tx
+                .update(emailMessages)
+                .set({
+                    completedAt: null,
+                    errorCode: failureCode,
+                    errorMessage:
+                        'Order confirmation delivery is waiting for provider configuration.',
+                    metadata: {
+                        ...message.metadata,
+                        attemptCount: Math.max(0, attempt - 1),
+                        claimExpiresAt: null,
+                        claimId: null,
+                        lastFailureAt: now.toISOString(),
+                        nextAttemptAt: nextAttemptAt.toISOString(),
+                        submissionStartedAt: null,
+                    },
+                    providerStatus: 'retry_scheduled',
+                    status: 'queued',
+                    updatedAt: now,
+                })
+                .where(eq(emailMessages.id, emailMessageId));
+            return { attempt, nextAttemptAt, status: 'retry_scheduled' };
+        }
+
+        const retryIsProvenSafe = isRetryableDefiniteFailure(failureCode);
+        if (retryIsProvenSafe && attempt < orderConfirmationEmailMaxAttempts) {
+            const retryDelayMs =
+                retryDelayMsByCompletedAttempt[attempt - 1] ??
+                retryDelayMsByCompletedAttempt[
+                    retryDelayMsByCompletedAttempt.length - 1
+                ];
+            const nextAttemptAt = new Date(now.getTime() + retryDelayMs);
+            await tx
+                .update(emailMessages)
+                .set({
+                    completedAt: null,
+                    errorCode: failureCode,
+                    errorMessage:
+                        'Order confirmation delivery failed before a provider submission could be confirmed.',
+                    metadata: {
+                        ...message.metadata,
+                        claimExpiresAt: null,
+                        claimId: null,
+                        lastFailureAt: now.toISOString(),
+                        nextAttemptAt: nextAttemptAt.toISOString(),
+                        submissionStartedAt: null,
+                    },
+                    providerStatus: 'retry_scheduled',
+                    status: 'queued',
+                    updatedAt: now,
+                })
+                .where(eq(emailMessages.id, emailMessageId));
+            return { attempt, nextAttemptAt, status: 'retry_scheduled' };
+        }
+
+        await tx
+            .update(emailMessages)
+            .set({
+                completedAt: now,
+                errorCode: failureCode,
+                errorMessage: retryIsProvenSafe
+                    ? 'Order confirmation delivery attempts were exhausted before provider submission.'
+                    : 'Order confirmation delivery failed with a non-retryable error.',
+                metadata: {
+                    ...message.metadata,
+                    lastFailureAt: now.toISOString(),
+                },
+                providerStatus: 'retry_exhausted',
+                status: 'failed',
+                updatedAt: now,
+            })
+            .where(eq(emailMessages.id, emailMessageId));
+        return { attempt, status: 'failed' };
+    });
+}
+
+function dueOrderConfirmationReconciliationWhere({
+    now,
+    staleBefore,
+}: {
+    now: Date;
+    staleBefore: Date;
+}) {
+    const nowIso = now.toISOString();
+    const staleBeforeIso = staleBefore.toISOString();
+    return and(
+        eq(emailMessages.templateName, orderConfirmationTemplateName),
+        eq(emailMessages.status, 'sending'),
+        sql<boolean>`${emailMessages.metadata}->>'outboxKind' = ${orderConfirmationOutboxKind}`,
+        sql<boolean>`${emailMessages.providerMessageId} ~ ${providerOperationIdPattern.source}`,
+        or(
+            and(
+                eq(emailMessages.providerStatus, 'submission_started'),
+                sql<boolean>`coalesce(${emailMessages.metadata}->>'submissionStartedAt', '') <= ${staleBeforeIso}`,
+            ),
+            and(
+                eq(emailMessages.providerStatus, 'submission_uncertain'),
+                sql<boolean>`coalesce(${emailMessages.metadata}->>'submissionUncertainAt', '') <= ${staleBeforeIso}`,
+            ),
+            and(
+                eq(emailMessages.providerStatus, 'reconciliation_pending'),
+                sql<boolean>`coalesce(${emailMessages.metadata}->>'nextReconciliationAt', '') <= ${nowIso}`,
+            ),
+            and(
+                eq(emailMessages.providerStatus, 'reconciliation_claimed'),
+                sql<boolean>`coalesce(${emailMessages.metadata}->>'reconciliationClaimExpiresAt', '') <= ${nowIso}`,
+            ),
+        ),
+    );
+}
+
+function reconciliationDelayMs(attempt: number) {
+    const delayIndex = Math.min(
+        Math.max(attempt - 1, 0),
+        reconciliationDelayMsByCompletedCheck.length - 1,
+    );
+    return reconciliationDelayMsByCompletedCheck[delayIndex];
+}
+
+/**
+ * Claims one stale or due provider submission for a read-only provider-status
+ * lookup. The claim intentionally contains no recipient, body, cart, or item
+ * data and can never be consumed by the delivery worker as a send retry.
+ */
+export async function claimOrderConfirmationEmailReconciliation({
+    claimId,
+    claimExpiresAt,
+    staleBefore,
+    now = new Date(),
+}: {
+    claimId: string;
+    claimExpiresAt: Date;
+    staleBefore: Date;
+    now?: Date;
+}): Promise<OrderConfirmationEmailReconciliationClaimResult> {
+    const normalizedClaimId = normalizeClaimId(claimId);
+    requireValidDate(claimExpiresAt, 'Reconciliation claim expiration');
+    requireValidDate(staleBefore, 'Reconciliation stale cutoff');
+    requireValidDate(now, 'Reconciliation claim time');
+    if (staleBefore.getTime() > now.getTime()) {
+        throw new RangeError(
+            'Reconciliation stale cutoff cannot be after the claim time',
+        );
+    }
+    const leaseMs = claimExpiresAt.getTime() - now.getTime();
+    if (
+        leaseMs <= 0 ||
+        leaseMs > orderConfirmationEmailReconciliationMaxClaimLeaseMs
+    ) {
+        throw new RangeError(
+            `Reconciliation claim lease must be between 1 and ${orderConfirmationEmailReconciliationMaxClaimLeaseMs.toString()} milliseconds`,
+        );
+    }
+
+    return storage().transaction(async (tx) => {
+        const [candidate] = await tx
+            .select({
+                emailMessageId: emailMessages.id,
+                operationId: emailMessages.providerMessageId,
+                providerStatus: emailMessages.providerStatus,
+                reconciliationAttempt: sql<
+                    string | null
+                >`${emailMessages.metadata}->>'reconciliationAttempt'`,
+                reconciliationFencedAt: sql<
+                    string | null
+                >`coalesce(${emailMessages.metadata}->>'reconciliationFencedAt', ${emailMessages.metadata}->>'submissionUncertainAt', ${emailMessages.metadata}->>'submissionStartedAt')`,
+                updatedAt: emailMessages.updatedAt,
+            })
+            .from(emailMessages)
+            .where(
+                dueOrderConfirmationReconciliationWhere({ now, staleBefore }),
+            )
+            .orderBy(asc(emailMessages.updatedAt), asc(emailMessages.id))
+            .for('update', { skipLocked: true })
+            .limit(1);
+        if (!candidate) {
+            return { status: 'empty' };
+        }
+
+        const operationId = candidate.operationId?.trim().toLowerCase();
+        if (!operationId || !providerOperationIdPattern.test(operationId)) {
+            return { status: 'empty' };
+        }
+        const priorAttempt = Number(candidate.reconciliationAttempt);
+        const attempt =
+            Number.isSafeInteger(priorAttempt) && priorAttempt >= 0
+                ? priorAttempt + 1
+                : 1;
+        const sourceStatus =
+            candidate.providerStatus === 'submission_started' ||
+            candidate.providerStatus === 'submission_uncertain'
+                ? candidate.providerStatus
+                : null;
+        const metadataPatch = {
+            nextReconciliationAt: null,
+            reconciliationAttempt: attempt,
+            reconciliationClaimExpiresAt: claimExpiresAt.toISOString(),
+            reconciliationClaimId: normalizedClaimId,
+            reconciliationClaimedAt: now.toISOString(),
+            reconciliationFencedAt:
+                candidate.reconciliationFencedAt ??
+                candidate.updatedAt.toISOString(),
+            ...(sourceStatus
+                ? { reconciliationFenceStatus: sourceStatus }
+                : {}),
+        };
+
+        await tx
+            .update(emailMessages)
+            .set({
+                metadata: sql`${emailMessages.metadata} || ${JSON.stringify(metadataPatch)}::jsonb`,
+                providerStatus: 'reconciliation_claimed',
+                updatedAt: now,
+            })
+            .where(eq(emailMessages.id, candidate.emailMessageId));
+
+        return {
+            claim: {
+                attempt,
+                claimId: normalizedClaimId,
+                emailMessageId: candidate.emailMessageId,
+                operationId,
+            },
+            status: 'claimed',
+        };
+    });
+}
+
+/**
+ * Applies a read-only provider-status result to a reconciliation claim. Only a
+ * terminal provider result can leave the fenced sending state. Every other
+ * result schedules another bounded-backoff lookup without re-queuing the send.
+ */
+export async function finalizeOrderConfirmationEmailReconciliation({
+    emailMessageId,
+    claimId,
+    outcome,
+    now = new Date(),
+}: {
+    emailMessageId: number;
+    claimId: string;
+    outcome: OrderConfirmationEmailReconciliationOutcome;
+    now?: Date;
+}): Promise<OrderConfirmationEmailReconciliationResult> {
+    requirePositiveInteger(emailMessageId, 'Email message ID');
+    const normalizedClaimId = normalizeClaimId(claimId);
+    requireValidDate(now, 'Reconciliation finalization time');
+
+    return storage().transaction(async (tx) => {
+        const [message] = await tx
+            .select({
+                claimExpiresAt: sql<
+                    string | null
+                >`${emailMessages.metadata}->>'reconciliationClaimExpiresAt'`,
+                claimId: sql<
+                    string | null
+                >`${emailMessages.metadata}->>'reconciliationClaimId'`,
+                providerStatus: emailMessages.providerStatus,
+                reconciliationAttempt: sql<
+                    string | null
+                >`${emailMessages.metadata}->>'reconciliationAttempt'`,
+                status: emailMessages.status,
+            })
+            .from(emailMessages)
+            .where(eq(emailMessages.id, emailMessageId))
+            .for('update')
+            .limit(1);
+        if (!message) {
+            return { reason: 'email_not_found', status: 'unavailable' };
+        }
+        if (message.status === 'sent') {
+            return { status: 'already_sent' };
+        }
+        if (message.status === 'failed') {
+            return {
+                providerStatus:
+                    message.providerStatus === 'Canceled' ||
+                    message.providerStatus === 'Failed'
+                        ? message.providerStatus
+                        : null,
+                status: 'already_failed',
+            };
+        }
+        if (
+            message.status !== 'sending' ||
+            message.providerStatus !== 'reconciliation_claimed'
+        ) {
+            return { reason: 'not_claimed', status: 'unavailable' };
+        }
+        if (message.claimId !== normalizedClaimId) {
+            return { reason: 'claim_mismatch', status: 'unavailable' };
+        }
+        if (
+            typeof message.claimExpiresAt !== 'string' ||
+            message.claimExpiresAt <= now.toISOString()
+        ) {
+            return { reason: 'claim_expired', status: 'unavailable' };
+        }
+
+        const parsedAttempt = Number(message.reconciliationAttempt);
+        const attempt =
+            Number.isSafeInteger(parsedAttempt) && parsedAttempt > 0
+                ? parsedAttempt
+                : 1;
+        const providerStatus =
+            outcome.kind === 'provider_status' ? outcome.status : null;
+
+        if (providerStatus === 'Succeeded') {
+            const metadataPatch = {
+                nextReconciliationAt: null,
+                reconciliationClaimExpiresAt: null,
+                reconciliationClaimId: null,
+                reconciliationCompletedAt: now.toISOString(),
+                reconciliationLastCheckedAt: now.toISOString(),
+                reconciliationLastOutcome: 'succeeded',
+                reconciliationLastProviderStatus: providerStatus,
+            };
+            await tx
+                .update(emailMessages)
+                .set({
+                    completedAt: now,
+                    errorCode: null,
+                    errorMessage: null,
+                    metadata: sql`${emailMessages.metadata} || ${JSON.stringify(metadataPatch)}::jsonb`,
+                    providerStatus,
+                    sentAt: now,
+                    status: 'sent',
+                    updatedAt: now,
+                })
+                .where(eq(emailMessages.id, emailMessageId));
+            return { status: 'sent' };
+        }
+
+        if (providerStatus === 'Failed' || providerStatus === 'Canceled') {
+            const metadataPatch = {
+                nextReconciliationAt: null,
+                reconciliationClaimExpiresAt: null,
+                reconciliationClaimId: null,
+                reconciliationCompletedAt: now.toISOString(),
+                reconciliationLastCheckedAt: now.toISOString(),
+                reconciliationLastOutcome: 'terminal_failure',
+                reconciliationLastProviderStatus: providerStatus,
+            };
+            await tx
+                .update(emailMessages)
+                .set({
+                    completedAt: now,
+                    errorCode:
+                        providerStatus === 'Canceled'
+                            ? 'provider_reconciliation_canceled'
+                            : 'provider_reconciliation_failed',
+                    errorMessage:
+                        'Order confirmation provider submission reached a terminal non-success status.',
+                    metadata: sql`${emailMessages.metadata} || ${JSON.stringify(metadataPatch)}::jsonb`,
+                    providerStatus,
+                    status: 'failed',
+                    updatedAt: now,
+                })
+                .where(eq(emailMessages.id, emailMessageId));
+            return { providerStatus, status: 'failed' };
+        }
+
+        const nextCheckAt = new Date(
+            now.getTime() + reconciliationDelayMs(attempt),
+        );
+        const lastOutcome =
+            outcome.kind === 'provider_status'
+                ? 'provider_non_terminal'
+                : outcome.kind;
+        const metadataPatch = {
+            nextReconciliationAt: nextCheckAt.toISOString(),
+            reconciliationClaimExpiresAt: null,
+            reconciliationClaimId: null,
+            reconciliationLastCheckedAt: now.toISOString(),
+            reconciliationLastOutcome: lastOutcome,
+            reconciliationLastProviderStatus: providerStatus,
+        };
+        await tx
+            .update(emailMessages)
+            .set({
+                metadata: sql`${emailMessages.metadata} || ${JSON.stringify(metadataPatch)}::jsonb`,
+                providerStatus: 'reconciliation_pending',
+                status: 'sending',
+                updatedAt: now,
+            })
+            .where(eq(emailMessages.id, emailMessageId));
+        return { attempt, nextCheckAt, status: 'pending' };
+    });
+}

--- a/packages/storage/tests/orderConfirmationOutboxRepo.node.spec.ts
+++ b/packages/storage/tests/orderConfirmationOutboxRepo.node.spec.ts
@@ -1,0 +1,1170 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    claimOrderConfirmationEmail,
+    claimOrderConfirmationEmailReconciliation,
+    emailMessages,
+    finalizeOrderConfirmationEmailReconciliation,
+    getEmailMessage,
+    getOrderConfirmationOutboxHealthSnapshot,
+    getShoppingCart,
+    markCartPaidAndEnqueueOrderConfirmation,
+    markOrderConfirmationEmailFailed,
+    markOrderConfirmationEmailSent,
+    orderConfirmationEmailReconciliationMaxClaimLeaseMs,
+    setCartItemPaid,
+    shoppingCarts,
+    startOrderConfirmationEmailSubmission,
+    storage,
+    upsertOrRemoveCartItem,
+} from '@gredice/storage';
+import { eq, sql } from 'drizzle-orm';
+import { createTestAccount } from './helpers/testHelpers';
+import { createTestDb } from './testDb';
+
+test.afterEach(async () => {
+    await storage()
+        .delete(emailMessages)
+        .where(
+            sql<boolean>`${emailMessages.metadata}->>'outboxKind' = 'order_confirmation'`,
+        );
+});
+
+const operationIds = [
+    '00000000-0000-4000-8000-000000000001',
+    '00000000-0000-4000-8000-000000000002',
+    '00000000-0000-4000-8000-000000000003',
+    '00000000-0000-4000-8000-000000000004',
+    '00000000-0000-4000-8000-000000000005',
+] as const;
+
+async function createCart({ ready = true }: { ready?: boolean } = {}) {
+    const accountId = await createTestAccount();
+    const { getOrCreateShoppingCart } = await import('@gredice/storage');
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart);
+    const itemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        `outbox-item-${cart.id.toString()}`,
+        'plantSort',
+        1,
+    );
+    assert.ok(itemId);
+    if (ready) {
+        await setCartItemPaid(itemId);
+    }
+    return { cartId: cart.id, itemId };
+}
+
+function payload(cartId: number) {
+    return {
+        cartId,
+        currency: null,
+        items: [
+            {
+                amountSubtotal: 25,
+                currency: 'sunflower',
+                name: 'Suncokret',
+                quantity: 1,
+            },
+        ],
+        manageUrl: 'https://vrt.gredice.com',
+        to: `checkout-${cartId.toString()}@example.test`,
+        totalAmountCents: null,
+    };
+}
+
+async function enqueueReadyCart(
+    operationId: string = operationIds[0],
+    now = new Date('2026-08-03T08:00:00.000Z'),
+) {
+    const { cartId } = await createCart();
+    const result = await markCartPaidAndEnqueueOrderConfirmation({
+        cartId,
+        now,
+        operationId,
+        payload: payload(cartId),
+    });
+    assert.equal(result.status, 'enqueued');
+    if (result.status !== 'enqueued') {
+        throw new Error('Expected an enqueued order confirmation');
+    }
+    return { cartId, emailMessageId: result.emailMessageId };
+}
+
+async function fenceProviderSubmission({
+    claimId,
+    now,
+    operationId = operationIds[0],
+    uncertain = false,
+}: {
+    claimId: string;
+    now: Date;
+    operationId?: string;
+    uncertain?: boolean;
+}) {
+    const enqueued = await enqueueReadyCart(operationId, now);
+    const deliveryClaim = await claimOrderConfirmationEmail({
+        claimExpiresAt: new Date(now.getTime() + 60_000),
+        claimId,
+        now,
+    });
+    assert.equal(deliveryClaim.status, 'claimed');
+    if (deliveryClaim.status !== 'claimed') {
+        throw new Error('Expected a delivery claim');
+    }
+    const startedAt = new Date(now.getTime() + 1_000);
+    assert.equal(
+        (
+            await startOrderConfirmationEmailSubmission({
+                claimId,
+                emailMessageId: enqueued.emailMessageId,
+                now: startedAt,
+            })
+        ).status,
+        'started',
+    );
+    const fencedAt = uncertain ? new Date(now.getTime() + 2_000) : startedAt;
+    if (uncertain) {
+        assert.deepEqual(
+            await markOrderConfirmationEmailFailed({
+                claimId,
+                emailMessageId: enqueued.emailMessageId,
+                failureCode: 'provider_submission_uncertain',
+                failureKind: 'uncertain',
+                now: fencedAt,
+            }),
+            { status: 'fenced' },
+        );
+    }
+
+    return { ...enqueued, fencedAt };
+}
+
+test('cart payment transition and confirmation enqueue are one idempotent operation', async () => {
+    createTestDb();
+    const now = new Date('2026-08-03T08:00:00.000Z');
+    const { cartId } = await createCart();
+
+    const first = await markCartPaidAndEnqueueOrderConfirmation({
+        cartId,
+        now,
+        operationId: operationIds[0],
+        payload: payload(cartId),
+    });
+    assert.equal(first.status, 'enqueued');
+    if (first.status !== 'enqueued') {
+        throw new Error('Expected an enqueued order confirmation');
+    }
+
+    const replay = await markCartPaidAndEnqueueOrderConfirmation({
+        cartId,
+        now: new Date(now.getTime() + 1_000),
+        operationId: operationIds[1],
+        payload: payload(cartId),
+    });
+    assert.deepEqual(replay, {
+        emailMessageId: first.emailMessageId,
+        operationId: operationIds[0],
+        status: 'already_paid',
+    });
+
+    const cart = await getShoppingCart(cartId);
+    assert.equal(cart?.status, 'paid');
+    const messages = await storage()
+        .select({ id: emailMessages.id })
+        .from(emailMessages)
+        .where(
+            sql<boolean>`${emailMessages.metadata}->>'cartId' = ${cartId.toString()}`,
+        );
+    assert.deepEqual(messages, [{ id: first.emailMessageId }]);
+});
+
+test('a cart with unpaid items is not transitioned or enqueued', async () => {
+    createTestDb();
+    const { cartId } = await createCart({ ready: false });
+
+    const result = await markCartPaidAndEnqueueOrderConfirmation({
+        cartId,
+        operationId: operationIds[0],
+        payload: payload(cartId),
+    });
+
+    assert.deepEqual(result, { status: 'cart_not_ready' });
+    assert.equal((await getShoppingCart(cartId))?.status, 'new');
+    const messages = await storage()
+        .select({ id: emailMessages.id })
+        .from(emailMessages)
+        .where(
+            sql<boolean>`${emailMessages.metadata}->>'cartId' = ${cartId.toString()}`,
+        );
+    assert.deepEqual(messages, []);
+});
+
+test('claimed confirmation is fenced before submission and finalized sent', async () => {
+    createTestDb();
+    const now = new Date('2026-08-03T09:00:00.000Z');
+    const { emailMessageId } = await enqueueReadyCart(operationIds[1], now);
+    const claim = await claimOrderConfirmationEmail({
+        claimExpiresAt: new Date(now.getTime() + 60_000),
+        claimId: 'worker-sent',
+        now,
+    });
+    assert.equal(claim.status, 'claimed');
+    if (claim.status !== 'claimed') {
+        throw new Error('Expected a claimed order confirmation');
+    }
+    assert.equal(claim.claim.emailMessageId, emailMessageId);
+    assert.equal(claim.claim.operationId, operationIds[1]);
+    assert.equal(claim.claim.queuedAt.toISOString(), now.toISOString());
+    assert.equal(claim.claim.payload.to.includes('@'), true);
+
+    assert.deepEqual(
+        await startOrderConfirmationEmailSubmission({
+            claimId: claim.claim.claimId,
+            emailMessageId,
+            now: new Date(now.getTime() + 1_000),
+        }),
+        { operationId: operationIds[1], status: 'started' },
+    );
+    assert.deepEqual(
+        await markOrderConfirmationEmailSent({
+            claimId: claim.claim.claimId,
+            emailMessageId,
+            now: new Date(now.getTime() + 2_000),
+            providerStatus: 'Succeeded',
+        }),
+        { status: 'sent' },
+    );
+
+    const stored = await getEmailMessage(emailMessageId);
+    assert.equal(stored?.status, 'sent');
+    assert.equal(stored?.providerStatus, 'Succeeded');
+    assert.ok(stored?.completedAt);
+    assert.ok(stored?.sentAt);
+});
+
+test('only proven-safe failures retry and attempts are bounded', async () => {
+    createTestDb();
+    let now = new Date('2026-08-03T10:00:00.000Z');
+    const { emailMessageId } = await enqueueReadyCart(operationIds[2], now);
+
+    for (let expectedAttempt = 1; expectedAttempt <= 3; expectedAttempt += 1) {
+        const claim = await claimOrderConfirmationEmail({
+            claimExpiresAt: new Date(now.getTime() + 60_000),
+            claimId: `worker-retry-${expectedAttempt.toString()}`,
+            now,
+        });
+        assert.equal(claim.status, 'claimed');
+        if (claim.status !== 'claimed') {
+            throw new Error('Expected a claimed order confirmation');
+        }
+        assert.equal(claim.claim.attempt, expectedAttempt);
+        assert.equal(
+            (
+                await startOrderConfirmationEmailSubmission({
+                    claimId: claim.claim.claimId,
+                    emailMessageId,
+                    now: new Date(now.getTime() + 1_000),
+                })
+            ).status,
+            'started',
+        );
+
+        const failedAt = new Date(now.getTime() + 2_000);
+        const failure = await markOrderConfirmationEmailFailed({
+            claimId: claim.claim.claimId,
+            emailMessageId,
+            failureCode: 'provider_rejected_retryable',
+            failureKind: 'definite',
+            now: failedAt,
+        });
+        if (expectedAttempt < 3) {
+            assert.equal(failure.status, 'retry_scheduled');
+            if (failure.status !== 'retry_scheduled') {
+                throw new Error('Expected a scheduled retry');
+            }
+            assert.equal(
+                (
+                    await claimOrderConfirmationEmail({
+                        claimExpiresAt: new Date(
+                            failure.nextAttemptAt.getTime() + 60_000,
+                        ),
+                        claimId: 'too-early',
+                        now: new Date(failure.nextAttemptAt.getTime() - 1),
+                    })
+                ).status,
+                'empty',
+            );
+            now = failure.nextAttemptAt;
+        } else {
+            assert.deepEqual(failure, {
+                attempt: expectedAttempt,
+                status: 'failed',
+            });
+        }
+    }
+
+    const stored = await getEmailMessage(emailMessageId);
+    assert.equal(stored?.status, 'failed');
+    assert.equal(stored?.providerStatus, 'retry_exhausted');
+    assert.equal(stored?.metadata.attemptCount, 3);
+});
+
+test('configuration failures defer indefinitely without consuming delivery attempts', async () => {
+    createTestDb();
+    let now = new Date('2026-08-03T10:30:00.000Z');
+    const { emailMessageId } = await enqueueReadyCart(operationIds[3], now);
+
+    for (let deferral = 1; deferral <= 5; deferral += 1) {
+        const claim = await claimOrderConfirmationEmail({
+            claimExpiresAt: new Date(now.getTime() + 60_000),
+            claimId: `worker-configuration-${deferral.toString()}`,
+            now,
+        });
+        assert.equal(claim.status, 'claimed');
+        if (claim.status !== 'claimed') {
+            throw new Error('Expected a claimed order confirmation');
+        }
+        assert.equal(claim.claim.attempt, 1);
+
+        const failedAt = new Date(now.getTime() + 1_000);
+        const nextAttemptAt = new Date(failedAt.getTime() + 60_000);
+        assert.deepEqual(
+            await markOrderConfirmationEmailFailed({
+                claimId: claim.claim.claimId,
+                emailMessageId,
+                failureCode: 'configuration_error',
+                failureKind: 'definite',
+                now: failedAt,
+            }),
+            { attempt: 1, nextAttemptAt, status: 'retry_scheduled' },
+        );
+
+        const deferred = await getEmailMessage(emailMessageId);
+        assert.equal(deferred?.metadata.attemptCount, 0);
+        assert.equal(deferred?.status, 'queued');
+        now = nextAttemptAt;
+    }
+
+    const restoredClaim = await claimOrderConfirmationEmail({
+        claimExpiresAt: new Date(now.getTime() + 60_000),
+        claimId: 'worker-configuration-restored',
+        now,
+    });
+    assert.equal(restoredClaim.status, 'claimed');
+    if (restoredClaim.status !== 'claimed') {
+        throw new Error(
+            'Expected delivery to drain after configuration repair',
+        );
+    }
+    assert.equal(restoredClaim.claim.attempt, 1);
+    await startOrderConfirmationEmailSubmission({
+        claimId: restoredClaim.claim.claimId,
+        emailMessageId,
+        now: new Date(now.getTime() + 1_000),
+    });
+    assert.deepEqual(
+        await markOrderConfirmationEmailSent({
+            claimId: restoredClaim.claim.claimId,
+            emailMessageId,
+            now: new Date(now.getTime() + 2_000),
+            providerStatus: 'Succeeded',
+        }),
+        { status: 'sent' },
+    );
+
+    const stored = await getEmailMessage(emailMessageId);
+    assert.equal(stored?.metadata.attemptCount, 1);
+    assert.equal(stored?.providerStatus, 'Succeeded');
+    assert.equal(stored?.status, 'sent');
+});
+
+test('non-retryable rejection fails immediately', async () => {
+    createTestDb();
+    const now = new Date('2026-08-03T11:00:00.000Z');
+    const { emailMessageId } = await enqueueReadyCart(operationIds[3], now);
+    const claim = await claimOrderConfirmationEmail({
+        claimExpiresAt: new Date(now.getTime() + 60_000),
+        claimId: 'worker-terminal',
+        now,
+    });
+    assert.equal(claim.status, 'claimed');
+    if (claim.status !== 'claimed') {
+        throw new Error('Expected a claimed order confirmation');
+    }
+    await startOrderConfirmationEmailSubmission({
+        claimId: claim.claim.claimId,
+        emailMessageId,
+        now: new Date(now.getTime() + 1_000),
+    });
+
+    assert.deepEqual(
+        await markOrderConfirmationEmailFailed({
+            claimId: claim.claim.claimId,
+            emailMessageId,
+            failureCode: 'provider_rejected_terminal',
+            failureKind: 'definite',
+            now: new Date(now.getTime() + 2_000),
+        }),
+        { attempt: 1, status: 'failed' },
+    );
+    assert.equal((await getEmailMessage(emailMessageId))?.status, 'failed');
+});
+
+test('an expired pre-submission claim is recoverable and fences its old owner', async () => {
+    createTestDb();
+    const now = new Date('2026-08-03T11:30:00.000Z');
+    const { emailMessageId } = await enqueueReadyCart(operationIds[3], now);
+    const firstClaim = await claimOrderConfirmationEmail({
+        claimExpiresAt: new Date(now.getTime() + 60_000),
+        claimId: 'worker-expired',
+        now,
+    });
+    assert.equal(firstClaim.status, 'claimed');
+
+    const recoveredAt = new Date(now.getTime() + 60_001);
+    const recovered = await claimOrderConfirmationEmail({
+        claimExpiresAt: new Date(recoveredAt.getTime() + 60_000),
+        claimId: 'worker-recovered',
+        now: recoveredAt,
+    });
+    assert.equal(recovered.status, 'claimed');
+    if (recovered.status !== 'claimed') {
+        throw new Error('Expected the expired claim to be recovered');
+    }
+    assert.equal(recovered.claim.attempt, 2);
+    assert.deepEqual(
+        await startOrderConfirmationEmailSubmission({
+            claimId: 'worker-expired',
+            emailMessageId,
+            now: recoveredAt,
+        }),
+        { reason: 'claim_mismatch', status: 'unavailable' },
+    );
+    assert.equal(
+        (
+            await startOrderConfirmationEmailSubmission({
+                claimId: recovered.claim.claimId,
+                emailMessageId,
+                now: recoveredAt,
+            })
+        ).status,
+        'started',
+    );
+});
+
+test('uncertain provider submission remains fenced from automatic retry', async () => {
+    createTestDb();
+    const now = new Date('2026-08-03T12:00:00.000Z');
+    const { emailMessageId } = await enqueueReadyCart(operationIds[4], now);
+    const claim = await claimOrderConfirmationEmail({
+        claimExpiresAt: new Date(now.getTime() + 60_000),
+        claimId: 'worker-uncertain',
+        now,
+    });
+    assert.equal(claim.status, 'claimed');
+    if (claim.status !== 'claimed') {
+        throw new Error('Expected a claimed order confirmation');
+    }
+    await startOrderConfirmationEmailSubmission({
+        claimId: claim.claim.claimId,
+        emailMessageId,
+        now: new Date(now.getTime() + 1_000),
+    });
+
+    assert.deepEqual(
+        await markOrderConfirmationEmailFailed({
+            claimId: claim.claim.claimId,
+            emailMessageId,
+            failureCode: 'provider_submission_uncertain',
+            failureKind: 'uncertain',
+            now: new Date(now.getTime() + 2_000),
+        }),
+        { status: 'fenced' },
+    );
+    assert.equal(
+        (
+            await claimOrderConfirmationEmail({
+                claimExpiresAt: new Date(now.getTime() + 3_700_000),
+                claimId: 'worker-must-not-retry',
+                now: new Date(now.getTime() + 3_600_000),
+            })
+        ).status,
+        'empty',
+    );
+
+    const stored = await getEmailMessage(emailMessageId);
+    assert.equal(stored?.status, 'sending');
+    assert.equal(stored?.providerStatus, 'submission_uncertain');
+    assert.equal(stored?.completedAt, null);
+});
+
+test('reconciliation claims only stale fenced submissions and exposes no delivery payload', async () => {
+    createTestDb();
+    const now = new Date('2026-08-03T12:30:00.000Z');
+    const privateRecipient = 'private-reconciliation-recipient@example.test';
+    const privateItemName = 'Private reconciliation item';
+    const fenced = await fenceProviderSubmission({
+        claimId: 'delivery-before-reconciliation',
+        now,
+        operationId: operationIds[0],
+        uncertain: true,
+    });
+    const storedBefore = await getEmailMessage(fenced.emailMessageId);
+    assert.ok(storedBefore);
+    await storage()
+        .update(emailMessages)
+        .set({
+            metadata: {
+                ...storedBefore.metadata,
+                items: [{ name: privateItemName, quantity: 1 }],
+            },
+            recipients: { to: [{ address: privateRecipient }] },
+        })
+        .where(eq(emailMessages.id, fenced.emailMessageId));
+
+    const reconcileAt = new Date(now.getTime() + 10 * 60_000);
+    assert.equal(
+        (
+            await claimOrderConfirmationEmailReconciliation({
+                claimExpiresAt: new Date(reconcileAt.getTime() + 60_000),
+                claimId: 'reconcile-too-fresh',
+                now: reconcileAt,
+                staleBefore: new Date(fenced.fencedAt.getTime() - 1),
+            })
+        ).status,
+        'empty',
+    );
+
+    const claimed = await claimOrderConfirmationEmailReconciliation({
+        claimExpiresAt: new Date(reconcileAt.getTime() + 60_000),
+        claimId: 'reconcile-stale',
+        now: reconcileAt,
+        staleBefore: fenced.fencedAt,
+    });
+    assert.deepEqual(claimed, {
+        claim: {
+            attempt: 1,
+            claimId: 'reconcile-stale',
+            emailMessageId: fenced.emailMessageId,
+            operationId: operationIds[0],
+        },
+        status: 'claimed',
+    });
+    const serializedClaim = JSON.stringify(claimed);
+    assert.equal(serializedClaim.includes(privateRecipient), false);
+    assert.equal(serializedClaim.includes(privateItemName), false);
+
+    const stored = await getEmailMessage(fenced.emailMessageId);
+    assert.equal(stored?.status, 'sending');
+    assert.equal(stored?.providerStatus, 'reconciliation_claimed');
+    assert.equal(
+        (
+            await claimOrderConfirmationEmail({
+                claimExpiresAt: new Date(reconcileAt.getTime() + 3_700_000),
+                claimId: 'delivery-must-not-reclaim',
+                now: new Date(reconcileAt.getTime() + 3_600_000),
+            })
+        ).status,
+        'empty',
+    );
+});
+
+test('reconciliation uses indefinite capped backoff without requeueing delivery', async () => {
+    createTestDb();
+    const startedAt = new Date('2026-08-03T13:00:00.000Z');
+    const fenced = await fenceProviderSubmission({
+        claimId: 'delivery-for-backoff',
+        now: startedAt,
+        operationId: operationIds[1],
+    });
+    const staleBefore = new Date(fenced.fencedAt.getTime() + 1);
+    const outcomes = [
+        { kind: 'provider_status', status: 'Running' },
+        { kind: 'provider_status', status: 'NotStarted' },
+        { kind: 'lookup_unavailable' },
+        { kind: 'unknown_status' },
+        { kind: 'provider_status', status: 'Running' },
+        { kind: 'lookup_unavailable' },
+    ] as const;
+    const expectedDelays = [
+        60_000,
+        5 * 60_000,
+        15 * 60_000,
+        60 * 60_000,
+        6 * 60 * 60_000,
+        6 * 60 * 60_000,
+    ];
+    let claimAt = new Date(startedAt.getTime() + 10 * 60_000);
+
+    for (const [index, outcome] of outcomes.entries()) {
+        const claimId = `reconcile-backoff-${(index + 1).toString()}`;
+        const claimed = await claimOrderConfirmationEmailReconciliation({
+            claimExpiresAt: new Date(claimAt.getTime() + 60_000),
+            claimId,
+            now: claimAt,
+            staleBefore,
+        });
+        assert.equal(claimed.status, 'claimed');
+        if (claimed.status !== 'claimed') {
+            throw new Error('Expected a reconciliation claim');
+        }
+        assert.equal(claimed.claim.attempt, index + 1);
+
+        const checkedAt = new Date(claimAt.getTime() + 1_000);
+        const finalized = await finalizeOrderConfirmationEmailReconciliation({
+            claimId,
+            emailMessageId: fenced.emailMessageId,
+            now: checkedAt,
+            outcome,
+        });
+        assert.deepEqual(finalized, {
+            attempt: index + 1,
+            nextCheckAt: new Date(
+                checkedAt.getTime() + (expectedDelays[index] ?? 0),
+            ),
+            status: 'pending',
+        });
+        if (finalized.status !== 'pending') {
+            throw new Error('Expected another reconciliation check');
+        }
+
+        assert.equal(
+            (
+                await claimOrderConfirmationEmailReconciliation({
+                    claimExpiresAt: new Date(
+                        finalized.nextCheckAt.getTime() + 60_000,
+                    ),
+                    claimId: 'reconcile-before-due',
+                    now: new Date(finalized.nextCheckAt.getTime() - 1),
+                    staleBefore,
+                })
+            ).status,
+            'empty',
+        );
+        claimAt = finalized.nextCheckAt;
+    }
+
+    const stored = await getEmailMessage(fenced.emailMessageId);
+    assert.equal(stored?.status, 'sending');
+    assert.equal(stored?.providerStatus, 'reconciliation_pending');
+    assert.equal(stored?.metadata.reconciliationAttempt, outcomes.length);
+});
+
+test('reconciliation maps terminal provider outcomes without resubmission', async () => {
+    createTestDb();
+    const cases = [
+        {
+            expectedStatus: 'sent',
+            operationId: operationIds[2],
+            providerStatus: 'Succeeded',
+        },
+        {
+            expectedStatus: 'failed',
+            operationId: operationIds[3],
+            providerStatus: 'Failed',
+        },
+        {
+            expectedStatus: 'failed',
+            operationId: operationIds[4],
+            providerStatus: 'Canceled',
+        },
+    ] as const;
+
+    for (const [index, scenario] of cases.entries()) {
+        const now = new Date(
+            new Date('2026-08-03T14:00:00.000Z').getTime() +
+                index * 60 * 60_000,
+        );
+        const fenced = await fenceProviderSubmission({
+            claimId: `delivery-terminal-${index.toString()}`,
+            now,
+            operationId: scenario.operationId,
+            uncertain: true,
+        });
+        const claimAt = new Date(now.getTime() + 10 * 60_000);
+        const claimId = `reconcile-terminal-${index.toString()}`;
+        const claimed = await claimOrderConfirmationEmailReconciliation({
+            claimExpiresAt: new Date(claimAt.getTime() + 60_000),
+            claimId,
+            now: claimAt,
+            staleBefore: fenced.fencedAt,
+        });
+        assert.equal(claimed.status, 'claimed');
+
+        const result = await finalizeOrderConfirmationEmailReconciliation({
+            claimId,
+            emailMessageId: fenced.emailMessageId,
+            now: new Date(claimAt.getTime() + 1_000),
+            outcome: {
+                kind: 'provider_status',
+                status: scenario.providerStatus,
+            },
+        });
+        assert.equal(result.status, scenario.expectedStatus);
+
+        const stored = await getEmailMessage(fenced.emailMessageId);
+        assert.equal(stored?.status, scenario.expectedStatus);
+        assert.equal(stored?.providerStatus, scenario.providerStatus);
+        assert.ok(stored?.completedAt);
+        assert.equal(
+            (
+                await finalizeOrderConfirmationEmailReconciliation({
+                    claimId,
+                    emailMessageId: fenced.emailMessageId,
+                    now: new Date(claimAt.getTime() + 2_000),
+                    outcome: {
+                        kind: 'provider_status',
+                        status: scenario.providerStatus,
+                    },
+                })
+            ).status,
+            scenario.expectedStatus === 'sent'
+                ? 'already_sent'
+                : 'already_failed',
+        );
+    }
+});
+
+test('expired reconciliation claims recover and fence their former owner', async () => {
+    createTestDb();
+    const now = new Date('2026-08-03T18:00:00.000Z');
+    const fenced = await fenceProviderSubmission({
+        claimId: 'delivery-for-recovery',
+        now,
+        operationId: operationIds[0],
+    });
+    const claimAt = new Date(now.getTime() + 10 * 60_000);
+    const expiresAt = new Date(claimAt.getTime() + 60_000);
+    const first = await claimOrderConfirmationEmailReconciliation({
+        claimExpiresAt: expiresAt,
+        claimId: 'reconcile-expired',
+        now: claimAt,
+        staleBefore: fenced.fencedAt,
+    });
+    assert.equal(first.status, 'claimed');
+
+    assert.deepEqual(
+        await finalizeOrderConfirmationEmailReconciliation({
+            claimId: 'reconcile-expired',
+            emailMessageId: fenced.emailMessageId,
+            now: expiresAt,
+            outcome: { kind: 'lookup_unavailable' },
+        }),
+        { reason: 'claim_expired', status: 'unavailable' },
+    );
+
+    const recoveredAt = new Date(expiresAt.getTime() + 1);
+    const recovered = await claimOrderConfirmationEmailReconciliation({
+        claimExpiresAt: new Date(recoveredAt.getTime() + 60_000),
+        claimId: 'reconcile-recovered',
+        now: recoveredAt,
+        staleBefore: fenced.fencedAt,
+    });
+    assert.equal(recovered.status, 'claimed');
+    if (recovered.status !== 'claimed') {
+        throw new Error('Expected an expired reconciliation claim to recover');
+    }
+    assert.equal(recovered.claim.attempt, 2);
+    assert.deepEqual(
+        await finalizeOrderConfirmationEmailReconciliation({
+            claimId: 'reconcile-expired',
+            emailMessageId: fenced.emailMessageId,
+            now: new Date(recoveredAt.getTime() + 1),
+            outcome: { kind: 'lookup_unavailable' },
+        }),
+        { reason: 'claim_mismatch', status: 'unavailable' },
+    );
+    assert.equal(
+        (
+            await finalizeOrderConfirmationEmailReconciliation({
+                claimId: recovered.claim.claimId,
+                emailMessageId: fenced.emailMessageId,
+                now: new Date(recoveredAt.getTime() + 2),
+                outcome: { kind: 'lookup_unavailable' },
+            })
+        ).status,
+        'pending',
+    );
+    const stored = await getEmailMessage(fenced.emailMessageId);
+    assert.equal(stored?.status, 'sending');
+    assert.equal(
+        stored?.metadata.reconciliationFenceStatus,
+        'submission_started',
+    );
+});
+
+test('reconciliation enforces a bounded claim lease', async () => {
+    createTestDb();
+    const now = new Date('2026-08-03T19:00:00.000Z');
+
+    await assert.rejects(
+        claimOrderConfirmationEmailReconciliation({
+            claimExpiresAt: new Date(
+                now.getTime() +
+                    orderConfirmationEmailReconciliationMaxClaimLeaseMs +
+                    1,
+            ),
+            claimId: 'reconcile-too-long',
+            now,
+            staleBefore: now,
+        }),
+        RangeError,
+    );
+});
+
+test('health snapshot exposes aggregate queue and fence state without private content', async () => {
+    createTestDb();
+    const now = new Date('2026-08-03T12:00:00.000Z');
+    const staleBefore = new Date('2026-08-03T11:30:00.000Z');
+    const healthRecipient = 'private-health-recipient@example.test';
+    const healthBody = 'private-health-body';
+
+    async function insertHealthRow({
+        completedAt = null,
+        errorCode = null,
+        lastAttemptAt = null,
+        metadata = {},
+        providerStatus,
+        queuedAt,
+        status,
+        templateName = 'commerce-order-confirmation',
+    }: {
+        completedAt?: Date | null;
+        errorCode?: string | null;
+        lastAttemptAt?: Date | null;
+        metadata?: Record<string, unknown>;
+        providerStatus: string;
+        queuedAt: Date;
+        status: 'failed' | 'queued' | 'sending';
+        templateName?: string;
+    }) {
+        await storage()
+            .insert(emailMessages)
+            .values({
+                completedAt,
+                createdAt: queuedAt,
+                errorCode,
+                fromAddress: 'suncokret@obavijesti.gredice.com',
+                htmlBody: healthBody,
+                lastAttemptAt,
+                messageType: 'commerce',
+                metadata: {
+                    attemptCount: 0,
+                    maxAttempts: 3,
+                    outboxKind: 'order_confirmation',
+                    privatePayload: healthBody,
+                    ...metadata,
+                },
+                providerStatus,
+                queuedAt,
+                recipients: { to: [{ address: healthRecipient }] },
+                status,
+                subject: 'Gredice - potvrda narudžbe',
+                templateName,
+                textBody: healthBody,
+                updatedAt: queuedAt,
+            });
+    }
+
+    await insertHealthRow({
+        providerStatus: 'outbox_ready',
+        queuedAt: new Date('2026-08-03T08:00:00.000Z'),
+        status: 'queued',
+    });
+    await insertHealthRow({
+        metadata: { nextAttemptAt: '2026-08-03T13:00:00.000Z' },
+        providerStatus: 'retry_scheduled',
+        queuedAt: new Date('2026-08-03T09:00:00.000Z'),
+        status: 'queued',
+    });
+    await insertHealthRow({
+        lastAttemptAt: new Date('2026-08-03T11:50:00.000Z'),
+        metadata: {
+            claimExpiresAt: '2026-08-03T12:10:00.000Z',
+            claimedAt: '2026-08-03T11:50:00.000Z',
+        },
+        providerStatus: 'outbox_claimed',
+        queuedAt: new Date('2026-08-03T09:10:00.000Z'),
+        status: 'sending',
+    });
+    await insertHealthRow({
+        lastAttemptAt: new Date('2026-08-03T10:45:00.000Z'),
+        metadata: {
+            claimExpiresAt: '2026-08-03T11:00:00.000Z',
+            claimedAt: '2026-08-03T10:45:00.000Z',
+        },
+        providerStatus: 'outbox_claimed',
+        queuedAt: new Date('2026-08-03T09:20:00.000Z'),
+        status: 'sending',
+    });
+    await insertHealthRow({
+        lastAttemptAt: new Date('2026-08-03T10:00:00.000Z'),
+        metadata: { submissionStartedAt: '2026-08-03T10:00:00.000Z' },
+        providerStatus: 'submission_started',
+        queuedAt: new Date('2026-08-03T09:30:00.000Z'),
+        status: 'sending',
+    });
+    await insertHealthRow({
+        lastAttemptAt: new Date('2026-08-03T11:45:00.000Z'),
+        metadata: { submissionStartedAt: '2026-08-03T11:45:00.000Z' },
+        providerStatus: 'submission_started',
+        queuedAt: new Date('2026-08-03T09:40:00.000Z'),
+        status: 'sending',
+    });
+    await insertHealthRow({
+        lastAttemptAt: new Date('2026-08-03T10:30:00.000Z'),
+        metadata: {
+            submissionUncertainAt: '2026-08-03T10:30:00.000Z',
+        },
+        providerStatus: 'submission_uncertain',
+        queuedAt: new Date('2026-08-03T09:50:00.000Z'),
+        status: 'sending',
+    });
+    await insertHealthRow({
+        lastAttemptAt: new Date('2026-08-03T11:45:00.000Z'),
+        metadata: {
+            submissionUncertainAt: '2026-08-03T11:45:00.000Z',
+        },
+        providerStatus: 'submission_uncertain',
+        queuedAt: new Date('2026-08-03T10:00:00.000Z'),
+        status: 'sending',
+    });
+    await insertHealthRow({
+        metadata: {
+            nextReconciliationAt: '2026-08-03T10:30:00.000Z',
+            reconciliationFencedAt: '2026-08-03T09:30:00.000Z',
+        },
+        providerStatus: 'reconciliation_pending',
+        queuedAt: new Date('2026-08-03T10:10:00.000Z'),
+        status: 'sending',
+    });
+    await insertHealthRow({
+        metadata: {
+            nextReconciliationAt: '2026-08-03T13:00:00.000Z',
+            reconciliationFencedAt: '2026-08-03T11:50:00.000Z',
+        },
+        providerStatus: 'reconciliation_pending',
+        queuedAt: new Date('2026-08-03T10:20:00.000Z'),
+        status: 'sending',
+    });
+    await insertHealthRow({
+        metadata: {
+            reconciliationClaimedAt: '2026-08-03T11:55:00.000Z',
+            reconciliationClaimExpiresAt: '2026-08-03T12:10:00.000Z',
+            reconciliationFencedAt: '2026-08-03T10:00:00.000Z',
+        },
+        providerStatus: 'reconciliation_claimed',
+        queuedAt: new Date('2026-08-03T10:30:00.000Z'),
+        status: 'sending',
+    });
+    await insertHealthRow({
+        metadata: {
+            reconciliationClaimedAt: '2026-08-03T11:40:00.000Z',
+            reconciliationClaimExpiresAt: '2026-08-03T11:00:00.000Z',
+            reconciliationFencedAt: '2026-08-03T09:00:00.000Z',
+        },
+        providerStatus: 'reconciliation_claimed',
+        queuedAt: new Date('2026-08-03T10:40:00.000Z'),
+        status: 'sending',
+    });
+    await insertHealthRow({
+        completedAt: new Date('2026-08-03T09:45:00.000Z'),
+        errorCode: 'configuration_error',
+        metadata: { attemptCount: 3 },
+        providerStatus: 'retry_exhausted',
+        queuedAt: new Date('2026-08-03T08:30:00.000Z'),
+        status: 'failed',
+    });
+    await insertHealthRow({
+        completedAt: new Date('2026-08-03T10:35:00.000Z'),
+        errorCode: 'provider_rejected_terminal',
+        metadata: { attemptCount: 1 },
+        providerStatus: 'retry_exhausted',
+        queuedAt: new Date('2026-08-03T08:40:00.000Z'),
+        status: 'failed',
+    });
+    await insertHealthRow({
+        providerStatus: 'outbox_ready',
+        queuedAt: new Date('2026-08-03T07:00:00.000Z'),
+        status: 'queued',
+        templateName: 'another-template',
+    });
+
+    const snapshot = await getOrderConfirmationOutboxHealthSnapshot({
+        now,
+        staleBefore,
+    });
+
+    assert.deepEqual(snapshot, {
+        fencedSubmissions: {
+            count: 8,
+            oldestFencedAt: '2026-08-03T09:00:00.000Z',
+            oldestStaleAt: '2026-08-03T09:00:00.000Z',
+            staleCount: 4,
+        },
+        observedAt: now.toISOString(),
+        pendingQueued: {
+            count: 2,
+            dueCount: 1,
+            oldestDueAt: '2026-08-03T08:00:00.000Z',
+            oldestQueuedAt: '2026-08-03T08:00:00.000Z',
+        },
+        preSubmissionClaims: {
+            expiredCount: 1,
+            inFlightCount: 1,
+            oldestExpiredClaimedAt: '2026-08-03T10:45:00.000Z',
+            oldestInFlightClaimedAt: '2026-08-03T11:50:00.000Z',
+        },
+        reconciliation: {
+            claimedCount: 2,
+            dueCount: 1,
+            expiredClaimCount: 1,
+            oldestClaimedAt: '2026-08-03T11:40:00.000Z',
+            oldestPendingAt: '2026-08-03T10:30:00.000Z',
+            oldestStaleAt: '2026-08-03T10:30:00.000Z',
+            pendingCount: 2,
+            staleCount: 2,
+        },
+        staleBefore: staleBefore.toISOString(),
+        staleSubmissionStarted: {
+            count: 1,
+            oldestStartedAt: '2026-08-03T10:00:00.000Z',
+        },
+        submissionUncertain: {
+            count: 2,
+            oldestStaleUncertainAt: '2026-08-03T10:30:00.000Z',
+            oldestUncertainAt: '2026-08-03T10:30:00.000Z',
+            staleCount: 1,
+        },
+        terminalFailures: {
+            count: 2,
+            oldestFailedAt: '2026-08-03T09:45:00.000Z',
+            retryExhaustedCount: 1,
+        },
+    });
+    assert.equal(JSON.stringify(snapshot).includes(healthRecipient), false);
+    assert.equal(JSON.stringify(snapshot).includes(healthBody), false);
+});
+
+test('health snapshot rejects a stale cutoff after its observation time', async () => {
+    createTestDb();
+
+    await assert.rejects(
+        getOrderConfirmationOutboxHealthSnapshot({
+            now: new Date('2026-08-03T12:00:00.000Z'),
+            staleBefore: new Date('2026-08-03T12:00:00.001Z'),
+        }),
+        RangeError,
+    );
+});
+
+test('claim skips a due row locked by another worker', {
+    skip: process.env.GREDICE_TEST_DB_PROVIDER === 'pglite',
+}, async () => {
+    createTestDb();
+    const now = new Date('2026-08-03T13:00:00.000Z');
+    const first = await enqueueReadyCart(operationIds[0], now);
+    const second = await enqueueReadyCart(operationIds[1], now);
+
+    let signalLocked: (() => void) | undefined;
+    const locked = new Promise<void>((resolve) => {
+        signalLocked = resolve;
+    });
+    let releaseLock: (() => void) | undefined;
+    const release = new Promise<void>((resolve) => {
+        releaseLock = resolve;
+    });
+    const heldTransaction = storage().transaction(async (tx) => {
+        await tx
+            .select({ id: emailMessages.id })
+            .from(emailMessages)
+            .where(eq(emailMessages.id, first.emailMessageId))
+            .for('update');
+        signalLocked?.();
+        await release;
+    });
+    await locked;
+
+    try {
+        const claimed = await claimOrderConfirmationEmail({
+            claimExpiresAt: new Date(now.getTime() + 60_000),
+            claimId: 'worker-skip-locked',
+            now,
+        });
+        assert.equal(claimed.status, 'claimed');
+        if (claimed.status !== 'claimed') {
+            throw new Error('Expected a claimed order confirmation');
+        }
+        assert.equal(claimed.claim.emailMessageId, second.emailMessageId);
+    } finally {
+        releaseLock?.();
+        await heldTransaction;
+    }
+
+    assert.equal(
+        (
+            await storage()
+                .select({ status: shoppingCarts.status })
+                .from(shoppingCarts)
+                .where(eq(shoppingCarts.id, first.cartId))
+        )[0]?.status,
+        'paid',
+    );
+});
+
+test('reconciliation claim skips a stale fenced row locked by another worker', {
+    skip: process.env.GREDICE_TEST_DB_PROVIDER === 'pglite',
+}, async () => {
+    createTestDb();
+    const now = new Date('2026-08-03T20:00:00.000Z');
+    const first = await fenceProviderSubmission({
+        claimId: 'delivery-reconcile-skip-locked-first',
+        now,
+        operationId: operationIds[0],
+    });
+    const second = await fenceProviderSubmission({
+        claimId: 'delivery-reconcile-skip-locked-second',
+        now,
+        operationId: operationIds[1],
+    });
+
+    let signalLocked: (() => void) | undefined;
+    const locked = new Promise<void>((resolve) => {
+        signalLocked = resolve;
+    });
+    let releaseLock: (() => void) | undefined;
+    const release = new Promise<void>((resolve) => {
+        releaseLock = resolve;
+    });
+    const heldTransaction = storage().transaction(async (tx) => {
+        await tx
+            .select({ id: emailMessages.id })
+            .from(emailMessages)
+            .where(eq(emailMessages.id, first.emailMessageId))
+            .for('update');
+        signalLocked?.();
+        await release;
+    });
+    await locked;
+
+    try {
+        const claimAt = new Date(now.getTime() + 10 * 60_000);
+        const claimed = await claimOrderConfirmationEmailReconciliation({
+            claimExpiresAt: new Date(claimAt.getTime() + 60_000),
+            claimId: 'reconcile-skip-locked',
+            now: claimAt,
+            staleBefore: new Date(now.getTime() + 5 * 60_000),
+        });
+        assert.equal(claimed.status, 'claimed');
+        if (claimed.status !== 'claimed') {
+            throw new Error('Expected a reconciliation claim');
+        }
+        assert.equal(claimed.claim.emailMessageId, second.emailMessageId);
+    } finally {
+        releaseLock?.();
+        await heldTransaction;
+    }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1136,12 +1136,18 @@ importers:
 
   packages/email:
     dependencies:
+      '@azure/communication-common':
+        specifier: 2.4.0
+        version: 2.4.0
       '@azure/communication-email':
         specifier: 1.1.0
         version: 1.1.0
       '@azure/core-lro':
         specifier: 3.3.1
         version: 3.3.1
+      '@azure/core-rest-pipeline':
+        specifier: 1.22.2
+        version: 1.22.2
       '@gredice/storage':
         specifier: workspace:*
         version: link:../storage
@@ -1161,6 +1167,9 @@ importers:
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
+      tsx:
+        specifier: 4.23.0
+        version: 4.23.0
       typescript:
         specifier: 7.0.2
         version: 7.0.2


### PR DESCRIPTION
## Summary

- return direct non-Stripe checkout after the cart is atomically marked paid and a durable confirmation intent is recorded
- process confirmation emails in a bounded, authenticated one-minute cron instead of rendering, submitting, and polling in the checkout request
- enforce at-most-once provider submission with expiring claims, a pre-submission fence, and GET-only reconciliation for ambiguous or post-success finalization states
- expose privacy-safe queue/fence/retry health and reuse the existing `email_messages` audit table without a schema migration
- add a protected `@gredice/email` CI job so provider-boundary and reconciliation-client tests gate merges

## Production safety

- checkout never relies on an untracked promise or post-response function lifetime
- cart `new -> paid` and confirmation intent insertion are one database transaction
- retries and concurrent workers use row locks, leases, claim IDs, and stable operation IDs
- ambiguous submissions and successful sends whose database finalization fails remain fenced and are never automatically resubmitted
- explicit provider `Failed`/`Canceled` results are terminal failures, never pre-submission retries
- reconciliation performs only authenticated `GET` requests and validates the returned operation ID before applying status
- missing provider configuration defers delivery without failing checkout or consuming delivery attempts
- rollback/deployment handling is documented in `docs/checkout-order-confirmation-outbox.md`

## Validation

- `pnpm --filter api test:node` — 321 passed
- `pnpm --filter api exec tsc --noEmit`
- `pnpm --filter api build`
- `pnpm --filter @gredice/email test` — 45 passed
- `pnpm --filter @gredice/email typecheck`
- storage outbox suite — 15 passed; 2 PGlite-only concurrency skips are covered by the Docker PostgreSQL CI job
- focused API worker/cron suite — 15 passed
- targeted API/email/storage Biome checks
- `pnpm lint:ci-filters`
- workflow YAML parse
- `git diff --check`
- independent final review and automated-review follow-up addressed

Closes #4368
