### PR TITLE
fix(checkout): make partial item fulfillment retry-safe

### DIFF
--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -3,6 +3,9 @@ import {
     cartContainsDeliverableItems,
     consumeInventoryItem,
     getAccount,
+    getCheckoutFulfillmentStartedCartItemIds,
+    getCheckoutOperationMapping,
+    getCheckoutOperationMappings,
     getDeliveryAddress,
     getHarvestScheduleForCart,
     getPickupLocation,
@@ -21,9 +24,11 @@ import {
     releaseOutletReservationsForCart,
     reserveOutletOffer,
     setCartItemPaid,
-    spendSunflowersBatch,
     sunflowerPackageEntityTypeName,
     validateHarvestDateSelections,
+    withCheckoutCartItemLock,
+    withCheckoutCartItemProcessingLock,
+    withInventoryAccountTransaction,
 } from '@gredice/storage';
 import {
     type CheckoutItem,
@@ -36,6 +41,10 @@ import { describeRoute, resolver, validator as zValidator } from 'hono-openapi';
 import { z } from 'zod';
 import { getCartInfo } from '../../../lib/checkout/cartInfo';
 import {
+    assertCheckoutCartItemSnapshot,
+    getCheckoutOperationRecoveryState,
+} from '../../../lib/checkout/checkoutRecovery';
+import {
     type CheckoutPaymentKind,
     type CheckoutTimingVariables,
     checkoutTimingMiddleware,
@@ -44,6 +53,7 @@ import {
     CheckoutDeliverySelectionError,
     validateCheckoutDeliverySelection,
 } from '../../../lib/checkout/deliverySelection';
+import { withDirectSunflowerCheckoutPayment } from '../../../lib/checkout/directSunflowerCheckout';
 import {
     buildCheckoutAdditionalData,
     encodeHarvestDatesMetadata,
@@ -52,7 +62,7 @@ import {
     buildOrderConfirmationItems,
     ORDER_CONFIRMATION_MANAGE_URL,
 } from '../../../lib/checkout/orderConfirmationEmail';
-import { calculateSunflowerAmount } from '../../../lib/checkout/sunflowerCalculations';
+import { calculateSunflowerReplayAmount } from '../../../lib/checkout/sunflowerCalculations';
 import { authSecurity } from '../../../lib/docs/security';
 import {
     type AuthVariables,
@@ -187,22 +197,70 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                 return context.json({ error: 'Cart already paid' }, 400);
             }
 
-            const cart = await checkoutTiming.measure(
-                'cart_normalization',
-                async () => {
+            const { cart, checkoutOperationMappings } =
+                await checkoutTiming.measure('cart_normalization', async () => {
+                    const mappings = await getCheckoutOperationMappings(
+                        initialCart.items
+                            .filter(
+                                (item) =>
+                                    item.status !== 'paid' &&
+                                    item.entityTypeName === 'operation',
+                            )
+                            .map((item) => item.id),
+                    );
                     const inventoryNormalizedCart =
                         (await normalizeShoppingCartInventoryUsage(cartId)) ??
                         initialCart;
-                    return (
+                    const normalizedCart =
                         (await normalizeShoppingCartScheduledDates(
                             inventoryNormalizedCart.id,
                             {
+                                checkoutOperationMappings: mappings,
                                 defaultMissingScheduledDates: true,
                             },
-                        )) ?? inventoryNormalizedCart
-                    );
-                },
+                        )) ?? inventoryNormalizedCart;
+                    return {
+                        cart: normalizedCart,
+                        checkoutOperationMappings: mappings,
+                    };
+                });
+            const mappedOperationCartItemIds = new Set(
+                checkoutOperationMappings.keys(),
             );
+            const pendingEuroItems = cart.items.filter(
+                (item) => item.status !== 'paid' && item.currency === 'eur',
+            );
+            const fulfillmentStartedCartItemIds =
+                pendingEuroItems.length > 0
+                    ? await getCheckoutFulfillmentStartedCartItemIds(
+                          accountId,
+                          pendingEuroItems,
+                      )
+                    : new Set<number>();
+            const checkoutOperationRecoveryState =
+                getCheckoutOperationRecoveryState(
+                    cart.items,
+                    checkoutOperationMappings,
+                    fulfillmentStartedCartItemIds,
+                );
+            if (checkoutOperationRecoveryState) {
+                checkoutTiming.setContext({ paymentKind: 'stripe' });
+                return context.json(
+                    {
+                        code:
+                            checkoutOperationRecoveryState ===
+                            'stripe_payment_processing'
+                                ? 'CHECKOUT_PAYMENT_PROCESSING'
+                                : 'CHECKOUT_PAYMENT_CONFLICT',
+                        error:
+                            checkoutOperationRecoveryState ===
+                            'stripe_payment_processing'
+                                ? 'Plaćanje se još obrađuje. Pričekaj trenutak i pokušaj ponovno.'
+                                : 'Način plaćanja promijenjen je tijekom obrade. Osvježi košaricu i pokušaj ponovno.',
+                    },
+                    409,
+                );
+            }
             const endDeliveryValidation = checkoutTiming.startPhase(
                 'delivery_validation',
             );
@@ -214,43 +272,71 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
             try {
                 const requiresDelivery = await cartContainsDeliverableItems(
                     cart.id,
+                    {
+                        excludeCartItemIds: [...mappedOperationCartItemIds],
+                    },
                 );
-                const [slot, address, location] = await Promise.all([
-                    deliveryInfo
-                        ? getTimeSlot(deliveryInfo.slotId)
-                        : Promise.resolve(undefined),
-                    deliveryInfo?.mode === 'delivery' && deliveryInfo.addressId
-                        ? getDeliveryAddress(deliveryInfo.addressId, accountId)
-                        : Promise.resolve(undefined),
-                    deliveryInfo?.mode === 'pickup' && deliveryInfo.locationId
-                        ? getPickupLocation(deliveryInfo.locationId)
-                        : Promise.resolve(undefined),
-                ]);
-                validateCheckoutDeliverySelection({
-                    address,
-                    location,
-                    requiresDelivery,
-                    selection: deliveryInfo,
-                    slot: slot
-                        ? {
-                              ...slot,
-                              effectiveClosesAt:
-                                  getTimeSlotEffectiveClosesAt(slot),
-                          }
-                        : undefined,
-                });
+                const requiresMutableDeliveryPreflight =
+                    mappedOperationCartItemIds.size === 0 || requiresDelivery;
+                const [slot, address, location] =
+                    requiresMutableDeliveryPreflight
+                        ? await Promise.all([
+                              deliveryInfo
+                                  ? getTimeSlot(deliveryInfo.slotId)
+                                  : Promise.resolve(undefined),
+                              deliveryInfo?.mode === 'delivery' &&
+                              deliveryInfo.addressId
+                                  ? getDeliveryAddress(
+                                        deliveryInfo.addressId,
+                                        accountId,
+                                    )
+                                  : Promise.resolve(undefined),
+                              deliveryInfo?.mode === 'pickup' &&
+                              deliveryInfo.locationId
+                                  ? getPickupLocation(deliveryInfo.locationId)
+                                  : Promise.resolve(undefined),
+                          ])
+                        : [undefined, undefined, undefined];
+                if (requiresMutableDeliveryPreflight) {
+                    validateCheckoutDeliverySelection({
+                        address,
+                        location,
+                        requiresDelivery,
+                        selection: deliveryInfo,
+                        slot: slot
+                            ? {
+                                  ...slot,
+                                  effectiveClosesAt:
+                                      getTimeSlotEffectiveClosesAt(slot),
+                              }
+                            : undefined,
+                    });
+                }
 
-                if (deliveryInfo) {
+                if (deliveryInfo && requiresMutableDeliveryPreflight) {
                     const schedule = await getHarvestScheduleForCart({
                         accountId,
                         cartId: cart.id,
                         deliverySlotId: deliveryInfo.slotId,
+                        excludeCartItemIds: [...mappedOperationCartItemIds],
                     });
                     canonicalHarvestDates = validateHarvestDateSelections(
                         schedule,
-                        harvestDates ?? [],
+                        (harvestDates ?? []).filter(
+                            (selection) =>
+                                !mappedOperationCartItemIds.has(
+                                    selection.cartItemId,
+                                ),
+                        ),
                     );
-                } else if (harvestDates?.length) {
+                } else if (
+                    harvestDates?.some(
+                        (selection) =>
+                            !mappedOperationCartItemIds.has(
+                                selection.cartItemId,
+                            ),
+                    )
+                ) {
                     return context.json(
                         {
                             error: 'Delivery selection is required for harvest dates',
@@ -291,12 +377,64 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                 ]),
             );
             // Retrieve entities data
-            const cartInfo = await checkoutTiming.measure(
-                'cart_enrichment',
-                () => getCartInfo(cart.items, accountId),
+            let cartInfo = await checkoutTiming.measure('cart_enrichment', () =>
+                getCartInfo(cart.items, accountId, {
+                    checkoutOperationMappings,
+                }),
             );
             if (!cartInfo.allowPurchase) {
+                const pendingDirectItems = cart.items.filter(
+                    (item) => item.status !== 'paid' && item.currency !== 'eur',
+                );
+                const resumableDirectCartItemIds =
+                    pendingDirectItems.length > 0
+                        ? await getCheckoutFulfillmentStartedCartItemIds(
+                              accountId,
+                              pendingDirectItems,
+                          )
+                        : new Set<number>();
+                if (resumableDirectCartItemIds.size > 0) {
+                    cartInfo = await getCartInfo(cart.items, accountId, {
+                        checkoutOperationMappings,
+                        resumableCartItemIds: resumableDirectCartItemIds,
+                    });
+                }
+            }
+            if (!cartInfo.allowPurchase) {
                 return context.json({ error: 'Cart in invalid state' }, 400);
+            }
+            let checkoutAdditionalDataByCartItemId: ReadonlyMap<
+                number,
+                ReturnType<typeof buildCheckoutAdditionalData>
+            >;
+            try {
+                checkoutAdditionalDataByCartItemId = new Map(
+                    cartInfo.items
+                        .filter((item) => item.status !== 'paid')
+                        .map((item) => [
+                            item.id,
+                            buildCheckoutAdditionalData({
+                                additionalData: item.additionalData,
+                                deliveryInfo,
+                                scheduledHarvestDate:
+                                    harvestDateByCartItemId.get(item.id),
+                            }),
+                        ]),
+                );
+            } catch (error) {
+                checkoutTiming.setErrorCategory('cart_validation_failed');
+                console.warn('Invalid checkout cart item additional data', {
+                    accountId,
+                    cartId,
+                    error,
+                });
+                return context.json(
+                    {
+                        error: 'Cart item additional data is invalid',
+                        code: 'CHECKOUT_ADDITIONAL_DATA_INVALID',
+                    },
+                    400,
+                );
             }
             const outletCheckoutStartedAt = new Date();
             const outletCheckoutExpiresAt = addMinutes(
@@ -382,59 +520,88 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                 const endNonStripeFulfillment = checkoutTiming.startPhase(
                     'non_stripe_fulfillment',
                 );
+                const resolvedSunflowerAmountsByCartItemId = new Map<
+                    number,
+                    number
+                >();
                 try {
                     const scheduledDeliveryEmailKeys = new Set<string>();
-                    const sunflowerCartItemsWithShopData =
+                    const allSunflowerCartItemsWithShopData =
                         cartInfo.items.filter(
-                            (item) =>
-                                item.status !== 'paid' &&
-                                item.currency === 'sunflower',
+                            (item) => item.currency === 'sunflower',
+                        );
+                    const sunflowerCartItemsWithShopData =
+                        allSunflowerCartItemsWithShopData.filter(
+                            (item) => item.status !== 'paid',
                         );
                     if (sunflowerCartItemsWithShopData.length > 0) {
                         // Check if there are enough sunflowers in the account
                         for (const item of sunflowerCartItemsWithShopData) {
-                            const scheduledHarvestDate =
-                                harvestDateByCartItemId.get(item.id);
-                            const sunflowerAmount =
-                                calculateSunflowerAmount(item);
-                            let didPaySunflowers = false;
+                            let processingStage: 'payment' | 'fulfillment' =
+                                'payment';
                             try {
-                                await spendSunflowersBatch(accountId, [
-                                    {
-                                        amount: sunflowerAmount,
-                                        reason: `shoppingCartItem:${item.id.toString()}`,
-                                    },
-                                ]);
-                                didPaySunflowers = true;
-                            } catch (error) {
-                                checkoutTiming.setErrorCategory(
-                                    'sunflower_spend_failed',
-                                );
-                                console.error('Error spending sunflowers', {
-                                    error,
+                                await withDirectSunflowerCheckoutPayment({
                                     accountId,
-                                    sunflowerAmount,
+                                    allSunflowerItems:
+                                        allSunflowerCartItemsWithShopData,
+                                    cartId: cart.id,
                                     item,
-                                });
-                            }
+                                    operation: async (payment) => {
+                                        if (payment.state === 'paid') {
+                                            return;
+                                        }
+                                        processingStage = 'fulfillment';
+                                        resolvedSunflowerAmountsByCartItemId.set(
+                                            item.id,
+                                            payment.resolvedAmount,
+                                        );
+                                        const checkoutOperationMapping =
+                                            item.entityTypeName === 'operation'
+                                                ? await getCheckoutOperationMapping(
+                                                      item.id,
+                                                  )
+                                                : undefined;
 
-                            if (didPaySunflowers) {
-                                const fulfillment = await processItem({
-                                    accountId,
-                                    cartItemId: item.id,
-                                    ...item,
-                                    amount_total: sunflowerAmount,
-                                    scheduledDeliveryEmailKeys,
-                                    additionalData: buildCheckoutAdditionalData(
-                                        {
-                                            additionalData: item.additionalData,
-                                            deliveryInfo,
-                                            scheduledHarvestDate,
-                                        },
-                                    ),
+                                        const fulfillment = await processItem({
+                                            accountId,
+                                            cartItemId: item.id,
+                                            ...item,
+                                            amount_total:
+                                                payment.resolvedAmount,
+                                            scheduledDeliveryEmailKeys,
+                                            additionalData:
+                                                checkoutAdditionalDataByCartItemId.get(
+                                                    item.id,
+                                                ) ?? {},
+                                            checkoutOperationMapping:
+                                                item.entityTypeName ===
+                                                'operation'
+                                                    ? checkoutOperationMapping
+                                                    : undefined,
+                                        });
+                                        assertCheckoutItemFulfilled(
+                                            fulfillment,
+                                        );
+                                        await setCartItemPaid(item.id);
+                                    },
                                 });
-                                assertCheckoutItemFulfilled(fulfillment);
-                                await setCartItemPaid(item.id);
+                            } catch (error) {
+                                if (processingStage === 'payment') {
+                                    checkoutTiming.setErrorCategory(
+                                        'sunflower_spend_failed',
+                                    );
+                                    console.error('Error spending sunflowers', {
+                                        accountId,
+                                        cartId: cart.id,
+                                        error,
+                                        cartItemId: item.id,
+                                    });
+                                } else {
+                                    checkoutTiming.setErrorCategory(
+                                        'unexpected',
+                                    );
+                                }
+                                throw error;
                             }
                         }
                     }
@@ -449,8 +616,6 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
 
                     if (inventoryCartItems.length > 0) {
                         for (const item of inventoryCartItems) {
-                            const scheduledHarvestDate =
-                                harvestDateByCartItemId.get(item.id);
                             if ((item.inventoryAvailable ?? 0) < item.amount) {
                                 return context.json(
                                     {
@@ -460,26 +625,83 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                                 );
                             }
 
-                            await consumeInventoryItem(accountId, {
-                                entityTypeName: item.entityTypeName,
-                                entityId: item.entityId,
-                                amount: item.amount,
-                                source: `shoppingCartItem:${item.id.toString()}`,
-                            });
-                            const fulfillment = await processItem({
-                                accountId,
-                                cartItemId: item.id,
-                                ...item,
-                                amount_total: 0,
-                                scheduledDeliveryEmailKeys,
-                                additionalData: buildCheckoutAdditionalData({
-                                    additionalData: item.additionalData,
-                                    deliveryInfo,
-                                    scheduledHarvestDate,
-                                }),
-                            });
-                            assertCheckoutItemFulfilled(fulfillment);
-                            await setCartItemPaid(item.id);
+                            await withCheckoutCartItemProcessingLock(
+                                item.id,
+                                async () => {
+                                    const state =
+                                        await withCheckoutCartItemLock(
+                                            item.id,
+                                            async (db) => {
+                                                const lockedCart =
+                                                    await getShoppingCart(
+                                                        cart.id,
+                                                        db,
+                                                    );
+                                                if (!lockedCart) {
+                                                    throw new Error(
+                                                        `Cart ${cart.id.toString()} disappeared before inventory fulfillment.`,
+                                                    );
+                                                }
+                                                const lockedState =
+                                                    assertCheckoutCartItemSnapshot(
+                                                        lockedCart.items.find(
+                                                            (lockedItem) =>
+                                                                lockedItem.id ===
+                                                                item.id,
+                                                        ),
+                                                        item,
+                                                    );
+                                                if (lockedState === 'pending') {
+                                                    await withInventoryAccountTransaction(
+                                                        accountId,
+                                                        (inventoryDb) =>
+                                                            consumeInventoryItem(
+                                                                accountId,
+                                                                {
+                                                                    entityTypeName:
+                                                                        item.entityTypeName,
+                                                                    entityId:
+                                                                        item.entityId,
+                                                                    amount: item.amount,
+                                                                    source: `shoppingCartItem:${item.id.toString()}`,
+                                                                },
+                                                                inventoryDb,
+                                                            ),
+                                                        db,
+                                                    );
+                                                }
+                                                return lockedState;
+                                            },
+                                        );
+                                    if (state === 'paid') {
+                                        return;
+                                    }
+                                    const checkoutOperationMapping =
+                                        item.entityTypeName === 'operation'
+                                            ? await getCheckoutOperationMapping(
+                                                  item.id,
+                                              )
+                                            : undefined;
+
+                                    const fulfillment = await processItem({
+                                        accountId,
+                                        cartItemId: item.id,
+                                        ...item,
+                                        amount_total: 0,
+                                        scheduledDeliveryEmailKeys,
+                                        additionalData:
+                                            checkoutAdditionalDataByCartItemId.get(
+                                                item.id,
+                                            ) ?? {},
+                                        checkoutOperationMapping:
+                                            item.entityTypeName === 'operation'
+                                                ? checkoutOperationMapping
+                                                : undefined,
+                                    });
+                                    assertCheckoutItemFulfilled(fulfillment);
+                                    await setCartItemPaid(item.id);
+                                },
+                            );
                         }
                     }
                 } finally {
@@ -496,7 +718,11 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                                 currency: null,
                                 items: buildOrderConfirmationItems(
                                     cartInfo.items,
-                                    calculateSunflowerAmount,
+                                    (item) =>
+                                        resolvedSunflowerAmountsByCartItemId.get(
+                                            item.id,
+                                        ) ??
+                                        calculateSunflowerReplayAmount(item),
                                 ),
                                 manageUrl: ORDER_CONFIRMATION_MANAGE_URL,
                                 to: user.userName,
@@ -528,9 +754,6 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
             for (const item of stripeCartItemsWithShopData) {
                 // TODO: Apply discounted price if available
 
-                const scheduledHarvestDate = harvestDateByCartItemId.get(
-                    item.id,
-                );
                 const name = item.shopData?.name;
                 const description = item.shopData?.description || undefined;
                 const finalPrice =
@@ -586,11 +809,9 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                             positionIndex:
                                 item.positionIndex?.toString() ?? null,
                             additionalData: JSON.stringify(
-                                buildCheckoutAdditionalData({
-                                    additionalData: item.additionalData,
-                                    deliveryInfo,
-                                    scheduledHarvestDate,
-                                }),
+                                checkoutAdditionalDataByCartItemId.get(
+                                    item.id,
+                                ) ?? {},
                             ),
                             outletOfferId: item.outlet?.offerId ?? null,
                             outletReservationId:

--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -62,7 +62,6 @@ import {
     buildOrderConfirmationItems,
     ORDER_CONFIRMATION_MANAGE_URL,
 } from '../../../lib/checkout/orderConfirmationEmail';
-import { calculateSunflowerReplayAmount } from '../../../lib/checkout/sunflowerCalculations';
 import { authSecurity } from '../../../lib/docs/security';
 import {
     type AuthVariables,
@@ -547,14 +546,19 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                                     cartId: cart.id,
                                     item,
                                     operation: async (payment) => {
+                                        for (const [
+                                            cartItemId,
+                                            resolvedAmount,
+                                        ] of payment.resolvedAmountsByCartItemId) {
+                                            resolvedSunflowerAmountsByCartItemId.set(
+                                                cartItemId,
+                                                resolvedAmount,
+                                            );
+                                        }
                                         if (payment.state === 'paid') {
                                             return;
                                         }
                                         processingStage = 'fulfillment';
-                                        resolvedSunflowerAmountsByCartItemId.set(
-                                            item.id,
-                                            payment.resolvedAmount,
-                                        );
                                         const checkoutOperationMapping =
                                             item.entityTypeName === 'operation'
                                                 ? await getCheckoutOperationMapping(
@@ -604,6 +608,63 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                                 throw error;
                             }
                         }
+                    }
+                    const unresolvedPaidSunflowerItem =
+                        allSunflowerCartItemsWithShopData.find(
+                            (item) =>
+                                item.status === 'paid' &&
+                                !resolvedSunflowerAmountsByCartItemId.has(
+                                    item.id,
+                                ),
+                        );
+                    if (unresolvedPaidSunflowerItem) {
+                        try {
+                            await withDirectSunflowerCheckoutPayment({
+                                accountId,
+                                allSunflowerItems:
+                                    allSunflowerCartItemsWithShopData,
+                                cartId: cart.id,
+                                item: unresolvedPaidSunflowerItem,
+                                operation: async (payment) => {
+                                    for (const [
+                                        cartItemId,
+                                        resolvedAmount,
+                                    ] of payment.resolvedAmountsByCartItemId) {
+                                        resolvedSunflowerAmountsByCartItemId.set(
+                                            cartItemId,
+                                            resolvedAmount,
+                                        );
+                                    }
+                                },
+                            });
+                        } catch (error) {
+                            checkoutTiming.setErrorCategory(
+                                'sunflower_spend_failed',
+                            );
+                            console.error(
+                                'Error resolving paid sunflower amounts',
+                                {
+                                    accountId,
+                                    cartId: cart.id,
+                                    error,
+                                },
+                            );
+                            throw error;
+                        }
+                    }
+                    const missingSunflowerAmountItemIds =
+                        allSunflowerCartItemsWithShopData
+                            .filter(
+                                (item) =>
+                                    !resolvedSunflowerAmountsByCartItemId.has(
+                                        item.id,
+                                    ),
+                            )
+                            .map((item) => item.id);
+                    if (missingSunflowerAmountItemIds.length > 0) {
+                        throw new Error(
+                            `Sunflower checkout did not resolve durable amounts for cart items ${missingSunflowerAmountItemIds.join(', ')}.`,
+                        );
                     }
 
                     // Handle inventory items
@@ -718,11 +779,18 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                                 currency: null,
                                 items: buildOrderConfirmationItems(
                                     cartInfo.items,
-                                    (item) =>
-                                        resolvedSunflowerAmountsByCartItemId.get(
-                                            item.id,
-                                        ) ??
-                                        calculateSunflowerReplayAmount(item),
+                                    (item) => {
+                                        const resolvedAmount =
+                                            resolvedSunflowerAmountsByCartItemId.get(
+                                                item.id,
+                                            );
+                                        if (resolvedAmount === undefined) {
+                                            throw new Error(
+                                                `Sunflower confirmation amount is missing for cart item ${item.id.toString()}.`,
+                                            );
+                                        }
+                                        return resolvedAmount;
+                                    },
                                 ),
                                 manageUrl: ORDER_CONFIRMATION_MANAGE_URL,
                                 to: user.userName,

--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -21,7 +21,7 @@ import {
     releaseOutletReservationsForCart,
     reserveOutletOffer,
     setCartItemPaid,
-    spendSunflowers,
+    spendSunflowersBatch,
     sunflowerPackageEntityTypeName,
     validateHarvestDateSelections,
 } from '@gredice/storage';
@@ -59,7 +59,10 @@ import {
     authValidator,
 } from '../../../lib/hono/authValidator';
 import { getPostHogClient } from '../../../lib/posthog-server';
-import { processItem } from '../../../lib/stripe/processCheckoutSession';
+import {
+    assertCheckoutItemFulfilled,
+    processItem,
+} from '../../../lib/stripe/processCheckoutSession';
 import {
     buildSunflowerPackageCatalogResponse,
     sunflowerPackageCatalogResponseSchema,
@@ -396,11 +399,12 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                                 calculateSunflowerAmount(item);
                             let didPaySunflowers = false;
                             try {
-                                await spendSunflowers(
-                                    accountId,
-                                    sunflowerAmount,
-                                    `shoppingCartItem:${item.id}`,
-                                );
+                                await spendSunflowersBatch(accountId, [
+                                    {
+                                        amount: sunflowerAmount,
+                                        reason: `shoppingCartItem:${item.id.toString()}`,
+                                    },
+                                ]);
                                 didPaySunflowers = true;
                             } catch (error) {
                                 checkoutTiming.setErrorCategory(
@@ -415,23 +419,22 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                             }
 
                             if (didPaySunflowers) {
-                                await Promise.all([
-                                    setCartItemPaid(item.id),
-                                    processItem({
-                                        accountId,
-                                        cartItemId: item.id,
-                                        ...item,
-                                        amount_total: sunflowerAmount,
-                                        scheduledDeliveryEmailKeys,
-                                        additionalData:
-                                            buildCheckoutAdditionalData({
-                                                additionalData:
-                                                    item.additionalData,
-                                                deliveryInfo,
-                                                scheduledHarvestDate,
-                                            }),
-                                    }),
-                                ]);
+                                const fulfillment = await processItem({
+                                    accountId,
+                                    cartItemId: item.id,
+                                    ...item,
+                                    amount_total: sunflowerAmount,
+                                    scheduledDeliveryEmailKeys,
+                                    additionalData: buildCheckoutAdditionalData(
+                                        {
+                                            additionalData: item.additionalData,
+                                            deliveryInfo,
+                                            scheduledHarvestDate,
+                                        },
+                                    ),
+                                });
+                                assertCheckoutItemFulfilled(fulfillment);
+                                await setCartItemPaid(item.id);
                             }
                         }
                     }
@@ -457,29 +460,26 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                                 );
                             }
 
-                            await Promise.all([
-                                consumeInventoryItem(accountId, {
-                                    entityTypeName: item.entityTypeName,
-                                    entityId: item.entityId,
-                                    amount: item.amount,
-                                    source: `shoppingCartItem:${item.id}`,
+                            await consumeInventoryItem(accountId, {
+                                entityTypeName: item.entityTypeName,
+                                entityId: item.entityId,
+                                amount: item.amount,
+                                source: `shoppingCartItem:${item.id.toString()}`,
+                            });
+                            const fulfillment = await processItem({
+                                accountId,
+                                cartItemId: item.id,
+                                ...item,
+                                amount_total: 0,
+                                scheduledDeliveryEmailKeys,
+                                additionalData: buildCheckoutAdditionalData({
+                                    additionalData: item.additionalData,
+                                    deliveryInfo,
+                                    scheduledHarvestDate,
                                 }),
-                                setCartItemPaid(item.id),
-                                processItem({
-                                    accountId,
-                                    cartItemId: item.id,
-                                    ...item,
-                                    amount_total: 0,
-                                    scheduledDeliveryEmailKeys,
-                                    additionalData: buildCheckoutAdditionalData(
-                                        {
-                                            additionalData: item.additionalData,
-                                            deliveryInfo,
-                                            scheduledHarvestDate,
-                                        },
-                                    ),
-                                }),
-                            ]);
+                            });
+                            assertCheckoutItemFulfilled(fulfillment);
+                            await setCartItemPaid(item.id);
                         }
                     }
                 } finally {

--- a/apps/api/app/api/[...route]/shoppingCartRoutes.ts
+++ b/apps/api/app/api/[...route]/shoppingCartRoutes.ts
@@ -4,6 +4,7 @@ import {
     RAISED_BED_ABANDONED_DUE_TO_INACTIVITY_MESSAGE,
 } from '@gredice/js/raisedBeds';
 import {
+    CheckoutCartItemFulfillmentStartedError,
     cartContainsDeliverableItems,
     deleteShoppingCart,
     getHarvestScheduleForCart,
@@ -365,6 +366,15 @@ const app = new Hono<{ Variables: AuthVariables }>()
                         400,
                     );
                 }
+                if (error instanceof CheckoutCartItemFulfillmentStartedError) {
+                    return context.json(
+                        {
+                            error: 'Checkout fulfillment is already processing for this item',
+                            code: 'CHECKOUT_FULFILLMENT_STARTED',
+                        },
+                        409,
+                    );
+                }
 
                 throw error;
             }
@@ -391,7 +401,20 @@ const app = new Hono<{ Variables: AuthVariables }>()
         authValidator(['user', 'admin']),
         async (context) => {
             const { accountId } = context.get('authContext');
-            await deleteShoppingCart(accountId);
+            try {
+                await deleteShoppingCart(accountId);
+            } catch (error) {
+                if (error instanceof CheckoutCartItemFulfillmentStartedError) {
+                    return context.json(
+                        {
+                            error: 'Checkout fulfillment is already processing for this cart',
+                            code: 'CHECKOUT_FULFILLMENT_STARTED',
+                        },
+                        409,
+                    );
+                }
+                throw error;
+            }
             return context.json({ success: true });
         },
     );

--- a/apps/api/lib/checkout/cartInfo.node.spec.ts
+++ b/apps/api/lib/checkout/cartInfo.node.spec.ts
@@ -7,6 +7,7 @@ import {
     getNewRaisedBedPlantingNote,
     getPendingInventoryCartItemIds,
     getTotalCartValueCents,
+    hasBlockingOpenItemsForRaisedBed,
     hasEnoughInventoryForCartItem,
 } from './cartInfo';
 
@@ -162,6 +163,67 @@ describe('getAbandonedRaisedBedCartNote', () => {
         assert.strictEqual(
             getAbandonedRaisedBedCartNote('Gredica 12'),
             'Gredica 12 je napuštena zbog neaktivnosti. Nove sjetve i radnje više nisu dostupne za ovu gredicu.',
+        );
+    });
+});
+
+describe('hasBlockingOpenItemsForRaisedBed', () => {
+    const mappedOperation = {
+        id: 71,
+        entityTypeName: 'operation',
+        raisedBedId: 9,
+        status: 'new',
+    };
+
+    it('lets direct and mixed retries continue for a durably mapped operation', () => {
+        assert.strictEqual(
+            hasBlockingOpenItemsForRaisedBed(
+                [mappedOperation],
+                9,
+                new Set([mappedOperation.id]),
+            ),
+            false,
+        );
+    });
+
+    it('still blocks unmapped operations and planting items on an abandoned bed', () => {
+        assert.strictEqual(
+            hasBlockingOpenItemsForRaisedBed([mappedOperation], 9, new Set()),
+            true,
+        );
+        assert.strictEqual(
+            hasBlockingOpenItemsForRaisedBed(
+                [
+                    mappedOperation,
+                    {
+                        id: 72,
+                        entityTypeName: 'plantSort',
+                        raisedBedId: 9,
+                        status: 'new',
+                    },
+                ],
+                9,
+                new Set([mappedOperation.id]),
+            ),
+            true,
+        );
+    });
+
+    it('lets a direct-currency item resume after its durable payment effect', () => {
+        const plantingItem = {
+            id: 72,
+            entityTypeName: 'plantSort',
+            raisedBedId: 9,
+            status: 'new',
+        };
+        assert.strictEqual(
+            hasBlockingOpenItemsForRaisedBed(
+                [plantingItem],
+                9,
+                new Set(),
+                new Set([plantingItem.id]),
+            ),
+            false,
         );
     });
 });

--- a/apps/api/lib/checkout/cartInfo.node.spec.ts
+++ b/apps/api/lib/checkout/cartInfo.node.spec.ts
@@ -2,10 +2,144 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
     getAbandonedRaisedBedCartNote,
+    getEffectiveInventoryAvailability,
     getMinimumOrderNote,
     getNewRaisedBedPlantingNote,
+    getPendingInventoryCartItemIds,
     getTotalCartValueCents,
+    hasEnoughInventoryForCartItem,
 } from './cartInfo';
+
+const pendingInventoryItem = {
+    id: 41,
+    amount: 2,
+    currency: 'inventory',
+    entityId: '7',
+    entityTypeName: 'plantSort',
+    status: 'new',
+};
+
+const pendingInventoryConsumption = {
+    cartItemId: 41,
+    source: 'shoppingCartItem:41',
+    entityId: '7',
+    entityTypeName: 'plantSort',
+    amount: 2,
+};
+
+describe('getEffectiveInventoryAvailability', () => {
+    it('credits a matching pending checkout consumption back to availability', () => {
+        const availability = getEffectiveInventoryAvailability(
+            [pendingInventoryItem],
+            [
+                {
+                    entityId: '7',
+                    entityTypeName: 'plantSort',
+                    amount: 1,
+                },
+            ],
+            [pendingInventoryConsumption],
+        );
+
+        assert.strictEqual(availability.get('plantSort-7'), 3);
+    });
+
+    it('does not credit a completed checkout consumption', () => {
+        const availability = getEffectiveInventoryAvailability(
+            [{ ...pendingInventoryItem, status: 'paid' }],
+            [
+                {
+                    entityId: '7',
+                    entityTypeName: 'plantSort',
+                    amount: 1,
+                },
+            ],
+            [pendingInventoryConsumption],
+        );
+
+        assert.strictEqual(availability.get('plantSort-7'), 1);
+    });
+
+    it('rejects a mismatched checkout source', () => {
+        assert.throws(
+            () =>
+                getEffectiveInventoryAvailability(
+                    [pendingInventoryItem],
+                    [],
+                    [
+                        {
+                            ...pendingInventoryConsumption,
+                            source: 'shoppingCartItem:42',
+                        },
+                    ],
+                ),
+            /source mismatch/,
+        );
+    });
+
+    it('rejects a consumption for a different inventory item', () => {
+        assert.throws(
+            () =>
+                getEffectiveInventoryAvailability(
+                    [pendingInventoryItem],
+                    [],
+                    [
+                        {
+                            ...pendingInventoryConsumption,
+                            entityId: '8',
+                        },
+                    ],
+                ),
+            /item mismatch/,
+        );
+    });
+
+    it('rejects a consumption with a different amount', () => {
+        assert.throws(
+            () =>
+                getEffectiveInventoryAvailability(
+                    [pendingInventoryItem],
+                    [],
+                    [{ ...pendingInventoryConsumption, amount: 1 }],
+                ),
+            /amount mismatch/,
+        );
+    });
+});
+
+describe('getPendingInventoryCartItemIds', () => {
+    it('skips inventory reads for sunflower-only and already-paid carts', () => {
+        assert.deepStrictEqual(
+            getPendingInventoryCartItemIds([
+                { id: 1, currency: 'sunflower', status: 'new' },
+                { id: 2, currency: 'inventory', status: 'paid' },
+            ]),
+            [],
+        );
+        assert.deepStrictEqual(
+            getPendingInventoryCartItemIds([
+                { id: 3, currency: 'inventory', status: 'new' },
+            ]),
+            [3],
+        );
+    });
+});
+
+describe('hasEnoughInventoryForCartItem', () => {
+    it('does not reject a paid inventory item based on the current balance', () => {
+        assert.strictEqual(
+            hasEnoughInventoryForCartItem(
+                { ...pendingInventoryItem, status: 'paid' },
+                0,
+            ),
+            true,
+        );
+        assert.strictEqual(
+            hasEnoughInventoryForCartItem(pendingInventoryItem, 1),
+            false,
+        );
+    });
+});
 
 describe('getNewRaisedBedPlantingNote', () => {
     it('uses singular raised-bed copy for two raised-bed blocks', () => {

--- a/apps/api/lib/checkout/cartInfo.ts
+++ b/apps/api/lib/checkout/cartInfo.ts
@@ -9,9 +9,9 @@ import {
 import {
     type CheckoutInventoryConsumption,
     type EntityStandardized,
-    getCheckoutInventoryConsumptions,
+    getCheckoutInventorySnapshot,
+    getCheckoutOperationMappings,
     getEntitiesFormatted,
-    getInventory,
     getOutletOfferReservationsForCartItems,
     getRaisedBed,
     type SelectShoppingCartItem,
@@ -144,6 +144,27 @@ export function getPendingInventoryCartItemIds(
         .map((item) => item.id);
 }
 
+export function hasBlockingOpenItemsForRaisedBed(
+    items: readonly Pick<
+        SelectShoppingCartItem,
+        'entityTypeName' | 'id' | 'raisedBedId' | 'status'
+    >[],
+    raisedBedId: number,
+    mappedOperationCartItemIds: ReadonlySet<number>,
+    resumableCartItemIds: ReadonlySet<number> = new Set(),
+) {
+    return items.some(
+        (item) =>
+            item.status !== 'paid' &&
+            item.raisedBedId === raisedBedId &&
+            !resumableCartItemIds.has(item.id) &&
+            !(
+                item.entityTypeName === 'operation' &&
+                mappedOperationCartItemIds.has(item.id)
+            ),
+    );
+}
+
 function getNewRaisedBedCount(newRaisedBedBlockCount: number) {
     return Math.ceil(newRaisedBedBlockCount / RAISED_BED_BLOCKS_PER_BED);
 }
@@ -207,11 +228,31 @@ export function getMinimumOrderNote(totalCartValueCents: number) {
 export async function getCartInfo(
     items: SelectShoppingCartItem[],
     accountId?: string,
+    {
+        checkoutOperationMappings: suppliedCheckoutOperationMappings,
+        resumableCartItemIds = new Set(),
+    }: {
+        checkoutOperationMappings?: Awaited<
+            ReturnType<typeof getCheckoutOperationMappings>
+        >;
+        resumableCartItemIds?: ReadonlySet<number>;
+    } = {},
 ) {
     const entityTypeNames = items.map((item) => item.entityTypeName);
     const uniqueEntityTypeNames = Array.from(new Set(entityTypeNames));
-    const entitiesData = await Promise.all(
-        uniqueEntityTypeNames.map(getEntitiesFormatted),
+    const pendingOperationCartItemIds = items
+        .filter(
+            (item) =>
+                item.status !== 'paid' && item.entityTypeName === 'operation',
+        )
+        .map((item) => item.id);
+    const [entitiesData, checkoutOperationMappings] = await Promise.all([
+        Promise.all(uniqueEntityTypeNames.map(getEntitiesFormatted)),
+        suppliedCheckoutOperationMappings ??
+            getCheckoutOperationMappings(pendingOperationCartItemIds),
+    ]);
+    const mappedOperationCartItemIds = new Set(
+        checkoutOperationMappings.keys(),
     );
     const entitiesByTypeName = uniqueEntityTypeNames.reduce(
         (acc, typeName, index) => {
@@ -266,13 +307,12 @@ export async function getCartInfo(
     let checkoutInventoryConsumptions: CheckoutInventoryConsumption[] = [];
     const pendingInventoryCartItemIds = getPendingInventoryCartItemIds(items);
     if (accountId && pendingInventoryCartItemIds.length > 0) {
-        [inventory, checkoutInventoryConsumptions] = await Promise.all([
-            getInventory(accountId),
-            getCheckoutInventoryConsumptions(
-                accountId,
-                pendingInventoryCartItemIds,
-            ),
-        ]);
+        const snapshot = await getCheckoutInventorySnapshot(
+            accountId,
+            pendingInventoryCartItemIds,
+        );
+        inventory = snapshot.inventory;
+        checkoutInventoryConsumptions = snapshot.consumptions;
     }
     const inventoryLookup = getEffectiveInventoryAvailability(
         items,
@@ -464,9 +504,11 @@ export async function getCartInfo(
     for (const raisedBed of abandonedRaisedBeds) {
         if (!raisedBed) continue;
 
-        const hasOpenCartItems = cartItemsWithShopInfo.some(
-            (item) =>
-                item.status !== 'paid' && item.raisedBedId === raisedBed.id,
+        const hasOpenCartItems = hasBlockingOpenItemsForRaisedBed(
+            cartItemsWithShopInfo,
+            raisedBed.id,
+            mappedOperationCartItemIds,
+            resumableCartItemIds,
         );
         if (!hasOpenCartItems) continue;
 

--- a/apps/api/lib/checkout/cartInfo.ts
+++ b/apps/api/lib/checkout/cartInfo.ts
@@ -7,7 +7,9 @@ import {
     minimumShoppingCartAmountEur,
 } from '@gredice/js/shoppingCart';
 import {
+    type CheckoutInventoryConsumption,
     type EntityStandardized,
+    getCheckoutInventoryConsumptions,
     getEntitiesFormatted,
     getInventory,
     getOutletOfferReservationsForCartItems,
@@ -52,8 +54,95 @@ type CartValueItem = Pick<
     'amount' | 'currency' | 'shopData' | 'status'
 >;
 
+type InventoryAvailabilityCartItem = Pick<
+    SelectShoppingCartItem,
+    'amount' | 'currency' | 'entityId' | 'entityTypeName' | 'id' | 'status'
+>;
+
+type InventoryAvailabilityItem = Pick<
+    CheckoutInventoryConsumption,
+    'amount' | 'entityId' | 'entityTypeName'
+>;
+
 const RAISED_BED_BLOCKS_PER_BED = 2;
 const REQUIRED_PLANT_ITEMS_PER_NEW_RAISED_BED = 9;
+
+function getInventoryKey(
+    item: Pick<InventoryAvailabilityItem, 'entityId' | 'entityTypeName'>,
+) {
+    return `${item.entityTypeName}-${item.entityId}`;
+}
+
+export function getEffectiveInventoryAvailability(
+    items: readonly InventoryAvailabilityCartItem[],
+    inventory: readonly InventoryAvailabilityItem[],
+    consumptions: readonly CheckoutInventoryConsumption[],
+) {
+    const itemsById = new Map(items.map((item) => [item.id, item]));
+    const availability = new Map<string, number>();
+
+    for (const item of inventory) {
+        const key = getInventoryKey(item);
+        availability.set(key, (availability.get(key) ?? 0) + item.amount);
+    }
+
+    for (const consumption of consumptions) {
+        const expectedSource = `shoppingCartItem:${consumption.cartItemId.toString()}`;
+        if (consumption.source !== expectedSource) {
+            throw new Error(
+                `Checkout inventory consumption source mismatch for cart item ${consumption.cartItemId.toString()}`,
+            );
+        }
+
+        const cartItem = itemsById.get(consumption.cartItemId);
+        if (
+            cartItem?.currency !== 'inventory' ||
+            cartItem.entityTypeName !== consumption.entityTypeName ||
+            cartItem.entityId !== consumption.entityId
+        ) {
+            throw new Error(
+                `Checkout inventory consumption item mismatch for cart item ${consumption.cartItemId.toString()}`,
+            );
+        }
+        if (cartItem.amount !== consumption.amount) {
+            throw new Error(
+                `Checkout inventory consumption amount mismatch for cart item ${consumption.cartItemId.toString()}`,
+            );
+        }
+
+        if (cartItem.status === 'paid') {
+            continue;
+        }
+
+        const key = getInventoryKey(consumption);
+        availability.set(
+            key,
+            (availability.get(key) ?? 0) + consumption.amount,
+        );
+    }
+
+    return availability;
+}
+
+export function hasEnoughInventoryForCartItem(
+    item: Pick<InventoryAvailabilityCartItem, 'amount' | 'status'>,
+    inventoryAvailable: number,
+) {
+    return item.status === 'paid' || inventoryAvailable >= item.amount;
+}
+
+export function getPendingInventoryCartItemIds(
+    items: readonly Pick<
+        InventoryAvailabilityCartItem,
+        'currency' | 'id' | 'status'
+    >[],
+) {
+    return items
+        .filter(
+            (item) => item.status !== 'paid' && item.currency === 'inventory',
+        )
+        .map((item) => item.id);
+}
 
 function getNewRaisedBedCount(newRaisedBedBlockCount: number) {
     return Math.ceil(newRaisedBedBlockCount / RAISED_BED_BLOCKS_PER_BED);
@@ -173,12 +262,22 @@ export async function getCartInfo(
         });
     }
 
-    const inventory = accountId ? await getInventory(accountId) : [];
-    const inventoryLookup = new Map(
-        inventory.map((item) => [
-            `${item.entityTypeName}-${item.entityId}`,
-            item.amount,
-        ]),
+    let inventory: InventoryAvailabilityItem[] = [];
+    let checkoutInventoryConsumptions: CheckoutInventoryConsumption[] = [];
+    const pendingInventoryCartItemIds = getPendingInventoryCartItemIds(items);
+    if (accountId && pendingInventoryCartItemIds.length > 0) {
+        [inventory, checkoutInventoryConsumptions] = await Promise.all([
+            getInventory(accountId),
+            getCheckoutInventoryConsumptions(
+                accountId,
+                pendingInventoryCartItemIds,
+            ),
+        ]);
+    }
+    const inventoryLookup = getEffectiveInventoryAvailability(
+        items,
+        inventory,
+        checkoutInventoryConsumptions,
     );
 
     // Process paid discounts for items that are already paid
@@ -201,7 +300,10 @@ export async function getCartInfo(
                 inventoryLookup.get(
                     `${item.entityTypeName}-${item.entityId}`,
                 ) ?? 0;
-            if (availableCount > 0) {
+            if (
+                item.status !== 'paid' &&
+                hasEnoughInventoryForCartItem(item, availableCount)
+            ) {
                 discounts.push({
                     cartItemId: item.id,
                     discountPrice: 0,
@@ -235,7 +337,10 @@ export async function getCartInfo(
                   ) ?? 0)
                 : 0;
 
-            if (wantsInventory && inventoryAvailable <= 0) {
+            if (
+                wantsInventory &&
+                !hasEnoughInventoryForCartItem(item, inventoryAvailable)
+            ) {
                 notes.push(
                     `${
                         entityData.information?.label ||

--- a/apps/api/lib/checkout/checkoutRecovery.node.spec.ts
+++ b/apps/api/lib/checkout/checkoutRecovery.node.spec.ts
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    assertCheckoutCartItemSnapshot,
+    getCheckoutOperationRecoveryState,
+} from './checkoutRecovery';
+
+const cartItemSnapshot = {
+    additionalData: null,
+    amount: 1,
+    currency: 'sunflower',
+    entityId: 'operation-1',
+    entityTypeName: 'operation',
+    gardenId: 7,
+    id: 42,
+    positionIndex: 2,
+    raisedBedId: 9,
+};
+
+describe('assertCheckoutCartItemSnapshot', () => {
+    it('accepts an unchanged pending item and an already-paid replay', () => {
+        assert.equal(
+            assertCheckoutCartItemSnapshot(
+                { ...cartItemSnapshot, status: 'new' },
+                cartItemSnapshot,
+            ),
+            'pending',
+        );
+        assert.equal(
+            assertCheckoutCartItemSnapshot(
+                {
+                    ...cartItemSnapshot,
+                    amount: 99,
+                    status: 'paid',
+                },
+                cartItemSnapshot,
+            ),
+            'paid',
+        );
+    });
+
+    it('fails closed when the pending item changed or disappeared', () => {
+        assert.throws(
+            () =>
+                assertCheckoutCartItemSnapshot(
+                    { ...cartItemSnapshot, amount: 2, status: 'new' },
+                    cartItemSnapshot,
+                ),
+            /changed before fulfillment/u,
+        );
+        assert.throws(
+            () => assertCheckoutCartItemSnapshot(undefined, cartItemSnapshot),
+            /disappeared before fulfillment/u,
+        );
+    });
+});
+
+describe('getCheckoutOperationRecoveryState', () => {
+    it('blocks a new Stripe session for a mapped pending euro operation', () => {
+        assert.equal(
+            getCheckoutOperationRecoveryState(
+                [
+                    {
+                        currency: 'eur',
+                        entityTypeName: 'operation',
+                        id: 42,
+                        status: 'new',
+                    },
+                ],
+                new Map([[42, { paymentCurrency: 'eur' }]]),
+            ),
+            'stripe_payment_processing',
+        );
+    });
+
+    it('allows direct recovery and ordinary first-attempt checkout items', () => {
+        const items = [
+            {
+                currency: 'sunflower',
+                entityTypeName: 'operation',
+                id: 42,
+                status: 'new',
+            },
+            {
+                currency: 'eur',
+                entityTypeName: 'operation',
+                id: 43,
+                status: 'new',
+            },
+            {
+                currency: 'eur',
+                entityTypeName: 'operation',
+                id: 44,
+                status: 'paid',
+            },
+        ];
+
+        assert.equal(
+            getCheckoutOperationRecoveryState(
+                items,
+                new Map([
+                    [42, { paymentCurrency: 'sunflower' }],
+                    [44, { paymentCurrency: 'eur' }],
+                ]),
+            ),
+            null,
+        );
+    });
+
+    it('rejects both directions of mutable payment-currency drift', () => {
+        const pendingOperation = {
+            currency: 'sunflower',
+            entityTypeName: 'operation',
+            id: 42,
+            status: 'new',
+        };
+
+        assert.equal(
+            getCheckoutOperationRecoveryState(
+                [pendingOperation],
+                new Map([[42, { paymentCurrency: 'eur' }]]),
+            ),
+            'currency_mismatch',
+        );
+        assert.equal(
+            getCheckoutOperationRecoveryState(
+                [{ ...pendingOperation, currency: 'eur' }],
+                new Map([[42, { paymentCurrency: 'inventory' }]]),
+            ),
+            'currency_mismatch',
+        );
+    });
+
+    it('blocks a second Stripe session after any pending euro item starts fulfillment', () => {
+        const pendingEuroItems = [
+            {
+                currency: 'eur',
+                entityTypeName: 'operation',
+                id: 42,
+                status: 'new',
+            },
+            {
+                currency: 'eur',
+                entityTypeName: 'plantSort',
+                id: 43,
+                status: 'new',
+            },
+        ];
+
+        assert.equal(
+            getCheckoutOperationRecoveryState(
+                pendingEuroItems,
+                new Map(),
+                new Set([42]),
+            ),
+            'stripe_payment_processing',
+        );
+        assert.equal(
+            getCheckoutOperationRecoveryState(
+                pendingEuroItems,
+                new Map(),
+                new Set([43]),
+            ),
+            'stripe_payment_processing',
+        );
+    });
+
+    it('keeps direct-currency retries and paid euro items recoverable', () => {
+        assert.equal(
+            getCheckoutOperationRecoveryState(
+                [
+                    {
+                        currency: 'sunflower',
+                        entityTypeName: 'operation',
+                        id: 42,
+                        status: 'new',
+                    },
+                    {
+                        currency: 'eur',
+                        entityTypeName: 'plantSort',
+                        id: 43,
+                        status: 'paid',
+                    },
+                ],
+                new Map(),
+                new Set([42, 43]),
+            ),
+            null,
+        );
+    });
+});

--- a/apps/api/lib/checkout/checkoutRecovery.ts
+++ b/apps/api/lib/checkout/checkoutRecovery.ts
@@ -1,0 +1,88 @@
+type CheckoutRecoveryCartItem = {
+    currency: string | null;
+    entityTypeName: string;
+    id: number;
+    status: string;
+};
+
+type CheckoutOperationPaymentMapping = {
+    paymentCurrency: 'eur' | 'inventory' | 'sunflower';
+};
+
+type CheckoutCartItemSnapshot = {
+    additionalData: string | null;
+    amount: number;
+    currency: string | null;
+    entityId: string;
+    entityTypeName: string;
+    gardenId: number | null;
+    id: number;
+    positionIndex: number | null;
+    raisedBedId: number | null;
+};
+
+export function assertCheckoutCartItemSnapshot(
+    current: (CheckoutCartItemSnapshot & { status: string }) | undefined,
+    expected: CheckoutCartItemSnapshot,
+) {
+    if (!current) {
+        throw new Error(
+            `Checkout cart item ${expected.id.toString()} disappeared before fulfillment.`,
+        );
+    }
+    if (current.status === 'paid') {
+        return 'paid' as const;
+    }
+    const unchanged =
+        current.additionalData === expected.additionalData &&
+        current.amount === expected.amount &&
+        current.currency === expected.currency &&
+        current.entityId === expected.entityId &&
+        current.entityTypeName === expected.entityTypeName &&
+        current.gardenId === expected.gardenId &&
+        current.positionIndex === expected.positionIndex &&
+        current.raisedBedId === expected.raisedBedId;
+    if (!unchanged) {
+        throw new Error(
+            `Checkout cart item ${expected.id.toString()} changed before fulfillment.`,
+        );
+    }
+    return 'pending' as const;
+}
+
+export type CheckoutOperationRecoveryState =
+    | 'currency_mismatch'
+    | 'stripe_payment_processing';
+
+export function getCheckoutOperationRecoveryState(
+    items: readonly CheckoutRecoveryCartItem[],
+    checkoutOperationMappings: ReadonlyMap<
+        number,
+        CheckoutOperationPaymentMapping
+    >,
+    fulfillmentStartedCartItemIds: ReadonlySet<number> = new Set(),
+): CheckoutOperationRecoveryState | null {
+    for (const item of items) {
+        if (item.status === 'paid') {
+            continue;
+        }
+        if (item.entityTypeName === 'operation') {
+            const mapping = checkoutOperationMappings.get(item.id);
+            if (mapping?.paymentCurrency !== undefined) {
+                if (mapping.paymentCurrency !== item.currency) {
+                    return 'currency_mismatch';
+                }
+                if (mapping.paymentCurrency === 'eur') {
+                    return 'stripe_payment_processing';
+                }
+            }
+        }
+        if (
+            item.currency === 'eur' &&
+            fulfillmentStartedCartItemIds.has(item.id)
+        ) {
+            return 'stripe_payment_processing';
+        }
+    }
+    return null;
+}

--- a/apps/api/lib/checkout/checkoutTiming.ts
+++ b/apps/api/lib/checkout/checkoutTiming.ts
@@ -24,6 +24,7 @@ export type CheckoutTimingOutcome =
     | 'unexpected_failure';
 
 export type CheckoutTimingErrorCategory =
+    | 'cart_validation_failed'
     | 'sunflower_spend_failed'
     | 'unexpected';
 

--- a/apps/api/lib/checkout/directSunflowerCheckout.node.spec.ts
+++ b/apps/api/lib/checkout/directSunflowerCheckout.node.spec.ts
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { ShoppingCartItemWithShopData } from './cartInfo';
+import { withDirectSunflowerCheckoutPayment } from './directSunflowerCheckout';
+
+function sunflowerItem({
+    discountPrice,
+    id,
+    price,
+    status,
+}: {
+    discountPrice?: number;
+    id: number;
+    price: number;
+    status: string;
+}): ShoppingCartItemWithShopData {
+    return {
+        additionalData: null,
+        amount: 1,
+        cartId: 100,
+        createdAt: new Date(`2026-07-01T10:0${id.toString()}:00.000Z`),
+        currency: 'sunflower',
+        entityData: { id },
+        entityId: id.toString(),
+        entityTypeName: 'plantSort',
+        gardenId: 200,
+        id,
+        inventoryAvailable: 0,
+        isDeleted: false,
+        outlet: undefined,
+        positionIndex: id,
+        raisedBedId: 300,
+        shopData: { discountPrice, price },
+        status,
+        updatedAt: new Date('2026-07-01T10:10:00.000Z'),
+        usesInventory: false,
+    };
+}
+
+test('direct sunflower checkout verifies full legacy coverage and returns the durable amount', async () => {
+    const paidItem = sunflowerItem({
+        discountPrice: 0,
+        id: 2,
+        price: 5,
+        status: 'paid',
+    });
+    const pendingItem = sunflowerItem({
+        discountPrice: 7,
+        id: 3,
+        price: 7,
+        status: 'new',
+    });
+    const calls: Array<{ args: unknown[]; name: string }> = [];
+
+    const result = await withDirectSunflowerCheckoutPayment({
+        accountId: 'account-1',
+        allSunflowerItems: [paidItem, pendingItem],
+        cartId: 100,
+        item: pendingItem,
+        dependencies: {
+            calculateSunflowerAmount: (item) => {
+                calls.push({ args: [item.shopData], name: 'calculate' });
+                return 7_000;
+            },
+            calculateSunflowerReplayAmount: (item) => {
+                calls.push({ args: [item.status], name: 'calculateReplay' });
+                return 5_000;
+            },
+            lockShoppingCartForCheckout: async (...args) => {
+                calls.push({ args: args.slice(0, 1), name: 'lockCart' });
+                return {
+                    accountId: 'account-1',
+                    id: 100,
+                    isDeleted: false,
+                    items: [paidItem, pendingItem],
+                    status: 'new',
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                };
+            },
+            spendSunflowersBatch: async (...args) => {
+                calls.push({ args, name: 'spend' });
+                return {
+                    createdReasons: [],
+                    existingReasons: ['shoppingCartItem:3'],
+                    resolvedAmountsByReason: {
+                        'shoppingCartItem:3': 6_000,
+                    },
+                };
+            },
+            withCheckoutCartItemLocks: async (ids, operation) => {
+                calls.push({ args: [ids], name: 'databaseLocksStarted' });
+                const value = await operation({
+                    transaction: 'checkout-test',
+                } as never);
+                calls.push({ args: [ids], name: 'databaseLocksFinished' });
+                return value;
+            },
+            withCheckoutCartItemProcessingLocks: async (ids, operation) => {
+                calls.push({ args: [ids], name: 'processingLocksStarted' });
+                const value = await operation();
+                calls.push({ args: [ids], name: 'processingLocksFinished' });
+                return value;
+            },
+        },
+        operation: async (payment) => {
+            calls.push({ args: [payment], name: 'fulfillment' });
+            return payment;
+        },
+    });
+
+    assert.deepStrictEqual(result, {
+        resolvedAmount: 6_000,
+        state: 'pending',
+    });
+    assert.deepStrictEqual(
+        calls.find((call) => call.name === 'processingLocksStarted')?.args,
+        [[2, 3]],
+    );
+    assert.deepStrictEqual(
+        calls.find((call) => call.name === 'databaseLocksStarted')?.args,
+        [[2, 3]],
+    );
+    assert.ok(
+        calls.findIndex((call) => call.name === 'databaseLocksFinished') <
+            calls.findIndex((call) => call.name === 'fulfillment'),
+    );
+    assert.ok(
+        calls.findIndex((call) => call.name === 'fulfillment') <
+            calls.findIndex((call) => call.name === 'processingLocksFinished'),
+    );
+    const spendCall = calls.find((call) => call.name === 'spend');
+    assert.deepStrictEqual(spendCall?.args.slice(0, 2), [
+        'account-1',
+        [{ amount: 7_000, reason: 'shoppingCartItem:3' }],
+    ]);
+    assert.deepStrictEqual(spendCall?.args[3], {
+        existingCheckoutItemAmountsAreAuthoritative: true,
+        legacyCartSpend: {
+            reason: 'shoppingCart:100',
+            coveredItems: [
+                {
+                    amount: 5_000,
+                    cartItemId: 2,
+                    createdAt: paidItem.createdAt,
+                    reason: 'shoppingCartItem:2',
+                },
+                {
+                    amount: 7_000,
+                    cartItemId: 3,
+                    createdAt: pendingItem.createdAt,
+                    reason: 'shoppingCartItem:3',
+                },
+            ],
+        },
+    });
+});

--- a/apps/api/lib/checkout/directSunflowerCheckout.node.spec.ts
+++ b/apps/api/lib/checkout/directSunflowerCheckout.node.spec.ts
@@ -84,6 +84,7 @@ test('direct sunflower checkout verifies full legacy coverage and returns the du
                     createdReasons: [],
                     existingReasons: ['shoppingCartItem:3'],
                     resolvedAmountsByReason: {
+                        'shoppingCartItem:2': 4_500,
                         'shoppingCartItem:3': 6_000,
                     },
                 };
@@ -111,6 +112,10 @@ test('direct sunflower checkout verifies full legacy coverage and returns the du
 
     assert.deepStrictEqual(result, {
         resolvedAmount: 6_000,
+        resolvedAmountsByCartItemId: new Map([
+            [2, 4_500],
+            [3, 6_000],
+        ]),
         state: 'pending',
     });
     assert.deepStrictEqual(
@@ -143,12 +148,14 @@ test('direct sunflower checkout verifies full legacy coverage and returns the du
                     amount: 5_000,
                     cartItemId: 2,
                     createdAt: paidItem.createdAt,
+                    paymentState: 'paid',
                     reason: 'shoppingCartItem:2',
                 },
                 {
                     amount: 7_000,
                     cartItemId: 3,
                     createdAt: pendingItem.createdAt,
+                    paymentState: 'pending',
                     reason: 'shoppingCartItem:3',
                 },
             ],

--- a/apps/api/lib/checkout/directSunflowerCheckout.ts
+++ b/apps/api/lib/checkout/directSunflowerCheckout.ts
@@ -1,0 +1,154 @@
+import {
+    lockShoppingCartForCheckout,
+    spendSunflowersBatch,
+    withCheckoutCartItemLocks,
+    withCheckoutCartItemProcessingLocks,
+} from '@gredice/storage';
+import type { ShoppingCartItemWithShopData } from './cartInfo';
+import { assertCheckoutCartItemSnapshot } from './checkoutRecovery';
+import {
+    calculateSunflowerAmount,
+    calculateSunflowerReplayAmount,
+} from './sunflowerCalculations';
+
+type DirectSunflowerCheckoutDependencies = {
+    calculateSunflowerAmount: typeof calculateSunflowerAmount;
+    calculateSunflowerReplayAmount: typeof calculateSunflowerReplayAmount;
+    lockShoppingCartForCheckout: typeof lockShoppingCartForCheckout;
+    spendSunflowersBatch: typeof spendSunflowersBatch;
+    withCheckoutCartItemLocks: typeof withCheckoutCartItemLocks;
+    withCheckoutCartItemProcessingLocks: typeof withCheckoutCartItemProcessingLocks;
+};
+
+const realDependencies: DirectSunflowerCheckoutDependencies = {
+    calculateSunflowerAmount,
+    calculateSunflowerReplayAmount,
+    lockShoppingCartForCheckout,
+    spendSunflowersBatch,
+    withCheckoutCartItemLocks,
+    withCheckoutCartItemProcessingLocks,
+};
+
+export async function withDirectSunflowerCheckoutPayment<T>({
+    accountId,
+    allSunflowerItems,
+    cartId,
+    dependencies = realDependencies,
+    item,
+    operation,
+}: {
+    accountId: string;
+    allSunflowerItems: readonly ShoppingCartItemWithShopData[];
+    cartId: number;
+    dependencies?: DirectSunflowerCheckoutDependencies;
+    item: ShoppingCartItemWithShopData;
+    operation: (
+        payment:
+            | { state: 'paid' }
+            | { resolvedAmount: number; state: 'pending' },
+    ) => Promise<T>;
+}): Promise<T> {
+    const coveredItemIds = allSunflowerItems.map(
+        (coveredItem) => coveredItem.id,
+    );
+    const sunflowerAmountsByCartItemId = new Map(
+        allSunflowerItems.map((coveredItem) => [
+            coveredItem.id,
+            coveredItem.status === 'paid'
+                ? dependencies.calculateSunflowerReplayAmount(coveredItem)
+                : dependencies.calculateSunflowerAmount(coveredItem),
+        ]),
+    );
+
+    return dependencies.withCheckoutCartItemProcessingLocks(
+        coveredItemIds,
+        async () => {
+            const payment = await dependencies.withCheckoutCartItemLocks(
+                coveredItemIds,
+                async (db) => {
+                    const lockedCart =
+                        await dependencies.lockShoppingCartForCheckout(
+                            cartId,
+                            db,
+                        );
+                    if (!lockedCart) {
+                        throw new Error(
+                            `Cart ${cartId.toString()} disappeared before sunflower fulfillment.`,
+                        );
+                    }
+                    if (lockedCart.accountId !== accountId) {
+                        throw new Error(
+                            `Cart ${cartId.toString()} account changed before sunflower fulfillment.`,
+                        );
+                    }
+
+                    let itemState: 'paid' | 'pending' | undefined;
+                    for (const coveredItem of allSunflowerItems) {
+                        const state = assertCheckoutCartItemSnapshot(
+                            lockedCart.items.find(
+                                (lockedItem) =>
+                                    lockedItem.id === coveredItem.id,
+                            ),
+                            coveredItem,
+                        );
+                        if (coveredItem.id === item.id) {
+                            itemState = state;
+                        }
+                    }
+                    if (!itemState) {
+                        throw new Error(
+                            `Sunflower cart item ${item.id.toString()} is not part of the checkout coverage.`,
+                        );
+                    }
+                    if (itemState === 'paid') {
+                        return { state: 'paid' as const };
+                    }
+
+                    const reason = `shoppingCartItem:${item.id.toString()}`;
+                    const spendResult = await dependencies.spendSunflowersBatch(
+                        accountId,
+                        [
+                            {
+                                amount:
+                                    sunflowerAmountsByCartItemId.get(item.id) ??
+                                    0,
+                                reason,
+                            },
+                        ],
+                        db,
+                        {
+                            existingCheckoutItemAmountsAreAuthoritative: true,
+                            legacyCartSpend: {
+                                reason: `shoppingCart:${cartId.toString()}`,
+                                coveredItems: allSunflowerItems.map(
+                                    (coveredItem) => ({
+                                        amount:
+                                            sunflowerAmountsByCartItemId.get(
+                                                coveredItem.id,
+                                            ) ?? 0,
+                                        cartItemId: coveredItem.id,
+                                        createdAt: coveredItem.createdAt,
+                                        reason: `shoppingCartItem:${coveredItem.id.toString()}`,
+                                    }),
+                                ),
+                            },
+                        },
+                    );
+                    const resolvedAmount =
+                        spendResult.resolvedAmountsByReason[reason];
+                    if (
+                        !Number.isSafeInteger(resolvedAmount) ||
+                        resolvedAmount <= 0
+                    ) {
+                        throw new Error(
+                            `Sunflower spend for cart item ${item.id.toString()} did not resolve a valid amount.`,
+                        );
+                    }
+
+                    return { resolvedAmount, state: 'pending' as const };
+                },
+            );
+            return operation(payment);
+        },
+    );
+}

--- a/apps/api/lib/checkout/directSunflowerCheckout.ts
+++ b/apps/api/lib/checkout/directSunflowerCheckout.ts
@@ -20,6 +20,17 @@ type DirectSunflowerCheckoutDependencies = {
     withCheckoutCartItemProcessingLocks: typeof withCheckoutCartItemProcessingLocks;
 };
 
+type DirectSunflowerCheckoutPayment =
+    | {
+          resolvedAmountsByCartItemId: ReadonlyMap<number, number>;
+          state: 'paid';
+      }
+    | {
+          resolvedAmount: number;
+          resolvedAmountsByCartItemId: ReadonlyMap<number, number>;
+          state: 'pending';
+      };
+
 const realDependencies: DirectSunflowerCheckoutDependencies = {
     calculateSunflowerAmount,
     calculateSunflowerReplayAmount,
@@ -42,11 +53,7 @@ export async function withDirectSunflowerCheckoutPayment<T>({
     cartId: number;
     dependencies?: DirectSunflowerCheckoutDependencies;
     item: ShoppingCartItemWithShopData;
-    operation: (
-        payment:
-            | { state: 'paid' }
-            | { resolvedAmount: number; state: 'pending' },
-    ) => Promise<T>;
+    operation: (payment: DirectSunflowerCheckoutPayment) => Promise<T>;
 }): Promise<T> {
     const coveredItemIds = allSunflowerItems.map(
         (coveredItem) => coveredItem.id,
@@ -82,7 +89,10 @@ export async function withDirectSunflowerCheckoutPayment<T>({
                         );
                     }
 
-                    let itemState: 'paid' | 'pending' | undefined;
+                    const paymentStatesByCartItemId = new Map<
+                        number,
+                        'paid' | 'pending'
+                    >();
                     for (const coveredItem of allSunflowerItems) {
                         const state = assertCheckoutCartItemSnapshot(
                             lockedCart.items.find(
@@ -91,52 +101,100 @@ export async function withDirectSunflowerCheckoutPayment<T>({
                             ),
                             coveredItem,
                         );
-                        if (coveredItem.id === item.id) {
-                            itemState = state;
-                        }
+                        paymentStatesByCartItemId.set(coveredItem.id, state);
                     }
+                    const itemState = paymentStatesByCartItemId.get(item.id);
                     if (!itemState) {
                         throw new Error(
                             `Sunflower cart item ${item.id.toString()} is not part of the checkout coverage.`,
                         );
                     }
-                    if (itemState === 'paid') {
-                        return { state: 'paid' as const };
-                    }
-
                     const reason = `shoppingCartItem:${item.id.toString()}`;
                     const spendResult = await dependencies.spendSunflowersBatch(
                         accountId,
-                        [
-                            {
-                                amount:
-                                    sunflowerAmountsByCartItemId.get(item.id) ??
-                                    0,
-                                reason,
-                            },
-                        ],
+                        itemState === 'pending'
+                            ? [
+                                  {
+                                      amount:
+                                          sunflowerAmountsByCartItemId.get(
+                                              item.id,
+                                          ) ?? 0,
+                                      reason,
+                                  },
+                              ]
+                            : [],
                         db,
                         {
                             existingCheckoutItemAmountsAreAuthoritative: true,
                             legacyCartSpend: {
                                 reason: `shoppingCart:${cartId.toString()}`,
                                 coveredItems: allSunflowerItems.map(
-                                    (coveredItem) => ({
-                                        amount:
-                                            sunflowerAmountsByCartItemId.get(
+                                    (coveredItem) => {
+                                        const paymentState =
+                                            paymentStatesByCartItemId.get(
                                                 coveredItem.id,
-                                            ) ?? 0,
-                                        cartItemId: coveredItem.id,
-                                        createdAt: coveredItem.createdAt,
-                                        reason: `shoppingCartItem:${coveredItem.id.toString()}`,
-                                    }),
+                                            );
+                                        if (!paymentState) {
+                                            throw new Error(
+                                                `Sunflower cart item ${coveredItem.id.toString()} lost its payment state.`,
+                                            );
+                                        }
+                                        return {
+                                            amount:
+                                                sunflowerAmountsByCartItemId.get(
+                                                    coveredItem.id,
+                                                ) ?? 0,
+                                            cartItemId: coveredItem.id,
+                                            createdAt: coveredItem.createdAt,
+                                            paymentState,
+                                            reason: `shoppingCartItem:${coveredItem.id.toString()}`,
+                                        };
+                                    },
                                 ),
                             },
                         },
                     );
-                    const resolvedAmount =
-                        spendResult.resolvedAmountsByReason[reason];
+                    const resolvedAmountsByCartItemId = new Map<
+                        number,
+                        number
+                    >();
+                    for (const coveredItem of allSunflowerItems) {
+                        const resolvedAmount =
+                            spendResult.resolvedAmountsByReason[
+                                `shoppingCartItem:${coveredItem.id.toString()}`
+                            ];
+                        if (resolvedAmount !== undefined) {
+                            if (
+                                !Number.isSafeInteger(resolvedAmount) ||
+                                resolvedAmount <= 0
+                            ) {
+                                throw new Error(
+                                    `Sunflower spend for cart item ${coveredItem.id.toString()} did not resolve a valid amount.`,
+                                );
+                            }
+                            resolvedAmountsByCartItemId.set(
+                                coveredItem.id,
+                                resolvedAmount,
+                            );
+                        }
+                    }
+                    if (itemState === 'paid') {
+                        if (!resolvedAmountsByCartItemId.has(item.id)) {
+                            throw new Error(
+                                `Paid sunflower cart item ${item.id.toString()} has no durable spend amount.`,
+                            );
+                        }
+                        return {
+                            resolvedAmountsByCartItemId,
+                            state: 'paid' as const,
+                        };
+                    }
+
+                    const resolvedAmount = resolvedAmountsByCartItemId.get(
+                        item.id,
+                    );
                     if (
+                        typeof resolvedAmount !== 'number' ||
                         !Number.isSafeInteger(resolvedAmount) ||
                         resolvedAmount <= 0
                     ) {
@@ -145,7 +203,11 @@ export async function withDirectSunflowerCheckoutPayment<T>({
                         );
                     }
 
-                    return { resolvedAmount, state: 'pending' as const };
+                    return {
+                        resolvedAmount,
+                        resolvedAmountsByCartItemId,
+                        state: 'pending' as const,
+                    };
                 },
             );
             return operation(payment);

--- a/apps/api/lib/checkout/sunflowerCalculations.node.spec.ts
+++ b/apps/api/lib/checkout/sunflowerCalculations.node.spec.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { getDefaultCartItemCurrency } from './sunflowerCalculations';
+import {
+    calculateSunflowerReplayAmount,
+    getDefaultCartItemCurrency,
+} from './sunflowerCalculations';
 
 function cartItem({
     currency = 'eur',
@@ -98,5 +101,30 @@ test('uses the effective discounted price and requires a positive price', () => 
             newCartItemId: 2,
         }),
         'eur',
+    );
+});
+
+test('reconstructs paid sunflower replay amounts without the paid-item zero discount', () => {
+    assert.equal(
+        calculateSunflowerReplayAmount({
+            shopData: { discountPrice: 0, price: 2.5 },
+            status: 'paid',
+        }),
+        2_500,
+    );
+    assert.equal(
+        calculateSunflowerReplayAmount({
+            outlet: { outletPrice: 1.2 },
+            shopData: { discountPrice: 0, price: 2.5 },
+            status: 'paid',
+        }),
+        1_200,
+    );
+    assert.equal(
+        calculateSunflowerReplayAmount({
+            shopData: { discountPrice: 1.4, price: 2.5 },
+            status: 'new',
+        }),
+        1_400,
     );
 });

--- a/apps/api/lib/checkout/sunflowerCalculations.ts
+++ b/apps/api/lib/checkout/sunflowerCalculations.ts
@@ -19,6 +19,25 @@ export function calculateSunflowerAmount(
     return Math.round(price * 1000);
 }
 
+/**
+ * Reconstructs the candidate amount for a durable checkout replay. Paid cart
+ * items are represented with a zero discount by getCartInfo, so their
+ * checkout amount must come from the captured outlet price or the base price.
+ * The durable spend event remains authoritative when one already exists.
+ */
+export function calculateSunflowerReplayAmount(item: {
+    outlet?: { outletPrice: number };
+    shopData: { discountPrice?: number; price?: number };
+    status: string;
+}): number {
+    if (item.status !== 'paid') {
+        return calculateSunflowerAmount(item);
+    }
+
+    const price = item.outlet?.outletPrice ?? item.shopData.price ?? 0;
+    return Math.round(price * 1000);
+}
+
 export function getDefaultCartItemCurrency({
     availableSunflowers,
     items,

--- a/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
@@ -76,9 +76,9 @@ function makeDependencies(
         convertOutletReservationForCartItem: async (...args: unknown[]) => {
             record(calls, 'convertOutletReservationForCartItem', args);
         },
-        createDeliveryRequest: async (...args: unknown[]) => {
-            record(calls, 'createDeliveryRequest', args);
-            return 701;
+        getOrCreateDeliveryRequest: async (...args: unknown[]) => {
+            record(calls, 'getOrCreateDeliveryRequest', args);
+            return { created: true, requestId: 'delivery-request-701' };
         },
         createEvent: async (...args: unknown[]) => {
             record(calls, 'createEvent', args);
@@ -96,9 +96,9 @@ function makeDependencies(
             await deliver();
             return { attempted: true, status: 'sent' as const };
         },
-        createOperation: async (...args: unknown[]) => {
-            record(calls, 'createOperation', args);
-            return 501;
+        getOrCreateCheckoutOperation: async (...args: unknown[]) => {
+            record(calls, 'getOrCreateCheckoutOperation', args);
+            return { created: true, operationId: 501 };
         },
         createTransaction: async (...args: unknown[]) => {
             record(calls, 'createTransaction', args);
@@ -151,10 +151,6 @@ function makeDependencies(
         getDefaultShoppingCartScheduledDate: (...args: unknown[]) => {
             record(calls, 'getDefaultShoppingCartScheduledDate', args);
             return '2026-07-02';
-        },
-        getInventory: async (...args: unknown[]) => {
-            record(calls, 'getInventory', args);
-            return [];
         },
         getOutletOfferReservationForCartItem: async (...args: unknown[]) => {
             record(calls, 'getOutletOfferReservationForCartItem', args);
@@ -235,8 +231,9 @@ function makeDependencies(
         setCartItemPaid: async (...args: unknown[]) => {
             record(calls, 'setCartItemPaid', args);
         },
-        spendSunflowers: async (...args: unknown[]) => {
-            record(calls, 'spendSunflowers', args);
+        spendSunflowersBatch: async (...args: unknown[]) => {
+            record(calls, 'spendSunflowersBatch', args);
+            return { createdReasons: [], existingReasons: [] };
         },
         topUpSunflowerPackage: async (...args: unknown[]) => {
             record(calls, 'topUpSunflowerPackage', args);
@@ -810,16 +807,16 @@ describe('processCheckoutSession', () => {
             callNames(calls).filter((name) =>
                 [
                     'setCartItemPaid',
-                    'createOperation',
+                    'getOrCreateCheckoutOperation',
                     'earnSunflowersForPayment',
                     'markCartPaidIfAllItemsPaid',
                     'createTransaction',
                 ].includes(name),
             ),
             [
-                'setCartItemPaid',
-                'createOperation',
+                'getOrCreateCheckoutOperation',
                 'earnSunflowersForPayment',
+                'setCartItemPaid',
                 'markCartPaidIfAllItemsPaid',
                 'createTransaction',
             ],
@@ -852,6 +849,54 @@ describe('processCheckoutSession', () => {
             callsNamed(calls, 'ensureInvoiceForTransaction').length,
             0,
         );
+    });
+
+    it('retries operation fulfillment before marking a Stripe-paid item complete', async () => {
+        const calls: RecordedCall[] = [];
+        let itemStatus = 'open';
+        let operationAttempts = 0;
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return makeSession();
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                return {
+                    ...makeCart(),
+                    status: itemStatus === 'paid' ? 'paid' : 'new',
+                    items: [{ ...makeCart().items[0], status: itemStatus }],
+                };
+            },
+            getOrCreateCheckoutOperation: async (...args: unknown[]) => {
+                record(calls, 'getOrCreateCheckoutOperation', args);
+                operationAttempts += 1;
+                if (operationAttempts === 1) {
+                    throw new Error('transient schedule transaction failure');
+                }
+                return { created: true, operationId: 501 };
+            },
+            setCartItemPaid: async (...args: unknown[]) => {
+                record(calls, 'setCartItemPaid', args);
+                itemStatus = 'paid';
+            },
+        });
+
+        await assert.rejects(
+            processCheckoutSession('cs_paid', dependencies),
+            /transient schedule transaction failure/,
+        );
+        assert.strictEqual(itemStatus, 'open');
+        assert.strictEqual(callsNamed(calls, 'createTransaction').length, 0);
+
+        await processCheckoutSession('cs_paid', dependencies);
+        assert.strictEqual(itemStatus, 'paid');
+        assert.strictEqual(
+            callsNamed(calls, 'getOrCreateCheckoutOperation').length,
+            2,
+        );
+        assert.strictEqual(callsNamed(calls, 'setCartItemPaid').length, 1);
+        assert.strictEqual(callsNamed(calls, 'createTransaction').length, 1);
     });
 
     it('generates an invoice from mapped Stripe line items when billing automation is enabled', async () => {
@@ -2040,7 +2085,10 @@ describe('processCheckoutSession', () => {
         );
         assert.equal(operationItemStatus, 'paid');
         assert.equal(plantingItemStatus, 'open');
-        assert.equal(callsNamed(calls, 'createOperation').length, 1);
+        assert.equal(
+            callsNamed(calls, 'getOrCreateCheckoutOperation').length,
+            1,
+        );
         assert.equal(callsNamed(calls, 'createTransaction').length, 0);
 
         targetOccupied = false;
@@ -2048,7 +2096,10 @@ describe('processCheckoutSession', () => {
 
         assert.equal(operationItemStatus, 'paid');
         assert.equal(plantingItemStatus, 'paid');
-        assert.equal(callsNamed(calls, 'createOperation').length, 1);
+        assert.equal(
+            callsNamed(calls, 'getOrCreateCheckoutOperation').length,
+            1,
+        );
         assert.deepStrictEqual(
             callsNamed(calls, 'markCartPaidIfAllItemsPaid')
                 .slice(-2)
@@ -2085,7 +2136,7 @@ describe('processCheckoutSession', () => {
         assert.deepStrictEqual(billingEmailInput.cartIds, [100, 200]);
     });
 
-    it('continues when sunflower spending fails for non-Stripe cart items but leaves them unpaid', async () => {
+    it('keeps checkout retryable when sunflower spending fails for non-Stripe cart items', async () => {
         const calls: RecordedCall[] = [];
         const sunflowerItem = makeSunflowerCartItem();
         const dependencies = makeDependencies(calls, {
@@ -2116,25 +2167,26 @@ describe('processCheckoutSession', () => {
                     items: [sunflowerItem],
                 };
             },
-            spendSunflowers: async (...args: unknown[]) => {
-                record(calls, 'spendSunflowers', args);
+            spendSunflowersBatch: async (...args: unknown[]) => {
+                record(calls, 'spendSunflowersBatch', args);
                 throw new Error('insufficient sunflowers');
             },
         });
 
-        await processCheckoutSession('cs_paid', dependencies);
+        await assert.rejects(
+            processCheckoutSession('cs_paid', dependencies),
+            /insufficient sunflowers/,
+        );
 
-        assert.deepStrictEqual(callsNamed(calls, 'spendSunflowers')[0]?.args, [
-            'account-1',
-            5000,
-            'shoppingCart:100',
-        ]);
-        // Characterization: see plan 006 — this silent-swallow behavior is slated to change.
+        assert.deepStrictEqual(
+            callsNamed(calls, 'spendSunflowersBatch')[0]?.args,
+            ['account-1', [{ amount: 5000, reason: 'shoppingCartItem:2' }]],
+        );
         assert.deepStrictEqual(
             callsNamed(calls, 'setCartItemPaid').map((call) => call.args[0]),
             [1],
         );
-        assert.equal(callsNamed(calls, 'createTransaction').length, 1);
+        assert.equal(callsNamed(calls, 'createTransaction').length, 0);
     });
 
     it('uses the canonical harvest date for a mixed checkout and ignores a later non-Stripe cart item', async () => {
@@ -2211,32 +2263,33 @@ describe('processCheckoutSession', () => {
 
         await processCheckoutSession('cs_paid', dependencies);
 
-        assert.deepStrictEqual(callsNamed(calls, 'spendSunflowers')[0]?.args, [
-            'account-1',
-            5000,
-            'shoppingCart:100',
-        ]);
+        assert.deepStrictEqual(
+            callsNamed(calls, 'spendSunflowersBatch')[0]?.args,
+            ['account-1', [{ amount: 5000, reason: 'shoppingCartItem:2' }]],
+        );
         assert.deepStrictEqual(
             callsNamed(calls, 'setCartItemPaid').map((call) => call.args[0]),
             [1, 2],
         );
         assert.deepStrictEqual(
-            callsNamed(calls, 'createOperation').map((call) =>
-                isRecord(call.args[0]) ? call.args[0].entityId : undefined,
+            callsNamed(calls, 'getOrCreateCheckoutOperation').map((call) =>
+                isRecord(call.args[1]) ? call.args[1].entityId : undefined,
             ),
             [42, 99],
         );
 
-        const scheduledEvents = callsNamed(calls, 'createEvent')
-            .map((call) => call.args[0])
-            .filter(isRecordedEvent)
-            .filter((event) => event.type === 'operations.scheduled');
-        assert.equal(scheduledEvents.length, 2);
+        const scheduledOperations = callsNamed(
+            calls,
+            'getOrCreateCheckoutOperation',
+        );
+        assert.equal(scheduledOperations.length, 2);
         assert.ok(
-            scheduledEvents.some(
-                (event) =>
-                    isRecord(event.data) &&
-                    event.data.scheduledDate === canonicalHarvestDate,
+            scheduledOperations.some(
+                (call) =>
+                    isRecord(call.args[2]) &&
+                    call.args[2].scheduledDate instanceof Date &&
+                    call.args[2].scheduledDate.toISOString() ===
+                        new Date(canonicalHarvestDate).toISOString(),
             ),
         );
         assert.equal(
@@ -2246,10 +2299,10 @@ describe('processCheckoutSession', () => {
             false,
         );
         assert.equal(
-            callsNamed(calls, 'createOperation').some(
+            callsNamed(calls, 'getOrCreateCheckoutOperation').some(
                 (call) =>
-                    isRecord(call.args[0]) &&
-                    call.args[0].entityId ===
+                    isRecord(call.args[1]) &&
+                    call.args[1].entityId ===
                         Number(laterSunflowerItem.entityId),
             ),
             false,
@@ -2288,7 +2341,10 @@ describe('processItem', () => {
             'getRaisedBed',
             'isRaisedBedAbandoned',
         ]);
-        assert.equal(callsNamed(calls, 'createOperation').length, 0);
+        assert.equal(
+            callsNamed(calls, 'getOrCreateCheckoutOperation').length,
+            0,
+        );
     });
 
     it('uses greenhouse sowing location from scheduled plant additional data', async () => {
@@ -2362,17 +2418,15 @@ describe('processItem', () => {
         assert.deepStrictEqual(
             callNames(calls).filter((name) =>
                 [
-                    'createOperation',
+                    'getOrCreateCheckoutOperation',
                     'earnSunflowersForPayment',
-                    'createEvent',
                     'notifyOperationUpdate',
                     'isCartItemDeliverable',
                 ].includes(name),
             ),
             [
-                'createOperation',
+                'getOrCreateCheckoutOperation',
                 'earnSunflowersForPayment',
-                'createEvent',
                 'notifyOperationUpdate',
                 'isCartItemDeliverable',
             ],
@@ -2380,6 +2434,164 @@ describe('processItem', () => {
         assert.deepStrictEqual(
             callsNamed(calls, 'earnSunflowersForPayment')[0]?.args,
             ['account-1', 25],
+        );
+    });
+
+    it('reuses a checkout operation without repeating its side effects', async () => {
+        const calls: RecordedCall[] = [];
+        const dependencies = makeDependencies(calls, {
+            getOrCreateCheckoutOperation: async (...args: unknown[]) => {
+                record(calls, 'getOrCreateCheckoutOperation', args);
+                return { created: false, operationId: 501 };
+            },
+        });
+
+        await processItem(
+            {
+                accountId: 'account-1',
+                amount_total: 2500,
+                additionalData: { scheduledDate: '2026-07-01' },
+                cartId: 100,
+                cartItemId: 1,
+                currency: 'eur',
+                entityId: '42',
+                entityTypeName: 'operation',
+                gardenId: 200,
+                positionIndex: null,
+                raisedBedId: null,
+            },
+            dependencies,
+        );
+
+        assert.equal(
+            callsNamed(calls, 'getOrCreateCheckoutOperation').length,
+            1,
+        );
+        assert.equal(callsNamed(calls, 'earnSunflowersForPayment').length, 0);
+        assert.equal(callsNamed(calls, 'notifyOperationUpdate').length, 0);
+    });
+
+    it('reuses a delivery request without repeating its notifications', async () => {
+        const calls: RecordedCall[] = [];
+        const dependencies = makeDependencies(calls, {
+            getOrCreateCheckoutOperation: async (...args: unknown[]) => {
+                record(calls, 'getOrCreateCheckoutOperation', args);
+                return { created: false, operationId: 501 };
+            },
+            isCartItemDeliverable: async (...args: unknown[]) => {
+                record(calls, 'isCartItemDeliverable', args);
+                return true;
+            },
+            getOrCreateDeliveryRequest: async (...args: unknown[]) => {
+                record(calls, 'getOrCreateDeliveryRequest', args);
+                return {
+                    created: false,
+                    requestId: 'delivery-request-701',
+                };
+            },
+        });
+
+        await processItem(
+            {
+                accountId: 'account-1',
+                amount_total: 2500,
+                additionalData: {
+                    scheduledDate: '2026-07-01',
+                    delivery: {
+                        slotId: 9,
+                        mode: 'pickup',
+                        locationId: 4,
+                    },
+                },
+                cartId: 100,
+                cartItemId: 1,
+                currency: 'sunflower',
+                entityId: '42',
+                entityTypeName: 'operation',
+                gardenId: 200,
+                positionIndex: null,
+                raisedBedId: null,
+            },
+            dependencies,
+        );
+
+        assert.equal(callsNamed(calls, 'getOrCreateDeliveryRequest').length, 1);
+        assert.equal(callsNamed(calls, 'notifyDeliveryRequestEvent').length, 0);
+        assert.equal(
+            callsNamed(calls, 'notifyScheduledDeliveryEmailOnce').length,
+            0,
+        );
+    });
+
+    it('retries delivery creation without duplicating the scheduled operation', async () => {
+        const calls: RecordedCall[] = [];
+        let operationAttempt = 0;
+        let deliveryAttempt = 0;
+        const dependencies = makeDependencies(calls, {
+            getOrCreateCheckoutOperation: async (...args: unknown[]) => {
+                record(calls, 'getOrCreateCheckoutOperation', args);
+                operationAttempt += 1;
+                return {
+                    created: operationAttempt === 1,
+                    operationId: 501,
+                };
+            },
+            isCartItemDeliverable: async (...args: unknown[]) => {
+                record(calls, 'isCartItemDeliverable', args);
+                return true;
+            },
+            getOrCreateDeliveryRequest: async (...args: unknown[]) => {
+                record(calls, 'getOrCreateDeliveryRequest', args);
+                deliveryAttempt += 1;
+                if (deliveryAttempt === 1) {
+                    throw new Error('transient delivery database failure');
+                }
+                return {
+                    created: true,
+                    requestId: 'delivery-request-701',
+                };
+            },
+        });
+        const item = {
+            accountId: 'account-1',
+            amount_total: 2500,
+            additionalData: {
+                scheduledDate: '2026-07-01',
+                delivery: {
+                    slotId: 9,
+                    mode: 'pickup' as const,
+                    locationId: 4,
+                },
+            },
+            cartId: 100,
+            cartItemId: 1,
+            currency: 'eur',
+            entityId: '42',
+            entityTypeName: 'operation',
+            gardenId: 200,
+            positionIndex: null,
+            raisedBedId: null,
+        };
+
+        const first = await processItem(item, dependencies);
+        const retry = await processItem(item, dependencies);
+
+        assert.deepStrictEqual(first, {
+            status: 'not_fulfilled',
+            reason: 'delivery_request_failed',
+        });
+        assert.deepStrictEqual(retry, { status: 'fulfilled' });
+        assert.equal(
+            callsNamed(calls, 'getOrCreateCheckoutOperation').length,
+            2,
+        );
+        assert.equal(callsNamed(calls, 'earnSunflowersForPayment').length, 1);
+        assert.equal(callsNamed(calls, 'notifyOperationUpdate').length, 1);
+        assert.equal(callsNamed(calls, 'getOrCreateDeliveryRequest').length, 2);
+        assert.equal(callsNamed(calls, 'notifyDeliveryRequestEvent').length, 1);
+        assert.equal(
+            callsNamed(calls, 'notifyScheduledDeliveryEmailOnce').length,
+            1,
         );
     });
 

--- a/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
@@ -53,6 +53,14 @@ function makeDependencies(
         Record<keyof ProcessCheckoutSessionDependencies, unknown>
     > = {},
 ): ProcessCheckoutSessionDependencies {
+    const readShoppingCart = async (...args: unknown[]) => {
+        const override = overrides.getShoppingCart;
+        if (typeof override === 'function') {
+            return override(...args);
+        }
+        record(calls, 'getShoppingCart', args);
+        return null;
+    };
     const dependencies = {
         isRaisedBedAbandoned: (status: unknown) => {
             record(calls, 'isRaisedBedAbandoned', [status]);
@@ -148,6 +156,24 @@ function makeDependencies(
             record(calls, 'getCompletedTransactionByStripePaymentId', args);
             return undefined;
         },
+        getCheckoutFulfillmentStartedCartItemIds: async (
+            ...args: unknown[]
+        ) => {
+            record(calls, 'getCheckoutFulfillmentStartedCartItemIds', args);
+            return new Set<number>();
+        },
+        getCheckoutOperationMapping: async (...args: unknown[]) => {
+            record(calls, 'getCheckoutOperationMapping', args);
+            return null;
+        },
+        getCheckoutOperationMappings: async (...args: unknown[]) => {
+            record(calls, 'getCheckoutOperationMappings', args);
+            return new Map();
+        },
+        hasMatchingCheckoutPlantingPurchase: async (...args: unknown[]) => {
+            record(calls, 'hasMatchingCheckoutPlantingPurchase', args);
+            return false;
+        },
         getDefaultShoppingCartScheduledDate: (...args: unknown[]) => {
             record(calls, 'getDefaultShoppingCartScheduledDate', args);
             return '2026-07-02';
@@ -164,10 +190,7 @@ function makeDependencies(
             record(calls, 'getRaisedBedFieldsWithEvents', args);
             return [];
         },
-        getShoppingCart: async (...args: unknown[]) => {
-            record(calls, 'getShoppingCart', args);
-            return null;
-        },
+        getShoppingCart: readShoppingCart,
         getUser: async (...args: unknown[]) => {
             record(calls, 'getUser', args);
             return { userName: 'buyer@example.test' };
@@ -210,6 +233,10 @@ function makeDependencies(
             record(calls, 'lockAndActivateRaisedBedForCheckoutPlanting', args);
             return { available: true, activatedAccountId: null };
         },
+        lockShoppingCartForCheckout: async (...args: unknown[]) => {
+            record(calls, 'lockShoppingCartForCheckout', args.slice(0, 1));
+            return readShoppingCart(...args);
+        },
         markCartPaidIfAllItemsPaid: async (cartId: unknown) => {
             record(calls, 'markCartPaidIfAllItemsPaid', [cartId]);
         },
@@ -233,7 +260,16 @@ function makeDependencies(
         },
         spendSunflowersBatch: async (...args: unknown[]) => {
             record(calls, 'spendSunflowersBatch', args);
-            return { createdReasons: [], existingReasons: [] };
+            const items = Array.isArray(args[1])
+                ? (args[1] as Array<{ amount: number; reason: string }>)
+                : [];
+            return {
+                createdReasons: items.map((item) => item.reason),
+                existingReasons: [],
+                resolvedAmountsByReason: Object.fromEntries(
+                    items.map((item) => [item.reason, item.amount]),
+                ),
+            };
         },
         topUpSunflowerPackage: async (...args: unknown[]) => {
             record(calls, 'topUpSunflowerPackage', args);
@@ -256,6 +292,60 @@ function makeDependencies(
                 throw new Error('Missing planting transaction callback.');
             }
             return callback({ transaction: 'planting-test' });
+        },
+        withCheckoutCartItemLock: async (...args: unknown[]) => {
+            record(calls, 'withCheckoutCartItemLock', args.slice(0, 1));
+            const callback = args[1];
+            if (typeof callback !== 'function') {
+                throw new Error('Missing checkout cart item lock callback.');
+            }
+            return callback({ transaction: 'checkout-item-test' });
+        },
+        withCheckoutCartItemLocks: async (...args: unknown[]) => {
+            record(calls, 'withCheckoutCartItemLocks', args.slice(0, 1));
+            const callback = args[1];
+            if (typeof callback !== 'function') {
+                throw new Error('Missing checkout cart item locks callback.');
+            }
+            return callback({ transaction: 'checkout-items-test' });
+        },
+        withCheckoutCartItemProcessingLock: async (...args: unknown[]) => {
+            record(
+                calls,
+                'withCheckoutCartItemProcessingLock',
+                args.slice(0, 1),
+            );
+            const callback = args[1];
+            if (typeof callback !== 'function') {
+                throw new Error(
+                    'Missing checkout cart item processing lock callback.',
+                );
+            }
+            return callback();
+        },
+        withCheckoutCartItemProcessingLocks: async (...args: unknown[]) => {
+            record(
+                calls,
+                'withCheckoutCartItemProcessingLocks',
+                args.slice(0, 1),
+            );
+            const callback = args[1];
+            if (typeof callback !== 'function') {
+                throw new Error(
+                    'Missing checkout cart item processing locks callback.',
+                );
+            }
+            return callback();
+        },
+        withInventoryAccountTransaction: async (...args: unknown[]) => {
+            record(calls, 'withInventoryAccountTransaction', args.slice(0, 1));
+            const callback = args[1];
+            if (typeof callback !== 'function') {
+                throw new Error('Missing inventory transaction callback.');
+            }
+            return callback(
+                args[2] ?? { transaction: 'inventory-account-test' },
+            );
         },
         withStripePaymentProcessingLock: async (
             id: string,
@@ -534,6 +624,31 @@ function makePlantingCart(status: 'open' | 'paid' = 'open') {
     };
 }
 
+function makeDetailedPlantingCart() {
+    const cart = makePlantingCart();
+    const item = cart.items[0];
+    if (!item) {
+        throw new Error('Planting cart fixture is invalid.');
+    }
+    return {
+        ...cart,
+        items: [
+            {
+                ...item,
+                additionalData: JSON.stringify({
+                    scheduledDate: '2026-07-01',
+                }),
+                amount: 1,
+                cartId: cart.id,
+                createdAt: new Date('2026-07-01T09:00:00.000Z'),
+                currency: 'eur',
+                gardenId: 200,
+                positionIndex: 2,
+            },
+        ],
+    };
+}
+
 function makeSunflowerCartItem() {
     return {
         id: 2,
@@ -547,6 +662,8 @@ function makeSunflowerCartItem() {
         positionIndex: 3,
         amount: 1,
         additionalData: null,
+        createdAt: new Date('2026-07-01T10:00:00.000Z'),
+        entityData: { attributes: { deliverable: false } },
         usesInventory: false,
         shopData: {
             price: 5,
@@ -814,8 +931,8 @@ describe('processCheckoutSession', () => {
                 ].includes(name),
             ),
             [
-                'getOrCreateCheckoutOperation',
                 'earnSunflowersForPayment',
+                'getOrCreateCheckoutOperation',
                 'setCartItemPaid',
                 'markCartPaidIfAllItemsPaid',
                 'createTransaction',
@@ -826,8 +943,22 @@ describe('processCheckoutSession', () => {
             [1],
         );
         assert.deepStrictEqual(
+            callsNamed(calls, 'withCheckoutCartItemLock')[0]?.args,
+            [1],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'withCheckoutCartItemProcessingLock')[0]?.args,
+            [1],
+        );
+        assert.deepStrictEqual(
             callsNamed(calls, 'earnSunflowersForPayment')[0]?.args,
-            ['account-1', 25],
+            [
+                'account-1',
+                25,
+                'shoppingCartItem:1',
+                { transaction: 'checkout-item-test' },
+                { legacyRewardAlreadyEarned: false },
+            ],
         );
         assert.deepStrictEqual(
             callsNamed(calls, 'markCartPaidIfAllItemsPaid')[0]?.args,
@@ -849,6 +980,134 @@ describe('processCheckoutSession', () => {
             callsNamed(calls, 'ensureInvoiceForTransaction').length,
             0,
         );
+    });
+
+    it('passes exact legacy planting evidence into the keyed payment reward', async () => {
+        for (const legacyRewardAlreadyEarned of [false, true]) {
+            const calls: RecordedCall[] = [];
+            const plantingCart = makeDetailedPlantingCart();
+            const dependencies = makeDependencies(calls, {
+                getStripeCheckoutSession: async (...args: unknown[]) => {
+                    record(calls, 'getStripeCheckoutSession', args);
+                    return makePlantingSession();
+                },
+                getShoppingCart: async (...args: unknown[]) => {
+                    record(calls, 'getShoppingCart', args);
+                    return plantingCart;
+                },
+                getRaisedBed: async (...args: unknown[]) => {
+                    record(calls, 'getRaisedBed', args);
+                    return { status: 'active' };
+                },
+                hasMatchingCheckoutPlantingPurchase: async (
+                    ...args: unknown[]
+                ) => {
+                    record(calls, 'hasMatchingCheckoutPlantingPurchase', args);
+                    return legacyRewardAlreadyEarned;
+                },
+            });
+
+            await processCheckoutSession('cs_paid', dependencies);
+
+            assert.deepStrictEqual(
+                callsNamed(calls, 'hasMatchingCheckoutPlantingPurchase')[0]
+                    ?.args,
+                [
+                    {
+                        cartItemId: 1,
+                        euroAmountCents: 2_500,
+                        plantSortId: '101',
+                        positionIndex: 2,
+                        raisedBedId: 300,
+                    },
+                    { transaction: 'checkout-item-test' },
+                ],
+            );
+            assert.deepStrictEqual(
+                callsNamed(calls, 'earnSunflowersForPayment')[0]?.args,
+                [
+                    'account-1',
+                    25,
+                    'shoppingCartItem:1',
+                    { transaction: 'checkout-item-test' },
+                    { legacyRewardAlreadyEarned },
+                ],
+            );
+        }
+    });
+
+    it('fails before rewarding or fulfilling when legacy planting evidence conflicts', async () => {
+        const calls: RecordedCall[] = [];
+        const plantingCart = makeDetailedPlantingCart();
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return makePlantingSession();
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                return plantingCart;
+            },
+            hasMatchingCheckoutPlantingPurchase: async (...args: unknown[]) => {
+                record(calls, 'hasMatchingCheckoutPlantingPurchase', args);
+                throw new Error('legacy planting purchase conflicts');
+            },
+        });
+
+        await assert.rejects(
+            processCheckoutSession('cs_paid', dependencies),
+            /legacy planting purchase conflicts/,
+        );
+
+        assert.equal(callsNamed(calls, 'earnSunflowersForPayment').length, 0);
+        assert.equal(callsNamed(calls, 'createEvent').length, 0);
+        assert.equal(callsNamed(calls, 'setCartItemPaid').length, 0);
+        assert.equal(callsNamed(calls, 'createTransaction').length, 0);
+    });
+
+    it('rejects Stripe metadata that does not match the cart owner before any payment effect', async () => {
+        const calls: RecordedCall[] = [];
+        const session = makeSession();
+        const lineItem = session.lineItems.data[0];
+        const product = lineItem?.price.product;
+        assert.ok(lineItem && product);
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return {
+                    ...session,
+                    lineItems: {
+                        data: [
+                            {
+                                ...lineItem,
+                                price: {
+                                    product: {
+                                        ...product,
+                                        metadata: {
+                                            ...product.metadata,
+                                            accountId: 'different-account',
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                };
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                return makeCart();
+            },
+        });
+
+        await assert.rejects(
+            processCheckoutSession('cs_paid', dependencies),
+            /metadata account does not own cart/u,
+        );
+
+        assert.equal(callsNamed(calls, 'earnSunflowersForPayment').length, 0);
+        assert.equal(callsNamed(calls, 'setCartItemPaid').length, 0);
+        assert.equal(callsNamed(calls, 'createTransaction').length, 0);
     });
 
     it('retries operation fulfillment before marking a Stripe-paid item complete', async () => {
@@ -897,6 +1156,71 @@ describe('processCheckoutSession', () => {
         );
         assert.strictEqual(callsNamed(calls, 'setCartItemPaid').length, 1);
         assert.strictEqual(callsNamed(calls, 'createTransaction').length, 1);
+    });
+
+    it('finishes a mapped Stripe operation after its raised bed is abandoned', async () => {
+        const calls: RecordedCall[] = [];
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return makeSession();
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                return makeCart();
+            },
+            getCheckoutOperationMapping: async (...args: unknown[]) => {
+                record(calls, 'getCheckoutOperationMapping', args);
+                return {
+                    operationId: 501,
+                    accountId: 'account-1',
+                    entityId: 42,
+                    entityTypeName: 'operation',
+                    farmId: null,
+                    gardenId: 200,
+                    raisedBedId: 300,
+                    raisedBedFieldId: 88,
+                    operationTimestamp: null,
+                    paymentCurrency: 'eur',
+                    delivery: null,
+                    scheduledDate: '2026-07-01T00:00:00.000Z',
+                    accepted: false,
+                };
+            },
+            getRaisedBed: async (...args: unknown[]) => {
+                record(calls, 'getRaisedBed', args);
+                return { status: 'abandoned' };
+            },
+            getOrCreateCheckoutOperation: async (...args: unknown[]) => {
+                record(calls, 'getOrCreateCheckoutOperation', args);
+                return { created: false, operationId: 501 };
+            },
+        });
+
+        await processCheckoutSession('cs_paid', dependencies);
+
+        assert.equal(
+            callsNamed(calls, 'getCheckoutOperationMapping').length,
+            1,
+        );
+        assert.equal(callsNamed(calls, 'getRaisedBed').length, 0);
+        assert.equal(callsNamed(calls, 'isRaisedBedAbandoned').length, 0);
+        assert.deepEqual(callsNamed(calls, 'setCartItemPaid')[0]?.args, [1]);
+        const operationCall = callsNamed(
+            calls,
+            'getOrCreateCheckoutOperation',
+        )[0];
+        assert.ok(operationCall);
+        const operationInput = operationCall.args[1];
+        assert.ok(isRecord(operationInput));
+        assert.equal(operationInput.raisedBedFieldId, 88);
+        const operationOptions = operationCall.args[2];
+        assert.ok(isRecord(operationOptions));
+        assert.ok(operationOptions.scheduledDate instanceof Date);
+        assert.equal(
+            operationOptions.scheduledDate.toISOString(),
+            '2026-07-01T00:00:00.000Z',
+        );
     });
 
     it('generates an invoice from mapped Stripe line items when billing automation is enabled', async () => {
@@ -1620,11 +1944,11 @@ describe('processCheckoutSession', () => {
             ).length,
             1,
         );
-        assert.equal(
-            writtenEvents.filter(
-                (event) => event.type === 'accounts.sunflowersEarned',
-            ).length,
-            1,
+        assert.deepStrictEqual(
+            callsNamed(calls, 'earnSunflowersForPayment').map(
+                (call) => call.args[2],
+            ),
+            ['shoppingCartItem:1', 'shoppingCartItem:1'],
         );
         assert.equal(activePlantCycle?.plantStatus, 'sprouted');
         assert.equal(raisedBedStatus, 'active');
@@ -1671,6 +1995,22 @@ describe('processCheckoutSession', () => {
                 record(calls, 'getRaisedBed', args);
                 return { status: 'active' };
             },
+            withCheckoutCartItemLock: async (...args: unknown[]) => {
+                record(calls, 'checkoutItemLock.enter', args.slice(0, 1));
+                const callback = args[1];
+                if (typeof callback !== 'function') {
+                    throw new Error(
+                        'Missing checkout cart item lock callback.',
+                    );
+                }
+                try {
+                    return await callback({
+                        transaction: 'checkout-item-test',
+                    });
+                } finally {
+                    record(calls, 'checkoutItemLock.exit', args.slice(0, 1));
+                }
+            },
             withPlantingScheduleTaskTransaction: async (
                 _raisedBedId: number,
                 _positionIndex: number,
@@ -1711,6 +2051,14 @@ describe('processCheckoutSession', () => {
             ?.args[0];
         assert.ok(isRecord(incident));
         assert.equal(incident.type, 'checkout_planting_raised_bed_unavailable');
+        assert.ok(
+            callNames(calls).indexOf('earnSunflowersForPayment') <
+                callNames(calls).indexOf('checkoutItemLock.exit'),
+        );
+        assert.ok(
+            callNames(calls).indexOf('checkoutItemLock.exit') <
+                callNames(calls).indexOf('createNotificationWithStatus'),
+        );
     });
 
     it('keeps an initially abandoned paid planting recoverable and fulfills it after reactivation', async () => {
@@ -1995,7 +2343,7 @@ describe('processCheckoutSession', () => {
         assert.equal(conflictCaptures.length, 2);
     });
 
-    it('rebuilds all invoice lines and cart finalization after a later planting item retries', async () => {
+    it('continues later paid lines after an earlier failure and rebuilds finalization on retry', async () => {
         const calls: RecordedCall[] = [];
         let operationItemStatus: 'open' | 'paid' = 'open';
         let plantingItemStatus: 'open' | 'paid' = 'open';
@@ -2033,7 +2381,13 @@ describe('processCheckoutSession', () => {
         const dependencies = makeDependencies(calls, {
             getStripeCheckoutSession: async (...args: unknown[]) => {
                 record(calls, 'getStripeCheckoutSession', args);
-                return makeMultiLinePlantingSession();
+                const session = makeMultiLinePlantingSession();
+                return {
+                    ...session,
+                    lineItems: {
+                        data: [...session.lineItems.data].reverse(),
+                    },
+                };
             },
             getShoppingCart: async (...args: unknown[]) => {
                 record(calls, 'getShoppingCart', args);
@@ -2104,7 +2458,7 @@ describe('processCheckoutSession', () => {
             callsNamed(calls, 'markCartPaidIfAllItemsPaid')
                 .slice(-2)
                 .map((call) => call.args[0]),
-            [100, 200],
+            [200, 100],
         );
         assert.equal(callsNamed(calls, 'createTransaction').length, 1);
         const invoiceInput = callsNamed(calls, 'ensureInvoiceForTransaction')[0]
@@ -2115,7 +2469,7 @@ describe('processCheckoutSession', () => {
             invoiceInput.items.map((item) =>
                 isRecord(item) ? item.entityTypeName : null,
             ),
-            ['operation', 'plantSort'],
+            ['plantSort', 'operation'],
         );
         assert.equal(
             callsNamed(calls, 'createEvent')
@@ -2126,14 +2480,114 @@ describe('processCheckoutSession', () => {
                         event.type === 'raisedBedFields.plantPlace' ||
                         event.type === 'accounts.sunflowersEarned',
                 ).length,
-            2,
+            1,
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'earnSunflowersForPayment').map(
+                (call) => call.args[2],
+            ),
+            ['shoppingCartItem:2', 'shoppingCartItem:1', 'shoppingCartItem:2'],
         );
         const billingEmailInput = callsNamed(
             calls,
             'notifyBillingDocumentsEmail',
         )[0]?.args[0];
         assert.ok(isRecord(billingEmailInput));
-        assert.deepStrictEqual(billingEmailInput.cartIds, [100, 200]);
+        assert.deepStrictEqual(billingEmailInput.cartIds, [200, 100]);
+    });
+
+    it('keeps finalization retryable when an earlier paid line cannot be resolved', async () => {
+        const calls: RecordedCall[] = [];
+        const baseSession = makeSession();
+        const validLine = baseSession.lineItems.data[0];
+        const validProduct = validLine?.price.product;
+        assert.ok(validLine && validProduct);
+
+        let repairedMalformedLine = false;
+        const itemStatuses = new Map<number, 'open' | 'paid'>([
+            [1, 'open'],
+            [2, 'open'],
+        ]);
+        const repairedLine = {
+            ...validLine,
+            id: 'li_repaired',
+            price: {
+                product: {
+                    ...validProduct,
+                    id: 'prod_repaired',
+                    metadata: {
+                        ...validProduct.metadata,
+                        cartId: '200',
+                        cartItemId: '2',
+                        entityId: '43',
+                    },
+                },
+            },
+        };
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return {
+                    ...baseSession,
+                    amountTotal: 5000,
+                    lineItems: {
+                        data: [
+                            repairedMalformedLine
+                                ? repairedLine
+                                : {
+                                      ...repairedLine,
+                                      price: { product: 'prod_repaired' },
+                                  },
+                            validLine,
+                        ],
+                    },
+                };
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                const cartId = Number(args[0]);
+                const itemId = cartId === 100 ? 1 : 2;
+                return {
+                    id: cartId,
+                    accountId: 'account-1',
+                    status:
+                        itemStatuses.get(itemId) === 'paid' ? 'paid' : 'new',
+                    items: [
+                        {
+                            id: itemId,
+                            status: itemStatuses.get(itemId) ?? 'open',
+                            entityId: itemId === 1 ? '42' : '43',
+                            entityTypeName: 'operation',
+                            raisedBedId: 300,
+                        },
+                    ],
+                };
+            },
+            setCartItemPaid: async (...args: unknown[]) => {
+                record(calls, 'setCartItemPaid', args);
+                itemStatuses.set(Number(args[0]), 'paid');
+            },
+        });
+
+        await assert.rejects(
+            processCheckoutSession('cs_paid', dependencies),
+            /unexpanded product/,
+        );
+        assert.equal(itemStatuses.get(1), 'paid');
+        assert.equal(itemStatuses.get(2), 'open');
+        assert.equal(callsNamed(calls, 'createTransaction').length, 0);
+
+        repairedMalformedLine = true;
+        await processCheckoutSession('cs_paid', dependencies);
+
+        assert.equal(itemStatuses.get(1), 'paid');
+        assert.equal(itemStatuses.get(2), 'paid');
+        assert.equal(callsNamed(calls, 'createTransaction').length, 1);
+        assert.equal(
+            callsNamed(calls, 'getCompletedTransactionByStripePaymentId')
+                .length,
+            2,
+        );
     });
 
     it('keeps checkout retryable when sunflower spending fails for non-Stripe cart items', async () => {
@@ -2146,7 +2600,8 @@ describe('processCheckoutSession', () => {
             },
             getShoppingCart: async (...args: unknown[]) => {
                 record(calls, 'getShoppingCart', args);
-                return makeCart();
+                const cart = makeCart();
+                return { ...cart, items: [...cart.items, sunflowerItem] };
             },
             getRaisedBedFieldsWithEvents: async (...args: unknown[]) => {
                 record(calls, 'getRaisedBedFieldsWithEvents', args);
@@ -2180,13 +2635,485 @@ describe('processCheckoutSession', () => {
 
         assert.deepStrictEqual(
             callsNamed(calls, 'spendSunflowersBatch')[0]?.args,
-            ['account-1', [{ amount: 5000, reason: 'shoppingCartItem:2' }]],
+            [
+                'account-1',
+                [{ amount: 5000, reason: 'shoppingCartItem:2' }],
+                { transaction: 'checkout-items-test' },
+                {
+                    existingCheckoutItemAmountsAreAuthoritative: true,
+                    legacyCartSpend: {
+                        reason: 'shoppingCart:100',
+                        coveredItems: [
+                            {
+                                amount: 5000,
+                                cartItemId: 2,
+                                createdAt: new Date('2026-07-01T10:00:00.000Z'),
+                                reason: 'shoppingCartItem:2',
+                            },
+                        ],
+                    },
+                },
+            ],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'withCheckoutCartItemLocks')[0]?.args,
+            [[2]],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'withCheckoutCartItemProcessingLocks')[0]?.args,
+            [[2]],
         );
         assert.deepStrictEqual(
             callsNamed(calls, 'setCartItemPaid').map((call) => call.args[0]),
             [1],
         );
         assert.equal(callsNamed(calls, 'createTransaction').length, 0);
+    });
+
+    it('rejects malformed non-Stripe additional data before committing its payment marker', async () => {
+        const calls: RecordedCall[] = [];
+        const malformedItem = {
+            ...makeSunflowerCartItem(),
+            additionalData: '[',
+        };
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return {
+                    ...makeSession(),
+                    metadata: encodeHarvestDatesMetadata(
+                        [],
+                        [malformedItem.id],
+                    ),
+                };
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                const cart = makeCart();
+                return { ...cart, items: [...cart.items, malformedItem] };
+            },
+            normalizeShoppingCartInventoryUsage: async (...args: unknown[]) => {
+                record(calls, 'normalizeShoppingCartInventoryUsage', args);
+                return { id: 100, items: [malformedItem] };
+            },
+            getCartInfo: async (...args: unknown[]) => {
+                record(calls, 'getCartInfo', args);
+                return {
+                    allowPurchase: true,
+                    notes: [],
+                    items: [malformedItem],
+                };
+            },
+        });
+
+        await assert.rejects(
+            processCheckoutSession('cs_paid', dependencies),
+            (error) => error instanceof SyntaxError,
+        );
+
+        assert.equal(callsNamed(calls, 'spendSunflowersBatch').length, 0);
+        assert.equal(callsNamed(calls, 'consumeInventoryItem').length, 0);
+        assert.equal(callsNamed(calls, 'createTransaction').length, 0);
+    });
+
+    it('resumes a direct-currency item that already has a durable checkout effect', async () => {
+        const calls: RecordedCall[] = [];
+        const sunflowerItem = {
+            ...makeSunflowerCartItem(),
+            entityData: { attributes: { deliverable: false } },
+        };
+        let cartInfoCalls = 0;
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return {
+                    ...makeSession(),
+                    metadata: encodeHarvestDatesMetadata(
+                        [],
+                        [sunflowerItem.id],
+                    ),
+                };
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                const cart = makeCart();
+                return { ...cart, items: [...cart.items, sunflowerItem] };
+            },
+            normalizeShoppingCartInventoryUsage: async (...args: unknown[]) => {
+                record(calls, 'normalizeShoppingCartInventoryUsage', args);
+                return { id: 100, items: [sunflowerItem] };
+            },
+            getCheckoutFulfillmentStartedCartItemIds: async (
+                ...args: unknown[]
+            ) => {
+                record(calls, 'getCheckoutFulfillmentStartedCartItemIds', args);
+                return new Set([sunflowerItem.id]);
+            },
+            getCartInfo: async (...args: unknown[]) => {
+                record(calls, 'getCartInfo', args);
+                cartInfoCalls += 1;
+                return {
+                    allowPurchase: cartInfoCalls > 1,
+                    notes:
+                        cartInfoCalls > 1
+                            ? []
+                            : ['raised bed is temporarily unavailable'],
+                    items: [sunflowerItem],
+                };
+            },
+        });
+
+        await processCheckoutSession('cs_paid', dependencies);
+
+        assert.equal(callsNamed(calls, 'getCartInfo').length, 2);
+        const recoveryOptions = callsNamed(calls, 'getCartInfo')[1]?.args[2];
+        assert.ok(isRecord(recoveryOptions));
+        assert.ok(recoveryOptions.resumableCartItemIds instanceof Set);
+        assert.equal(
+            recoveryOptions.resumableCartItemIds.has(sunflowerItem.id),
+            true,
+        );
+        assert.equal(callsNamed(calls, 'spendSunflowersBatch').length, 1);
+        assert.deepStrictEqual(
+            callsNamed(calls, 'setCartItemPaid').map((call) => call.args[0]),
+            [1, 2],
+        );
+    });
+
+    it('covers paid and pending legacy sunflower items and fulfills with the durable resolved amount', async () => {
+        const calls: RecordedCall[] = [];
+        const paidSunflowerItem = {
+            ...makeSunflowerCartItem(),
+            shopData: { discountPrice: 0, price: 5 },
+            status: 'paid',
+        };
+        const pendingSunflowerItem = {
+            ...makeSunflowerCartItem(),
+            createdAt: new Date('2026-07-01T10:05:00.000Z'),
+            entityId: '101',
+            entityTypeName: 'plantSort',
+            id: 3,
+            positionIndex: 4,
+            shopData: { discountPrice: 7, price: 7 },
+        };
+        const allCartItems = [
+            ...makeCart().items,
+            paidSunflowerItem,
+            pendingSunflowerItem,
+        ];
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return {
+                    ...makeSession(),
+                    metadata: encodeHarvestDatesMetadata(
+                        [],
+                        [paidSunflowerItem.id, pendingSunflowerItem.id],
+                    ),
+                };
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                return {
+                    ...makeCart(),
+                    status: 'new',
+                    items: allCartItems,
+                };
+            },
+            normalizeShoppingCartInventoryUsage: async (...args: unknown[]) => {
+                record(calls, 'normalizeShoppingCartInventoryUsage', args);
+                return {
+                    id: 100,
+                    items: [paidSunflowerItem, pendingSunflowerItem],
+                };
+            },
+            getCartInfo: async (...args: unknown[]) => {
+                record(calls, 'getCartInfo', args);
+                return {
+                    allowPurchase: true,
+                    notes: [],
+                    items: [paidSunflowerItem, pendingSunflowerItem],
+                };
+            },
+            calculateSunflowerAmount: (...args: unknown[]) => {
+                record(calls, 'calculateSunflowerAmount', args);
+                return 7_000;
+            },
+            spendSunflowersBatch: async (...args: unknown[]) => {
+                record(calls, 'spendSunflowersBatch', args);
+                return {
+                    createdReasons: [],
+                    existingReasons: ['shoppingCartItem:3'],
+                    resolvedAmountsByReason: {
+                        'shoppingCartItem:3': 6_000,
+                    },
+                };
+            },
+            getRaisedBed: async (...args: unknown[]) => {
+                record(calls, 'getRaisedBed', args);
+                return { status: 'active' };
+            },
+            getRaisedBedFieldsWithEvents: async (...args: unknown[]) => {
+                record(calls, 'getRaisedBedFieldsWithEvents', args);
+                return [
+                    {
+                        id: 89,
+                        positionIndex: 4,
+                        active: true,
+                        plantCycles: [],
+                    },
+                ];
+            },
+        });
+
+        await processCheckoutSession('cs_paid', dependencies);
+
+        assert.deepStrictEqual(
+            callsNamed(calls, 'withCheckoutCartItemLocks')[0]?.args,
+            [[2, 3]],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'spendSunflowersBatch')[0]?.args,
+            [
+                'account-1',
+                [{ amount: 7_000, reason: 'shoppingCartItem:3' }],
+                { transaction: 'checkout-items-test' },
+                {
+                    existingCheckoutItemAmountsAreAuthoritative: true,
+                    legacyCartSpend: {
+                        reason: 'shoppingCart:100',
+                        coveredItems: [
+                            {
+                                amount: 5_000,
+                                cartItemId: 2,
+                                createdAt: new Date('2026-07-01T10:00:00.000Z'),
+                                reason: 'shoppingCartItem:2',
+                            },
+                            {
+                                amount: 7_000,
+                                cartItemId: 3,
+                                createdAt: new Date('2026-07-01T10:05:00.000Z'),
+                                reason: 'shoppingCartItem:3',
+                            },
+                        ],
+                    },
+                },
+            ],
+        );
+        const plantingEvent = callsNamed(calls, 'createEvent')
+            .map((call) => call.args[0])
+            .find(
+                (event) =>
+                    isRecordedEvent(event) &&
+                    event.type === 'raisedBedFields.plantPlace',
+            );
+        assert.ok(isRecordedEvent(plantingEvent));
+        assert.deepStrictEqual(plantingEvent.data, {
+            plantSortId: '101',
+            scheduledDate: '2026-07-02',
+            sowingLocation: undefined,
+            purchase: {
+                cartItemId: 3,
+                currency: 'sunflower',
+                sunflowerAmount: 6_000,
+            },
+        });
+        assert.deepStrictEqual(
+            callsNamed(calls, 'setCartItemPaid').map((call) => call.args[0]),
+            [1, 3],
+        );
+        const confirmationCall = callsNamed(
+            calls,
+            'buildOrderConfirmationItems',
+        ).at(-1);
+        assert.deepStrictEqual(confirmationCall?.args[0], [
+            paidSunflowerItem,
+            pendingSunflowerItem,
+        ]);
+        const resolveSunflowerAmount = confirmationCall?.args[1];
+        assert.equal(typeof resolveSunflowerAmount, 'function');
+        if (typeof resolveSunflowerAmount !== 'function') {
+            throw new Error('Missing sunflower confirmation resolver.');
+        }
+        assert.equal(resolveSunflowerAmount(paidSunflowerItem), 5_000);
+        assert.equal(resolveSunflowerAmount(pendingSunflowerItem), 6_000);
+    });
+
+    it('commits inventory consumption inside the short cart-item gate before fulfillment', async () => {
+        const calls: RecordedCall[] = [];
+        const inventoryItem = {
+            ...makeSunflowerCartItem(),
+            currency: 'inventory',
+            entityData: { attributes: { deliverable: false } },
+            inventoryAvailable: 1,
+            usesInventory: true,
+        };
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return {
+                    ...makeSession(),
+                    metadata: encodeHarvestDatesMetadata(
+                        [],
+                        [inventoryItem.id],
+                    ),
+                };
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                const cart = makeCart();
+                return { ...cart, items: [...cart.items, inventoryItem] };
+            },
+            getRaisedBedFieldsWithEvents: async (...args: unknown[]) => {
+                record(calls, 'getRaisedBedFieldsWithEvents', args);
+                return [
+                    { id: 88, positionIndex: 2, active: true },
+                    { id: 89, positionIndex: 3, active: true },
+                ];
+            },
+            normalizeShoppingCartInventoryUsage: async (...args: unknown[]) => {
+                record(calls, 'normalizeShoppingCartInventoryUsage', args);
+                return { id: 100, items: [inventoryItem] };
+            },
+            getCartInfo: async (...args: unknown[]) => {
+                record(calls, 'getCartInfo', args);
+                return {
+                    allowPurchase: true,
+                    notes: [],
+                    items: [inventoryItem],
+                };
+            },
+        });
+
+        await processCheckoutSession('cs_paid', dependencies);
+
+        assert.deepStrictEqual(
+            callsNamed(calls, 'withCheckoutCartItemProcessingLock').at(-1)
+                ?.args,
+            [2],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'withCheckoutCartItemLock').at(-1)?.args,
+            [2],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'withInventoryAccountTransaction')[0]?.args,
+            ['account-1'],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'consumeInventoryItem')[0]?.args,
+            [
+                'account-1',
+                {
+                    entityTypeName: 'operation',
+                    entityId: '99',
+                    amount: 1,
+                    source: 'shoppingCartItem:2',
+                },
+                { transaction: 'checkout-item-test' },
+            ],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'setCartItemPaid').map((call) => call.args[0]),
+            [1, 2],
+        );
+        assert.equal(callsNamed(calls, 'createTransaction').length, 1);
+    });
+
+    it('blocks finalization when an expected non-Stripe item is missing', async () => {
+        const calls: RecordedCall[] = [];
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return {
+                    ...makeSession(),
+                    metadata: encodeHarvestDatesMetadata([], [2]),
+                };
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                return makeCart();
+            },
+            normalizeShoppingCartInventoryUsage: async (...args: unknown[]) => {
+                record(calls, 'normalizeShoppingCartInventoryUsage', args);
+                return { id: 100, items: [] };
+            },
+            getCartInfo: async (...args: unknown[]) => {
+                record(calls, 'getCartInfo', args);
+                return { allowPurchase: true, notes: [], items: [] };
+            },
+        });
+
+        await assert.rejects(
+            processCheckoutSession('cs_paid', dependencies),
+            /Expected non-Stripe cart items are missing before fulfillment: 2/,
+        );
+
+        assert.deepStrictEqual(
+            callsNamed(calls, 'setCartItemPaid').map((call) => call.args[0]),
+            [],
+        );
+        assert.equal(callsNamed(calls, 'createTransaction').length, 0);
+    });
+
+    it('accepts an expected non-Stripe item that was already paid on replay', async () => {
+        const calls: RecordedCall[] = [];
+        const paidSunflowerItem = {
+            ...makeSunflowerCartItem(),
+            status: 'paid',
+        };
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return {
+                    ...makeSession(),
+                    metadata: encodeHarvestDatesMetadata(
+                        [],
+                        [paidSunflowerItem.id],
+                    ),
+                };
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                const cart = makeCart();
+                return {
+                    ...cart,
+                    items: [...cart.items, paidSunflowerItem],
+                };
+            },
+            normalizeShoppingCartInventoryUsage: async (...args: unknown[]) => {
+                record(calls, 'normalizeShoppingCartInventoryUsage', args);
+                return { id: 100, items: [paidSunflowerItem] };
+            },
+            getCartInfo: async (...args: unknown[]) => {
+                record(calls, 'getCartInfo', args);
+                return {
+                    allowPurchase: false,
+                    notes: ['historical cart state changed'],
+                    items: [paidSunflowerItem],
+                };
+            },
+        });
+
+        await processCheckoutSession('cs_paid', dependencies);
+
+        assert.deepStrictEqual(
+            callsNamed(calls, 'setCartItemPaid').map((call) => call.args[0]),
+            [1],
+        );
+        assert.equal(callsNamed(calls, 'spendSunflowersBatch').length, 0);
+        assert.equal(callsNamed(calls, 'createTransaction').length, 1);
+        const confirmationCall = callsNamed(
+            calls,
+            'buildOrderConfirmationItems',
+        ).at(-1);
+        assert.deepStrictEqual(confirmationCall?.args[0], [paidSunflowerItem]);
+        const resolveSunflowerAmount = confirmationCall?.args[1];
+        assert.equal(typeof resolveSunflowerAmount, 'function');
+        if (typeof resolveSunflowerAmount !== 'function') {
+            throw new Error('Missing sunflower confirmation resolver.');
+        }
+        assert.equal(resolveSunflowerAmount(paidSunflowerItem), 5_000);
     });
 
     it('uses the canonical harvest date for a mixed checkout and ignores a later non-Stripe cart item', async () => {
@@ -2234,7 +3161,15 @@ describe('processCheckoutSession', () => {
             },
             getShoppingCart: async (...args: unknown[]) => {
                 record(calls, 'getShoppingCart', args);
-                return makeCart();
+                const cart = makeCart();
+                return {
+                    ...cart,
+                    items: [
+                        ...cart.items,
+                        expectedSunflowerItem,
+                        laterSunflowerItem,
+                    ],
+                };
             },
             getRaisedBedFieldsWithEvents: async (...args: unknown[]) => {
                 record(calls, 'getRaisedBedFieldsWithEvents', args);
@@ -2265,7 +3200,37 @@ describe('processCheckoutSession', () => {
 
         assert.deepStrictEqual(
             callsNamed(calls, 'spendSunflowersBatch')[0]?.args,
-            ['account-1', [{ amount: 5000, reason: 'shoppingCartItem:2' }]],
+            [
+                'account-1',
+                [{ amount: 5000, reason: 'shoppingCartItem:2' }],
+                { transaction: 'checkout-items-test' },
+                {
+                    existingCheckoutItemAmountsAreAuthoritative: true,
+                    legacyCartSpend: {
+                        reason: 'shoppingCart:100',
+                        coveredItems: [
+                            {
+                                amount: 5000,
+                                cartItemId: 2,
+                                createdAt: new Date('2026-07-01T10:00:00.000Z'),
+                                reason: 'shoppingCartItem:2',
+                            },
+                        ],
+                    },
+                },
+            ],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'withCheckoutCartItemLocks')[0]?.args,
+            [[2]],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'withCheckoutCartItemProcessingLocks')[0]?.args,
+            [[2]],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'getCheckoutOperationMapping').at(-1)?.args,
+            [2],
         );
         assert.deepStrictEqual(
             callsNamed(calls, 'setCartItemPaid').map((call) => call.args[0]),
@@ -2338,6 +3303,7 @@ describe('processItem', () => {
         );
 
         assert.deepStrictEqual(callNames(calls), [
+            'getCheckoutOperationMapping',
             'getRaisedBed',
             'isRaisedBedAbandoned',
         ]);
@@ -2387,57 +3353,92 @@ describe('processItem', () => {
         });
     });
 
-    it('continues operation processing when earning sunflowers fails', async () => {
+    it('reuses an empty mapping snapshot on a first-attempt operation', async () => {
         const calls: RecordedCall[] = [];
-        const dependencies = makeDependencies(calls, {
-            earnSunflowersForPayment: async (...args: unknown[]) => {
-                record(calls, 'earnSunflowersForPayment', args);
-                throw new Error('sunflower ledger unavailable');
-            },
-        });
+        const dependencies = makeDependencies(calls);
 
         await processItem(
             {
                 accountId: 'account-1',
-                amount_total: 2500,
-                additionalData: {
-                    scheduledDate: '2026-07-01',
-                },
+                amount_total: 5000,
+                additionalData: { scheduledDate: '2026-07-01' },
                 cartId: 100,
-                cartItemId: 1,
-                currency: 'eur',
+                cartItemId: 2,
+                checkoutOperationMapping: null,
+                currency: 'sunflower',
                 entityId: '42',
                 entityTypeName: 'operation',
                 gardenId: 200,
-                positionIndex: null,
-                raisedBedId: null,
+                positionIndex: 2,
+                raisedBedId: 300,
             },
             dependencies,
         );
 
-        assert.deepStrictEqual(
-            callNames(calls).filter((name) =>
-                [
-                    'getOrCreateCheckoutOperation',
-                    'earnSunflowersForPayment',
-                    'notifyOperationUpdate',
-                    'isCartItemDeliverable',
-                ].includes(name),
-            ),
-            [
-                'getOrCreateCheckoutOperation',
-                'earnSunflowersForPayment',
-                'notifyOperationUpdate',
-                'isCartItemDeliverable',
-            ],
+        assert.equal(
+            callsNamed(calls, 'getCheckoutOperationMapping').length,
+            0,
         );
-        assert.deepStrictEqual(
-            callsNamed(calls, 'earnSunflowersForPayment')[0]?.args,
-            ['account-1', 25],
+        assert.equal(
+            callsNamed(calls, 'getOrCreateCheckoutOperation').length,
+            1,
         );
     });
 
-    it('reuses a checkout operation without repeating its side effects', async () => {
+    it('keeps an operation retryable until its payment reward is durably earned', async () => {
+        const calls: RecordedCall[] = [];
+        let rewardAttempts = 0;
+        const dependencies = makeDependencies(calls, {
+            earnSunflowersForPayment: async (...args: unknown[]) => {
+                record(calls, 'earnSunflowersForPayment', args);
+                rewardAttempts += 1;
+                if (rewardAttempts === 1) {
+                    throw new Error('sunflower ledger unavailable');
+                }
+            },
+        });
+
+        const item = {
+            accountId: 'account-1',
+            amount_total: 2500,
+            additionalData: {
+                scheduledDate: '2026-07-01',
+            },
+            cartId: 100,
+            cartItemId: 1,
+            currency: 'eur',
+            entityId: '42',
+            entityTypeName: 'operation',
+            gardenId: 200,
+            positionIndex: null,
+            raisedBedId: null,
+        };
+
+        await assert.rejects(
+            processItem(item, dependencies),
+            /sunflower ledger unavailable/,
+        );
+        assert.equal(
+            callsNamed(calls, 'getOrCreateCheckoutOperation').length,
+            0,
+        );
+
+        assert.deepStrictEqual(await processItem(item, dependencies), {
+            status: 'fulfilled',
+        });
+
+        assert.equal(callsNamed(calls, 'earnSunflowersForPayment').length, 2);
+        assert.equal(
+            callsNamed(calls, 'getOrCreateCheckoutOperation').length,
+            1,
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'earnSunflowersForPayment')[0]?.args,
+            ['account-1', 25, 'shoppingCartItem:1'],
+        );
+    });
+
+    it('reuses a checkout operation while replaying its idempotent reward', async () => {
         const calls: RecordedCall[] = [];
         const dependencies = makeDependencies(calls, {
             getOrCreateCheckoutOperation: async (...args: unknown[]) => {
@@ -2467,8 +3468,96 @@ describe('processItem', () => {
             callsNamed(calls, 'getOrCreateCheckoutOperation').length,
             1,
         );
-        assert.equal(callsNamed(calls, 'earnSunflowersForPayment').length, 0);
+        assert.equal(callsNamed(calls, 'earnSunflowersForPayment').length, 1);
         assert.equal(callsNamed(calls, 'notifyOperationUpdate').length, 0);
+    });
+
+    it('reuses mapped operation state after the field changes and bed is abandoned', async () => {
+        const calls: RecordedCall[] = [];
+        const dependencies = makeDependencies(calls, {
+            getCheckoutOperationMapping: async (...args: unknown[]) => {
+                record(calls, 'getCheckoutOperationMapping', args);
+                return {
+                    operationId: 501,
+                    accountId: 'account-1',
+                    entityId: 42,
+                    entityTypeName: 'operation',
+                    farmId: null,
+                    gardenId: 200,
+                    raisedBedId: 300,
+                    raisedBedFieldId: 701,
+                    operationTimestamp: null,
+                    paymentCurrency: 'eur',
+                    delivery: null,
+                    scheduledDate: '2026-07-01T00:00:00.000Z',
+                    accepted: false,
+                };
+            },
+            getRaisedBedFieldsWithEvents: async (...args: unknown[]) => {
+                record(calls, 'getRaisedBedFieldsWithEvents', args);
+                return [
+                    {
+                        id: 702,
+                        positionIndex: 2,
+                        active: true,
+                    },
+                ];
+            },
+            getRaisedBed: async (...args: unknown[]) => {
+                record(calls, 'getRaisedBed', args);
+                return { status: 'abandoned' };
+            },
+            getOrCreateCheckoutOperation: async (...args: unknown[]) => {
+                record(calls, 'getOrCreateCheckoutOperation', args);
+                return { created: false, operationId: 501 };
+            },
+        });
+
+        await processItem(
+            {
+                accountId: 'account-1',
+                amount_total: 2500,
+                additionalData: {
+                    scheduledDate: '2026-07-09T00:00:00.000Z',
+                },
+                cartId: 100,
+                cartItemId: 1,
+                currency: 'sunflower',
+                entityId: '42',
+                entityTypeName: 'operation',
+                gardenId: 200,
+                positionIndex: 2,
+                raisedBedId: 300,
+            },
+            dependencies,
+        );
+
+        assert.equal(
+            callsNamed(calls, 'getCheckoutOperationMapping').length,
+            1,
+        );
+        assert.equal(
+            callsNamed(calls, 'getRaisedBedFieldsWithEvents').length,
+            0,
+        );
+        assert.equal(callsNamed(calls, 'getRaisedBed').length, 0);
+        assert.equal(callsNamed(calls, 'isRaisedBedAbandoned').length, 0);
+        const operationInput = callsNamed(
+            calls,
+            'getOrCreateCheckoutOperation',
+        )[0]?.args[1];
+        assert.ok(isRecord(operationInput));
+        assert.equal(operationInput.raisedBedFieldId, 701);
+        const operationOptions = callsNamed(
+            calls,
+            'getOrCreateCheckoutOperation',
+        )[0]?.args[2];
+        assert.ok(isRecord(operationOptions));
+        assert.ok(operationOptions.scheduledDate instanceof Date);
+        assert.equal(
+            operationOptions.scheduledDate.toISOString(),
+            '2026-07-01T00:00:00.000Z',
+        );
     });
 
     it('reuses a delivery request without repeating its notifications', async () => {
@@ -2497,14 +3586,30 @@ describe('processItem', () => {
                 amount_total: 2500,
                 additionalData: {
                     scheduledDate: '2026-07-01',
-                    delivery: {
-                        slotId: 9,
-                        mode: 'pickup',
-                        locationId: 4,
-                    },
                 },
                 cartId: 100,
                 cartItemId: 1,
+                checkoutOperationMapping: {
+                    accepted: false,
+                    accountId: 'account-1',
+                    delivery: {
+                        addressId: null,
+                        locationId: 4,
+                        mode: 'pickup',
+                        notes: null,
+                        slotId: 9,
+                    },
+                    entityId: 42,
+                    entityTypeName: 'operation',
+                    farmId: null,
+                    gardenId: 200,
+                    operationId: 501,
+                    operationTimestamp: null,
+                    paymentCurrency: 'sunflower',
+                    raisedBedFieldId: null,
+                    raisedBedId: null,
+                    scheduledDate: '2026-07-01T00:00:00.000Z',
+                },
                 currency: 'sunflower',
                 entityId: '42',
                 entityTypeName: 'operation',
@@ -2516,6 +3621,18 @@ describe('processItem', () => {
         );
 
         assert.equal(callsNamed(calls, 'getOrCreateDeliveryRequest').length, 1);
+        assert.deepStrictEqual(
+            callsNamed(calls, 'getOrCreateDeliveryRequest')[0]?.args[0],
+            {
+                accountId: 'account-1',
+                addressId: undefined,
+                locationId: 4,
+                mode: 'pickup',
+                notes: undefined,
+                operationId: 501,
+                slotId: 9,
+            },
+        );
         assert.equal(callsNamed(calls, 'notifyDeliveryRequestEvent').length, 0);
         assert.equal(
             callsNamed(calls, 'notifyScheduledDeliveryEmailOnce').length,
@@ -2527,7 +3644,35 @@ describe('processItem', () => {
         const calls: RecordedCall[] = [];
         let operationAttempt = 0;
         let deliveryAttempt = 0;
+        let mappingAttempt = 0;
         const dependencies = makeDependencies(calls, {
+            getCheckoutOperationMapping: async (...args: unknown[]) => {
+                record(calls, 'getCheckoutOperationMapping', args);
+                mappingAttempt += 1;
+                return mappingAttempt === 1
+                    ? null
+                    : {
+                          accepted: false,
+                          accountId: 'account-1',
+                          delivery: {
+                              addressId: null,
+                              locationId: 4,
+                              mode: 'pickup',
+                              notes: null,
+                              slotId: 9,
+                          },
+                          entityId: 42,
+                          entityTypeName: 'operation',
+                          farmId: null,
+                          gardenId: 200,
+                          operationId: 501,
+                          operationTimestamp: null,
+                          paymentCurrency: 'eur',
+                          raisedBedFieldId: null,
+                          raisedBedId: null,
+                          scheduledDate: '2026-07-01T00:00:00.000Z',
+                      };
+            },
             getOrCreateCheckoutOperation: async (...args: unknown[]) => {
                 record(calls, 'getOrCreateCheckoutOperation', args);
                 operationAttempt += 1;
@@ -2574,7 +3719,13 @@ describe('processItem', () => {
         };
 
         const first = await processItem(item, dependencies);
-        const retry = await processItem(item, dependencies);
+        const retry = await processItem(
+            {
+                ...item,
+                additionalData: { scheduledDate: '2026-07-01' },
+            },
+            dependencies,
+        );
 
         assert.deepStrictEqual(first, {
             status: 'not_fulfilled',
@@ -2585,7 +3736,7 @@ describe('processItem', () => {
             callsNamed(calls, 'getOrCreateCheckoutOperation').length,
             2,
         );
-        assert.equal(callsNamed(calls, 'earnSunflowersForPayment').length, 1);
+        assert.equal(callsNamed(calls, 'earnSunflowersForPayment').length, 2);
         assert.equal(callsNamed(calls, 'notifyOperationUpdate').length, 1);
         assert.equal(callsNamed(calls, 'getOrCreateDeliveryRequest').length, 2);
         assert.equal(callsNamed(calls, 'notifyDeliveryRequestEvent').length, 1);
@@ -2874,7 +4025,11 @@ describe('processItem', () => {
                 .filter(isRecordedEvent)
                 .filter((event) => event.type === 'accounts.sunflowersEarned')
                 .length,
-            1,
+            0,
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'earnSunflowersForPayment')[0]?.args,
+            ['account-1', 25, 'shoppingCartItem:1'],
         );
     });
 

--- a/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
@@ -263,12 +263,31 @@ function makeDependencies(
             const items = Array.isArray(args[1])
                 ? (args[1] as Array<{ amount: number; reason: string }>)
                 : [];
+            const options = args[3];
+            const legacyCartSpend =
+                isRecord(options) && isRecord(options.legacyCartSpend)
+                    ? options.legacyCartSpend
+                    : undefined;
+            const paidCoveredItems = Array.isArray(
+                legacyCartSpend?.coveredItems,
+            )
+                ? legacyCartSpend.coveredItems.filter(
+                      (item) => isRecord(item) && item.paymentState === 'paid',
+                  )
+                : [];
             return {
                 createdReasons: items.map((item) => item.reason),
                 existingReasons: [],
-                resolvedAmountsByReason: Object.fromEntries(
-                    items.map((item) => [item.reason, item.amount]),
-                ),
+                resolvedAmountsByReason: Object.fromEntries([
+                    ...items.map((item) => [item.reason, item.amount]),
+                    ...paidCoveredItems.flatMap((item) =>
+                        isRecord(item) &&
+                        typeof item.reason === 'string' &&
+                        typeof item.amount === 'number'
+                            ? [[item.reason, item.amount]]
+                            : [],
+                    ),
+                ]),
             };
         },
         topUpSunflowerPackage: async (...args: unknown[]) => {
@@ -2648,6 +2667,7 @@ describe('processCheckoutSession', () => {
                                 amount: 5000,
                                 cartItemId: 2,
                                 createdAt: new Date('2026-07-01T10:00:00.000Z'),
+                                paymentState: 'pending',
                                 reason: 'shoppingCartItem:2',
                             },
                         ],
@@ -2845,6 +2865,7 @@ describe('processCheckoutSession', () => {
                     createdReasons: [],
                     existingReasons: ['shoppingCartItem:3'],
                     resolvedAmountsByReason: {
+                        'shoppingCartItem:2': 4_500,
                         'shoppingCartItem:3': 6_000,
                     },
                 };
@@ -2887,12 +2908,14 @@ describe('processCheckoutSession', () => {
                                 amount: 5_000,
                                 cartItemId: 2,
                                 createdAt: new Date('2026-07-01T10:00:00.000Z'),
+                                paymentState: 'paid',
                                 reason: 'shoppingCartItem:2',
                             },
                             {
                                 amount: 7_000,
                                 cartItemId: 3,
                                 createdAt: new Date('2026-07-01T10:05:00.000Z'),
+                                paymentState: 'pending',
                                 reason: 'shoppingCartItem:3',
                             },
                         ],
@@ -2935,7 +2958,7 @@ describe('processCheckoutSession', () => {
         if (typeof resolveSunflowerAmount !== 'function') {
             throw new Error('Missing sunflower confirmation resolver.');
         }
-        assert.equal(resolveSunflowerAmount(paidSunflowerItem), 5_000);
+        assert.equal(resolveSunflowerAmount(paidSunflowerItem), 4_500);
         assert.equal(resolveSunflowerAmount(pendingSunflowerItem), 6_000);
     });
 
@@ -3093,6 +3116,16 @@ describe('processCheckoutSession', () => {
                     items: [paidSunflowerItem],
                 };
             },
+            spendSunflowersBatch: async (...args: unknown[]) => {
+                record(calls, 'spendSunflowersBatch', args);
+                return {
+                    createdReasons: [],
+                    existingReasons: [],
+                    resolvedAmountsByReason: {
+                        [`shoppingCartItem:${paidSunflowerItem.id.toString()}`]: 4_500,
+                    },
+                };
+            },
         });
 
         await processCheckoutSession('cs_paid', dependencies);
@@ -3101,7 +3134,7 @@ describe('processCheckoutSession', () => {
             callsNamed(calls, 'setCartItemPaid').map((call) => call.args[0]),
             [1],
         );
-        assert.equal(callsNamed(calls, 'spendSunflowersBatch').length, 0);
+        assert.equal(callsNamed(calls, 'spendSunflowersBatch').length, 1);
         assert.equal(callsNamed(calls, 'createTransaction').length, 1);
         const confirmationCall = callsNamed(
             calls,
@@ -3113,7 +3146,7 @@ describe('processCheckoutSession', () => {
         if (typeof resolveSunflowerAmount !== 'function') {
             throw new Error('Missing sunflower confirmation resolver.');
         }
-        assert.equal(resolveSunflowerAmount(paidSunflowerItem), 5_000);
+        assert.equal(resolveSunflowerAmount(paidSunflowerItem), 4_500);
     });
 
     it('uses the canonical harvest date for a mixed checkout and ignores a later non-Stripe cart item', async () => {
@@ -3213,6 +3246,7 @@ describe('processCheckoutSession', () => {
                                 amount: 5000,
                                 cartItemId: 2,
                                 createdAt: new Date('2026-07-01T10:00:00.000Z'),
+                                paymentState: 'pending',
                                 reason: 'shoppingCartItem:2',
                             },
                         ],

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -17,17 +17,16 @@ import {
     type CheckoutPlantingRaisedBedActivation,
     consumeInventoryItem,
     convertOutletReservationForCartItem,
-    createDeliveryRequest,
     createEvent,
     createNotificationWithStatus,
-    createOperation,
     createTransaction,
     deliverNotificationOperatorAlert,
     earnSunflowersForPayment,
     ensureInvoiceForTransaction,
     getCompletedTransactionByStripePaymentId,
     getDefaultShoppingCartScheduledDate,
-    getInventory,
+    getOrCreateCheckoutOperation,
+    getOrCreateDeliveryRequest,
     getOutletOfferReservationForCartItem,
     getRaisedBed,
     getRaisedBedFieldsWithEvents,
@@ -44,7 +43,7 @@ import {
     processReferralRewardsForAccount,
     SunflowerPackageAlreadyPurchasedError,
     setCartItemPaid,
-    spendSunflowers,
+    spendSunflowersBatch,
     sunflowerPackageEntityTypeName,
     topUpSunflowerPackage,
     upsertRaisedBedField,
@@ -83,10 +82,10 @@ export type ProcessCheckoutSessionDependencies = {
     notifyPurchase: typeof notifyPurchase;
     consumeInventoryItem: typeof consumeInventoryItem;
     convertOutletReservationForCartItem: typeof convertOutletReservationForCartItem;
-    createDeliveryRequest: typeof createDeliveryRequest;
+    getOrCreateDeliveryRequest: typeof getOrCreateDeliveryRequest;
     createEvent: typeof createEvent;
     createNotificationWithStatus: typeof createNotificationWithStatus;
-    createOperation: typeof createOperation;
+    getOrCreateCheckoutOperation: typeof getOrCreateCheckoutOperation;
     createTransaction: typeof createTransaction;
     deliverNotificationOperatorAlert: typeof deliverNotificationOperatorAlert;
     earnSunflowersForPayment: typeof earnSunflowersForPayment;
@@ -94,7 +93,6 @@ export type ProcessCheckoutSessionDependencies = {
     getSunflowerPackageByCode: typeof getSunflowerPackageByCode;
     getCompletedTransactionByStripePaymentId: typeof getCompletedTransactionByStripePaymentId;
     getDefaultShoppingCartScheduledDate: typeof getDefaultShoppingCartScheduledDate;
-    getInventory: typeof getInventory;
     getOutletOfferReservationForCartItem: typeof getOutletOfferReservationForCartItem;
     getRaisedBed: typeof getRaisedBed;
     getRaisedBedFieldsWithEvents: typeof getRaisedBedFieldsWithEvents;
@@ -108,7 +106,7 @@ export type ProcessCheckoutSessionDependencies = {
     normalizeShoppingCartScheduledDates: typeof normalizeShoppingCartScheduledDates;
     processReferralRewardsForAccount: typeof processReferralRewardsForAccount;
     setCartItemPaid: typeof setCartItemPaid;
-    spendSunflowers: typeof spendSunflowers;
+    spendSunflowersBatch: typeof spendSunflowersBatch;
     topUpSunflowerPackage: typeof topUpSunflowerPackage;
     upsertRaisedBedField: typeof upsertRaisedBedField;
     withPlantingScheduleTaskTransaction: typeof withPlantingScheduleTaskTransaction;
@@ -137,10 +135,10 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     notifyPurchase,
     consumeInventoryItem,
     convertOutletReservationForCartItem,
-    createDeliveryRequest,
+    getOrCreateDeliveryRequest,
     createEvent,
     createNotificationWithStatus,
-    createOperation,
+    getOrCreateCheckoutOperation,
     createTransaction,
     deliverNotificationOperatorAlert,
     earnSunflowersForPayment,
@@ -148,7 +146,6 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     getSunflowerPackageByCode,
     getCompletedTransactionByStripePaymentId,
     getDefaultShoppingCartScheduledDate,
-    getInventory,
     getOutletOfferReservationForCartItem,
     getRaisedBed,
     getRaisedBedFieldsWithEvents,
@@ -162,7 +159,7 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     normalizeShoppingCartScheduledDates,
     processReferralRewardsForAccount,
     setCartItemPaid,
-    spendSunflowers,
+    spendSunflowersBatch,
     topUpSunflowerPackage,
     upsertRaisedBedField,
     withPlantingScheduleTaskTransaction,
@@ -395,77 +392,70 @@ async function processNonStripeCartItems(
             isExpectedNonStripeItem(item),
     );
 
-    // Precompute sunflower amounts and total required, so we can spend in a single operation
+    // Precompute sunflower amounts so the durable batch debit can be retried
+    // without charging an already-processed item again.
     const sunflowerAmountsByItem = new Map<number, number>();
-    let totalSunflowersToSpend = 0;
 
     for (const item of sunflowerCartItemsWithShopData) {
         const sunflowerAmount = dependencies.calculateSunflowerAmount(item);
         sunflowerAmountsByItem.set(item.id, sunflowerAmount);
-        totalSunflowersToSpend += sunflowerAmount;
     }
 
-    let didSpendSunflowersForCart = false;
-    if (totalSunflowersToSpend > 0) {
+    if (sunflowerCartItemsWithShopData.length > 0) {
         try {
-            // Spend all sunflowers in a single transaction for the entire cart
-            // to prevent race conditions. Reference format: shoppingCart:${cartId}
-            // (Note: This differs from immediate processing which uses shoppingCartItem:${item.id})
-            await dependencies.spendSunflowers(
+            await dependencies.spendSunflowersBatch(
                 accountId,
-                totalSunflowersToSpend,
-                `shoppingCart:${cartId}`,
+                sunflowerCartItemsWithShopData.map((item) => ({
+                    amount: sunflowerAmountsByItem.get(item.id) ?? 0,
+                    reason: `shoppingCartItem:${item.id.toString()}`,
+                })),
             );
-            didSpendSunflowersForCart = true;
         } catch (error) {
             console.error('Error spending sunflowers during cart processing', {
                 error,
                 accountId,
-                totalSunflowersToSpend,
                 cartId,
             });
+            throw error;
         }
     }
 
-    if (didSpendSunflowersForCart) {
-        for (const item of sunflowerCartItemsWithShopData) {
-            const sunflowerAmount = sunflowerAmountsByItem.get(item.id) ?? 0;
-            const baseAdditionalData = item.additionalData
-                ? JSON.parse(item.additionalData)
-                : {};
-            const additionalData = {
-                ...baseAdditionalData,
-                ...(deliveryInfo ? { delivery: deliveryInfo } : {}),
-                ...(harvestDateByCartItemId.has(item.id)
-                    ? {
-                          scheduledDate: harvestDateByCartItemId.get(item.id),
-                      }
-                    : {}),
-            };
+    for (const item of sunflowerCartItemsWithShopData) {
+        const sunflowerAmount = sunflowerAmountsByItem.get(item.id) ?? 0;
+        const baseAdditionalData = item.additionalData
+            ? JSON.parse(item.additionalData)
+            : {};
+        const additionalData = {
+            ...baseAdditionalData,
+            ...(deliveryInfo ? { delivery: deliveryInfo } : {}),
+            ...(harvestDateByCartItemId.has(item.id)
+                ? {
+                      scheduledDate: harvestDateByCartItemId.get(item.id),
+                  }
+                : {}),
+        };
 
-            await Promise.all([
-                dependencies.setCartItemPaid(item.id),
-                processItem(
-                    {
-                        accountId,
-                        cartItemId: item.id,
-                        entityId: item.entityId,
-                        entityTypeName: item.entityTypeName,
-                        cartId: item.cartId,
-                        gardenId: item.gardenId,
-                        raisedBedId: item.raisedBedId,
-                        positionIndex: item.positionIndex,
-                        currency: item.currency,
-                        amount_total: sunflowerAmount,
-                        additionalData,
-                        scheduledDeliveryEmailKeys,
-                        checkoutSessionId,
-                    },
-                    dependencies,
-                ),
-            ]);
-            processedItems.push(item);
-        }
+        const fulfillment = await processItem(
+            {
+                accountId,
+                cartItemId: item.id,
+                entityId: item.entityId,
+                entityTypeName: item.entityTypeName,
+                cartId: item.cartId,
+                gardenId: item.gardenId,
+                raisedBedId: item.raisedBedId,
+                positionIndex: item.positionIndex,
+                currency: item.currency,
+                amount_total: sunflowerAmount,
+                additionalData,
+                scheduledDeliveryEmailKeys,
+                checkoutSessionId,
+            },
+            dependencies,
+        );
+        assertCheckoutItemFulfilled(fulfillment);
+        await dependencies.setCartItemPaid(item.id);
+        processedItems.push(item);
     }
 
     const inventoryCartItems = cartInfo.items.filter(
@@ -483,22 +473,15 @@ async function processNonStripeCartItems(
 
     // Pre-validate that total required inventory for all items is available
     // This prevents partial processing when multiple items consume the same inventory
-    let inventoryLookup = new Map<string, number>();
     if (inventoryCartItems.length > 0) {
-        const inventory = await dependencies.getInventory(accountId);
-        inventoryLookup = new Map(
-            inventory.map((inventoryItem) => [
-                getInventoryKey(inventoryItem),
-                inventoryItem.amount,
-            ]),
-        );
-
         // Calculate total required inventory for each unique entity
         const requiredInventory = new Map<string, number>();
+        const availableInventory = new Map<string, number>();
         for (const item of inventoryCartItems) {
             const inventoryKey = getInventoryKey(item);
             const currentRequired = requiredInventory.get(inventoryKey) ?? 0;
             requiredInventory.set(inventoryKey, currentRequired + item.amount);
+            availableInventory.set(inventoryKey, item.inventoryAvailable ?? 0);
         }
 
         // Validate all required inventory is available before processing any items
@@ -506,7 +489,7 @@ async function processNonStripeCartItems(
             inventoryKey,
             requiredAmount,
         ] of requiredInventory.entries()) {
-            const available = inventoryLookup.get(inventoryKey) ?? 0;
+            const available = availableInventory.get(inventoryKey) ?? 0;
             if (available < requiredAmount) {
                 const errorMsg = `Insufficient inventory for key ${inventoryKey} in cart ${cartId}. Required: ${requiredAmount}, Available: ${available}. Manual intervention required to refund or fulfill this order.`;
                 console.error(errorMsg);
@@ -515,8 +498,6 @@ async function processNonStripeCartItems(
         }
 
         for (const item of inventoryCartItems) {
-            const inventoryKey = getInventoryKey(item);
-            const available = inventoryLookup.get(inventoryKey) ?? 0;
             const baseAdditionalData = item.additionalData
                 ? JSON.parse(item.additionalData)
                 : {};
@@ -530,37 +511,33 @@ async function processNonStripeCartItems(
                     : {}),
             };
 
-            await Promise.all([
-                dependencies.consumeInventoryItem(accountId, {
-                    entityTypeName: item.entityTypeName,
+            await dependencies.consumeInventoryItem(accountId, {
+                entityTypeName: item.entityTypeName,
+                entityId: item.entityId,
+                amount: item.amount,
+                source: `shoppingCartItem:${item.id}`,
+            });
+            const fulfillment = await processItem(
+                {
+                    accountId,
+                    cartItemId: item.id,
                     entityId: item.entityId,
-                    amount: item.amount,
-                    source: `shoppingCartItem:${item.id}`,
-                }),
-                dependencies.setCartItemPaid(item.id),
-                processItem(
-                    {
-                        accountId,
-                        cartItemId: item.id,
-                        entityId: item.entityId,
-                        entityTypeName: item.entityTypeName,
-                        cartId: item.cartId,
-                        gardenId: item.gardenId,
-                        raisedBedId: item.raisedBedId,
-                        positionIndex: item.positionIndex,
-                        currency: item.currency,
-                        amount_total: 0,
-                        additionalData,
-                        scheduledDeliveryEmailKeys,
-                        checkoutSessionId,
-                    },
-                    dependencies,
-                ),
-            ]);
+                    entityTypeName: item.entityTypeName,
+                    cartId: item.cartId,
+                    gardenId: item.gardenId,
+                    raisedBedId: item.raisedBedId,
+                    positionIndex: item.positionIndex,
+                    currency: item.currency,
+                    amount_total: 0,
+                    additionalData,
+                    scheduledDeliveryEmailKeys,
+                    checkoutSessionId,
+                },
+                dependencies,
+            );
+            assertCheckoutItemFulfilled(fulfillment);
+            await dependencies.setCartItemPaid(item.id);
             processedItems.push(item);
-
-            // Update the lookup to reflect consumed inventory
-            inventoryLookup.set(inventoryKey, available - item.amount);
         }
     }
 
@@ -1237,14 +1214,12 @@ async function processPaidCheckoutSession(
                         'abandoned',
                     );
                 }
-                continue;
+                throw new CheckoutItemFulfillmentError(
+                    'raised_bed_unavailable',
+                );
             }
 
-            if (!isPlantingItem) {
-                await dependencies.setCartItemPaid(cartItem.id);
-            }
-
-            await processItem(
+            const fulfillment = await processItem(
                 {
                     ...itemData,
                     accountId: resolvedAccountId,
@@ -1254,9 +1229,8 @@ async function processPaidCheckoutSession(
                 },
                 dependencies,
             );
-            if (isPlantingItem) {
-                await dependencies.setCartItemPaid(cartItem.id);
-            }
+            assertCheckoutItemFulfilled(fulfillment);
+            await dependencies.setCartItemPaid(cartItem.id);
         } catch (error) {
             if (
                 error instanceof CheckoutPlantingRaisedBedUnavailableError &&
@@ -1278,9 +1252,7 @@ async function processPaidCheckoutSession(
                 `Error processing cart item ${itemData.cartItemId} in session ${checkoutSessionId}`,
                 error,
             );
-            if (itemData.entityTypeName === 'plantSort') {
-                throw error;
-            }
+            throw error;
         }
 
         // TODO: Send invoice to customer
@@ -1775,6 +1747,40 @@ class CheckoutPlantingTargetConflictError extends Error {
     override readonly name = 'CheckoutPlantingTargetConflictError';
 }
 
+export type ProcessItemFulfillmentResult =
+    | { status: 'fulfilled' }
+    | {
+          reason:
+              | 'delivery_configuration_missing'
+              | 'delivery_request_failed'
+              | 'invalid_entity_id'
+              | 'missing_metadata'
+              | 'raised_bed_unavailable'
+              | 'unsupported_item';
+          status: 'not_fulfilled';
+      };
+
+type CheckoutItemFulfillmentFailureReason = Extract<
+    ProcessItemFulfillmentResult,
+    { status: 'not_fulfilled' }
+>['reason'];
+
+export class CheckoutItemFulfillmentError extends Error {
+    override readonly name = 'CheckoutItemFulfillmentError';
+
+    constructor(readonly reason: CheckoutItemFulfillmentFailureReason) {
+        super(`Checkout item fulfillment was not confirmed (${reason})`);
+    }
+}
+
+export function assertCheckoutItemFulfilled(
+    result: ProcessItemFulfillmentResult,
+): asserts result is { status: 'fulfilled' } {
+    if (result.status !== 'fulfilled') {
+        throw new CheckoutItemFulfillmentError(result.reason);
+    }
+}
+
 export async function processItem(
     itemData: {
         entityId: string | null | undefined;
@@ -1797,7 +1803,7 @@ export async function processItem(
         checkoutSessionId?: string | null;
     },
     dependencies: ProcessCheckoutSessionDependencies = realDependencies,
-) {
+): Promise<ProcessItemFulfillmentResult> {
     console.debug(
         `Processing item with entityId ${itemData.entityId} and entityTypeName ${itemData.entityTypeName} for account ${itemData.accountId} in total amount ${itemData.amount_total}`,
     );
@@ -1818,6 +1824,7 @@ export async function processItem(
         // Validate item data
         if (
             !itemData.accountId ||
+            !itemData.cartItemId ||
             !itemData.entityId ||
             !itemData.entityTypeName
         ) {
@@ -1825,7 +1832,7 @@ export async function processItem(
                 `Missing required metadata for operation item in order.`,
                 itemData,
             );
-            return;
+            return { status: 'not_fulfilled', reason: 'missing_metadata' };
         }
         const entityIdNumber = parseInt(itemData.entityId, 10);
         if (Number.isNaN(entityIdNumber)) {
@@ -1833,7 +1840,7 @@ export async function processItem(
                 `Invalid entityId ${itemData.entityId} for operation item in order.`,
                 itemData,
             );
-            return;
+            return { status: 'not_fulfilled', reason: 'invalid_entity_id' };
         }
         if (
             !(await assertRaisedBedAllowsCheckoutItem(
@@ -1841,7 +1848,10 @@ export async function processItem(
                 dependencies,
             ))
         ) {
-            return;
+            return {
+                status: 'not_fulfilled',
+                reason: 'raised_bed_unavailable',
+            };
         }
 
         // Try to resolve field ID from position index (only active fields)
@@ -1882,49 +1892,47 @@ export async function processItem(
             dependencies,
         );
 
-        const operationId = await dependencies.createOperation({
-            accountId: itemData.accountId,
-            entityId: entityIdNumber,
-            entityTypeName: itemData.entityTypeName,
-            gardenId: itemData.gardenId,
-            raisedBedId: itemData.raisedBedId,
-            raisedBedFieldId: fieldId,
-        });
-
-        try {
-            await earnSunflowersFunc();
-        } catch (error) {
-            console.error(
-                `Failed to award sunflowers for operation item in order.`,
-                error,
+        const { created, operationId } =
+            await dependencies.getOrCreateCheckoutOperation(
+                itemData.cartItemId,
+                {
+                    accountId: itemData.accountId,
+                    entityId: entityIdNumber,
+                    entityTypeName: itemData.entityTypeName,
+                    gardenId: itemData.gardenId,
+                    raisedBedId: itemData.raisedBedId,
+                    raisedBedFieldId: fieldId,
+                },
+                { scheduledDate: new Date(scheduledDate) },
             );
+
+        if (created) {
+            try {
+                await earnSunflowersFunc();
+            } catch (error) {
+                console.error(
+                    `Failed to award sunflowers for operation item in order.`,
+                    error,
+                );
+            }
+            try {
+                await dependencies.notifyOperationUpdate(
+                    operationId,
+                    'scheduled',
+                    {
+                        scheduledDate: new Date(scheduledDate).toISOString(),
+                    },
+                );
+            } catch (error) {
+                console.error(
+                    `Failed to notify about scheduled operation ${operationId.toString()}:`,
+                    error,
+                );
+            }
         }
         console.debug(
-            `Created operation ${itemData.entityId} of type ${itemData.entityTypeName} for account ${itemData.accountId} in garden ${itemData.gardenId ?? 'N/A'} with raised bed ${itemData.raisedBedId ?? 'N/A'} and field ${fieldId ?? 'N/A'}.`,
+            `${created ? 'Created' : 'Reused'} scheduled operation ${operationId.toString()} for cart item ${itemData.cartItemId.toString()}.`,
         );
-
-        // Every purchased operation is scheduled; missing dates default to tomorrow.
-        try {
-            await dependencies.createEvent(
-                dependencies.knownEvents.operations.scheduledV1(
-                    operationId.toString(),
-                    {
-                        scheduledDate,
-                    },
-                ),
-            );
-            console.debug(
-                `Scheduled operation ${operationId} for date ${scheduledDate}.`,
-            );
-        } catch (error) {
-            console.error(
-                `Failed to create scheduled event for operation ${operationId}:`,
-                error,
-            );
-        }
-        await dependencies.notifyOperationUpdate(operationId, 'scheduled', {
-            scheduledDate: new Date(scheduledDate).toISOString(),
-        });
 
         // Check if this operation/entity is deliverable and create delivery request if needed
         if (itemData.cartId) {
@@ -1961,8 +1969,8 @@ export async function processItem(
 
                 if (deliveryInfo?.slotId && deliveryInfo.mode) {
                     try {
-                        const deliveryRequestId =
-                            await dependencies.createDeliveryRequest({
+                        const deliveryRequest =
+                            await dependencies.getOrCreateDeliveryRequest({
                                 operationId,
                                 slotId: deliveryInfo.slotId,
                                 mode: deliveryInfo.mode,
@@ -1972,19 +1980,37 @@ export async function processItem(
                                 accountId: itemData.accountId,
                             });
                         console.debug(
-                            `Created delivery request ${deliveryRequestId} for operation ${operationId}`,
+                            `${deliveryRequest.created ? 'Created' : 'Reused'} delivery request ${deliveryRequest.requestId} for operation ${operationId.toString()}`,
                         );
-                        await dependencies.notifyDeliveryRequestEvent(
-                            deliveryRequestId,
-                            'created',
-                        );
-                        await dependencies.notifyScheduledDeliveryEmailOnce({
-                            requestId: deliveryRequestId,
-                            accountId: itemData.accountId,
-                            deliveryInfo,
-                            notifiedKeys: itemData.scheduledDeliveryEmailKeys,
-                            notify: dependencies.notifyDeliveryScheduled,
-                        });
+                        if (deliveryRequest.created) {
+                            const notificationResults =
+                                await Promise.allSettled([
+                                    dependencies.notifyDeliveryRequestEvent(
+                                        deliveryRequest.requestId,
+                                        'created',
+                                    ),
+                                    dependencies.notifyScheduledDeliveryEmailOnce(
+                                        {
+                                            requestId:
+                                                deliveryRequest.requestId,
+                                            accountId: itemData.accountId,
+                                            deliveryInfo,
+                                            notifiedKeys:
+                                                itemData.scheduledDeliveryEmailKeys,
+                                            notify: dependencies.notifyDeliveryScheduled,
+                                        },
+                                    ),
+                                ]);
+                            const failedNotificationCount =
+                                notificationResults.filter(
+                                    (result) => result.status === 'rejected',
+                                ).length;
+                            if (failedNotificationCount > 0) {
+                                console.error(
+                                    `Failed to send ${failedNotificationCount.toString()} notification(s) for delivery request ${deliveryRequest.requestId}`,
+                                );
+                            }
+                        }
                     } catch (error) {
                         console.error(
                             `Failed to create delivery request for operation ${operationId}:`,
@@ -2004,14 +2030,23 @@ export async function processItem(
                                     itemData.checkoutSessionId ?? null,
                             },
                         });
+                        return {
+                            status: 'not_fulfilled',
+                            reason: 'delivery_request_failed',
+                        };
                     }
                 } else {
                     console.warn(
                         `Operation ${operationId} is deliverable but no delivery information found in metadata`,
                     );
+                    return {
+                        status: 'not_fulfilled',
+                        reason: 'delivery_configuration_missing',
+                    };
                 }
             }
         }
+        return { status: 'fulfilled' };
     } else if (
         itemData.entityId &&
         itemData.entityTypeName === 'plantSort' &&
@@ -2292,10 +2327,12 @@ export async function processItem(
                 },
             });
         }
+        return { status: 'fulfilled' };
     } else {
         console.error(
             `Unsupported item type for entityId ${itemData.entityId} in order.`,
             itemData,
         );
+        return { status: 'not_fulfilled', reason: 'unsupported_item' };
     }
 }

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -23,6 +23,9 @@ import {
     deliverNotificationOperatorAlert,
     earnSunflowersForPayment,
     ensureInvoiceForTransaction,
+    getCheckoutFulfillmentStartedCartItemIds,
+    getCheckoutOperationMapping,
+    getCheckoutOperationMappings,
     getCompletedTransactionByStripePaymentId,
     getDefaultShoppingCartScheduledDate,
     getOrCreateCheckoutOperation,
@@ -33,10 +36,12 @@ import {
     getShoppingCart,
     getSunflowerPackageByCode,
     getUser,
+    hasMatchingCheckoutPlantingPurchase,
     type InvoiceForTransactionLineItem,
     isCartItemDeliverable,
     knownEvents,
     lockAndActivateRaisedBedForCheckoutPlanting,
+    lockShoppingCartForCheckout,
     markCartPaidIfAllItemsPaid,
     normalizeShoppingCartInventoryUsage,
     normalizeShoppingCartScheduledDates,
@@ -47,6 +52,11 @@ import {
     sunflowerPackageEntityTypeName,
     topUpSunflowerPackage,
     upsertRaisedBedField,
+    withCheckoutCartItemLock,
+    withCheckoutCartItemLocks,
+    withCheckoutCartItemProcessingLock,
+    withCheckoutCartItemProcessingLocks,
+    withInventoryAccountTransaction,
     withPlantingScheduleTaskTransaction,
     withStripePaymentProcessingLock,
 } from '@gredice/storage';
@@ -61,6 +71,7 @@ import {
     getCartInfo,
     type ShoppingCartItemWithShopData,
 } from '../checkout/cartInfo';
+import { assertCheckoutCartItemSnapshot } from '../checkout/checkoutRecovery';
 import {
     decodeExpectedNonStripeCartItemIdsMetadata,
     decodeHarvestDatesMetadata,
@@ -69,7 +80,10 @@ import {
     buildOrderConfirmationItems,
     notifyOrderConfirmationEmail,
 } from '../checkout/orderConfirmationEmail';
-import { calculateSunflowerAmount } from '../checkout/sunflowerCalculations';
+import {
+    calculateSunflowerAmount,
+    calculateSunflowerReplayAmount,
+} from '../checkout/sunflowerCalculations';
 import { notifyDeliveryScheduled } from '../delivery/emailNotifications';
 import { notifyScheduledDeliveryEmailOnce } from '../delivery/scheduledEmailDeduper';
 import { getPostHogClient } from '../posthog-server';
@@ -92,6 +106,10 @@ export type ProcessCheckoutSessionDependencies = {
     ensureInvoiceForTransaction: typeof ensureInvoiceForTransaction;
     getSunflowerPackageByCode: typeof getSunflowerPackageByCode;
     getCompletedTransactionByStripePaymentId: typeof getCompletedTransactionByStripePaymentId;
+    getCheckoutFulfillmentStartedCartItemIds: typeof getCheckoutFulfillmentStartedCartItemIds;
+    getCheckoutOperationMapping: typeof getCheckoutOperationMapping;
+    getCheckoutOperationMappings: typeof getCheckoutOperationMappings;
+    hasMatchingCheckoutPlantingPurchase: typeof hasMatchingCheckoutPlantingPurchase;
     getDefaultShoppingCartScheduledDate: typeof getDefaultShoppingCartScheduledDate;
     getOutletOfferReservationForCartItem: typeof getOutletOfferReservationForCartItem;
     getRaisedBed: typeof getRaisedBed;
@@ -101,6 +119,7 @@ export type ProcessCheckoutSessionDependencies = {
     isCartItemDeliverable: typeof isCartItemDeliverable;
     knownEvents: typeof knownEvents;
     lockAndActivateRaisedBedForCheckoutPlanting: typeof lockAndActivateRaisedBedForCheckoutPlanting;
+    lockShoppingCartForCheckout: typeof lockShoppingCartForCheckout;
     markCartPaidIfAllItemsPaid: typeof markCartPaidIfAllItemsPaid;
     normalizeShoppingCartInventoryUsage: typeof normalizeShoppingCartInventoryUsage;
     normalizeShoppingCartScheduledDates: typeof normalizeShoppingCartScheduledDates;
@@ -110,6 +129,11 @@ export type ProcessCheckoutSessionDependencies = {
     topUpSunflowerPackage: typeof topUpSunflowerPackage;
     upsertRaisedBedField: typeof upsertRaisedBedField;
     withPlantingScheduleTaskTransaction: typeof withPlantingScheduleTaskTransaction;
+    withCheckoutCartItemLock: typeof withCheckoutCartItemLock;
+    withCheckoutCartItemLocks: typeof withCheckoutCartItemLocks;
+    withCheckoutCartItemProcessingLock: typeof withCheckoutCartItemProcessingLock;
+    withCheckoutCartItemProcessingLocks: typeof withCheckoutCartItemProcessingLocks;
+    withInventoryAccountTransaction: typeof withInventoryAccountTransaction;
     withStripePaymentProcessingLock: typeof withStripePaymentProcessingLock;
     getStripeCheckoutSession: typeof getStripeCheckoutSession;
     isBillingAutomationEnabled: typeof isBillingAutomationEnabled;
@@ -145,6 +169,10 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     ensureInvoiceForTransaction,
     getSunflowerPackageByCode,
     getCompletedTransactionByStripePaymentId,
+    getCheckoutFulfillmentStartedCartItemIds,
+    getCheckoutOperationMapping,
+    getCheckoutOperationMappings,
+    hasMatchingCheckoutPlantingPurchase,
     getDefaultShoppingCartScheduledDate,
     getOutletOfferReservationForCartItem,
     getRaisedBed,
@@ -154,6 +182,7 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     isCartItemDeliverable,
     knownEvents,
     lockAndActivateRaisedBedForCheckoutPlanting,
+    lockShoppingCartForCheckout,
     markCartPaidIfAllItemsPaid,
     normalizeShoppingCartInventoryUsage,
     normalizeShoppingCartScheduledDates,
@@ -163,6 +192,11 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     topUpSunflowerPackage,
     upsertRaisedBedField,
     withPlantingScheduleTaskTransaction,
+    withCheckoutCartItemLock,
+    withCheckoutCartItemLocks,
+    withCheckoutCartItemProcessingLock,
+    withCheckoutCartItemProcessingLocks,
+    withInventoryAccountTransaction,
     withStripePaymentProcessingLock,
     getStripeCheckoutSession,
     isBillingAutomationEnabled,
@@ -197,6 +231,95 @@ function sortObjectKeys(obj: unknown): unknown {
             result[key] = sortObjectKeys((obj as Record<string, unknown>)[key]);
             return result;
         }, {});
+}
+
+function parseShoppingCartItemAdditionalData(
+    value: string | null | undefined,
+): object {
+    if (!value) {
+        return {};
+    }
+    const parsed: unknown = JSON.parse(value);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('Shopping cart item additional data must be an object');
+    }
+    return parsed;
+}
+
+type CheckoutDeliveryInfo = {
+    addressId?: number;
+    locationId?: number;
+    mode: 'delivery' | 'pickup';
+    notes?: string;
+    slotId: number;
+};
+
+function checkoutDeliveryInfoFromAdditionalData(
+    additionalData: unknown,
+): CheckoutDeliveryInfo | null {
+    if (
+        !additionalData ||
+        typeof additionalData !== 'object' ||
+        !('delivery' in additionalData)
+    ) {
+        return null;
+    }
+    const delivery = additionalData.delivery;
+    if (!delivery || typeof delivery !== 'object') {
+        return null;
+    }
+    const value = delivery as Record<string, unknown>;
+    if (
+        typeof value.slotId !== 'number' ||
+        !Number.isSafeInteger(value.slotId) ||
+        (value.mode !== 'delivery' && value.mode !== 'pickup') ||
+        (value.addressId !== undefined &&
+            !Number.isSafeInteger(value.addressId)) ||
+        (value.locationId !== undefined &&
+            !Number.isSafeInteger(value.locationId)) ||
+        (value.notes !== undefined && typeof value.notes !== 'string')
+    ) {
+        return null;
+    }
+    return {
+        addressId:
+            typeof value.addressId === 'number' ? value.addressId : undefined,
+        locationId:
+            typeof value.locationId === 'number' ? value.locationId : undefined,
+        mode: value.mode,
+        notes: typeof value.notes === 'string' ? value.notes : undefined,
+        slotId: value.slotId,
+    };
+}
+
+function checkoutDeliveryProvenance(deliveryInfo: CheckoutDeliveryInfo | null) {
+    return deliveryInfo
+        ? {
+              addressId: deliveryInfo.addressId ?? null,
+              locationId: deliveryInfo.locationId ?? null,
+              mode: deliveryInfo.mode,
+              notes: deliveryInfo.notes ?? null,
+              slotId: deliveryInfo.slotId,
+          }
+        : null;
+}
+
+function checkoutDeliveryInfoFromProvenance(
+    provenance: NonNullable<
+        NonNullable<
+            Awaited<ReturnType<typeof getCheckoutOperationMapping>>
+        >['delivery']
+    > | null,
+): CheckoutDeliveryInfo | null {
+    return provenance
+        ? {
+              addressId: provenance.addressId ?? undefined,
+              locationId: provenance.locationId ?? undefined,
+              mode: provenance.mode,
+              notes: provenance.notes ?? undefined,
+              slotId: provenance.slotId,
+          }
+        : null;
 }
 
 type PaidCheckoutSession = NonNullable<
@@ -342,34 +465,112 @@ async function processNonStripeCartItems(
     scheduledDeliveryEmailKeys?: Set<string>,
     checkoutSessionId?: string | null,
     dependencies: ProcessCheckoutSessionDependencies = realDependencies,
-): Promise<ShoppingCartItemWithShopData[]> {
+): Promise<{
+    confirmationItems: ShoppingCartItemWithShopData[];
+    processedItems: ShoppingCartItemWithShopData[];
+    resolvedSunflowerAmountsByCartItemId: Map<number, number>;
+    satisfiedExpectedItemIds: Set<number>;
+}> {
+    let confirmationItems: ShoppingCartItemWithShopData[] = [];
     const processedItems: ShoppingCartItemWithShopData[] = [];
+    const resolvedSunflowerAmountsByCartItemId = new Map<number, number>();
+    const satisfiedExpectedItemIds = new Set<number>();
     const inventoryNormalizedCart =
         await dependencies.normalizeShoppingCartInventoryUsage(cartId);
     if (!inventoryNormalizedCart) {
-        console.warn(
-            `No cart found for ID ${cartId} when processing non-stripe items.`,
-        );
-        return [];
+        const message = `No cart found for ID ${cartId} when processing non-stripe items.`;
+        if (expectedNonStripeCartItemIds !== null) {
+            throw new Error(message);
+        }
+        console.warn(message);
+        return {
+            confirmationItems,
+            processedItems,
+            resolvedSunflowerAmountsByCartItemId,
+            satisfiedExpectedItemIds,
+        };
     }
+    const checkoutOperationMappings =
+        await dependencies.getCheckoutOperationMappings(
+            inventoryNormalizedCart.items
+                .filter(
+                    (item) =>
+                        item.status !== 'paid' &&
+                        item.entityTypeName === 'operation',
+                )
+                .map((item) => item.id),
+        );
     const cart =
         (await dependencies.normalizeShoppingCartScheduledDates(
             inventoryNormalizedCart.id,
             {
+                checkoutOperationMappings,
                 defaultMissingScheduledDates: true,
             },
         )) ?? inventoryNormalizedCart;
 
-    const cartInfo = await dependencies.getCartInfo(cart.items, accountId);
-    if (!cartInfo.allowPurchase) {
-        console.warn(
-            `Cart ${cartId} failed validation when processing non-stripe items: ${cartInfo.notes.join('; ')}`,
-        );
-        return [];
-    }
     const isExpectedNonStripeItem = (item: { id: number }) =>
         expectedNonStripeCartItemIds === null ||
         expectedNonStripeCartItemIds.has(item.id);
+    for (const item of cart.items) {
+        if (
+            item.status === 'paid' &&
+            expectedNonStripeCartItemIds?.has(item.id)
+        ) {
+            satisfiedExpectedItemIds.add(item.id);
+        }
+    }
+
+    let cartInfo = await dependencies.getCartInfo(cart.items, accountId, {
+        checkoutOperationMappings,
+    });
+    if (!cartInfo.allowPurchase) {
+        const pendingDirectItems = cart.items.filter(
+            (item) =>
+                item.status !== 'paid' &&
+                item.currency !== 'eur' &&
+                isExpectedNonStripeItem(item),
+        );
+        const resumableDirectCartItemIds =
+            pendingDirectItems.length > 0
+                ? await dependencies.getCheckoutFulfillmentStartedCartItemIds(
+                      accountId,
+                      pendingDirectItems,
+                  )
+                : new Set<number>();
+        if (resumableDirectCartItemIds.size > 0) {
+            cartInfo = await dependencies.getCartInfo(cart.items, accountId, {
+                checkoutOperationMappings,
+                resumableCartItemIds: resumableDirectCartItemIds,
+            });
+        }
+    }
+    confirmationItems = cartInfo.items.filter(
+        (item) =>
+            isExpectedNonStripeItem(item) &&
+            (item.currency === 'sunflower' ||
+                item.currency === 'inventory' ||
+                item.usesInventory),
+    );
+    if (!cartInfo.allowPurchase) {
+        const pendingExpectedItem = cart.items.find(
+            (item) => item.status !== 'paid' && isExpectedNonStripeItem(item),
+        );
+        if (pendingExpectedItem) {
+            throw new Error(
+                `Cart ${cartId} failed validation when processing expected non-stripe item ${pendingExpectedItem.id.toString()}: ${cartInfo.notes.join('; ')}`,
+            );
+        }
+        console.warn(
+            `Cart ${cartId} failed validation after all expected non-stripe items were already paid: ${cartInfo.notes.join('; ')}`,
+        );
+        return {
+            confirmationItems,
+            processedItems,
+            resolvedSunflowerAmountsByCartItemId,
+            satisfiedExpectedItemIds,
+        };
+    }
     for (const item of cartInfo.items) {
         if (
             expectedNonStripeCartItemIds?.has(item.id) &&
@@ -385,77 +586,220 @@ async function processNonStripeCartItems(
         }
     }
 
-    const sunflowerCartItemsWithShopData = cartInfo.items.filter(
-        (item) =>
-            item.status !== 'paid' &&
-            item.currency === 'sunflower' &&
-            isExpectedNonStripeItem(item),
+    const checkoutAdditionalDataByCartItemId = new Map(
+        cartInfo.items
+            .filter(
+                (item) =>
+                    item.status !== 'paid' && isExpectedNonStripeItem(item),
+            )
+            .map((item) => [
+                item.id,
+                {
+                    ...parseShoppingCartItemAdditionalData(item.additionalData),
+                    ...(deliveryInfo ? { delivery: deliveryInfo } : {}),
+                    ...(harvestDateByCartItemId.has(item.id)
+                        ? {
+                              scheduledDate: harvestDateByCartItemId.get(
+                                  item.id,
+                              ),
+                          }
+                        : {}),
+                },
+            ]),
     );
+
+    const expectedSunflowerCartItemsWithShopData = cartInfo.items.filter(
+        (item) =>
+            item.currency === 'sunflower' && isExpectedNonStripeItem(item),
+    );
+    const sunflowerCartItemsWithShopData =
+        expectedSunflowerCartItemsWithShopData.filter(
+            (item) => item.status !== 'paid',
+        );
 
     // Precompute sunflower amounts so the durable batch debit can be retried
     // without charging an already-processed item again.
     const sunflowerAmountsByItem = new Map<number, number>();
 
-    for (const item of sunflowerCartItemsWithShopData) {
-        const sunflowerAmount = dependencies.calculateSunflowerAmount(item);
+    for (const item of expectedSunflowerCartItemsWithShopData) {
+        const sunflowerAmount =
+            item.status === 'paid'
+                ? calculateSunflowerReplayAmount(item)
+                : dependencies.calculateSunflowerAmount(item);
         sunflowerAmountsByItem.set(item.id, sunflowerAmount);
+        resolvedSunflowerAmountsByCartItemId.set(item.id, sunflowerAmount);
     }
 
     if (sunflowerCartItemsWithShopData.length > 0) {
-        try {
-            await dependencies.spendSunflowersBatch(
-                accountId,
-                sunflowerCartItemsWithShopData.map((item) => ({
-                    amount: sunflowerAmountsByItem.get(item.id) ?? 0,
-                    reason: `shoppingCartItem:${item.id.toString()}`,
-                })),
-            );
-        } catch (error) {
-            console.error('Error spending sunflowers during cart processing', {
-                error,
-                accountId,
-                cartId,
-            });
-            throw error;
-        }
-    }
+        await dependencies.withCheckoutCartItemProcessingLocks(
+            expectedSunflowerCartItemsWithShopData.map((item) => item.id),
+            async () => {
+                const { pendingItems, resolvedAmountsByItemId } =
+                    await dependencies.withCheckoutCartItemLocks(
+                        expectedSunflowerCartItemsWithShopData.map(
+                            (item) => item.id,
+                        ),
+                        async (db) => {
+                            const lockedCart =
+                                await dependencies.lockShoppingCartForCheckout(
+                                    cartId,
+                                    db,
+                                );
+                            if (!lockedCart) {
+                                throw new Error(
+                                    `Cart ${cartId.toString()} disappeared before sunflower fulfillment.`,
+                                );
+                            }
+                            if (lockedCart.accountId !== accountId) {
+                                throw new Error(
+                                    `Cart ${cartId.toString()} account changed before sunflower fulfillment.`,
+                                );
+                            }
+                            const lockedPendingItems =
+                                expectedSunflowerCartItemsWithShopData.filter(
+                                    (item) => {
+                                        const state =
+                                            assertCheckoutCartItemSnapshot(
+                                                lockedCart.items.find(
+                                                    (lockedItem) =>
+                                                        lockedItem.id ===
+                                                        item.id,
+                                                ),
+                                                item,
+                                            );
+                                        if (
+                                            state === 'paid' &&
+                                            expectedNonStripeCartItemIds?.has(
+                                                item.id,
+                                            )
+                                        ) {
+                                            satisfiedExpectedItemIds.add(
+                                                item.id,
+                                            );
+                                        }
+                                        return state === 'pending';
+                                    },
+                                );
+                            try {
+                                const spendResult =
+                                    await dependencies.spendSunflowersBatch(
+                                        accountId,
+                                        lockedPendingItems.map((item) => ({
+                                            amount:
+                                                sunflowerAmountsByItem.get(
+                                                    item.id,
+                                                ) ?? 0,
+                                            reason: `shoppingCartItem:${item.id.toString()}`,
+                                        })),
+                                        db,
+                                        {
+                                            existingCheckoutItemAmountsAreAuthoritative: true,
+                                            legacyCartSpend: {
+                                                reason: `shoppingCart:${cartId.toString()}`,
+                                                coveredItems:
+                                                    expectedSunflowerCartItemsWithShopData.map(
+                                                        (item) => ({
+                                                            amount:
+                                                                sunflowerAmountsByItem.get(
+                                                                    item.id,
+                                                                ) ?? 0,
+                                                            cartItemId: item.id,
+                                                            createdAt:
+                                                                item.createdAt,
+                                                            reason: `shoppingCartItem:${item.id.toString()}`,
+                                                        }),
+                                                    ),
+                                            },
+                                        },
+                                    );
+                                const resolvedAmountsByItemId = new Map<
+                                    number,
+                                    number
+                                >();
+                                for (const item of lockedPendingItems) {
+                                    const resolvedAmount =
+                                        spendResult.resolvedAmountsByReason[
+                                            `shoppingCartItem:${item.id.toString()}`
+                                        ];
+                                    if (
+                                        !Number.isSafeInteger(resolvedAmount) ||
+                                        resolvedAmount <= 0
+                                    ) {
+                                        throw new Error(
+                                            `Sunflower spend for cart item ${item.id.toString()} did not resolve a valid amount.`,
+                                        );
+                                    }
+                                    resolvedAmountsByItemId.set(
+                                        item.id,
+                                        resolvedAmount,
+                                    );
+                                }
+                                return {
+                                    pendingItems: lockedPendingItems,
+                                    resolvedAmountsByItemId,
+                                };
+                            } catch (error) {
+                                console.error(
+                                    'Error spending sunflowers during cart processing',
+                                    { error, accountId, cartId },
+                                );
+                                throw error;
+                            }
+                        },
+                    );
 
-    for (const item of sunflowerCartItemsWithShopData) {
-        const sunflowerAmount = sunflowerAmountsByItem.get(item.id) ?? 0;
-        const baseAdditionalData = item.additionalData
-            ? JSON.parse(item.additionalData)
-            : {};
-        const additionalData = {
-            ...baseAdditionalData,
-            ...(deliveryInfo ? { delivery: deliveryInfo } : {}),
-            ...(harvestDateByCartItemId.has(item.id)
-                ? {
-                      scheduledDate: harvestDateByCartItemId.get(item.id),
-                  }
-                : {}),
-        };
-
-        const fulfillment = await processItem(
-            {
-                accountId,
-                cartItemId: item.id,
-                entityId: item.entityId,
-                entityTypeName: item.entityTypeName,
-                cartId: item.cartId,
-                gardenId: item.gardenId,
-                raisedBedId: item.raisedBedId,
-                positionIndex: item.positionIndex,
-                currency: item.currency,
-                amount_total: sunflowerAmount,
-                additionalData,
-                scheduledDeliveryEmailKeys,
-                checkoutSessionId,
+                for (const item of pendingItems) {
+                    const sunflowerAmount = resolvedAmountsByItemId.get(
+                        item.id,
+                    );
+                    if (sunflowerAmount === undefined) {
+                        throw new Error(
+                            `Sunflower spend for cart item ${item.id.toString()} lost its resolved amount.`,
+                        );
+                    }
+                    resolvedSunflowerAmountsByCartItemId.set(
+                        item.id,
+                        sunflowerAmount,
+                    );
+                    const checkoutOperationMapping =
+                        item.entityTypeName === 'operation'
+                            ? await dependencies.getCheckoutOperationMapping(
+                                  item.id,
+                              )
+                            : undefined;
+                    const additionalData =
+                        checkoutAdditionalDataByCartItemId.get(item.id) ?? {};
+                    const fulfillment = await processItem(
+                        {
+                            accountId,
+                            cartItemId: item.id,
+                            entityId: item.entityId,
+                            entityTypeName: item.entityTypeName,
+                            cartId: item.cartId,
+                            gardenId: item.gardenId,
+                            raisedBedId: item.raisedBedId,
+                            positionIndex: item.positionIndex,
+                            currency: item.currency,
+                            amount_total: sunflowerAmount,
+                            additionalData,
+                            scheduledDeliveryEmailKeys,
+                            checkoutSessionId,
+                            checkoutOperationMapping:
+                                item.entityTypeName === 'operation'
+                                    ? checkoutOperationMapping
+                                    : undefined,
+                        },
+                        dependencies,
+                    );
+                    assertCheckoutItemFulfilled(fulfillment);
+                    await dependencies.setCartItemPaid(item.id);
+                    processedItems.push(item);
+                    if (expectedNonStripeCartItemIds?.has(item.id)) {
+                        satisfiedExpectedItemIds.add(item.id);
+                    }
+                }
             },
-            dependencies,
         );
-        assertCheckoutItemFulfilled(fulfillment);
-        await dependencies.setCartItemPaid(item.id);
-        processedItems.push(item);
     }
 
     const inventoryCartItems = cartInfo.items.filter(
@@ -498,50 +842,101 @@ async function processNonStripeCartItems(
         }
 
         for (const item of inventoryCartItems) {
-            const baseAdditionalData = item.additionalData
-                ? JSON.parse(item.additionalData)
-                : {};
-            const additionalData = {
-                ...baseAdditionalData,
-                ...(deliveryInfo ? { delivery: deliveryInfo } : {}),
-                ...(harvestDateByCartItemId.has(item.id)
-                    ? {
-                          scheduledDate: harvestDateByCartItemId.get(item.id),
-                      }
-                    : {}),
-            };
+            await dependencies.withCheckoutCartItemProcessingLock(
+                item.id,
+                async () => {
+                    const state = await dependencies.withCheckoutCartItemLock(
+                        item.id,
+                        async (db) => {
+                            const lockedCart =
+                                await dependencies.getShoppingCart(cartId, db);
+                            if (!lockedCart) {
+                                throw new Error(
+                                    `Cart ${cartId.toString()} disappeared before inventory fulfillment.`,
+                                );
+                            }
+                            const lockedState = assertCheckoutCartItemSnapshot(
+                                lockedCart.items.find(
+                                    (lockedItem) => lockedItem.id === item.id,
+                                ),
+                                item,
+                            );
+                            if (lockedState === 'pending') {
+                                await dependencies.withInventoryAccountTransaction(
+                                    accountId,
+                                    (inventoryDb) =>
+                                        dependencies.consumeInventoryItem(
+                                            accountId,
+                                            {
+                                                entityTypeName:
+                                                    item.entityTypeName,
+                                                entityId: item.entityId,
+                                                amount: item.amount,
+                                                source: `shoppingCartItem:${item.id}`,
+                                            },
+                                            inventoryDb,
+                                        ),
+                                    db,
+                                );
+                            }
+                            return lockedState;
+                        },
+                    );
+                    if (state === 'paid') {
+                        if (expectedNonStripeCartItemIds?.has(item.id)) {
+                            satisfiedExpectedItemIds.add(item.id);
+                        }
+                        return;
+                    }
+                    const checkoutOperationMapping =
+                        item.entityTypeName === 'operation'
+                            ? await dependencies.getCheckoutOperationMapping(
+                                  item.id,
+                              )
+                            : undefined;
 
-            await dependencies.consumeInventoryItem(accountId, {
-                entityTypeName: item.entityTypeName,
-                entityId: item.entityId,
-                amount: item.amount,
-                source: `shoppingCartItem:${item.id}`,
-            });
-            const fulfillment = await processItem(
-                {
-                    accountId,
-                    cartItemId: item.id,
-                    entityId: item.entityId,
-                    entityTypeName: item.entityTypeName,
-                    cartId: item.cartId,
-                    gardenId: item.gardenId,
-                    raisedBedId: item.raisedBedId,
-                    positionIndex: item.positionIndex,
-                    currency: item.currency,
-                    amount_total: 0,
-                    additionalData,
-                    scheduledDeliveryEmailKeys,
-                    checkoutSessionId,
+                    const additionalData =
+                        checkoutAdditionalDataByCartItemId.get(item.id) ?? {};
+
+                    const fulfillment = await processItem(
+                        {
+                            accountId,
+                            cartItemId: item.id,
+                            entityId: item.entityId,
+                            entityTypeName: item.entityTypeName,
+                            cartId: item.cartId,
+                            gardenId: item.gardenId,
+                            raisedBedId: item.raisedBedId,
+                            positionIndex: item.positionIndex,
+                            currency: item.currency,
+                            amount_total: 0,
+                            additionalData,
+                            scheduledDeliveryEmailKeys,
+                            checkoutSessionId,
+                            checkoutOperationMapping:
+                                item.entityTypeName === 'operation'
+                                    ? checkoutOperationMapping
+                                    : undefined,
+                        },
+                        dependencies,
+                    );
+                    assertCheckoutItemFulfilled(fulfillment);
+                    await dependencies.setCartItemPaid(item.id);
+                    processedItems.push(item);
+                    if (expectedNonStripeCartItemIds?.has(item.id)) {
+                        satisfiedExpectedItemIds.add(item.id);
+                    }
                 },
-                dependencies,
             );
-            assertCheckoutItemFulfilled(fulfillment);
-            await dependencies.setCartItemPaid(item.id);
-            processedItems.push(item);
         }
     }
 
-    return processedItems;
+    return {
+        confirmationItems,
+        processedItems,
+        resolvedSunflowerAmountsByCartItemId,
+        satisfiedExpectedItemIds,
+    };
 }
 
 export async function processCheckoutSession(
@@ -1023,21 +1418,59 @@ async function processPaidCheckoutSession(
     let accountId: string | undefined;
     let customerUserId: string | undefined;
     const invoiceLineItems: InvoiceForTransactionLineItem[] = [];
+    const fulfillmentErrors: unknown[] = [];
+    const expectedNonStripeCartItemIds =
+        decodeExpectedNonStripeCartItemIdsMetadata(session.metadata);
+    if (expectedNonStripeCartItemIds?.size) {
+        const candidateCartIds = new Set<number>();
+        for (const lineItem of session.lineItems?.data ?? []) {
+            const product = lineItem.price?.product;
+            if (typeof product === 'string' || product?.deleted) {
+                continue;
+            }
+            const cartId = Number(product?.metadata.cartId);
+            if (Number.isSafeInteger(cartId) && cartId > 0) {
+                candidateCartIds.add(cartId);
+            }
+        }
+
+        const presentExpectedItemIds = new Set<number>();
+        for (const cartId of candidateCartIds) {
+            const candidateCart = await dependencies.getShoppingCart(cartId);
+            for (const item of candidateCart?.items ?? []) {
+                if (expectedNonStripeCartItemIds.has(item.id)) {
+                    presentExpectedItemIds.add(item.id);
+                }
+            }
+        }
+        const missingExpectedItemIds = [...expectedNonStripeCartItemIds].filter(
+            (itemId) => !presentExpectedItemIds.has(itemId),
+        );
+        if (missingExpectedItemIds.length > 0) {
+            throw new Error(
+                `Expected non-Stripe cart items are missing before fulfillment: ${missingExpectedItemIds.join(', ')}`,
+            );
+        }
+    }
     for (const item of session.lineItems?.data ?? []) {
         console.debug(`Item: ${item.id} Quantity: ${item.quantity}`);
 
         const product = item.price?.product;
         if (typeof product === 'string') {
-            console.warn(
-                `Product is a string: ${product}. This is not supported.`,
+            const error = new Error(
+                `Stripe line item ${item.id} has an unexpanded product and cannot be fulfilled.`,
             );
+            console.warn(error.message);
+            fulfillmentErrors.push(error);
             continue;
         }
 
         if (product?.deleted) {
-            console.warn(
-                `Product is deleted: ${product.id}. This is not supported.`,
+            const error = new Error(
+                `Stripe line item ${item.id} references deleted product ${product.id} and cannot be fulfilled.`,
             );
+            console.warn(error.message);
+            fulfillmentErrors.push(error);
             continue;
         }
 
@@ -1063,6 +1496,21 @@ async function processPaidCheckoutSession(
         });
 
         // Extract metadata from the product
+        let additionalData: unknown;
+        try {
+            additionalData = product?.metadata.additionalData
+                ? JSON.parse(product.metadata.additionalData)
+                : undefined;
+        } catch (cause) {
+            const error = new Error(
+                `Stripe line item ${item.id} has invalid additionalData metadata.`,
+                { cause },
+            );
+            console.warn(error.message);
+            fulfillmentErrors.push(error);
+            continue;
+        }
+
         const itemData = {
             cartItemId: product?.metadata.cartItemId
                 ? parseInt(product.metadata.cartItemId, 10)
@@ -1083,9 +1531,7 @@ async function processPaidCheckoutSession(
             positionIndex: product?.metadata.positionIndex
                 ? parseInt(product.metadata.positionIndex, 10)
                 : undefined,
-            additionalData: product?.metadata.additionalData
-                ? JSON.parse(product.metadata.additionalData)
-                : undefined,
+            additionalData,
             outletOfferId: product?.metadata.outletOfferId
                 ? parseInt(product.metadata.outletOfferId, 10)
                 : undefined,
@@ -1101,8 +1547,6 @@ async function processPaidCheckoutSession(
             currency: 'eur',
         };
 
-        // Save accountId from metadata if not already set
-        accountId ??= itemData.accountId;
         customerUserId ??= itemData.userId;
 
         // Validate required metadata (accountId can be derived from cart)
@@ -1112,9 +1556,11 @@ async function processPaidCheckoutSession(
             !itemData.entityTypeName ||
             !itemData.cartId
         ) {
-            console.warn(
-                `Missing required metadata for item ${item.id} in session ${checkoutSessionId}`,
+            const error = new Error(
+                `Missing required metadata for item ${item.id} in session ${checkoutSessionId}.`,
             );
+            console.warn(error.message);
+            fulfillmentErrors.push(error);
             continue;
         }
 
@@ -1123,28 +1569,31 @@ async function processPaidCheckoutSession(
         try {
             const cart = await dependencies.getShoppingCart(itemData.cartId);
             if (!cart) {
-                console.warn(
-                    `No cart found for ID ${itemData.cartId} in session ${checkoutSessionId}`,
+                throw new Error(
+                    `No cart found for ID ${itemData.cartId} in session ${checkoutSessionId}.`,
                 );
-                continue;
             }
 
-            resolvedAccountId =
-                itemData.accountId ?? cart.accountId ?? undefined;
-            if (!resolvedAccountId) {
-                console.warn(
-                    `Missing accountId for cart ${itemData.cartId} when processing session ${checkoutSessionId}`,
+            if (!cart.accountId) {
+                throw new Error(
+                    `Missing accountId for cart ${itemData.cartId} when processing session ${checkoutSessionId}.`,
                 );
-                continue;
             }
+            if (itemData.accountId && itemData.accountId !== cart.accountId) {
+                throw new Error(
+                    `Stripe metadata account does not own cart ${itemData.cartId} in session ${checkoutSessionId}.`,
+                );
+            }
+            resolvedAccountId = cart.accountId;
+            const checkoutAccountId = resolvedAccountId;
 
-            // Ensure we have an accountId for the whole session (prefer the cart value)
+            // Every line in one checkout must resolve to the same cart owner.
             if (accountId && accountId !== resolvedAccountId) {
-                console.warn(
-                    `AccountId mismatch for session ${checkoutSessionId}: metadata ${accountId} vs cart ${resolvedAccountId}. Using cart accountId.`,
+                throw new Error(
+                    `Checkout session ${checkoutSessionId} references carts owned by different accounts.`,
                 );
             }
-            accountId = resolvedAccountId;
+            accountId = checkoutAccountId;
 
             // Find cart item by cartItemId for more reliable matching
             const cartItem = cart.items.find(
@@ -1152,10 +1601,9 @@ async function processPaidCheckoutSession(
             );
 
             if (!cartItem) {
-                console.warn(
-                    `No cart item found with ID ${itemData.cartItemId} in cart ${itemData.cartId} for session ${checkoutSessionId}`,
+                throw new Error(
+                    `No cart item found with ID ${itemData.cartItemId} in cart ${itemData.cartId} for session ${checkoutSessionId}.`,
                 );
-                continue;
             }
 
             // Additional validation: ensure the cart item matches the expected entity details
@@ -1163,17 +1611,15 @@ async function processPaidCheckoutSession(
                 cartItem.entityId !== itemData.entityId ||
                 cartItem.entityTypeName !== itemData.entityTypeName
             ) {
-                console.warn(
-                    `Cart item ${itemData.cartItemId} entity mismatch. Expected: ${itemData.entityId}/${itemData.entityTypeName}, Found: ${cartItem.entityId}/${cartItem.entityTypeName}`,
+                throw new Error(
+                    `Cart item ${itemData.cartItemId} entity mismatch. Expected: ${itemData.entityId}/${itemData.entityTypeName}, Found: ${cartItem.entityId}/${cartItem.entityTypeName}.`,
                 );
-                continue;
             }
 
             if (typeof item.amount_total !== 'number') {
-                console.warn(
-                    `Missing amount_total for Stripe line item ${item.id} in session ${checkoutSessionId}. Skipping processing to avoid inconsistent state.`,
+                throw new Error(
+                    `Missing amount_total for Stripe line item ${item.id} in session ${checkoutSessionId}.`,
                 );
-                continue;
             }
 
             affectedCartIds.push(cart.id);
@@ -1202,60 +1648,147 @@ async function processPaidCheckoutSession(
                 );
                 continue;
             }
-            const isPlantingItem = itemData.entityTypeName === 'plantSort';
-            if (
-                !(await assertRaisedBedAllowsCheckoutItem(
-                    cartItem.raisedBedId,
-                    dependencies,
-                ))
-            ) {
-                if (isPlantingItem) {
-                    throw new CheckoutPlantingRaisedBedUnavailableError(
-                        'abandoned',
+            await dependencies.withCheckoutCartItemProcessingLock(
+                cartItem.id,
+                async () => {
+                    const state = await dependencies.withCheckoutCartItemLock(
+                        cartItem.id,
+                        async (db) => {
+                            const lockedCart =
+                                await dependencies.getShoppingCart(cart.id, db);
+                            if (!lockedCart) {
+                                throw new Error(
+                                    `Cart ${cart.id.toString()} disappeared before Stripe fulfillment.`,
+                                );
+                            }
+                            const lockedState = assertCheckoutCartItemSnapshot(
+                                lockedCart.items.find(
+                                    (lockedItem) =>
+                                        lockedItem.id === cartItem.id,
+                                ),
+                                cartItem,
+                            );
+                            if (lockedState === 'pending') {
+                                const legacyRewardAlreadyEarned =
+                                    itemData.entityTypeName === 'plantSort' &&
+                                    typeof cartItem.positionIndex ===
+                                        'number' &&
+                                    typeof cartItem.raisedBedId === 'number' &&
+                                    (await dependencies.hasMatchingCheckoutPlantingPurchase(
+                                        {
+                                            cartItemId: cartItem.id,
+                                            euroAmountCents: item.amount_total,
+                                            plantSortId: cartItem.entityId,
+                                            positionIndex:
+                                                cartItem.positionIndex,
+                                            raisedBedId: cartItem.raisedBedId,
+                                        },
+                                        db,
+                                    ));
+                                await dependencies.earnSunflowersForPayment(
+                                    checkoutAccountId,
+                                    item.amount_total / 100,
+                                    `shoppingCartItem:${cartItem.id.toString()}`,
+                                    db,
+                                    { legacyRewardAlreadyEarned },
+                                );
+                            }
+                            return lockedState;
+                        },
                     );
-                }
-                throw new CheckoutItemFulfillmentError(
-                    'raised_bed_unavailable',
-                );
-            }
+                    if (state === 'paid') {
+                        console.warn(
+                            `Cart item ${cartItem.id} became paid while waiting for its fulfillment lock. Skipping replay.`,
+                        );
+                        return;
+                    }
 
-            const fulfillment = await processItem(
-                {
-                    ...itemData,
-                    accountId: resolvedAccountId,
-                    amount_total: item.amount_total,
-                    scheduledDeliveryEmailKeys,
-                    checkoutSessionId: session.id,
+                    try {
+                        const isPlantingItem =
+                            itemData.entityTypeName === 'plantSort';
+                        const checkoutOperationMapping =
+                            itemData.entityTypeName === 'operation'
+                                ? await dependencies.getCheckoutOperationMapping(
+                                      cartItem.id,
+                                  )
+                                : undefined;
+                        if (
+                            !checkoutOperationMapping &&
+                            !(await assertRaisedBedAllowsCheckoutItem(
+                                cartItem.raisedBedId,
+                                dependencies,
+                            ))
+                        ) {
+                            if (isPlantingItem) {
+                                throw new CheckoutPlantingRaisedBedUnavailableError(
+                                    'abandoned',
+                                );
+                            }
+                            throw new CheckoutItemFulfillmentError(
+                                'raised_bed_unavailable',
+                            );
+                        }
+
+                        const fulfillment = await processItem(
+                            {
+                                ...itemData,
+                                accountId: checkoutAccountId,
+                                amount_total: item.amount_total,
+                                scheduledDeliveryEmailKeys,
+                                checkoutSessionId: session.id,
+                                paymentRewardAlreadyEnsured: true,
+                                checkoutOperationMapping,
+                            },
+                            dependencies,
+                        );
+                        assertCheckoutItemFulfilled(fulfillment);
+                        await dependencies.setCartItemPaid(cartItem.id);
+                    } catch (error) {
+                        if (
+                            error instanceof
+                            CheckoutPlantingRaisedBedUnavailableError
+                        ) {
+                            try {
+                                await recordCheckoutPlantingRaisedBedUnavailable(
+                                    {
+                                        accountId: checkoutAccountId,
+                                        cartItemId: cartItem.id,
+                                        checkoutSessionId: session.id,
+                                        dependencies,
+                                        gardenId: itemData.gardenId,
+                                        positionIndex: itemData.positionIndex,
+                                        raisedBedId: itemData.raisedBedId,
+                                        reason: error.reason,
+                                    },
+                                );
+                            } catch (incidentError) {
+                                console.error(
+                                    'Failed to record checkout planting incident',
+                                    incidentError,
+                                );
+                            }
+                        }
+                        throw error;
+                    }
                 },
-                dependencies,
             );
-            assertCheckoutItemFulfilled(fulfillment);
-            await dependencies.setCartItemPaid(cartItem.id);
         } catch (error) {
-            if (
-                error instanceof CheckoutPlantingRaisedBedUnavailableError &&
-                resolvedAccountId &&
-                itemData.cartItemId
-            ) {
-                await recordCheckoutPlantingRaisedBedUnavailable({
-                    accountId: resolvedAccountId,
-                    cartItemId: itemData.cartItemId,
-                    checkoutSessionId: session.id,
-                    dependencies,
-                    gardenId: itemData.gardenId,
-                    positionIndex: itemData.positionIndex,
-                    raisedBedId: itemData.raisedBedId,
-                    reason: error.reason,
-                });
-            }
             console.error(
                 `Error processing cart item ${itemData.cartItemId} in session ${checkoutSessionId}`,
                 error,
             );
-            throw error;
+            fulfillmentErrors.push(error);
         }
 
         // TODO: Send invoice to customer
+    }
+
+    if (fulfillmentErrors.length > 0) {
+        const firstFulfillmentError = fulfillmentErrors[0];
+        if (firstFulfillmentError !== undefined) {
+            throw firstFulfillmentError;
+        }
+        throw new Error('Checkout item fulfillment failed');
     }
 
     // Extract and validate delivery info from Stripe items to use for non-Stripe items.
@@ -1299,11 +1832,11 @@ async function processPaidCheckoutSession(
     const harvestDateByCartItemId = decodeHarvestDatesMetadata(
         session.metadata,
     );
-    const expectedNonStripeCartItemIds =
-        decodeExpectedNonStripeCartItemIdsMetadata(session.metadata);
+    const satisfiedExpectedNonStripeItemIds = new Set<number>();
+    const resolvedSunflowerAmountsByCartItemId = new Map<number, number>();
     if (accountId && uniqueAffectedCartIds.length > 0) {
         for (const cartId of uniqueAffectedCartIds) {
-            const nonStripeItems = await processNonStripeCartItems(
+            const nonStripeResult = await processNonStripeCartItems(
                 cartId,
                 accountId,
                 deliveryInfo,
@@ -1313,11 +1846,32 @@ async function processPaidCheckoutSession(
                 session.id,
                 dependencies,
             );
+            for (const itemId of nonStripeResult.satisfiedExpectedItemIds) {
+                satisfiedExpectedNonStripeItemIds.add(itemId);
+            }
+            for (const [
+                itemId,
+                amount,
+            ] of nonStripeResult.resolvedSunflowerAmountsByCartItemId) {
+                resolvedSunflowerAmountsByCartItemId.set(itemId, amount);
+            }
             purchasedItems.push(
                 ...dependencies.buildOrderConfirmationItems(
-                    nonStripeItems,
-                    dependencies.calculateSunflowerAmount,
+                    nonStripeResult.confirmationItems,
+                    (item) =>
+                        resolvedSunflowerAmountsByCartItemId.get(item.id) ??
+                        calculateSunflowerReplayAmount(item),
                 ),
+            );
+        }
+    }
+    if (expectedNonStripeCartItemIds !== null) {
+        const missingExpectedItemIds = [...expectedNonStripeCartItemIds].filter(
+            (itemId) => !satisfiedExpectedNonStripeItemIds.has(itemId),
+        );
+        if (missingExpectedItemIds.length > 0) {
+            throw new Error(
+                `Expected non-Stripe cart items were not fulfilled: ${missingExpectedItemIds.join(', ')}`,
             );
         }
     }
@@ -1801,6 +2355,10 @@ export async function processItem(
         amount_total: number; // Amount in cents or sunflowers
         scheduledDeliveryEmailKeys?: Set<string>;
         checkoutSessionId?: string | null;
+        paymentRewardAlreadyEnsured?: boolean;
+        checkoutOperationMapping?: Awaited<
+            ReturnType<typeof getCheckoutOperationMapping>
+        >;
     },
     dependencies: ProcessCheckoutSessionDependencies = realDependencies,
 ): Promise<ProcessItemFulfillmentResult> {
@@ -1809,10 +2367,14 @@ export async function processItem(
     );
 
     const earnSunflowersFunc = () =>
-        itemData.accountId && itemData.currency === 'eur'
+        itemData.accountId &&
+        itemData.cartItemId &&
+        itemData.currency === 'eur' &&
+        itemData.paymentRewardAlreadyEnsured !== true
             ? dependencies.earnSunflowersForPayment(
                   itemData.accountId,
                   itemData.amount_total / 100,
+                  `shoppingCartItem:${itemData.cartItemId.toString()}`,
               )
             : Promise.resolve();
 
@@ -1842,7 +2404,26 @@ export async function processItem(
             );
             return { status: 'not_fulfilled', reason: 'invalid_entity_id' };
         }
+        const paymentCurrency = itemData.currency;
         if (
+            paymentCurrency !== 'eur' &&
+            paymentCurrency !== 'inventory' &&
+            paymentCurrency !== 'sunflower'
+        ) {
+            console.error(
+                `Invalid payment currency for operation item in order.`,
+                itemData,
+            );
+            return { status: 'not_fulfilled', reason: 'unsupported_item' };
+        }
+        const checkoutOperationMapping =
+            itemData.checkoutOperationMapping === undefined
+                ? await dependencies.getCheckoutOperationMapping(
+                      itemData.cartItemId,
+                  )
+                : itemData.checkoutOperationMapping;
+        if (
+            !checkoutOperationMapping &&
             !(await assertRaisedBedAllowsCheckoutItem(
                 itemData.raisedBedId,
                 dependencies,
@@ -1854,9 +2435,13 @@ export async function processItem(
             };
         }
 
-        // Try to resolve field ID from position index (only active fields)
+        // New operations target the currently active field. Retries must keep
+        // the field captured in the durable mapping, even if the active field
+        // at this position has changed since the first attempt.
         let fieldId: number | undefined;
-        if (
+        if (checkoutOperationMapping) {
+            fieldId = checkoutOperationMapping.raisedBedFieldId ?? undefined;
+        } else if (
             typeof itemData.positionIndex === 'number' &&
             itemData.raisedBedId
         ) {
@@ -1891,7 +2476,19 @@ export async function processItem(
             additionalData,
             dependencies,
         );
+        const operationScheduledDate =
+            checkoutOperationMapping?.scheduledDate ?? scheduledDate;
+        const requestedDeliveryInfo =
+            checkoutDeliveryInfoFromAdditionalData(additionalData);
+        const deliveryProvenance = checkoutOperationMapping
+            ? checkoutOperationMapping.delivery
+            : checkoutDeliveryProvenance(requestedDeliveryInfo);
+        const deliveryInfo =
+            checkoutDeliveryInfoFromProvenance(deliveryProvenance);
 
+        // Credit the captured-payment reward first. Its cart-item key makes a
+        // replay a no-op if operation creation or later fulfillment fails.
+        await earnSunflowersFunc();
         const { created, operationId } =
             await dependencies.getOrCreateCheckoutOperation(
                 itemData.cartItemId,
@@ -1903,24 +2500,22 @@ export async function processItem(
                     raisedBedId: itemData.raisedBedId,
                     raisedBedFieldId: fieldId,
                 },
-                { scheduledDate: new Date(scheduledDate) },
+                {
+                    delivery: deliveryProvenance,
+                    paymentCurrency,
+                    scheduledDate: new Date(operationScheduledDate),
+                },
             );
 
         if (created) {
-            try {
-                await earnSunflowersFunc();
-            } catch (error) {
-                console.error(
-                    `Failed to award sunflowers for operation item in order.`,
-                    error,
-                );
-            }
             try {
                 await dependencies.notifyOperationUpdate(
                     operationId,
                     'scheduled',
                     {
-                        scheduledDate: new Date(scheduledDate).toISOString(),
+                        scheduledDate: new Date(
+                            operationScheduledDate,
+                        ).toISOString(),
                     },
                 );
             } catch (error) {
@@ -1944,30 +2539,7 @@ export async function processItem(
                     `Operation ${operationId} is deliverable - checking for delivery configuration in metadata`,
                 );
 
-                // Check if delivery information was stored in additionalData
-                let deliveryInfo: {
-                    slotId?: number;
-                    mode?: 'delivery' | 'pickup';
-                    addressId?: number;
-                    locationId?: number;
-                    notes?: string;
-                } | null = null;
-                if (
-                    typeof additionalData === 'object' &&
-                    additionalData !== null &&
-                    'delivery' in additionalData
-                ) {
-                    deliveryInfo = (additionalData as Record<string, unknown>)
-                        .delivery as {
-                        slotId?: number;
-                        mode?: 'delivery' | 'pickup';
-                        addressId?: number;
-                        locationId?: number;
-                        notes?: string;
-                    };
-                }
-
-                if (deliveryInfo?.slotId && deliveryInfo.mode) {
+                if (deliveryInfo) {
                     try {
                         const deliveryRequest =
                             await dependencies.getOrCreateDeliveryRequest({
@@ -2072,6 +2644,7 @@ export async function processItem(
         const aggregateId = `${raisedBedId}|${positionIndex}`;
         const purchase = plantingPurchaseFromCheckoutItem(itemData);
 
+        await earnSunflowersFunc();
         let placementResult: 'already-placed' | 'placed';
         try {
             placementResult =
@@ -2197,25 +2770,6 @@ export async function processItem(
                                 );
                             }
                         }
-
-                        if (itemData.accountId && itemData.currency === 'eur') {
-                            const earnedSunflowers = Math.round(
-                                itemData.amount_total / 10,
-                            );
-                            if (earnedSunflowers > 0) {
-                                await dependencies.createEvent(
-                                    dependencies.knownEvents.accounts.sunflowersEarnedV1(
-                                        itemData.accountId,
-                                        {
-                                            amount: earnedSunflowers,
-                                            reason: 'payment',
-                                        },
-                                    ),
-                                    transaction,
-                                );
-                            }
-                        }
-
                         return 'placed';
                     },
                 );

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -564,12 +564,6 @@ async function processNonStripeCartItems(
         console.warn(
             `Cart ${cartId} failed validation after all expected non-stripe items were already paid: ${cartInfo.notes.join('; ')}`,
         );
-        return {
-            confirmationItems,
-            processedItems,
-            resolvedSunflowerAmountsByCartItemId,
-            satisfiedExpectedItemIds,
-        };
     }
     for (const item of cartInfo.items) {
         if (
@@ -612,11 +606,6 @@ async function processNonStripeCartItems(
         (item) =>
             item.currency === 'sunflower' && isExpectedNonStripeItem(item),
     );
-    const sunflowerCartItemsWithShopData =
-        expectedSunflowerCartItemsWithShopData.filter(
-            (item) => item.status !== 'paid',
-        );
-
     // Precompute sunflower amounts so the durable batch debit can be retried
     // without charging an already-processed item again.
     const sunflowerAmountsByItem = new Map<number, number>();
@@ -627,10 +616,9 @@ async function processNonStripeCartItems(
                 ? calculateSunflowerReplayAmount(item)
                 : dependencies.calculateSunflowerAmount(item);
         sunflowerAmountsByItem.set(item.id, sunflowerAmount);
-        resolvedSunflowerAmountsByCartItemId.set(item.id, sunflowerAmount);
     }
 
-    if (sunflowerCartItemsWithShopData.length > 0) {
+    if (expectedSunflowerCartItemsWithShopData.length > 0) {
         await dependencies.withCheckoutCartItemProcessingLocks(
             expectedSunflowerCartItemsWithShopData.map((item) => item.id),
             async () => {
@@ -655,30 +643,32 @@ async function processNonStripeCartItems(
                                     `Cart ${cartId.toString()} account changed before sunflower fulfillment.`,
                                 );
                             }
+                            const paymentStatesByCartItemId = new Map<
+                                number,
+                                'paid' | 'pending'
+                            >();
+                            for (const item of expectedSunflowerCartItemsWithShopData) {
+                                const state = assertCheckoutCartItemSnapshot(
+                                    lockedCart.items.find(
+                                        (lockedItem) =>
+                                            lockedItem.id === item.id,
+                                    ),
+                                    item,
+                                );
+                                paymentStatesByCartItemId.set(item.id, state);
+                                if (
+                                    state === 'paid' &&
+                                    expectedNonStripeCartItemIds?.has(item.id)
+                                ) {
+                                    satisfiedExpectedItemIds.add(item.id);
+                                }
+                            }
                             const lockedPendingItems =
                                 expectedSunflowerCartItemsWithShopData.filter(
-                                    (item) => {
-                                        const state =
-                                            assertCheckoutCartItemSnapshot(
-                                                lockedCart.items.find(
-                                                    (lockedItem) =>
-                                                        lockedItem.id ===
-                                                        item.id,
-                                                ),
-                                                item,
-                                            );
-                                        if (
-                                            state === 'paid' &&
-                                            expectedNonStripeCartItemIds?.has(
-                                                item.id,
-                                            )
-                                        ) {
-                                            satisfiedExpectedItemIds.add(
-                                                item.id,
-                                            );
-                                        }
-                                        return state === 'pending';
-                                    },
+                                    (item) =>
+                                        paymentStatesByCartItemId.get(
+                                            item.id,
+                                        ) === 'pending',
                                 );
                             try {
                                 const spendResult =
@@ -698,16 +688,29 @@ async function processNonStripeCartItems(
                                                 reason: `shoppingCart:${cartId.toString()}`,
                                                 coveredItems:
                                                     expectedSunflowerCartItemsWithShopData.map(
-                                                        (item) => ({
-                                                            amount:
-                                                                sunflowerAmountsByItem.get(
+                                                        (item) => {
+                                                            const paymentState =
+                                                                paymentStatesByCartItemId.get(
                                                                     item.id,
-                                                                ) ?? 0,
-                                                            cartItemId: item.id,
-                                                            createdAt:
-                                                                item.createdAt,
-                                                            reason: `shoppingCartItem:${item.id.toString()}`,
-                                                        }),
+                                                                );
+                                                            if (!paymentState) {
+                                                                throw new Error(
+                                                                    `Sunflower cart item ${item.id.toString()} lost its payment state.`,
+                                                                );
+                                                            }
+                                                            return {
+                                                                amount:
+                                                                    sunflowerAmountsByItem.get(
+                                                                        item.id,
+                                                                    ) ?? 0,
+                                                                cartItemId:
+                                                                    item.id,
+                                                                createdAt:
+                                                                    item.createdAt,
+                                                                paymentState,
+                                                                reason: `shoppingCartItem:${item.id.toString()}`,
+                                                            };
+                                                        },
                                                     ),
                                             },
                                         },
@@ -716,7 +719,7 @@ async function processNonStripeCartItems(
                                     number,
                                     number
                                 >();
-                                for (const item of lockedPendingItems) {
+                                for (const item of expectedSunflowerCartItemsWithShopData) {
                                     const resolvedAmount =
                                         spendResult.resolvedAmountsByReason[
                                             `shoppingCartItem:${item.id.toString()}`
@@ -730,6 +733,10 @@ async function processNonStripeCartItems(
                                         );
                                     }
                                     resolvedAmountsByItemId.set(
+                                        item.id,
+                                        resolvedAmount,
+                                    );
+                                    resolvedSunflowerAmountsByCartItemId.set(
                                         item.id,
                                         resolvedAmount,
                                     );
@@ -1858,9 +1865,16 @@ async function processPaidCheckoutSession(
             purchasedItems.push(
                 ...dependencies.buildOrderConfirmationItems(
                     nonStripeResult.confirmationItems,
-                    (item) =>
-                        resolvedSunflowerAmountsByCartItemId.get(item.id) ??
-                        calculateSunflowerReplayAmount(item),
+                    (item) => {
+                        const resolvedAmount =
+                            resolvedSunflowerAmountsByCartItemId.get(item.id);
+                        if (resolvedAmount === undefined) {
+                            throw new Error(
+                                `Sunflower confirmation amount is missing for cart item ${item.id.toString()}.`,
+                            );
+                        }
+                        return resolvedAmount;
+                    },
                 ),
             );
         }

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -34,6 +34,7 @@ export * from './repositories/attributeDefinitionsRepo';
 export * from './repositories/attributeValuesRepo';
 export * from './repositories/automationsRepo';
 export * from './repositories/billingReconciliationRepo';
+export * from './repositories/checkoutCartItemLock';
 export * from './repositories/cmsPagesRepo';
 export * from './repositories/communityEditRequestsRepo';
 export * from './repositories/deliveryAddressesRepo';

--- a/packages/storage/src/repositories/accountsRepo.ts
+++ b/packages/storage/src/repositories/accountsRepo.ts
@@ -1,7 +1,13 @@
 import 'server-only';
 import { randomUUID } from 'node:crypto';
-import { asc, desc, eq, sql } from 'drizzle-orm';
-import { accounts, accountUsers, ensureAccountAchievement, storage } from '..';
+import { and, asc, desc, eq, inArray, sql } from 'drizzle-orm';
+import {
+    accounts,
+    accountUsers,
+    ensureAccountAchievement,
+    events,
+    storage,
+} from '..';
 import {
     createEvent,
     getAllEvents,
@@ -15,6 +21,39 @@ interface SunflowerEventData {
     amount: number;
     reason?: string;
 }
+
+export class InsufficientSunflowersError extends Error {
+    override readonly name = 'InsufficientSunflowersError';
+
+    constructor(
+        readonly availableAmount: number,
+        readonly requiredAmount: number,
+    ) {
+        super('Insufficient sunflowers');
+    }
+}
+
+export class SunflowerSpendAmountConflictError extends Error {
+    override readonly name = 'SunflowerSpendAmountConflictError';
+
+    constructor(
+        readonly reason: string,
+        readonly existingAmount: number,
+        readonly requestedAmount: number,
+    ) {
+        super('Sunflower spend amount conflicts with an existing event');
+    }
+}
+
+export type SunflowerSpendBatchItem = {
+    amount: number;
+    reason: string;
+};
+
+export type SunflowerSpendBatchResult = {
+    createdReasons: string[];
+    existingReasons: string[];
+};
 
 export type BirthdaySunflowerGrantResult =
     | {
@@ -283,7 +322,7 @@ export async function spendSunflowers(
 
         const currentSunflowers = await getSunflowers(accountId, tx);
         if (currentSunflowers < amount) {
-            throw new Error('Insufficient sunflowers');
+            throw new InsufficientSunflowersError(currentSunflowers, amount);
         }
 
         await createEvent(
@@ -293,5 +332,123 @@ export async function spendSunflowers(
             }),
             tx,
         );
+    });
+}
+
+/**
+ * Spend sunflowers for durable, independently retryable operations.
+ *
+ * Each reason is an idempotency key. A retry with the same amount is a no-op,
+ * while reusing a reason for a different amount is rejected. All missing
+ * debits are validated before any event is written.
+ */
+export async function spendSunflowersBatch(
+    accountId: string,
+    items: readonly SunflowerSpendBatchItem[],
+    db: ReturnType<typeof storage> = storage(),
+): Promise<SunflowerSpendBatchResult> {
+    const uniqueItems = new Map<string, SunflowerSpendBatchItem>();
+    for (const item of items) {
+        if (!Number.isInteger(item.amount) || item.amount <= 0) {
+            throw new Error(
+                'Sunflower spend amount must be a positive integer',
+            );
+        }
+        if (!item.reason.trim()) {
+            throw new Error('Sunflower spend reason is required');
+        }
+
+        const duplicate = uniqueItems.get(item.reason);
+        if (duplicate && duplicate.amount !== item.amount) {
+            throw new SunflowerSpendAmountConflictError(
+                item.reason,
+                duplicate.amount,
+                item.amount,
+            );
+        }
+        uniqueItems.set(item.reason, item);
+    }
+
+    if (uniqueItems.size === 0) {
+        return { createdReasons: [], existingReasons: [] };
+    }
+
+    return db.transaction(async (tx) => {
+        await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtext(${`account-sunflowers:${accountId}`}));`,
+        );
+
+        const reasons = Array.from(uniqueItems.keys());
+        const existingEvents = await tx
+            .select({ data: events.data })
+            .from(events)
+            .where(
+                and(
+                    eq(events.aggregateId, accountId),
+                    eq(events.type, knownEventTypes.accounts.spendSunflowers),
+                    inArray(sql<string>`${events.data}->>'reason'`, reasons),
+                ),
+            );
+        const existingAmounts = new Map<string, number>();
+        for (const event of existingEvents) {
+            const { amount, reason } = parseSunflowerEventData(event.data);
+            if (!reason) continue;
+
+            const previousAmount = existingAmounts.get(reason);
+            if (previousAmount !== undefined && previousAmount !== amount) {
+                throw new SunflowerSpendAmountConflictError(
+                    reason,
+                    previousAmount,
+                    amount,
+                );
+            }
+            existingAmounts.set(reason, amount);
+        }
+
+        const missingItems: SunflowerSpendBatchItem[] = [];
+        const existingReasons: string[] = [];
+        for (const item of uniqueItems.values()) {
+            const existingAmount = existingAmounts.get(item.reason);
+            if (existingAmount === undefined) {
+                missingItems.push(item);
+                continue;
+            }
+            if (existingAmount !== item.amount) {
+                throw new SunflowerSpendAmountConflictError(
+                    item.reason,
+                    existingAmount,
+                    item.amount,
+                );
+            }
+            existingReasons.push(item.reason);
+        }
+
+        if (missingItems.length === 0) {
+            return { createdReasons: [], existingReasons };
+        }
+
+        const currentSunflowers = await getSunflowers(accountId, tx);
+        const requiredSunflowers = missingItems.reduce(
+            (total, item) => total + item.amount,
+            0,
+        );
+        if (currentSunflowers < requiredSunflowers) {
+            throw new InsufficientSunflowersError(
+                currentSunflowers,
+                requiredSunflowers,
+            );
+        }
+
+        for (const item of missingItems) {
+            await createEvent(
+                knownEvents.accounts.sunflowersSpentV1(accountId, item),
+                tx,
+            );
+        }
+
+        return {
+            createdReasons: missingItems.map((item) => item.reason),
+            existingReasons,
+        };
     });
 }

--- a/packages/storage/src/repositories/accountsRepo.ts
+++ b/packages/storage/src/repositories/accountsRepo.ts
@@ -12,13 +12,23 @@ import {
     createEvent,
     getAllEvents,
     getLastBirthdayRewardEvent,
-    getLatestEvents,
     knownEvents,
     knownEventTypes,
 } from './eventsRepo';
 
+type StorageClient = ReturnType<typeof storage>;
+type TransactionClient = Parameters<
+    Parameters<StorageClient['transaction']>[0]
+>[0];
+type DatabaseClient = StorageClient | TransactionClient;
+
 interface SunflowerEventData {
     amount: number;
+    amountIsValid: boolean;
+    coveredAmount?: number;
+    coveredAmountIsValid: boolean;
+    legacyCartReason?: string;
+    legacyRewardAlreadyEarned: boolean;
     reason?: string;
 }
 
@@ -45,14 +55,44 @@ export class SunflowerSpendAmountConflictError extends Error {
     }
 }
 
+export class SunflowerEarnAmountConflictError extends Error {
+    override readonly name = 'SunflowerEarnAmountConflictError';
+
+    constructor(
+        readonly reason: string,
+        readonly existingAmount: number,
+        readonly requestedAmount: number,
+    ) {
+        super('Sunflower earn amount conflicts with an existing event');
+    }
+}
+
 export type SunflowerSpendBatchItem = {
     amount: number;
     reason: string;
 };
 
+export type LegacySunflowerCartSpendCoveredItem = SunflowerSpendBatchItem & {
+    cartItemId: number;
+    createdAt: Date;
+};
+
 export type SunflowerSpendBatchResult = {
     createdReasons: string[];
     existingReasons: string[];
+    resolvedAmountsByReason: Record<string, number>;
+};
+
+export type SunflowerSpendBatchOptions = {
+    existingCheckoutItemAmountsAreAuthoritative?: boolean;
+    legacyCartSpend?: {
+        reason: string;
+        coveredItems: readonly LegacySunflowerCartSpendCoveredItem[];
+    };
+};
+
+export type SunflowerPaymentRewardOptions = {
+    legacyRewardAlreadyEarned?: boolean;
 };
 
 export type BirthdaySunflowerGrantResult =
@@ -67,26 +107,47 @@ export type BirthdaySunflowerGrantResult =
 
 function parseSunflowerEventData(data: unknown): SunflowerEventData {
     if (!data || typeof data !== 'object') {
-        return { amount: 0 };
+        return {
+            amount: 0,
+            amountIsValid: false,
+            coveredAmountIsValid: false,
+            legacyRewardAlreadyEarned: false,
+        };
     }
 
     const record = data as Record<string, unknown>;
-    const amountValue = record.amount;
-    let amount = 0;
-    if (typeof amountValue === 'number') {
-        amount = amountValue;
-    } else if (typeof amountValue === 'string') {
-        const parsed = Number.parseFloat(amountValue);
-        if (!Number.isNaN(parsed)) {
-            amount = parsed;
-        }
-    }
+    const parsedAmount = parseSunflowerEventAmount(record.amount);
+    const parsedCoveredAmount = parseSunflowerEventAmount(record.coveredAmount);
 
     const reasonValue = record.reason;
+    const legacyCartReasonValue = record.legacyCartReason;
     return {
-        amount,
+        amount: parsedAmount.amount,
+        amountIsValid: parsedAmount.isValid,
+        ...(parsedCoveredAmount.isValid
+            ? { coveredAmount: parsedCoveredAmount.amount }
+            : {}),
+        coveredAmountIsValid: parsedCoveredAmount.isValid,
+        legacyCartReason:
+            typeof legacyCartReasonValue === 'string'
+                ? legacyCartReasonValue
+                : undefined,
+        legacyRewardAlreadyEarned: record.legacyRewardAlreadyEarned === true,
         reason: typeof reasonValue === 'string' ? reasonValue : undefined,
     };
+}
+
+function parseSunflowerEventAmount(value: unknown) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return { amount: value, isValid: true };
+    }
+    if (typeof value === 'string' && value.trim()) {
+        const amount = Number(value);
+        if (Number.isFinite(amount)) {
+            return { amount, isValid: true };
+        }
+    }
+    return { amount: 0, isValid: false };
 }
 
 export function getAccounts() {
@@ -173,7 +234,7 @@ export async function updateAccountTimeZone(
 
 export async function getSunflowers(
     accountId: string,
-    db: ReturnType<typeof storage> = storage(),
+    db: DatabaseClient = storage(),
 ) {
     // Calculate sunflowers based on events
     let currentSunflowers = 0;
@@ -264,16 +325,20 @@ export async function getSunflowersHistory(
     offset: number = 0,
     limit: number = 10,
 ) {
-    const earnEvents = await getLatestEvents(
-        [
-            knownEventTypes.accounts.earnSunflowers,
-            knownEventTypes.accounts.earnSunflowerDrop,
-            knownEventTypes.accounts.spendSunflowers,
-        ],
-        [accountId],
+    const earnEvents = await storage().query.events.findMany({
+        where: and(
+            eq(events.aggregateId, accountId),
+            inArray(events.type, [
+                knownEventTypes.accounts.earnSunflowers,
+                knownEventTypes.accounts.earnSunflowerDrop,
+                knownEventTypes.accounts.spendSunflowers,
+            ]),
+            sql<boolean>`not (${events.type} in (${knownEventTypes.accounts.earnSunflowers}, ${knownEventTypes.accounts.spendSunflowers}) and ${events.data}->>'amount' = '0')`,
+        ),
+        orderBy: [desc(events.createdAt), desc(events.id)],
         offset,
         limit,
-    );
+    });
     return earnEvents.map((event) => {
         const { amount, reason } = parseSunflowerEventData(event.data);
         return {
@@ -288,24 +353,230 @@ export async function earnSunflowers(
     accountId: string,
     amount: number,
     reason: string,
-    db: ReturnType<typeof storage> = storage(),
+    db: DatabaseClient = storage(),
 ) {
-    if (amount === 0) return;
+    if (!Number.isInteger(amount) || amount <= 0) {
+        throw new Error('Sunflower earn amount must be a positive integer');
+    }
+    if (!reason.trim()) {
+        throw new Error('Sunflower earn reason is required');
+    }
     await createEvent(
         knownEvents.accounts.sunflowersEarnedV1(accountId, { amount, reason }),
         db,
     );
 }
 
+async function earnSunflowersAmountOnceInTransaction(
+    accountId: string,
+    amount: number,
+    reason: string,
+    tx: TransactionClient,
+) {
+    await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtext(${`account-sunflowers:${accountId}`}));`,
+    );
+    const existingEvents = await tx
+        .select({ data: events.data })
+        .from(events)
+        .where(
+            and(
+                eq(events.aggregateId, accountId),
+                eq(events.type, knownEventTypes.accounts.earnSunflowers),
+                eq(sql<string>`${events.data}->>'reason'`, reason),
+            ),
+        );
+    if (existingEvents.length > 1) {
+        const existingAmount = parseSunflowerEventData(
+            existingEvents[0]?.data,
+        ).amount;
+        throw new SunflowerEarnAmountConflictError(
+            reason,
+            existingAmount,
+            amount,
+        );
+    }
+
+    const existingEvent = existingEvents[0];
+    if (existingEvent) {
+        const existingAmount = parseSunflowerEventData(
+            existingEvent.data,
+        ).amount;
+        if (existingAmount !== amount) {
+            throw new SunflowerEarnAmountConflictError(
+                reason,
+                existingAmount,
+                amount,
+            );
+        }
+        return { status: 'existing' as const };
+    }
+
+    await createEvent(
+        knownEvents.accounts.sunflowersEarnedV1(accountId, {
+            amount,
+            reason,
+        }),
+        tx,
+    );
+    return { status: 'created' as const };
+}
+
+async function earnSunflowersForPaymentInTransaction(
+    accountId: string,
+    sunflowers: number,
+    reason: string,
+    tx: TransactionClient,
+    options: SunflowerPaymentRewardOptions,
+) {
+    await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtext(${`account-sunflowers:${accountId}`}));`,
+    );
+    const existingEvents = await tx
+        .select({ data: events.data })
+        .from(events)
+        .where(
+            and(
+                eq(events.aggregateId, accountId),
+                eq(events.type, knownEventTypes.accounts.earnSunflowers),
+                eq(sql<string>`${events.data}->>'reason'`, reason),
+            ),
+        );
+    if (existingEvents.length > 1) {
+        const existingAmount = parseSunflowerEventData(
+            existingEvents[0]?.data,
+        ).amount;
+        throw new SunflowerEarnAmountConflictError(
+            reason,
+            existingAmount,
+            sunflowers,
+        );
+    }
+
+    const existingEvent = existingEvents[0];
+    if (existingEvent) {
+        const existingData = parseSunflowerEventData(existingEvent.data);
+        const isActualReward =
+            sunflowers > 0 &&
+            existingData.amountIsValid &&
+            existingData.amount === sunflowers &&
+            !existingData.coveredAmountIsValid &&
+            existingData.legacyCartReason === undefined &&
+            !existingData.legacyRewardAlreadyEarned;
+        const isZeroRewardCheckpoint =
+            sunflowers === 0 &&
+            existingData.amountIsValid &&
+            existingData.amount === 0 &&
+            !existingData.coveredAmountIsValid &&
+            existingData.legacyCartReason === undefined &&
+            !existingData.legacyRewardAlreadyEarned;
+        const isLegacyRewardCheckpoint =
+            options.legacyRewardAlreadyEarned === true &&
+            sunflowers > 0 &&
+            existingData.amountIsValid &&
+            existingData.amount === 0 &&
+            existingData.coveredAmountIsValid &&
+            existingData.coveredAmount === sunflowers &&
+            existingData.legacyCartReason === undefined &&
+            existingData.legacyRewardAlreadyEarned;
+        if (
+            isActualReward ||
+            isZeroRewardCheckpoint ||
+            isLegacyRewardCheckpoint
+        ) {
+            return { status: 'existing' as const };
+        }
+        throw new SunflowerEarnAmountConflictError(
+            reason,
+            existingData.amount,
+            sunflowers,
+        );
+    }
+
+    const isLegacyRewardCheckpoint = options.legacyRewardAlreadyEarned === true;
+    await createEvent(
+        knownEvents.accounts.sunflowersEarnedV1(accountId, {
+            amount: isLegacyRewardCheckpoint ? 0 : sunflowers,
+            ...(isLegacyRewardCheckpoint
+                ? {
+                      coveredAmount: sunflowers,
+                      legacyRewardAlreadyEarned: true,
+                  }
+                : {}),
+            reason,
+        }),
+        tx,
+    );
+    return { status: 'created' as const };
+}
+
+export async function earnSunflowersOnce(
+    accountId: string,
+    amount: number,
+    reason: string,
+    transaction?: TransactionClient,
+) {
+    if (!Number.isInteger(amount) || amount <= 0) {
+        throw new Error('Sunflower earn amount must be a positive integer');
+    }
+    if (!reason.trim()) {
+        throw new Error('Sunflower earn reason is required');
+    }
+
+    return transaction
+        ? earnSunflowersAmountOnceInTransaction(
+              accountId,
+              amount,
+              reason,
+              transaction,
+          )
+        : storage().transaction((tx) =>
+              earnSunflowersAmountOnceInTransaction(
+                  accountId,
+                  amount,
+                  reason,
+                  tx,
+              ),
+          );
+}
+
 export async function earnSunflowersForPayment(
     accountId: string,
     payment: number,
+    idempotencyKey?: string,
+    transaction?: TransactionClient,
+    options: SunflowerPaymentRewardOptions = {},
 ) {
     // Calculate sunflowers based on payment amount
     // For every 1 unit spent, earn 10 sunflowers
     const sunflowers = Math.round(payment * 10);
+    if (idempotencyKey && sunflowers >= 0) {
+        const reason = `payment:${idempotencyKey}`;
+        if (options.legacyRewardAlreadyEarned === true && sunflowers <= 0) {
+            throw new Error(
+                'Legacy sunflower payment reward must cover a positive amount',
+            );
+        }
+        const recordReward = (tx: TransactionClient) =>
+            earnSunflowersForPaymentInTransaction(
+                accountId,
+                sunflowers,
+                reason,
+                tx,
+                options,
+            );
+        await (transaction
+            ? recordReward(transaction)
+            : storage().transaction(recordReward));
+        return;
+    }
+    if (options.legacyRewardAlreadyEarned === true) {
+        throw new Error(
+            'Legacy sunflower payment reward requires an idempotency key',
+        );
+    }
     if (sunflowers > 0) {
-        await earnSunflowers(accountId, sunflowers, 'payment');
+        await earnSunflowers(accountId, sunflowers, 'payment', transaction);
     }
 }
 
@@ -315,6 +586,12 @@ export async function spendSunflowers(
     reason: string,
     db: ReturnType<typeof storage> = storage(),
 ) {
+    if (!Number.isInteger(amount) || amount <= 0) {
+        throw new Error('Sunflower spend amount must be a positive integer');
+    }
+    if (!reason.trim()) {
+        throw new Error('Sunflower spend reason is required');
+    }
     await db.transaction(async (tx) => {
         await tx.execute(
             sql`select pg_advisory_xact_lock(hashtext(${`account-sunflowers:${accountId}`}));`,
@@ -335,19 +612,13 @@ export async function spendSunflowers(
     });
 }
 
-/**
- * Spend sunflowers for durable, independently retryable operations.
- *
- * Each reason is an idempotency key. A retry with the same amount is a no-op,
- * while reusing a reason for a different amount is rejected. All missing
- * debits are validated before any event is written.
- */
-export async function spendSunflowersBatch(
-    accountId: string,
-    items: readonly SunflowerSpendBatchItem[],
-    db: ReturnType<typeof storage> = storage(),
-): Promise<SunflowerSpendBatchResult> {
-    const uniqueItems = new Map<string, SunflowerSpendBatchItem>();
+const checkoutCartItemSpendReasonPattern = /^shoppingCartItem:[1-9]\d*$/;
+const legacyCheckoutCartSpendReasonPattern = /^shoppingCart:[1-9]\d*$/;
+
+function normalizeSunflowerSpendBatchItems<
+    Item extends SunflowerSpendBatchItem,
+>(items: readonly Item[], rejectDuplicateReasons: boolean) {
+    const uniqueItems = new Map<string, Item>();
     for (const item of items) {
         if (!Number.isInteger(item.amount) || item.amount <= 0) {
             throw new Error(
@@ -359,6 +630,13 @@ export async function spendSunflowersBatch(
         }
 
         const duplicate = uniqueItems.get(item.reason);
+        if (duplicate && rejectDuplicateReasons) {
+            throw new SunflowerSpendAmountConflictError(
+                item.reason,
+                duplicate.amount,
+                item.amount,
+            );
+        }
         if (duplicate && duplicate.amount !== item.amount) {
             throw new SunflowerSpendAmountConflictError(
                 item.reason,
@@ -368,19 +646,116 @@ export async function spendSunflowersBatch(
         }
         uniqueItems.set(item.reason, item);
     }
+    return uniqueItems;
+}
 
-    if (uniqueItems.size === 0) {
-        return { createdReasons: [], existingReasons: [] };
+function assertCheckoutCartItemSpendReason(reason: string) {
+    if (!checkoutCartItemSpendReasonPattern.test(reason)) {
+        throw new Error(
+            'Checkout sunflower replay requires a shoppingCartItem:<id> reason',
+        );
+    }
+}
+
+/**
+ * Spend sunflowers for durable, independently retryable operations.
+ *
+ * Each reason is an idempotency key. By default, a retry with the same amount
+ * is a no-op and a changed amount is rejected. Checkout can explicitly elect
+ * to use a unique stored item debit as the source of truth on replay.
+ */
+export async function spendSunflowersBatch(
+    accountId: string,
+    items: readonly SunflowerSpendBatchItem[],
+    transaction?: TransactionClient,
+    options: SunflowerSpendBatchOptions = {},
+): Promise<SunflowerSpendBatchResult> {
+    const uniqueItems = normalizeSunflowerSpendBatchItems(items, false);
+    const checkoutReplayEnabled =
+        options.existingCheckoutItemAmountsAreAuthoritative === true ||
+        options.legacyCartSpend !== undefined;
+    if (checkoutReplayEnabled) {
+        for (const reason of uniqueItems.keys()) {
+            assertCheckoutCartItemSpendReason(reason);
+        }
     }
 
-    return db.transaction(async (tx) => {
+    const legacyCartSpend = options.legacyCartSpend;
+    const coveredItems = legacyCartSpend
+        ? normalizeSunflowerSpendBatchItems(legacyCartSpend.coveredItems, true)
+        : undefined;
+    if (legacyCartSpend) {
+        if (
+            !legacyCheckoutCartSpendReasonPattern.test(legacyCartSpend.reason)
+        ) {
+            throw new Error(
+                'Legacy checkout sunflower replay requires a shoppingCart:<id> reason',
+            );
+        }
+        if (!coveredItems || coveredItems.size === 0) {
+            throw new Error(
+                'Legacy checkout sunflower replay requires covered items',
+            );
+        }
+        for (const coveredItem of coveredItems.values()) {
+            assertCheckoutCartItemSpendReason(coveredItem.reason);
+            if (
+                !Number.isSafeInteger(coveredItem.cartItemId) ||
+                coveredItem.cartItemId <= 0 ||
+                coveredItem.reason !==
+                    `shoppingCartItem:${coveredItem.cartItemId.toString()}`
+            ) {
+                throw new Error(
+                    'Legacy checkout sunflower covered-item reason must match its cart item ID',
+                );
+            }
+            if (
+                !(coveredItem.createdAt instanceof Date) ||
+                Number.isNaN(coveredItem.createdAt.getTime())
+            ) {
+                throw new Error(
+                    'Legacy checkout sunflower covered item requires a valid creation time',
+                );
+            }
+        }
+        for (const item of uniqueItems.values()) {
+            const coveredItem = coveredItems.get(item.reason);
+            if (!coveredItem) {
+                throw new Error(
+                    'Legacy checkout sunflower replay must cover every pending item',
+                );
+            }
+            if (coveredItem.amount !== item.amount) {
+                throw new SunflowerSpendAmountConflictError(
+                    item.reason,
+                    coveredItem.amount,
+                    item.amount,
+                );
+            }
+        }
+    }
+
+    if (uniqueItems.size === 0) {
+        return {
+            createdReasons: [],
+            existingReasons: [],
+            resolvedAmountsByReason: {},
+        };
+    }
+
+    const spendInTransaction = async (tx: TransactionClient) => {
         await tx.execute(
             sql`select pg_advisory_xact_lock(hashtext(${`account-sunflowers:${accountId}`}));`,
         );
 
-        const reasons = Array.from(uniqueItems.keys());
+        const reasons = Array.from(
+            new Set([
+                ...(coveredItems?.keys() ?? uniqueItems.keys()),
+                ...(legacyCartSpend ? [legacyCartSpend.reason] : []),
+            ]),
+        );
         const existingEvents = await tx
-            .select({ data: events.data })
+            .select({ createdAt: events.createdAt, data: events.data })
             .from(events)
             .where(
                 and(
@@ -389,31 +764,172 @@ export async function spendSunflowersBatch(
                     inArray(sql<string>`${events.data}->>'reason'`, reasons),
                 ),
             );
-        const existingAmounts = new Map<string, number>();
+        const existingEventsByReason = new Map<
+            string,
+            (SunflowerEventData & { createdAt: Date })[]
+        >();
         for (const event of existingEvents) {
-            const { amount, reason } = parseSunflowerEventData(event.data);
+            const eventData = {
+                ...parseSunflowerEventData(event.data),
+                createdAt: event.createdAt,
+            };
+            const { reason } = eventData;
             if (!reason) continue;
-
-            const previousAmount = existingAmounts.get(reason);
-            if (previousAmount !== undefined && previousAmount !== amount) {
+            const matchingEvents = existingEventsByReason.get(reason) ?? [];
+            matchingEvents.push(eventData);
+            existingEventsByReason.set(reason, matchingEvents);
+        }
+        for (const reason of reasons) {
+            const matchingEvents = existingEventsByReason.get(reason) ?? [];
+            if (matchingEvents.length > 1) {
                 throw new SunflowerSpendAmountConflictError(
                     reason,
-                    previousAmount,
-                    amount,
+                    matchingEvents[0]?.amount ?? 0,
+                    uniqueItems.get(reason)?.amount ??
+                        coveredItems?.get(reason)?.amount ??
+                        0,
                 );
             }
-            existingAmounts.set(reason, amount);
+        }
+
+        if (legacyCartSpend && coveredItems) {
+            const legacyEvent = existingEventsByReason.get(
+                legacyCartSpend.reason,
+            )?.[0];
+            const existingCheckpoints = new Set<string>();
+            const resolvedCoveredAmounts = new Map(
+                Array.from(coveredItems.values(), (item) => [
+                    item.reason,
+                    item.amount,
+                ]),
+            );
+
+            for (const coveredItem of coveredItems.values()) {
+                const existingEvent = existingEventsByReason.get(
+                    coveredItem.reason,
+                )?.[0];
+                if (!existingEvent) continue;
+
+                if (existingEvent.amount !== 0) {
+                    if (legacyEvent) {
+                        throw new SunflowerSpendAmountConflictError(
+                            coveredItem.reason,
+                            existingEvent.amount,
+                            0,
+                        );
+                    }
+                    continue;
+                }
+                const isMatchingCheckpoint =
+                    existingEvent.amountIsValid &&
+                    existingEvent.coveredAmountIsValid &&
+                    Number.isInteger(existingEvent.coveredAmount) &&
+                    (existingEvent.coveredAmount ?? 0) > 0 &&
+                    existingEvent.legacyCartReason === legacyCartSpend.reason &&
+                    !existingEvent.legacyRewardAlreadyEarned;
+                if (!isMatchingCheckpoint || !legacyEvent) {
+                    throw new SunflowerSpendAmountConflictError(
+                        coveredItem.reason,
+                        existingEvent.coveredAmount ?? 0,
+                        coveredItem.amount,
+                    );
+                }
+                existingCheckpoints.add(coveredItem.reason);
+                resolvedCoveredAmounts.set(
+                    coveredItem.reason,
+                    existingEvent.coveredAmount ?? coveredItem.amount,
+                );
+            }
+
+            if (legacyEvent) {
+                for (const coveredItem of coveredItems.values()) {
+                    if (coveredItem.createdAt > legacyEvent.createdAt) {
+                        throw new Error(
+                            'Legacy checkout sunflower covered item was created after the cart debit',
+                        );
+                    }
+                }
+                const coveredAmount = Array.from(
+                    resolvedCoveredAmounts.values(),
+                ).reduce((total, amount) => total + amount, 0);
+                const isMatchingLegacyEvent =
+                    legacyEvent.amountIsValid &&
+                    Number.isInteger(legacyEvent.amount) &&
+                    legacyEvent.amount > 0 &&
+                    legacyEvent.amount === coveredAmount &&
+                    !legacyEvent.coveredAmountIsValid &&
+                    legacyEvent.legacyCartReason === undefined &&
+                    !legacyEvent.legacyRewardAlreadyEarned;
+                if (!isMatchingLegacyEvent) {
+                    throw new SunflowerSpendAmountConflictError(
+                        legacyCartSpend.reason,
+                        legacyEvent.amount,
+                        coveredAmount,
+                    );
+                }
+
+                const createdReasons: string[] = [];
+                const existingReasons: string[] = [];
+                const resolvedAmounts = new Map<string, number>();
+                for (const item of uniqueItems.values()) {
+                    const coveredItem = coveredItems.get(item.reason);
+                    if (!coveredItem) {
+                        throw new Error(
+                            'Legacy checkout sunflower replay lost a covered item',
+                        );
+                    }
+                    const resolvedAmount =
+                        resolvedCoveredAmounts.get(item.reason) ??
+                        coveredItem.amount;
+                    resolvedAmounts.set(item.reason, resolvedAmount);
+                    if (existingCheckpoints.has(item.reason)) {
+                        existingReasons.push(item.reason);
+                        continue;
+                    }
+                    await createEvent(
+                        knownEvents.accounts.sunflowersSpentV1(accountId, {
+                            amount: 0,
+                            coveredAmount: resolvedAmount,
+                            legacyCartReason: legacyCartSpend.reason,
+                            reason: item.reason,
+                        }),
+                        tx,
+                    );
+                    createdReasons.push(item.reason);
+                }
+                return {
+                    createdReasons,
+                    existingReasons,
+                    resolvedAmountsByReason:
+                        Object.fromEntries(resolvedAmounts),
+                };
+            }
         }
 
         const missingItems: SunflowerSpendBatchItem[] = [];
         const existingReasons: string[] = [];
+        const resolvedAmounts = new Map<string, number>();
         for (const item of uniqueItems.values()) {
-            const existingAmount = existingAmounts.get(item.reason);
-            if (existingAmount === undefined) {
+            const existingEvent = existingEventsByReason.get(item.reason)?.[0];
+            if (!existingEvent) {
                 missingItems.push(item);
+                resolvedAmounts.set(item.reason, item.amount);
                 continue;
             }
-            if (existingAmount !== item.amount) {
+            const existingAmount = existingEvent.amount;
+            const isValidExistingDebit =
+                existingEvent.amountIsValid &&
+                Number.isInteger(existingAmount) &&
+                existingAmount > 0 &&
+                !existingEvent.coveredAmountIsValid &&
+                existingEvent.legacyCartReason === undefined &&
+                !existingEvent.legacyRewardAlreadyEarned;
+            if (
+                !isValidExistingDebit ||
+                (existingAmount !== item.amount &&
+                    options.existingCheckoutItemAmountsAreAuthoritative !==
+                        true)
+            ) {
                 throw new SunflowerSpendAmountConflictError(
                     item.reason,
                     existingAmount,
@@ -421,10 +937,15 @@ export async function spendSunflowersBatch(
                 );
             }
             existingReasons.push(item.reason);
+            resolvedAmounts.set(item.reason, existingAmount);
         }
 
         if (missingItems.length === 0) {
-            return { createdReasons: [], existingReasons };
+            return {
+                createdReasons: [],
+                existingReasons,
+                resolvedAmountsByReason: Object.fromEntries(resolvedAmounts),
+            };
         }
 
         const currentSunflowers = await getSunflowers(accountId, tx);
@@ -449,6 +970,10 @@ export async function spendSunflowersBatch(
         return {
             createdReasons: missingItems.map((item) => item.reason),
             existingReasons,
+            resolvedAmountsByReason: Object.fromEntries(resolvedAmounts),
         };
-    });
+    };
+    return transaction
+        ? spendInTransaction(transaction)
+        : storage().transaction(spendInTransaction);
 }

--- a/packages/storage/src/repositories/accountsRepo.ts
+++ b/packages/storage/src/repositories/accountsRepo.ts
@@ -75,6 +75,7 @@ export type SunflowerSpendBatchItem = {
 export type LegacySunflowerCartSpendCoveredItem = SunflowerSpendBatchItem & {
     cartItemId: number;
     createdAt: Date;
+    paymentState: 'paid' | 'pending';
 };
 
 export type SunflowerSpendBatchResult = {
@@ -717,6 +718,22 @@ export async function spendSunflowersBatch(
                     'Legacy checkout sunflower covered item requires a valid creation time',
                 );
             }
+            if (
+                coveredItem.paymentState !== 'paid' &&
+                coveredItem.paymentState !== 'pending'
+            ) {
+                throw new Error(
+                    'Legacy checkout sunflower covered item requires a payment state',
+                );
+            }
+            if (
+                coveredItem.paymentState === 'paid' &&
+                uniqueItems.has(coveredItem.reason)
+            ) {
+                throw new Error(
+                    'Legacy checkout sunflower paid covered item cannot be requested for debit',
+                );
+            }
         }
         for (const item of uniqueItems.values()) {
             const coveredItem = coveredItems.get(item.reason);
@@ -735,7 +752,7 @@ export async function spendSunflowersBatch(
         }
     }
 
-    if (uniqueItems.size === 0) {
+    if (uniqueItems.size === 0 && !legacyCartSpend) {
         return {
             createdReasons: [],
             existingReasons: [],
@@ -792,17 +809,18 @@ export async function spendSunflowersBatch(
             }
         }
 
+        const resolvedCoveredAmounts = new Map<string, number>();
         if (legacyCartSpend && coveredItems) {
             const legacyEvent = existingEventsByReason.get(
                 legacyCartSpend.reason,
             )?.[0];
             const existingCheckpoints = new Set<string>();
-            const resolvedCoveredAmounts = new Map(
-                Array.from(coveredItems.values(), (item) => [
-                    item.reason,
-                    item.amount,
-                ]),
-            );
+            for (const coveredItem of coveredItems.values()) {
+                resolvedCoveredAmounts.set(
+                    coveredItem.reason,
+                    coveredItem.amount,
+                );
+            }
 
             for (const coveredItem of coveredItems.values()) {
                 const existingEvent = existingEventsByReason.get(
@@ -811,6 +829,20 @@ export async function spendSunflowersBatch(
                 if (!existingEvent) continue;
 
                 if (existingEvent.amount !== 0) {
+                    const isValidExistingDebit =
+                        existingEvent.amountIsValid &&
+                        Number.isInteger(existingEvent.amount) &&
+                        existingEvent.amount > 0 &&
+                        !existingEvent.coveredAmountIsValid &&
+                        existingEvent.legacyCartReason === undefined &&
+                        !existingEvent.legacyRewardAlreadyEarned;
+                    if (!isValidExistingDebit) {
+                        throw new SunflowerSpendAmountConflictError(
+                            coveredItem.reason,
+                            existingEvent.amount,
+                            coveredItem.amount,
+                        );
+                    }
                     if (legacyEvent) {
                         throw new SunflowerSpendAmountConflictError(
                             coveredItem.reason,
@@ -818,6 +850,10 @@ export async function spendSunflowersBatch(
                             0,
                         );
                     }
+                    resolvedCoveredAmounts.set(
+                        coveredItem.reason,
+                        existingEvent.amount,
+                    );
                     continue;
                 }
                 const isMatchingCheckpoint =
@@ -868,22 +904,18 @@ export async function spendSunflowersBatch(
                     );
                 }
 
-                const createdReasons: string[] = [];
-                const existingReasons: string[] = [];
-                const resolvedAmounts = new Map<string, number>();
-                for (const item of uniqueItems.values()) {
-                    const coveredItem = coveredItems.get(item.reason);
-                    if (!coveredItem) {
-                        throw new Error(
-                            'Legacy checkout sunflower replay lost a covered item',
-                        );
+                const newlyCreatedCheckpointReasons = new Set<string>();
+                for (const coveredItem of coveredItems.values()) {
+                    if (
+                        coveredItem.paymentState !== 'paid' &&
+                        !uniqueItems.has(coveredItem.reason)
+                    ) {
+                        continue;
                     }
                     const resolvedAmount =
-                        resolvedCoveredAmounts.get(item.reason) ??
+                        resolvedCoveredAmounts.get(coveredItem.reason) ??
                         coveredItem.amount;
-                    resolvedAmounts.set(item.reason, resolvedAmount);
-                    if (existingCheckpoints.has(item.reason)) {
-                        existingReasons.push(item.reason);
+                    if (existingCheckpoints.has(coveredItem.reason)) {
                         continue;
                     }
                     await createEvent(
@@ -891,11 +923,30 @@ export async function spendSunflowersBatch(
                             amount: 0,
                             coveredAmount: resolvedAmount,
                             legacyCartReason: legacyCartSpend.reason,
-                            reason: item.reason,
+                            reason: coveredItem.reason,
                         }),
                         tx,
                     );
-                    createdReasons.push(item.reason);
+                    newlyCreatedCheckpointReasons.add(coveredItem.reason);
+                }
+                const createdReasons = [...uniqueItems.keys()].filter(
+                    (reason) => newlyCreatedCheckpointReasons.has(reason),
+                );
+                const existingReasons = [...uniqueItems.keys()].filter(
+                    (reason) => existingCheckpoints.has(reason),
+                );
+                const resolvedAmounts = new Map<string, number>();
+                for (const coveredItem of coveredItems.values()) {
+                    if (
+                        coveredItem.paymentState === 'paid' ||
+                        uniqueItems.has(coveredItem.reason)
+                    ) {
+                        resolvedAmounts.set(
+                            coveredItem.reason,
+                            resolvedCoveredAmounts.get(coveredItem.reason) ??
+                                coveredItem.amount,
+                        );
+                    }
                 }
                 return {
                     createdReasons,
@@ -903,6 +954,19 @@ export async function spendSunflowersBatch(
                     resolvedAmountsByReason:
                         Object.fromEntries(resolvedAmounts),
                 };
+            }
+
+            for (const coveredItem of coveredItems.values()) {
+                if (
+                    coveredItem.paymentState === 'paid' &&
+                    !existingEventsByReason.has(coveredItem.reason)
+                ) {
+                    throw new SunflowerSpendAmountConflictError(
+                        coveredItem.reason,
+                        0,
+                        coveredItem.amount,
+                    );
+                }
             }
         }
 
@@ -938,6 +1002,22 @@ export async function spendSunflowersBatch(
             }
             existingReasons.push(item.reason);
             resolvedAmounts.set(item.reason, existingAmount);
+        }
+        for (const coveredItem of coveredItems?.values() ?? []) {
+            if (coveredItem.paymentState !== 'paid') {
+                continue;
+            }
+            const resolvedAmount = resolvedCoveredAmounts.get(
+                coveredItem.reason,
+            );
+            if (resolvedAmount === undefined) {
+                throw new SunflowerSpendAmountConflictError(
+                    coveredItem.reason,
+                    0,
+                    coveredItem.amount,
+                );
+            }
+            resolvedAmounts.set(coveredItem.reason, resolvedAmount);
         }
 
         if (missingItems.length === 0) {

--- a/packages/storage/src/repositories/checkoutCartItemLock.ts
+++ b/packages/storage/src/repositories/checkoutCartItemLock.ts
@@ -1,0 +1,137 @@
+import { sql } from 'drizzle-orm';
+import { storage } from '../storage';
+
+type StorageClient = ReturnType<typeof storage>;
+export type CheckoutCartItemLockTransaction = Parameters<
+    Parameters<StorageClient['transaction']>[0]
+>[0];
+export type CheckoutCartItemLockDatabase = CheckoutCartItemLockTransaction;
+
+const checkoutCartItemDatabaseLockTails = new Map<number, Promise<void>>();
+const checkoutCartItemProcessingLockTails = new Map<number, Promise<void>>();
+
+function isPgliteTestDatabase() {
+    return (
+        process.env.TEST_ENV === '1' &&
+        process.env.GREDICE_TEST_DB_PROVIDER === 'pglite'
+    );
+}
+
+function normalizeCartItemIds(cartItemIds: readonly number[]) {
+    const uniqueIds = new Set<number>();
+    for (const cartItemId of cartItemIds) {
+        if (!Number.isSafeInteger(cartItemId) || cartItemId <= 0) {
+            throw new RangeError(
+                'Checkout cart item lock requires a positive safe integer ID',
+            );
+        }
+        uniqueIds.add(cartItemId);
+    }
+    return Array.from(uniqueIds).sort((left, right) => left - right);
+}
+
+async function withCheckoutCartItemInProcessLock<T>(
+    lockTails: Map<number, Promise<void>>,
+    cartItemId: number,
+    operation: () => Promise<T>,
+) {
+    const previous = lockTails.get(cartItemId) ?? Promise.resolve();
+    let release = () => {};
+    const current = new Promise<void>((resolve) => {
+        release = resolve;
+    });
+    const tail = previous.then(() => current);
+    lockTails.set(cartItemId, tail);
+
+    await previous;
+    try {
+        return await operation();
+    } finally {
+        release();
+        if (lockTails.get(cartItemId) === tail) {
+            lockTails.delete(cartItemId);
+        }
+    }
+}
+
+function withCheckoutCartItemInProcessLocks<T>(
+    lockTails: Map<number, Promise<void>>,
+    cartItemIds: readonly number[],
+    operation: () => Promise<T>,
+): Promise<T> {
+    const [cartItemId, ...remainingIds] = cartItemIds;
+    if (cartItemId === undefined) {
+        return operation();
+    }
+
+    return withCheckoutCartItemInProcessLock(lockTails, cartItemId, () =>
+        withCheckoutCartItemInProcessLocks(lockTails, remainingIds, operation),
+    );
+}
+
+/**
+ * Prevents duplicate checkout callbacks in this process without retaining a
+ * database connection while fulfillment performs non-database work. Durable
+ * effects must still use the transaction-scoped checkout-item lock below.
+ */
+export function withCheckoutCartItemProcessingLocks<T>(
+    cartItemIds: readonly number[],
+    operation: () => Promise<T>,
+) {
+    return withCheckoutCartItemInProcessLocks(
+        checkoutCartItemProcessingLockTails,
+        normalizeCartItemIds(cartItemIds),
+        operation,
+    );
+}
+
+export function withCheckoutCartItemProcessingLock<T>(
+    cartItemId: number,
+    operation: () => Promise<T>,
+) {
+    return withCheckoutCartItemProcessingLocks([cartItemId], operation);
+}
+
+/**
+ * Serializes checkout effects and cart mutations for a deterministic set of
+ * cart items. Callers acquire this checkout-item lock before inventory,
+ * account, or row locks. PostgreSQL transactions retain cross-instance
+ * advisory locks; PGlite tests use the equivalent process-local keyed mutex.
+ */
+export async function withCheckoutCartItemLocks<T>(
+    cartItemIds: readonly number[],
+    operation: (db: CheckoutCartItemLockTransaction) => Promise<T>,
+    transaction?: CheckoutCartItemLockTransaction,
+) {
+    const normalizedCartItemIds = normalizeCartItemIds(cartItemIds);
+    if (isPgliteTestDatabase()) {
+        return withCheckoutCartItemInProcessLocks(
+            checkoutCartItemDatabaseLockTails,
+            normalizedCartItemIds,
+            () =>
+                transaction
+                    ? operation(transaction)
+                    : storage().transaction(operation),
+        );
+    }
+
+    const runInTransaction = async (db: CheckoutCartItemLockTransaction) => {
+        for (const cartItemId of normalizedCartItemIds) {
+            await db.execute(
+                sql`select pg_advisory_xact_lock(hashtext(${`checkout-cart-item:${cartItemId.toString()}`}));`,
+            );
+        }
+        return operation(db);
+    };
+    return transaction
+        ? runInTransaction(transaction)
+        : storage().transaction(runInTransaction);
+}
+
+export async function withCheckoutCartItemLock<T>(
+    cartItemId: number,
+    operation: (db: CheckoutCartItemLockTransaction) => Promise<T>,
+    transaction?: CheckoutCartItemLockTransaction,
+) {
+    return withCheckoutCartItemLocks([cartItemId], operation, transaction);
+}

--- a/packages/storage/src/repositories/deliveryRequestsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRequestsRepo.ts
@@ -64,6 +64,15 @@ type TransactionClient = Parameters<
     Parameters<StorageClient['transaction']>[0]
 >[0];
 type DatabaseClient = StorageClient | TransactionClient;
+type DeliveryRequestInput = {
+    operationId: number;
+    slotId: number;
+    mode: 'delivery' | 'pickup';
+    addressId?: number;
+    locationId?: number;
+    notes?: string;
+    accountId: string;
+};
 type DbEvent = Awaited<ReturnType<typeof getAllEvents>>[number];
 type DeliveryTraceLink = Awaited<
     ReturnType<typeof getHarvestTraceLinksForOperationIds>
@@ -92,6 +101,10 @@ export class DeliveryRequestFulfillmentError extends Error {
     ) {
         super(message);
     }
+}
+
+export class CheckoutDeliveryRequestConflictError extends Error {
+    override name = 'CheckoutDeliveryRequestConflictError';
 }
 
 // TODO: Should use types from union of payloads for delivery events
@@ -1506,20 +1519,13 @@ export async function getDeliveryRequestByOperation(
     return reconstructDeliveryRequestFromEvents(request, events);
 }
 
-// Create a new delivery request with event sourcing
-export async function createDeliveryRequest(data: {
-    operationId: number;
-    slotId: number;
-    mode: 'delivery' | 'pickup';
-    addressId?: number;
-    locationId?: number;
-    notes?: string;
-    accountId: string;
-}): Promise<string> {
-    const requestId = randomUUID();
-
+async function validateDeliveryRequestInput(
+    data: DeliveryRequestInput,
+    db: DatabaseClient = storage(),
+    options: { closeExpiredSlot?: boolean } = {},
+) {
     // Validate slot is available and not in the past
-    const slot = await storage().query.timeSlots.findFirst({
+    const slot = await db.query.timeSlots.findFirst({
         where: eq(timeSlots.id, data.slotId),
     });
 
@@ -1538,7 +1544,9 @@ export async function createDeliveryRequest(data: {
     }
 
     if (hasTimeSlotCloseDeadlinePassed(slot, now)) {
-        await closeTimeSlot(slot.id);
+        if (options.closeExpiredSlot ?? true) {
+            await closeTimeSlot(slot.id);
+        }
         throw new Error('Time slot is not available for booking');
     }
 
@@ -1555,7 +1563,7 @@ export async function createDeliveryRequest(data: {
         throw new Error('Location ID is required for pickup mode');
     }
 
-    const operation = await storage().query.operations.findFirst({
+    const operation = await db.query.operations.findFirst({
         columns: {
             id: true,
         },
@@ -1571,23 +1579,150 @@ export async function createDeliveryRequest(data: {
     }
 
     if (data.mode === 'delivery' && data.addressId) {
-        const address = await getDeliveryAddress(
-            data.addressId,
-            data.accountId,
-        );
+        const address = await db.query.deliveryAddresses.findFirst({
+            columns: { id: true },
+            where: and(
+                eq(deliveryAddresses.id, data.addressId),
+                eq(deliveryAddresses.accountId, data.accountId),
+                isNull(deliveryAddresses.deletedAt),
+            ),
+        });
         if (!address) {
             throw new Error('Delivery address not found or access denied');
         }
     }
 
     if (data.mode === 'pickup' && data.locationId) {
-        const location = await getPickupLocation(data.locationId);
+        const location = await db.query.pickupLocations.findFirst({
+            where: eq(pickupLocations.id, data.locationId),
+        });
         if (!location?.isActive || location.id !== slot.locationId) {
             throw new Error(
                 'Pickup location does not match the selected time slot',
             );
         }
     }
+}
+
+async function insertDeliveryRequest(
+    requestId: string,
+    data: DeliveryRequestInput,
+    db: DatabaseClient,
+) {
+    await db.insert(deliveryRequests).values({
+        id: requestId,
+        operationId: data.operationId,
+    });
+    await createEvent(
+        knownEvents.delivery.requestCreatedV1(requestId, {
+            operationId: data.operationId,
+            slotId: data.slotId,
+            mode: data.mode,
+            addressId: data.addressId,
+            locationId: data.locationId,
+            notes: data.notes,
+            accountId: data.accountId,
+        }),
+        db,
+    );
+}
+
+function assertExistingCheckoutDeliveryRequest(
+    data: DeliveryRequestInput,
+    event: DbEvent,
+) {
+    if (
+        event.version !== 1 ||
+        !event.data ||
+        typeof event.data !== 'object' ||
+        Array.isArray(event.data)
+    ) {
+        throw new CheckoutDeliveryRequestConflictError(
+            'Existing checkout delivery request has malformed creation data.',
+        );
+    }
+    const stored = event.data as Record<string, unknown>;
+    const expected = {
+        operationId: data.operationId,
+        slotId: data.slotId,
+        mode: data.mode,
+        addressId: data.addressId ?? null,
+        locationId: data.locationId ?? null,
+        notes: data.notes ?? null,
+        accountId: data.accountId,
+    };
+    const storedFingerprint = {
+        operationId: stored.operationId,
+        slotId: stored.slotId,
+        mode: stored.mode,
+        addressId: stored.addressId ?? null,
+        locationId: stored.locationId ?? null,
+        notes: stored.notes ?? null,
+        accountId: stored.accountId,
+    };
+    const mismatch = (
+        Object.keys(expected) as Array<keyof typeof expected>
+    ).find((field) => storedFingerprint[field] !== expected[field]);
+    if (mismatch) {
+        throw new CheckoutDeliveryRequestConflictError(
+            `Existing checkout delivery request conflicts on ${mismatch}.`,
+        );
+    }
+}
+
+async function getExistingCheckoutDeliveryRequest(
+    data: DeliveryRequestInput,
+    db: DatabaseClient,
+): Promise<{ requestId: string; created: false } | null> {
+    const existingRequests = await db.query.deliveryRequests.findMany({
+        columns: { id: true },
+        where: eq(deliveryRequests.operationId, data.operationId),
+        limit: 2,
+    });
+    if (existingRequests.length > 1) {
+        throw new CheckoutDeliveryRequestConflictError(
+            'Operation has multiple delivery requests.',
+        );
+    }
+
+    const existingRequest = existingRequests[0];
+    if (!existingRequest) {
+        return null;
+    }
+
+    const ownedOperation = await db.query.operations.findFirst({
+        columns: { id: true },
+        where: and(
+            eq(operations.id, data.operationId),
+            eq(operations.accountId, data.accountId),
+            eq(operations.isDeleted, false),
+        ),
+    });
+    if (!ownedOperation) {
+        throw new Error('Operation not found or access denied');
+    }
+
+    const creationEvents = await getAllEvents(
+        knownEventTypes.delivery.requestCreated,
+        [existingRequest.id],
+        { db },
+    );
+    if (creationEvents.length !== 1) {
+        throw new CheckoutDeliveryRequestConflictError(
+            'Existing checkout delivery request has invalid creation history.',
+        );
+    }
+    assertExistingCheckoutDeliveryRequest(data, creationEvents[0]);
+    return { requestId: existingRequest.id, created: false };
+}
+
+// Create a new delivery request with event sourcing.
+// Ordinary callers retain the historical duplicate-rejection contract.
+export async function createDeliveryRequest(
+    data: DeliveryRequestInput,
+): Promise<string> {
+    const requestId = randomUUID();
+    await validateDeliveryRequestInput(data);
 
     return await withDeliveryDispatchTransaction(async (tx) => {
         const existingRequest = await tx.query.deliveryRequests.findFirst({
@@ -1598,24 +1733,39 @@ export async function createDeliveryRequest(data: {
             throw new Error('Operation already has a delivery request');
         }
 
-        await tx.insert(deliveryRequests).values({
-            id: requestId,
-            operationId: data.operationId,
-        });
-        await createEvent(
-            knownEvents.delivery.requestCreatedV1(requestId, {
-                operationId: data.operationId,
-                slotId: data.slotId,
-                mode: data.mode,
-                addressId: data.addressId,
-                locationId: data.locationId,
-                notes: data.notes,
-                accountId: data.accountId,
-            }),
-            tx,
-        );
+        await insertDeliveryRequest(requestId, data, tx);
 
         return requestId;
+    });
+}
+
+export async function getOrCreateDeliveryRequest(
+    data: DeliveryRequestInput,
+): Promise<{ requestId: string; created: boolean }> {
+    const existing = await getExistingCheckoutDeliveryRequest(data, storage());
+    if (existing) {
+        return existing;
+    }
+
+    // Validate before acquiring the dispatch lock because closing an expired
+    // slot acquires that same lock on its own transaction.
+    await validateDeliveryRequestInput(data);
+
+    return await withDeliveryDispatchTransaction(async (tx) => {
+        const existingAfterLock = await getExistingCheckoutDeliveryRequest(
+            data,
+            tx,
+        );
+        if (existingAfterLock) {
+            return existingAfterLock;
+        }
+
+        await validateDeliveryRequestInput(data, tx, {
+            closeExpiredSlot: false,
+        });
+        const requestId = randomUUID();
+        await insertDeliveryRequest(requestId, data, tx);
+        return { requestId, created: true };
     });
 }
 

--- a/packages/storage/src/repositories/deliveryUtilsRepo.ts
+++ b/packages/storage/src/repositories/deliveryUtilsRepo.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, notInArray } from 'drizzle-orm';
 import {
     attributeDefinitions,
     attributeValues,
@@ -11,6 +11,9 @@ import { storage } from '../storage';
 // Check if a shopping cart contains any deliverable items
 export async function cartContainsDeliverableItems(
     cartId: number,
+    {
+        excludeCartItemIds = [],
+    }: { excludeCartItemIds?: readonly number[] } = {},
 ): Promise<boolean> {
     const items = await storage().query.shoppingCartItems.findMany({
         where: and(
@@ -18,6 +21,9 @@ export async function cartContainsDeliverableItems(
             eq(shoppingCartItems.entityTypeName, 'operation'),
             eq(shoppingCartItems.isDeleted, false),
             eq(shoppingCartItems.status, 'new'), // Only check unpaid items
+            excludeCartItemIds.length > 0
+                ? notInArray(shoppingCartItems.id, [...excludeCartItemIds])
+                : undefined,
         ),
     });
 

--- a/packages/storage/src/repositories/events/index.ts
+++ b/packages/storage/src/repositories/events/index.ts
@@ -54,6 +54,8 @@ export type {
     AdventCalendarOpenPayload,
     AdventGiftAward,
     AiRequestKind,
+    // Checkout
+    CheckoutOperationCreatedPayload,
     // Delivery
     DeliveryRequestAddressChangedPayload,
     DeliveryRequestCancelledPayload,

--- a/packages/storage/src/repositories/events/knownEventTypes.ts
+++ b/packages/storage/src/repositories/events/knownEventTypes.ts
@@ -1,4 +1,7 @@
 export const knownEventTypes = {
+    checkout: {
+        operationCreated: 'checkout.operation.created',
+    },
     accounts: {
         create: 'account.create',
         assignUser: 'account.assignUser',

--- a/packages/storage/src/repositories/events/knownEvents.ts
+++ b/packages/storage/src/repositories/events/knownEvents.ts
@@ -8,6 +8,7 @@ import type {
     AdventCalendarOpenPayload,
     ApprovalRequestCreatePayload,
     ApprovalRequestReviewPayload,
+    CheckoutOperationCreatedPayload,
     DeliveryRequestAddressChangedPayload,
     DeliveryRequestCancelledPayload,
     DeliveryRequestCreatePayload,
@@ -66,6 +67,17 @@ import type {
 } from './types';
 
 export const knownEvents = {
+    checkout: {
+        operationCreatedV1: (
+            aggregateId: string,
+            data: CheckoutOperationCreatedPayload,
+        ) => ({
+            type: knownEventTypes.checkout.operationCreated,
+            version: 1,
+            aggregateId,
+            data,
+        }),
+    },
     accounts: {
         createdV1: (aggregateId: string) => ({
             type: knownEventTypes.accounts.create,

--- a/packages/storage/src/repositories/events/types.ts
+++ b/packages/storage/src/repositories/events/types.ts
@@ -13,6 +13,14 @@ export type CheckoutOperationCreatedPayload = {
     raisedBedId: number | null;
     raisedBedFieldId: number | null;
     operationTimestamp: string | null;
+    paymentCurrency: 'eur' | 'inventory' | 'sunflower';
+    delivery: {
+        addressId: number | null;
+        locationId: number | null;
+        mode: 'delivery' | 'pickup';
+        notes: string | null;
+        slotId: number;
+    } | null;
     scheduledDate: string;
     accepted: boolean;
 };
@@ -26,7 +34,10 @@ export type AccountAssignUserPayload = {
 
 export type AccountSunflowersPayload = {
     amount: number;
+    coveredAmount?: number;
     idempotencyKey?: string;
+    legacyCartReason?: string;
+    legacyRewardAlreadyEarned?: boolean;
     reason: string;
 };
 

--- a/packages/storage/src/repositories/events/types.ts
+++ b/packages/storage/src/repositories/events/types.ts
@@ -1,6 +1,23 @@
 import type { ScheduleTaskBlockPayload } from './scheduleTaskBlock';
 
 // ============================================================================
+// Checkout event payload types
+// ============================================================================
+export type CheckoutOperationCreatedPayload = {
+    operationId: number;
+    accountId: string | null;
+    entityId: number;
+    entityTypeName: string;
+    farmId: number | null;
+    gardenId: number | null;
+    raisedBedId: number | null;
+    raisedBedFieldId: number | null;
+    operationTimestamp: string | null;
+    scheduledDate: string;
+    accepted: boolean;
+};
+
+// ============================================================================
 // Account event payload types
 // ============================================================================
 export type AccountAssignUserPayload = {

--- a/packages/storage/src/repositories/harvestScheduleRepo.ts
+++ b/packages/storage/src/repositories/harvestScheduleRepo.ts
@@ -424,11 +424,13 @@ export async function getHarvestScheduleForCart({
     accountId,
     cartId,
     deliverySlotId,
+    excludeCartItemIds = [],
     now = new Date(),
 }: {
     accountId?: string;
     cartId: number;
     deliverySlotId: number;
+    excludeCartItemIds?: readonly number[];
     now?: Date;
 }): Promise<HarvestSchedule> {
     const [cart, deliverySlot, operations] = await Promise.all([
@@ -481,8 +483,12 @@ export async function getHarvestScheduleForCart({
             .filter(operationIsDeliverableHarvest)
             .map((operation) => [operation.id, operation]),
     );
+    const excludedCartItemIds = new Set(excludeCartItemIds);
     const harvestItems = cart.items.flatMap((item) => {
         if (item.status !== 'new' || item.entityTypeName !== 'operation') {
+            return [];
+        }
+        if (excludedCartItemIds.has(item.id)) {
             return [];
         }
         const operationId = parseEntityId(item.entityId);

--- a/packages/storage/src/repositories/inventoryRepo.ts
+++ b/packages/storage/src/repositories/inventoryRepo.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, sql } from 'drizzle-orm';
+import { and, eq, gte, inArray, sql } from 'drizzle-orm';
 import { events } from '../schema';
 import { storage } from '../storage';
 import {
@@ -13,6 +13,9 @@ type TransactionClient = Parameters<
     Parameters<StorageClient['transaction']>[0]
 >[0];
 type DatabaseClient = TransactionClient | StorageClient;
+
+const checkoutInventorySourcePrefix = 'shoppingCartItem:';
+const inventoryLockTails = new Map<string, Promise<void>>();
 
 export const GARDEN_BOX_BLOCK_STACK_LIMIT = 6;
 export const GARDEN_BOX_BLOCK_STACK_SIZE = 10;
@@ -29,6 +32,25 @@ type InventoryItemFields = Pick<
     'entityTypeName' | 'entityId' | 'amount'
 >;
 
+export type CheckoutInventoryConsumption = {
+    cartItemId: number;
+    source: string;
+    entityTypeName: string;
+    entityId: string;
+    amount: number;
+};
+
+export class InventoryConsumptionSourceConflictError extends Error {
+    override name = 'InventoryConsumptionSourceConflictError';
+
+    constructor(
+        readonly source: string,
+        message: string,
+    ) {
+        super(message);
+    }
+}
+
 export class GardenBoxInventoryLimitError extends Error {
     constructor(message: string) {
         super(message);
@@ -37,6 +59,36 @@ export class GardenBoxInventoryLimitError extends Error {
 }
 
 const INVENTORY_PREFIX = 'inventory:';
+
+function isPgliteTestDatabase() {
+    return (
+        process.env.TEST_ENV === '1' &&
+        process.env.GREDICE_TEST_DB_PROVIDER === 'pglite'
+    );
+}
+
+async function withInventoryInProcessLock<T>(
+    key: string,
+    callback: () => Promise<T>,
+) {
+    const previous = inventoryLockTails.get(key) ?? Promise.resolve();
+    let release = () => {};
+    const current = new Promise<void>((resolve) => {
+        release = resolve;
+    });
+    const tail = previous.then(() => current);
+    inventoryLockTails.set(key, tail);
+
+    await previous;
+    try {
+        return await callback();
+    } finally {
+        release();
+        if (inventoryLockTails.get(key) === tail) {
+            inventoryLockTails.delete(key);
+        }
+    }
+}
 
 function getInventoryAggregateId(accountId: string) {
     return `${INVENTORY_PREFIX}${accountId}`;
@@ -179,11 +231,191 @@ async function getInventoryForAggregateIds(
     return Array.from(totals.values()).filter((item) => item.amount > 0);
 }
 
-export async function consumeInventoryItem(
+function checkoutCartItemIdFromSource(source: string) {
+    if (!source.startsWith(checkoutInventorySourcePrefix)) {
+        return null;
+    }
+    const value = source.slice(checkoutInventorySourcePrefix.length);
+    const cartItemId = Number(value);
+    if (
+        !Number.isSafeInteger(cartItemId) ||
+        cartItemId <= 0 ||
+        value !== cartItemId.toString()
+    ) {
+        throw new InventoryConsumptionSourceConflictError(
+            source,
+            'Checkout inventory consumption source has an invalid cart item id.',
+        );
+    }
+    return cartItemId;
+}
+
+function checkoutInventoryConsumptionFromPayload(
+    payload: InventoryItemEventPayload,
+): CheckoutInventoryConsumption | null {
+    if (typeof payload.source !== 'string') {
+        return null;
+    }
+    const cartItemId = checkoutCartItemIdFromSource(payload.source);
+    if (cartItemId === null) {
+        return null;
+    }
+    if (
+        payload.entityTypeName.length === 0 ||
+        payload.entityId.length === 0 ||
+        !Number.isSafeInteger(payload.amount) ||
+        payload.amount <= 0
+    ) {
+        throw new InventoryConsumptionSourceConflictError(
+            payload.source,
+            'Checkout inventory consumption payload is malformed.',
+        );
+    }
+    return {
+        cartItemId,
+        source: payload.source,
+        entityTypeName: payload.entityTypeName,
+        entityId: payload.entityId,
+        amount: payload.amount,
+    };
+}
+
+function parseCheckoutInventoryConsumption(
+    data: unknown,
+): CheckoutInventoryConsumption | null {
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+        return null;
+    }
+    const payload = data as Record<string, unknown>;
+    if (
+        typeof payload.source !== 'string' ||
+        !payload.source.startsWith(checkoutInventorySourcePrefix)
+    ) {
+        return null;
+    }
+    if (
+        typeof payload.entityTypeName !== 'string' ||
+        typeof payload.entityId !== 'string' ||
+        typeof payload.amount !== 'number'
+    ) {
+        throw new InventoryConsumptionSourceConflictError(
+            payload.source,
+            'Checkout inventory consumption payload is malformed.',
+        );
+    }
+    return checkoutInventoryConsumptionFromPayload({
+        source: payload.source,
+        entityTypeName: payload.entityTypeName,
+        entityId: payload.entityId,
+        amount: payload.amount,
+    });
+}
+
+function assertMatchingCheckoutInventoryConsumption(
+    existing: CheckoutInventoryConsumption,
+    expected: CheckoutInventoryConsumption,
+) {
+    if (
+        existing.cartItemId !== expected.cartItemId ||
+        existing.entityTypeName !== expected.entityTypeName ||
+        existing.entityId !== expected.entityId ||
+        existing.amount !== expected.amount
+    ) {
+        throw new InventoryConsumptionSourceConflictError(
+            expected.source,
+            'Checkout inventory consumption source has conflicting item data.',
+        );
+    }
+}
+
+async function readCheckoutInventoryConsumptions(
+    accountId: string,
+    sources: readonly string[],
+    db: DatabaseClient,
+) {
+    if (sources.length === 0) {
+        return new Map<string, CheckoutInventoryConsumption>();
+    }
+    const consumptionEvents = await db.query.events.findMany({
+        where: and(
+            eq(events.type, knownEventTypes.inventory.consume),
+            eq(events.aggregateId, getInventoryAggregateId(accountId)),
+            inArray(sql<string>`${events.data}->>'source'`, [...sources]),
+        ),
+        orderBy: (events, { asc }) => [asc(events.id)],
+    });
+    const bySource = new Map<string, CheckoutInventoryConsumption>();
+    for (const event of consumptionEvents) {
+        const consumption = parseCheckoutInventoryConsumption(event.data);
+        if (!consumption) {
+            continue;
+        }
+        const existing = bySource.get(consumption.source);
+        if (existing) {
+            assertMatchingCheckoutInventoryConsumption(existing, consumption);
+            continue;
+        }
+        bySource.set(consumption.source, consumption);
+    }
+    return bySource;
+}
+
+export async function getCheckoutInventoryConsumptions(
+    accountId: string,
+    cartItemIds: readonly number[],
+    db: DatabaseClient = storage(),
+): Promise<CheckoutInventoryConsumption[]> {
+    const requestedSources = new Set(
+        cartItemIds.map((cartItemId) => {
+            if (!Number.isSafeInteger(cartItemId) || cartItemId <= 0) {
+                const source = `${checkoutInventorySourcePrefix}${cartItemId.toString()}`;
+                throw new InventoryConsumptionSourceConflictError(
+                    source,
+                    'Checkout cart item id must be a positive safe integer.',
+                );
+            }
+            return `${checkoutInventorySourcePrefix}${cartItemId.toString()}`;
+        }),
+    );
+    if (requestedSources.size === 0) {
+        return [];
+    }
+
+    const consumptions = await readCheckoutInventoryConsumptions(
+        accountId,
+        [...requestedSources],
+        db,
+    );
+    return Array.from(consumptions.values()).filter((consumption) =>
+        requestedSources.has(consumption.source),
+    );
+}
+
+async function consumeInventoryItemInTransaction(
     accountId: string,
     payload: InventoryItemEventPayload,
-    db: DatabaseClient = storage(),
+    db: DatabaseClient,
 ) {
+    const expectedCheckoutConsumption =
+        checkoutInventoryConsumptionFromPayload(payload);
+    if (expectedCheckoutConsumption) {
+        const existingConsumptions = await readCheckoutInventoryConsumptions(
+            accountId,
+            [expectedCheckoutConsumption.source],
+            db,
+        );
+        const existing = existingConsumptions.get(
+            expectedCheckoutConsumption.source,
+        );
+        if (existing) {
+            assertMatchingCheckoutInventoryConsumption(
+                existing,
+                expectedCheckoutConsumption,
+            );
+            return;
+        }
+    }
+
     const inventory = await getInventoryForAggregateIds(
         [getInventoryAggregateId(accountId)],
         db,
@@ -208,8 +440,44 @@ export async function consumeInventoryItem(
     );
 }
 
-export async function getInventory(accountId: string) {
-    return getInventoryForAggregateIds([getInventoryAggregateId(accountId)]);
+export async function consumeInventoryItem(
+    accountId: string,
+    payload: InventoryItemEventPayload,
+    db?: DatabaseClient,
+) {
+    if (db) {
+        await consumeInventoryItemInTransaction(accountId, payload, db);
+        return;
+    }
+
+    const aggregateId = getInventoryAggregateId(accountId);
+    const consumeInTransaction = () =>
+        storage().transaction(async (transaction) => {
+            if (!isPgliteTestDatabase()) {
+                await lockInventoryAggregate(aggregateId, transaction);
+            }
+            await consumeInventoryItemInTransaction(
+                accountId,
+                payload,
+                transaction,
+            );
+        });
+
+    if (isPgliteTestDatabase()) {
+        await withInventoryInProcessLock(aggregateId, consumeInTransaction);
+        return;
+    }
+    await consumeInTransaction();
+}
+
+export async function getInventory(
+    accountId: string,
+    db: DatabaseClient = storage(),
+) {
+    return getInventoryForAggregateIds(
+        [getInventoryAggregateId(accountId)],
+        db,
+    );
 }
 
 export async function getGardenBoxInventory(

--- a/packages/storage/src/repositories/inventoryRepo.ts
+++ b/packages/storage/src/repositories/inventoryRepo.ts
@@ -188,6 +188,33 @@ async function lockInventoryAggregate(aggregateId: string, db: DatabaseClient) {
     );
 }
 
+/**
+ * Run account-inventory work while holding the same aggregate lock used by
+ * checkout consumption. Acquire this lock before any cart-row locks so
+ * normalization and consumption have one stable lock order.
+ */
+export async function withInventoryAccountTransaction<T>(
+    accountId: string,
+    callback: (db: TransactionClient) => Promise<T>,
+    transaction?: TransactionClient,
+) {
+    const aggregateId = getInventoryAggregateId(accountId);
+    const runInTransaction = async (db: TransactionClient) => {
+        if (!isPgliteTestDatabase()) {
+            await lockInventoryAggregate(aggregateId, db);
+        }
+        return callback(db);
+    };
+    const run = () =>
+        transaction
+            ? runInTransaction(transaction)
+            : storage().transaction(runInTransaction);
+
+    return isPgliteTestDatabase()
+        ? withInventoryInProcessLock(aggregateId, run)
+        : run();
+}
+
 async function getInventoryForAggregateIds(
     aggregateIds: string[],
     db: DatabaseClient = storage(),
@@ -353,7 +380,10 @@ async function readCheckoutInventoryConsumptions(
         const existing = bySource.get(consumption.source);
         if (existing) {
             assertMatchingCheckoutInventoryConsumption(existing, consumption);
-            continue;
+            throw new InventoryConsumptionSourceConflictError(
+                consumption.source,
+                'Checkout inventory consumption source has multiple events.',
+            );
         }
         bySource.set(consumption.source, consumption);
     }
@@ -389,6 +419,24 @@ export async function getCheckoutInventoryConsumptions(
     return Array.from(consumptions.values()).filter((consumption) =>
         requestedSources.has(consumption.source),
     );
+}
+
+export async function getCheckoutInventorySnapshot(
+    accountId: string,
+    cartItemIds: readonly number[],
+) {
+    return withInventoryAccountTransaction(accountId, async (db) => {
+        // Keep these reads ordered inside the locked transaction. Under READ
+        // COMMITTED, the aggregate lock prevents checkout consumption from
+        // committing between the balance and source projections.
+        const inventory = await getInventory(accountId, db);
+        const consumptions = await getCheckoutInventoryConsumptions(
+            accountId,
+            cartItemIds,
+            db,
+        );
+        return { inventory, consumptions };
+    });
 }
 
 async function consumeInventoryItemInTransaction(
@@ -450,24 +498,9 @@ export async function consumeInventoryItem(
         return;
     }
 
-    const aggregateId = getInventoryAggregateId(accountId);
-    const consumeInTransaction = () =>
-        storage().transaction(async (transaction) => {
-            if (!isPgliteTestDatabase()) {
-                await lockInventoryAggregate(aggregateId, transaction);
-            }
-            await consumeInventoryItemInTransaction(
-                accountId,
-                payload,
-                transaction,
-            );
-        });
-
-    if (isPgliteTestDatabase()) {
-        await withInventoryInProcessLock(aggregateId, consumeInTransaction);
-        return;
-    }
-    await consumeInTransaction();
+    await withInventoryAccountTransaction(accountId, (transaction) =>
+        consumeInventoryItemInTransaction(accountId, payload, transaction),
+    );
 }
 
 export async function getInventory(

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -31,7 +31,13 @@ import {
     users,
 } from '../schema';
 import { storage } from '../storage';
-import { createEvent, getEvents, knownEvents, knownEventTypes } from './events';
+import {
+    createEvent,
+    getAllEvents,
+    getEvents,
+    knownEvents,
+    knownEventTypes,
+} from './events';
 import { normalizeAssignedUserIds } from './events/normalizeAssignedUserIds';
 import { scheduleTaskBlockDetailsFromEvent } from './events/scheduleTaskBlock';
 import type {
@@ -1594,6 +1600,8 @@ export async function createScheduledOperation(
 
 type CheckoutOperationOptions = {
     accept?: boolean;
+    delivery: CheckoutOperationCreatedPayload['delivery'];
+    paymentCurrency: CheckoutOperationCreatedPayload['paymentCurrency'];
     scheduledDate: Date;
 };
 
@@ -1622,6 +1630,8 @@ function checkoutOperationFingerprint(
         raisedBedId: operation.raisedBedId ?? null,
         raisedBedFieldId: operation.raisedBedFieldId ?? null,
         operationTimestamp,
+        paymentCurrency: options.paymentCurrency,
+        delivery: options.delivery,
         scheduledDate,
         accepted: options.accept ?? false,
     };
@@ -1639,7 +1649,56 @@ function parseCheckoutOperationCreatedPayload(
     const nullableNumber = (candidate: unknown): candidate is number | null =>
         (typeof candidate === 'number' && Number.isSafeInteger(candidate)) ||
         candidate === null;
+    const paymentCurrency = (
+        candidate: unknown,
+    ): candidate is CheckoutOperationCreatedPayload['paymentCurrency'] =>
+        candidate === 'eur' ||
+        candidate === 'inventory' ||
+        candidate === 'sunflower';
+    const delivery = (
+        candidate: unknown,
+    ): CheckoutOperationCreatedPayload['delivery'] | undefined => {
+        if (candidate === null) {
+            return null;
+        }
+        if (
+            !candidate ||
+            typeof candidate !== 'object' ||
+            Array.isArray(candidate)
+        ) {
+            return undefined;
+        }
+        const value = candidate as Record<string, unknown>;
+        if (
+            typeof value.slotId !== 'number' ||
+            !Number.isSafeInteger(value.slotId) ||
+            (value.mode !== 'delivery' && value.mode !== 'pickup') ||
+            !nullableNumber(value.addressId) ||
+            !nullableNumber(value.locationId) ||
+            !nullableString(value.notes)
+        ) {
+            return undefined;
+        }
+        return {
+            addressId: value.addressId,
+            locationId: value.locationId,
+            mode: value.mode,
+            notes: value.notes,
+            slotId: value.slotId,
+        };
+    };
+    const isoDateString = (candidate: unknown): candidate is string => {
+        if (typeof candidate !== 'string') {
+            return false;
+        }
+        const parsed = new Date(candidate);
+        return (
+            !Number.isNaN(parsed.getTime()) &&
+            parsed.toISOString() === candidate
+        );
+    };
 
+    const parsedDelivery = delivery(data.delivery);
     if (
         typeof data.operationId !== 'number' ||
         !Number.isSafeInteger(data.operationId) ||
@@ -1653,7 +1712,11 @@ function parseCheckoutOperationCreatedPayload(
         !nullableNumber(data.raisedBedId) ||
         !nullableNumber(data.raisedBedFieldId) ||
         !nullableString(data.operationTimestamp) ||
-        typeof data.scheduledDate !== 'string' ||
+        (data.operationTimestamp !== null &&
+            !isoDateString(data.operationTimestamp)) ||
+        !paymentCurrency(data.paymentCurrency) ||
+        parsedDelivery === undefined ||
+        !isoDateString(data.scheduledDate) ||
         typeof data.accepted !== 'boolean'
     ) {
         return null;
@@ -1669,9 +1732,75 @@ function parseCheckoutOperationCreatedPayload(
         raisedBedId: data.raisedBedId,
         raisedBedFieldId: data.raisedBedFieldId,
         operationTimestamp: data.operationTimestamp,
+        paymentCurrency: data.paymentCurrency,
+        delivery: parsedDelivery,
         scheduledDate: data.scheduledDate,
         accepted: data.accepted,
     };
+}
+
+export async function getCheckoutOperationMappings(
+    cartItemIds: number[],
+    db: DatabaseClient = storage(),
+): Promise<ReadonlyMap<number, CheckoutOperationCreatedPayload>> {
+    const uniqueCartItemIds = Array.from(new Set(cartItemIds));
+    if (uniqueCartItemIds.length === 0) {
+        return new Map();
+    }
+
+    const cartItemIdsByAggregateId = new Map(
+        uniqueCartItemIds.map((cartItemId) => [
+            checkoutOperationAggregateId(cartItemId),
+            cartItemId,
+        ]),
+    );
+    const mappingEvents = await getAllEvents(
+        knownEventTypes.checkout.operationCreated,
+        Array.from(cartItemIdsByAggregateId.keys()),
+        { db },
+    );
+    const mappings = new Map<number, CheckoutOperationCreatedPayload>();
+
+    for (const mappingEvent of mappingEvents) {
+        const cartItemId = cartItemIdsByAggregateId.get(
+            mappingEvent.aggregateId,
+        );
+        if (cartItemId === undefined) {
+            throw new CheckoutOperationConflictError(
+                'Checkout operation mapping has an unexpected aggregate.',
+            );
+        }
+        if (mappings.has(cartItemId)) {
+            throw new CheckoutOperationConflictError(
+                'Checkout cart item has multiple operation mappings.',
+            );
+        }
+        if (mappingEvent.version !== 1) {
+            throw new CheckoutOperationConflictError(
+                'Checkout operation mapping has an unsupported version.',
+            );
+        }
+        const mapping = parseCheckoutOperationCreatedPayload(mappingEvent.data);
+        if (!mapping) {
+            throw new CheckoutOperationConflictError(
+                'Checkout operation mapping is malformed.',
+            );
+        }
+        mappings.set(cartItemId, mapping);
+    }
+
+    return mappings;
+}
+
+export async function getCheckoutOperationMapping(
+    cartItemId: number,
+    db: DatabaseClient = storage(),
+) {
+    return (
+        (await getCheckoutOperationMappings([cartItemId], db)).get(
+            cartItemId,
+        ) ?? null
+    );
 }
 
 function assertCheckoutOperationFingerprint(
@@ -1687,6 +1816,7 @@ function assertCheckoutOperationFingerprint(
         'raisedBedId',
         'raisedBedFieldId',
         'operationTimestamp',
+        'paymentCurrency',
         'scheduledDate',
         'accepted',
     ] as const;
@@ -1698,6 +1828,22 @@ function assertCheckoutOperationFingerprint(
             `Checkout operation fingerprint conflicts on ${mismatch}.`,
         );
     }
+    const storedDelivery = stored.delivery;
+    const expectedDelivery = expected.delivery;
+    const deliveryMismatch =
+        (storedDelivery === null) !== (expectedDelivery === null) ||
+        (storedDelivery !== null &&
+            expectedDelivery !== null &&
+            (storedDelivery.addressId !== expectedDelivery.addressId ||
+                storedDelivery.locationId !== expectedDelivery.locationId ||
+                storedDelivery.mode !== expectedDelivery.mode ||
+                storedDelivery.notes !== expectedDelivery.notes ||
+                storedDelivery.slotId !== expectedDelivery.slotId));
+    if (deliveryMismatch) {
+        throw new CheckoutOperationConflictError(
+            'Checkout operation fingerprint conflicts on delivery.',
+        );
+    }
 }
 
 async function ensureCheckoutOperation(
@@ -1706,35 +1852,9 @@ async function ensureCheckoutOperation(
     options: CheckoutOperationOptions,
     db: DatabaseClient,
 ) {
-    const aggregateId = checkoutOperationAggregateId(cartItemId);
     const fingerprint = checkoutOperationFingerprint(operation, options);
-    const mappingEvents = await getEvents(
-        knownEventTypes.checkout.operationCreated,
-        [aggregateId],
-        0,
-        2,
-        db,
-    );
-
-    if (mappingEvents.length > 1) {
-        throw new CheckoutOperationConflictError(
-            'Checkout cart item has multiple operation mappings.',
-        );
-    }
-
-    const mappingEvent = mappingEvents[0];
-    if (mappingEvent) {
-        if (mappingEvent.version !== 1) {
-            throw new CheckoutOperationConflictError(
-                'Checkout operation mapping has an unsupported version.',
-            );
-        }
-        const stored = parseCheckoutOperationCreatedPayload(mappingEvent.data);
-        if (!stored) {
-            throw new CheckoutOperationConflictError(
-                'Checkout operation mapping is malformed.',
-            );
-        }
+    const stored = await getCheckoutOperationMapping(cartItemId, db);
+    if (stored) {
         assertCheckoutOperationFingerprint(stored, fingerprint);
 
         const mappedOperation = await db.query.operations.findFirst({
@@ -1794,10 +1914,13 @@ async function ensureCheckoutOperation(
         await acceptOperation(operationId, db);
     }
     await createEvent(
-        knownEvents.checkout.operationCreatedV1(aggregateId, {
-            operationId,
-            ...fingerprint,
-        }),
+        knownEvents.checkout.operationCreatedV1(
+            checkoutOperationAggregateId(cartItemId),
+            {
+                operationId,
+                ...fingerprint,
+            },
+        ),
         db,
     );
 

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -34,7 +34,10 @@ import { storage } from '../storage';
 import { createEvent, getEvents, knownEvents, knownEventTypes } from './events';
 import { normalizeAssignedUserIds } from './events/normalizeAssignedUserIds';
 import { scheduleTaskBlockDetailsFromEvent } from './events/scheduleTaskBlock';
-import type { OperationEventsAnyPayload } from './events/types';
+import type {
+    CheckoutOperationCreatedPayload,
+    OperationEventsAnyPayload,
+} from './events/types';
 
 export type OperationStatus =
     | 'new'
@@ -50,6 +53,42 @@ type TransactionClient = Parameters<
     Parameters<StorageClient['transaction']>[0]
 >[0];
 type DatabaseClient = StorageClient | TransactionClient;
+
+const checkoutOperationLockTails = new Map<string, Promise<void>>();
+
+export class CheckoutOperationConflictError extends Error {
+    override name = 'CheckoutOperationConflictError';
+}
+
+async function withCheckoutOperationInProcessLock<T>(
+    key: string,
+    callback: () => Promise<T>,
+) {
+    const previous = checkoutOperationLockTails.get(key) ?? Promise.resolve();
+    let release = () => {};
+    const current = new Promise<void>((resolve) => {
+        release = resolve;
+    });
+    const tail = previous.then(() => current);
+    checkoutOperationLockTails.set(key, tail);
+
+    await previous;
+    try {
+        return await callback();
+    } finally {
+        release();
+        if (checkoutOperationLockTails.get(key) === tail) {
+            checkoutOperationLockTails.delete(key);
+        }
+    }
+}
+
+function isPgliteTestDatabase() {
+    return (
+        process.env.TEST_ENV === '1' &&
+        process.env.GREDICE_TEST_DB_PROVIDER === 'pglite'
+    );
+}
 
 type OperationsFilter = {
     from?: Date;
@@ -1551,6 +1590,256 @@ export async function createScheduledOperation(
     });
     await bustScheduleCache();
     return operationId;
+}
+
+type CheckoutOperationOptions = {
+    accept?: boolean;
+    scheduledDate: Date;
+};
+
+function checkoutOperationAggregateId(cartItemId: number) {
+    if (!Number.isSafeInteger(cartItemId) || cartItemId <= 0) {
+        throw new CheckoutOperationConflictError(
+            'Checkout cart item id must be a positive safe integer.',
+        );
+    }
+    return `shoppingCartItem:${cartItemId.toString()}`;
+}
+
+function checkoutOperationFingerprint(
+    operation: InsertOperation,
+    options: CheckoutOperationOptions,
+): Omit<CheckoutOperationCreatedPayload, 'operationId'> {
+    const scheduledDate = options.scheduledDate.toISOString();
+    const operationTimestamp = operation.timestamp?.toISOString() ?? null;
+
+    return {
+        accountId: operation.accountId ?? null,
+        entityId: operation.entityId,
+        entityTypeName: operation.entityTypeName,
+        farmId: operation.farmId ?? null,
+        gardenId: operation.gardenId ?? null,
+        raisedBedId: operation.raisedBedId ?? null,
+        raisedBedFieldId: operation.raisedBedFieldId ?? null,
+        operationTimestamp,
+        scheduledDate,
+        accepted: options.accept ?? false,
+    };
+}
+
+function parseCheckoutOperationCreatedPayload(
+    value: unknown,
+): CheckoutOperationCreatedPayload | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return null;
+    }
+    const data = value as Record<string, unknown>;
+    const nullableString = (candidate: unknown): candidate is string | null =>
+        typeof candidate === 'string' || candidate === null;
+    const nullableNumber = (candidate: unknown): candidate is number | null =>
+        (typeof candidate === 'number' && Number.isSafeInteger(candidate)) ||
+        candidate === null;
+
+    if (
+        typeof data.operationId !== 'number' ||
+        !Number.isSafeInteger(data.operationId) ||
+        data.operationId <= 0 ||
+        !nullableString(data.accountId) ||
+        typeof data.entityId !== 'number' ||
+        !Number.isSafeInteger(data.entityId) ||
+        typeof data.entityTypeName !== 'string' ||
+        !nullableNumber(data.farmId) ||
+        !nullableNumber(data.gardenId) ||
+        !nullableNumber(data.raisedBedId) ||
+        !nullableNumber(data.raisedBedFieldId) ||
+        !nullableString(data.operationTimestamp) ||
+        typeof data.scheduledDate !== 'string' ||
+        typeof data.accepted !== 'boolean'
+    ) {
+        return null;
+    }
+
+    return {
+        operationId: data.operationId,
+        accountId: data.accountId,
+        entityId: data.entityId,
+        entityTypeName: data.entityTypeName,
+        farmId: data.farmId,
+        gardenId: data.gardenId,
+        raisedBedId: data.raisedBedId,
+        raisedBedFieldId: data.raisedBedFieldId,
+        operationTimestamp: data.operationTimestamp,
+        scheduledDate: data.scheduledDate,
+        accepted: data.accepted,
+    };
+}
+
+function assertCheckoutOperationFingerprint(
+    stored: CheckoutOperationCreatedPayload,
+    expected: Omit<CheckoutOperationCreatedPayload, 'operationId'>,
+) {
+    const fingerprintFields = [
+        'accountId',
+        'entityId',
+        'entityTypeName',
+        'farmId',
+        'gardenId',
+        'raisedBedId',
+        'raisedBedFieldId',
+        'operationTimestamp',
+        'scheduledDate',
+        'accepted',
+    ] as const;
+    const mismatch = fingerprintFields.find(
+        (field) => stored[field] !== expected[field],
+    );
+    if (mismatch) {
+        throw new CheckoutOperationConflictError(
+            `Checkout operation fingerprint conflicts on ${mismatch}.`,
+        );
+    }
+}
+
+async function ensureCheckoutOperation(
+    cartItemId: number,
+    operation: InsertOperation,
+    options: CheckoutOperationOptions,
+    db: DatabaseClient,
+) {
+    const aggregateId = checkoutOperationAggregateId(cartItemId);
+    const fingerprint = checkoutOperationFingerprint(operation, options);
+    const mappingEvents = await getEvents(
+        knownEventTypes.checkout.operationCreated,
+        [aggregateId],
+        0,
+        2,
+        db,
+    );
+
+    if (mappingEvents.length > 1) {
+        throw new CheckoutOperationConflictError(
+            'Checkout cart item has multiple operation mappings.',
+        );
+    }
+
+    const mappingEvent = mappingEvents[0];
+    if (mappingEvent) {
+        if (mappingEvent.version !== 1) {
+            throw new CheckoutOperationConflictError(
+                'Checkout operation mapping has an unsupported version.',
+            );
+        }
+        const stored = parseCheckoutOperationCreatedPayload(mappingEvent.data);
+        if (!stored) {
+            throw new CheckoutOperationConflictError(
+                'Checkout operation mapping is malformed.',
+            );
+        }
+        assertCheckoutOperationFingerprint(stored, fingerprint);
+
+        const mappedOperation = await db.query.operations.findFirst({
+            columns: {
+                id: true,
+                accountId: true,
+                entityId: true,
+                entityTypeName: true,
+                farmId: true,
+                gardenId: true,
+                raisedBedId: true,
+                raisedBedFieldId: true,
+                timestamp: true,
+            },
+            where: and(
+                eq(operations.id, stored.operationId),
+                eq(operations.isDeleted, false),
+            ),
+        });
+        if (!mappedOperation) {
+            throw new CheckoutOperationConflictError(
+                'Checkout operation mapping points to a missing or deleted operation.',
+            );
+        }
+        const operationMismatch = (
+            [
+                'accountId',
+                'entityId',
+                'entityTypeName',
+                'farmId',
+                'gardenId',
+                'raisedBedId',
+                'raisedBedFieldId',
+            ] as const
+        ).find((field) => mappedOperation[field] !== fingerprint[field]);
+        if (
+            operationMismatch ||
+            (fingerprint.operationTimestamp !== null &&
+                mappedOperation.timestamp.toISOString() !==
+                    fingerprint.operationTimestamp)
+        ) {
+            throw new CheckoutOperationConflictError(
+                'Checkout operation mapping conflicts with the stored operation.',
+            );
+        }
+        return { operationId: stored.operationId, created: false } as const;
+    }
+
+    const operationId = await createOperation(operation, db);
+    await createEvent(
+        knownEvents.operations.scheduledV1(operationId.toString(), {
+            scheduledDate: fingerprint.scheduledDate,
+        }),
+        db,
+    );
+    if (fingerprint.accepted) {
+        await acceptOperation(operationId, db);
+    }
+    await createEvent(
+        knownEvents.checkout.operationCreatedV1(aggregateId, {
+            operationId,
+            ...fingerprint,
+        }),
+        db,
+    );
+
+    return { operationId, created: true } as const;
+}
+
+export async function getOrCreateCheckoutOperation(
+    cartItemId: number,
+    operation: InsertOperation,
+    options: CheckoutOperationOptions,
+    db?: DatabaseClient,
+): Promise<{ operationId: number; created: boolean }> {
+    if (db) {
+        return ensureCheckoutOperation(cartItemId, operation, options, db);
+    }
+
+    const aggregateId = checkoutOperationAggregateId(cartItemId);
+    const runInTransaction = () =>
+        storage().transaction(async (transaction) => {
+            if (!isPgliteTestDatabase()) {
+                await transaction.execute(
+                    sql`select pg_advisory_xact_lock(hashtext(${`checkout-operation:${aggregateId}`}));`,
+                );
+            }
+            return ensureCheckoutOperation(
+                cartItemId,
+                operation,
+                options,
+                transaction,
+            );
+        });
+
+    const result = isPgliteTestDatabase()
+        ? await withCheckoutOperationInProcessLock(
+              aggregateId,
+              runInTransaction,
+          )
+        : await runInTransaction();
+    if (result.created) {
+        await bustScheduleCache();
+    }
+    return result;
 }
 
 export async function switchOperationEntity(

--- a/packages/storage/src/repositories/shoppingCartRepo.ts
+++ b/packages/storage/src/repositories/shoppingCartRepo.ts
@@ -5,7 +5,10 @@ import {
     knownEventTypes,
     type RaisedBedFieldPlantPurchase,
 } from './eventsRepo';
-import { getInventory } from './inventoryRepo';
+import {
+    getCheckoutInventoryConsumptions,
+    getInventory,
+} from './inventoryRepo';
 import {
     getOutletOfferReservationForCartItem,
     releaseOutletReservationForCartItem,
@@ -558,14 +561,7 @@ export async function normalizeShoppingCartInventoryUsage(cartId: number) {
     if (!cart?.accountId) {
         return cart;
     }
-
-    const inventory = await getInventory(cart.accountId);
-    const availableInventory = new Map(
-        inventory.map((item) => [
-            `${item.entityTypeName}-${item.entityId}`,
-            item.amount,
-        ]),
-    );
+    const accountId = cart.accountId;
 
     await storage().transaction(async (tx) => {
         const inventoryItems = await tx
@@ -585,7 +581,50 @@ export async function normalizeShoppingCartInventoryUsage(cartId: number) {
             )
             .for('update');
 
+        if (inventoryItems.length === 0) {
+            return;
+        }
+
+        const [inventory, checkoutConsumptions] = await Promise.all([
+            getInventory(accountId, tx),
+            getCheckoutInventoryConsumptions(
+                accountId,
+                inventoryItems.map((item) => item.id),
+                tx,
+            ),
+        ]);
+        const availableInventory = new Map(
+            inventory.map((item) => [
+                `${item.entityTypeName}-${item.entityId}`,
+                item.amount,
+            ]),
+        );
+        const inventoryItemsById = new Map(
+            inventoryItems.map((item) => [item.id, item]),
+        );
+        const consumedInventoryItemIds = new Set<number>();
+        for (const consumption of checkoutConsumptions) {
+            const item = inventoryItemsById.get(consumption.cartItemId);
+            if (
+                !item ||
+                item.entityTypeName !== consumption.entityTypeName ||
+                item.entityId !== consumption.entityId ||
+                item.amount !== consumption.amount
+            ) {
+                throw new Error(
+                    `Inventory consumption for cart item ${consumption.cartItemId.toString()} conflicts with the pending cart item`,
+                );
+            }
+            consumedInventoryItemIds.add(item.id);
+        }
+
         for (const item of inventoryItems) {
+            // A prior checkout attempt already consumed this exact item's
+            // inventory. Reserve that durable consumption for the same item;
+            // only still-live inventory may be allocated to other cart items.
+            if (consumedInventoryItemIds.has(item.id)) {
+                continue;
+            }
             const inventoryKey = `${item.entityTypeName}-${item.entityId}`;
             const remainingInventory =
                 availableInventory.get(inventoryKey) ?? 0;

--- a/packages/storage/src/repositories/shoppingCartRepo.ts
+++ b/packages/storage/src/repositories/shoppingCartRepo.ts
@@ -1,6 +1,15 @@
-import { and, asc, desc, eq, gte, lte, sql } from 'drizzle-orm';
-import { events, shoppingCartItems, shoppingCarts } from '../schema';
+import { and, asc, desc, eq, gte, inArray, lte, sql } from 'drizzle-orm';
+import {
+    events,
+    notifications,
+    shoppingCartItems,
+    shoppingCarts,
+} from '../schema';
 import { storage } from '../storage';
+import {
+    withCheckoutCartItemLock,
+    withCheckoutCartItemLocks,
+} from './checkoutCartItemLock';
 import {
     knownEventTypes,
     type RaisedBedFieldPlantPurchase,
@@ -8,7 +17,9 @@ import {
 import {
     getCheckoutInventoryConsumptions,
     getInventory,
+    withInventoryAccountTransaction,
 } from './inventoryRepo';
+import { getCheckoutOperationMappings } from './operationsRepo';
 import {
     getOutletOfferReservationForCartItem,
     releaseOutletReservationForCartItem,
@@ -23,6 +34,345 @@ type TransactionClient = Parameters<
 type DatabaseClient = StorageClient | TransactionClient;
 
 const raisedBedFieldPurchaseMatchWindowMs = 10 * 60 * 1000;
+
+export class CheckoutCartItemFulfillmentStartedError extends Error {
+    override readonly name = 'CheckoutCartItemFulfillmentStartedError';
+
+    constructor(readonly cartItemId: number) {
+        super(
+            `Shopping cart item ${cartItemId.toString()} cannot change after checkout fulfillment starts.`,
+        );
+    }
+}
+
+class CheckoutCartChangedDuringDeleteError extends Error {
+    override readonly name = 'CheckoutCartChangedDuringDeleteError';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+type CheckoutPlantingProjectionItem = {
+    id: number;
+    raisedBedId: number | null;
+    positionIndex: number | null;
+};
+
+export async function getCheckoutPlantingFulfilledCartItemIds(
+    items: readonly CheckoutPlantingProjectionItem[],
+    db: DatabaseClient = storage(),
+) {
+    const itemIdByString = new Map(
+        items.map((item) => [item.id.toString(), item.id]),
+    );
+    const itemIdsByPlantingAggregateId = new Map<string, Set<number>>();
+    for (const item of items) {
+        if (
+            typeof item.raisedBedId !== 'number' ||
+            typeof item.positionIndex !== 'number'
+        ) {
+            continue;
+        }
+        const aggregateId = `${item.raisedBedId.toString()}|${item.positionIndex.toString()}`;
+        const aggregateItemIds =
+            itemIdsByPlantingAggregateId.get(aggregateId) ?? new Set<number>();
+        aggregateItemIds.add(item.id);
+        itemIdsByPlantingAggregateId.set(aggregateId, aggregateItemIds);
+    }
+
+    const plantingAggregateIds = [...itemIdsByPlantingAggregateId.keys()];
+    if (plantingAggregateIds.length === 0) {
+        return new Set<number>();
+    }
+
+    const fulfilledItemIds = new Set<number>();
+    const plantingEvents = await db
+        .select({
+            aggregateId: events.aggregateId,
+            cartItemId: sql<string>`${events.data}->'purchase'->>'cartItemId'`,
+        })
+        .from(events)
+        .where(
+            and(
+                eq(events.type, knownEventTypes.raisedBedFields.plantPlace),
+                inArray(events.aggregateId, plantingAggregateIds),
+            ),
+        );
+    for (const event of plantingEvents) {
+        const itemId = itemIdByString.get(event.cartItemId);
+        if (
+            itemId !== undefined &&
+            itemIdsByPlantingAggregateId.get(event.aggregateId)?.has(itemId)
+        ) {
+            if (fulfilledItemIds.has(itemId)) {
+                throw new Error(
+                    'Checkout cart item has multiple planting fulfillment events.',
+                );
+            }
+            fulfilledItemIds.add(itemId);
+        }
+    }
+    return fulfilledItemIds;
+}
+
+export async function hasMatchingCheckoutPlantingPurchase(
+    {
+        cartItemId,
+        euroAmountCents,
+        plantSortId,
+        positionIndex,
+        raisedBedId,
+    }: {
+        cartItemId: number;
+        euroAmountCents: number;
+        plantSortId: string;
+        positionIndex: number;
+        raisedBedId: number;
+    },
+    db: DatabaseClient = storage(),
+) {
+    const aggregateId = `${raisedBedId.toString()}|${positionIndex.toString()}`;
+    const plantingEvents = await db
+        .select({ aggregateId: events.aggregateId, data: events.data })
+        .from(events)
+        .where(
+            and(
+                eq(events.type, knownEventTypes.raisedBedFields.plantPlace),
+                eq(
+                    sql<string>`${events.data}->'purchase'->>'cartItemId'`,
+                    cartItemId.toString(),
+                ),
+            ),
+        );
+    if (plantingEvents.length > 1) {
+        throw new Error(
+            'Checkout cart item has multiple planting fulfillment events.',
+        );
+    }
+    const event = plantingEvents[0];
+    if (!event) {
+        return false;
+    }
+    if (!isRecord(event.data)) {
+        throw new Error('Checkout planting fulfillment event is malformed.');
+    }
+    const eventData = event.data;
+    const purchase = eventData.purchase;
+    if (!isRecord(purchase)) {
+        throw new Error('Checkout planting purchase is malformed.');
+    }
+    if (
+        event.aggregateId !== aggregateId ||
+        eventData.plantSortId !== plantSortId ||
+        purchase.cartItemId !== cartItemId ||
+        purchase.currency !== 'eur' ||
+        purchase.euroAmountCents !== euroAmountCents
+    ) {
+        throw new Error(
+            'Checkout planting purchase conflicts with the paid cart item.',
+        );
+    }
+    return true;
+}
+
+export async function getCheckoutFulfillmentStartedCartItemIds(
+    accountId: string,
+    items: readonly {
+        cartId?: number;
+        createdAt?: Date;
+        currency?: string | null;
+        id: number;
+        entityTypeName: string;
+        raisedBedId: number | null;
+        positionIndex: number | null;
+    }[],
+    db: DatabaseClient = storage(),
+) {
+    const itemIds = items.map((item) => item.id);
+    if (itemIds.length === 0) {
+        return new Set<number>();
+    }
+    const itemIdByString = new Map(
+        itemIds.map((itemId) => [itemId.toString(), itemId]),
+    );
+    const startedItemIds = new Set(
+        (
+            await getCheckoutOperationMappings(
+                items
+                    .filter((item) => item.entityTypeName === 'operation')
+                    .map((item) => item.id),
+                db,
+            )
+        ).keys(),
+    );
+    for (const consumption of await getCheckoutInventoryConsumptions(
+        accountId,
+        itemIds,
+        db,
+    )) {
+        startedItemIds.add(consumption.cartItemId);
+    }
+
+    const reasons = itemIds.map(
+        (itemId) => `shoppingCartItem:${itemId.toString()}`,
+    );
+    const sunflowerSpendEvents = await db
+        .select({ reason: sql<string>`${events.data}->>'reason'` })
+        .from(events)
+        .where(
+            and(
+                eq(events.aggregateId, accountId),
+                eq(events.type, knownEventTypes.accounts.spendSunflowers),
+                inArray(sql<string>`${events.data}->>'reason'`, reasons),
+            ),
+        );
+    const itemIdByReason = new Map(
+        itemIds.map((itemId) => [
+            `shoppingCartItem:${itemId.toString()}`,
+            itemId,
+        ]),
+    );
+    for (const event of sunflowerSpendEvents) {
+        const itemId = itemIdByReason.get(event.reason);
+        if (itemId !== undefined) {
+            startedItemIds.add(itemId);
+        }
+    }
+
+    const legacySunflowerItems = items.filter(
+        (item) =>
+            item.currency === 'sunflower' &&
+            Number.isSafeInteger(item.cartId) &&
+            item.cartId !== undefined &&
+            item.cartId > 0 &&
+            item.createdAt instanceof Date &&
+            !Number.isNaN(item.createdAt.getTime()),
+    );
+    const legacyCartReasons = [
+        ...new Set(
+            legacySunflowerItems.map(
+                (item) => `shoppingCart:${String(item.cartId)}`,
+            ),
+        ),
+    ];
+    if (legacyCartReasons.length > 0) {
+        const legacyCartSpendEvents = await db
+            .select({
+                createdAt: events.createdAt,
+                data: events.data,
+                reason: sql<string>`${events.data}->>'reason'`,
+            })
+            .from(events)
+            .where(
+                and(
+                    eq(events.aggregateId, accountId),
+                    eq(events.type, knownEventTypes.accounts.spendSunflowers),
+                    inArray(
+                        sql<string>`${events.data}->>'reason'`,
+                        legacyCartReasons,
+                    ),
+                ),
+            );
+        const eventsByReason = new Map<
+            string,
+            (typeof legacyCartSpendEvents)[number][]
+        >();
+        for (const event of legacyCartSpendEvents) {
+            const matchingEvents = eventsByReason.get(event.reason) ?? [];
+            matchingEvents.push(event);
+            eventsByReason.set(event.reason, matchingEvents);
+        }
+        for (const item of legacySunflowerItems) {
+            const reason = `shoppingCart:${String(item.cartId)}`;
+            const matchingEvents = eventsByReason.get(reason) ?? [];
+            if (matchingEvents.length > 1) {
+                throw new Error(
+                    'Checkout cart has multiple legacy sunflower spend events.',
+                );
+            }
+            const legacyEvent = matchingEvents[0];
+            if (!legacyEvent) {
+                continue;
+            }
+            if (
+                !isRecord(legacyEvent.data) ||
+                parsePositiveInteger(legacyEvent.data.amount) === null
+            ) {
+                throw new Error(
+                    'Checkout cart legacy sunflower spend event is malformed.',
+                );
+            }
+            if (
+                item.createdAt instanceof Date &&
+                legacyEvent.createdAt >= item.createdAt
+            ) {
+                startedItemIds.add(item.id);
+            }
+        }
+    }
+
+    const rewardReasons = itemIds.map(
+        (itemId) => `payment:shoppingCartItem:${itemId.toString()}`,
+    );
+    const paymentRewardEvents = await db
+        .select({ reason: sql<string>`${events.data}->>'reason'` })
+        .from(events)
+        .where(
+            and(
+                eq(events.aggregateId, accountId),
+                eq(events.type, knownEventTypes.accounts.earnSunflowers),
+                inArray(sql<string>`${events.data}->>'reason'`, rewardReasons),
+            ),
+        );
+    const itemIdByRewardReason = new Map(
+        itemIds.map((itemId) => [
+            `payment:shoppingCartItem:${itemId.toString()}`,
+            itemId,
+        ]),
+    );
+    for (const event of paymentRewardEvents) {
+        const itemId = itemIdByRewardReason.get(event.reason);
+        if (itemId !== undefined) {
+            startedItemIds.add(itemId);
+        }
+    }
+
+    for (const itemId of await getCheckoutPlantingFulfilledCartItemIds(
+        items,
+        db,
+    )) {
+        startedItemIds.add(itemId);
+    }
+
+    const itemIdStrings = [...itemIdByString.keys()];
+    const checkoutIncidentNotifications = await db
+        .select({
+            cartItemId: sql<string>`${notifications.metadata}->>'cartItemId'`,
+        })
+        .from(notifications)
+        .where(
+            and(
+                eq(notifications.accountId, accountId),
+                eq(notifications.category, 'checkout_fulfillment'),
+                inArray(notifications.type, [
+                    'checkout_planting_raised_bed_unavailable',
+                    'checkout_planting_target_conflict',
+                ]),
+                inArray(
+                    sql<string>`${notifications.metadata}->>'cartItemId'`,
+                    itemIdStrings,
+                ),
+            ),
+        );
+    for (const notification of checkoutIncidentNotifications) {
+        const itemId = itemIdByString.get(notification.cartItemId);
+        if (itemId !== undefined) {
+            startedItemIds.add(itemId);
+        }
+    }
+    return startedItemIds;
+}
 
 function parsePositiveInteger(value: unknown) {
     if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
@@ -229,8 +579,14 @@ function normalizeScheduledDateAdditionalData(
 export async function normalizeShoppingCartScheduledDates(
     cartId: number,
     {
+        checkoutOperationMappings: suppliedCheckoutOperationMappings,
         defaultMissingScheduledDates = false,
-    }: { defaultMissingScheduledDates?: boolean } = {},
+    }: {
+        checkoutOperationMappings?: Awaited<
+            ReturnType<typeof getCheckoutOperationMappings>
+        >;
+        defaultMissingScheduledDates?: boolean;
+    } = {},
 ) {
     const cart = await getShoppingCart(cartId);
     if (!cart) {
@@ -242,8 +598,16 @@ export async function normalizeShoppingCartScheduledDates(
         return cart;
     }
 
-    const itemUpdates = cart.items
-        .filter((item) => item.status === 'new')
+    const pendingItems = cart.items.filter((item) => item.status === 'new');
+    const checkoutOperationMappings =
+        suppliedCheckoutOperationMappings ??
+        (await getCheckoutOperationMappings(
+            pendingItems
+                .filter((item) => item.entityTypeName === 'operation')
+                .map((item) => item.id),
+        ));
+    const itemUpdates = pendingItems
+        .filter((item) => !checkoutOperationMappings.has(item.id))
         .map((item) => ({
             id: item.id,
             originalAdditionalData: item.additionalData,
@@ -260,16 +624,44 @@ export async function normalizeShoppingCartScheduledDates(
         return cart;
     }
 
-    await Promise.all(
-        itemUpdates.map((item) =>
-            storage()
+    const itemIds = itemUpdates.map((item) => item.id);
+    await withCheckoutCartItemLocks(itemIds, async (db) => {
+        const lockedItems = await db
+            .select()
+            .from(shoppingCartItems)
+            .where(
+                and(
+                    eq(shoppingCartItems.cartId, cartId),
+                    eq(shoppingCartItems.isDeleted, false),
+                    eq(shoppingCartItems.status, 'new'),
+                    inArray(shoppingCartItems.id, itemIds),
+                ),
+            )
+            .for('update');
+        const fulfillmentStartedItemIds =
+            await getCheckoutFulfillmentStartedCartItemIds(
+                cart.accountId ?? '',
+                lockedItems,
+                db,
+            );
+
+        for (const item of lockedItems) {
+            if (fulfillmentStartedItemIds.has(item.id)) {
+                continue;
+            }
+            const normalizedAdditionalData =
+                normalizeScheduledDateAdditionalData(item.additionalData, {
+                    defaultMissingScheduledDate: defaultMissingScheduledDates,
+                });
+            if (normalizedAdditionalData === item.additionalData) {
+                continue;
+            }
+            await db
                 .update(shoppingCartItems)
-                .set({
-                    additionalData: item.additionalData,
-                })
-                .where(eq(shoppingCartItems.id, item.id)),
-        ),
-    );
+                .set({ additionalData: normalizedAdditionalData })
+                .where(eq(shoppingCartItems.id, item.id));
+        }
+    });
 
     return getShoppingCart(cartId);
 }
@@ -331,8 +723,11 @@ export async function markCartPaidIfAllItemsPaid(cartId: number) {
     }
 }
 
-export async function setCartItemPaid(itemId: number) {
-    await storage()
+export async function setCartItemPaid(
+    itemId: number,
+    db: DatabaseClient = storage(),
+) {
+    await db
         .update(shoppingCartItems)
         .set({ status: 'paid' })
         .where(eq(shoppingCartItems.id, itemId));
@@ -351,7 +746,7 @@ export async function upsertOrRemoveCartItem(
     currency?: string | null,
     forceCreate?: boolean,
     forceDelete: boolean = false,
-    db: DatabaseClient = storage(),
+    transaction?: TransactionClient,
 ) {
     if (additionalData !== undefined) {
         additionalData = normalizeScheduledDateAdditionalData(additionalData);
@@ -361,94 +756,166 @@ export async function upsertOrRemoveCartItem(
         throw new Error('Cannot create an item with an existing ID');
     }
 
-    const existingItem = id
-        ? await db.query.shoppingCartItems.findFirst({
-              where: and(
-                  eq(shoppingCartItems.id, id),
-                  eq(shoppingCartItems.isDeleted, false),
-              ),
-          })
-        : !forceCreate
-          ? await db.query.shoppingCartItems.findFirst({
+    const findExistingItem = (db: DatabaseClient, lockedItemId?: number) => {
+        const targetItemId = lockedItemId ?? id;
+        if (targetItemId) {
+            return db.query.shoppingCartItems.findFirst({
                 where: and(
-                    eq(shoppingCartItems.cartId, cartId),
-                    eq(shoppingCartItems.entityTypeName, entityTypeName),
-                    eq(shoppingCartItems.entityId, entityId),
-                    gardenId
-                        ? eq(shoppingCartItems.gardenId, gardenId)
-                        : undefined,
-                    raisedBedId
-                        ? eq(shoppingCartItems.raisedBedId, raisedBedId)
-                        : undefined,
-                    typeof positionIndex === 'number'
-                        ? eq(shoppingCartItems.positionIndex, positionIndex)
-                        : undefined,
-                    typeof additionalData === 'string'
-                        ? eq(shoppingCartItems.additionalData, additionalData)
-                        : undefined,
-                    currency
-                        ? eq(shoppingCartItems.currency, currency)
-                        : undefined,
-                    eq(shoppingCartItems.isDeleted, false),
-                ),
-            })
-          : null;
-
-    // Prevent API changes to paid items. Historical cart rows are immutable.
-    if (!forceDelete && existingItem?.status === 'paid') {
-        throw new Error('Cannot update paid shopping cart item via API');
-    }
-
-    if (amount <= 0) {
-        if (existingItem) {
-            await db
-                .update(shoppingCartItems)
-                .set({
-                    isDeleted: true,
-                })
-                .where(eq(shoppingCartItems.id, existingItem.id));
-            await releaseOutletReservationForCartItem(
-                existingItem.id,
-                new Date(),
-                db,
-            );
-
-            const remainingItems = await db.query.shoppingCartItems.findMany({
-                where: and(
-                    eq(shoppingCartItems.cartId, cartId),
+                    eq(shoppingCartItems.id, targetItemId),
                     eq(shoppingCartItems.isDeleted, false),
                 ),
             });
+        }
+        if (forceCreate) {
+            return null;
+        }
+        return db.query.shoppingCartItems.findFirst({
+            where: and(
+                eq(shoppingCartItems.cartId, cartId),
+                eq(shoppingCartItems.entityTypeName, entityTypeName),
+                eq(shoppingCartItems.entityId, entityId),
+                gardenId ? eq(shoppingCartItems.gardenId, gardenId) : undefined,
+                raisedBedId
+                    ? eq(shoppingCartItems.raisedBedId, raisedBedId)
+                    : undefined,
+                typeof positionIndex === 'number'
+                    ? eq(shoppingCartItems.positionIndex, positionIndex)
+                    : undefined,
+                typeof additionalData === 'string'
+                    ? eq(shoppingCartItems.additionalData, additionalData)
+                    : undefined,
+                currency ? eq(shoppingCartItems.currency, currency) : undefined,
+                eq(shoppingCartItems.isDeleted, false),
+            ),
+        });
+    };
 
-            if (remainingItems.length === 0) {
-                await db
-                    .update(shoppingCarts)
-                    .set({ isDeleted: true })
-                    .where(eq(shoppingCarts.id, cartId));
+    const applyMutation = async (
+        db: TransactionClient,
+        lockedItemId?: number,
+    ) => {
+        // Re-read after taking the checkout-item lock. A checkout that won the
+        // race may have committed a payment or fulfillment effect meanwhile.
+        const existingItem = await findExistingItem(db, lockedItemId);
+        if (existingItem) {
+            const cart = await db.query.shoppingCarts.findFirst({
+                columns: { accountId: true },
+                where: eq(shoppingCarts.id, existingItem.cartId),
+            });
+            if (!cart) {
+                throw new Error('Shopping cart not found');
+            }
+            if (!cart.accountId) {
+                throw new Error('Shopping cart account is missing');
+            }
+            const fulfillmentStartedItemIds =
+                await getCheckoutFulfillmentStartedCartItemIds(
+                    cart.accountId,
+                    [existingItem],
+                    db,
+                );
+            if (fulfillmentStartedItemIds.has(existingItem.id)) {
+                throw new CheckoutCartItemFulfillmentStartedError(
+                    existingItem.id,
+                );
             }
         }
-        return null;
-    }
 
-    if (existingItem) {
-        return (
-            await db
-                .update(shoppingCartItems)
-                .set({
-                    amount,
-                    additionalData,
-                    currency: currency ? currency : undefined, // Update only if provided
-                    positionIndex:
-                        typeof positionIndex === 'number'
-                            ? positionIndex
-                            : undefined,
-                })
-                .where(eq(shoppingCartItems.id, existingItem.id))
-                .returning({
-                    id: shoppingCartItems.id,
-                })
-        )[0].id;
-    } else {
+        if (!existingItem && lockedItemId !== undefined) {
+            if (amount <= 0) {
+                return null;
+            }
+            throw new Error('Shopping cart item not found');
+        }
+
+        // Prevent API changes to paid items. Historical cart rows are immutable.
+        if (!forceDelete && existingItem?.status === 'paid') {
+            throw new Error('Cannot update paid shopping cart item via API');
+        }
+
+        if (amount <= 0) {
+            if (existingItem) {
+                const [activeCart] = await db
+                    .select({ id: shoppingCarts.id })
+                    .from(shoppingCarts)
+                    .where(
+                        and(
+                            eq(shoppingCarts.id, existingItem.cartId),
+                            eq(shoppingCarts.isDeleted, false),
+                            eq(shoppingCarts.status, 'new'),
+                        ),
+                    )
+                    .for('update')
+                    .limit(1);
+                if (!activeCart) {
+                    return null;
+                }
+                await db
+                    .update(shoppingCartItems)
+                    .set({
+                        isDeleted: true,
+                    })
+                    .where(eq(shoppingCartItems.id, existingItem.id));
+                await releaseOutletReservationForCartItem(
+                    existingItem.id,
+                    new Date(),
+                    db,
+                );
+
+                const remainingItems =
+                    await db.query.shoppingCartItems.findMany({
+                        where: and(
+                            eq(shoppingCartItems.cartId, cartId),
+                            eq(shoppingCartItems.isDeleted, false),
+                        ),
+                    });
+
+                if (remainingItems.length === 0) {
+                    await db
+                        .update(shoppingCarts)
+                        .set({ isDeleted: true })
+                        .where(eq(shoppingCarts.id, cartId));
+                }
+            }
+            return null;
+        }
+
+        if (existingItem) {
+            return (
+                await db
+                    .update(shoppingCartItems)
+                    .set({
+                        amount,
+                        additionalData,
+                        currency: currency ? currency : undefined, // Update only if provided
+                        positionIndex:
+                            typeof positionIndex === 'number'
+                                ? positionIndex
+                                : undefined,
+                    })
+                    .where(eq(shoppingCartItems.id, existingItem.id))
+                    .returning({
+                        id: shoppingCartItems.id,
+                    })
+            )[0].id;
+        }
+
+        const [activeCart] = await db
+            .select({ id: shoppingCarts.id })
+            .from(shoppingCarts)
+            .where(
+                and(
+                    eq(shoppingCarts.id, cartId),
+                    eq(shoppingCarts.isDeleted, false),
+                    eq(shoppingCarts.status, 'new'),
+                ),
+            )
+            .for('update')
+            .limit(1);
+        if (!activeCart) {
+            throw new Error('Cannot add an item to an inactive shopping cart');
+        }
+
         return (
             await db
                 .insert(shoppingCartItems)
@@ -467,7 +934,31 @@ export async function upsertOrRemoveCartItem(
                     id: shoppingCartItems.id,
                 })
         )[0].id;
+    };
+
+    const applyLockedMutation = (db: TransactionClient, lockedItemId: number) =>
+        applyMutation(db, lockedItemId);
+
+    if (id) {
+        return withCheckoutCartItemLock(
+            id,
+            (db) => applyLockedMutation(db, id),
+            transaction,
+        );
     }
+
+    const existingItem = await findExistingItem(transaction ?? storage());
+    if (existingItem) {
+        return withCheckoutCartItemLock(
+            existingItem.id,
+            (db) => applyLockedMutation(db, existingItem.id),
+            transaction,
+        );
+    }
+
+    return transaction
+        ? applyMutation(transaction)
+        : storage().transaction((db) => applyMutation(db));
 }
 
 export async function upsertOrRemoveCartItemWithOutletReservation({
@@ -541,19 +1032,107 @@ export async function upsertOrRemoveCartItemWithOutletReservation({
 
 export async function deleteShoppingCart(accountId: string) {
     const cart = await getOrCreateShoppingCart(accountId);
-    if (cart) {
-        await Promise.all([
-            storage()
-                .update(shoppingCarts)
-                .set({ isDeleted: true })
-                .where(eq(shoppingCarts.id, cart.id)),
-            storage()
-                .update(shoppingCartItems)
-                .set({ isDeleted: true })
-                .where(eq(shoppingCartItems.cartId, cart.id)),
-            releaseOutletReservationsForCart(cart.id),
-        ]);
+    if (!cart) {
+        return;
     }
+
+    const deleteCartWithItemLocks = async (
+        liveItemIds: readonly number[],
+    ): Promise<void> => {
+        try {
+            await withCheckoutCartItemLocks(liveItemIds, async (db) => {
+                // Cart-item locks are acquired first in canonical order. The
+                // cart row then prevents a new item from being attached while
+                // the pending set is rechecked and deleted.
+                const [lockedCart] = await db
+                    .select({
+                        accountId: shoppingCarts.accountId,
+                        id: shoppingCarts.id,
+                    })
+                    .from(shoppingCarts)
+                    .where(
+                        and(
+                            eq(shoppingCarts.id, cart.id),
+                            eq(shoppingCarts.isDeleted, false),
+                        ),
+                    )
+                    .for('update')
+                    .limit(1);
+                if (!lockedCart) {
+                    return;
+                }
+                if (lockedCart.accountId !== accountId) {
+                    throw new Error('Shopping cart account mismatch');
+                }
+
+                const liveItems = await db.query.shoppingCartItems.findMany({
+                    where: and(
+                        eq(shoppingCartItems.cartId, lockedCart.id),
+                        eq(shoppingCartItems.isDeleted, false),
+                    ),
+                });
+                const lockedItemIds = new Set(liveItemIds);
+                if (
+                    liveItems.length !== lockedItemIds.size ||
+                    liveItems.some((item) => !lockedItemIds.has(item.id))
+                ) {
+                    throw new CheckoutCartChangedDuringDeleteError();
+                }
+
+                const paidItem = liveItems.find(
+                    (item) => item.status === 'paid',
+                );
+                if (paidItem) {
+                    throw new CheckoutCartItemFulfillmentStartedError(
+                        paidItem.id,
+                    );
+                }
+
+                const fulfillmentStartedItemIds =
+                    await getCheckoutFulfillmentStartedCartItemIds(
+                        accountId,
+                        liveItems,
+                        db,
+                    );
+                const startedCartItemId = fulfillmentStartedItemIds
+                    .values()
+                    .next().value;
+                if (startedCartItemId !== undefined) {
+                    throw new CheckoutCartItemFulfillmentStartedError(
+                        startedCartItemId,
+                    );
+                }
+
+                await db
+                    .update(shoppingCarts)
+                    .set({ isDeleted: true })
+                    .where(eq(shoppingCarts.id, lockedCart.id));
+                await db
+                    .update(shoppingCartItems)
+                    .set({ isDeleted: true })
+                    .where(eq(shoppingCartItems.cartId, lockedCart.id));
+                await releaseOutletReservationsForCart(
+                    lockedCart.id,
+                    new Date(),
+                    db,
+                );
+            });
+        } catch (error) {
+            if (!(error instanceof CheckoutCartChangedDuringDeleteError)) {
+                throw error;
+            }
+
+            const refreshedCart = await getShoppingCart(cart.id);
+            if (!refreshedCart) {
+                return;
+            }
+            await deleteCartWithItemLocks(
+                refreshedCart.items.map((item) => item.id),
+            );
+        }
+    };
+
+    await deleteCartWithItemLocks(cart.items.map((item) => item.id));
 }
 
 export async function normalizeShoppingCartInventoryUsage(cartId: number) {
@@ -562,112 +1141,140 @@ export async function normalizeShoppingCartInventoryUsage(cartId: number) {
         return cart;
     }
     const accountId = cart.accountId;
+    const inventoryItemIds = cart.items
+        .filter(
+            (item) => item.status === 'new' && item.currency === 'inventory',
+        )
+        .map((item) => item.id);
+    if (inventoryItemIds.length === 0) {
+        return cart;
+    }
 
-    await storage().transaction(async (tx) => {
-        const inventoryItems = await tx
-            .select()
-            .from(shoppingCartItems)
-            .where(
-                and(
-                    eq(shoppingCartItems.cartId, cartId),
-                    eq(shoppingCartItems.isDeleted, false),
-                    eq(shoppingCartItems.status, 'new'),
-                    eq(shoppingCartItems.currency, 'inventory'),
-                ),
-            )
-            .orderBy(
-                asc(shoppingCartItems.createdAt),
-                asc(shoppingCartItems.id),
-            )
-            .for('update');
+    await withCheckoutCartItemLocks(inventoryItemIds, async (checkoutTx) => {
+        await withInventoryAccountTransaction(
+            accountId,
+            async (tx) => {
+                const inventoryItems = await tx
+                    .select()
+                    .from(shoppingCartItems)
+                    .where(
+                        and(
+                            eq(shoppingCartItems.cartId, cartId),
+                            eq(shoppingCartItems.isDeleted, false),
+                            eq(shoppingCartItems.status, 'new'),
+                            eq(shoppingCartItems.currency, 'inventory'),
+                            inArray(shoppingCartItems.id, inventoryItemIds),
+                        ),
+                    )
+                    .orderBy(
+                        asc(shoppingCartItems.createdAt),
+                        asc(shoppingCartItems.id),
+                    )
+                    .for('update');
 
-        if (inventoryItems.length === 0) {
-            return;
-        }
+                if (inventoryItems.length === 0) {
+                    return;
+                }
 
-        const [inventory, checkoutConsumptions] = await Promise.all([
-            getInventory(accountId, tx),
-            getCheckoutInventoryConsumptions(
-                accountId,
-                inventoryItems.map((item) => item.id),
-                tx,
-            ),
-        ]);
-        const availableInventory = new Map(
-            inventory.map((item) => [
-                `${item.entityTypeName}-${item.entityId}`,
-                item.amount,
-            ]),
-        );
-        const inventoryItemsById = new Map(
-            inventoryItems.map((item) => [item.id, item]),
-        );
-        const consumedInventoryItemIds = new Set<number>();
-        for (const consumption of checkoutConsumptions) {
-            const item = inventoryItemsById.get(consumption.cartItemId);
-            if (
-                !item ||
-                item.entityTypeName !== consumption.entityTypeName ||
-                item.entityId !== consumption.entityId ||
-                item.amount !== consumption.amount
-            ) {
-                throw new Error(
-                    `Inventory consumption for cart item ${consumption.cartItemId.toString()} conflicts with the pending cart item`,
+                const inventory = await getInventory(accountId, tx);
+                const checkoutConsumptions =
+                    await getCheckoutInventoryConsumptions(
+                        accountId,
+                        inventoryItems.map((item) => item.id),
+                        tx,
+                    );
+                const fulfillmentStartedItemIds =
+                    await getCheckoutFulfillmentStartedCartItemIds(
+                        accountId,
+                        inventoryItems,
+                        tx,
+                    );
+                const availableInventory = new Map(
+                    inventory.map((item) => [
+                        `${item.entityTypeName}-${item.entityId}`,
+                        item.amount,
+                    ]),
                 );
-            }
-            consumedInventoryItemIds.add(item.id);
-        }
-
-        for (const item of inventoryItems) {
-            // A prior checkout attempt already consumed this exact item's
-            // inventory. Reserve that durable consumption for the same item;
-            // only still-live inventory may be allocated to other cart items.
-            if (consumedInventoryItemIds.has(item.id)) {
-                continue;
-            }
-            const inventoryKey = `${item.entityTypeName}-${item.entityId}`;
-            const remainingInventory =
-                availableInventory.get(inventoryKey) ?? 0;
-
-            if (remainingInventory <= 0) {
-                await tx
-                    .update(shoppingCartItems)
-                    .set({ currency: 'eur' })
-                    .where(eq(shoppingCartItems.id, item.id));
-                continue;
-            }
-
-            if (item.amount <= remainingInventory) {
-                availableInventory.set(
-                    inventoryKey,
-                    remainingInventory - item.amount,
+                const inventoryItemsById = new Map(
+                    inventoryItems.map((item) => [item.id, item]),
                 );
-                continue;
-            }
+                const consumedInventoryItemIds = new Set<number>();
+                for (const consumption of checkoutConsumptions) {
+                    const item = inventoryItemsById.get(consumption.cartItemId);
+                    if (
+                        !item ||
+                        item.entityTypeName !== consumption.entityTypeName ||
+                        item.entityId !== consumption.entityId ||
+                        item.amount !== consumption.amount
+                    ) {
+                        throw new Error(
+                            `Inventory consumption for cart item ${consumption.cartItemId.toString()} conflicts with the pending cart item`,
+                        );
+                    }
+                    consumedInventoryItemIds.add(item.id);
+                }
 
-            const inventoryAmount = remainingInventory;
-            const purchaseAmount = item.amount - inventoryAmount;
+                for (const item of inventoryItems) {
+                    // A prior checkout attempt already consumed this exact item's
+                    // inventory. Reserve that durable consumption for the same item;
+                    // only still-live inventory may be allocated to other cart items.
+                    if (consumedInventoryItemIds.has(item.id)) {
+                        continue;
+                    }
+                    const inventoryKey = `${item.entityTypeName}-${item.entityId}`;
+                    const remainingInventory =
+                        availableInventory.get(inventoryKey) ?? 0;
 
-            await tx
-                .update(shoppingCartItems)
-                .set({ amount: inventoryAmount })
-                .where(eq(shoppingCartItems.id, item.id));
+                    if (fulfillmentStartedItemIds.has(item.id)) {
+                        availableInventory.set(
+                            inventoryKey,
+                            Math.max(remainingInventory - item.amount, 0),
+                        );
+                        continue;
+                    }
 
-            await tx.insert(shoppingCartItems).values({
-                cartId: item.cartId,
-                entityId: item.entityId,
-                entityTypeName: item.entityTypeName,
-                gardenId: item.gardenId,
-                raisedBedId: item.raisedBedId,
-                positionIndex: item.positionIndex,
-                additionalData: item.additionalData,
-                amount: purchaseAmount,
-                currency: 'eur',
-                status: item.status,
-            });
+                    if (remainingInventory <= 0) {
+                        await tx
+                            .update(shoppingCartItems)
+                            .set({ currency: 'eur' })
+                            .where(eq(shoppingCartItems.id, item.id));
+                        continue;
+                    }
 
-            availableInventory.set(inventoryKey, 0);
-        }
+                    if (item.amount <= remainingInventory) {
+                        availableInventory.set(
+                            inventoryKey,
+                            remainingInventory - item.amount,
+                        );
+                        continue;
+                    }
+
+                    const inventoryAmount = remainingInventory;
+                    const purchaseAmount = item.amount - inventoryAmount;
+
+                    await tx
+                        .update(shoppingCartItems)
+                        .set({ amount: inventoryAmount })
+                        .where(eq(shoppingCartItems.id, item.id));
+
+                    await tx.insert(shoppingCartItems).values({
+                        cartId: item.cartId,
+                        entityId: item.entityId,
+                        entityTypeName: item.entityTypeName,
+                        gardenId: item.gardenId,
+                        raisedBedId: item.raisedBedId,
+                        positionIndex: item.positionIndex,
+                        additionalData: item.additionalData,
+                        amount: purchaseAmount,
+                        currency: 'eur',
+                        status: item.status,
+                    });
+
+                    availableInventory.set(inventoryKey, 0);
+                }
+            },
+            checkoutTx,
+        );
     });
 
     return getShoppingCart(cartId);
@@ -709,8 +1316,11 @@ export async function getAllShoppingCarts({
     });
 }
 
-export async function getShoppingCart(cartId: number) {
-    return await storage().query.shoppingCarts.findFirst({
+export async function getShoppingCart(
+    cartId: number,
+    db: DatabaseClient = storage(),
+) {
+    return await db.query.shoppingCarts.findFirst({
         where: and(
             eq(shoppingCarts.id, cartId),
             eq(shoppingCarts.isDeleted, false),
@@ -722,4 +1332,26 @@ export async function getShoppingCart(cartId: number) {
             },
         },
     });
+}
+
+export async function lockShoppingCartForCheckout(
+    cartId: number,
+    db: TransactionClient,
+) {
+    const [activeCart] = await db
+        .select({ id: shoppingCarts.id })
+        .from(shoppingCarts)
+        .where(
+            and(
+                eq(shoppingCarts.id, cartId),
+                eq(shoppingCarts.isDeleted, false),
+                eq(shoppingCarts.status, 'new'),
+            ),
+        )
+        .for('update')
+        .limit(1);
+    if (!activeCart) {
+        return undefined;
+    }
+    return getShoppingCart(activeCart.id, db);
 }

--- a/packages/storage/tests/accountsRepo.node.spec.ts
+++ b/packages/storage/tests/accountsRepo.node.spec.ts
@@ -12,7 +12,10 @@ import {
     getSunflowers,
     getSunflowersHistory,
     grantBirthdaySunflowers,
+    InsufficientSunflowersError,
+    SunflowerSpendAmountConflictError,
     spendSunflowers,
+    spendSunflowersBatch,
     storage,
     users,
 } from '@gredice/storage';
@@ -274,6 +277,124 @@ test('spendSunflowers allows sequential spends', async () => {
     await spendSunflowers(accountId, 300, 'second-spend');
     const sunflowers = await getSunflowers(accountId);
     assert.strictEqual(sunflowers, 500);
+});
+
+test('spendSunflowersBatch writes one durable debit per item', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+
+    const result = await spendSunflowersBatch(accountId, [
+        { amount: 200, reason: 'shoppingCartItem:batch-1' },
+        { amount: 300, reason: 'shoppingCartItem:batch-2' },
+    ]);
+
+    assert.deepStrictEqual(result, {
+        createdReasons: [
+            'shoppingCartItem:batch-1',
+            'shoppingCartItem:batch-2',
+        ],
+        existingReasons: [],
+    });
+    assert.strictEqual(await getSunflowers(accountId), 500);
+    const history = await getSunflowersHistory(accountId, 0, 20);
+    assert.deepStrictEqual(
+        history
+            .filter((event) => event.reason?.startsWith('shoppingCartItem:'))
+            .map((event) => [event.reason, event.amount])
+            .sort(),
+        [
+            ['shoppingCartItem:batch-1', 200],
+            ['shoppingCartItem:batch-2', 300],
+        ],
+    );
+});
+
+test('spendSunflowersBatch validates the full debit before writing', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+
+    await assert.rejects(
+        () =>
+            spendSunflowersBatch(accountId, [
+                { amount: 700, reason: 'shoppingCartItem:no-partial-1' },
+                { amount: 400, reason: 'shoppingCartItem:no-partial-2' },
+            ]),
+        InsufficientSunflowersError,
+    );
+
+    assert.strictEqual(await getSunflowers(accountId), 1000);
+    const history = await getSunflowersHistory(accountId, 0, 20);
+    assert.ok(
+        history.every(
+            (event) =>
+                event.reason !== 'shoppingCartItem:no-partial-1' &&
+                event.reason !== 'shoppingCartItem:no-partial-2',
+        ),
+    );
+});
+
+test('spendSunflowersBatch treats an identical retry as already spent', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const debit = {
+        amount: 250,
+        reason: 'shoppingCartItem:identical-retry',
+    };
+
+    const first = await spendSunflowersBatch(accountId, [debit]);
+    const retry = await spendSunflowersBatch(accountId, [debit]);
+
+    assert.deepStrictEqual(first, {
+        createdReasons: [debit.reason],
+        existingReasons: [],
+    });
+    assert.deepStrictEqual(retry, {
+        createdReasons: [],
+        existingReasons: [debit.reason],
+    });
+    assert.strictEqual(await getSunflowers(accountId), 750);
+});
+
+test('spendSunflowersBatch rejects a retry with a changed amount', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const reason = 'shoppingCartItem:amount-conflict';
+    await spendSunflowersBatch(accountId, [{ amount: 200, reason }]);
+
+    await assert.rejects(
+        () => spendSunflowersBatch(accountId, [{ amount: 300, reason }]),
+        (error) => {
+            assert.ok(error instanceof SunflowerSpendAmountConflictError);
+            assert.strictEqual(error.reason, reason);
+            assert.strictEqual(error.existingAmount, 200);
+            assert.strictEqual(error.requestedAmount, 300);
+            return true;
+        },
+    );
+    assert.strictEqual(await getSunflowers(accountId), 800);
+});
+
+test('spendSunflowersBatch serializes concurrent identical retries', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const debit = {
+        amount: 400,
+        reason: 'shoppingCartItem:concurrent-retry',
+    };
+
+    const results = await Promise.all([
+        spendSunflowersBatch(accountId, [debit]),
+        spendSunflowersBatch(accountId, [debit]),
+    ]);
+
+    assert.strictEqual(
+        results.reduce(
+            (count, result) => count + result.createdReasons.length,
+            0,
+        ),
+        1,
+    );
+    assert.strictEqual(await getSunflowers(accountId), 600);
 });
 
 test('getSunflowersHistory returns correct history', async () => {

--- a/packages/storage/tests/accountsRepo.node.spec.ts
+++ b/packages/storage/tests/accountsRepo.node.spec.ts
@@ -134,10 +134,11 @@ function createInsertBarrierDb(
 function legacyCoveredItem(
     item: { amount: number; reason: string },
     createdAt = new Date('2025-01-01T00:00:00.000Z'),
+    paymentState: 'paid' | 'pending' = 'pending',
 ) {
     const cartItemId = Number(item.reason.replace('shoppingCartItem:', ''));
     assert.ok(Number.isSafeInteger(cartItemId) && cartItemId > 0);
-    return { ...item, cartItemId, createdAt };
+    return { ...item, cartItemId, createdAt, paymentState };
 }
 
 test('createAccount creates a new account', async () => {
@@ -634,7 +635,56 @@ test('checkout replay can resolve a unique stored per-item amount across catalog
     );
 });
 
-test('legacy cart debit creates hidden per-item checkpoints only for pending covered items', async () => {
+test('checkout replay resolves paid covered items from durable per-item debits', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const paidItem = {
+        amount: 300,
+        reason: 'shoppingCartItem:8031',
+    };
+    await spendSunflowersBatch(accountId, [{ ...paidItem, amount: 200 }]);
+
+    const replay = await spendSunflowersBatch(accountId, [], undefined, {
+        legacyCartSpend: {
+            reason: 'shoppingCart:803',
+            coveredItems: [
+                legacyCoveredItem(
+                    paidItem,
+                    new Date('2025-01-01T00:00:00.000Z'),
+                    'paid',
+                ),
+            ],
+        },
+    });
+
+    assert.deepEqual(replay, {
+        createdReasons: [],
+        existingReasons: [],
+        resolvedAmountsByReason: { [paidItem.reason]: 200 },
+    });
+    assert.equal(await getSunflowers(accountId), 800);
+
+    await assert.rejects(
+        spendSunflowersBatch(accountId, [], undefined, {
+            legacyCartSpend: {
+                reason: 'shoppingCart:804',
+                coveredItems: [
+                    legacyCoveredItem(
+                        {
+                            amount: 400,
+                            reason: 'shoppingCartItem:8041',
+                        },
+                        new Date('2025-01-01T00:00:00.000Z'),
+                        'paid',
+                    ),
+                ],
+            },
+        }),
+        SunflowerSpendAmountConflictError,
+    );
+});
+
+test('legacy cart debit materializes durable amounts for paid and pending covered items', async () => {
     createTestDb();
     const accountId = await createTestAccount();
     const legacyCartReason = 'shoppingCart:901';
@@ -644,9 +694,15 @@ test('legacy cart debit creates hidden per-item checkpoints only for pending cov
         amount: 100,
         reason: 'shoppingCartItem:9013',
     };
-    const coveredItems = [firstItem, secondItem, alreadyPaidItem].map((item) =>
-        legacyCoveredItem(item),
-    );
+    const coveredItems = [
+        legacyCoveredItem(firstItem),
+        legacyCoveredItem(secondItem),
+        legacyCoveredItem(
+            alreadyPaidItem,
+            new Date('2025-01-01T00:00:00.000Z'),
+            'paid',
+        ),
+    ];
     const options = {
         legacyCartSpend: { reason: legacyCartReason, coveredItems },
     };
@@ -665,6 +721,7 @@ test('legacy cart debit creates hidden per-item checkpoints only for pending cov
         resolvedAmountsByReason: {
             [firstItem.reason]: firstItem.amount,
             [secondItem.reason]: secondItem.amount,
+            [alreadyPaidItem.reason]: alreadyPaidItem.amount,
         },
     });
     assert.equal(await getSunflowers(accountId), 401);
@@ -703,7 +760,13 @@ test('legacy cart debit creates hidden per-item checkpoints only for pending cov
         legacyCartReason,
         reason: secondItem.reason,
     });
-    assert.equal(firstCheckpointEvents.length, 2);
+    assert.deepEqual(checkpointDataForReason(alreadyPaidItem.reason), {
+        amount: 0,
+        coveredAmount: alreadyPaidItem.amount,
+        legacyCartReason,
+        reason: alreadyPaidItem.reason,
+    });
+    assert.equal(firstCheckpointEvents.length, 3);
 
     const driftedSecondItem = { ...secondItem, amount: 350 };
     const retry = await spendSunflowersBatch(
@@ -714,10 +777,14 @@ test('legacy cart debit creates hidden per-item checkpoints only for pending cov
             legacyCartSpend: {
                 reason: legacyCartReason,
                 coveredItems: [
-                    firstItem,
-                    driftedSecondItem,
-                    alreadyPaidItem,
-                ].map((item) => legacyCoveredItem(item)),
+                    legacyCoveredItem(firstItem),
+                    legacyCoveredItem(driftedSecondItem),
+                    legacyCoveredItem(
+                        alreadyPaidItem,
+                        new Date('2025-01-01T00:00:00.000Z'),
+                        'paid',
+                    ),
+                ],
             },
         },
     );
@@ -726,16 +793,37 @@ test('legacy cart debit creates hidden per-item checkpoints only for pending cov
         existingReasons: [secondItem.reason],
         resolvedAmountsByReason: {
             [secondItem.reason]: secondItem.amount,
+            [alreadyPaidItem.reason]: alreadyPaidItem.amount,
         },
     });
 
-    const finalPendingItem = await spendSunflowersBatch(
+    const allPaidResolution = await spendSunflowersBatch(
         accountId,
-        [alreadyPaidItem],
+        [],
         undefined,
-        options,
+        {
+            legacyCartSpend: {
+                reason: legacyCartReason,
+                coveredItems: [firstItem, secondItem, alreadyPaidItem].map(
+                    (item) =>
+                        legacyCoveredItem(
+                            item,
+                            new Date('2025-01-01T00:00:00.000Z'),
+                            'paid',
+                        ),
+                ),
+            },
+        },
     );
-    assert.deepEqual(finalPendingItem.createdReasons, [alreadyPaidItem.reason]);
+    assert.deepEqual(allPaidResolution, {
+        createdReasons: [],
+        existingReasons: [],
+        resolvedAmountsByReason: {
+            [firstItem.reason]: firstItem.amount,
+            [secondItem.reason]: secondItem.amount,
+            [alreadyPaidItem.reason]: alreadyPaidItem.amount,
+        },
+    });
     assert.equal(await getSunflowers(accountId), 401);
 
     await earnSunflowers(accountId, 2, 'legacy-history-new');

--- a/packages/storage/tests/accountsRepo.node.spec.ts
+++ b/packages/storage/tests/accountsRepo.node.spec.ts
@@ -4,7 +4,10 @@ import test from 'node:test';
 import {
     accountUsers,
     assignStripeCustomerId,
+    createEvent,
     earnSunflowers,
+    earnSunflowersForPayment,
+    earnSunflowersOnce,
     getAccount,
     getAccounts,
     getAccountUsers,
@@ -13,9 +16,13 @@ import {
     getSunflowersHistory,
     grantBirthdaySunflowers,
     InsufficientSunflowersError,
+    knownEvents,
+    knownEventTypes,
+    SunflowerEarnAmountConflictError,
     SunflowerSpendAmountConflictError,
     spendSunflowers,
     spendSunflowersBatch,
+    sql,
     storage,
     users,
 } from '@gredice/storage';
@@ -124,6 +131,15 @@ function createInsertBarrierDb(
     });
 }
 
+function legacyCoveredItem(
+    item: { amount: number; reason: string },
+    createdAt = new Date('2025-01-01T00:00:00.000Z'),
+) {
+    const cartItemId = Number(item.reason.replace('shoppingCartItem:', ''));
+    assert.ok(Number.isSafeInteger(cartItemId) && cartItemId > 0);
+    return { ...item, cartItemId, createdAt };
+}
+
 test('createAccount creates a new account', async () => {
     createTestDb();
     const accountId = await createTestAccount();
@@ -177,6 +193,197 @@ test('earnSunflowers increases sunflowers', async () => {
     await earnSunflowers(accountId, 500, 'bonus');
     const sunflowers = await getSunflowers(accountId);
     assert.strictEqual(sunflowers, 1500);
+});
+
+test('earnSunflowersForPayment is source-idempotent under concurrency and rejects amount conflicts', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const source = 'shoppingCartItem:payment-retry';
+
+    await Promise.all([
+        earnSunflowersForPayment(accountId, 25, source),
+        earnSunflowersForPayment(accountId, 25, source),
+    ]);
+
+    assert.strictEqual(await getSunflowers(accountId), 1250);
+    await assert.rejects(
+        earnSunflowersForPayment(accountId, 30, source),
+        SunflowerEarnAmountConflictError,
+    );
+});
+
+test('zero payment reward is a hidden idempotent checkout marker without a balance delta', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const source = 'shoppingCartItem:zero-payment-reward';
+    const reason = `payment:${source}`;
+
+    await earnSunflowers(accountId, 1, 'zero-marker-history-old');
+    await earnSunflowersForPayment(accountId, 0.01, source);
+    await earnSunflowersForPayment(accountId, 0.01, source);
+    await earnSunflowers(accountId, 2, 'zero-marker-history-new');
+
+    assert.equal(await getSunflowers(accountId), 1003);
+    const firstPage = await getSunflowersHistory(accountId, 0, 1);
+    const secondPage = await getSunflowersHistory(accountId, 1, 1);
+    assert.deepEqual(
+        [firstPage[0]?.reason, secondPage[0]?.reason],
+        ['zero-marker-history-new', 'zero-marker-history-old'],
+    );
+    assert.equal(
+        [...firstPage, ...secondPage].some((event) => event.reason === reason),
+        false,
+    );
+
+    const markerEvents = await storage().query.events.findMany({
+        where: (event, { and, eq }) =>
+            and(
+                eq(event.aggregateId, accountId),
+                eq(event.type, knownEventTypes.accounts.earnSunflowers),
+                sql`${event.data}->>'reason' = ${reason}`,
+            ),
+    });
+    assert.equal(markerEvents.length, 1);
+    assert.deepEqual(markerEvents[0]?.data, { amount: 0, reason });
+
+    await assert.rejects(
+        earnSunflowersForPayment(accountId, 1, source),
+        (error) => {
+            assert.ok(error instanceof SunflowerEarnAmountConflictError);
+            assert.equal(error.existingAmount, 0);
+            assert.equal(error.requestedAmount, 10);
+            return true;
+        },
+    );
+    await assert.rejects(
+        earnSunflowersOnce(accountId, 0, 'general-zero-reward'),
+        /positive integer/,
+    );
+});
+
+test('payment reward reuses an existing transaction without an inner commit', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const source = 'shoppingCartItem:rolled-back-payment-reward';
+    const rollback = new Error('roll back payment reward test');
+
+    await assert.rejects(
+        storage().transaction(async (tx) => {
+            await earnSunflowersForPayment(accountId, 2, source, tx);
+            throw rollback;
+        }),
+        (error) => error === rollback,
+    );
+    assert.equal(await getSunflowers(accountId), 1000);
+
+    await earnSunflowersForPayment(accountId, 2, source);
+    assert.equal(await getSunflowers(accountId), 1020);
+});
+
+test('legacy payment reward writes one hidden balance-neutral keyed checkpoint', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const source = 'shoppingCartItem:701';
+    const reason = `payment:${source}`;
+    const options = { legacyRewardAlreadyEarned: true };
+
+    await earnSunflowersForPayment(accountId, 25, source, undefined, options);
+    await earnSunflowersForPayment(accountId, 25, source, undefined, options);
+
+    assert.equal(await getSunflowers(accountId), 1000);
+    const markerEvents = await storage().query.events.findMany({
+        where: (event, { and, eq }) =>
+            and(
+                eq(event.aggregateId, accountId),
+                eq(event.type, knownEventTypes.accounts.earnSunflowers),
+                sql`${event.data}->>'reason' = ${reason}`,
+            ),
+    });
+    assert.equal(markerEvents.length, 1);
+    assert.deepEqual(markerEvents[0]?.data, {
+        amount: 0,
+        coveredAmount: 250,
+        legacyRewardAlreadyEarned: true,
+        reason,
+    });
+    assert.equal(
+        (await getSunflowersHistory(accountId, 0, 20)).some(
+            (event) => event.reason === reason,
+        ),
+        false,
+    );
+
+    await assert.rejects(
+        earnSunflowersForPayment(accountId, 25, source),
+        SunflowerEarnAmountConflictError,
+    );
+});
+
+test('legacy payment reward accepts an exact existing keyed reward without adding a checkpoint', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const source = 'shoppingCartItem:702';
+    const reason = `payment:${source}`;
+
+    await earnSunflowersForPayment(accountId, 25, source);
+    await earnSunflowersForPayment(accountId, 25, source, undefined, {
+        legacyRewardAlreadyEarned: true,
+    });
+
+    assert.equal(await getSunflowers(accountId), 1250);
+    const rewardEvents = await storage().query.events.findMany({
+        where: (event, { and, eq }) =>
+            and(
+                eq(event.aggregateId, accountId),
+                eq(event.type, knownEventTypes.accounts.earnSunflowers),
+                sql`${event.data}->>'reason' = ${reason}`,
+            ),
+    });
+    assert.equal(rewardEvents.length, 1);
+    assert.deepEqual(rewardEvents[0]?.data, { amount: 250, reason });
+});
+
+test('legacy payment reward rejects unrelated zero markers, changed amounts, and duplicate keyed rewards', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const source = 'shoppingCartItem:703';
+    const options = { legacyRewardAlreadyEarned: true };
+
+    await earnSunflowersForPayment(accountId, 0.01, source);
+    await assert.rejects(
+        earnSunflowersForPayment(accountId, 25, source, undefined, options),
+        SunflowerEarnAmountConflictError,
+    );
+
+    const duplicateSource = 'shoppingCartItem:704';
+    const duplicateReason = `payment:${duplicateSource}`;
+    await createEvent(
+        knownEvents.accounts.sunflowersEarnedV1(accountId, {
+            amount: 250,
+            reason: duplicateReason,
+        }),
+    );
+    await createEvent(
+        knownEvents.accounts.sunflowersEarnedV1(accountId, {
+            amount: 250,
+            reason: duplicateReason,
+        }),
+    );
+    await assert.rejects(
+        earnSunflowersForPayment(
+            accountId,
+            25,
+            duplicateSource,
+            undefined,
+            options,
+        ),
+        SunflowerEarnAmountConflictError,
+    );
+
+    await assert.rejects(
+        earnSunflowersForPayment(accountId, 25, undefined, undefined, options),
+        /idempotency key/,
+    );
 });
 
 test('grantBirthdaySunflowers is idempotent for a user reward year', async () => {
@@ -294,6 +501,10 @@ test('spendSunflowersBatch writes one durable debit per item', async () => {
             'shoppingCartItem:batch-2',
         ],
         existingReasons: [],
+        resolvedAmountsByReason: {
+            'shoppingCartItem:batch-1': 200,
+            'shoppingCartItem:batch-2': 300,
+        },
     });
     assert.strictEqual(await getSunflowers(accountId), 500);
     const history = await getSunflowersHistory(accountId, 0, 20);
@@ -347,10 +558,12 @@ test('spendSunflowersBatch treats an identical retry as already spent', async ()
     assert.deepStrictEqual(first, {
         createdReasons: [debit.reason],
         existingReasons: [],
+        resolvedAmountsByReason: { [debit.reason]: debit.amount },
     });
     assert.deepStrictEqual(retry, {
         createdReasons: [],
         existingReasons: [debit.reason],
+        resolvedAmountsByReason: { [debit.reason]: debit.amount },
     });
     assert.strictEqual(await getSunflowers(accountId), 750);
 });
@@ -372,6 +585,316 @@ test('spendSunflowersBatch rejects a retry with a changed amount', async () => {
         },
     );
     assert.strictEqual(await getSunflowers(accountId), 800);
+});
+
+test('spendSunflowersBatch fails closed on duplicate stored events even when amounts match', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const debit = { amount: 200, reason: 'shoppingCartItem:801' };
+    await createEvent(knownEvents.accounts.sunflowersSpentV1(accountId, debit));
+    await createEvent(knownEvents.accounts.sunflowersSpentV1(accountId, debit));
+
+    await assert.rejects(spendSunflowersBatch(accountId, [debit]), (error) => {
+        assert.ok(error instanceof SunflowerSpendAmountConflictError);
+        assert.equal(error.reason, debit.reason);
+        assert.equal(error.existingAmount, debit.amount);
+        assert.equal(error.requestedAmount, debit.amount);
+        return true;
+    });
+});
+
+test('checkout replay can resolve a unique stored per-item amount across catalog drift', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const reason = 'shoppingCartItem:802';
+    await spendSunflowersBatch(accountId, [{ amount: 200, reason }]);
+
+    const replay = await spendSunflowersBatch(
+        accountId,
+        [{ amount: 300, reason }],
+        undefined,
+        { existingCheckoutItemAmountsAreAuthoritative: true },
+    );
+
+    assert.deepEqual(replay, {
+        createdReasons: [],
+        existingReasons: [reason],
+        resolvedAmountsByReason: { [reason]: 200 },
+    });
+    assert.equal(await getSunflowers(accountId), 800);
+
+    await assert.rejects(
+        spendSunflowersBatch(
+            accountId,
+            [{ amount: 1, reason: 'not-a-checkout-item' }],
+            undefined,
+            { existingCheckoutItemAmountsAreAuthoritative: true },
+        ),
+        /shoppingCartItem:<id>/,
+    );
+});
+
+test('legacy cart debit creates hidden per-item checkpoints only for pending covered items', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const legacyCartReason = 'shoppingCart:901';
+    const firstItem = { amount: 200, reason: 'shoppingCartItem:9011' };
+    const secondItem = { amount: 300, reason: 'shoppingCartItem:9012' };
+    const alreadyPaidItem = {
+        amount: 100,
+        reason: 'shoppingCartItem:9013',
+    };
+    const coveredItems = [firstItem, secondItem, alreadyPaidItem].map((item) =>
+        legacyCoveredItem(item),
+    );
+    const options = {
+        legacyCartSpend: { reason: legacyCartReason, coveredItems },
+    };
+    await earnSunflowers(accountId, 1, 'legacy-history-old');
+    await spendSunflowers(accountId, 600, legacyCartReason);
+
+    const firstReplay = await spendSunflowersBatch(
+        accountId,
+        [firstItem, secondItem],
+        undefined,
+        options,
+    );
+    assert.deepEqual(firstReplay, {
+        createdReasons: [firstItem.reason, secondItem.reason],
+        existingReasons: [],
+        resolvedAmountsByReason: {
+            [firstItem.reason]: firstItem.amount,
+            [secondItem.reason]: secondItem.amount,
+        },
+    });
+    assert.equal(await getSunflowers(accountId), 401);
+
+    const firstCheckpointEvents = await storage().query.events.findMany({
+        where: (event, { and, eq, inArray }) =>
+            and(
+                eq(event.aggregateId, accountId),
+                eq(event.type, knownEventTypes.accounts.spendSunflowers),
+                inArray(sql<string>`${event.data}->>'reason'`, [
+                    firstItem.reason,
+                    secondItem.reason,
+                    alreadyPaidItem.reason,
+                ]),
+            ),
+    });
+    const checkpointDataForReason = (reason: string) =>
+        firstCheckpointEvents.find((event) => {
+            const data = event.data;
+            return (
+                typeof data === 'object' &&
+                data !== null &&
+                'reason' in data &&
+                data.reason === reason
+            );
+        })?.data;
+    assert.deepEqual(checkpointDataForReason(firstItem.reason), {
+        amount: 0,
+        coveredAmount: firstItem.amount,
+        legacyCartReason,
+        reason: firstItem.reason,
+    });
+    assert.deepEqual(checkpointDataForReason(secondItem.reason), {
+        amount: 0,
+        coveredAmount: secondItem.amount,
+        legacyCartReason,
+        reason: secondItem.reason,
+    });
+    assert.equal(firstCheckpointEvents.length, 2);
+
+    const driftedSecondItem = { ...secondItem, amount: 350 };
+    const retry = await spendSunflowersBatch(
+        accountId,
+        [driftedSecondItem],
+        undefined,
+        {
+            legacyCartSpend: {
+                reason: legacyCartReason,
+                coveredItems: [
+                    firstItem,
+                    driftedSecondItem,
+                    alreadyPaidItem,
+                ].map((item) => legacyCoveredItem(item)),
+            },
+        },
+    );
+    assert.deepEqual(retry, {
+        createdReasons: [],
+        existingReasons: [secondItem.reason],
+        resolvedAmountsByReason: {
+            [secondItem.reason]: secondItem.amount,
+        },
+    });
+
+    const finalPendingItem = await spendSunflowersBatch(
+        accountId,
+        [alreadyPaidItem],
+        undefined,
+        options,
+    );
+    assert.deepEqual(finalPendingItem.createdReasons, [alreadyPaidItem.reason]);
+    assert.equal(await getSunflowers(accountId), 401);
+
+    await earnSunflowers(accountId, 2, 'legacy-history-new');
+    const firstHistoryPage = await getSunflowersHistory(accountId, 0, 1);
+    const secondHistoryPage = await getSunflowersHistory(accountId, 1, 1);
+    assert.deepEqual(
+        [firstHistoryPage[0]?.reason, secondHistoryPage[0]?.reason],
+        ['legacy-history-new', legacyCartReason],
+    );
+});
+
+test('legacy cart debit rejects wrong totals, duplicate history, positive per-item overlap, and orphan checkpoints', async () => {
+    createTestDb();
+    const wrongTotalAccountId = await createTestAccount();
+    const legacyCartReason = 'shoppingCart:902';
+    const item = { amount: 200, reason: 'shoppingCartItem:9021' };
+    await spendSunflowers(wrongTotalAccountId, 300, legacyCartReason);
+    await assert.rejects(
+        spendSunflowersBatch(wrongTotalAccountId, [item], undefined, {
+            legacyCartSpend: {
+                reason: legacyCartReason,
+                coveredItems: [legacyCoveredItem(item)],
+            },
+        }),
+        SunflowerSpendAmountConflictError,
+    );
+    await assert.rejects(
+        spendSunflowersBatch(wrongTotalAccountId, [item], undefined, {
+            legacyCartSpend: {
+                reason: legacyCartReason,
+                coveredItems: [],
+            },
+        }),
+        /requires covered items/,
+    );
+
+    const duplicateAccountId = await createTestAccount();
+    const duplicateLegacyReason = 'shoppingCart:903';
+    const duplicateItem = {
+        amount: 200,
+        reason: 'shoppingCartItem:9031',
+    };
+    await createEvent(
+        knownEvents.accounts.sunflowersSpentV1(duplicateAccountId, {
+            amount: 200,
+            reason: duplicateLegacyReason,
+        }),
+    );
+    await createEvent(
+        knownEvents.accounts.sunflowersSpentV1(duplicateAccountId, {
+            amount: 200,
+            reason: duplicateLegacyReason,
+        }),
+    );
+    await assert.rejects(
+        spendSunflowersBatch(duplicateAccountId, [duplicateItem], undefined, {
+            legacyCartSpend: {
+                reason: duplicateLegacyReason,
+                coveredItems: [legacyCoveredItem(duplicateItem)],
+            },
+        }),
+        SunflowerSpendAmountConflictError,
+    );
+
+    const overlapAccountId = await createTestAccount();
+    const overlapLegacyReason = 'shoppingCart:904';
+    const overlapItem = {
+        amount: 200,
+        reason: 'shoppingCartItem:9041',
+    };
+    await spendSunflowers(overlapAccountId, 200, overlapLegacyReason);
+    await createEvent(
+        knownEvents.accounts.sunflowersSpentV1(overlapAccountId, overlapItem),
+    );
+    await assert.rejects(
+        spendSunflowersBatch(overlapAccountId, [overlapItem], undefined, {
+            legacyCartSpend: {
+                reason: overlapLegacyReason,
+                coveredItems: [legacyCoveredItem(overlapItem)],
+            },
+        }),
+        SunflowerSpendAmountConflictError,
+    );
+
+    const orphanAccountId = await createTestAccount();
+    const orphanLegacyReason = 'shoppingCart:905';
+    const orphanItem = {
+        amount: 200,
+        reason: 'shoppingCartItem:9051',
+    };
+    await createEvent(
+        knownEvents.accounts.sunflowersSpentV1(orphanAccountId, {
+            amount: 0,
+            coveredAmount: orphanItem.amount,
+            legacyCartReason: orphanLegacyReason,
+            reason: orphanItem.reason,
+        }),
+    );
+    await assert.rejects(
+        spendSunflowersBatch(orphanAccountId, [orphanItem], undefined, {
+            legacyCartSpend: {
+                reason: orphanLegacyReason,
+                coveredItems: [legacyCoveredItem(orphanItem)],
+            },
+        }),
+        SunflowerSpendAmountConflictError,
+    );
+
+    const laterItemAccountId = await createTestAccount();
+    const laterItemLegacyReason = 'shoppingCart:906';
+    const laterItem = {
+        amount: 200,
+        reason: 'shoppingCartItem:9061',
+    };
+    await spendSunflowers(laterItemAccountId, 200, laterItemLegacyReason);
+    await assert.rejects(
+        spendSunflowersBatch(laterItemAccountId, [laterItem], undefined, {
+            legacyCartSpend: {
+                reason: laterItemLegacyReason,
+                coveredItems: [
+                    legacyCoveredItem(
+                        laterItem,
+                        new Date('2100-01-01T00:00:00.000Z'),
+                    ),
+                ],
+            },
+        }),
+        /created after the cart debit/,
+    );
+
+    await assert.rejects(
+        spendSunflowersBatch(laterItemAccountId, [laterItem], undefined, {
+            legacyCartSpend: {
+                reason: laterItemLegacyReason,
+                coveredItems: [
+                    {
+                        ...legacyCoveredItem(laterItem),
+                        cartItemId: 9999,
+                    },
+                ],
+            },
+        }),
+        /reason must match its cart item ID/,
+    );
+});
+
+test('general sunflower earn and spend APIs reject zero amounts', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+
+    await assert.rejects(
+        earnSunflowers(accountId, 0, 'invalid-zero-earn'),
+        /positive integer/,
+    );
+    await assert.rejects(
+        spendSunflowers(accountId, 0, 'invalid-zero-spend'),
+        /positive integer/,
+    );
+    assert.equal(await getSunflowers(accountId), 1000);
 });
 
 test('spendSunflowersBatch serializes concurrent identical retries', async () => {

--- a/packages/storage/tests/checkoutFulfillmentIdempotency.node.spec.ts
+++ b/packages/storage/tests/checkoutFulfillmentIdempotency.node.spec.ts
@@ -1,0 +1,315 @@
+import assert from 'node:assert/strict';
+import { randomInt, randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    acceptOperation,
+    addInventoryItem,
+    CheckoutDeliveryRequestConflictError,
+    CheckoutOperationConflictError,
+    consumeInventoryItem,
+    createAccount,
+    createDeliveryRequest,
+    createOperation,
+    createPickupLocation,
+    createTimeSlot,
+    deliveryRequests,
+    events,
+    getCheckoutInventoryConsumptions,
+    getInventory,
+    getOrCreateCheckoutOperation,
+    getOrCreateDeliveryRequest,
+    InventoryConsumptionSourceConflictError,
+    knownEventTypes,
+    operations,
+    storage,
+    TimeSlotStatuses,
+    timeSlots,
+} from '@gredice/storage';
+import { and, eq } from 'drizzle-orm';
+import { createTestDb } from './testDb';
+
+function uniqueCartItemId() {
+    return randomInt(1_000_000_000, 2_000_000_000);
+}
+
+test('checkout operation ensure atomically maps one scheduled operation and rejects changed fingerprints', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const cartItemId = uniqueCartItemId();
+    const scheduledDate = new Date('2099-04-05T00:00:00.000Z');
+    const operationInput = {
+        accountId,
+        entityId: 17,
+        entityTypeName: 'operation',
+        gardenId: 23,
+        raisedBedId: 29,
+        raisedBedFieldId: 31,
+    };
+
+    const results = await Promise.all([
+        getOrCreateCheckoutOperation(cartItemId, operationInput, {
+            scheduledDate,
+        }),
+        getOrCreateCheckoutOperation(cartItemId, operationInput, {
+            scheduledDate,
+        }),
+    ]);
+    assert.equal(new Set(results.map((result) => result.operationId)).size, 1);
+    assert.deepEqual(results.map((result) => result.created).sort(), [
+        false,
+        true,
+    ]);
+
+    const operationId = results[0].operationId;
+    const [storedOperation] = await storage()
+        .select()
+        .from(operations)
+        .where(eq(operations.id, operationId));
+    assert.equal(storedOperation?.accountId, accountId);
+    const scheduleEvents = await storage().query.events.findMany({
+        where: and(
+            eq(events.type, knownEventTypes.operations.schedule),
+            eq(events.aggregateId, operationId.toString()),
+        ),
+    });
+    assert.equal(scheduleEvents.length, 1);
+    const mappingEvents = await storage().query.events.findMany({
+        where: and(
+            eq(events.type, knownEventTypes.checkout.operationCreated),
+            eq(events.aggregateId, `shoppingCartItem:${cartItemId.toString()}`),
+        ),
+    });
+    assert.equal(mappingEvents.length, 1);
+
+    await acceptOperation(operationId);
+    const acceptedRetry = await getOrCreateCheckoutOperation(
+        cartItemId,
+        operationInput,
+        { scheduledDate },
+    );
+    assert.deepEqual(acceptedRetry, { operationId, created: false });
+
+    await assert.rejects(
+        getOrCreateCheckoutOperation(cartItemId, operationInput, {
+            scheduledDate: new Date('2099-04-06T00:00:00.000Z'),
+        }),
+        CheckoutOperationConflictError,
+    );
+});
+
+test('checkout operation mapping rolls back with operation and schedule', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const cartItemId = uniqueCartItemId();
+
+    await assert.rejects(
+        storage().transaction(async (tx) => {
+            await getOrCreateCheckoutOperation(
+                cartItemId,
+                {
+                    accountId,
+                    entityId: 37,
+                    entityTypeName: 'operation',
+                },
+                { scheduledDate: new Date('2099-04-07T00:00:00.000Z') },
+                tx,
+            );
+            throw new Error('force rollback');
+        }),
+        /force rollback/,
+    );
+
+    const mappingEvents = await storage().query.events.findMany({
+        where: and(
+            eq(events.type, knownEventTypes.checkout.operationCreated),
+            eq(events.aggregateId, `shoppingCartItem:${cartItemId.toString()}`),
+        ),
+    });
+    assert.equal(mappingEvents.length, 0);
+    const storedOperations = await storage().query.operations.findMany({
+        where: and(
+            eq(operations.accountId, accountId),
+            eq(operations.entityId, 37),
+        ),
+    });
+    assert.equal(storedOperations.length, 0);
+});
+
+test('checkout delivery ensure reuses one owned request after its slot closes while ordinary create rejects duplicates', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const operationId = await createOperation({
+        accountId,
+        entityId: 41,
+        entityTypeName: 'operation',
+    });
+    const locationId = await createPickupLocation({
+        name: `Checkout retry ${randomUUID()}`,
+        street1: 'Testna 1',
+        city: 'Zagreb',
+        postalCode: '10000',
+        countryCode: 'HR',
+    });
+    const startAt = new Date('2099-05-01T08:00:00.000Z');
+    const slotId = await createTimeSlot({
+        locationId,
+        type: 'pickup',
+        startAt,
+        endAt: new Date(startAt.getTime() + 2 * 60 * 60 * 1000),
+        status: TimeSlotStatuses.SCHEDULED,
+    });
+    const input = {
+        operationId,
+        slotId,
+        mode: 'pickup' as const,
+        locationId,
+        accountId,
+    };
+
+    const results = await Promise.all([
+        getOrCreateDeliveryRequest(input),
+        getOrCreateDeliveryRequest(input),
+    ]);
+    assert.equal(new Set(results.map((result) => result.requestId)).size, 1);
+    assert.deepEqual(results.map((result) => result.created).sort(), [
+        false,
+        true,
+    ]);
+    await assert.rejects(
+        createDeliveryRequest(input),
+        /Operation already has a delivery request/,
+    );
+
+    await storage()
+        .update(timeSlots)
+        .set({ status: TimeSlotStatuses.CLOSED })
+        .where(eq(timeSlots.id, slotId));
+    const retried = await getOrCreateDeliveryRequest(input);
+    assert.equal(retried.requestId, results[0].requestId);
+    assert.equal(retried.created, false);
+    await assert.rejects(
+        getOrCreateDeliveryRequest({ ...input, notes: 'changed' }),
+        CheckoutDeliveryRequestConflictError,
+    );
+
+    const requests = await storage()
+        .select({ id: deliveryRequests.id })
+        .from(deliveryRequests)
+        .where(eq(deliveryRequests.operationId, operationId));
+    assert.equal(requests.length, 1);
+});
+
+test('checkout delivery ensure closes and rejects an expired new slot without nested locking', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const operationId = await createOperation({
+        accountId,
+        entityId: 43,
+        entityTypeName: 'operation',
+    });
+    const locationId = await createPickupLocation({
+        name: `Expired checkout slot ${randomUUID()}`,
+        street1: 'Testna 2',
+        city: 'Zagreb',
+        postalCode: '10000',
+        countryCode: 'HR',
+    });
+    const startAt = new Date('2099-05-02T08:00:00.000Z');
+    const slotId = await createTimeSlot({
+        locationId,
+        type: 'pickup',
+        startAt,
+        endAt: new Date(startAt.getTime() + 2 * 60 * 60 * 1000),
+        closesAt: new Date('2026-01-01T00:00:00.000Z'),
+        status: TimeSlotStatuses.SCHEDULED,
+    });
+
+    await assert.rejects(
+        getOrCreateDeliveryRequest({
+            operationId,
+            slotId,
+            mode: 'pickup',
+            locationId,
+            accountId,
+        }),
+        /Time slot is not available for booking/,
+    );
+    const slot = await storage().query.timeSlots.findFirst({
+        where: eq(timeSlots.id, slotId),
+    });
+    assert.equal(slot?.status, TimeSlotStatuses.CLOSED);
+});
+
+test('checkout inventory consumption is source-idempotent under concurrency and rejects conflicts', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const cartItemId = uniqueCartItemId();
+    const source = `shoppingCartItem:${cartItemId.toString()}`;
+    const payload = {
+        entityTypeName: 'block',
+        entityId: 'checkout-retry-block',
+        amount: 1,
+        source,
+    };
+    await addInventoryItem(accountId, {
+        entityTypeName: payload.entityTypeName,
+        entityId: payload.entityId,
+        amount: 2,
+        source: 'test',
+    });
+
+    await Promise.all([
+        consumeInventoryItem(accountId, payload),
+        consumeInventoryItem(accountId, payload),
+    ]);
+    const inventory = await getInventory(accountId);
+    assert.equal(
+        inventory.find(
+            (item) =>
+                item.entityTypeName === payload.entityTypeName &&
+                item.entityId === payload.entityId,
+        )?.amount,
+        1,
+    );
+    assert.deepEqual(
+        await getCheckoutInventoryConsumptions(accountId, [cartItemId]),
+        [
+            {
+                cartItemId,
+                source,
+                entityTypeName: payload.entityTypeName,
+                entityId: payload.entityId,
+                amount: payload.amount,
+            },
+        ],
+    );
+    await assert.rejects(
+        consumeInventoryItem(accountId, { ...payload, amount: 2 }),
+        InventoryConsumptionSourceConflictError,
+    );
+});
+
+test('checkout inventory lookup surfaces malformed requested source rows', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const cartItemId = uniqueCartItemId();
+    const source = `shoppingCartItem:${cartItemId.toString()}`;
+    await storage()
+        .insert(events)
+        .values({
+            type: knownEventTypes.inventory.consume,
+            version: 1,
+            aggregateId: `inventory:${accountId}`,
+            data: {
+                entityTypeName: 'block',
+                entityId: 'malformed-checkout-consumption',
+                amount: 'one',
+                source,
+            },
+        });
+
+    await assert.rejects(
+        getCheckoutInventoryConsumptions(accountId, [cartItemId]),
+        InventoryConsumptionSourceConflictError,
+    );
+});

--- a/packages/storage/tests/checkoutFulfillmentIdempotency.node.spec.ts
+++ b/packages/storage/tests/checkoutFulfillmentIdempotency.node.spec.ts
@@ -15,6 +15,9 @@ import {
     deliveryRequests,
     events,
     getCheckoutInventoryConsumptions,
+    getCheckoutInventorySnapshot,
+    getCheckoutOperationMapping,
+    getCheckoutOperationMappings,
     getInventory,
     getOrCreateCheckoutOperation,
     getOrCreateDeliveryRequest,
@@ -48,9 +51,13 @@ test('checkout operation ensure atomically maps one scheduled operation and reje
 
     const results = await Promise.all([
         getOrCreateCheckoutOperation(cartItemId, operationInput, {
+            delivery: null,
+            paymentCurrency: 'eur',
             scheduledDate,
         }),
         getOrCreateCheckoutOperation(cartItemId, operationInput, {
+            delivery: null,
+            paymentCurrency: 'eur',
             scheduledDate,
         }),
     ]);
@@ -80,17 +87,29 @@ test('checkout operation ensure atomically maps one scheduled operation and reje
         ),
     });
     assert.equal(mappingEvents.length, 1);
+    assert.deepEqual(
+        await getCheckoutOperationMapping(cartItemId),
+        mappingEvents[0]?.data,
+    );
+    assert.deepEqual(
+        Array.from(
+            (await getCheckoutOperationMappings([cartItemId])).entries(),
+        ),
+        [[cartItemId, mappingEvents[0]?.data]],
+    );
 
     await acceptOperation(operationId);
     const acceptedRetry = await getOrCreateCheckoutOperation(
         cartItemId,
         operationInput,
-        { scheduledDate },
+        { delivery: null, paymentCurrency: 'eur', scheduledDate },
     );
     assert.deepEqual(acceptedRetry, { operationId, created: false });
 
     await assert.rejects(
         getOrCreateCheckoutOperation(cartItemId, operationInput, {
+            delivery: null,
+            paymentCurrency: 'eur',
             scheduledDate: new Date('2099-04-06T00:00:00.000Z'),
         }),
         CheckoutOperationConflictError,
@@ -111,7 +130,11 @@ test('checkout operation mapping rolls back with operation and schedule', async 
                     entityId: 37,
                     entityTypeName: 'operation',
                 },
-                { scheduledDate: new Date('2099-04-07T00:00:00.000Z') },
+                {
+                    delivery: null,
+                    paymentCurrency: 'eur',
+                    scheduledDate: new Date('2099-04-07T00:00:00.000Z'),
+                },
                 tx,
             );
             throw new Error('force rollback');
@@ -133,6 +156,60 @@ test('checkout operation mapping rolls back with operation and schedule', async 
         ),
     });
     assert.equal(storedOperations.length, 0);
+});
+
+test('checkout operation mapping lookup rejects malformed and duplicate mappings', async () => {
+    createTestDb();
+    const malformedCartItemId = uniqueCartItemId();
+    await storage()
+        .insert(events)
+        .values({
+            type: knownEventTypes.checkout.operationCreated,
+            version: 1,
+            aggregateId: `shoppingCartItem:${malformedCartItemId.toString()}`,
+            data: {},
+        });
+    await assert.rejects(
+        getCheckoutOperationMapping(malformedCartItemId),
+        CheckoutOperationConflictError,
+    );
+
+    const accountId = await createAccount();
+    const duplicateCartItemId = uniqueCartItemId();
+    await getOrCreateCheckoutOperation(
+        duplicateCartItemId,
+        {
+            accountId,
+            entityId: 41,
+            entityTypeName: 'operation',
+        },
+        {
+            delivery: null,
+            paymentCurrency: 'eur',
+            scheduledDate: new Date('2099-04-08T00:00:00.000Z'),
+        },
+    );
+    const [storedMapping] = await storage().query.events.findMany({
+        where: and(
+            eq(events.type, knownEventTypes.checkout.operationCreated),
+            eq(
+                events.aggregateId,
+                `shoppingCartItem:${duplicateCartItemId.toString()}`,
+            ),
+        ),
+    });
+    assert.ok(storedMapping);
+    await storage().insert(events).values({
+        type: storedMapping.type,
+        version: storedMapping.version,
+        aggregateId: storedMapping.aggregateId,
+        data: storedMapping.data,
+    });
+
+    await assert.rejects(
+        getCheckoutOperationMappings([duplicateCartItemId]),
+        CheckoutOperationConflictError,
+    );
 });
 
 test('checkout delivery ensure reuses one owned request after its slot closes while ordinary create rejects duplicates', async () => {
@@ -310,6 +387,40 @@ test('checkout inventory lookup surfaces malformed requested source rows', async
 
     await assert.rejects(
         getCheckoutInventoryConsumptions(accountId, [cartItemId]),
+        InventoryConsumptionSourceConflictError,
+    );
+});
+
+test('checkout inventory lookup surfaces duplicate requested source rows', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const cartItemId = uniqueCartItemId();
+    const source = `shoppingCartItem:${cartItemId.toString()}`;
+    const duplicateConsumption = {
+        entityTypeName: 'block',
+        entityId: 'duplicate-checkout-consumption',
+        amount: 1,
+        source,
+    };
+    await storage()
+        .insert(events)
+        .values([
+            {
+                type: knownEventTypes.inventory.consume,
+                version: 1,
+                aggregateId: `inventory:${accountId}`,
+                data: duplicateConsumption,
+            },
+            {
+                type: knownEventTypes.inventory.consume,
+                version: 1,
+                aggregateId: `inventory:${accountId}`,
+                data: duplicateConsumption,
+            },
+        ]);
+
+    await assert.rejects(
+        getCheckoutInventorySnapshot(accountId, [cartItemId]),
         InventoryConsumptionSourceConflictError,
     );
 });

--- a/packages/storage/tests/shoppingCartRepo.node.spec.ts
+++ b/packages/storage/tests/shoppingCartRepo.node.spec.ts
@@ -2,16 +2,32 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
     addInventoryItem,
+    CheckoutCartItemFulfillmentStartedError,
     consumeInventoryItem,
+    createEvent,
+    createNotificationWithStatus,
     deleteShoppingCart,
+    earnSunflowersForPayment,
     getAllShoppingCarts,
+    getCheckoutFulfillmentStartedCartItemIds,
+    getInventory,
+    getOrCreateCheckoutOperation,
     getOrCreateShoppingCart,
     getShoppingCart,
+    getSunflowers,
+    hasMatchingCheckoutPlantingPurchase,
+    knownEvents,
     markCartPaidIfAllItemsPaid,
     normalizeShoppingCartInventoryUsage,
     normalizeShoppingCartScheduledDates,
     setCartItemPaid,
+    spendSunflowersBatch,
+    sql,
+    storage,
     upsertOrRemoveCartItem,
+    withCheckoutCartItemLock,
+    withCheckoutCartItemProcessingLock,
+    withInventoryAccountTransaction,
 } from '@gredice/storage';
 import {
     createTestAccount,
@@ -34,6 +50,91 @@ test('getOrCreateShoppingCart creates and retrieves cart', async () => {
     const cart2 = await getOrCreateShoppingCart(accountId);
     assert.ok(cart2);
     assert.strictEqual(cart.id, cart2.id);
+});
+
+test('checkout processing lock is connection-free and separate from the database lock', async () => {
+    createTestDb();
+    const cartItemId = 900_001;
+    let signalProcessingLockHeld = () => {};
+    let signalReleaseProcessingLock = () => {};
+    const processingLockHeld = new Promise<void>((resolve) => {
+        signalProcessingLockHeld = resolve;
+    });
+    const releaseProcessingLock = new Promise<void>((resolve) => {
+        signalReleaseProcessingLock = resolve;
+    });
+    const first = withCheckoutCartItemProcessingLock(cartItemId, async () => {
+        signalProcessingLockHeld();
+        await releaseProcessingLock;
+    });
+    await processingLockHeld;
+
+    let secondProcessingLockEntered = false;
+    const second = withCheckoutCartItemProcessingLock(cartItemId, async () => {
+        secondProcessingLockEntered = true;
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(secondProcessingLockEntered, false);
+
+    let databaseLockEntered = false;
+    await withCheckoutCartItemLock(cartItemId, async () => {
+        databaseLockEntered = true;
+    });
+    assert.equal(databaseLockEntered, true);
+
+    signalReleaseProcessingLock();
+    await Promise.all([first, second]);
+    assert.equal(secondProcessingLockEntered, true);
+});
+
+test('short checkout effect helpers reuse and roll back an existing transaction', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    if (!cart) throw new Error('Cart not created');
+    const rollback = new Error('roll back checkout effect test');
+
+    await assert.rejects(
+        storage().transaction(async (tx) => {
+            assert.ok(await getShoppingCart(cart.id, tx));
+            await withInventoryAccountTransaction(
+                accountId,
+                async (inventoryTx) => {
+                    assert.equal(inventoryTx, tx);
+                    await addInventoryItem(
+                        accountId,
+                        {
+                            entityTypeName: 'plantSort',
+                            entityId: 'rolled-back-inventory',
+                            amount: 1,
+                        },
+                        inventoryTx,
+                    );
+                },
+                tx,
+            );
+            await spendSunflowersBatch(
+                accountId,
+                [
+                    {
+                        amount: 100,
+                        reason: 'shoppingCartItem:rolled-back-spend',
+                    },
+                ],
+                tx,
+            );
+            throw rollback;
+        }),
+        (error) => error === rollback,
+    );
+
+    assert.equal(
+        (await getInventory(accountId)).some(
+            (item) => item.entityId === 'rolled-back-inventory',
+        ),
+        false,
+    );
+    assert.equal(await getSunflowers(accountId), 1000);
 });
 
 test('upsertOrRemoveCartItem adds and removes item', async () => {
@@ -136,6 +237,134 @@ test('deleteShoppingCart removes cart', async () => {
     await deleteShoppingCart(accountId);
     const allCarts = await getAllShoppingCarts();
     assert.ok(!allCarts.some((c) => c.id === cart.id));
+});
+
+test('last-item removal waits for a concurrent insert and keeps the cart active', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    if (!cart) throw new Error('Cart not created');
+    const originalItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'original-cart-item',
+        'plantSort',
+        1,
+    );
+    assert.ok(originalItemId);
+
+    let signalInserted = () => {};
+    let signalCommitInsert = () => {};
+    const inserted = new Promise<void>((resolve) => {
+        signalInserted = resolve;
+    });
+    const commitInsert = new Promise<void>((resolve) => {
+        signalCommitInsert = resolve;
+    });
+    const insertion = storage().transaction(async (tx) => {
+        const insertedItemId = await upsertOrRemoveCartItem(
+            null,
+            cart.id,
+            'concurrent-cart-item',
+            'plantSort',
+            1,
+            undefined,
+            undefined,
+            undefined,
+            null,
+            'eur',
+            true,
+            false,
+            tx,
+        );
+        signalInserted();
+        await commitInsert;
+        return insertedItemId;
+    });
+    await inserted;
+
+    let removalSettled = false;
+    const removal = upsertOrRemoveCartItem(
+        originalItemId,
+        cart.id,
+        'original-cart-item',
+        'plantSort',
+        0,
+    ).finally(() => {
+        removalSettled = true;
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(removalSettled, false);
+
+    signalCommitInsert();
+    const insertedItemId = await insertion;
+    await removal;
+
+    const persistedCart = await getShoppingCart(cart.id);
+    assert.ok(persistedCart);
+    assert.equal(persistedCart.status, 'new');
+    assert.deepStrictEqual(
+        persistedCart.items.map((item) => item.id),
+        [insertedItemId],
+    );
+});
+
+test('new item insert waits for cart soft delete and then rejects', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    if (!cart) throw new Error('Cart not created');
+
+    let signalCartRowLocked = () => {};
+    let signalReleaseCartRow = () => {};
+    const cartRowLocked = new Promise<void>((resolve) => {
+        signalCartRowLocked = resolve;
+    });
+    const releaseCartRow = new Promise<void>((resolve) => {
+        signalReleaseCartRow = resolve;
+    });
+    const softDelete = storage().transaction(async (tx) => {
+        await tx.execute(
+            sql`select id from shopping_carts where id = ${cart.id} for update`,
+        );
+        signalCartRowLocked();
+        await releaseCartRow;
+        await tx.execute(
+            sql`update shopping_carts set is_deleted = true where id = ${cart.id}`,
+        );
+    });
+    await cartRowLocked;
+
+    let insertSettled = false;
+    const insert = upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'late-cart-item',
+        'plantSort',
+        1,
+        undefined,
+        undefined,
+        undefined,
+        null,
+        'eur',
+        true,
+    );
+    void insert.then(
+        () => {
+            insertSettled = true;
+        },
+        () => {
+            insertSettled = true;
+        },
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const insertSettledWhileCartLocked = insertSettled;
+
+    signalReleaseCartRow();
+    await softDelete;
+    assert.equal(insertSettledWhileCartLocked, false);
+    await assert.rejects(insert, /inactive shopping cart/);
+    assert.equal(await getShoppingCart(cart.id), undefined);
 });
 
 test('getAllShoppingCarts filters by status', async () => {
@@ -410,6 +639,695 @@ test('normalizeShoppingCartInventoryUsage preserves a consumed pending checkout 
     );
 });
 
+test('legacy checkout planting evidence requires one exact EUR purchase fingerprint', async () => {
+    createTestDb();
+    const aggregateId = '700001|2';
+    const cartItemId = 700_002;
+    const plantingEvent = knownEvents.raisedBedFields.plantPlaceV1(
+        aggregateId,
+        {
+            plantSortId: 'legacy-plant-sort',
+            purchase: {
+                cartItemId,
+                currency: 'eur',
+                euroAmountCents: 2500,
+            },
+            scheduledDate: null,
+        },
+    );
+    await createEvent(plantingEvent);
+
+    assert.equal(
+        await hasMatchingCheckoutPlantingPurchase({
+            cartItemId,
+            euroAmountCents: 2500,
+            plantSortId: 'legacy-plant-sort',
+            positionIndex: 2,
+            raisedBedId: 700_001,
+        }),
+        true,
+    );
+    await assert.rejects(
+        hasMatchingCheckoutPlantingPurchase({
+            cartItemId,
+            euroAmountCents: 2500,
+            plantSortId: 'legacy-plant-sort',
+            positionIndex: 3,
+            raisedBedId: 700_001,
+        }),
+        /conflicts with the paid cart item/u,
+    );
+    await assert.rejects(
+        hasMatchingCheckoutPlantingPurchase({
+            cartItemId,
+            euroAmountCents: 2600,
+            plantSortId: 'legacy-plant-sort',
+            positionIndex: 2,
+            raisedBedId: 700_001,
+        }),
+        /conflicts with the paid cart item/u,
+    );
+
+    await createEvent(plantingEvent);
+    await assert.rejects(
+        hasMatchingCheckoutPlantingPurchase({
+            cartItemId,
+            euroAmountCents: 2500,
+            plantSortId: 'legacy-plant-sort',
+            positionIndex: 2,
+            raisedBedId: 700_001,
+        }),
+        /multiple planting fulfillment events/u,
+    );
+});
+
+test('direct payment effects freeze pending cart item mutation and deletion', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    if (!cart) throw new Error('Cart not created');
+
+    const sunflowerItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'sunflower-plant',
+        'plantSort',
+        1,
+        undefined,
+        undefined,
+        undefined,
+        null,
+        'sunflower',
+    );
+    assert.ok(sunflowerItemId);
+    await spendSunflowersBatch(accountId, [
+        {
+            amount: 1,
+            reason: `shoppingCartItem:${sunflowerItemId.toString()}`,
+        },
+    ]);
+    await assert.rejects(
+        upsertOrRemoveCartItem(
+            sunflowerItemId,
+            cart.id,
+            'sunflower-plant',
+            'plantSort',
+            1,
+            undefined,
+            undefined,
+            undefined,
+            null,
+            'eur',
+        ),
+        CheckoutCartItemFulfillmentStartedError,
+    );
+
+    const legacySunflowerItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'legacy-sunflower-plant',
+        'plantSort',
+        1,
+        undefined,
+        undefined,
+        undefined,
+        null,
+        'sunflower',
+        true,
+    );
+    assert.ok(legacySunflowerItemId);
+    await createEvent(
+        knownEvents.accounts.sunflowersSpentV1(accountId, {
+            amount: 1,
+            reason: `shoppingCart:${cart.id.toString()}`,
+        }),
+    );
+    const cartAfterLegacySpend = await getShoppingCart(cart.id);
+    assert.ok(cartAfterLegacySpend);
+    assert.equal(
+        (
+            await getCheckoutFulfillmentStartedCartItemIds(
+                accountId,
+                cartAfterLegacySpend.items,
+            )
+        ).has(legacySunflowerItemId),
+        true,
+    );
+    await assert.rejects(
+        upsertOrRemoveCartItem(
+            legacySunflowerItemId,
+            cart.id,
+            'legacy-sunflower-plant',
+            'plantSort',
+            0,
+            undefined,
+            undefined,
+            undefined,
+            null,
+            'sunflower',
+        ),
+        CheckoutCartItemFulfillmentStartedError,
+    );
+
+    await addInventoryItem(accountId, {
+        entityTypeName: 'plantSort',
+        entityId: 'inventory-plant',
+        amount: 1,
+    });
+    const inventoryItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'inventory-plant',
+        'plantSort',
+        1,
+        undefined,
+        undefined,
+        undefined,
+        null,
+        'inventory',
+    );
+    assert.ok(inventoryItemId);
+    await consumeInventoryItem(accountId, {
+        entityTypeName: 'plantSort',
+        entityId: 'inventory-plant',
+        amount: 1,
+        source: `shoppingCartItem:${inventoryItemId.toString()}`,
+    });
+    await assert.rejects(
+        upsertOrRemoveCartItem(
+            inventoryItemId,
+            cart.id,
+            'inventory-plant',
+            'plantSort',
+            0,
+            undefined,
+            undefined,
+            undefined,
+            null,
+            'inventory',
+        ),
+        CheckoutCartItemFulfillmentStartedError,
+    );
+    await assert.rejects(
+        deleteShoppingCart(accountId),
+        CheckoutCartItemFulfillmentStartedError,
+    );
+
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'checkout-projection');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+    const plantedItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'placed-plant',
+        'plantSort',
+        1,
+        gardenId,
+        raisedBedId,
+        0,
+        null,
+        'eur',
+        true,
+    );
+    assert.ok(plantedItemId);
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(`${raisedBedId}|1`, {
+            plantSortId: 'placed-plant',
+            purchase: {
+                cartItemId: plantedItemId,
+                currency: 'eur',
+                euroAmountCents: 2500,
+            },
+            scheduledDate: null,
+        }),
+    );
+    const cartAfterWrongTargetPlanting = await getShoppingCart(cart.id);
+    assert.ok(cartAfterWrongTargetPlanting);
+    assert.equal(
+        (
+            await getCheckoutFulfillmentStartedCartItemIds(
+                accountId,
+                cartAfterWrongTargetPlanting.items,
+            )
+        ).has(plantedItemId),
+        false,
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(`${raisedBedId}|0`, {
+            plantSortId: 'placed-plant',
+            purchase: {
+                cartItemId: plantedItemId,
+                currency: 'eur',
+                euroAmountCents: 2500,
+            },
+            scheduledDate: null,
+        }),
+    );
+    await assert.rejects(
+        upsertOrRemoveCartItem(
+            plantedItemId,
+            cart.id,
+            'placed-plant',
+            'plantSort',
+            1,
+            gardenId,
+            raisedBedId,
+            0,
+            null,
+            'sunflower',
+        ),
+        CheckoutCartItemFulfillmentStartedError,
+    );
+
+    const rewardedOperationItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'rewarded-operation',
+        'operation',
+        1,
+        undefined,
+        undefined,
+        undefined,
+        null,
+        'eur',
+        true,
+    );
+    assert.ok(rewardedOperationItemId);
+    await earnSunflowersForPayment(
+        accountId,
+        25,
+        `shoppingCartItem:${rewardedOperationItemId.toString()}`,
+    );
+    await assert.rejects(
+        upsertOrRemoveCartItem(
+            rewardedOperationItemId,
+            cart.id,
+            'rewarded-operation',
+            'operation',
+            1,
+            undefined,
+            undefined,
+            undefined,
+            null,
+            'sunflower',
+        ),
+        CheckoutCartItemFulfillmentStartedError,
+    );
+
+    const zeroRewardOperationItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'zero-reward-operation',
+        'operation',
+        1,
+        undefined,
+        undefined,
+        undefined,
+        null,
+        'eur',
+        true,
+    );
+    assert.ok(zeroRewardOperationItemId);
+    const balanceBeforeZeroReward = await getSunflowers(accountId);
+    await earnSunflowersForPayment(
+        accountId,
+        0.01,
+        `shoppingCartItem:${zeroRewardOperationItemId.toString()}`,
+    );
+    assert.equal(await getSunflowers(accountId), balanceBeforeZeroReward);
+    const cartAfterZeroReward = await getShoppingCart(cart.id);
+    assert.ok(cartAfterZeroReward);
+    assert.equal(
+        (
+            await getCheckoutFulfillmentStartedCartItemIds(
+                accountId,
+                cartAfterZeroReward.items,
+            )
+        ).has(zeroRewardOperationItemId),
+        true,
+    );
+    await assert.rejects(
+        upsertOrRemoveCartItem(
+            zeroRewardOperationItemId,
+            cart.id,
+            'zero-reward-operation',
+            'operation',
+            1,
+            undefined,
+            undefined,
+            undefined,
+            null,
+            'sunflower',
+        ),
+        CheckoutCartItemFulfillmentStartedError,
+    );
+});
+
+test('checkout planting incident notifications freeze pending cart items', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    if (!cart) throw new Error('Cart not created');
+
+    const incidentTypes = [
+        'checkout_planting_raised_bed_unavailable',
+        'checkout_planting_target_conflict',
+    ] as const;
+    const itemIds: number[] = [];
+    for (const [index, type] of incidentTypes.entries()) {
+        const itemId = await upsertOrRemoveCartItem(
+            null,
+            cart.id,
+            `incident-plant-${index.toString()}`,
+            'plantSort',
+            1,
+            undefined,
+            undefined,
+            undefined,
+            null,
+            'eur',
+            true,
+        );
+        assert.ok(itemId);
+        itemIds.push(itemId);
+        await createNotificationWithStatus(
+            {
+                accountId,
+                header: 'Plaćena sadnja čeka provjeru',
+                content: 'Zadatak je evidentiran za pregled tima farme.',
+                category: 'checkout_fulfillment',
+                type,
+                metadata: { cartItemId: itemId },
+                timestamp: new Date(),
+            },
+            {
+                idempotencyKey: `checkout-planting-incident:${itemId.toString()}`,
+                routeDelivery: false,
+            },
+        );
+    }
+
+    const incidentCart = await getShoppingCart(cart.id);
+    assert.ok(incidentCart);
+    const startedItemIds = await getCheckoutFulfillmentStartedCartItemIds(
+        accountId,
+        incidentCart.items,
+    );
+    assert.deepEqual(
+        [...startedItemIds].sort((left, right) => left - right),
+        [...itemIds].sort((left, right) => left - right),
+    );
+
+    for (const [index, itemId] of itemIds.entries()) {
+        await assert.rejects(
+            upsertOrRemoveCartItem(
+                itemId,
+                cart.id,
+                `incident-plant-${index.toString()}`,
+                'plantSort',
+                1,
+                undefined,
+                undefined,
+                undefined,
+                null,
+                'sunflower',
+            ),
+            CheckoutCartItemFulfillmentStartedError,
+        );
+    }
+    await assert.rejects(
+        deleteShoppingCart(accountId),
+        CheckoutCartItemFulfillmentStartedError,
+    );
+});
+
+test('cart item mutation waits for a checkout effect and then rejects', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    if (!cart) throw new Error('Cart not created');
+    const itemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'checkout-race-plant',
+        'plantSort',
+        1,
+        undefined,
+        undefined,
+        undefined,
+        null,
+        'sunflower',
+    );
+    assert.ok(itemId);
+
+    let signalCheckoutLockHeld = () => {};
+    let signalReleaseCheckoutLock = () => {};
+    const checkoutLockHeld = new Promise<void>((resolve) => {
+        signalCheckoutLockHeld = resolve;
+    });
+    const releaseCheckoutLock = new Promise<void>((resolve) => {
+        signalReleaseCheckoutLock = resolve;
+    });
+    const checkout = withCheckoutCartItemLock(itemId, async (db) => {
+        await spendSunflowersBatch(
+            accountId,
+            [
+                {
+                    amount: 1,
+                    reason: `shoppingCartItem:${itemId.toString()}`,
+                },
+            ],
+            db,
+        );
+        signalCheckoutLockHeld();
+        await releaseCheckoutLock;
+    });
+    await checkoutLockHeld;
+
+    let mutationSettled = false;
+    const mutation = upsertOrRemoveCartItem(
+        itemId,
+        cart.id,
+        'checkout-race-plant',
+        'plantSort',
+        2,
+        undefined,
+        undefined,
+        undefined,
+        null,
+        'sunflower',
+    );
+    void mutation.then(
+        () => {
+            mutationSettled = true;
+        },
+        () => {
+            mutationSettled = true;
+        },
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const mutationSettledWhileLocked = mutationSettled;
+
+    signalReleaseCheckoutLock();
+    await checkout;
+    assert.equal(mutationSettledWhileLocked, false);
+    await assert.rejects(mutation, CheckoutCartItemFulfillmentStartedError);
+    const persistedCart = await getShoppingCart(cart.id);
+    assert.equal(
+        persistedCart?.items.find((item) => item.id === itemId)?.amount,
+        1,
+    );
+});
+
+test('explicit item update does not recreate an item deleted while waiting', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    if (!cart) throw new Error('Cart not created');
+    const deletedItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'deleted-while-waiting',
+        'plantSort',
+        1,
+    );
+    const retainedItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'retained-cart-item',
+        'plantSort',
+        1,
+    );
+    assert.ok(deletedItemId);
+    assert.ok(retainedItemId);
+
+    let signalItemDeleted = () => {};
+    let signalReleaseItemLock = () => {};
+    const itemDeleted = new Promise<void>((resolve) => {
+        signalItemDeleted = resolve;
+    });
+    const releaseItemLock = new Promise<void>((resolve) => {
+        signalReleaseItemLock = resolve;
+    });
+    const deletion = withCheckoutCartItemLock(
+        deletedItemId,
+        async (database) => {
+            await database.execute(
+                sql`update shopping_cart_items set is_deleted = true where id = ${deletedItemId}`,
+            );
+            signalItemDeleted();
+            await releaseItemLock;
+        },
+    );
+    await itemDeleted;
+
+    let updateSettled = false;
+    const update = upsertOrRemoveCartItem(
+        deletedItemId,
+        cart.id,
+        'deleted-while-waiting',
+        'plantSort',
+        2,
+    );
+    void update.then(
+        () => {
+            updateSettled = true;
+        },
+        () => {
+            updateSettled = true;
+        },
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const updateSettledWhileLocked = updateSettled;
+
+    signalReleaseItemLock();
+    await deletion;
+    assert.equal(updateSettledWhileLocked, false);
+    await assert.rejects(update, /Shopping cart item not found/);
+    const persistedCart = await getShoppingCart(cart.id);
+    assert.deepStrictEqual(
+        persistedCart?.items.map((item) => item.id),
+        [retainedItemId],
+    );
+});
+
+test('cart deletion waits for checkout paid status and then rejects', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    if (!cart) throw new Error('Cart not created');
+    const itemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'paid-while-delete-waits',
+        'plantSort',
+        1,
+    );
+    assert.ok(itemId);
+
+    let signalItemPaid = () => {};
+    let signalReleaseItemLock = () => {};
+    const itemPaid = new Promise<void>((resolve) => {
+        signalItemPaid = resolve;
+    });
+    const releaseItemLock = new Promise<void>((resolve) => {
+        signalReleaseItemLock = resolve;
+    });
+    const checkout = withCheckoutCartItemLock(itemId, async (db) => {
+        await setCartItemPaid(itemId, db);
+        signalItemPaid();
+        await releaseItemLock;
+    });
+    await itemPaid;
+
+    let deletionSettled = false;
+    const deletion = deleteShoppingCart(accountId);
+    void deletion.then(
+        () => {
+            deletionSettled = true;
+        },
+        () => {
+            deletionSettled = true;
+        },
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const deletionSettledWhileLocked = deletionSettled;
+
+    signalReleaseItemLock();
+    await checkout;
+    assert.equal(deletionSettledWhileLocked, false);
+    await assert.rejects(deletion, CheckoutCartItemFulfillmentStartedError);
+    const persistedCart = await getShoppingCart(cart.id);
+    assert.equal(
+        persistedCart?.items.find((item) => item.id === itemId)?.status,
+        'paid',
+    );
+});
+
+test('normalizeShoppingCartInventoryUsage serializes with checkout consumption', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    await addInventoryItem(accountId, {
+        entityTypeName: 'plant',
+        entityId: 'serialized-inventory-item',
+        amount: 1,
+    });
+    const cart = await getOrCreateShoppingCart(accountId);
+    if (!cart) throw new Error('Cart not created');
+    const itemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'serialized-inventory-item',
+        'plant',
+        1,
+        undefined,
+        undefined,
+        undefined,
+        null,
+        'inventory',
+    );
+    assert.ok(itemId);
+
+    let signalReleaseInventoryLock = () => {};
+    let signalInventoryLockHeld = () => {};
+    const inventoryLockHeld = new Promise<void>((resolve) => {
+        signalInventoryLockHeld = resolve;
+    });
+    const inventoryLockRelease = new Promise<void>((resolve) => {
+        signalReleaseInventoryLock = resolve;
+    });
+    const lockHolder = withInventoryAccountTransaction(accountId, async () => {
+        signalInventoryLockHeld();
+        await inventoryLockRelease;
+    });
+    await inventoryLockHeld;
+
+    let normalizationSettled = false;
+    const normalization = normalizeShoppingCartInventoryUsage(cart.id).finally(
+        () => {
+            normalizationSettled = true;
+        },
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(normalizationSettled, false);
+
+    const consumption = consumeInventoryItem(accountId, {
+        entityTypeName: 'plant',
+        entityId: 'serialized-inventory-item',
+        amount: 1,
+        source: `shoppingCartItem:${itemId.toString()}`,
+    });
+    signalReleaseInventoryLock();
+    await Promise.all([lockHolder, normalization, consumption]);
+
+    const retriedCart = await normalizeShoppingCartInventoryUsage(cart.id);
+    assert.equal(
+        retriedCart?.items.find((item) => item.id === itemId)?.currency,
+        'inventory',
+    );
+});
+
 test('normalizeShoppingCartInventoryUsage reserves a durable consumption for its cart item', async () => {
     createTestDb();
     const accountId = await createTestAccount();
@@ -633,6 +1551,214 @@ test('normalizeShoppingCartScheduledDates updates past scheduled dates in cart',
         futureDate.toISOString(),
         expectedTomorrow.toISOString(),
     ]);
+});
+
+test('normalizeShoppingCartScheduledDates preserves a mapped operation for a later-day retry', async () => {
+    createTestDb();
+    const checkoutStartedAt = new Date('2026-07-01T12:00:00.000Z');
+    const scheduledDate = new Date('2026-07-02T00:00:00.000Z');
+    test.mock.timers.enable({ apis: ['Date'], now: checkoutStartedAt });
+    try {
+        const accountId = await createTestAccount();
+        const cart = await getOrCreateShoppingCart(accountId);
+        if (!cart) throw new Error('Cart not created');
+        const cartItemId = await upsertOrRemoveCartItem(
+            null,
+            cart.id,
+            '17',
+            'operation',
+            1,
+            undefined,
+            undefined,
+            undefined,
+            JSON.stringify({ scheduledDate: scheduledDate.toISOString() }),
+        );
+        assert.ok(cartItemId);
+        const operationInput = {
+            accountId,
+            entityId: 17,
+            entityTypeName: 'operation',
+        };
+        const firstAttempt = await getOrCreateCheckoutOperation(
+            cartItemId,
+            operationInput,
+            { delivery: null, paymentCurrency: 'eur', scheduledDate },
+        );
+        assert.equal(firstAttempt.created, true);
+        await assert.rejects(
+            upsertOrRemoveCartItem(
+                cartItemId,
+                cart.id,
+                '17',
+                'operation',
+                1,
+                undefined,
+                undefined,
+                undefined,
+                JSON.stringify({
+                    scheduledDate: scheduledDate.toISOString(),
+                }),
+                'sunflower',
+            ),
+            CheckoutCartItemFulfillmentStartedError,
+        );
+
+        test.mock.timers.setTime(
+            new Date('2026-07-05T12:00:00.000Z').getTime(),
+        );
+        const normalizedCart = await normalizeShoppingCartScheduledDates(
+            cart.id,
+        );
+        const normalizedItem = normalizedCart?.items.find(
+            (item) => item.id === cartItemId,
+        );
+        assert.ok(normalizedItem?.additionalData);
+        assert.equal(
+            JSON.parse(normalizedItem.additionalData).scheduledDate,
+            scheduledDate.toISOString(),
+        );
+
+        assert.deepEqual(
+            await getOrCreateCheckoutOperation(cartItemId, operationInput, {
+                delivery: null,
+                paymentCurrency: 'eur',
+                scheduledDate,
+            }),
+            { operationId: firstAttempt.operationId, created: false },
+        );
+    } finally {
+        test.mock.timers.reset();
+    }
+});
+
+test('scheduled-date normalization waits for checkout and preserves a spent item', async () => {
+    createTestDb();
+    const checkoutStartedAt = new Date('2026-07-01T12:00:00.000Z');
+    const scheduledDate = new Date('2026-07-02T00:00:00.000Z');
+    test.mock.timers.enable({ apis: ['Date'], now: checkoutStartedAt });
+    try {
+        const accountId = await createTestAccount();
+        const cart = await getOrCreateShoppingCart(accountId);
+        if (!cart) throw new Error('Cart not created');
+        const cartItemId = await upsertOrRemoveCartItem(
+            null,
+            cart.id,
+            'scheduled-checkout-race',
+            'plantSort',
+            1,
+            undefined,
+            undefined,
+            undefined,
+            JSON.stringify({ scheduledDate: scheduledDate.toISOString() }),
+            'sunflower',
+        );
+        assert.ok(cartItemId);
+
+        let signalCheckoutEffectCreated = () => {};
+        let signalReleaseCheckoutLock = () => {};
+        const checkoutEffectCreated = new Promise<void>((resolve) => {
+            signalCheckoutEffectCreated = resolve;
+        });
+        const releaseCheckoutLock = new Promise<void>((resolve) => {
+            signalReleaseCheckoutLock = resolve;
+        });
+        const checkout = withCheckoutCartItemLock(
+            cartItemId,
+            async (database) => {
+                await spendSunflowersBatch(
+                    accountId,
+                    [
+                        {
+                            amount: 1,
+                            reason: `shoppingCartItem:${cartItemId.toString()}`,
+                        },
+                    ],
+                    database,
+                );
+                signalCheckoutEffectCreated();
+                await releaseCheckoutLock;
+            },
+        );
+        await checkoutEffectCreated;
+        test.mock.timers.setTime(
+            new Date('2026-07-05T12:00:00.000Z').getTime(),
+        );
+
+        let normalizationSettled = false;
+        const normalization = normalizeShoppingCartScheduledDates(
+            cart.id,
+        ).finally(() => {
+            normalizationSettled = true;
+        });
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        const normalizationSettledWhileLocked = normalizationSettled;
+
+        signalReleaseCheckoutLock();
+        await checkout;
+        const normalizedCart = await normalization;
+        assert.equal(normalizationSettledWhileLocked, false);
+        const normalizedItem = normalizedCart?.items.find(
+            (item) => item.id === cartItemId,
+        );
+        assert.ok(normalizedItem?.additionalData);
+        assert.equal(
+            JSON.parse(normalizedItem.additionalData).scheduledDate,
+            scheduledDate.toISOString(),
+        );
+    } finally {
+        test.mock.timers.reset();
+    }
+});
+
+test('normalizeShoppingCartScheduledDates does not treat a sunflower item as an operation mapping', async () => {
+    createTestDb();
+    const checkoutStartedAt = new Date('2026-07-01T12:00:00.000Z');
+    const scheduledDate = new Date('2026-07-02T00:00:00.000Z');
+    test.mock.timers.enable({ apis: ['Date'], now: checkoutStartedAt });
+    try {
+        const accountId = await createTestAccount();
+        const cart = await getOrCreateShoppingCart(accountId);
+        if (!cart) throw new Error('Cart not created');
+        const cartItemId = await upsertOrRemoveCartItem(
+            null,
+            cart.id,
+            'sunflower-package-small',
+            'sunflowerPackage',
+            1,
+            undefined,
+            undefined,
+            undefined,
+            JSON.stringify({ scheduledDate: scheduledDate.toISOString() }),
+            'sunflower',
+        );
+        assert.ok(cartItemId);
+        await getOrCreateCheckoutOperation(
+            cartItemId,
+            {
+                accountId,
+                entityId: 19,
+                entityTypeName: 'operation',
+            },
+            { delivery: null, paymentCurrency: 'sunflower', scheduledDate },
+        );
+
+        test.mock.timers.setTime(
+            new Date('2026-07-05T12:00:00.000Z').getTime(),
+        );
+        const normalizedCart = await normalizeShoppingCartScheduledDates(
+            cart.id,
+        );
+        const normalizedItem = normalizedCart?.items.find(
+            (item) => item.id === cartItemId,
+        );
+        assert.ok(normalizedItem?.additionalData);
+        assert.equal(
+            JSON.parse(normalizedItem.additionalData).scheduledDate,
+            '2026-07-06T00:00:00.000Z',
+        );
+    } finally {
+        test.mock.timers.reset();
+    }
 });
 
 test('normalizeShoppingCartScheduledDates can default missing scheduled dates to tomorrow', async () => {

--- a/packages/storage/tests/shoppingCartRepo.node.spec.ts
+++ b/packages/storage/tests/shoppingCartRepo.node.spec.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
     addInventoryItem,
+    consumeInventoryItem,
     deleteShoppingCart,
     getAllShoppingCarts,
     getOrCreateShoppingCart,
@@ -362,6 +363,111 @@ test('normalizeShoppingCartInventoryUsage splits partially covered inventory ite
         eurItems.map((item) => item.amount),
         [1],
     );
+});
+
+test('normalizeShoppingCartInventoryUsage preserves a consumed pending checkout item for retry', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    await addInventoryItem(accountId, {
+        entityTypeName: 'plant',
+        entityId: 'entity-1',
+        amount: 1,
+    });
+
+    const cart = await getOrCreateShoppingCart(accountId);
+    if (!cart) throw new Error('Cart not created');
+    const itemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'entity-1',
+        'plant',
+        1,
+        undefined,
+        undefined,
+        undefined,
+        null,
+        'inventory',
+    );
+    assert.ok(itemId);
+    await consumeInventoryItem(accountId, {
+        entityTypeName: 'plant',
+        entityId: 'entity-1',
+        amount: 1,
+        source: `shoppingCartItem:${itemId.toString()}`,
+    });
+
+    const normalizedCart = await normalizeShoppingCartInventoryUsage(cart.id);
+    assert.ok(normalizedCart);
+    const retriableItem = normalizedCart.items.find(
+        (item) => item.id === itemId,
+    );
+    assert.strictEqual(retriableItem?.currency, 'inventory');
+    assert.strictEqual(retriableItem?.amount, 1);
+    assert.strictEqual(retriableItem?.status, 'new');
+    assert.strictEqual(
+        normalizedCart.items.some((item) => item.currency === 'eur'),
+        false,
+    );
+});
+
+test('normalizeShoppingCartInventoryUsage reserves a durable consumption for its cart item', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    await addInventoryItem(accountId, {
+        entityTypeName: 'plant',
+        entityId: 'entity-1',
+        amount: 1,
+    });
+
+    const cart = await getOrCreateShoppingCart(accountId);
+    if (!cart) throw new Error('Cart not created');
+    const unconsumedItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'entity-1',
+        'plant',
+        1,
+        undefined,
+        undefined,
+        undefined,
+        'older-item',
+        'inventory',
+        true,
+    );
+    const consumedItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'entity-1',
+        'plant',
+        1,
+        undefined,
+        undefined,
+        undefined,
+        'consumed-item',
+        'inventory',
+        true,
+    );
+    assert.ok(unconsumedItemId);
+    assert.ok(consumedItemId);
+    await consumeInventoryItem(accountId, {
+        entityTypeName: 'plant',
+        entityId: 'entity-1',
+        amount: 1,
+        source: `shoppingCartItem:${consumedItemId.toString()}`,
+    });
+
+    const normalizedCart = await normalizeShoppingCartInventoryUsage(cart.id);
+    assert.ok(normalizedCart);
+    const unconsumedItem = normalizedCart.items.find(
+        (item) => item.id === unconsumedItemId,
+    );
+    const consumedItem = normalizedCart.items.find(
+        (item) => item.id === consumedItemId,
+    );
+    assert.strictEqual(unconsumedItem?.currency, 'eur');
+    assert.strictEqual(consumedItem?.currency, 'inventory');
+    assert.strictEqual(consumedItem?.amount, 1);
+    assert.strictEqual(consumedItem?.status, 'new');
 });
 
 test('upsertOrRemoveCartItem normalizes scheduled date to tomorrow when date is in the past', async () => {


### PR DESCRIPTION
## Summary

- make checkout item effects resumable and source-idempotent across direct and Stripe retries;
- serialize each cart item with a process-local fulfillment lock plus a short PostgreSQL advisory-lock transaction;
- validate the locked cart/account/item snapshot before recording any debit or inventory effect;
- preserve authoritative sunflower debit amounts across catalog drift, including legacy cart-level debits and already-paid rows;
- atomically create/reuse operation mappings, inventory consumption, planting evidence, and delivery requests;
- continue later Stripe line items after an earlier fulfillment failure, then propagate the aggregate failure;
- freeze cart mutation once durable fulfillment evidence exists;
- build retry confirmations from durable paid amounts and fail closed on missing, duplicate, malformed, or conflicting evidence.

No database schema change or migration is required.

## Retry and concurrency guarantees

- database locks are held only while validating snapshots and committing durable markers; fulfillment and external calls run after that transaction commits;
- the process-local lock remains held through fulfillment and the final paid marker;
- identical retries reuse stored effects; changed fingerprints or duplicate evidence are rejected;
- paid sunflower rows are resolved from their per-item debit or an exactly validated legacy cart debit/checkpoint;
- cart ownership and expected non-Stripe item completeness are checked before ordinary Stripe fulfillment effects.

## Validation

- `pnpm --dir apps/api test:node` — 362 passed;
- Accounts PGlite suite — 31 passed;
- shopping-cart PGlite suite — 31 passed;
- fulfillment-idempotency PGlite suite — 8 passed;
- `pnpm --dir apps/api exec tsc --noEmit`;
- `pnpm --filter api build` — production build passed, 37 pages generated;
- targeted Biome checks for all changed API/storage files;
- `git diff --check origin/main...HEAD`;
- two independent production-readiness re-reviews with no blocking findings.

## Follow-ups

- #4369 batches all direct sunflower debits into one transaction without weakening these retry guarantees.
- #4375 moves remaining notification provider calls off the request path.
- #4378 adds a durable cross-instance Stripe session claim.
- #4379 freezes or reconciles the complete cart snapshot across Stripe payment.

Closes #4374
