### PR TITLE
perf(checkout): batch direct sunflower checkout

### DIFF
--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -27,7 +27,6 @@ import {
     sunflowerPackageEntityTypeName,
     validateHarvestDateSelections,
     withCheckoutCartItemLock,
-    withCheckoutCartItemProcessingLock,
     withInventoryAccountTransaction,
 } from '@gredice/storage';
 import {
@@ -53,7 +52,9 @@ import {
     CheckoutDeliverySelectionError,
     validateCheckoutDeliverySelection,
 } from '../../../lib/checkout/deliverySelection';
-import { withDirectSunflowerCheckoutPayment } from '../../../lib/checkout/directSunflowerCheckout';
+import { getDirectCheckoutPaymentErrorResponse } from '../../../lib/checkout/directCheckoutErrors';
+import { getPaidCartCheckoutRetryResponse } from '../../../lib/checkout/directCheckoutRetry';
+import { withDirectSunflowerCheckoutBatch } from '../../../lib/checkout/directSunflowerCheckout';
 import {
     buildCheckoutAdditionalData,
     encodeHarvestDatesMetadata,
@@ -193,7 +194,17 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                 return context.json({ error: 'Cart not found' }, 404);
             }
             if (initialCart.status === 'paid') {
-                return context.json({ error: 'Cart already paid' }, 400);
+                if (initialCart.items.some((item) => item.currency === 'eur')) {
+                    return context.json({ error: 'Cart already paid' }, 400);
+                }
+                const retryResponse = await getPaidCartCheckoutRetryResponse({
+                    accountId,
+                    cart: initialCart,
+                });
+                if (!retryResponse) {
+                    return context.json({ error: 'Cart not found' }, 404);
+                }
+                return context.json(retryResponse.body, retryResponse.status);
             }
 
             const { cart, checkoutOperationMappings } =
@@ -514,303 +525,291 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                 paymentKind,
             });
 
-            // Handle sunflower items
+            // Batch and fulfill direct checkout while one process lock covers
+            // the complete cart snapshot. Database locks are released before
+            // any fulfillment or notification work begins.
             if (!requiresStripePayment) {
                 const endNonStripeFulfillment = checkoutTiming.startPhase(
                     'non_stripe_fulfillment',
                 );
-                const resolvedSunflowerAmountsByCartItemId = new Map<
-                    number,
-                    number
-                >();
+                let fulfillmentPhaseEnded = false;
+                const finishFulfillmentPhase = () => {
+                    if (fulfillmentPhaseEnded) {
+                        return;
+                    }
+                    fulfillmentPhaseEnded = true;
+                    endNonStripeFulfillment();
+                };
+                let processingStage:
+                    | 'payment'
+                    | 'fulfillment'
+                    | 'confirmation' = 'payment';
+
                 try {
-                    const scheduledDeliveryEmailKeys = new Set<string>();
-                    const allSunflowerCartItemsWithShopData =
-                        cartInfo.items.filter(
-                            (item) => item.currency === 'sunflower',
-                        );
-                    const sunflowerCartItemsWithShopData =
-                        allSunflowerCartItemsWithShopData.filter(
-                            (item) => item.status !== 'paid',
-                        );
-                    if (sunflowerCartItemsWithShopData.length > 0) {
-                        // Check if there are enough sunflowers in the account
-                        for (const item of sunflowerCartItemsWithShopData) {
-                            let processingStage: 'payment' | 'fulfillment' =
-                                'payment';
-                            try {
-                                await withDirectSunflowerCheckoutPayment({
-                                    accountId,
-                                    allSunflowerItems:
-                                        allSunflowerCartItemsWithShopData,
-                                    cartId: cart.id,
-                                    item,
-                                    operation: async (payment) => {
-                                        for (const [
-                                            cartItemId,
-                                            resolvedAmount,
-                                        ] of payment.resolvedAmountsByCartItemId) {
-                                            resolvedSunflowerAmountsByCartItemId.set(
-                                                cartItemId,
-                                                resolvedAmount,
+                    const directCheckoutResult =
+                        await withDirectSunflowerCheckoutBatch({
+                            accountId,
+                            allCheckoutItems: cartInfo.items,
+                            cartId: cart.id,
+                            operation: async ({
+                                pendingItems,
+                                resolvedAmountsByCartItemId,
+                            }) => {
+                                processingStage = 'fulfillment';
+                                const scheduledDeliveryEmailKeys =
+                                    new Set<string>();
+                                try {
+                                    for (const item of pendingItems) {
+                                        const resolvedAmount =
+                                            resolvedAmountsByCartItemId.get(
+                                                item.id,
+                                            );
+                                        if (resolvedAmount === undefined) {
+                                            throw new Error(
+                                                `Sunflower checkout amount is missing for cart item ${item.id.toString()}.`,
                                             );
                                         }
-                                        if (payment.state === 'paid') {
-                                            return;
-                                        }
-                                        processingStage = 'fulfillment';
                                         const checkoutOperationMapping =
                                             item.entityTypeName === 'operation'
                                                 ? await getCheckoutOperationMapping(
                                                       item.id,
                                                   )
                                                 : undefined;
-
                                         const fulfillment = await processItem({
                                             accountId,
                                             cartItemId: item.id,
                                             ...item,
-                                            amount_total:
-                                                payment.resolvedAmount,
+                                            amount_total: resolvedAmount,
                                             scheduledDeliveryEmailKeys,
                                             additionalData:
                                                 checkoutAdditionalDataByCartItemId.get(
                                                     item.id,
                                                 ) ?? {},
-                                            checkoutOperationMapping:
-                                                item.entityTypeName ===
-                                                'operation'
-                                                    ? checkoutOperationMapping
-                                                    : undefined,
+                                            checkoutOperationMapping,
                                         });
                                         assertCheckoutItemFulfilled(
                                             fulfillment,
                                         );
                                         await setCartItemPaid(item.id);
-                                    },
-                                });
-                            } catch (error) {
-                                if (processingStage === 'payment') {
-                                    checkoutTiming.setErrorCategory(
-                                        'sunflower_spend_failed',
-                                    );
-                                    console.error('Error spending sunflowers', {
-                                        accountId,
-                                        cartId: cart.id,
-                                        error,
-                                        cartItemId: item.id,
-                                    });
-                                } else {
-                                    checkoutTiming.setErrorCategory(
-                                        'unexpected',
-                                    );
-                                }
-                                throw error;
-                            }
-                        }
-                    }
-                    const unresolvedPaidSunflowerItem =
-                        allSunflowerCartItemsWithShopData.find(
-                            (item) =>
-                                item.status === 'paid' &&
-                                !resolvedSunflowerAmountsByCartItemId.has(
-                                    item.id,
-                                ),
-                        );
-                    if (unresolvedPaidSunflowerItem) {
-                        try {
-                            await withDirectSunflowerCheckoutPayment({
-                                accountId,
-                                allSunflowerItems:
-                                    allSunflowerCartItemsWithShopData,
-                                cartId: cart.id,
-                                item: unresolvedPaidSunflowerItem,
-                                operation: async (payment) => {
-                                    for (const [
-                                        cartItemId,
-                                        resolvedAmount,
-                                    ] of payment.resolvedAmountsByCartItemId) {
-                                        resolvedSunflowerAmountsByCartItemId.set(
-                                            cartItemId,
-                                            resolvedAmount,
-                                        );
                                     }
-                                },
-                            });
-                        } catch (error) {
-                            checkoutTiming.setErrorCategory(
-                                'sunflower_spend_failed',
-                            );
-                            console.error(
-                                'Error resolving paid sunflower amounts',
-                                {
-                                    accountId,
-                                    cartId: cart.id,
-                                    error,
-                                },
-                            );
-                            throw error;
-                        }
-                    }
-                    const missingSunflowerAmountItemIds =
-                        allSunflowerCartItemsWithShopData
-                            .filter(
-                                (item) =>
-                                    !resolvedSunflowerAmountsByCartItemId.has(
-                                        item.id,
-                                    ),
-                            )
-                            .map((item) => item.id);
-                    if (missingSunflowerAmountItemIds.length > 0) {
-                        throw new Error(
-                            `Sunflower checkout did not resolve durable amounts for cart items ${missingSunflowerAmountItemIds.join(', ')}.`,
-                        );
-                    }
 
-                    // Handle inventory items
-                    const inventoryCartItems = cartInfo.items.filter(
-                        (item) =>
-                            item.status !== 'paid' &&
-                            (item.currency === 'inventory' ||
-                                item.usesInventory),
-                    );
-
-                    if (inventoryCartItems.length > 0) {
-                        for (const item of inventoryCartItems) {
-                            if ((item.inventoryAvailable ?? 0) < item.amount) {
-                                return context.json(
-                                    {
-                                        error: 'Nema dovoljno predmeta u ruksaku',
-                                    },
-                                    400,
-                                );
-                            }
-
-                            await withCheckoutCartItemProcessingLock(
-                                item.id,
-                                async () => {
-                                    const state =
-                                        await withCheckoutCartItemLock(
-                                            item.id,
-                                            async (db) => {
-                                                const lockedCart =
-                                                    await getShoppingCart(
-                                                        cart.id,
-                                                        db,
-                                                    );
-                                                if (!lockedCart) {
-                                                    throw new Error(
-                                                        `Cart ${cart.id.toString()} disappeared before inventory fulfillment.`,
-                                                    );
-                                                }
-                                                const lockedState =
-                                                    assertCheckoutCartItemSnapshot(
-                                                        lockedCart.items.find(
-                                                            (lockedItem) =>
-                                                                lockedItem.id ===
-                                                                item.id,
-                                                        ),
-                                                        item,
-                                                    );
-                                                if (lockedState === 'pending') {
-                                                    await withInventoryAccountTransaction(
-                                                        accountId,
-                                                        (inventoryDb) =>
-                                                            consumeInventoryItem(
-                                                                accountId,
-                                                                {
-                                                                    entityTypeName:
-                                                                        item.entityTypeName,
-                                                                    entityId:
-                                                                        item.entityId,
-                                                                    amount: item.amount,
-                                                                    source: `shoppingCartItem:${item.id.toString()}`,
-                                                                },
-                                                                inventoryDb,
-                                                            ),
-                                                        db,
-                                                    );
-                                                }
-                                                return lockedState;
-                                            },
+                                    const inventoryCartItems =
+                                        cartInfo.items.filter(
+                                            (item) =>
+                                                item.status !== 'paid' &&
+                                                (item.currency ===
+                                                    'inventory' ||
+                                                    item.usesInventory),
                                         );
-                                    if (state === 'paid') {
-                                        return;
-                                    }
-                                    const checkoutOperationMapping =
-                                        item.entityTypeName === 'operation'
-                                            ? await getCheckoutOperationMapping(
-                                                  item.id,
-                                              )
-                                            : undefined;
-
-                                    const fulfillment = await processItem({
-                                        accountId,
-                                        cartItemId: item.id,
-                                        ...item,
-                                        amount_total: 0,
-                                        scheduledDeliveryEmailKeys,
-                                        additionalData:
-                                            checkoutAdditionalDataByCartItemId.get(
-                                                item.id,
-                                            ) ?? {},
-                                        checkoutOperationMapping:
-                                            item.entityTypeName === 'operation'
-                                                ? checkoutOperationMapping
-                                                : undefined,
-                                    });
-                                    assertCheckoutItemFulfilled(fulfillment);
-                                    await setCartItemPaid(item.id);
-                                },
-                            );
-                        }
-                    }
-                } finally {
-                    endNonStripeFulfillment();
-                }
-
-                const confirmationIntent = await checkoutTiming.measure(
-                    'confirmation_side_effects',
-                    () =>
-                        markCartPaidAndEnqueueOrderConfirmation({
-                            cartId: cart.id,
-                            payload: {
-                                cartId: cart.id,
-                                currency: null,
-                                items: buildOrderConfirmationItems(
-                                    cartInfo.items,
-                                    (item) => {
-                                        const resolvedAmount =
-                                            resolvedSunflowerAmountsByCartItemId.get(
-                                                item.id,
-                                            );
-                                        if (resolvedAmount === undefined) {
-                                            throw new Error(
-                                                `Sunflower confirmation amount is missing for cart item ${item.id.toString()}.`,
-                                            );
+                                    for (const item of inventoryCartItems) {
+                                        if (
+                                            (item.inventoryAvailable ?? 0) <
+                                            item.amount
+                                        ) {
+                                            return {
+                                                status: 'inventory_insufficient' as const,
+                                            };
                                         }
-                                        return resolvedAmount;
-                                    },
-                                ),
-                                manageUrl: ORDER_CONFIRMATION_MANAGE_URL,
-                                to: user.userName,
-                                totalAmountCents: null,
+
+                                        const state =
+                                            await withCheckoutCartItemLock(
+                                                item.id,
+                                                async (db) => {
+                                                    const lockedCart =
+                                                        await getShoppingCart(
+                                                            cart.id,
+                                                            db,
+                                                        );
+                                                    if (!lockedCart) {
+                                                        throw new Error(
+                                                            `Cart ${cart.id.toString()} disappeared before inventory fulfillment.`,
+                                                        );
+                                                    }
+                                                    const lockedState =
+                                                        assertCheckoutCartItemSnapshot(
+                                                            lockedCart.items.find(
+                                                                (lockedItem) =>
+                                                                    lockedItem.id ===
+                                                                    item.id,
+                                                            ),
+                                                            item,
+                                                        );
+                                                    if (
+                                                        lockedState ===
+                                                        'pending'
+                                                    ) {
+                                                        await withInventoryAccountTransaction(
+                                                            accountId,
+                                                            (inventoryDb) =>
+                                                                consumeInventoryItem(
+                                                                    accountId,
+                                                                    {
+                                                                        entityTypeName:
+                                                                            item.entityTypeName,
+                                                                        entityId:
+                                                                            item.entityId,
+                                                                        amount: item.amount,
+                                                                        source: `shoppingCartItem:${item.id.toString()}`,
+                                                                    },
+                                                                    inventoryDb,
+                                                                ),
+                                                            db,
+                                                        );
+                                                    }
+                                                    return lockedState;
+                                                },
+                                            );
+                                        if (state === 'paid') {
+                                            continue;
+                                        }
+
+                                        const checkoutOperationMapping =
+                                            item.entityTypeName === 'operation'
+                                                ? await getCheckoutOperationMapping(
+                                                      item.id,
+                                                  )
+                                                : undefined;
+                                        const fulfillment = await processItem({
+                                            accountId,
+                                            cartItemId: item.id,
+                                            ...item,
+                                            amount_total: 0,
+                                            scheduledDeliveryEmailKeys,
+                                            additionalData:
+                                                checkoutAdditionalDataByCartItemId.get(
+                                                    item.id,
+                                                ) ?? {},
+                                            checkoutOperationMapping,
+                                        });
+                                        assertCheckoutItemFulfilled(
+                                            fulfillment,
+                                        );
+                                        await setCartItemPaid(item.id);
+                                    }
+                                } finally {
+                                    finishFulfillmentPhase();
+                                }
+
+                                processingStage = 'confirmation';
+                                const confirmationIntent =
+                                    await checkoutTiming.measure(
+                                        'confirmation_side_effects',
+                                        () =>
+                                            markCartPaidAndEnqueueOrderConfirmation(
+                                                {
+                                                    cartId: cart.id,
+                                                    payload: {
+                                                        cartId: cart.id,
+                                                        currency: null,
+                                                        items: buildOrderConfirmationItems(
+                                                            cartInfo.items,
+                                                            (item) => {
+                                                                const resolvedAmount =
+                                                                    resolvedAmountsByCartItemId.get(
+                                                                        item.id,
+                                                                    );
+                                                                if (
+                                                                    resolvedAmount ===
+                                                                    undefined
+                                                                ) {
+                                                                    throw new Error(
+                                                                        `Sunflower confirmation amount is missing for cart item ${item.id.toString()}.`,
+                                                                    );
+                                                                }
+                                                                return resolvedAmount;
+                                                            },
+                                                        ),
+                                                        manageUrl:
+                                                            ORDER_CONFIRMATION_MANAGE_URL,
+                                                        to: user.userName,
+                                                        totalAmountCents: null,
+                                                    },
+                                                },
+                                            ),
+                                    );
+                                const confirmationRecorded =
+                                    confirmationIntent.status === 'enqueued' ||
+                                    (confirmationIntent.status ===
+                                        'already_paid' &&
+                                        confirmationIntent.emailMessageId !==
+                                            null);
+                                return {
+                                    status: confirmationRecorded
+                                        ? ('completed' as const)
+                                        : ('confirmation_incomplete' as const),
+                                };
                             },
-                        }),
-                );
-                if (
-                    confirmationIntent.status !== 'enqueued' &&
-                    !(
-                        confirmationIntent.status === 'already_paid' &&
-                        confirmationIntent.emailMessageId !== null
-                    )
-                ) {
-                    return context.json(
-                        {
-                            error: 'Narudžbu nije moguće dovršiti. Pokušaj ponovno.',
-                        },
-                        409,
+                        });
+
+                    if (directCheckoutResult.state === 'cart_paid') {
+                        const retryResponse =
+                            await getPaidCartCheckoutRetryResponse({
+                                accountId,
+                                cart: directCheckoutResult.cart,
+                            });
+                        if (!retryResponse) {
+                            return context.json(
+                                { error: 'Cart not found' },
+                                404,
+                            );
+                        }
+                        return context.json(
+                            retryResponse.body,
+                            retryResponse.status,
+                        );
+                    }
+                    if (
+                        directCheckoutResult.value.status ===
+                        'inventory_insufficient'
+                    ) {
+                        return context.json(
+                            {
+                                error: 'Nema dovoljno predmeta u ruksaku',
+                            },
+                            400,
+                        );
+                    }
+                    if (
+                        directCheckoutResult.value.status ===
+                        'confirmation_incomplete'
+                    ) {
+                        return context.json(
+                            {
+                                code: 'CHECKOUT_CONFIRMATION_MISSING',
+                                error: 'Narudžbu nije moguće dovršiti. Pokušaj ponovno.',
+                            },
+                            409,
+                        );
+                    }
+                } catch (error) {
+                    const paymentErrorResponse =
+                        getDirectCheckoutPaymentErrorResponse(error);
+                    if (paymentErrorResponse) {
+                        checkoutTiming.setErrorCategory(
+                            paymentErrorResponse.errorCategory,
+                        );
+                        return context.json(
+                            paymentErrorResponse.body,
+                            paymentErrorResponse.status,
+                        );
+                    }
+
+                    checkoutTiming.setErrorCategory(
+                        processingStage === 'payment'
+                            ? 'sunflower_spend_failed'
+                            : processingStage === 'fulfillment'
+                              ? 'direct_checkout_fulfillment_failed'
+                              : 'unexpected',
                     );
+                    console.error('Direct checkout failed', {
+                        accountId,
+                        cartId: cart.id,
+                        error,
+                        processingStage,
+                    });
+                    throw error;
+                } finally {
+                    finishFulfillmentPhase();
                 }
             }
 

--- a/apps/api/lib/checkout/checkoutTiming.node.spec.ts
+++ b/apps/api/lib/checkout/checkoutTiming.node.spec.ts
@@ -84,6 +84,21 @@ test('checkout timing emits one privacy-safe unexpected failure record', () => {
     ]);
 });
 
+test('checkout timing preserves a route-classified failure from middleware fallback', () => {
+    let record: Record<string, unknown> | undefined;
+    const timing = new CheckoutTiming({
+        write: (_level, _event, attributes) => {
+            record = attributes;
+        },
+    });
+
+    timing.setErrorCategory('direct_checkout_fulfillment_failed');
+    timing.setErrorCategoryIfUnset('unexpected');
+    timing.finish({ outcome: 'unexpected_failure', status: 500 });
+
+    assert.equal(record?.errorCategory, 'direct_checkout_fulfillment_failed');
+});
+
 test('checkout timing accumulates repeated phases and ends each phase once', () => {
     let currentTime = 0;
     let record: Record<string, unknown> | undefined;

--- a/apps/api/lib/checkout/checkoutTiming.ts
+++ b/apps/api/lib/checkout/checkoutTiming.ts
@@ -25,6 +25,9 @@ export type CheckoutTimingOutcome =
 
 export type CheckoutTimingErrorCategory =
     | 'cart_validation_failed'
+    | 'direct_checkout_fulfillment_failed'
+    | 'sunflower_amount_conflict'
+    | 'sunflower_insufficient'
     | 'sunflower_spend_failed'
     | 'unexpected';
 
@@ -173,6 +176,10 @@ export class CheckoutTiming {
         this.errorCategory = errorCategory;
     }
 
+    setErrorCategoryIfUnset(errorCategory: CheckoutTimingErrorCategory) {
+        this.errorCategory ??= errorCategory;
+    }
+
     startPhase(phase: CheckoutTimingPhase) {
         const startedAtMs = this.now();
         let ended = false;
@@ -245,7 +252,7 @@ export function checkoutTimingMiddleware<
         try {
             await next();
             if (context.error) {
-                checkoutTiming.setErrorCategory('unexpected');
+                checkoutTiming.setErrorCategoryIfUnset('unexpected');
                 checkoutTiming.finish({
                     outcome: 'unexpected_failure',
                     status: context.res.status,
@@ -254,7 +261,7 @@ export function checkoutTimingMiddleware<
             }
             checkoutTiming.finish({ status: context.res.status });
         } catch (error) {
-            checkoutTiming.setErrorCategory('unexpected');
+            checkoutTiming.setErrorCategoryIfUnset('unexpected');
             checkoutTiming.finish({
                 outcome: 'unexpected_failure',
                 status: 500,

--- a/apps/api/lib/checkout/directCheckoutErrors.node.spec.ts
+++ b/apps/api/lib/checkout/directCheckoutErrors.node.spec.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    InsufficientSunflowersError,
+    SunflowerSpendAmountConflictError,
+} from '@gredice/storage';
+import { getDirectCheckoutPaymentErrorResponse } from './directCheckoutErrors';
+
+test('direct checkout maps insufficient balance to an explicit recoverable conflict', () => {
+    assert.deepStrictEqual(
+        getDirectCheckoutPaymentErrorResponse(
+            new InsufficientSunflowersError(1_000, 2_000),
+        ),
+        {
+            body: {
+                code: 'INSUFFICIENT_SUNFLOWERS',
+                error: 'Nema dovoljno suncokreta za ovu kupnju.',
+            },
+            errorCategory: 'sunflower_insufficient',
+            status: 409,
+        },
+    );
+});
+
+test('direct checkout maps changed durable amount to an explicit conflict', () => {
+    assert.deepStrictEqual(
+        getDirectCheckoutPaymentErrorResponse(
+            new SunflowerSpendAmountConflictError(
+                'shoppingCartItem:1',
+                2_000,
+                3_000,
+            ),
+        ),
+        {
+            body: {
+                code: 'SUNFLOWER_SPEND_CONFLICT',
+                error: 'Cijena stavke promijenila se tijekom obrade. Osvježi košaricu i pokušaj ponovno.',
+            },
+            errorCategory: 'sunflower_amount_conflict',
+            status: 409,
+        },
+    );
+});
+
+test('direct checkout does not hide infrastructure or fulfillment failures', () => {
+    assert.equal(
+        getDirectCheckoutPaymentErrorResponse(new Error('database offline')),
+        null,
+    );
+});

--- a/apps/api/lib/checkout/directCheckoutErrors.ts
+++ b/apps/api/lib/checkout/directCheckoutErrors.ts
@@ -1,0 +1,40 @@
+import {
+    InsufficientSunflowersError,
+    SunflowerSpendAmountConflictError,
+} from '@gredice/storage';
+import type { CheckoutTimingErrorCategory } from './checkoutTiming';
+
+type DirectCheckoutPaymentErrorResponse = {
+    body: {
+        code: 'INSUFFICIENT_SUNFLOWERS' | 'SUNFLOWER_SPEND_CONFLICT';
+        error: string;
+    };
+    errorCategory: CheckoutTimingErrorCategory;
+    status: 409;
+};
+
+export function getDirectCheckoutPaymentErrorResponse(
+    error: unknown,
+): DirectCheckoutPaymentErrorResponse | null {
+    if (error instanceof InsufficientSunflowersError) {
+        return {
+            body: {
+                code: 'INSUFFICIENT_SUNFLOWERS',
+                error: 'Nema dovoljno suncokreta za ovu kupnju.',
+            },
+            errorCategory: 'sunflower_insufficient',
+            status: 409,
+        };
+    }
+    if (error instanceof SunflowerSpendAmountConflictError) {
+        return {
+            body: {
+                code: 'SUNFLOWER_SPEND_CONFLICT',
+                error: 'Cijena stavke promijenila se tijekom obrade. Osvježi košaricu i pokušaj ponovno.',
+            },
+            errorCategory: 'sunflower_amount_conflict',
+            status: 409,
+        };
+    }
+    return null;
+}

--- a/apps/api/lib/checkout/directCheckoutRetry.node.spec.ts
+++ b/apps/api/lib/checkout/directCheckoutRetry.node.spec.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    type DirectCheckoutRetryDependencies,
+    getPaidCartCheckoutRetryResponse,
+} from './directCheckoutRetry';
+
+const cart = {
+    accountId: 'account-1',
+    id: 44,
+    status: 'paid',
+};
+
+function dependencies(
+    metadata: Record<string, unknown> | null,
+): DirectCheckoutRetryDependencies {
+    return {
+        getConfirmationIntent: async () =>
+            metadata
+                ? {
+                      metadata,
+                  }
+                : undefined,
+    };
+}
+
+test('owned paid cart is an idempotent success with a durable outbox intent', async () => {
+    const response = await getPaidCartCheckoutRetryResponse(
+        { accountId: 'account-1', cart },
+        dependencies({ outboxKind: 'order_confirmation', cartId: 44 }),
+    );
+
+    assert.deepStrictEqual(response, {
+        body: { success: true },
+        status: 200,
+    });
+});
+
+test('paid cart without a durable outbox intent remains a visible conflict', async () => {
+    const missing = await getPaidCartCheckoutRetryResponse(
+        { accountId: 'account-1', cart },
+        dependencies(null),
+    );
+    const legacyLog = await getPaidCartCheckoutRetryResponse(
+        { accountId: 'account-1', cart },
+        dependencies({ orderReference: 'Narudžba #44' }),
+    );
+
+    assert.strictEqual(missing?.status, 409);
+    assert.strictEqual(missing?.body.code, 'CHECKOUT_CONFIRMATION_MISSING');
+    assert.strictEqual(legacyLog?.status, 409);
+});
+
+test('paid cart retry helper never confirms a cart owned by another account', async () => {
+    const response = await getPaidCartCheckoutRetryResponse(
+        { accountId: 'account-2', cart },
+        dependencies({ outboxKind: 'order_confirmation', cartId: 44 }),
+    );
+
+    assert.strictEqual(response, null);
+});

--- a/apps/api/lib/checkout/directCheckoutRetry.ts
+++ b/apps/api/lib/checkout/directCheckoutRetry.ts
@@ -1,0 +1,82 @@
+import { getEmailMessageByTemplateAndMetadata } from '@gredice/storage';
+
+const orderConfirmationTemplateName = 'commerce-order-confirmation';
+const orderConfirmationOutboxKind = 'order_confirmation';
+
+type PaidCart = {
+    accountId: string | null;
+    id: number;
+    status: string;
+};
+
+type DirectCheckoutRetryResponse =
+    | {
+          body: { success: true };
+          status: 200;
+      }
+    | {
+          body: {
+              code: 'CHECKOUT_CONFIRMATION_MISSING';
+              error: string;
+          };
+          status: 409;
+      };
+
+export type DirectCheckoutRetryDependencies = {
+    getConfirmationIntent: (input: {
+        metadataKey: string;
+        metadataValue: string;
+        templateName: string;
+    }) => Promise<{ metadata: unknown } | undefined>;
+};
+
+const realDependencies: DirectCheckoutRetryDependencies = {
+    getConfirmationIntent: getEmailMessageByTemplateAndMetadata,
+};
+
+function hasOrderConfirmationOutboxMetadata(metadata: unknown) {
+    return (
+        typeof metadata === 'object' &&
+        metadata !== null &&
+        !Array.isArray(metadata) &&
+        'outboxKind' in metadata &&
+        metadata.outboxKind === orderConfirmationOutboxKind
+    );
+}
+
+/**
+ * A paid cart is an idempotent direct-checkout success only after its durable
+ * confirmation intent exists. A paid-but-not-enqueued state stays visible as
+ * a retryable conflict instead of hiding a partial completion.
+ */
+export async function getPaidCartCheckoutRetryResponse(
+    {
+        accountId,
+        cart,
+    }: {
+        accountId: string;
+        cart: PaidCart;
+    },
+    dependencies: DirectCheckoutRetryDependencies = realDependencies,
+): Promise<DirectCheckoutRetryResponse | null> {
+    if (cart.accountId !== accountId || cart.status !== 'paid') {
+        return null;
+    }
+
+    const intent = await dependencies.getConfirmationIntent({
+        metadataKey: 'cartId',
+        metadataValue: cart.id.toString(),
+        templateName: orderConfirmationTemplateName,
+    });
+    if (intent && hasOrderConfirmationOutboxMetadata(intent.metadata)) {
+        return { body: { success: true }, status: 200 };
+    }
+
+    return {
+        body: {
+            code: 'CHECKOUT_CONFIRMATION_MISSING',
+            error: 'Narudžba je obrađena, ali potvrda nije zabilježena. Ako se stanje ne osvježi, javi se podršci.',
+        },
+        status: 409,
+    };
+}

--- a/apps/api/lib/checkout/directSunflowerCheckout.node.spec.ts
+++ b/apps/api/lib/checkout/directSunflowerCheckout.node.spec.ts
@@ -1,31 +1,34 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { withCheckoutCartItemProcessingLocks } from '@gredice/storage';
 import type { ShoppingCartItemWithShopData } from './cartInfo';
-import { withDirectSunflowerCheckoutPayment } from './directSunflowerCheckout';
+import { withDirectSunflowerCheckoutBatch } from './directSunflowerCheckout';
 
-function sunflowerItem({
+function cartItem({
+    currency = 'sunflower',
     discountPrice,
     id,
     price,
-    status,
+    status = 'new',
 }: {
+    currency?: string;
     discountPrice?: number;
     id: number;
     price: number;
-    status: string;
+    status?: string;
 }): ShoppingCartItemWithShopData {
     return {
         additionalData: null,
         amount: 1,
         cartId: 100,
         createdAt: new Date(`2026-07-01T10:0${id.toString()}:00.000Z`),
-        currency: 'sunflower',
+        currency,
         entityData: { id },
         entityId: id.toString(),
         entityTypeName: 'plantSort',
         gardenId: 200,
         id,
-        inventoryAvailable: 0,
+        inventoryAvailable: currency === 'inventory' ? 1 : 0,
         isDeleted: false,
         outlet: undefined,
         positionIndex: id,
@@ -33,59 +36,54 @@ function sunflowerItem({
         shopData: { discountPrice, price },
         status,
         updatedAt: new Date('2026-07-01T10:10:00.000Z'),
-        usesInventory: false,
+        usesInventory: currency === 'inventory',
     };
 }
 
-test('direct sunflower checkout verifies full legacy coverage and returns the durable amount', async () => {
-    const paidItem = sunflowerItem({
-        discountPrice: 0,
-        id: 2,
-        price: 5,
-        status: 'paid',
+function deferred<T>() {
+    let resolve = (_value: T | PromiseLike<T>) => {};
+    const promise = new Promise<T>((promiseResolve) => {
+        resolve = promiseResolve;
     });
-    const pendingItem = sunflowerItem({
-        discountPrice: 7,
-        id: 3,
-        price: 7,
-        status: 'new',
-    });
+    return { promise, resolve };
+}
+
+test('direct checkout debits every pending sunflower in one short transaction', async () => {
+    const first = cartItem({ id: 1, price: 2 });
+    const second = cartItem({ id: 2, price: 3 });
+    const inventory = cartItem({ currency: 'inventory', id: 3, price: 4 });
+    const allItems = [first, second, inventory];
     const calls: Array<{ args: unknown[]; name: string }> = [];
 
-    const result = await withDirectSunflowerCheckoutPayment({
+    const result = await withDirectSunflowerCheckoutBatch({
         accountId: 'account-1',
-        allSunflowerItems: [paidItem, pendingItem],
+        allCheckoutItems: allItems,
         cartId: 100,
-        item: pendingItem,
         dependencies: {
-            calculateSunflowerAmount: (item) => {
-                calls.push({ args: [item.shopData], name: 'calculate' });
-                return 7_000;
-            },
-            calculateSunflowerReplayAmount: (item) => {
-                calls.push({ args: [item.status], name: 'calculateReplay' });
-                return 5_000;
-            },
-            lockShoppingCartForCheckout: async (...args) => {
-                calls.push({ args: args.slice(0, 1), name: 'lockCart' });
-                return {
-                    accountId: 'account-1',
-                    id: 100,
-                    isDeleted: false,
-                    items: [paidItem, pendingItem],
-                    status: 'new',
-                    createdAt: new Date(),
-                    updatedAt: new Date(),
-                };
-            },
+            calculateSunflowerAmount: (item) =>
+                Math.round((item.shopData.price ?? 0) * 1000),
+            calculateSunflowerReplayAmount: () => 9_999,
+            getShoppingCart: async () => undefined,
+            lockShoppingCartForCheckout: async () => ({
+                accountId: 'account-1',
+                id: 100,
+                isDeleted: false,
+                items: allItems,
+                status: 'new',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            }),
             spendSunflowersBatch: async (...args) => {
                 calls.push({ args, name: 'spend' });
                 return {
-                    createdReasons: [],
-                    existingReasons: ['shoppingCartItem:3'],
+                    createdReasons: [
+                        'shoppingCartItem:1',
+                        'shoppingCartItem:2',
+                    ],
+                    existingReasons: [],
                     resolvedAmountsByReason: {
-                        'shoppingCartItem:2': 4_500,
-                        'shoppingCartItem:3': 6_000,
+                        'shoppingCartItem:1': 2_000,
+                        'shoppingCartItem:2': 3_000,
                     },
                 };
             },
@@ -106,26 +104,27 @@ test('direct sunflower checkout verifies full legacy coverage and returns the du
         },
         operation: async (payment) => {
             calls.push({ args: [payment], name: 'fulfillment' });
-            return payment;
+            assert.deepStrictEqual(
+                payment.pendingItems.map((item) => item.id),
+                [1, 2],
+            );
+            return 'fulfilled';
         },
     });
 
     assert.deepStrictEqual(result, {
-        resolvedAmount: 6_000,
-        resolvedAmountsByCartItemId: new Map([
-            [2, 4_500],
-            [3, 6_000],
-        ]),
-        state: 'pending',
+        state: 'processed',
+        value: 'fulfilled',
     });
     assert.deepStrictEqual(
         calls.find((call) => call.name === 'processingLocksStarted')?.args,
-        [[2, 3]],
+        [[1, 2, 3]],
     );
     assert.deepStrictEqual(
         calls.find((call) => call.name === 'databaseLocksStarted')?.args,
-        [[2, 3]],
+        [[1, 2, 3]],
     );
+    assert.equal(calls.filter((call) => call.name === 'spend').length, 1);
     assert.ok(
         calls.findIndex((call) => call.name === 'databaseLocksFinished') <
             calls.findIndex((call) => call.name === 'fulfillment'),
@@ -134,10 +133,14 @@ test('direct sunflower checkout verifies full legacy coverage and returns the du
         calls.findIndex((call) => call.name === 'fulfillment') <
             calls.findIndex((call) => call.name === 'processingLocksFinished'),
     );
+
     const spendCall = calls.find((call) => call.name === 'spend');
     assert.deepStrictEqual(spendCall?.args.slice(0, 2), [
         'account-1',
-        [{ amount: 7_000, reason: 'shoppingCartItem:3' }],
+        [
+            { amount: 2_000, reason: 'shoppingCartItem:1' },
+            { amount: 3_000, reason: 'shoppingCartItem:2' },
+        ],
     ]);
     assert.deepStrictEqual(spendCall?.args[3], {
         existingCheckoutItemAmountsAreAuthoritative: true,
@@ -145,20 +148,311 @@ test('direct sunflower checkout verifies full legacy coverage and returns the du
             reason: 'shoppingCart:100',
             coveredItems: [
                 {
-                    amount: 5_000,
-                    cartItemId: 2,
-                    createdAt: paidItem.createdAt,
-                    paymentState: 'paid',
-                    reason: 'shoppingCartItem:2',
+                    amount: 2_000,
+                    cartItemId: 1,
+                    createdAt: first.createdAt,
+                    paymentState: 'pending',
+                    reason: 'shoppingCartItem:1',
                 },
                 {
-                    amount: 7_000,
-                    cartItemId: 3,
-                    createdAt: pendingItem.createdAt,
+                    amount: 3_000,
+                    cartItemId: 2,
+                    createdAt: second.createdAt,
                     paymentState: 'pending',
-                    reason: 'shoppingCartItem:3',
+                    reason: 'shoppingCartItem:2',
                 },
             ],
         },
     });
+});
+
+test('direct checkout returns durable paid and pending amounts across catalog drift', async () => {
+    const paid = cartItem({
+        discountPrice: 0,
+        id: 1,
+        price: 5,
+        status: 'paid',
+    });
+    const pending = cartItem({ discountPrice: 7, id: 2, price: 7 });
+    let capturedPayment:
+        | {
+              pendingItems: readonly ShoppingCartItemWithShopData[];
+              resolvedAmountsByCartItemId: ReadonlyMap<number, number>;
+          }
+        | undefined;
+    let requestedDebits: unknown;
+
+    await withDirectSunflowerCheckoutBatch({
+        accountId: 'account-1',
+        allCheckoutItems: [paid, pending],
+        cartId: 100,
+        dependencies: {
+            calculateSunflowerAmount: () => 7_000,
+            calculateSunflowerReplayAmount: () => 5_000,
+            getShoppingCart: async () => undefined,
+            lockShoppingCartForCheckout: async () => ({
+                accountId: 'account-1',
+                id: 100,
+                isDeleted: false,
+                items: [paid, pending],
+                status: 'new',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            }),
+            spendSunflowersBatch: async (_accountId, items) => {
+                requestedDebits = items;
+                return {
+                    createdReasons: ['shoppingCartItem:2'],
+                    existingReasons: ['shoppingCartItem:1'],
+                    resolvedAmountsByReason: {
+                        'shoppingCartItem:1': 4_500,
+                        'shoppingCartItem:2': 6_000,
+                    },
+                };
+            },
+            withCheckoutCartItemLocks: async (_ids, operation) =>
+                operation({ transaction: 'checkout-test' } as never),
+            withCheckoutCartItemProcessingLocks: async (_ids, operation) =>
+                operation(),
+        },
+        operation: async (payment) => {
+            capturedPayment = payment;
+        },
+    });
+
+    assert.deepStrictEqual(requestedDebits, [
+        { amount: 7_000, reason: 'shoppingCartItem:2' },
+    ]);
+    assert.deepStrictEqual(
+        capturedPayment?.pendingItems.map((item) => item.id),
+        [2],
+    );
+    assert.deepStrictEqual(
+        capturedPayment?.resolvedAmountsByCartItemId,
+        new Map([
+            [1, 4_500],
+            [2, 6_000],
+        ]),
+    );
+});
+
+test('batch debit failure starts no fulfillment work', async () => {
+    const item = cartItem({ id: 1, price: 2 });
+    const failure = new Error('account unavailable');
+    let operationCalled = false;
+
+    await assert.rejects(
+        withDirectSunflowerCheckoutBatch({
+            accountId: 'account-1',
+            allCheckoutItems: [item],
+            cartId: 100,
+            dependencies: {
+                calculateSunflowerAmount: () => 2_000,
+                calculateSunflowerReplayAmount: () => 2_000,
+                getShoppingCart: async () => undefined,
+                lockShoppingCartForCheckout: async () => ({
+                    accountId: 'account-1',
+                    id: 100,
+                    isDeleted: false,
+                    items: [item],
+                    status: 'new',
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                }),
+                spendSunflowersBatch: async () => {
+                    throw failure;
+                },
+                withCheckoutCartItemLocks: async (_ids, operation) =>
+                    operation({ transaction: 'checkout-test' } as never),
+                withCheckoutCartItemProcessingLocks: async (_ids, operation) =>
+                    operation(),
+            },
+            operation: async () => {
+                operationCalled = true;
+            },
+        }),
+        failure,
+    );
+    assert.equal(operationCalled, false);
+});
+
+test('missing durable amount evidence fails before fulfillment', async () => {
+    const first = cartItem({ id: 1, price: 2 });
+    const second = cartItem({ id: 2, price: 3 });
+    let operationCalled = false;
+
+    await assert.rejects(
+        withDirectSunflowerCheckoutBatch({
+            accountId: 'account-1',
+            allCheckoutItems: [first, second],
+            cartId: 100,
+            dependencies: {
+                calculateSunflowerAmount: (item) =>
+                    Math.round((item.shopData.price ?? 0) * 1000),
+                calculateSunflowerReplayAmount: () => 1,
+                getShoppingCart: async () => undefined,
+                lockShoppingCartForCheckout: async () => ({
+                    accountId: 'account-1',
+                    id: 100,
+                    isDeleted: false,
+                    items: [first, second],
+                    status: 'new',
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                }),
+                spendSunflowersBatch: async () => ({
+                    createdReasons: ['shoppingCartItem:1'],
+                    existingReasons: [],
+                    resolvedAmountsByReason: {
+                        'shoppingCartItem:1': 2_000,
+                    },
+                }),
+                withCheckoutCartItemLocks: async (_ids, operation) =>
+                    operation({ transaction: 'checkout-test' } as never),
+                withCheckoutCartItemProcessingLocks: async (_ids, operation) =>
+                    operation(),
+            },
+            operation: async () => {
+                operationCalled = true;
+            },
+        }),
+        /cart item 2 did not resolve a valid amount/u,
+    );
+    assert.equal(operationCalled, false);
+});
+
+test('a duplicate direct checkout waits for the first and observes its paid cart', async () => {
+    const item = cartItem({ id: 1, price: 2 });
+    const firstFulfillmentStarted = deferred<void>();
+    const releaseFirstFulfillment = deferred<void>();
+    let cartPaid = false;
+    let lockCartCalls = 0;
+    let operationCalls = 0;
+    let spendCalls = 0;
+
+    const dependencies = {
+        calculateSunflowerAmount: () => 2_000,
+        calculateSunflowerReplayAmount: () => 2_000,
+        getShoppingCart: async () => ({
+            accountId: 'account-1',
+            id: 100,
+            isDeleted: false,
+            items: [{ ...item, status: 'paid' }],
+            status: 'paid',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        }),
+        lockShoppingCartForCheckout: async () => {
+            lockCartCalls += 1;
+            return cartPaid
+                ? undefined
+                : {
+                      accountId: 'account-1',
+                      id: 100,
+                      isDeleted: false,
+                      items: [item],
+                      status: 'new',
+                      createdAt: new Date(),
+                      updatedAt: new Date(),
+                  };
+        },
+        spendSunflowersBatch: async () => {
+            spendCalls += 1;
+            return {
+                createdReasons: ['shoppingCartItem:1'],
+                existingReasons: [],
+                resolvedAmountsByReason: {
+                    'shoppingCartItem:1': 2_000,
+                },
+            };
+        },
+        withCheckoutCartItemLocks: async <T>(
+            _ids: readonly number[],
+            operation: (db: never) => Promise<T>,
+        ) => operation({ transaction: 'checkout-test' } as never),
+        withCheckoutCartItemProcessingLocks,
+    };
+    const operation = async () => {
+        operationCalls += 1;
+        firstFulfillmentStarted.resolve();
+        await releaseFirstFulfillment.promise;
+        cartPaid = true;
+        return 'fulfilled';
+    };
+
+    const first = withDirectSunflowerCheckoutBatch({
+        accountId: 'account-1',
+        allCheckoutItems: [item],
+        cartId: 100,
+        dependencies,
+        operation,
+    });
+    await firstFulfillmentStarted.promise;
+    const duplicate = withDirectSunflowerCheckoutBatch({
+        accountId: 'account-1',
+        allCheckoutItems: [item],
+        cartId: 100,
+        dependencies,
+        operation,
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    assert.equal(lockCartCalls, 1);
+    assert.equal(spendCalls, 1);
+    assert.equal(operationCalls, 1);
+
+    releaseFirstFulfillment.resolve();
+    assert.deepStrictEqual(await first, {
+        state: 'processed',
+        value: 'fulfilled',
+    });
+    assert.equal((await duplicate).state, 'cart_paid');
+    assert.equal(lockCartCalls, 2);
+    assert.equal(spendCalls, 1);
+    assert.equal(operationCalls, 1);
+});
+
+test('a cart paid while waiting returns completed-elsewhere state without another debit', async () => {
+    const item = cartItem({ id: 1, price: 2 });
+    let spendCalled = false;
+    let operationCalled = false;
+
+    const result = await withDirectSunflowerCheckoutBatch({
+        accountId: 'account-1',
+        allCheckoutItems: [item],
+        cartId: 100,
+        dependencies: {
+            calculateSunflowerAmount: () => 2_000,
+            calculateSunflowerReplayAmount: () => 2_000,
+            getShoppingCart: async () => ({
+                accountId: 'account-1',
+                id: 100,
+                isDeleted: false,
+                items: [{ ...item, status: 'paid' }],
+                status: 'paid',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            }),
+            lockShoppingCartForCheckout: async () => undefined,
+            spendSunflowersBatch: async () => {
+                spendCalled = true;
+                return {
+                    createdReasons: [],
+                    existingReasons: [],
+                    resolvedAmountsByReason: {},
+                };
+            },
+            withCheckoutCartItemLocks: async (_ids, operation) =>
+                operation({ transaction: 'checkout-test' } as never),
+            withCheckoutCartItemProcessingLocks: async (_ids, operation) =>
+                operation(),
+        },
+        operation: async () => {
+            operationCalled = true;
+        },
+    });
+
+    assert.equal(result.state, 'cart_paid');
+    assert.equal(spendCalled, false);
+    assert.equal(operationCalled, false);
 });

--- a/apps/api/lib/checkout/directSunflowerCheckout.ts
+++ b/apps/api/lib/checkout/directSunflowerCheckout.ts
@@ -1,4 +1,5 @@
 import {
+    getShoppingCart,
     lockShoppingCartForCheckout,
     spendSunflowersBatch,
     withCheckoutCartItemLocks,
@@ -14,63 +15,75 @@ import {
 type DirectSunflowerCheckoutDependencies = {
     calculateSunflowerAmount: typeof calculateSunflowerAmount;
     calculateSunflowerReplayAmount: typeof calculateSunflowerReplayAmount;
+    getShoppingCart: typeof getShoppingCart;
     lockShoppingCartForCheckout: typeof lockShoppingCartForCheckout;
     spendSunflowersBatch: typeof spendSunflowersBatch;
     withCheckoutCartItemLocks: typeof withCheckoutCartItemLocks;
     withCheckoutCartItemProcessingLocks: typeof withCheckoutCartItemProcessingLocks;
 };
 
-type DirectSunflowerCheckoutPayment =
+export type DirectSunflowerCheckoutBatch = {
+    pendingItems: readonly ShoppingCartItemWithShopData[];
+    resolvedAmountsByCartItemId: ReadonlyMap<number, number>;
+};
+
+export type DirectSunflowerCheckoutResult<T> =
     | {
-          resolvedAmountsByCartItemId: ReadonlyMap<number, number>;
-          state: 'paid';
+          cart: {
+              accountId: string | null;
+              id: number;
+              status: string;
+          };
+          state: 'cart_paid';
       }
     | {
-          resolvedAmount: number;
-          resolvedAmountsByCartItemId: ReadonlyMap<number, number>;
-          state: 'pending';
+          state: 'processed';
+          value: T;
       };
 
 const realDependencies: DirectSunflowerCheckoutDependencies = {
     calculateSunflowerAmount,
     calculateSunflowerReplayAmount,
+    getShoppingCart,
     lockShoppingCartForCheckout,
     spendSunflowersBatch,
     withCheckoutCartItemLocks,
     withCheckoutCartItemProcessingLocks,
 };
 
-export async function withDirectSunflowerCheckoutPayment<T>({
+/**
+ * Serializes one direct checkout across every captured cart item. The database
+ * transaction is intentionally limited to snapshot validation and the durable
+ * sunflower debit; fulfillment runs after it commits while the process lock is
+ * still held.
+ */
+export async function withDirectSunflowerCheckoutBatch<T>({
     accountId,
-    allSunflowerItems,
+    allCheckoutItems,
     cartId,
     dependencies = realDependencies,
-    item,
     operation,
 }: {
     accountId: string;
-    allSunflowerItems: readonly ShoppingCartItemWithShopData[];
+    allCheckoutItems: readonly ShoppingCartItemWithShopData[];
     cartId: number;
     dependencies?: DirectSunflowerCheckoutDependencies;
-    item: ShoppingCartItemWithShopData;
-    operation: (payment: DirectSunflowerCheckoutPayment) => Promise<T>;
-}): Promise<T> {
-    const coveredItemIds = allSunflowerItems.map(
-        (coveredItem) => coveredItem.id,
-    );
-    const sunflowerAmountsByCartItemId = new Map(
-        allSunflowerItems.map((coveredItem) => [
-            coveredItem.id,
-            coveredItem.status === 'paid'
-                ? dependencies.calculateSunflowerReplayAmount(coveredItem)
-                : dependencies.calculateSunflowerAmount(coveredItem),
-        ]),
+    operation: (payment: DirectSunflowerCheckoutBatch) => Promise<T>;
+}): Promise<DirectSunflowerCheckoutResult<T>> {
+    const coveredItemIds = allCheckoutItems.map((item) => item.id);
+    if (coveredItemIds.length === 0) {
+        throw new Error('Direct checkout requires at least one cart item.');
+    }
+
+    const expectedItemIds = new Set(coveredItemIds);
+    const sunflowerItems = allCheckoutItems.filter(
+        (item) => item.currency === 'sunflower',
     );
 
     return dependencies.withCheckoutCartItemProcessingLocks(
         coveredItemIds,
         async () => {
-            const payment = await dependencies.withCheckoutCartItemLocks(
+            const prepared = await dependencies.withCheckoutCartItemLocks(
                 coveredItemIds,
                 async (db) => {
                     const lockedCart =
@@ -79,13 +92,43 @@ export async function withDirectSunflowerCheckoutPayment<T>({
                             db,
                         );
                     if (!lockedCart) {
+                        const currentCart = await dependencies.getShoppingCart(
+                            cartId,
+                            db,
+                        );
+                        if (!currentCart) {
+                            throw new Error(
+                                `Cart ${cartId.toString()} disappeared before direct checkout.`,
+                            );
+                        }
+                        if (currentCart.accountId !== accountId) {
+                            throw new Error(
+                                `Cart ${cartId.toString()} account changed before direct checkout.`,
+                            );
+                        }
+                        if (currentCart.status === 'paid') {
+                            return {
+                                cart: currentCart,
+                                state: 'cart_paid' as const,
+                            };
+                        }
                         throw new Error(
-                            `Cart ${cartId.toString()} disappeared before sunflower fulfillment.`,
+                            `Cart ${cartId.toString()} is not active for direct checkout.`,
                         );
                     }
                     if (lockedCart.accountId !== accountId) {
                         throw new Error(
-                            `Cart ${cartId.toString()} account changed before sunflower fulfillment.`,
+                            `Cart ${cartId.toString()} account changed before direct checkout.`,
+                        );
+                    }
+                    if (
+                        lockedCart.items.length !== expectedItemIds.size ||
+                        lockedCart.items.some(
+                            (item) => !expectedItemIds.has(item.id),
+                        )
+                    ) {
+                        throw new Error(
+                            `Cart ${cartId.toString()} changed before direct checkout.`,
                         );
                     }
 
@@ -93,64 +136,88 @@ export async function withDirectSunflowerCheckoutPayment<T>({
                         number,
                         'paid' | 'pending'
                     >();
-                    for (const coveredItem of allSunflowerItems) {
-                        const state = assertCheckoutCartItemSnapshot(
+                    for (const expectedItem of allCheckoutItems) {
+                        const paymentState = assertCheckoutCartItemSnapshot(
                             lockedCart.items.find(
-                                (lockedItem) =>
-                                    lockedItem.id === coveredItem.id,
+                                (item) => item.id === expectedItem.id,
                             ),
-                            coveredItem,
+                            expectedItem,
                         );
-                        paymentStatesByCartItemId.set(coveredItem.id, state);
-                    }
-                    const itemState = paymentStatesByCartItemId.get(item.id);
-                    if (!itemState) {
-                        throw new Error(
-                            `Sunflower cart item ${item.id.toString()} is not part of the checkout coverage.`,
+                        paymentStatesByCartItemId.set(
+                            expectedItem.id,
+                            paymentState,
                         );
                     }
-                    const reason = `shoppingCartItem:${item.id.toString()}`;
+
+                    if (sunflowerItems.length === 0) {
+                        return {
+                            pendingItems: [] as const,
+                            resolvedAmountsByCartItemId: new Map<
+                                number,
+                                number
+                            >(),
+                            state: 'ready' as const,
+                        };
+                    }
+
+                    const sunflowerAmountsByCartItemId = new Map(
+                        sunflowerItems.map((item) => {
+                            const paymentState = paymentStatesByCartItemId.get(
+                                item.id,
+                            );
+                            if (!paymentState) {
+                                throw new Error(
+                                    `Sunflower cart item ${item.id.toString()} lost its payment state.`,
+                                );
+                            }
+                            return [
+                                item.id,
+                                paymentState === 'paid'
+                                    ? dependencies.calculateSunflowerReplayAmount(
+                                          { ...item, status: 'paid' },
+                                      )
+                                    : dependencies.calculateSunflowerAmount(
+                                          item,
+                                      ),
+                            ] as const;
+                        }),
+                    );
+                    const pendingItems = sunflowerItems.filter(
+                        (item) =>
+                            paymentStatesByCartItemId.get(item.id) ===
+                            'pending',
+                    );
                     const spendResult = await dependencies.spendSunflowersBatch(
                         accountId,
-                        itemState === 'pending'
-                            ? [
-                                  {
-                                      amount:
-                                          sunflowerAmountsByCartItemId.get(
-                                              item.id,
-                                          ) ?? 0,
-                                      reason,
-                                  },
-                              ]
-                            : [],
+                        pendingItems.map((item) => ({
+                            amount:
+                                sunflowerAmountsByCartItemId.get(item.id) ?? 0,
+                            reason: `shoppingCartItem:${item.id.toString()}`,
+                        })),
                         db,
                         {
                             existingCheckoutItemAmountsAreAuthoritative: true,
                             legacyCartSpend: {
                                 reason: `shoppingCart:${cartId.toString()}`,
-                                coveredItems: allSunflowerItems.map(
-                                    (coveredItem) => {
-                                        const paymentState =
-                                            paymentStatesByCartItemId.get(
-                                                coveredItem.id,
-                                            );
-                                        if (!paymentState) {
-                                            throw new Error(
-                                                `Sunflower cart item ${coveredItem.id.toString()} lost its payment state.`,
-                                            );
-                                        }
-                                        return {
-                                            amount:
-                                                sunflowerAmountsByCartItemId.get(
-                                                    coveredItem.id,
-                                                ) ?? 0,
-                                            cartItemId: coveredItem.id,
-                                            createdAt: coveredItem.createdAt,
-                                            paymentState,
-                                            reason: `shoppingCartItem:${coveredItem.id.toString()}`,
-                                        };
-                                    },
-                                ),
+                                coveredItems: sunflowerItems.map((item) => {
+                                    const paymentState =
+                                        paymentStatesByCartItemId.get(item.id);
+                                    if (!paymentState) {
+                                        throw new Error(
+                                            `Sunflower cart item ${item.id.toString()} lost its payment state.`,
+                                        );
+                                    }
+                                    return {
+                                        amount:
+                                            sunflowerAmountsByCartItemId.get(
+                                                item.id,
+                                            ) ?? 0,
+                                        cartItemId: item.id,
+                                        createdAt: item.createdAt,
+                                        paymentState,
+                                        reason: `shoppingCartItem:${item.id.toString()}`,
+                                    };
+                                }),
                             },
                         },
                     );
@@ -158,59 +225,45 @@ export async function withDirectSunflowerCheckoutPayment<T>({
                         number,
                         number
                     >();
-                    for (const coveredItem of allSunflowerItems) {
+                    for (const item of sunflowerItems) {
                         const resolvedAmount =
                             spendResult.resolvedAmountsByReason[
-                                `shoppingCartItem:${coveredItem.id.toString()}`
+                                `shoppingCartItem:${item.id.toString()}`
                             ];
-                        if (resolvedAmount !== undefined) {
-                            if (
-                                !Number.isSafeInteger(resolvedAmount) ||
-                                resolvedAmount <= 0
-                            ) {
-                                throw new Error(
-                                    `Sunflower spend for cart item ${coveredItem.id.toString()} did not resolve a valid amount.`,
-                                );
-                            }
-                            resolvedAmountsByCartItemId.set(
-                                coveredItem.id,
-                                resolvedAmount,
-                            );
-                        }
-                    }
-                    if (itemState === 'paid') {
-                        if (!resolvedAmountsByCartItemId.has(item.id)) {
+                        if (
+                            typeof resolvedAmount !== 'number' ||
+                            !Number.isSafeInteger(resolvedAmount) ||
+                            resolvedAmount <= 0
+                        ) {
                             throw new Error(
-                                `Paid sunflower cart item ${item.id.toString()} has no durable spend amount.`,
+                                `Sunflower spend for cart item ${item.id.toString()} did not resolve a valid amount.`,
                             );
                         }
-                        return {
-                            resolvedAmountsByCartItemId,
-                            state: 'paid' as const,
-                        };
-                    }
-
-                    const resolvedAmount = resolvedAmountsByCartItemId.get(
-                        item.id,
-                    );
-                    if (
-                        typeof resolvedAmount !== 'number' ||
-                        !Number.isSafeInteger(resolvedAmount) ||
-                        resolvedAmount <= 0
-                    ) {
-                        throw new Error(
-                            `Sunflower spend for cart item ${item.id.toString()} did not resolve a valid amount.`,
+                        resolvedAmountsByCartItemId.set(
+                            item.id,
+                            resolvedAmount,
                         );
                     }
 
                     return {
-                        resolvedAmount,
+                        pendingItems,
                         resolvedAmountsByCartItemId,
-                        state: 'pending' as const,
+                        state: 'ready' as const,
                     };
                 },
             );
-            return operation(payment);
+            if (prepared.state === 'cart_paid') {
+                return prepared;
+            }
+
+            return {
+                state: 'processed',
+                value: await operation({
+                    pendingItems: prepared.pendingItems,
+                    resolvedAmountsByCartItemId:
+                        prepared.resolvedAmountsByCartItemId,
+                }),
+            };
         },
     );
 }

--- a/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
+++ b/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
@@ -857,6 +857,76 @@ test.describe('shopping cart item presence', () => {
         await expect(page).toHaveURL(initialUrl);
     });
 
+    test('shows a sunflower checkout conflict and keeps the cart open', async ({
+        mount,
+        page,
+    }) => {
+        let shoppingCartGetCount = 0;
+        await page.route(
+            '**/api/gredice/api/checkout/checkout',
+            async (route) => {
+                await route.fulfill({
+                    body: JSON.stringify({
+                        error: 'Nema dovoljno suncokreta za ovu kupnju.',
+                        code: 'INSUFFICIENT_SUNFLOWERS',
+                    }),
+                    contentType: 'application/json',
+                    status: 409,
+                });
+            },
+        );
+        await page.route('**/api/gredice/**/shopping-cart', async (route) => {
+            if (route.request().method() !== 'GET') {
+                await route.fallback();
+                return;
+            }
+
+            shoppingCartGetCount += 1;
+            await route.fulfill({
+                body: JSON.stringify({
+                    ...createShoppingCartServerData(),
+                    items: [
+                        {
+                            ...shoppingCartServerItem,
+                            currency: 'sunflower',
+                        },
+                    ],
+                    total: 0,
+                    totalSunflowers: 2500,
+                }),
+                contentType: 'application/json',
+                status: 200,
+            });
+        });
+
+        await mount(<ShoppingCartSunflowerCheckoutStory />);
+        const initialUrl = page.url();
+
+        await page.getByTitle('Košara').click();
+        await page.getByRole('button', { name: 'Potvrdi i plati' }).click();
+        await page
+            .getByRole('alertdialog')
+            .getByRole('button', { name: 'Potvrdi' })
+            .click();
+
+        await expect(
+            page.getByRole('alert').filter({
+                hasText: 'Nema dovoljno suncokreta za ovu kupnju.',
+            }),
+        ).toBeVisible();
+        await expect(
+            page.getByRole('dialog', { name: 'Košara' }),
+        ).toBeVisible();
+        await expect(
+            page.locator('[data-shopping-cart-item-id="1"]'),
+        ).toBeVisible();
+        await expect.poll(() => shoppingCartGetCount).toBeGreaterThanOrEqual(2);
+        await expect(
+            page.getByRole('button', { name: 'Potvrdi i plati' }),
+        ).toBeEnabled();
+        await expect(page).toHaveURL(initialUrl);
+    });
+
     test('redirects when checkout returns a Stripe URL', async ({
         mount,
         page,

--- a/packages/game/src/hooks/useCheckout.ts
+++ b/packages/game/src/hooks/useCheckout.ts
@@ -24,6 +24,25 @@ type CheckoutResult =
     | { kind: 'completed-in-app' }
     | { kind: 'stripe'; url: string };
 
+async function getCheckoutErrorMessage(response: Response) {
+    try {
+        const responseData: unknown = await response.json();
+        if (
+            responseData &&
+            typeof responseData === 'object' &&
+            'error' in responseData &&
+            typeof responseData.error === 'string' &&
+            responseData.error.trim()
+        ) {
+            return responseData.error;
+        }
+    } catch {
+        // The fallback also covers non-JSON gateway responses.
+    }
+
+    return 'Nije moguće pokrenuti plaćanje. Provjeri košaricu i pokušaj ponovno.';
+}
+
 // Type guard to check if delivery selection is complete
 export function isCompleteDeliverySelection(
     selection:
@@ -55,10 +74,7 @@ export function useCheckout() {
                     json: data,
                 });
             if (!response.ok) {
-                throw new Error(
-                    response.statusText ||
-                        'Nije moguće pokrenuti plaćanje. Provjeri odabrane datume.',
-                );
+                throw new Error(await getCheckoutErrorMessage(response));
             }
 
             const responseData = await response.json();
@@ -72,14 +88,13 @@ export function useCheckout() {
                 return { kind: 'completed-in-app' };
             }
 
-            const { url } = responseData;
-            if (!url) {
+            if (!('url' in responseData) || !responseData.url) {
                 throw new Error(
                     'Poslužitelj nije vratio poveznicu za plaćanje.',
                 );
             }
 
-            return { kind: 'stripe', url };
+            return { kind: 'stripe', url: responseData.url };
         },
         onSuccess: (result) => {
             if (result.kind === 'stripe') {
@@ -89,6 +104,12 @@ export function useCheckout() {
 
             setShoppingCartOpen(false);
             setPaymentStatus('uspjesno');
+            void queryClient.invalidateQueries();
+        },
+        onError: () => {
+            // A direct checkout can fail after durable payment or fulfillment
+            // work. Keep the cart open, but reconcile every active checkout-
+            // affected view before the user retries.
             void queryClient.invalidateQueries();
         },
         // Prevent the mutation from being run in parallel

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -317,10 +317,7 @@ export function ShoppingCart({
                     />
                 ) : null}
                 {checkout.isError ? (
-                    <Alert color="danger">
-                        Plaćanje nije pokrenuto. Provjeri termin i datume branja
-                        pa pokušaj ponovno.
-                    </Alert>
+                    <Alert color="danger">{checkout.error.message}</Alert>
                 ) : null}
             </ShoppingCartStepTransition>
         );
@@ -415,6 +412,11 @@ export function ShoppingCart({
                                     ))}
                                 </Stack>
                             )}
+                            {checkout.isError ? (
+                                <Alert color="danger">
+                                    {checkout.error.message}
+                                </Alert>
+                            ) : null}
                             <div className="flex flex-row gap-2 justify-between flex-wrap">
                                 {/* TODO: Localize */}
                                 <ModalConfirm


### PR DESCRIPTION
## Summary

- validate the complete direct-checkout cart snapshot and debit every pending sunflower item in one short database transaction
- acquire the sunflower account lock and read its balance once while retaining one durable `shoppingCartItem:<id>` ledger event per item
- keep one full-cart process lock through sequential fulfillment and confirmation, without holding a database connection across fulfillment or network work
- replay durable paid amounts across catalog drift and make duplicate/paid-cart retries succeed only after a durable confirmation outbox intent exists
- return explicit `409` responses for recoverable balance/amount conflicts; Garden shows the Croatian API error, refreshes affected state, keeps the cart open, and re-enables retry

## Production safety

- the batch validates the full missing debit before writing any new spend
- duplicate requests use the production item lock and cannot start a second debit or fulfillment pass in the same process
- merged #4374 idempotency protects fulfillment replays across instances; item effects are committed before their paid markers
- final cart payment and confirmation intent remain atomic and fail closed when the live cart is not complete
- database item/account locks end before `processItem`, Slack, email, or other network work
- paid EUR carts retain their existing response path; Stripe and mixed-currency session creation are unchanged
- the post-preflight cart-insert race cannot return false success; durable cart snapshot reconciliation remains separately tracked in #4379
- no schema migration

## Validation

- full API Node suite: 374 passed
- focused direct checkout, retry, error mapping, and timing suites: 18 passed
- storage account/PGlite suite: 31 passed
- Garden checkout component suite: 20 passed
- API production build
- API, Game, and Garden TypeScript checks
- targeted API/Game/Garden Biome checks
- `git diff --check`

Closes #4369
