### PR TITLE
[Checkout] Freeze and reconcile cart snapshots across Stripe payment

### DIFF
--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -4,6 +4,7 @@ import {
     cartContainsDeliverableItems,
     consumeInventoryItem,
     createStripeCheckoutAttempt,
+    fingerprintStripeCheckoutValue,
     getAccount,
     getActiveStripeCheckoutAttempt,
     getCheckoutFulfillmentStartedCartItemIds,
@@ -37,8 +38,9 @@ import {
     withInventoryAccountTransaction,
 } from '@gredice/storage';
 import {
-    type CheckoutItem,
+    getStripeCheckoutReturnUrls,
     getStripeCheckoutSession,
+    resolveStripeCustomerId,
     stripeCheckout,
     stripeSessionCancel,
 } from '@gredice/stripe/server';
@@ -62,18 +64,16 @@ import {
 import { getDirectCheckoutPaymentErrorResponse } from '../../../lib/checkout/directCheckoutErrors';
 import { getPaidCartCheckoutRetryResponse } from '../../../lib/checkout/directCheckoutRetry';
 import { withDirectSunflowerCheckoutBatch } from '../../../lib/checkout/directSunflowerCheckout';
-import {
-    buildCheckoutAdditionalData,
-    encodeHarvestDatesMetadata,
-} from '../../../lib/checkout/harvestCheckout';
+import { buildCheckoutAdditionalData } from '../../../lib/checkout/harvestCheckout';
 import {
     buildOrderConfirmationItems,
     ORDER_CONFIRMATION_MANAGE_URL,
 } from '../../../lib/checkout/orderConfirmationEmail';
+import { recoverStripeCheckoutAttemptSession } from '../../../lib/checkout/stripeCheckoutRecovery';
 import {
     buildStripeCheckoutAttemptSnapshot,
     decodeStripeCheckoutAttemptMetadata,
-    encodeStripeCheckoutAttemptMetadata,
+    rebuildStripeCheckoutAttemptAdditionalData,
 } from '../../../lib/checkout/stripeCheckoutSnapshot';
 import { authSecurity } from '../../../lib/docs/security';
 import {
@@ -217,6 +217,90 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                     return context.json({ error: 'Cart not found' }, 404);
                 }
                 return context.json(retryResponse.body, retryResponse.status);
+            }
+
+            const recoverAttempt = async (
+                attempt: NonNullable<
+                    Awaited<ReturnType<typeof getActiveStripeCheckoutAttempt>>
+                >,
+                liveItems: typeof initialCart.items = initialCart.items,
+                resolvedCustomerId = account.stripeCustomerId ?? undefined,
+            ) => {
+                const attemptUser = account.accountUsers.find(
+                    (accountUser) =>
+                        fingerprintStripeCheckoutValue(accountUser.userId) ===
+                        attempt.snapshot.userFingerprint,
+                );
+                if (
+                    !attemptUser ||
+                    !resolvedCustomerId ||
+                    fingerprintStripeCheckoutValue(resolvedCustomerId) !==
+                        attempt.snapshot.stripeSession.customerFingerprint
+                ) {
+                    throw new StripeCheckoutAttemptConflictError(
+                        'checkout_identity_changed',
+                    );
+                }
+                const checkoutAdditionalDataByCartItemId = attempt.sessionId
+                    ? undefined
+                    : rebuildStripeCheckoutAttemptAdditionalData({
+                          attempt,
+                          deliveryInfo,
+                          liveItems,
+                      });
+                return recoverStripeCheckoutAttemptSession({
+                    account: {
+                        email: user.userName,
+                        id: account.id,
+                        name: user.userName,
+                        stripeCustomerId: resolvedCustomerId,
+                    },
+                    accountId,
+                    attempt,
+                    checkoutAdditionalDataByCartItemId,
+                    customerId: resolvedCustomerId,
+                    dependencies: {
+                        bindAttempt: bindStripeCheckoutAttempt,
+                        checkout: stripeCheckout,
+                        getAttempt: getStripeCheckoutAttempt,
+                        getSession: getStripeCheckoutSession,
+                        releaseAttempt: releaseStripeCheckoutAttempt,
+                    },
+                    userId: attemptUser.userId,
+                });
+            };
+
+            const activeAttempt = await getActiveStripeCheckoutAttempt(cartId);
+            if (activeAttempt) {
+                try {
+                    const recovery = await recoverAttempt(activeAttempt);
+                    if (recovery.status === 'open' && recovery.url) {
+                        return context.json({
+                            sessionId: recovery.sessionId,
+                            url: recovery.url,
+                        });
+                    }
+                    if (recovery.status === 'processing') {
+                        return context.json(
+                            {
+                                code: 'CHECKOUT_PAYMENT_PROCESSING',
+                                error: 'Plaćanje se još obrađuje. Pričekaj trenutak i pokušaj ponovno.',
+                            },
+                            409,
+                        );
+                    }
+                } catch (error) {
+                    if (error instanceof StripeCheckoutAttemptConflictError) {
+                        return context.json(
+                            {
+                                code: 'CHECKOUT_CART_CHANGED',
+                                error: 'Košarica se promijenila. Osvježi je i pokušaj ponovno.',
+                            },
+                            409,
+                        );
+                    }
+                    throw error;
+                }
             }
 
             const { cart, checkoutOperationMappings } =
@@ -816,25 +900,16 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
             const stripeCartItemsWithShopData = cartInfo.items.filter(
                 (item) => item.status !== 'paid' && item.currency === 'eur',
             ); // Exclude paid items and sunflowers
-            const stripeItems: CheckoutItem[] = [];
             for (const item of stripeCartItemsWithShopData) {
                 // TODO: Apply discounted price if available
 
                 const name = item.shopData?.name;
-                const description = item.shopData?.description || undefined;
                 const finalPrice =
                     typeof item.shopData.discountPrice === 'number'
                         ? item.shopData.discountPrice
                         : (item.shopData.price ?? 0);
                 const valueInCents = Math.round((finalPrice ?? 0) * 100);
                 const quantity = item.amount;
-                const imageUrls = item.shopData.image
-                    ? [
-                          /^https?:\/\//u.test(item.shopData.image)
-                              ? item.shopData.image
-                              : `https://www.gredice.com${item.shopData.image}`,
-                      ]
-                    : [];
 
                 // TODO: Validate item data
                 if (!name || !valueInCents || !quantity) {
@@ -874,83 +949,54 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                         409,
                     );
                 }
-
-                stripeItems.push({
-                    product: {
-                        name,
-                        description,
-                        imageUrls,
-                        // TODO: Construct/deconstruct functions
-                        metadata: {
-                            cartItemId: item.id.toString(),
-                            entityId: item.entityId,
-                            entityTypeName: item.entityTypeName,
-                            accountId: account.id,
-                            userId: user.id,
-                            cartId: cart.id,
-                            gardenId: item.gardenId,
-                            raisedBedId: item.raisedBedId,
-                            positionIndex:
-                                item.positionIndex?.toString() ?? null,
-                            additionalData: JSON.stringify(
-                                checkoutAdditionalDataByCartItemId.get(
-                                    item.id,
-                                ) ?? {},
-                            ),
-                            outletOfferId: item.outlet?.offerId ?? null,
-                            outletReservationId:
-                                item.outlet?.reservationId ?? null,
-                            outletSowingDate:
-                                item.outlet?.sowingDate.toISOString() ?? null,
-                            outletInitialPlantStatus:
-                                item.outlet?.initialPlantStatus ?? null,
-                            outletPriceCents:
-                                typeof item.outlet?.outletPrice === 'number'
-                                    ? Math.round(item.outlet.outletPrice * 100)
-                                    : null,
-                            outletComparePriceCents:
-                                typeof item.outlet?.comparePrice === 'number'
-                                    ? Math.round(item.outlet.comparePrice * 100)
-                                    : null,
-                        },
-                    },
-                    price: {
-                        valueInCents,
-                        currency: 'eur',
-                    },
-                    quantity,
-                });
             }
 
             if (stripeCartItemsWithShopData.length) {
+                const resolvedCustomerId = await resolveStripeCustomerId({
+                    email: user.userName,
+                    id: account.id,
+                    name: user.userName,
+                    stripeCustomerId: account.stripeCustomerId ?? undefined,
+                });
+                if (account.stripeCustomerId !== resolvedCustomerId) {
+                    // Persist before the durable attempt so recovery always
+                    // derives the exact customer used by the idempotent request.
+                    await assignStripeCustomerId(
+                        account.id,
+                        resolvedCustomerId,
+                    );
+                }
+                const checkoutExpiresAt = hasOutletStripeItems
+                    ? outletCheckoutExpiresAt
+                    : addMinutes(outletCheckoutStartedAt, 24 * 60 - 1);
                 const checkoutAttempt = buildStripeCheckoutAttemptSnapshot({
-                    accountId,
                     cartId: cart.id,
                     checkoutAdditionalDataByCartItemId,
+                    customerId: resolvedCustomerId,
+                    expiresAt: checkoutExpiresAt,
                     harvestDates: canonicalHarvestDates,
                     items: cartInfo.items,
+                    returnUrls: getStripeCheckoutReturnUrls(),
                     userId,
                 });
                 try {
-                    await createStripeCheckoutAttempt(checkoutAttempt);
+                    await createStripeCheckoutAttempt(checkoutAttempt, {
+                        accountId,
+                    });
                 } catch (error) {
                     if (error instanceof StripeCheckoutAttemptInProgressError) {
                         const activeAttempt =
                             await getActiveStripeCheckoutAttempt(cart.id);
-                        if (activeAttempt?.sessionId) {
-                            const activeSession =
-                                await getStripeCheckoutSession(
-                                    activeAttempt.sessionId,
-                                );
-                            if (
-                                activeSession?.status === 'open' &&
-                                activeAttempt.snapshot.accountId ===
-                                    accountId &&
-                                activeSession.url
-                            ) {
+                        if (activeAttempt) {
+                            const recovery = await recoverAttempt(
+                                activeAttempt,
+                                cart.items,
+                                resolvedCustomerId,
+                            );
+                            if (recovery.status === 'open' && recovery.url) {
                                 return context.json({
-                                    sessionId: activeSession.id,
-                                    url: activeSession.url,
+                                    sessionId: recovery.sessionId,
+                                    url: recovery.url,
                                 });
                             }
                         }
@@ -977,94 +1023,25 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                     throw error;
                 }
 
-                let stripeResult: Awaited<ReturnType<typeof stripeCheckout>>;
-                try {
-                    stripeResult = await checkoutTiming.measure(
-                        'stripe_session',
-                        () =>
-                            stripeCheckout(
-                                {
-                                    id: account.id,
-                                    email: user.userName,
-                                    name: user.userName,
-                                    stripeCustomerId:
-                                        account.stripeCustomerId ?? undefined,
-                                },
-                                {
-                                    items: stripeItems,
-                                    expiresAt: hasOutletStripeItems
-                                        ? outletCheckoutExpiresAt
-                                        : undefined,
-                                    metadata: {
-                                        ...encodeHarvestDatesMetadata(
-                                            canonicalHarvestDates,
-                                            checkoutAttempt.expectedNonStripeCartItemIds,
-                                        ),
-                                        ...encodeStripeCheckoutAttemptMetadata(
-                                            checkoutAttempt,
-                                        ),
-                                    },
-                                },
-                            ),
+                const recovery = await checkoutTiming.measure(
+                    'stripe_session',
+                    () =>
+                        recoverAttempt(
+                            { snapshot: checkoutAttempt },
+                            cart.items,
+                            resolvedCustomerId,
+                        ),
+                );
+                if (recovery.status !== 'open' || !recovery.url) {
+                    return context.json(
+                        {
+                            code: 'CHECKOUT_PAYMENT_PROCESSING',
+                            error: 'Plaćanje se još obrađuje. Pričekaj trenutak i pokušaj ponovno.',
+                        },
+                        409,
                     );
-                } catch (error) {
-                    await releaseStripeCheckoutAttempt({
-                        attemptId: checkoutAttempt.attemptId,
-                        cartId: cart.id,
-                        reason: 'session_creation_failed',
-                        sessionId: null,
-                    });
-                    if (hasOutletStripeItems) {
-                        await releaseOutletReservationsForCart(cart.id);
-                    }
-                    throw error;
                 }
-
-                const { customerId, sessionId, url } = stripeResult;
-                try {
-                    await bindStripeCheckoutAttempt({
-                        attemptId: checkoutAttempt.attemptId,
-                        cartId: cart.id,
-                        sessionId,
-                    });
-                } catch (error) {
-                    try {
-                        await stripeSessionCancel(sessionId);
-                        await releaseStripeCheckoutAttempt({
-                            attemptId: checkoutAttempt.attemptId,
-                            cartId: cart.id,
-                            reason: 'session_binding_failed',
-                            sessionId,
-                        });
-                        if (hasOutletStripeItems) {
-                            await releaseOutletReservationsForCart(cart.id);
-                        }
-                    } catch (recoveryError) {
-                        console.error(
-                            'Stripe checkout session binding recovery failed',
-                            {
-                                attemptId: checkoutAttempt.attemptId,
-                                cartId: cart.id,
-                                error: recoveryError,
-                                sessionId,
-                            },
-                        );
-                    }
-                    throw error;
-                }
-
-                if (account.stripeCustomerId !== customerId) {
-                    try {
-                        await assignStripeCustomerId(account.id, customerId);
-                    } catch (error) {
-                        console.error('Stripe customer persistence failed', {
-                            accountId,
-                            attemptId: checkoutAttempt.attemptId,
-                            error,
-                            sessionId,
-                        });
-                    }
-                }
+                const { sessionId, url } = recovery;
 
                 try {
                     await checkoutTiming.measure('analytics', async () => {
@@ -1074,7 +1051,7 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                             properties: {
                                 cart_id: cartId,
                                 payment_method: 'stripe',
-                                item_count: stripeItems.length,
+                                item_count: stripeCartItemsWithShopData.length,
                             },
                         });
                     });
@@ -1284,7 +1261,10 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                             attemptMetadata.cartId,
                             attemptMetadata.attemptId,
                         );
-                        if (attempt?.snapshot.accountId !== accountId) {
+                        const attemptCart = await getShoppingCart(
+                            attemptMetadata.cartId,
+                        );
+                        if (!attempt || attemptCart?.accountId !== accountId) {
                             return context.json(
                                 {
                                     error: 'Session does not belong to this account',
@@ -1297,9 +1277,6 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                             reason: 'expired',
                             sessionId,
                         });
-                        await releaseOutletReservationsForCart(
-                            attemptMetadata.cartId,
-                        );
                     }
                     return context.json({ success: true });
                 }
@@ -1309,7 +1286,10 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                         attemptMetadata.cartId,
                         attemptMetadata.attemptId,
                     );
-                    if (attempt?.snapshot.accountId !== accountId) {
+                    const attemptCart = await getShoppingCart(
+                        attemptMetadata.cartId,
+                    );
+                    if (!attempt || attemptCart?.accountId !== accountId) {
                         return context.json(
                             {
                                 error: 'Session does not belong to this account',
@@ -1324,10 +1304,9 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                     });
                 }
                 const outletCartIds = new Set<number>();
-                if (attemptMetadata) {
-                    outletCartIds.add(attemptMetadata.cartId);
-                }
-                for (const item of session.lineItems?.data ?? []) {
+                for (const item of attemptMetadata
+                    ? []
+                    : (session.lineItems?.data ?? [])) {
                     const product = item.price?.product;
                     if (typeof product === 'string' || product?.deleted) {
                         continue;

--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -585,7 +585,7 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
             }
             if (hasOutletStripeItems) {
                 cartInfo = await checkoutTiming.measure(
-                    'cart_outlet_revalidation',
+                    'cart_enrichment',
                     () =>
                         getCartInfo(cart.items, accountId, {
                             checkoutOperationMappings,

--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -1,8 +1,11 @@
 import {
     assignStripeCustomerId,
+    bindStripeCheckoutAttempt,
     cartContainsDeliverableItems,
     consumeInventoryItem,
+    createStripeCheckoutAttempt,
     getAccount,
+    getActiveStripeCheckoutAttempt,
     getCheckoutFulfillmentStartedCartItemIds,
     getCheckoutOperationMapping,
     getCheckoutOperationMappings,
@@ -10,6 +13,7 @@ import {
     getHarvestScheduleForCart,
     getPickupLocation,
     getShoppingCart,
+    getStripeCheckoutAttempt,
     getSunflowerPackageEligibilityForAccount,
     getTimeSlot,
     getTimeSlotEffectiveClosesAt,
@@ -22,7 +26,10 @@ import {
     OutletOfferUnavailableError,
     OutletReservationUnavailableError,
     releaseOutletReservationsForCart,
+    releaseStripeCheckoutAttempt,
     reserveOutletOffer,
+    StripeCheckoutAttemptConflictError,
+    StripeCheckoutAttemptInProgressError,
     setCartItemPaid,
     sunflowerPackageEntityTypeName,
     validateHarvestDateSelections,
@@ -63,6 +70,11 @@ import {
     buildOrderConfirmationItems,
     ORDER_CONFIRMATION_MANAGE_URL,
 } from '../../../lib/checkout/orderConfirmationEmail';
+import {
+    buildStripeCheckoutAttemptSnapshot,
+    decodeStripeCheckoutAttemptMetadata,
+    encodeStripeCheckoutAttemptMetadata,
+} from '../../../lib/checkout/stripeCheckoutSnapshot';
 import { authSecurity } from '../../../lib/docs/security';
 import {
     type AuthVariables,
@@ -490,15 +502,6 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
             const requiresStripePayment = cartInfo.items.some(
                 (item) => item.status !== 'paid' && item.currency === 'eur',
             );
-            const expectedNonStripeCartItemIds = cartInfo.items.flatMap(
-                (item) =>
-                    item.status !== 'paid' &&
-                    (item.currency === 'sunflower' ||
-                        item.currency === 'inventory' ||
-                        item.usesInventory)
-                        ? [item.id]
-                        : [],
-            );
             const hasSunflowerItems = cartInfo.items.some(
                 (item) =>
                     item.status !== 'paid' && item.currency === 'sunflower',
@@ -840,18 +843,36 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                         valueInCents,
                         quantity,
                     });
-                    continue;
+                    return context.json(
+                        {
+                            code: 'CHECKOUT_CART_CHANGED',
+                            error: 'Košarica se promijenila. Osvježi je i pokušaj ponovno.',
+                        },
+                        409,
+                    );
                 }
                 if (quantity <= 0) {
                     console.warn('Invalid item quantity', { quantity });
-                    continue;
+                    return context.json(
+                        {
+                            code: 'CHECKOUT_CART_CHANGED',
+                            error: 'Košarica se promijenila. Osvježi je i pokušaj ponovno.',
+                        },
+                        409,
+                    );
                 }
                 // Invalid price check
                 // - valueInCents should be a positive integer
                 // - valueInCents should not exceed a certain limit (e.g., 10000 cents = 100 EUR)
                 if (valueInCents < 0 || valueInCents > 10000) {
                     console.warn('Invalid item price', { valueInCents });
-                    continue;
+                    return context.json(
+                        {
+                            code: 'CHECKOUT_CART_CHANGED',
+                            error: 'Košarica se promijenila. Osvježi je i pokušaj ponovno.',
+                        },
+                        409,
+                    );
                 }
 
                 stripeItems.push({
@@ -902,44 +923,169 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
             }
 
             if (stripeCartItemsWithShopData.length) {
-                const { customerId, sessionId, url } =
-                    await checkoutTiming.measure('stripe_session', () =>
-                        stripeCheckout(
+                const checkoutAttempt = buildStripeCheckoutAttemptSnapshot({
+                    accountId,
+                    cartId: cart.id,
+                    checkoutAdditionalDataByCartItemId,
+                    harvestDates: canonicalHarvestDates,
+                    items: cartInfo.items,
+                    userId,
+                });
+                try {
+                    await createStripeCheckoutAttempt(checkoutAttempt);
+                } catch (error) {
+                    if (error instanceof StripeCheckoutAttemptInProgressError) {
+                        const activeAttempt =
+                            await getActiveStripeCheckoutAttempt(cart.id);
+                        if (activeAttempt?.sessionId) {
+                            const activeSession =
+                                await getStripeCheckoutSession(
+                                    activeAttempt.sessionId,
+                                );
+                            if (
+                                activeSession?.status === 'open' &&
+                                activeAttempt.snapshot.accountId ===
+                                    accountId &&
+                                activeSession.url
+                            ) {
+                                return context.json({
+                                    sessionId: activeSession.id,
+                                    url: activeSession.url,
+                                });
+                            }
+                        }
+                        return context.json(
                             {
-                                id: account.id,
-                                email: user.userName,
-                                name: user.userName,
-                                stripeCustomerId:
-                                    account.stripeCustomerId ?? undefined,
+                                code: 'CHECKOUT_IN_PROGRESS',
+                                error: 'Plaćanje za ovu košaricu je već otvoreno. Dovrši ili otkaži postojeće plaćanje.',
                             },
+                            409,
+                        );
+                    }
+                    if (error instanceof StripeCheckoutAttemptConflictError) {
+                        checkoutTiming.setErrorCategory(
+                            'cart_validation_failed',
+                        );
+                        return context.json(
                             {
-                                items: stripeItems,
-                                expiresAt: hasOutletStripeItems
-                                    ? outletCheckoutExpiresAt
-                                    : undefined,
-                                metadata: encodeHarvestDatesMetadata(
-                                    canonicalHarvestDates,
-                                    expectedNonStripeCartItemIds,
-                                ),
+                                code: 'CHECKOUT_CART_CHANGED',
+                                error: 'Košarica se promijenila. Osvježi je i pokušaj ponovno.',
                             },
-                        ),
-                    );
-
-                if (account.stripeCustomerId !== customerId) {
-                    await assignStripeCustomerId(account.id, customerId);
+                            409,
+                        );
+                    }
+                    throw error;
                 }
 
-                await checkoutTiming.measure('analytics', async () => {
-                    (await getPostHogClient()).capture({
-                        distinctId: accountId,
-                        event: 'checkout_initiated',
-                        properties: {
-                            cart_id: cartId,
-                            payment_method: 'stripe',
-                            item_count: stripeItems.length,
-                        },
+                let stripeResult: Awaited<ReturnType<typeof stripeCheckout>>;
+                try {
+                    stripeResult = await checkoutTiming.measure(
+                        'stripe_session',
+                        () =>
+                            stripeCheckout(
+                                {
+                                    id: account.id,
+                                    email: user.userName,
+                                    name: user.userName,
+                                    stripeCustomerId:
+                                        account.stripeCustomerId ?? undefined,
+                                },
+                                {
+                                    items: stripeItems,
+                                    expiresAt: hasOutletStripeItems
+                                        ? outletCheckoutExpiresAt
+                                        : undefined,
+                                    metadata: {
+                                        ...encodeHarvestDatesMetadata(
+                                            canonicalHarvestDates,
+                                            checkoutAttempt.expectedNonStripeCartItemIds,
+                                        ),
+                                        ...encodeStripeCheckoutAttemptMetadata(
+                                            checkoutAttempt,
+                                        ),
+                                    },
+                                },
+                            ),
+                    );
+                } catch (error) {
+                    await releaseStripeCheckoutAttempt({
+                        attemptId: checkoutAttempt.attemptId,
+                        cartId: cart.id,
+                        reason: 'session_creation_failed',
+                        sessionId: null,
                     });
-                });
+                    if (hasOutletStripeItems) {
+                        await releaseOutletReservationsForCart(cart.id);
+                    }
+                    throw error;
+                }
+
+                const { customerId, sessionId, url } = stripeResult;
+                try {
+                    await bindStripeCheckoutAttempt({
+                        attemptId: checkoutAttempt.attemptId,
+                        cartId: cart.id,
+                        sessionId,
+                    });
+                } catch (error) {
+                    try {
+                        await stripeSessionCancel(sessionId);
+                        await releaseStripeCheckoutAttempt({
+                            attemptId: checkoutAttempt.attemptId,
+                            cartId: cart.id,
+                            reason: 'session_binding_failed',
+                            sessionId,
+                        });
+                        if (hasOutletStripeItems) {
+                            await releaseOutletReservationsForCart(cart.id);
+                        }
+                    } catch (recoveryError) {
+                        console.error(
+                            'Stripe checkout session binding recovery failed',
+                            {
+                                attemptId: checkoutAttempt.attemptId,
+                                cartId: cart.id,
+                                error: recoveryError,
+                                sessionId,
+                            },
+                        );
+                    }
+                    throw error;
+                }
+
+                if (account.stripeCustomerId !== customerId) {
+                    try {
+                        await assignStripeCustomerId(account.id, customerId);
+                    } catch (error) {
+                        console.error('Stripe customer persistence failed', {
+                            accountId,
+                            attemptId: checkoutAttempt.attemptId,
+                            error,
+                            sessionId,
+                        });
+                    }
+                }
+
+                try {
+                    await checkoutTiming.measure('analytics', async () => {
+                        (await getPostHogClient()).capture({
+                            distinctId: accountId,
+                            event: 'checkout_initiated',
+                            properties: {
+                                cart_id: cartId,
+                                payment_method: 'stripe',
+                                item_count: stripeItems.length,
+                            },
+                        });
+                    });
+                } catch (error) {
+                    console.warn('Checkout initiation analytics failed', {
+                        attemptId: checkoutAttempt.attemptId,
+                        cartId,
+                        error,
+                        sessionId,
+                    });
+                }
 
                 return context.json({ sessionId, url });
             }
@@ -1129,14 +1275,58 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                         400,
                     );
                 }
+                const attemptMetadata = decodeStripeCheckoutAttemptMetadata(
+                    session.metadata,
+                );
                 if (session.status === 'expired') {
-                    return context.json(
-                        { error: 'Session already canceled' },
-                        400,
-                    );
+                    if (attemptMetadata) {
+                        const attempt = await getStripeCheckoutAttempt(
+                            attemptMetadata.cartId,
+                            attemptMetadata.attemptId,
+                        );
+                        if (attempt?.snapshot.accountId !== accountId) {
+                            return context.json(
+                                {
+                                    error: 'Session does not belong to this account',
+                                },
+                                403,
+                            );
+                        }
+                        await releaseStripeCheckoutAttempt({
+                            ...attemptMetadata,
+                            reason: 'expired',
+                            sessionId,
+                        });
+                        await releaseOutletReservationsForCart(
+                            attemptMetadata.cartId,
+                        );
+                    }
+                    return context.json({ success: true });
                 }
                 await stripeSessionCancel(sessionId);
+                if (attemptMetadata) {
+                    const attempt = await getStripeCheckoutAttempt(
+                        attemptMetadata.cartId,
+                        attemptMetadata.attemptId,
+                    );
+                    if (attempt?.snapshot.accountId !== accountId) {
+                        return context.json(
+                            {
+                                error: 'Session does not belong to this account',
+                            },
+                            403,
+                        );
+                    }
+                    await releaseStripeCheckoutAttempt({
+                        ...attemptMetadata,
+                        reason: 'cancelled',
+                        sessionId,
+                    });
+                }
                 const outletCartIds = new Set<number>();
+                if (attemptMetadata) {
+                    outletCartIds.add(attemptMetadata.cartId);
+                }
                 for (const item of session.lineItems?.data ?? []) {
                     const product = item.price?.product;
                     if (typeof product === 'string' || product?.deleted) {

--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -1,5 +1,4 @@
 import {
-    assignStripeCustomerId,
     assignStripeCustomerIdIfUnchanged,
     bindStripeCheckoutAttempt,
     cartContainsDeliverableItems,
@@ -584,12 +583,10 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                 }
             }
             if (hasOutletStripeItems) {
-                cartInfo = await checkoutTiming.measure(
-                    'cart_enrichment',
-                    () =>
-                        getCartInfo(cart.items, accountId, {
-                            checkoutOperationMappings,
-                        }),
+                cartInfo = await checkoutTiming.measure('cart_enrichment', () =>
+                    getCartInfo(cart.items, accountId, {
+                        checkoutOperationMappings,
+                    }),
                 );
                 if (!cartInfo.allowPurchase) {
                     return context.json(
@@ -1171,7 +1168,25 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                 return context.json({ error: 'Package is not available' }, 400);
             }
 
-            const { customerId, sessionId, url } = await stripeCheckout(
+            const resolvedCustomerId = await resolveStripeCustomerId({
+                id: account.id,
+                email: user.userName,
+                name: user.userName,
+                stripeCustomerId: account.stripeCustomerId ?? undefined,
+            });
+            const canonicalCustomerId = await assignStripeCustomerIdIfUnchanged(
+                account.id,
+                account.stripeCustomerId,
+                resolvedCustomerId,
+            );
+            if (!canonicalCustomerId) {
+                return context.json(
+                    { error: 'Package checkout is temporarily unavailable' },
+                    409,
+                );
+            }
+
+            const { sessionId, url } = await stripeCheckout(
                 {
                     id: account.id,
                     email: user.userName,
@@ -1218,11 +1233,8 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                     ],
                     allowPromotionCodes: false,
                 },
+                { customerId: canonicalCustomerId },
             );
-
-            if (account.stripeCustomerId !== customerId) {
-                await assignStripeCustomerId(account.id, customerId);
-            }
 
             (await getPostHogClient()).capture({
                 distinctId: accountId,

--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -1,5 +1,6 @@
 import {
     assignStripeCustomerId,
+    assignStripeCustomerIdIfUnchanged,
     bindStripeCheckoutAttempt,
     cartContainsDeliverableItems,
     consumeInventoryItem,
@@ -582,6 +583,24 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                     throw error;
                 }
             }
+            if (hasOutletStripeItems) {
+                cartInfo = await checkoutTiming.measure(
+                    'cart_outlet_revalidation',
+                    () =>
+                        getCartInfo(cart.items, accountId, {
+                            checkoutOperationMappings,
+                        }),
+                );
+                if (!cartInfo.allowPurchase) {
+                    return context.json(
+                        {
+                            code: 'CHECKOUT_CART_CHANGED',
+                            error: 'Košarica se promijenila. Osvježi je i pokušaj ponovno.',
+                        },
+                        409,
+                    );
+                }
+            }
 
             const requiresStripePayment = cartInfo.items.some(
                 (item) => item.status !== 'paid' && item.currency === 'eur',
@@ -958,12 +977,15 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                     name: user.userName,
                     stripeCustomerId: account.stripeCustomerId ?? undefined,
                 });
-                if (account.stripeCustomerId !== resolvedCustomerId) {
-                    // Persist before the durable attempt so recovery always
-                    // derives the exact customer used by the idempotent request.
-                    await assignStripeCustomerId(
+                const canonicalCustomerId =
+                    await assignStripeCustomerIdIfUnchanged(
                         account.id,
+                        account.stripeCustomerId,
                         resolvedCustomerId,
+                    );
+                if (!canonicalCustomerId) {
+                    throw new StripeCheckoutAttemptConflictError(
+                        'checkout_identity_changed',
                     );
                 }
                 const checkoutExpiresAt = hasOutletStripeItems
@@ -972,7 +994,7 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                 const checkoutAttempt = buildStripeCheckoutAttemptSnapshot({
                     cartId: cart.id,
                     checkoutAdditionalDataByCartItemId,
-                    customerId: resolvedCustomerId,
+                    customerId: canonicalCustomerId,
                     expiresAt: checkoutExpiresAt,
                     harvestDates: canonicalHarvestDates,
                     items: cartInfo.items,
@@ -991,7 +1013,7 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                             const recovery = await recoverAttempt(
                                 activeAttempt,
                                 cart.items,
-                                resolvedCustomerId,
+                                canonicalCustomerId,
                             );
                             if (recovery.status === 'open' && recovery.url) {
                                 return context.json({
@@ -1029,7 +1051,7 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                         recoverAttempt(
                             { snapshot: checkoutAttempt },
                             cart.items,
-                            resolvedCustomerId,
+                            canonicalCustomerId,
                         ),
                 );
                 if (recovery.status !== 'open' || !recovery.url) {

--- a/apps/api/app/api/[...route]/shoppingCartRoutes.ts
+++ b/apps/api/app/api/[...route]/shoppingCartRoutes.ts
@@ -19,6 +19,7 @@ import {
     OutletOfferUnavailableError,
     OutletReservationUnavailableError,
     releaseOutletReservationForCartItem,
+    StripeCheckoutAttemptInProgressError,
     upsertOrRemoveCartItem,
     upsertOrRemoveCartItemWithOutletReservation,
 } from '@gredice/storage';
@@ -375,6 +376,15 @@ const app = new Hono<{ Variables: AuthVariables }>()
                         409,
                     );
                 }
+                if (error instanceof StripeCheckoutAttemptInProgressError) {
+                    return context.json(
+                        {
+                            error: 'Plaćanje za ovu košaricu je u tijeku. Dovrši ili otkaži plaćanje prije izmjene košarice.',
+                            code: 'CHECKOUT_IN_PROGRESS',
+                        },
+                        409,
+                    );
+                }
 
                 throw error;
             }
@@ -409,6 +419,15 @@ const app = new Hono<{ Variables: AuthVariables }>()
                         {
                             error: 'Checkout fulfillment is already processing for this cart',
                             code: 'CHECKOUT_FULFILLMENT_STARTED',
+                        },
+                        409,
+                    );
+                }
+                if (error instanceof StripeCheckoutAttemptInProgressError) {
+                    return context.json(
+                        {
+                            error: 'Plaćanje za ovu košaricu je u tijeku. Dovrši ili otkaži plaćanje prije brisanja košarice.',
+                            code: 'CHECKOUT_IN_PROGRESS',
                         },
                         409,
                     );

--- a/apps/api/app/api/stripe/webhook/route.ts
+++ b/apps/api/app/api/stripe/webhook/route.ts
@@ -1,18 +1,36 @@
+import {
+    releaseOutletReservationsForCart,
+    releaseStripeCheckoutAttempt,
+} from '@gredice/storage';
 import { stripeWebhookConstructEvent } from '@gredice/stripe/server';
+import { decodeStripeCheckoutAttemptMetadata } from '../../../../lib/checkout/stripeCheckoutSnapshot';
 import { processCheckoutSession } from '../../../../lib/stripe/processCheckoutSession';
 
 export const dynamic = 'force-dynamic';
 
-function isPaymentCheckoutSession(
-    value: unknown,
-): value is { id: string; mode: 'payment' } {
+function isPaymentCheckoutSession(value: unknown): value is {
+    id: string;
+    metadata?: Record<string, string> | null;
+    mode: 'payment';
+} {
+    const metadata =
+        value && typeof value === 'object' && 'metadata' in value
+            ? value.metadata
+            : undefined;
     return (
         !!value &&
         typeof value === 'object' &&
         'id' in value &&
         typeof value.id === 'string' &&
         'mode' in value &&
-        value.mode === 'payment'
+        value.mode === 'payment' &&
+        (metadata === undefined ||
+            metadata === null ||
+            (typeof metadata === 'object' &&
+                !Array.isArray(metadata) &&
+                Object.values(metadata).every(
+                    (entry) => typeof entry === 'string',
+                )))
     );
 }
 
@@ -24,6 +42,7 @@ const relevantEvents = new Set([
     // 'price.updated',
     // 'price.deleted',
     'checkout.session.completed',
+    'checkout.session.expired',
 ]);
 
 export async function POST(req: Request) {
@@ -45,6 +64,25 @@ export async function POST(req: Request) {
                 const checkoutSession = event.data.object;
                 if (isPaymentCheckoutSession(checkoutSession)) {
                     await processCheckoutSession(checkoutSession.id);
+                }
+                break;
+            }
+            case 'checkout.session.expired': {
+                const checkoutSession = event.data.object;
+                if (isPaymentCheckoutSession(checkoutSession)) {
+                    const attemptMetadata = decodeStripeCheckoutAttemptMetadata(
+                        checkoutSession.metadata,
+                    );
+                    if (attemptMetadata) {
+                        await releaseStripeCheckoutAttempt({
+                            ...attemptMetadata,
+                            reason: 'expired',
+                            sessionId: checkoutSession.id,
+                        });
+                        await releaseOutletReservationsForCart(
+                            attemptMetadata.cartId,
+                        );
+                    }
                 }
                 break;
             }

--- a/apps/api/app/api/stripe/webhook/route.ts
+++ b/apps/api/app/api/stripe/webhook/route.ts
@@ -1,7 +1,4 @@
-import {
-    releaseOutletReservationsForCart,
-    releaseStripeCheckoutAttempt,
-} from '@gredice/storage';
+import { releaseStripeCheckoutAttempt } from '@gredice/storage';
 import { stripeWebhookConstructEvent } from '@gredice/stripe/server';
 import { decodeStripeCheckoutAttemptMetadata } from '../../../../lib/checkout/stripeCheckoutSnapshot';
 import { processCheckoutSession } from '../../../../lib/stripe/processCheckoutSession';
@@ -79,9 +76,6 @@ export async function POST(req: Request) {
                             reason: 'expired',
                             sessionId: checkoutSession.id,
                         });
-                        await releaseOutletReservationsForCart(
-                            attemptMetadata.cartId,
-                        );
                     }
                 }
                 break;

--- a/apps/api/lib/checkout/stripeCheckoutRecovery.node.spec.ts
+++ b/apps/api/lib/checkout/stripeCheckoutRecovery.node.spec.ts
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    fingerprintStripeCheckoutValue,
+    type StripeCheckoutAttempt,
+} from '@gredice/storage';
+import type { CheckoutItem } from '@gredice/stripe/server';
+import { recoverStripeCheckoutAttemptSession } from './stripeCheckoutRecovery';
+
+function checkoutAttempt(): StripeCheckoutAttempt {
+    return {
+        snapshot: {
+            attemptId: '93b43108-696d-48ca-92ef-9990c0a84d43',
+            cartId: 12,
+            expectedNonStripeCartItemIds: [],
+            harvestDates: [],
+            items: [
+                {
+                    additionalDataFingerprint:
+                        fingerprintStripeCheckoutValue(null),
+                    amount: 1,
+                    cartId: 12,
+                    checkoutAdditionalDataFingerprint:
+                        fingerprintStripeCheckoutValue({
+                            delivery: { mode: 'pickup', slotId: 7 },
+                        }),
+                    currency: 'eur',
+                    entityId: 'plant-7',
+                    entityTypeName: 'plantSort',
+                    gardenId: 5,
+                    id: 41,
+                    paymentAmount: 350,
+                    paymentKind: 'stripe',
+                    positionIndex: 3,
+                    raisedBedId: 6,
+                    status: 'new',
+                },
+            ],
+            stripeSession: {
+                allowPromotionCodes: true,
+                customerFingerprint: fingerprintStripeCheckoutValue('cus_1'),
+                expiresAt: '2026-08-04T00:00:00.000Z',
+                items: [
+                    {
+                        cartItemId: 41,
+                        price: { currency: 'eur', valueInCents: 350 },
+                        product: { name: 'Frozen catalog name' },
+                        quantity: 1,
+                    },
+                ],
+                returnUrls: {
+                    cancel: 'https://old.example.test/cancel',
+                    success: 'https://old.example.test/success',
+                },
+            },
+            userFingerprint: fingerprintStripeCheckoutValue('user-1'),
+            version: 1,
+        },
+    };
+}
+
+test('recovers create-before-bind with exact parameters and one Stripe session', async () => {
+    let attempt = checkoutAttempt();
+    let checkoutCalls = 0;
+    const serializedRequests: string[] = [];
+    const sessionsByKey = new Map<string, string>();
+    const checkout = async (
+        _account: {
+            email: string;
+            id: string;
+            name: string;
+            stripeCustomerId?: string;
+        },
+        data: {
+            allowPromotionCodes?: boolean;
+            expiresAt?: Date;
+            items: CheckoutItem[];
+            metadata?: Record<string, string | number | null>;
+        },
+        options: {
+            customerId?: string;
+            idempotencyKey?: string;
+            returnUrls?: { cancel: string; success: string };
+        } = {},
+    ) => {
+        checkoutCalls += 1;
+        serializedRequests.push(JSON.stringify({ data, options }));
+        const key = options.idempotencyKey;
+        assert.ok(key);
+        const sessionId = sessionsByKey.get(key) ?? 'cs_recovered';
+        sessionsByKey.set(key, sessionId);
+        if (checkoutCalls === 1) {
+            throw new Error('connection lost after Stripe created the session');
+        }
+        return { customerId: 'cus_1', sessionId, url: 'https://stripe.test/1' };
+    };
+    const dependencies = {
+        bindAttempt: async (binding: {
+            attemptId: string;
+            cartId: number;
+            sessionId: string;
+        }) => {
+            attempt = { ...attempt, sessionId: binding.sessionId };
+            throw new Error('binding response lost after commit');
+        },
+        checkout,
+        getAttempt: async () => attempt,
+        getSession: async () => undefined,
+        releaseAttempt: async () => undefined,
+    };
+    const input = {
+        account: {
+            email: 'buyer@example.test',
+            id: 'account-1',
+            name: 'Buyer',
+            stripeCustomerId: 'cus_1',
+        },
+        accountId: 'account-1',
+        attempt,
+        checkoutAdditionalDataByCartItemId: new Map([
+            [41, { delivery: { mode: 'pickup', slotId: 7 } }],
+        ]),
+        customerId: 'cus_1',
+        dependencies,
+        now: new Date('2026-08-03T12:00:00.000Z'),
+        userId: 'user-1',
+    };
+
+    await assert.rejects(
+        recoverStripeCheckoutAttemptSession(input),
+        /connection lost/,
+    );
+
+    // A catalog/URL deployment change cannot alter the persisted replay input.
+    const result = await recoverStripeCheckoutAttemptSession({
+        ...input,
+        attempt,
+    });
+    assert.deepEqual(result, {
+        sessionId: 'cs_recovered',
+        status: 'open',
+        url: 'https://stripe.test/1',
+    });
+    assert.equal(sessionsByKey.size, 1);
+    assert.equal(serializedRequests[0], serializedRequests[1]);
+    assert.match(serializedRequests[1] ?? '', /Frozen catalog name/);
+    assert.match(serializedRequests[1] ?? '', /old\.example\.test/);
+    assert.match(
+        serializedRequests[1] ?? '',
+        /93b43108-696d-48ca-92ef-9990c0a84d43/,
+    );
+});

--- a/apps/api/lib/checkout/stripeCheckoutRecovery.node.spec.ts
+++ b/apps/api/lib/checkout/stripeCheckoutRecovery.node.spec.ts
@@ -150,3 +150,46 @@ test('recovers create-before-bind with exact parameters and one Stripe session',
         /93b43108-696d-48ca-92ef-9990c0a84d43/,
     );
 });
+
+test('keeps an expired unbound attempt fenced until Stripe reconciliation', async () => {
+    const attempt = checkoutAttempt();
+    let checkoutCalls = 0;
+    let releaseCalls = 0;
+
+    const result = await recoverStripeCheckoutAttemptSession({
+        account: {
+            email: 'buyer@example.test',
+            id: 'account-1',
+            name: 'Buyer',
+            stripeCustomerId: 'cus_1',
+        },
+        accountId: 'account-1',
+        attempt,
+        checkoutAdditionalDataByCartItemId: new Map([
+            [41, { delivery: { mode: 'pickup', slotId: 7 } }],
+        ]),
+        customerId: 'cus_1',
+        dependencies: {
+            bindAttempt: async () => undefined,
+            checkout: async () => {
+                checkoutCalls += 1;
+                return {
+                    customerId: 'cus_1',
+                    sessionId: 'cs_unsafe_replay',
+                    url: 'https://stripe.test/unsafe',
+                };
+            },
+            getAttempt: async () => attempt,
+            getSession: async () => undefined,
+            releaseAttempt: async () => {
+                releaseCalls += 1;
+            },
+        },
+        now: new Date('2026-08-04T00:00:00.001Z'),
+        userId: 'user-1',
+    });
+
+    assert.deepEqual(result, { status: 'processing' });
+    assert.equal(checkoutCalls, 0);
+    assert.equal(releaseCalls, 0);
+});

--- a/apps/api/lib/checkout/stripeCheckoutRecovery.ts
+++ b/apps/api/lib/checkout/stripeCheckoutRecovery.ts
@@ -92,13 +92,11 @@ export async function recoverStripeCheckoutAttemptSession({
 
     const expiresAt = attempt.snapshot.stripeSession.expiresAt;
     if (expiresAt && new Date(expiresAt).getTime() <= now.getTime()) {
-        await dependencies.releaseAttempt({
-            attemptId: attempt.snapshot.attemptId,
-            cartId: attempt.snapshot.cartId,
-            reason: 'expired',
-            sessionId: null,
-        });
-        return { status: 'released' };
+        // A lost create response can leave a real (or even paid) Stripe
+        // session unbound. Local time alone cannot prove that no session was
+        // created, so keep the cart fenced until Stripe-authoritative
+        // reconciliation binds or releases the attempt.
+        return { status: 'processing' };
     }
     if (!checkoutAdditionalDataByCartItemId) {
         throw new StripeCheckoutAttemptConflictError(

--- a/apps/api/lib/checkout/stripeCheckoutRecovery.ts
+++ b/apps/api/lib/checkout/stripeCheckoutRecovery.ts
@@ -1,0 +1,141 @@
+import {
+    type StripeCheckoutAttempt,
+    StripeCheckoutAttemptConflictError,
+} from '@gredice/storage';
+import type { stripeCheckout, UserAccount } from '@gredice/stripe/server';
+import { buildStripeCheckoutReplayInput } from './stripeCheckoutSnapshot';
+
+type RecoveryDependencies = {
+    bindAttempt: (input: {
+        attemptId: string;
+        cartId: number;
+        sessionId: string;
+    }) => Promise<unknown>;
+    checkout: typeof stripeCheckout;
+    getAttempt: (
+        cartId: number,
+        attemptId: string,
+    ) => Promise<StripeCheckoutAttempt | undefined>;
+    getSession: (sessionId: string) => Promise<
+        | {
+              id: string;
+              customerId: string | { id: string } | null;
+              status: 'complete' | 'expired' | 'open' | null;
+              url: string | null;
+          }
+        | undefined
+    >;
+    releaseAttempt: (input: {
+        attemptId: string;
+        cartId: number;
+        reason: 'expired';
+        sessionId: string | null;
+    }) => Promise<unknown>;
+};
+
+export type StripeCheckoutRecoveryResult =
+    | { status: 'open'; sessionId: string; url: string | null }
+    | { status: 'processing' }
+    | { status: 'released' };
+
+export async function recoverStripeCheckoutAttemptSession({
+    account,
+    accountId,
+    attempt,
+    checkoutAdditionalDataByCartItemId,
+    customerId,
+    dependencies,
+    now = new Date(),
+    userId,
+}: {
+    account: UserAccount;
+    accountId: string;
+    attempt: StripeCheckoutAttempt;
+    checkoutAdditionalDataByCartItemId?: ReadonlyMap<number, unknown>;
+    customerId: string;
+    dependencies: RecoveryDependencies;
+    now?: Date;
+    userId: string;
+}): Promise<StripeCheckoutRecoveryResult> {
+    if (attempt.releaseReason) {
+        return { status: 'released' };
+    }
+    if (attempt.sessionId) {
+        const session = await dependencies.getSession(attempt.sessionId);
+        const sessionCustomerId =
+            typeof session?.customerId === 'string'
+                ? session.customerId
+                : session?.customerId?.id;
+        if (session && sessionCustomerId !== customerId) {
+            throw new StripeCheckoutAttemptConflictError(
+                'stripe_customer_changed',
+            );
+        }
+        if (session?.status === 'open') {
+            return {
+                status: 'open',
+                sessionId: session.id,
+                url: session.url,
+            };
+        }
+        if (session?.status === 'expired') {
+            await dependencies.releaseAttempt({
+                attemptId: attempt.snapshot.attemptId,
+                cartId: attempt.snapshot.cartId,
+                reason: 'expired',
+                sessionId: attempt.sessionId,
+            });
+            return { status: 'released' };
+        }
+        return { status: 'processing' };
+    }
+
+    const expiresAt = attempt.snapshot.stripeSession.expiresAt;
+    if (expiresAt && new Date(expiresAt).getTime() <= now.getTime()) {
+        await dependencies.releaseAttempt({
+            attemptId: attempt.snapshot.attemptId,
+            cartId: attempt.snapshot.cartId,
+            reason: 'expired',
+            sessionId: null,
+        });
+        return { status: 'released' };
+    }
+    if (!checkoutAdditionalDataByCartItemId) {
+        throw new StripeCheckoutAttemptConflictError(
+            'checkout_additional_data_missing',
+        );
+    }
+
+    const replay = buildStripeCheckoutReplayInput({
+        accountId,
+        attempt,
+        checkoutAdditionalDataByCartItemId,
+        customerId,
+        userId,
+    });
+    const stripeResult = await dependencies.checkout(
+        account,
+        replay.data,
+        replay.options,
+    );
+    try {
+        await dependencies.bindAttempt({
+            attemptId: attempt.snapshot.attemptId,
+            cartId: attempt.snapshot.cartId,
+            sessionId: stripeResult.sessionId,
+        });
+    } catch (error) {
+        const recoveredAttempt = await dependencies.getAttempt(
+            attempt.snapshot.cartId,
+            attempt.snapshot.attemptId,
+        );
+        if (recoveredAttempt?.sessionId !== stripeResult.sessionId) {
+            throw error;
+        }
+    }
+    return {
+        status: 'open',
+        sessionId: stripeResult.sessionId,
+        url: stripeResult.url,
+    };
+}

--- a/apps/api/lib/checkout/stripeCheckoutSnapshot.node.spec.ts
+++ b/apps/api/lib/checkout/stripeCheckoutSnapshot.node.spec.ts
@@ -1,13 +1,14 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+    fingerprintStripeCheckoutValue,
     type StripeCheckoutAttempt,
     StripeCheckoutAttemptConflictError,
 } from '@gredice/storage';
 import {
     assertStripeSessionMatchesCheckoutAttempt,
+    buildVerifiedStripeCheckoutAdditionalData,
     decodeStripeCheckoutAttemptMetadata,
-    getStripeCheckoutSnapshotAdditionalData,
     getStripeCheckoutSnapshotNonStripeAmounts,
     getStripeCheckoutSnapshotNonStripePaymentKinds,
     type StripeCheckoutSessionForSnapshot,
@@ -16,19 +17,19 @@ import {
 const attempt: StripeCheckoutAttempt = {
     sessionId: 'cs_snapshot',
     snapshot: {
-        accountId: 'account-1',
         attemptId: 'f67ed76e-41f3-4a10-a7f6-472d21b3678b',
         cartId: 12,
         expectedNonStripeCartItemIds: [42],
         harvestDates: [],
         items: [
             {
-                additionalData: null,
+                additionalDataFingerprint: fingerprintStripeCheckoutValue(null),
                 amount: 2,
                 cartId: 12,
-                checkoutAdditionalData: {
-                    delivery: { mode: 'pickup', slotId: 7 },
-                },
+                checkoutAdditionalDataFingerprint:
+                    fingerprintStripeCheckoutValue({
+                        delivery: { mode: 'pickup', slotId: 7 },
+                    }),
                 currency: 'eur',
                 entityId: 'plant-7',
                 entityTypeName: 'plantSort',
@@ -41,12 +42,16 @@ const attempt: StripeCheckoutAttempt = {
                 status: 'new',
             },
             {
-                additionalData: '{"scheduledDate":"2026-08-10T00:00:00.000Z"}',
+                additionalDataFingerprint: fingerprintStripeCheckoutValue(
+                    '{"scheduledDate":"2026-08-10T00:00:00.000Z"}',
+                ),
                 amount: 1,
                 cartId: 12,
-                checkoutAdditionalData: {
-                    scheduledDate: '2026-08-10T00:00:00.000Z',
-                },
+                checkoutAdditionalDataFingerprint:
+                    fingerprintStripeCheckoutValue({
+                        delivery: { mode: 'pickup', slotId: 7 },
+                        scheduledDate: '2026-08-10T00:00:00.000Z',
+                    }),
                 currency: 'sunflower',
                 entityId: 'operation-9',
                 entityTypeName: 'operation',
@@ -59,16 +64,36 @@ const attempt: StripeCheckoutAttempt = {
                 status: 'new',
             },
         ],
-        userId: 'user-1',
+        stripeSession: {
+            allowPromotionCodes: true,
+            customerFingerprint: fingerprintStripeCheckoutValue('cus_1'),
+            expiresAt: '2026-08-10T12:00:00.000Z',
+            items: [
+                {
+                    cartItemId: 41,
+                    price: { currency: 'eur', valueInCents: 350 },
+                    product: { name: 'Biljka' },
+                    quantity: 2,
+                },
+            ],
+            returnUrls: {
+                cancel: 'https://example.test/cancel',
+                success: 'https://example.test/success',
+            },
+        },
+        userFingerprint: fingerprintStripeCheckoutValue('user-1'),
         version: 1,
     },
 };
+
+const runtimeIdentity = { accountId: 'account-1', userId: 'user-1' };
 
 function session(
     overrides: Partial<StripeCheckoutSessionForSnapshot> = {},
 ): StripeCheckoutSessionForSnapshot {
     return {
         amountTotal: 630,
+        customerId: 'cus_1',
         id: 'cs_snapshot',
         lineItems: {
             data: [
@@ -137,7 +162,11 @@ describe('Stripe checkout snapshot metadata', () => {
 describe('assertStripeSessionMatchesCheckoutAttempt', () => {
     it('accepts the immutable item identity and a Stripe promotion discount', () => {
         assert.doesNotThrow(() =>
-            assertStripeSessionMatchesCheckoutAttempt(session(), attempt),
+            assertStripeSessionMatchesCheckoutAttempt(
+                session(),
+                attempt,
+                runtimeIdentity,
+            ),
         );
     });
 
@@ -158,6 +187,7 @@ describe('assertStripeSessionMatchesCheckoutAttempt', () => {
                         },
                     }),
                     attempt,
+                    runtimeIdentity,
                 ),
             'stripe_membership_changed',
         );
@@ -166,6 +196,7 @@ describe('assertStripeSessionMatchesCheckoutAttempt', () => {
                 assertStripeSessionMatchesCheckoutAttempt(
                     session({ amountTotal: 0, lineItems: { data: [] } }),
                     attempt,
+                    runtimeIdentity,
                 ),
             'stripe_membership_changed',
         );
@@ -188,6 +219,7 @@ describe('assertStripeSessionMatchesCheckoutAttempt', () => {
                         },
                     }),
                     attempt,
+                    runtimeIdentity,
                 ),
             'stripe_item_changed',
         );
@@ -216,6 +248,7 @@ describe('assertStripeSessionMatchesCheckoutAttempt', () => {
                         },
                     }),
                     attempt,
+                    runtimeIdentity,
                 ),
             'stripe_item_changed',
         );
@@ -242,6 +275,7 @@ describe('assertStripeSessionMatchesCheckoutAttempt', () => {
                         },
                     }),
                     attempt,
+                    runtimeIdentity,
                 ),
             'stripe_item_changed',
         );
@@ -254,6 +288,7 @@ describe('assertStripeSessionMatchesCheckoutAttempt', () => {
                         },
                     }),
                     attempt,
+                    runtimeIdentity,
                 ),
             'stripe_membership_changed',
         );
@@ -261,7 +296,7 @@ describe('assertStripeSessionMatchesCheckoutAttempt', () => {
 });
 
 describe('immutable non-Stripe fulfillment inputs', () => {
-    it('replays the recorded amount and additional data independently of later catalog values', () => {
+    it('replays recorded amounts and verifies reconstructed delivery data', () => {
         assert.equal(
             getStripeCheckoutSnapshotNonStripeAmounts(attempt).get(42),
             275,
@@ -270,9 +305,21 @@ describe('immutable non-Stripe fulfillment inputs', () => {
             getStripeCheckoutSnapshotNonStripePaymentKinds(attempt).get(42),
             'sunflower',
         );
-        assert.deepEqual(
-            getStripeCheckoutSnapshotAdditionalData(attempt).get(42),
-            { scheduledDate: '2026-08-10T00:00:00.000Z' },
-        );
+        const additionalData = buildVerifiedStripeCheckoutAdditionalData({
+            attempt,
+            liveItems: [
+                { additionalData: null, id: 41 },
+                {
+                    additionalData:
+                        '{"scheduledDate":"2026-08-10T00:00:00.000Z"}',
+                    id: 42,
+                },
+            ],
+            session: session(),
+        });
+        assert.deepEqual(additionalData.get(42), {
+            delivery: { mode: 'pickup', slotId: 7 },
+            scheduledDate: '2026-08-10T00:00:00.000Z',
+        });
     });
 });

--- a/apps/api/lib/checkout/stripeCheckoutSnapshot.node.spec.ts
+++ b/apps/api/lib/checkout/stripeCheckoutSnapshot.node.spec.ts
@@ -1,0 +1,278 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    type StripeCheckoutAttempt,
+    StripeCheckoutAttemptConflictError,
+} from '@gredice/storage';
+import {
+    assertStripeSessionMatchesCheckoutAttempt,
+    decodeStripeCheckoutAttemptMetadata,
+    getStripeCheckoutSnapshotAdditionalData,
+    getStripeCheckoutSnapshotNonStripeAmounts,
+    getStripeCheckoutSnapshotNonStripePaymentKinds,
+    type StripeCheckoutSessionForSnapshot,
+} from './stripeCheckoutSnapshot';
+
+const attempt: StripeCheckoutAttempt = {
+    sessionId: 'cs_snapshot',
+    snapshot: {
+        accountId: 'account-1',
+        attemptId: 'f67ed76e-41f3-4a10-a7f6-472d21b3678b',
+        cartId: 12,
+        expectedNonStripeCartItemIds: [42],
+        harvestDates: [],
+        items: [
+            {
+                additionalData: null,
+                amount: 2,
+                cartId: 12,
+                checkoutAdditionalData: {
+                    delivery: { mode: 'pickup', slotId: 7 },
+                },
+                currency: 'eur',
+                entityId: 'plant-7',
+                entityTypeName: 'plantSort',
+                gardenId: 5,
+                id: 41,
+                paymentAmount: 350,
+                paymentKind: 'stripe',
+                positionIndex: 3,
+                raisedBedId: 6,
+                status: 'new',
+            },
+            {
+                additionalData: '{"scheduledDate":"2026-08-10T00:00:00.000Z"}',
+                amount: 1,
+                cartId: 12,
+                checkoutAdditionalData: {
+                    scheduledDate: '2026-08-10T00:00:00.000Z',
+                },
+                currency: 'sunflower',
+                entityId: 'operation-9',
+                entityTypeName: 'operation',
+                gardenId: 5,
+                id: 42,
+                paymentAmount: 275,
+                paymentKind: 'sunflower',
+                positionIndex: 3,
+                raisedBedId: 6,
+                status: 'new',
+            },
+        ],
+        userId: 'user-1',
+        version: 1,
+    },
+};
+
+function session(
+    overrides: Partial<StripeCheckoutSessionForSnapshot> = {},
+): StripeCheckoutSessionForSnapshot {
+    return {
+        amountTotal: 630,
+        id: 'cs_snapshot',
+        lineItems: {
+            data: [
+                {
+                    amount_total: 630,
+                    price: {
+                        currency: 'eur',
+                        product: {
+                            metadata: {
+                                accountId: 'account-1',
+                                additionalData: JSON.stringify({
+                                    delivery: {
+                                        mode: 'pickup',
+                                        slotId: 7,
+                                    },
+                                }),
+                                cartId: '12',
+                                cartItemId: '41',
+                                entityId: 'plant-7',
+                                entityTypeName: 'plantSort',
+                                gardenId: '5',
+                                positionIndex: '3',
+                                raisedBedId: '6',
+                                userId: 'user-1',
+                            },
+                        },
+                        unit_amount: 350,
+                    },
+                    quantity: 2,
+                },
+            ],
+        },
+        ...overrides,
+    };
+}
+
+function expectConflict(operation: () => void, category: string): void {
+    assert.throws(operation, (error) => {
+        assert.ok(error instanceof StripeCheckoutAttemptConflictError);
+        assert.equal(error.category, category);
+        return true;
+    });
+}
+
+describe('Stripe checkout snapshot metadata', () => {
+    it('keeps legacy sessions on the compatibility path and rejects partial metadata', () => {
+        assert.equal(decodeStripeCheckoutAttemptMetadata(undefined), null);
+        assert.deepEqual(
+            decodeStripeCheckoutAttemptMetadata({
+                checkoutAttemptId: attempt.snapshot.attemptId,
+                checkoutCartId: '12',
+                checkoutSnapshotVersion: '1',
+            }),
+            { attemptId: attempt.snapshot.attemptId, cartId: 12 },
+        );
+        expectConflict(
+            () =>
+                decodeStripeCheckoutAttemptMetadata({
+                    checkoutAttemptId: attempt.snapshot.attemptId,
+                }),
+            'session_metadata_invalid',
+        );
+    });
+});
+
+describe('assertStripeSessionMatchesCheckoutAttempt', () => {
+    it('accepts the immutable item identity and a Stripe promotion discount', () => {
+        assert.doesNotThrow(() =>
+            assertStripeSessionMatchesCheckoutAttempt(session(), attempt),
+        );
+    });
+
+    it('rejects inserted, deleted, repriced, retargeted, and duplicated lines', () => {
+        expectConflict(
+            () =>
+                assertStripeSessionMatchesCheckoutAttempt(
+                    session({
+                        lineItems: {
+                            data: [
+                                ...(session().lineItems?.data ?? []),
+                                {
+                                    amount_total: 10,
+                                    price: { currency: 'eur', unit_amount: 10 },
+                                    quantity: 1,
+                                },
+                            ],
+                        },
+                    }),
+                    attempt,
+                ),
+            'stripe_membership_changed',
+        );
+        expectConflict(
+            () =>
+                assertStripeSessionMatchesCheckoutAttempt(
+                    session({ amountTotal: 0, lineItems: { data: [] } }),
+                    attempt,
+                ),
+            'stripe_membership_changed',
+        );
+        const repricedLine = session().lineItems?.data[0];
+        assert.ok(repricedLine?.price);
+        expectConflict(
+            () =>
+                assertStripeSessionMatchesCheckoutAttempt(
+                    session({
+                        lineItems: {
+                            data: [
+                                {
+                                    ...repricedLine,
+                                    price: {
+                                        ...repricedLine.price,
+                                        unit_amount: 351,
+                                    },
+                                },
+                            ],
+                        },
+                    }),
+                    attempt,
+                ),
+            'stripe_item_changed',
+        );
+        const retargetedProduct = repricedLine.price.product;
+        assert.ok(retargetedProduct && typeof retargetedProduct !== 'string');
+        expectConflict(
+            () =>
+                assertStripeSessionMatchesCheckoutAttempt(
+                    session({
+                        lineItems: {
+                            data: [
+                                {
+                                    ...repricedLine,
+                                    price: {
+                                        ...repricedLine.price,
+                                        product: {
+                                            ...retargetedProduct,
+                                            metadata: {
+                                                ...retargetedProduct.metadata,
+                                                positionIndex: '4',
+                                            },
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    }),
+                    attempt,
+                ),
+            'stripe_item_changed',
+        );
+        expectConflict(
+            () =>
+                assertStripeSessionMatchesCheckoutAttempt(
+                    session({
+                        lineItems: {
+                            data: [
+                                {
+                                    ...repricedLine,
+                                    price: {
+                                        ...repricedLine.price,
+                                        product: {
+                                            ...retargetedProduct,
+                                            metadata: {
+                                                ...retargetedProduct.metadata,
+                                                userId: 'user-2',
+                                            },
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    }),
+                    attempt,
+                ),
+            'stripe_item_changed',
+        );
+        expectConflict(
+            () =>
+                assertStripeSessionMatchesCheckoutAttempt(
+                    session({
+                        lineItems: {
+                            data: [repricedLine, repricedLine],
+                        },
+                    }),
+                    attempt,
+                ),
+            'stripe_membership_changed',
+        );
+    });
+});
+
+describe('immutable non-Stripe fulfillment inputs', () => {
+    it('replays the recorded amount and additional data independently of later catalog values', () => {
+        assert.equal(
+            getStripeCheckoutSnapshotNonStripeAmounts(attempt).get(42),
+            275,
+        );
+        assert.equal(
+            getStripeCheckoutSnapshotNonStripePaymentKinds(attempt).get(42),
+            'sunflower',
+        );
+        assert.deepEqual(
+            getStripeCheckoutSnapshotAdditionalData(attempt).get(42),
+            { scheduledDate: '2026-08-10T00:00:00.000Z' },
+        );
+    });
+});

--- a/apps/api/lib/checkout/stripeCheckoutSnapshot.ts
+++ b/apps/api/lib/checkout/stripeCheckoutSnapshot.ts
@@ -1,11 +1,22 @@
 import { randomUUID } from 'node:crypto';
 import {
+    fingerprintStripeCheckoutValue,
     type StripeCheckoutAttempt,
     StripeCheckoutAttemptConflictError,
     type StripeCheckoutAttemptSnapshot,
     type StripeCheckoutAttemptSnapshotItem,
+    serializeStripeCheckoutValue,
 } from '@gredice/storage';
+import type {
+    CheckoutItem,
+    StripeCheckoutReturnUrls,
+} from '@gredice/stripe/server';
 import type { ShoppingCartItemWithShopData } from './cartInfo';
+import type { CheckoutDeliverySelection } from './deliverySelection';
+import {
+    buildCheckoutAdditionalData,
+    encodeHarvestDatesMetadata,
+} from './harvestCheckout';
 import { calculateSunflowerAmount } from './sunflowerCalculations';
 
 export const stripeCheckoutAttemptMetadataKeys = {
@@ -16,6 +27,7 @@ export const stripeCheckoutAttemptMetadataKeys = {
 
 export type StripeCheckoutSessionForSnapshot = {
     amountTotal: number | null;
+    customerId?: string | { id: string } | null;
     id: string;
     lineItems?: {
         data: Array<{
@@ -40,22 +52,6 @@ type SnapshotMetadata = {
     attemptId: string;
     cartId: number;
 };
-
-function normalizedJson(value: unknown): string {
-    if (Array.isArray(value)) {
-        return `[${value.map(normalizedJson).join(',')}]`;
-    }
-    if (value && typeof value === 'object') {
-        return `{${Object.entries(value)
-            .sort(([left], [right]) => left.localeCompare(right))
-            .map(
-                ([key, entry]) =>
-                    `${JSON.stringify(key)}:${normalizedJson(entry)}`,
-            )
-            .join(',')}}`;
-    }
-    return JSON.stringify(value);
-}
 
 function parseOptionalInteger(value: string | null | undefined) {
     if (value === null || value === undefined || value === '') {
@@ -143,31 +139,38 @@ function getPaymentAmount(
 }
 
 export function buildStripeCheckoutAttemptSnapshot({
-    accountId,
     cartId,
     checkoutAdditionalDataByCartItemId,
+    customerId,
+    expiresAt,
     harvestDates,
     items,
+    returnUrls,
     userId,
 }: {
-    accountId: string;
     cartId: number;
     checkoutAdditionalDataByCartItemId: ReadonlyMap<number, unknown>;
+    customerId: string;
+    expiresAt?: Date;
     harvestDates: readonly {
         cartItemId: number;
         scheduledDate: string;
     }[];
     items: readonly ShoppingCartItemWithShopData[];
+    returnUrls: StripeCheckoutReturnUrls;
     userId: string;
 }): StripeCheckoutAttemptSnapshot {
     const snapshotItems = items.map((item) => {
         const paymentKind = getPaymentKind(item);
         return {
-            additionalData: item.additionalData,
+            additionalDataFingerprint: fingerprintStripeCheckoutValue(
+                item.additionalData,
+            ),
             amount: item.amount,
             cartId: item.cartId,
-            checkoutAdditionalData:
+            checkoutAdditionalDataFingerprint: fingerprintStripeCheckoutValue(
                 checkoutAdditionalDataByCartItemId.get(item.id) ?? {},
+            ),
             currency: item.currency,
             entityId: item.entityId,
             entityTypeName: item.entityTypeName,
@@ -196,7 +199,6 @@ export function buildStripeCheckoutAttemptSnapshot({
         } satisfies StripeCheckoutAttemptSnapshotItem;
     });
     return {
-        accountId,
         attemptId: randomUUID(),
         cartId,
         expectedNonStripeCartItemIds: snapshotItems.flatMap((item) =>
@@ -206,7 +208,51 @@ export function buildStripeCheckoutAttemptSnapshot({
         ),
         harvestDates: harvestDates.map((selection) => ({ ...selection })),
         items: snapshotItems,
-        userId,
+        stripeSession: {
+            allowPromotionCodes: true,
+            customerFingerprint: fingerprintStripeCheckoutValue(customerId),
+            expiresAt: expiresAt?.toISOString() ?? null,
+            items: items.flatMap((item) => {
+                const snapshotItem = snapshotItems.find(
+                    (candidate) => candidate.id === item.id,
+                );
+                if (snapshotItem?.paymentKind !== 'stripe') {
+                    return [];
+                }
+                const name = item.shopData.name;
+                if (!name) {
+                    throw new StripeCheckoutAttemptConflictError(
+                        'stripe_item_name_invalid',
+                    );
+                }
+                const imageUrls = item.shopData.image
+                    ? [
+                          /^https?:\/\//u.test(item.shopData.image)
+                              ? item.shopData.image
+                              : `https://www.gredice.com${item.shopData.image}`,
+                      ]
+                    : undefined;
+                return [
+                    {
+                        cartItemId: item.id,
+                        price: {
+                            currency: 'eur' as const,
+                            valueInCents: snapshotItem.paymentAmount,
+                        },
+                        product: {
+                            ...(item.shopData.description
+                                ? { description: item.shopData.description }
+                                : {}),
+                            ...(imageUrls ? { imageUrls } : {}),
+                            name,
+                        },
+                        quantity: item.amount,
+                    },
+                ];
+            }),
+            returnUrls,
+        },
+        userFingerprint: fingerprintStripeCheckoutValue(userId),
         version: 1,
     };
 }
@@ -254,10 +300,167 @@ function parseProductAdditionalData(value: string | undefined) {
     }
 }
 
+export function buildStripeCheckoutReplayInput({
+    accountId,
+    attempt,
+    checkoutAdditionalDataByCartItemId,
+    customerId,
+    userId,
+}: {
+    accountId: string;
+    attempt: StripeCheckoutAttempt;
+    checkoutAdditionalDataByCartItemId: ReadonlyMap<number, unknown>;
+    customerId: string;
+    userId: string;
+}) {
+    if (
+        fingerprintStripeCheckoutValue(customerId) !==
+            attempt.snapshot.stripeSession.customerFingerprint ||
+        fingerprintStripeCheckoutValue(userId) !==
+            attempt.snapshot.userFingerprint
+    ) {
+        throw new StripeCheckoutAttemptConflictError(
+            'checkout_identity_changed',
+        );
+    }
+    for (const item of attempt.snapshot.items) {
+        if (
+            fingerprintStripeCheckoutValue(
+                checkoutAdditionalDataByCartItemId.get(item.id) ?? {},
+            ) !== item.checkoutAdditionalDataFingerprint
+        ) {
+            throw new StripeCheckoutAttemptConflictError(
+                'checkout_additional_data_changed',
+            );
+        }
+    }
+
+    const items: CheckoutItem[] = attempt.snapshot.stripeSession.items.map(
+        (sessionItem) => {
+            const item = attempt.snapshot.items.find(
+                (candidate) => candidate.id === sessionItem.cartItemId,
+            );
+            if (item?.paymentKind !== 'stripe') {
+                throw new StripeCheckoutAttemptConflictError(
+                    'stripe_membership_changed',
+                );
+            }
+            return {
+                price: { ...sessionItem.price },
+                product: {
+                    ...sessionItem.product,
+                    metadata: {
+                        accountId,
+                        additionalData: serializeStripeCheckoutValue(
+                            checkoutAdditionalDataByCartItemId.get(item.id) ??
+                                {},
+                        ),
+                        cartId: attempt.snapshot.cartId,
+                        cartItemId: item.id.toString(),
+                        entityId: item.entityId,
+                        entityTypeName: item.entityTypeName,
+                        gardenId: item.gardenId,
+                        outletComparePriceCents:
+                            item.outlet?.comparePriceCents ?? null,
+                        outletInitialPlantStatus:
+                            item.outlet?.initialPlantStatus ?? null,
+                        outletOfferId: item.outlet?.offerId ?? null,
+                        outletPriceCents: item.outlet?.priceCents ?? null,
+                        outletReservationId: item.outlet?.reservationId ?? null,
+                        outletSowingDate: item.outlet?.sowingDate ?? null,
+                        positionIndex: item.positionIndex?.toString() ?? null,
+                        raisedBedId: item.raisedBedId,
+                        userId,
+                    },
+                },
+                quantity: sessionItem.quantity,
+            };
+        },
+    );
+    return {
+        data: {
+            allowPromotionCodes:
+                attempt.snapshot.stripeSession.allowPromotionCodes,
+            ...(attempt.snapshot.stripeSession.expiresAt
+                ? {
+                      expiresAt: new Date(
+                          attempt.snapshot.stripeSession.expiresAt,
+                      ),
+                  }
+                : {}),
+            items,
+            metadata: {
+                ...encodeHarvestDatesMetadata(
+                    attempt.snapshot.harvestDates,
+                    attempt.snapshot.expectedNonStripeCartItemIds,
+                ),
+                ...encodeStripeCheckoutAttemptMetadata(attempt.snapshot),
+            },
+        },
+        options: {
+            customerId,
+            idempotencyKey: attempt.snapshot.attemptId,
+            returnUrls: attempt.snapshot.stripeSession.returnUrls,
+        },
+    };
+}
+
+export function rebuildStripeCheckoutAttemptAdditionalData({
+    attempt,
+    deliveryInfo,
+    liveItems,
+}: {
+    attempt: StripeCheckoutAttempt;
+    deliveryInfo?: CheckoutDeliverySelection;
+    liveItems: readonly { additionalData: string | null; id: number }[];
+}) {
+    const liveItemsById = new Map(liveItems.map((item) => [item.id, item]));
+    const harvestDates = getStripeCheckoutSnapshotHarvestDates(attempt);
+    const result = new Map<number, unknown>();
+    for (const item of attempt.snapshot.items) {
+        const live = liveItemsById.get(item.id);
+        if (!live) {
+            throw new StripeCheckoutAttemptConflictError(
+                'cart_membership_changed',
+            );
+        }
+        const additionalData =
+            item.paymentKind === 'paid'
+                ? {}
+                : buildCheckoutAdditionalData({
+                      additionalData: live.additionalData,
+                      deliveryInfo,
+                      scheduledHarvestDate: harvestDates.get(item.id),
+                  });
+        if (
+            fingerprintStripeCheckoutValue(additionalData) !==
+            item.checkoutAdditionalDataFingerprint
+        ) {
+            throw new StripeCheckoutAttemptConflictError(
+                'checkout_additional_data_changed',
+            );
+        }
+        result.set(item.id, additionalData);
+    }
+    return result;
+}
+
 export function assertStripeSessionMatchesCheckoutAttempt(
     session: StripeCheckoutSessionForSnapshot,
     attempt: StripeCheckoutAttempt,
+    { accountId, userId }: { accountId: string; userId: string },
 ) {
+    const sessionCustomerId =
+        typeof session.customerId === 'string'
+            ? session.customerId
+            : session.customerId?.id;
+    if (
+        !sessionCustomerId ||
+        fingerprintStripeCheckoutValue(sessionCustomerId) !==
+            attempt.snapshot.stripeSession.customerFingerprint
+    ) {
+        throw new StripeCheckoutAttemptConflictError('stripe_customer_changed');
+    }
     const expectedStripeItems = attempt.snapshot.items.filter(
         (item) => item.paymentKind === 'stripe',
     );
@@ -293,8 +496,8 @@ export function assertStripeSessionMatchesCheckoutAttempt(
             !Number.isSafeInteger(lineAmount) ||
             lineAmount < 0 ||
             lineAmount > expected.paymentAmount * expected.amount ||
-            productMetadata.accountId !== attempt.snapshot.accountId ||
-            productMetadata.userId !== attempt.snapshot.userId ||
+            productMetadata.accountId !== accountId ||
+            productMetadata.userId !== userId ||
             Number(productMetadata.cartId) !== attempt.snapshot.cartId ||
             productMetadata.entityId !== expected.entityId ||
             productMetadata.entityTypeName !== expected.entityTypeName ||
@@ -305,9 +508,9 @@ export function assertStripeSessionMatchesCheckoutAttempt(
             parseOptionalInteger(productMetadata.positionIndex) !==
                 expected.positionIndex ||
             !outletMetadataMatchesSnapshot(productMetadata, expected.outlet) ||
-            normalizedJson(
+            fingerprintStripeCheckoutValue(
                 parseProductAdditionalData(productMetadata.additionalData),
-            ) !== normalizedJson(expected.checkoutAdditionalData)
+            ) !== expected.checkoutAdditionalDataFingerprint
         ) {
             throw new StripeCheckoutAttemptConflictError('stripe_item_changed');
         }
@@ -350,15 +553,114 @@ export function getStripeCheckoutSnapshotNonStripePaymentKinds(
     );
 }
 
-export function getStripeCheckoutSnapshotAdditionalData(
-    attempt: StripeCheckoutAttempt,
-) {
-    return new Map(
-        attempt.snapshot.items.map((item) => [
-            item.id,
-            item.checkoutAdditionalData,
-        ]),
-    );
+function parseCheckoutDeliverySelection(
+    value: unknown,
+): CheckoutDeliverySelection | undefined {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return undefined;
+    }
+    const slotId = Reflect.get(value, 'slotId');
+    const mode = Reflect.get(value, 'mode');
+    const addressId = Reflect.get(value, 'addressId');
+    const locationId = Reflect.get(value, 'locationId');
+    const notes = Reflect.get(value, 'notes');
+    if (
+        !Number.isSafeInteger(slotId) ||
+        (mode !== 'delivery' && mode !== 'pickup') ||
+        (addressId !== undefined && !Number.isSafeInteger(addressId)) ||
+        (locationId !== undefined && !Number.isSafeInteger(locationId)) ||
+        (notes !== undefined && typeof notes !== 'string')
+    ) {
+        throw new StripeCheckoutAttemptConflictError(
+            'stripe_delivery_data_invalid',
+        );
+    }
+    return {
+        ...(typeof addressId === 'number' ? { addressId } : {}),
+        ...(typeof locationId === 'number' ? { locationId } : {}),
+        mode,
+        ...(typeof notes === 'string' ? { notes } : {}),
+        slotId,
+    };
+}
+
+export function buildVerifiedStripeCheckoutAdditionalData({
+    attempt,
+    liveItems,
+    session,
+}: {
+    attempt: StripeCheckoutAttempt;
+    liveItems: readonly { additionalData: string | null; id: number }[];
+    session: StripeCheckoutSessionForSnapshot;
+}) {
+    const stripeAdditionalDataByCartItemId = new Map<number, unknown>();
+    const deliverySelections = new Map<string, CheckoutDeliverySelection>();
+    for (const lineItem of session.lineItems?.data ?? []) {
+        const product = lineItem.price?.product;
+        if (typeof product === 'string' || product?.deleted) {
+            continue;
+        }
+        const cartItemId = Number(product?.metadata?.cartItemId);
+        if (!Number.isSafeInteger(cartItemId) || cartItemId <= 0) {
+            continue;
+        }
+        const additionalData = parseProductAdditionalData(
+            product?.metadata?.additionalData,
+        );
+        stripeAdditionalDataByCartItemId.set(cartItemId, additionalData);
+        if (
+            additionalData &&
+            typeof additionalData === 'object' &&
+            !Array.isArray(additionalData)
+        ) {
+            const delivery = parseCheckoutDeliverySelection(
+                Reflect.get(additionalData, 'delivery'),
+            );
+            if (delivery) {
+                deliverySelections.set(
+                    fingerprintStripeCheckoutValue(delivery),
+                    delivery,
+                );
+            }
+        }
+    }
+    if (deliverySelections.size > 1) {
+        throw new StripeCheckoutAttemptConflictError(
+            'stripe_delivery_data_changed',
+        );
+    }
+    const deliveryInfo = deliverySelections.values().next().value;
+    const liveItemsById = new Map(liveItems.map((item) => [item.id, item]));
+    const harvestDates = getStripeCheckoutSnapshotHarvestDates(attempt);
+    const verified = new Map<number, unknown>();
+    for (const item of attempt.snapshot.items) {
+        const live = liveItemsById.get(item.id);
+        if (!live) {
+            throw new StripeCheckoutAttemptConflictError(
+                'cart_membership_changed',
+            );
+        }
+        const additionalData =
+            item.paymentKind === 'stripe'
+                ? stripeAdditionalDataByCartItemId.get(item.id)
+                : item.paymentKind === 'paid'
+                  ? {}
+                  : buildCheckoutAdditionalData({
+                        additionalData: live.additionalData,
+                        deliveryInfo,
+                        scheduledHarvestDate: harvestDates.get(item.id),
+                    });
+        if (
+            fingerprintStripeCheckoutValue(additionalData ?? {}) !==
+            item.checkoutAdditionalDataFingerprint
+        ) {
+            throw new StripeCheckoutAttemptConflictError(
+                'checkout_additional_data_changed',
+            );
+        }
+        verified.set(item.id, additionalData ?? {});
+    }
+    return verified;
 }
 
 export function getStripeCheckoutSnapshotHarvestDates(

--- a/apps/api/lib/checkout/stripeCheckoutSnapshot.ts
+++ b/apps/api/lib/checkout/stripeCheckoutSnapshot.ts
@@ -1,0 +1,373 @@
+import { randomUUID } from 'node:crypto';
+import {
+    type StripeCheckoutAttempt,
+    StripeCheckoutAttemptConflictError,
+    type StripeCheckoutAttemptSnapshot,
+    type StripeCheckoutAttemptSnapshotItem,
+} from '@gredice/storage';
+import type { ShoppingCartItemWithShopData } from './cartInfo';
+import { calculateSunflowerAmount } from './sunflowerCalculations';
+
+export const stripeCheckoutAttemptMetadataKeys = {
+    attemptId: 'checkoutAttemptId',
+    cartId: 'checkoutCartId',
+    version: 'checkoutSnapshotVersion',
+} as const;
+
+export type StripeCheckoutSessionForSnapshot = {
+    amountTotal: number | null;
+    id: string;
+    lineItems?: {
+        data: Array<{
+            amount_total?: number | null;
+            price?: {
+                currency?: string | null;
+                product?:
+                    | string
+                    | {
+                          deleted?: unknown;
+                          metadata?: Record<string, string | undefined>;
+                      }
+                    | null;
+                unit_amount?: number | null;
+            } | null;
+            quantity?: number | null;
+        }>;
+    } | null;
+};
+
+type SnapshotMetadata = {
+    attemptId: string;
+    cartId: number;
+};
+
+function normalizedJson(value: unknown): string {
+    if (Array.isArray(value)) {
+        return `[${value.map(normalizedJson).join(',')}]`;
+    }
+    if (value && typeof value === 'object') {
+        return `{${Object.entries(value)
+            .sort(([left], [right]) => left.localeCompare(right))
+            .map(
+                ([key, entry]) =>
+                    `${JSON.stringify(key)}:${normalizedJson(entry)}`,
+            )
+            .join(',')}}`;
+    }
+    return JSON.stringify(value);
+}
+
+function parseOptionalInteger(value: string | null | undefined) {
+    if (value === null || value === undefined || value === '') {
+        return null;
+    }
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) ? parsed : Number.NaN;
+}
+
+function parseOptionalString(value: string | null | undefined) {
+    return value === null || value === undefined || value === '' ? null : value;
+}
+
+function outletMetadataMatchesSnapshot(
+    metadata: Record<string, string | undefined>,
+    outlet: StripeCheckoutAttemptSnapshotItem['outlet'],
+) {
+    if (!outlet) {
+        return (
+            parseOptionalInteger(metadata.outletOfferId) === null &&
+            parseOptionalInteger(metadata.outletReservationId) === null &&
+            parseOptionalString(metadata.outletSowingDate) === null &&
+            parseOptionalString(metadata.outletInitialPlantStatus) === null &&
+            parseOptionalInteger(metadata.outletPriceCents) === null &&
+            parseOptionalInteger(metadata.outletComparePriceCents) === null
+        );
+    }
+    return (
+        parseOptionalInteger(metadata.outletOfferId) === outlet.offerId &&
+        parseOptionalInteger(metadata.outletReservationId) ===
+            outlet.reservationId &&
+        metadata.outletSowingDate === outlet.sowingDate &&
+        metadata.outletInitialPlantStatus === outlet.initialPlantStatus &&
+        parseOptionalInteger(metadata.outletPriceCents) === outlet.priceCents &&
+        parseOptionalInteger(metadata.outletComparePriceCents) ===
+            outlet.comparePriceCents
+    );
+}
+
+function getPaymentKind(item: ShoppingCartItemWithShopData) {
+    if (item.status === 'paid') {
+        return 'paid' as const;
+    }
+    if (item.currency === 'eur') {
+        return 'stripe' as const;
+    }
+    if (item.currency === 'sunflower') {
+        return 'sunflower' as const;
+    }
+    if (item.currency === 'inventory' || item.usesInventory) {
+        return 'inventory' as const;
+    }
+    throw new StripeCheckoutAttemptConflictError(
+        'unsupported_payment_currency',
+    );
+}
+
+function getPaymentAmount(
+    item: ShoppingCartItemWithShopData,
+    paymentKind: StripeCheckoutAttemptSnapshotItem['paymentKind'],
+) {
+    if (paymentKind === 'stripe') {
+        const price =
+            typeof item.shopData.discountPrice === 'number'
+                ? item.shopData.discountPrice
+                : item.shopData.price;
+        const cents = typeof price === 'number' ? Math.round(price * 100) : 0;
+        if (!Number.isSafeInteger(cents) || cents <= 0) {
+            throw new StripeCheckoutAttemptConflictError(
+                'stripe_amount_invalid',
+            );
+        }
+        return cents;
+    }
+    if (paymentKind === 'sunflower') {
+        const amount = calculateSunflowerAmount(item);
+        if (!Number.isSafeInteger(amount) || amount <= 0) {
+            throw new StripeCheckoutAttemptConflictError(
+                'sunflower_amount_invalid',
+            );
+        }
+        return amount;
+    }
+    return 0;
+}
+
+export function buildStripeCheckoutAttemptSnapshot({
+    accountId,
+    cartId,
+    checkoutAdditionalDataByCartItemId,
+    harvestDates,
+    items,
+    userId,
+}: {
+    accountId: string;
+    cartId: number;
+    checkoutAdditionalDataByCartItemId: ReadonlyMap<number, unknown>;
+    harvestDates: readonly {
+        cartItemId: number;
+        scheduledDate: string;
+    }[];
+    items: readonly ShoppingCartItemWithShopData[];
+    userId: string;
+}): StripeCheckoutAttemptSnapshot {
+    const snapshotItems = items.map((item) => {
+        const paymentKind = getPaymentKind(item);
+        return {
+            additionalData: item.additionalData,
+            amount: item.amount,
+            cartId: item.cartId,
+            checkoutAdditionalData:
+                checkoutAdditionalDataByCartItemId.get(item.id) ?? {},
+            currency: item.currency,
+            entityId: item.entityId,
+            entityTypeName: item.entityTypeName,
+            gardenId: item.gardenId,
+            id: item.id,
+            ...(item.outlet
+                ? {
+                      outlet: {
+                          comparePriceCents:
+                              typeof item.outlet.comparePrice === 'number'
+                                  ? Math.round(item.outlet.comparePrice * 100)
+                                  : null,
+                          initialPlantStatus: item.outlet.initialPlantStatus,
+                          offerId: item.outlet.offerId,
+                          priceCents: Math.round(item.outlet.outletPrice * 100),
+                          reservationId: item.outlet.reservationId,
+                          sowingDate: item.outlet.sowingDate.toISOString(),
+                      },
+                  }
+                : {}),
+            paymentAmount: getPaymentAmount(item, paymentKind),
+            paymentKind,
+            positionIndex: item.positionIndex,
+            raisedBedId: item.raisedBedId,
+            status: item.status === 'paid' ? 'paid' : 'new',
+        } satisfies StripeCheckoutAttemptSnapshotItem;
+    });
+    return {
+        accountId,
+        attemptId: randomUUID(),
+        cartId,
+        expectedNonStripeCartItemIds: snapshotItems.flatMap((item) =>
+            item.paymentKind === 'sunflower' || item.paymentKind === 'inventory'
+                ? [item.id]
+                : [],
+        ),
+        harvestDates: harvestDates.map((selection) => ({ ...selection })),
+        items: snapshotItems,
+        userId,
+        version: 1,
+    };
+}
+
+export function encodeStripeCheckoutAttemptMetadata(
+    snapshot: StripeCheckoutAttemptSnapshot,
+) {
+    return {
+        [stripeCheckoutAttemptMetadataKeys.attemptId]: snapshot.attemptId,
+        [stripeCheckoutAttemptMetadataKeys.cartId]: snapshot.cartId,
+        [stripeCheckoutAttemptMetadataKeys.version]: snapshot.version,
+    };
+}
+
+export function decodeStripeCheckoutAttemptMetadata(
+    metadata: Record<string, string> | null | undefined,
+): SnapshotMetadata | null {
+    const attemptId = metadata?.[stripeCheckoutAttemptMetadataKeys.attemptId];
+    const cartIdValue = metadata?.[stripeCheckoutAttemptMetadataKeys.cartId];
+    const version = metadata?.[stripeCheckoutAttemptMetadataKeys.version];
+    if (!attemptId && !cartIdValue && !version) {
+        return null;
+    }
+    const cartId = Number(cartIdValue);
+    if (
+        !attemptId ||
+        !Number.isSafeInteger(cartId) ||
+        cartId <= 0 ||
+        version !== '1'
+    ) {
+        throw new StripeCheckoutAttemptConflictError(
+            'session_metadata_invalid',
+        );
+    }
+    return { attemptId, cartId };
+}
+
+function parseProductAdditionalData(value: string | undefined) {
+    try {
+        return value ? JSON.parse(value) : {};
+    } catch {
+        throw new StripeCheckoutAttemptConflictError(
+            'stripe_additional_data_invalid',
+        );
+    }
+}
+
+export function assertStripeSessionMatchesCheckoutAttempt(
+    session: StripeCheckoutSessionForSnapshot,
+    attempt: StripeCheckoutAttempt,
+) {
+    const expectedStripeItems = attempt.snapshot.items.filter(
+        (item) => item.paymentKind === 'stripe',
+    );
+    const expectedById = new Map(
+        expectedStripeItems.map((item) => [item.id, item]),
+    );
+    const seen = new Set<number>();
+    let lineAmountTotal = 0;
+
+    for (const lineItem of session.lineItems?.data ?? []) {
+        const product = lineItem.price?.product;
+        if (typeof product === 'string' || product?.deleted) {
+            throw new StripeCheckoutAttemptConflictError(
+                'stripe_product_unavailable',
+            );
+        }
+        const productMetadata = product?.metadata ?? {};
+        const cartItemId = Number(productMetadata.cartItemId);
+        const expected = expectedById.get(cartItemId);
+        if (!expected || seen.has(cartItemId)) {
+            throw new StripeCheckoutAttemptConflictError(
+                'stripe_membership_changed',
+            );
+        }
+        seen.add(cartItemId);
+        const lineAmount = lineItem.amount_total;
+        const unitAmount = lineItem.price?.unit_amount;
+        if (
+            lineItem.quantity !== expected.amount ||
+            lineItem.price?.currency !== 'eur' ||
+            unitAmount !== expected.paymentAmount ||
+            typeof lineAmount !== 'number' ||
+            !Number.isSafeInteger(lineAmount) ||
+            lineAmount < 0 ||
+            lineAmount > expected.paymentAmount * expected.amount ||
+            productMetadata.accountId !== attempt.snapshot.accountId ||
+            productMetadata.userId !== attempt.snapshot.userId ||
+            Number(productMetadata.cartId) !== attempt.snapshot.cartId ||
+            productMetadata.entityId !== expected.entityId ||
+            productMetadata.entityTypeName !== expected.entityTypeName ||
+            parseOptionalInteger(productMetadata.gardenId) !==
+                expected.gardenId ||
+            parseOptionalInteger(productMetadata.raisedBedId) !==
+                expected.raisedBedId ||
+            parseOptionalInteger(productMetadata.positionIndex) !==
+                expected.positionIndex ||
+            !outletMetadataMatchesSnapshot(productMetadata, expected.outlet) ||
+            normalizedJson(
+                parseProductAdditionalData(productMetadata.additionalData),
+            ) !== normalizedJson(expected.checkoutAdditionalData)
+        ) {
+            throw new StripeCheckoutAttemptConflictError('stripe_item_changed');
+        }
+        lineAmountTotal += lineAmount;
+    }
+
+    if (
+        seen.size !== expectedStripeItems.length ||
+        lineAmountTotal !== session.amountTotal
+    ) {
+        throw new StripeCheckoutAttemptConflictError(
+            seen.size !== expectedStripeItems.length
+                ? 'stripe_membership_changed'
+                : 'stripe_total_changed',
+        );
+    }
+}
+
+export function getStripeCheckoutSnapshotNonStripeAmounts(
+    attempt: StripeCheckoutAttempt,
+) {
+    return new Map(
+        attempt.snapshot.items.flatMap((item) =>
+            item.paymentKind === 'sunflower'
+                ? [[item.id, item.paymentAmount] as const]
+                : [],
+        ),
+    );
+}
+
+export function getStripeCheckoutSnapshotNonStripePaymentKinds(
+    attempt: StripeCheckoutAttempt,
+) {
+    return new Map(
+        attempt.snapshot.items.flatMap((item) =>
+            item.paymentKind === 'sunflower' || item.paymentKind === 'inventory'
+                ? [[item.id, item.paymentKind] as const]
+                : [],
+        ),
+    );
+}
+
+export function getStripeCheckoutSnapshotAdditionalData(
+    attempt: StripeCheckoutAttempt,
+) {
+    return new Map(
+        attempt.snapshot.items.map((item) => [
+            item.id,
+            item.checkoutAdditionalData,
+        ]),
+    );
+}
+
+export function getStripeCheckoutSnapshotHarvestDates(
+    attempt: StripeCheckoutAttempt,
+) {
+    return new Map(
+        attempt.snapshot.harvestDates.map((selection) => [
+            selection.cartItemId,
+            selection.scheduledDate,
+        ]),
+    );
+}

--- a/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
@@ -78,6 +78,10 @@ function makeDependencies(
         convertOutletReservationForCartItem: async (...args: unknown[]) => {
             record(calls, 'convertOutletReservationForCartItem', args);
         },
+        bindStripeCheckoutAttempt: async (...args: unknown[]) => {
+            record(calls, 'bindStripeCheckoutAttempt', args);
+            return undefined;
+        },
         getOrCreateDeliveryRequest: async (...args: unknown[]) => {
             record(calls, 'getOrCreateDeliveryRequest', args);
             return { created: true, requestId: 'delivery-request-701' };
@@ -185,6 +189,10 @@ function makeDependencies(
             return [];
         },
         getShoppingCart: readShoppingCart,
+        getStripeCheckoutAttempt: async (...args: unknown[]) => {
+            record(calls, 'getStripeCheckoutAttempt', args);
+            return undefined;
+        },
         getUser: async (...args: unknown[]) => {
             record(calls, 'getUser', args);
             return { userName: 'buyer@example.test' };
@@ -251,6 +259,9 @@ function makeDependencies(
         },
         setCartItemPaid: async (...args: unknown[]) => {
             record(calls, 'setCartItemPaid', args);
+        },
+        releaseStripeCheckoutAttempt: async (...args: unknown[]) => {
+            record(calls, 'releaseStripeCheckoutAttempt', args);
         },
         spendSunflowersBatch: async (...args: unknown[]) => {
             record(calls, 'spendSunflowersBatch', args);
@@ -366,6 +377,10 @@ function makeDependencies(
         ) => {
             record(calls, 'withStripePaymentProcessingLock', [id]);
             return callback();
+        },
+        verifyStripeCheckoutAttemptLiveCart: async (...args: unknown[]) => {
+            record(calls, 'verifyStripeCheckoutAttemptLiveCart', args);
+            return [];
         },
         getStripeCheckoutSession: async (...args: unknown[]) => {
             record(calls, 'getStripeCheckoutSession', args);
@@ -986,6 +1001,182 @@ describe('processCheckoutSession', () => {
         assert.equal(
             callsNamed(calls, 'ensureInvoiceForTransaction').length,
             0,
+        );
+    });
+
+    it('uses captured sunflower amount when the catalog price changes while Stripe is open', async () => {
+        const calls: RecordedCall[] = [];
+        const createdAt = new Date('2026-07-01T09:00:00.000Z');
+        const euroItem = {
+            additionalData: null,
+            amount: 1,
+            cartId: 100,
+            createdAt,
+            currency: 'eur',
+            entityId: '42',
+            entityTypeName: 'operation',
+            gardenId: 200,
+            id: 1,
+            isDeleted: false,
+            positionIndex: 2,
+            raisedBedId: 300,
+            status: 'paid',
+            updatedAt: createdAt,
+        };
+        const sunflowerItem = {
+            ...euroItem,
+            additionalData: JSON.stringify({
+                scheduledDate: '2026-07-01',
+            }),
+            currency: 'sunflower',
+            entityId: '99',
+            id: 2,
+            positionIndex: 3,
+            status: 'new',
+        };
+        const cart = {
+            accountId: 'account-1',
+            createdAt,
+            id: 100,
+            isDeleted: false,
+            items: [euroItem, sunflowerItem],
+            status: 'new',
+            updatedAt: createdAt,
+        };
+        const attempt = {
+            sessionId: 'cs_snapshot_drift',
+            snapshot: {
+                accountId: 'account-1',
+                attemptId: '5fe9b460-9b8d-4dd0-90a9-d05e46a3b0d5',
+                cartId: 100,
+                expectedNonStripeCartItemIds: [2],
+                harvestDates: [],
+                items: [
+                    {
+                        additionalData: null,
+                        amount: 1,
+                        cartId: 100,
+                        checkoutAdditionalData: {
+                            scheduledDate: '2026-07-01',
+                        },
+                        currency: 'eur',
+                        entityId: '42',
+                        entityTypeName: 'operation',
+                        gardenId: 200,
+                        id: 1,
+                        paymentAmount: 2500,
+                        paymentKind: 'stripe' as const,
+                        positionIndex: 2,
+                        raisedBedId: 300,
+                        status: 'new' as const,
+                    },
+                    {
+                        additionalData: sunflowerItem.additionalData,
+                        amount: 1,
+                        cartId: 100,
+                        checkoutAdditionalData: {
+                            scheduledDate: '2026-07-01',
+                        },
+                        currency: 'sunflower',
+                        entityId: '99',
+                        entityTypeName: 'operation',
+                        gardenId: 200,
+                        id: 2,
+                        paymentAmount: 275,
+                        paymentKind: 'sunflower' as const,
+                        positionIndex: 3,
+                        raisedBedId: 300,
+                        status: 'new' as const,
+                    },
+                ],
+                userId: 'user-1',
+                version: 1 as const,
+            },
+        };
+        const enrichedItems = [
+            {
+                ...euroItem,
+                entityData: { attributes: { deliverable: false } },
+                inventoryAvailable: 0,
+                shopData: { price: 25 },
+                usesInventory: false,
+            },
+            {
+                ...sunflowerItem,
+                entityData: { attributes: { deliverable: false } },
+                inventoryAvailable: 0,
+                // The live catalog has drifted from 0.275 to 999. The debit
+                // must still use the amount captured before Stripe opened.
+                shopData: { price: 999 },
+                usesInventory: false,
+            },
+        ];
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async () => ({
+                ...makeSession(),
+                id: 'cs_snapshot_drift',
+                metadata: {
+                    checkoutAttemptId: attempt.snapshot.attemptId,
+                    checkoutCartId: '100',
+                    checkoutSnapshotVersion: '1',
+                    harvestDatesChunkCount: '0',
+                    harvestDatesVersion: '1',
+                    nonStripeCartItemIds0: '[2]',
+                    nonStripeCartItemIdsChunkCount: '1',
+                },
+                lineItems: {
+                    data: [
+                        {
+                            ...makeSession().lineItems.data[0],
+                            price: {
+                                ...makeSession().lineItems.data[0]?.price,
+                                currency: 'eur',
+                                unit_amount: 2500,
+                            },
+                        },
+                    ],
+                },
+            }),
+            getStripeCheckoutAttempt: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutAttempt', args);
+                return attempt;
+            },
+            verifyStripeCheckoutAttemptLiveCart: async (...args: unknown[]) => {
+                record(calls, 'verifyStripeCheckoutAttemptLiveCart', args);
+                return cart.items;
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                return cart;
+            },
+            normalizeShoppingCartInventoryUsage: async (...args: unknown[]) => {
+                record(calls, 'normalizeShoppingCartInventoryUsage', args);
+                return cart;
+            },
+            getCartInfo: async (...args: unknown[]) => {
+                record(calls, 'getCartInfo', args);
+                return {
+                    // A live EUR catalog price can now fail the minimum-order
+                    // validation, but it must not strand an already captured
+                    // Stripe checkout snapshot.
+                    allowPurchase: false,
+                    notes: ['live catalog value is below the minimum'],
+                    items: enrichedItems,
+                };
+            },
+        });
+
+        await processCheckoutSession('cs_snapshot_drift', dependencies);
+
+        const spend = callsNamed(calls, 'spendSunflowersBatch')[0];
+        assert.ok(spend);
+        assert.deepStrictEqual(spend.args[1], [
+            { amount: 275, reason: 'shoppingCartItem:2' },
+        ]);
+        assert.equal(callsNamed(calls, 'calculateSunflowerAmount').length, 0);
+        assert.equal(
+            callsNamed(calls, 'releaseStripeCheckoutAttempt').length,
+            1,
         );
     });
 

--- a/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
@@ -476,6 +476,23 @@ function makeSession() {
     };
 }
 
+function makeSnapshotMetadata() {
+    return {
+        checkoutAttemptId: '5fe9b460-9b8d-4dd0-90a9-d05e46a3b0d5',
+        checkoutCartId: '100',
+        checkoutSnapshotVersion: '1',
+    };
+}
+
+function makeNoPaymentRequiredSnapshotSession(amountTotal = 0) {
+    return {
+        ...makeSession(),
+        amountTotal,
+        metadata: makeSnapshotMetadata(),
+        paymentStatus: 'no_payment_required',
+    };
+}
+
 function makePlantingSession() {
     const session = makeSession();
     const [lineItem] = session.lineItems.data;
@@ -921,6 +938,95 @@ describe('processCheckoutSession', () => {
         ]);
         assert.equal(callsNamed(calls, 'createTransaction').length, 0);
         assert.equal(callsNamed(calls, 'setCartItemPaid').length, 0);
+    });
+
+    it('accepts a zero-total no-payment-required snapshot and tolerates absent attempt history on completed replay', async () => {
+        const calls: RecordedCall[] = [];
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return makeNoPaymentRequiredSnapshotSession();
+            },
+            getCompletedTransactionByStripePaymentId: async (
+                ...args: unknown[]
+            ) => {
+                record(calls, 'getCompletedTransactionByStripePaymentId', args);
+                return { id: 123 };
+            },
+        });
+
+        await processCheckoutSession('cs_paid', dependencies);
+
+        assert.deepStrictEqual(callNames(calls), [
+            'getStripeCheckoutSession',
+            'withStripePaymentProcessingLock',
+            'getCompletedTransactionByStripePaymentId',
+            'getStripeCheckoutAttempt',
+        ]);
+        assert.equal(
+            callsNamed(calls, 'releaseStripeCheckoutAttempt').length,
+            0,
+        );
+        assert.equal(callsNamed(calls, 'createTransaction').length, 0);
+        assert.equal(callsNamed(calls, 'setCartItemPaid').length, 0);
+    });
+
+    it('still requires attempt history for first fulfillment of a zero-total no-payment-required snapshot', async () => {
+        const calls: RecordedCall[] = [];
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return makeNoPaymentRequiredSnapshotSession();
+            },
+        });
+
+        await assert.rejects(
+            processCheckoutSession('cs_paid', dependencies),
+            /Stripe checkout attempt conflict \(attempt_missing\)\./u,
+        );
+
+        assert.equal(
+            callsNamed(calls, 'withStripePaymentProcessingLock').length,
+            1,
+        );
+        assert.equal(callsNamed(calls, 'getStripeCheckoutAttempt').length, 1);
+        assert.equal(callsNamed(calls, 'createTransaction').length, 0);
+        assert.equal(callsNamed(calls, 'setCartItemPaid').length, 0);
+    });
+
+    it('rejects unpaid sessions and no-payment-required sessions without both a zero total and snapshot metadata', async () => {
+        const rejectedSessions = [
+            {
+                ...makeNoPaymentRequiredSnapshotSession(1),
+                id: 'cs_nonzero_no_payment_required',
+            },
+            {
+                ...makeNoPaymentRequiredSnapshotSession(),
+                id: 'cs_no_snapshot',
+                metadata: undefined,
+            },
+            {
+                ...makeNoPaymentRequiredSnapshotSession(),
+                id: 'cs_unpaid',
+                paymentStatus: 'unpaid',
+            },
+        ];
+
+        for (const session of rejectedSessions) {
+            const calls: RecordedCall[] = [];
+            const dependencies = makeDependencies(calls, {
+                getStripeCheckoutSession: async (...args: unknown[]) => {
+                    record(calls, 'getStripeCheckoutSession', args);
+                    return session;
+                },
+            });
+
+            await processCheckoutSession(session.id, dependencies);
+
+            assert.deepStrictEqual(callNames(calls), [
+                'getStripeCheckoutSession',
+            ]);
+        }
     });
 
     it('marks a Stripe-paid cart item paid, records the transaction, and awards sunflowers', async () => {

--- a/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { SunflowerPackageAlreadyPurchasedError } from '@gredice/storage';
+import {
+    fingerprintStripeCheckoutValue,
+    SunflowerPackageAlreadyPurchasedError,
+} from '@gredice/storage';
 import {
     buildCheckoutInvoiceBillingSnapshot,
     buildCheckoutInvoiceLineItem,
@@ -193,6 +196,10 @@ function makeDependencies(
             record(calls, 'getStripeCheckoutAttempt', args);
             return undefined;
         },
+        getAccountUsers: async (...args: unknown[]) => {
+            record(calls, 'getAccountUsers', args);
+            return [{ userId: 'user-1' }];
+        },
         getUser: async (...args: unknown[]) => {
             record(calls, 'getUser', args);
             return { userName: 'buyer@example.test' };
@@ -380,7 +387,7 @@ function makeDependencies(
         },
         verifyStripeCheckoutAttemptLiveCart: async (...args: unknown[]) => {
             record(calls, 'verifyStripeCheckoutAttemptLiveCart', args);
-            return [];
+            return { accountId: 'account-1', items: [] };
         },
         getStripeCheckoutSession: async (...args: unknown[]) => {
             record(calls, 'getStripeCheckoutSession', args);
@@ -439,6 +446,7 @@ function makeDependencies(
 
 function makeSession() {
     return {
+        customerId: 'cus_1',
         id: 'cs_paid',
         status: 'complete',
         paymentStatus: 'paid',
@@ -1152,19 +1160,20 @@ describe('processCheckoutSession', () => {
         const attempt = {
             sessionId: 'cs_snapshot_drift',
             snapshot: {
-                accountId: 'account-1',
                 attemptId: '5fe9b460-9b8d-4dd0-90a9-d05e46a3b0d5',
                 cartId: 100,
                 expectedNonStripeCartItemIds: [2],
                 harvestDates: [],
                 items: [
                     {
-                        additionalData: null,
+                        additionalDataFingerprint:
+                            fingerprintStripeCheckoutValue(null),
                         amount: 1,
                         cartId: 100,
-                        checkoutAdditionalData: {
-                            scheduledDate: '2026-07-01',
-                        },
+                        checkoutAdditionalDataFingerprint:
+                            fingerprintStripeCheckoutValue({
+                                scheduledDate: '2026-07-01',
+                            }),
                         currency: 'eur',
                         entityId: '42',
                         entityTypeName: 'operation',
@@ -1177,12 +1186,16 @@ describe('processCheckoutSession', () => {
                         status: 'new' as const,
                     },
                     {
-                        additionalData: sunflowerItem.additionalData,
+                        additionalDataFingerprint:
+                            fingerprintStripeCheckoutValue(
+                                sunflowerItem.additionalData,
+                            ),
                         amount: 1,
                         cartId: 100,
-                        checkoutAdditionalData: {
-                            scheduledDate: '2026-07-01',
-                        },
+                        checkoutAdditionalDataFingerprint:
+                            fingerprintStripeCheckoutValue({
+                                scheduledDate: '2026-07-01',
+                            }),
                         currency: 'sunflower',
                         entityId: '99',
                         entityTypeName: 'operation',
@@ -1195,7 +1208,28 @@ describe('processCheckoutSession', () => {
                         status: 'new' as const,
                     },
                 ],
-                userId: 'user-1',
+                stripeSession: {
+                    allowPromotionCodes: true,
+                    customerFingerprint:
+                        fingerprintStripeCheckoutValue('cus_1'),
+                    expiresAt: '2026-08-04T00:00:00.000Z',
+                    items: [
+                        {
+                            cartItemId: 1,
+                            price: {
+                                currency: 'eur' as const,
+                                valueInCents: 2500,
+                            },
+                            product: { name: 'Planting' },
+                            quantity: 1,
+                        },
+                    ],
+                    returnUrls: {
+                        cancel: 'https://example.test/cancel',
+                        success: 'https://example.test/success',
+                    },
+                },
+                userFingerprint: fingerprintStripeCheckoutValue('user-1'),
                 version: 1 as const,
             },
         };
@@ -1249,7 +1283,7 @@ describe('processCheckoutSession', () => {
             },
             verifyStripeCheckoutAttemptLiveCart: async (...args: unknown[]) => {
                 record(calls, 'verifyStripeCheckoutAttemptLiveCart', args);
-                return cart.items;
+                return { accountId: 'account-1', items: cart.items };
             },
             getShoppingCart: async (...args: unknown[]) => {
                 record(calls, 'getShoppingCart', args);

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -12,6 +12,7 @@ import {
     notifyPurchase,
 } from '@gredice/notifications';
 import {
+    bindStripeCheckoutAttempt,
     type CheckoutPlantingRaisedBedActivation,
     consumeInventoryItem,
     convertOutletReservationForCartItem,
@@ -32,6 +33,7 @@ import {
     getRaisedBed,
     getRaisedBedFieldsWithEvents,
     getShoppingCart,
+    getStripeCheckoutAttempt,
     getSunflowerPackageByCode,
     getUser,
     hasMatchingCheckoutPlantingPurchase,
@@ -44,12 +46,16 @@ import {
     normalizeShoppingCartInventoryUsage,
     normalizeShoppingCartScheduledDates,
     processReferralRewardsForAccount,
+    releaseStripeCheckoutAttempt,
+    type StripeCheckoutAttempt,
+    StripeCheckoutAttemptConflictError,
     SunflowerPackageAlreadyPurchasedError,
     setCartItemPaid,
     spendSunflowersBatch,
     sunflowerPackageEntityTypeName,
     topUpSunflowerPackage,
     upsertRaisedBedField,
+    verifyStripeCheckoutAttemptLiveCart,
     withCheckoutCartItemLock,
     withCheckoutCartItemLocks,
     withCheckoutCartItemProcessingLock,
@@ -79,6 +85,14 @@ import {
     notifyOrderConfirmationEmail,
 } from '../checkout/orderConfirmationEmail';
 import {
+    assertStripeSessionMatchesCheckoutAttempt,
+    decodeStripeCheckoutAttemptMetadata,
+    getStripeCheckoutSnapshotAdditionalData,
+    getStripeCheckoutSnapshotHarvestDates,
+    getStripeCheckoutSnapshotNonStripeAmounts,
+    getStripeCheckoutSnapshotNonStripePaymentKinds,
+} from '../checkout/stripeCheckoutSnapshot';
+import {
     calculateSunflowerAmount,
     calculateSunflowerReplayAmount,
 } from '../checkout/sunflowerCalculations';
@@ -90,6 +104,7 @@ export type ProcessCheckoutSessionDependencies = {
     notifyPurchase: typeof notifyPurchase;
     consumeInventoryItem: typeof consumeInventoryItem;
     convertOutletReservationForCartItem: typeof convertOutletReservationForCartItem;
+    bindStripeCheckoutAttempt: typeof bindStripeCheckoutAttempt;
     getOrCreateDeliveryRequest: typeof getOrCreateDeliveryRequest;
     createEvent: typeof createEvent;
     createNotificationWithStatus: typeof createNotificationWithStatus;
@@ -109,6 +124,7 @@ export type ProcessCheckoutSessionDependencies = {
     getRaisedBed: typeof getRaisedBed;
     getRaisedBedFieldsWithEvents: typeof getRaisedBedFieldsWithEvents;
     getShoppingCart: typeof getShoppingCart;
+    getStripeCheckoutAttempt: typeof getStripeCheckoutAttempt;
     getUser: typeof getUser;
     isCartItemDeliverable: typeof isCartItemDeliverable;
     knownEvents: typeof knownEvents;
@@ -119,6 +135,7 @@ export type ProcessCheckoutSessionDependencies = {
     normalizeShoppingCartScheduledDates: typeof normalizeShoppingCartScheduledDates;
     processReferralRewardsForAccount: typeof processReferralRewardsForAccount;
     setCartItemPaid: typeof setCartItemPaid;
+    releaseStripeCheckoutAttempt: typeof releaseStripeCheckoutAttempt;
     spendSunflowersBatch: typeof spendSunflowersBatch;
     topUpSunflowerPackage: typeof topUpSunflowerPackage;
     upsertRaisedBedField: typeof upsertRaisedBedField;
@@ -129,6 +146,7 @@ export type ProcessCheckoutSessionDependencies = {
     withCheckoutCartItemProcessingLocks: typeof withCheckoutCartItemProcessingLocks;
     withInventoryAccountTransaction: typeof withInventoryAccountTransaction;
     withStripePaymentProcessingLock: typeof withStripePaymentProcessingLock;
+    verifyStripeCheckoutAttemptLiveCart: typeof verifyStripeCheckoutAttemptLiveCart;
     getStripeCheckoutSession: typeof getStripeCheckoutSession;
     isBillingAutomationEnabled: typeof isBillingAutomationEnabled;
     buildCheckoutInvoiceBillingSnapshot: typeof buildCheckoutInvoiceBillingSnapshot;
@@ -149,6 +167,7 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     notifyPurchase,
     consumeInventoryItem,
     convertOutletReservationForCartItem,
+    bindStripeCheckoutAttempt,
     getOrCreateDeliveryRequest,
     createEvent,
     createNotificationWithStatus,
@@ -168,6 +187,7 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     getRaisedBed,
     getRaisedBedFieldsWithEvents,
     getShoppingCart,
+    getStripeCheckoutAttempt,
     getUser,
     isCartItemDeliverable,
     knownEvents,
@@ -178,6 +198,7 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     normalizeShoppingCartScheduledDates,
     processReferralRewardsForAccount,
     setCartItemPaid,
+    releaseStripeCheckoutAttempt,
     spendSunflowersBatch,
     topUpSunflowerPackage,
     upsertRaisedBedField,
@@ -188,6 +209,7 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     withCheckoutCartItemProcessingLocks,
     withInventoryAccountTransaction,
     withStripePaymentProcessingLock,
+    verifyStripeCheckoutAttemptLiveCart,
     getStripeCheckoutSession,
     isBillingAutomationEnabled,
     buildCheckoutInvoiceBillingSnapshot,
@@ -452,6 +474,11 @@ async function processNonStripeCartItems(
     expectedNonStripeCartItemIds: ReadonlySet<number> | null = null,
     checkoutSessionId?: string | null,
     dependencies: ProcessCheckoutSessionDependencies = realDependencies,
+    checkoutSnapshot?: {
+        additionalDataByCartItemId: ReadonlyMap<number, unknown>;
+        paymentKindByCartItemId: ReadonlyMap<number, 'inventory' | 'sunflower'>;
+        sunflowerAmountsByCartItemId: ReadonlyMap<number, number>;
+    },
 ): Promise<{
     confirmationItems: ShoppingCartItemWithShopData[];
     processedItems: ShoppingCartItemWithShopData[];
@@ -499,6 +526,22 @@ async function processNonStripeCartItems(
     const isExpectedNonStripeItem = (item: { id: number }) =>
         expectedNonStripeCartItemIds === null ||
         expectedNonStripeCartItemIds.has(item.id);
+    const hasSnapshotPaymentKind = (
+        item: { id: number },
+        paymentKind: 'inventory' | 'sunflower',
+    ) =>
+        checkoutSnapshot
+            ? checkoutSnapshot.paymentKindByCartItemId.get(item.id) ===
+              paymentKind
+            : null;
+    const isSunflowerItem = (item: ShoppingCartItemWithShopData) =>
+        hasSnapshotPaymentKind(item, 'sunflower') ??
+        item.currency === 'sunflower';
+    const isInventoryItem = (item: ShoppingCartItemWithShopData) =>
+        hasSnapshotPaymentKind(item, 'inventory') ??
+        (item.currency === 'inventory' || item.usesInventory === true);
+    const isDirectNonStripeItem = (item: ShoppingCartItemWithShopData) =>
+        isSunflowerItem(item) || isInventoryItem(item);
     for (const item of cart.items) {
         if (
             item.status === 'paid' &&
@@ -511,7 +554,11 @@ async function processNonStripeCartItems(
     let cartInfo = await dependencies.getCartInfo(cart.items, accountId, {
         checkoutOperationMappings,
     });
-    if (!cartInfo.allowPurchase) {
+    // Snapshot-backed checkouts already passed cart validation before Stripe
+    // opened. Do not let a later catalog price/minimum-order change strand the
+    // captured payment; inventory and fulfillment availability are still
+    // checked explicitly below before their respective effects.
+    if (!checkoutSnapshot && !cartInfo.allowPurchase) {
         const pendingDirectItems = cart.items.filter(
             (item) =>
                 item.status !== 'paid' &&
@@ -533,13 +580,9 @@ async function processNonStripeCartItems(
         }
     }
     confirmationItems = cartInfo.items.filter(
-        (item) =>
-            isExpectedNonStripeItem(item) &&
-            (item.currency === 'sunflower' ||
-                item.currency === 'inventory' ||
-                item.usesInventory),
+        (item) => isExpectedNonStripeItem(item) && isDirectNonStripeItem(item),
     );
-    if (!cartInfo.allowPurchase) {
+    if (!checkoutSnapshot && !cartInfo.allowPurchase) {
         const pendingExpectedItem = cart.items.find(
             (item) => item.status !== 'paid' && isExpectedNonStripeItem(item),
         );
@@ -567,7 +610,7 @@ async function processNonStripeCartItems(
         }
     }
 
-    const checkoutAdditionalDataByCartItemId = new Map(
+    const checkoutAdditionalDataByCartItemId = new Map<number, unknown>(
         cartInfo.items
             .filter(
                 (item) =>
@@ -588,20 +631,37 @@ async function processNonStripeCartItems(
                 },
             ]),
     );
+    for (const [
+        cartItemId,
+        additionalData,
+    ] of checkoutSnapshot?.additionalDataByCartItemId ?? []) {
+        checkoutAdditionalDataByCartItemId.set(cartItemId, additionalData);
+    }
 
     const expectedSunflowerCartItemsWithShopData = cartInfo.items.filter(
-        (item) =>
-            item.currency === 'sunflower' && isExpectedNonStripeItem(item),
+        (item) => isSunflowerItem(item) && isExpectedNonStripeItem(item),
     );
     // Precompute sunflower amounts so the durable batch debit can be retried
     // without charging an already-processed item again.
     const sunflowerAmountsByItem = new Map<number, number>();
 
     for (const item of expectedSunflowerCartItemsWithShopData) {
+        const snapshotAmount =
+            checkoutSnapshot?.sunflowerAmountsByCartItemId.get(item.id);
         const sunflowerAmount =
-            item.status === 'paid'
+            snapshotAmount ??
+            (item.status === 'paid'
                 ? calculateSunflowerReplayAmount(item)
-                : dependencies.calculateSunflowerAmount(item);
+                : dependencies.calculateSunflowerAmount(item));
+        if (
+            checkoutSnapshot &&
+            (!Number.isSafeInteger(snapshotAmount) ||
+                (snapshotAmount ?? 0) <= 0)
+        ) {
+            throw new StripeCheckoutAttemptConflictError(
+                'snapshot_sunflower_amount_missing',
+            );
+        }
         sunflowerAmountsByItem.set(item.id, sunflowerAmount);
     }
 
@@ -798,7 +858,7 @@ async function processNonStripeCartItems(
     const inventoryCartItems = cartInfo.items.filter(
         (item) =>
             item.status !== 'paid' &&
-            (item.currency === 'inventory' || item.usesInventory) &&
+            isInventoryItem(item) &&
             isExpectedNonStripeItem(item),
     );
 
@@ -1348,6 +1408,156 @@ class CheckoutPlantingRaisedBedUnavailableError extends Error {
     }
 }
 
+async function reconcileStripeCheckoutAttempt(
+    session: NonNullable<Awaited<ReturnType<typeof getStripeCheckoutSession>>>,
+    dependencies: ProcessCheckoutSessionDependencies,
+): Promise<StripeCheckoutAttempt | null> {
+    const metadata = decodeStripeCheckoutAttemptMetadata(session.metadata);
+    if (!metadata) {
+        // Sessions created before durable snapshots were deployed keep their
+        // existing recovery path. Every newly created cart session has metadata.
+        return null;
+    }
+
+    try {
+        let attempt = await dependencies.getStripeCheckoutAttempt(
+            metadata.cartId,
+            metadata.attemptId,
+        );
+        if (!attempt) {
+            throw new StripeCheckoutAttemptConflictError('attempt_missing');
+        }
+        if (attempt.releaseReason) {
+            throw new StripeCheckoutAttemptConflictError('attempt_released');
+        }
+        if (!attempt.sessionId) {
+            attempt = await dependencies.bindStripeCheckoutAttempt({
+                ...metadata,
+                sessionId: session.id,
+            });
+        } else if (attempt.sessionId !== session.id) {
+            throw new StripeCheckoutAttemptConflictError(
+                'session_binding_changed',
+            );
+        }
+        if (
+            attempt.snapshot.accountId.length === 0 ||
+            attempt.snapshot.cartId !== metadata.cartId
+        ) {
+            throw new StripeCheckoutAttemptConflictError(
+                'snapshot_identity_changed',
+            );
+        }
+        let metadataNonStripeItemIds: Set<number> | null;
+        try {
+            metadataNonStripeItemIds =
+                decodeExpectedNonStripeCartItemIdsMetadata(session.metadata);
+        } catch {
+            throw new StripeCheckoutAttemptConflictError(
+                'non_stripe_metadata_changed',
+            );
+        }
+        if (
+            metadataNonStripeItemIds === null ||
+            metadataNonStripeItemIds.size !==
+                attempt.snapshot.expectedNonStripeCartItemIds.length ||
+            attempt.snapshot.expectedNonStripeCartItemIds.some(
+                (itemId) => !metadataNonStripeItemIds.has(itemId),
+            )
+        ) {
+            throw new StripeCheckoutAttemptConflictError(
+                'non_stripe_metadata_changed',
+            );
+        }
+        let metadataHarvestDates: Map<number, string>;
+        try {
+            metadataHarvestDates = decodeHarvestDatesMetadata(session.metadata);
+        } catch {
+            throw new StripeCheckoutAttemptConflictError(
+                'harvest_metadata_changed',
+            );
+        }
+        if (
+            metadataHarvestDates.size !==
+                attempt.snapshot.harvestDates.length ||
+            attempt.snapshot.harvestDates.some(
+                (selection) =>
+                    metadataHarvestDates.get(selection.cartItemId) !==
+                    selection.scheduledDate,
+            )
+        ) {
+            throw new StripeCheckoutAttemptConflictError(
+                'harvest_metadata_changed',
+            );
+        }
+
+        const liveItems =
+            await dependencies.verifyStripeCheckoutAttemptLiveCart(attempt);
+        assertStripeSessionMatchesCheckoutAttempt(session, attempt);
+
+        // Catalog labels and prices may legitimately change while Stripe is
+        // open. Verify every snapshotted entity still resolves, then use the
+        // immutable snapshot amounts below instead of today's catalog prices.
+        const cartInfo = await dependencies.getCartInfo(
+            liveItems,
+            attempt.snapshot.accountId,
+        );
+        if (
+            cartInfo.items.length !== liveItems.length ||
+            cartInfo.items.some(
+                (item) =>
+                    !attempt.snapshot.items.some(
+                        (snapshotItem) => snapshotItem.id === item.id,
+                    ),
+            )
+        ) {
+            throw new StripeCheckoutAttemptConflictError(
+                'catalog_entity_unavailable',
+            );
+        }
+        return attempt;
+    } catch (error) {
+        console.error('Stripe checkout snapshot reconciliation failed', {
+            attemptId: metadata.attemptId,
+            cartId: metadata.cartId,
+            mismatchCategory:
+                error instanceof StripeCheckoutAttemptConflictError
+                    ? error.category
+                    : 'unexpected',
+            sessionId: session.id,
+        });
+        throw error;
+    }
+}
+
+async function releaseCompletedStripeCheckoutAttempt(
+    session: NonNullable<Awaited<ReturnType<typeof getStripeCheckoutSession>>>,
+    dependencies: ProcessCheckoutSessionDependencies,
+) {
+    const metadata = decodeStripeCheckoutAttemptMetadata(session.metadata);
+    if (!metadata) {
+        return;
+    }
+    const attempt = await dependencies.getStripeCheckoutAttempt(
+        metadata.cartId,
+        metadata.attemptId,
+    );
+    if (!attempt) {
+        throw new StripeCheckoutAttemptConflictError('attempt_missing');
+    }
+    if (
+        attempt.releaseReason === 'completed' &&
+        attempt.sessionId === session.id
+    ) {
+        return;
+    }
+    await dependencies.releaseStripeCheckoutAttempt({
+        ...metadata,
+        reason: 'completed',
+        sessionId: session.id,
+    });
+}
+
 async function processPaidCheckoutSession(
     checkoutSessionId: string,
     session: NonNullable<Awaited<ReturnType<typeof getStripeCheckoutSession>>>,
@@ -1389,6 +1599,7 @@ async function processPaidCheckoutSession(
     }
 
     if (alreadyProcessed) {
+        await releaseCompletedStripeCheckoutAttempt(session, dependencies);
         console.info(
             `Checkout session ${checkoutSessionId} already processed; skipping.`,
         );
@@ -1397,6 +1608,11 @@ async function processPaidCheckoutSession(
 
     console.debug(
         `Processing checkout session ${checkoutSessionId} with amount ${session.amountTotal} cents`,
+    );
+
+    const checkoutAttempt = await reconcileStripeCheckoutAttempt(
+        session,
+        dependencies,
     );
 
     const affectedCartIds: number[] = [];
@@ -1410,8 +1626,9 @@ async function processPaidCheckoutSession(
     let customerUserId: string | undefined;
     const invoiceLineItems: InvoiceForTransactionLineItem[] = [];
     const fulfillmentErrors: unknown[] = [];
-    const expectedNonStripeCartItemIds =
-        decodeExpectedNonStripeCartItemIdsMetadata(session.metadata);
+    const expectedNonStripeCartItemIds = checkoutAttempt
+        ? new Set(checkoutAttempt.snapshot.expectedNonStripeCartItemIds)
+        : decodeExpectedNonStripeCartItemIdsMetadata(session.metadata);
     if (expectedNonStripeCartItemIds?.size) {
         const candidateCartIds = new Set<number>();
         for (const lineItem of session.lineItems?.data ?? []) {
@@ -1819,9 +2036,9 @@ async function processPaidCheckoutSession(
     }
 
     const uniqueAffectedCartIds = Array.from(new Set(affectedCartIds));
-    const harvestDateByCartItemId = decodeHarvestDatesMetadata(
-        session.metadata,
-    );
+    const harvestDateByCartItemId = checkoutAttempt
+        ? getStripeCheckoutSnapshotHarvestDates(checkoutAttempt)
+        : decodeHarvestDatesMetadata(session.metadata);
     const satisfiedExpectedNonStripeItemIds = new Set<number>();
     const resolvedSunflowerAmountsByCartItemId = new Map<number, number>();
     if (accountId && uniqueAffectedCartIds.length > 0) {
@@ -1834,6 +2051,22 @@ async function processPaidCheckoutSession(
                 expectedNonStripeCartItemIds,
                 session.id,
                 dependencies,
+                checkoutAttempt
+                    ? {
+                          additionalDataByCartItemId:
+                              getStripeCheckoutSnapshotAdditionalData(
+                                  checkoutAttempt,
+                              ),
+                          paymentKindByCartItemId:
+                              getStripeCheckoutSnapshotNonStripePaymentKinds(
+                                  checkoutAttempt,
+                              ),
+                          sunflowerAmountsByCartItemId:
+                              getStripeCheckoutSnapshotNonStripeAmounts(
+                                  checkoutAttempt,
+                              ),
+                      }
+                    : undefined,
             );
             for (const itemId of nonStripeResult.satisfiedExpectedItemIds) {
                 satisfiedExpectedNonStripeItemIds.add(itemId);
@@ -2017,6 +2250,10 @@ async function processPaidCheckoutSession(
                 checkout_session_id: session.id,
             },
         });
+    }
+
+    if (checkoutAttempt) {
+        await releaseCompletedStripeCheckoutAttempt(session, dependencies);
     }
 }
 

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -1583,6 +1583,16 @@ async function processPaidCheckoutSession(
 ) {
     const alreadyProcessed =
         await dependencies.getCompletedTransactionByStripePaymentId(session.id);
+    let checkoutAttempt: StripeCheckoutAttempt | null | undefined;
+    if (session.paymentStatus === 'no_payment_required' && !alreadyProcessed) {
+        // Zero-total sessions are accepted only for durable cart attempts. Do
+        // this before specialized fulfillment branches so metadata alone can
+        // never opt an unrelated checkout into no-payment fulfillment.
+        checkoutAttempt = await reconcileStripeCheckoutAttempt(
+            session,
+            dependencies,
+        );
+    }
     const sunflowerPackageCheckout =
         getSunflowerPackageCheckoutLineItems(session);
     if (sunflowerPackageCheckout.malformedCount > 0) {
@@ -1630,7 +1640,7 @@ async function processPaidCheckoutSession(
         `Processing checkout session ${checkoutSessionId} with amount ${session.amountTotal} cents`,
     );
 
-    const checkoutAttempt = await reconcileStripeCheckoutAttempt(
+    checkoutAttempt ??= await reconcileStripeCheckoutAttempt(
         session,
         dependencies,
     );

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -1019,7 +1019,21 @@ export async function processCheckoutSession(
         );
         return;
     }
-    if (session.paymentStatus !== 'paid') {
+    let isZeroTotalSnapshotCheckout = false;
+    if (
+        session.paymentStatus === 'no_payment_required' &&
+        session.amountTotal === 0
+    ) {
+        try {
+            isZeroTotalSnapshotCheckout =
+                decodeStripeCheckoutAttemptMetadata(session.metadata) !== null;
+        } catch {
+            // Malformed snapshot metadata must not turn an unpaid session into
+            // a fulfillment candidate. Paid sessions retain the stricter
+            // reconciliation error below.
+        }
+    }
+    if (session.paymentStatus !== 'paid' && !isZeroTotalSnapshotCheckout) {
         console.warn(
             `Payment not completed for session ${checkoutSessionId} with status: ${session.paymentStatus}`,
         );
@@ -1533,6 +1547,7 @@ async function reconcileStripeCheckoutAttempt(
 async function releaseCompletedStripeCheckoutAttempt(
     session: NonNullable<Awaited<ReturnType<typeof getStripeCheckoutSession>>>,
     dependencies: ProcessCheckoutSessionDependencies,
+    { allowMissingAttempt = false }: { allowMissingAttempt?: boolean } = {},
 ) {
     const metadata = decodeStripeCheckoutAttemptMetadata(session.metadata);
     if (!metadata) {
@@ -1543,6 +1558,9 @@ async function releaseCompletedStripeCheckoutAttempt(
         metadata.attemptId,
     );
     if (!attempt) {
+        if (allowMissingAttempt) {
+            return;
+        }
         throw new StripeCheckoutAttemptConflictError('attempt_missing');
     }
     if (
@@ -1599,7 +1617,9 @@ async function processPaidCheckoutSession(
     }
 
     if (alreadyProcessed) {
-        await releaseCompletedStripeCheckoutAttempt(session, dependencies);
+        await releaseCompletedStripeCheckoutAttempt(session, dependencies, {
+            allowMissingAttempt: true,
+        });
         console.info(
             `Checkout session ${checkoutSessionId} already processed; skipping.`,
         );

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -22,6 +22,8 @@ import {
     deliverNotificationOperatorAlert,
     earnSunflowersForPayment,
     ensureInvoiceForTransaction,
+    fingerprintStripeCheckoutValue,
+    getAccountUsers,
     getCheckoutFulfillmentStartedCartItemIds,
     getCheckoutOperationMapping,
     getCheckoutOperationMappings,
@@ -86,8 +88,8 @@ import {
 } from '../checkout/orderConfirmationEmail';
 import {
     assertStripeSessionMatchesCheckoutAttempt,
+    buildVerifiedStripeCheckoutAdditionalData,
     decodeStripeCheckoutAttemptMetadata,
-    getStripeCheckoutSnapshotAdditionalData,
     getStripeCheckoutSnapshotHarvestDates,
     getStripeCheckoutSnapshotNonStripeAmounts,
     getStripeCheckoutSnapshotNonStripePaymentKinds,
@@ -125,6 +127,7 @@ export type ProcessCheckoutSessionDependencies = {
     getRaisedBedFieldsWithEvents: typeof getRaisedBedFieldsWithEvents;
     getShoppingCart: typeof getShoppingCart;
     getStripeCheckoutAttempt: typeof getStripeCheckoutAttempt;
+    getAccountUsers: typeof getAccountUsers;
     getUser: typeof getUser;
     isCartItemDeliverable: typeof isCartItemDeliverable;
     knownEvents: typeof knownEvents;
@@ -188,6 +191,7 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     getRaisedBedFieldsWithEvents,
     getShoppingCart,
     getStripeCheckoutAttempt,
+    getAccountUsers,
     getUser,
     isCartItemDeliverable,
     knownEvents,
@@ -1425,7 +1429,12 @@ class CheckoutPlantingRaisedBedUnavailableError extends Error {
 async function reconcileStripeCheckoutAttempt(
     session: NonNullable<Awaited<ReturnType<typeof getStripeCheckoutSession>>>,
     dependencies: ProcessCheckoutSessionDependencies,
-): Promise<StripeCheckoutAttempt | null> {
+): Promise<{
+    accountId: string;
+    additionalDataByCartItemId: ReadonlyMap<number, unknown>;
+    attempt: StripeCheckoutAttempt;
+    userId: string;
+} | null> {
     const metadata = decodeStripeCheckoutAttemptMetadata(session.metadata);
     if (!metadata) {
         // Sessions created before durable snapshots were deployed keep their
@@ -1454,10 +1463,7 @@ async function reconcileStripeCheckoutAttempt(
                 'session_binding_changed',
             );
         }
-        if (
-            attempt.snapshot.accountId.length === 0 ||
-            attempt.snapshot.cartId !== metadata.cartId
-        ) {
+        if (attempt.snapshot.cartId !== metadata.cartId) {
             throw new StripeCheckoutAttemptConflictError(
                 'snapshot_identity_changed',
             );
@@ -1505,19 +1511,46 @@ async function reconcileStripeCheckoutAttempt(
             );
         }
 
-        const liveItems =
+        const liveCart =
             await dependencies.verifyStripeCheckoutAttemptLiveCart(attempt);
-        assertStripeSessionMatchesCheckoutAttempt(session, attempt);
+        const matchingAccountUsers = (
+            await dependencies.getAccountUsers(liveCart.accountId)
+        ).filter(
+            (accountUser) =>
+                fingerprintStripeCheckoutValue(accountUser.userId) ===
+                attempt.snapshot.userFingerprint,
+        );
+        if (matchingAccountUsers.length !== 1) {
+            throw new StripeCheckoutAttemptConflictError(
+                'checkout_user_inactive',
+            );
+        }
+        const checkoutUser = matchingAccountUsers[0];
+        if (!checkoutUser) {
+            throw new StripeCheckoutAttemptConflictError(
+                'checkout_user_inactive',
+            );
+        }
+        assertStripeSessionMatchesCheckoutAttempt(session, attempt, {
+            accountId: liveCart.accountId,
+            userId: checkoutUser.userId,
+        });
+        const additionalDataByCartItemId =
+            buildVerifiedStripeCheckoutAdditionalData({
+                attempt,
+                liveItems: liveCart.items,
+                session,
+            });
 
         // Catalog labels and prices may legitimately change while Stripe is
         // open. Verify every snapshotted entity still resolves, then use the
         // immutable snapshot amounts below instead of today's catalog prices.
         const cartInfo = await dependencies.getCartInfo(
-            liveItems,
-            attempt.snapshot.accountId,
+            liveCart.items,
+            liveCart.accountId,
         );
         if (
-            cartInfo.items.length !== liveItems.length ||
+            cartInfo.items.length !== liveCart.items.length ||
             cartInfo.items.some(
                 (item) =>
                     !attempt.snapshot.items.some(
@@ -1529,7 +1562,12 @@ async function reconcileStripeCheckoutAttempt(
                 'catalog_entity_unavailable',
             );
         }
-        return attempt;
+        return {
+            accountId: liveCart.accountId,
+            additionalDataByCartItemId,
+            attempt,
+            userId: checkoutUser.userId,
+        };
     } catch (error) {
         console.error('Stripe checkout snapshot reconciliation failed', {
             attemptId: metadata.attemptId,
@@ -1583,12 +1621,14 @@ async function processPaidCheckoutSession(
 ) {
     const alreadyProcessed =
         await dependencies.getCompletedTransactionByStripePaymentId(session.id);
-    let checkoutAttempt: StripeCheckoutAttempt | null | undefined;
+    let checkoutReconciliation:
+        | Awaited<ReturnType<typeof reconcileStripeCheckoutAttempt>>
+        | undefined;
     if (session.paymentStatus === 'no_payment_required' && !alreadyProcessed) {
         // Zero-total sessions are accepted only for durable cart attempts. Do
         // this before specialized fulfillment branches so metadata alone can
         // never opt an unrelated checkout into no-payment fulfillment.
-        checkoutAttempt = await reconcileStripeCheckoutAttempt(
+        checkoutReconciliation = await reconcileStripeCheckoutAttempt(
             session,
             dependencies,
         );
@@ -1640,10 +1680,11 @@ async function processPaidCheckoutSession(
         `Processing checkout session ${checkoutSessionId} with amount ${session.amountTotal} cents`,
     );
 
-    checkoutAttempt ??= await reconcileStripeCheckoutAttempt(
+    checkoutReconciliation ??= await reconcileStripeCheckoutAttempt(
         session,
         dependencies,
     );
+    const checkoutAttempt = checkoutReconciliation?.attempt ?? null;
 
     const affectedCartIds: number[] = [];
     const purchasedItems: {
@@ -1652,8 +1693,8 @@ async function processPaidCheckoutSession(
         amountSubtotal?: number | null;
         currency?: string | null;
     }[] = [];
-    let accountId: string | undefined;
-    let customerUserId: string | undefined;
+    let accountId = checkoutReconciliation?.accountId;
+    let customerUserId = checkoutReconciliation?.userId;
     const invoiceLineItems: InvoiceForTransactionLineItem[] = [];
     const fulfillmentErrors: unknown[] = [];
     const expectedNonStripeCartItemIds = checkoutAttempt
@@ -2032,7 +2073,9 @@ async function processPaidCheckoutSession(
     // All items in a single checkout session should share the same delivery information.
     let deliveryInfo: unknown;
     const deliveryInfosFound = new Set<string>();
-    for (const item of session.lineItems?.data ?? []) {
+    for (const item of checkoutReconciliation
+        ? []
+        : (session.lineItems?.data ?? [])) {
         const product = item.price?.product;
         if (typeof product !== 'string' && !product?.deleted) {
             const additionalData = product?.metadata?.additionalData
@@ -2081,19 +2124,17 @@ async function processPaidCheckoutSession(
                 expectedNonStripeCartItemIds,
                 session.id,
                 dependencies,
-                checkoutAttempt
+                checkoutReconciliation
                     ? {
                           additionalDataByCartItemId:
-                              getStripeCheckoutSnapshotAdditionalData(
-                                  checkoutAttempt,
-                              ),
+                              checkoutReconciliation.additionalDataByCartItemId,
                           paymentKindByCartItemId:
                               getStripeCheckoutSnapshotNonStripePaymentKinds(
-                                  checkoutAttempt,
+                                  checkoutReconciliation.attempt,
                               ),
                           sunflowerAmountsByCartItemId:
                               getStripeCheckoutSnapshotNonStripeAmounts(
-                                  checkoutAttempt,
+                                  checkoutReconciliation.attempt,
                               ),
                       }
                     : undefined,

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -23,6 +23,7 @@ export * from './helpers/plantStatusChronology';
 export * from './helpers/raisedBedPhotoOperations';
 export * from './helpers/timeSlotAutomation';
 export * from './helpers/timezoneUtils';
+export * from './repositories/accountDeletionFenceRepo';
 export * from './repositories/accountDeletionRepo';
 export * from './repositories/accountInvitationsRepo';
 export * from './repositories/accountsRepo';

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -91,6 +91,7 @@ export * from './repositories/settingsRepo';
 export * from './repositories/shoppingCartRepo';
 export * from './repositories/socialAccountsRepo';
 export * from './repositories/socialPostsRepo';
+export * from './repositories/stripeCheckoutAttemptRepo';
 export * from './repositories/sunflowerDropsRepo';
 export * from './repositories/sunflowerLedgerRepo';
 export * from './repositories/sunflowerPackagesRepo';

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -76,6 +76,7 @@ export * from './repositories/notificationsRepo';
 export * from './repositories/occasionsRepo';
 export * from './repositories/operationsRepo';
 export * from './repositories/orderConfirmationOutboxRepo';
+export * from './repositories/outletCheckoutReservationRepo';
 export * from './repositories/outletOffersRepo';
 export * from './repositories/payoutsRepo';
 export * from './repositories/pickupLocationsRepo';

--- a/packages/storage/src/repositories/accountDeletionFenceRepo.ts
+++ b/packages/storage/src/repositories/accountDeletionFenceRepo.ts
@@ -1,0 +1,75 @@
+import { and, eq } from 'drizzle-orm';
+import { accounts, events } from '../schema';
+import type { storage } from '../storage';
+
+type StorageClient = ReturnType<typeof storage>;
+export type AccountDeletionFenceTransaction = Parameters<
+    Parameters<StorageClient['transaction']>[0]
+>[0];
+
+export const accountDeletionStartedEventType = 'account.deletion.started';
+
+export class AccountDeletionInProgressError extends Error {
+    override readonly name = 'AccountDeletionInProgressError';
+
+    constructor(readonly accountId: string) {
+        super('The account is being deleted.');
+    }
+}
+
+export async function lockAccountForDeletionLifecycle(
+    accountId: string,
+    db: AccountDeletionFenceTransaction,
+) {
+    const [account] = await db
+        .select({ id: accounts.id })
+        .from(accounts)
+        .where(eq(accounts.id, accountId))
+        .for('update')
+        .limit(1);
+    return account;
+}
+
+async function hasAccountDeletionStarted(
+    accountId: string,
+    db: AccountDeletionFenceTransaction,
+) {
+    const event = await db.query.events.findFirst({
+        columns: { id: true },
+        where: and(
+            eq(events.aggregateId, accountId),
+            eq(events.type, accountDeletionStartedEventType),
+        ),
+    });
+    return event !== undefined;
+}
+
+export async function lockAccountAndAssertNotDeleting(
+    accountId: string,
+    db: AccountDeletionFenceTransaction,
+) {
+    const account = await lockAccountForDeletionLifecycle(accountId, db);
+    if (!account) {
+        return undefined;
+    }
+    if (await hasAccountDeletionStarted(accountId, db)) {
+        throw new AccountDeletionInProgressError(accountId);
+    }
+    return account;
+}
+
+export async function markAccountDeletionStarted(
+    accountId: string,
+    db: AccountDeletionFenceTransaction,
+) {
+    if (await hasAccountDeletionStarted(accountId, db)) {
+        return false;
+    }
+    await db.insert(events).values({
+        aggregateId: accountId,
+        data: {},
+        type: accountDeletionStartedEventType,
+        version: 1,
+    });
+    return true;
+}

--- a/packages/storage/src/repositories/accountDeletionFenceRepo.ts
+++ b/packages/storage/src/repositories/accountDeletionFenceRepo.ts
@@ -22,7 +22,10 @@ export async function lockAccountForDeletionLifecycle(
     db: AccountDeletionFenceTransaction,
 ) {
     const [account] = await db
-        .select({ id: accounts.id })
+        .select({
+            id: accounts.id,
+            stripeCustomerId: accounts.stripeCustomerId,
+        })
         .from(accounts)
         .where(eq(accounts.id, accountId))
         .for('update')

--- a/packages/storage/src/repositories/accountDeletionRepo.ts
+++ b/packages/storage/src/repositories/accountDeletionRepo.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import { bustScheduleCache } from '../cache/scheduleCache';
 import { events } from '../schema/eventsSchema';
 import {
@@ -13,12 +13,67 @@ import { shoppingCartItems, shoppingCarts } from '../schema/shoppingCartSchema';
 import { transactions } from '../schema/transactionSchema';
 import { accounts, accountUsers, users } from '../schema/usersSchema';
 import { storage } from '../storage';
+import { withCheckoutCartItemLocks } from './checkoutCartItemLock';
 import { getAccountGardens, getRaisedBeds } from './gardensRepo';
 import {
     deleteNotification,
     getNotificationsByAccount,
     getNotificationsByUser,
 } from './notificationsRepo';
+import { lockAndAssertShoppingCartsMutable } from './stripeCheckoutAttemptRepo';
+
+async function detachOrDeleteAccountShoppingCarts(accountId: string) {
+    const expectedCarts = await storage().query.shoppingCarts.findMany({
+        where: eq(shoppingCarts.accountId, accountId),
+    });
+    const expectedCartIds = expectedCarts.map((cart) => cart.id);
+    const items =
+        expectedCartIds.length > 0
+            ? await storage().query.shoppingCartItems.findMany({
+                  where: inArray(shoppingCartItems.cartId, expectedCartIds),
+              })
+            : [];
+
+    await withCheckoutCartItemLocks(
+        items.map((item) => item.id),
+        async (db) => {
+            await lockAndAssertShoppingCartsMutable(expectedCartIds, db);
+            const liveCarts = await db.query.shoppingCarts.findMany({
+                where: eq(shoppingCarts.accountId, accountId),
+            });
+            const expectedCartIdSet = new Set(expectedCartIds);
+            if (
+                liveCarts.length !== expectedCartIds.length ||
+                liveCarts.some((cart) => !expectedCartIdSet.has(cart.id))
+            ) {
+                throw new Error(
+                    `Shopping carts changed while fencing account ${accountId} for deletion.`,
+                );
+            }
+
+            const newCartIds = liveCarts.flatMap((cart) =>
+                cart.status === 'new' ? [cart.id] : [],
+            );
+            const retainedCartIds = liveCarts.flatMap((cart) =>
+                cart.status === 'new' ? [] : [cart.id],
+            );
+            if (newCartIds.length > 0) {
+                await db
+                    .delete(shoppingCartItems)
+                    .where(inArray(shoppingCartItems.cartId, newCartIds));
+                await db
+                    .delete(shoppingCarts)
+                    .where(inArray(shoppingCarts.id, newCartIds));
+            }
+            if (retainedCartIds.length > 0) {
+                await db
+                    .update(shoppingCarts)
+                    .set({ accountId: null })
+                    .where(inArray(shoppingCarts.id, retainedCartIds));
+            }
+        },
+    );
+}
 
 /**
  * Deletes an account and all related entities in the required order.
@@ -49,6 +104,17 @@ export async function deleteAccountWithDependencies(
         console.info(
             `[AccountDelete] Starting deletion for accountId=${accountId}, userId=${userId}`,
         );
+
+        // Fence every account cart in one transaction before touching gardens,
+        // notifications, or any other account data. If a checkout snapshot won
+        // the race, the whole transaction rolls back and deletion has made no
+        // destructive changes. If deletion wins, later snapshot creation sees
+        // a detached or deleted cart and fails before Stripe session creation.
+        console.info(
+            `[AccountDelete] Detaching/deleting shopping carts for accountId=${accountId}`,
+        );
+        await detachOrDeleteAccountShoppingCarts(accountId);
+
         const gardens = await getAccountGardens(accountId);
         if (gardens.length > 0) {
             hasScheduleAffectingChanges = true;
@@ -120,35 +186,6 @@ export async function deleteAccountWithDependencies(
         );
         for (const notification of accountNotifications) {
             await deleteNotification(notification.id);
-        }
-
-        // 11. Detach shopping carts from account - set account to null or delete new carts and their items
-        console.info(
-            `[AccountDelete] Detaching/deleting shopping carts for accountId=${accountId}`,
-        );
-        const carts = await storage().query.shoppingCarts.findMany({
-            where: eq(shoppingCarts.accountId, accountId),
-        });
-        for (const cart of carts) {
-            if (cart.status !== 'new') {
-                await storage()
-                    .update(shoppingCarts)
-                    .set({ accountId: null })
-                    .where(eq(shoppingCarts.id, cart.id));
-            }
-            if (cart.status === 'new') {
-                const items = await storage().query.shoppingCartItems.findMany({
-                    where: eq(shoppingCartItems.cartId, cart.id),
-                });
-                for (const item of items) {
-                    await storage()
-                        .delete(shoppingCartItems)
-                        .where(eq(shoppingCartItems.id, item.id));
-                }
-                await storage()
-                    .delete(shoppingCarts)
-                    .where(eq(shoppingCarts.id, cart.id));
-            }
         }
 
         // 12. Detach transactions from account - set account to null

--- a/packages/storage/src/repositories/accountDeletionRepo.ts
+++ b/packages/storage/src/repositories/accountDeletionRepo.ts
@@ -13,6 +13,10 @@ import { shoppingCartItems, shoppingCarts } from '../schema/shoppingCartSchema';
 import { transactions } from '../schema/transactionSchema';
 import { accounts, accountUsers, users } from '../schema/usersSchema';
 import { storage } from '../storage';
+import {
+    lockAccountForDeletionLifecycle,
+    markAccountDeletionStarted,
+} from './accountDeletionFenceRepo';
 import { withCheckoutCartItemLocks } from './checkoutCartItemLock';
 import { getAccountGardens, getRaisedBeds } from './gardensRepo';
 import {
@@ -22,7 +26,7 @@ import {
 } from './notificationsRepo';
 import { lockAndAssertShoppingCartsMutable } from './stripeCheckoutAttemptRepo';
 
-async function detachOrDeleteAccountShoppingCarts(accountId: string) {
+export async function fenceAccountShoppingCartsForDeletion(accountId: string) {
     const expectedCarts = await storage().query.shoppingCarts.findMany({
         where: eq(shoppingCarts.accountId, accountId),
     });
@@ -34,9 +38,16 @@ async function detachOrDeleteAccountShoppingCarts(accountId: string) {
               })
             : [];
 
-    await withCheckoutCartItemLocks(
+    return withCheckoutCartItemLocks(
         items.map((item) => item.id),
         async (db) => {
+            const account = await lockAccountForDeletionLifecycle(
+                accountId,
+                db,
+            );
+            if (!account) {
+                return false;
+            }
             await lockAndAssertShoppingCartsMutable(expectedCartIds, db);
             const liveCarts = await db.query.shoppingCarts.findMany({
                 where: eq(shoppingCarts.accountId, accountId),
@@ -50,6 +61,8 @@ async function detachOrDeleteAccountShoppingCarts(accountId: string) {
                     `Shopping carts changed while fencing account ${accountId} for deletion.`,
                 );
             }
+
+            await markAccountDeletionStarted(accountId, db);
 
             const newCartIds = liveCarts.flatMap((cart) =>
                 cart.status === 'new' ? [cart.id] : [],
@@ -71,6 +84,7 @@ async function detachOrDeleteAccountShoppingCarts(accountId: string) {
                     .set({ accountId: null })
                     .where(inArray(shoppingCarts.id, retainedCartIds));
             }
+            return true;
         },
     );
 }
@@ -113,7 +127,7 @@ export async function deleteAccountWithDependencies(
         console.info(
             `[AccountDelete] Detaching/deleting shopping carts for accountId=${accountId}`,
         );
-        await detachOrDeleteAccountShoppingCarts(accountId);
+        await fenceAccountShoppingCartsForDeletion(accountId);
 
         const gardens = await getAccountGardens(accountId);
         if (gardens.length > 0) {
@@ -219,12 +233,6 @@ export async function deleteAccountWithDependencies(
                 .where(eq(operations.id, op.id));
         }
 
-        // 14. Delete account events
-        console.info(
-            `[AccountDelete] Deleting account events for accountId=${accountId}`,
-        );
-        await storage().delete(events).where(eq(events.aggregateId, accountId));
-
         // Delete user-account association
         console.info(
             `[AccountDelete] Deleting user-account association for accountId=${accountId}, userId=${userId}`,
@@ -264,9 +272,13 @@ export async function deleteAccountWithDependencies(
 
         // Final - Delete account
         console.info(
-            `[AccountDelete] Deleting account record for accountId=${accountId}`,
+            `[AccountDelete] Deleting account events and record for accountId=${accountId}`,
         );
-        await storage().delete(accounts).where(eq(accounts.id, accountId));
+        await storage().transaction(async (db) => {
+            await lockAccountForDeletionLifecycle(accountId, db);
+            await db.delete(events).where(eq(events.aggregateId, accountId));
+            await db.delete(accounts).where(eq(accounts.id, accountId));
+        });
         await bustScheduleCacheIfNeeded('after account deletion');
         console.info(
             `[AccountDelete] Deletion complete for accountId=${accountId}, userId=${userId}`,

--- a/packages/storage/src/repositories/accountsRepo.ts
+++ b/packages/storage/src/repositories/accountsRepo.ts
@@ -8,6 +8,7 @@ import {
     events,
     storage,
 } from '..';
+import { lockAccountAndAssertNotDeleting } from './accountDeletionFenceRepo';
 import {
     createEvent,
     getAllEvents,
@@ -219,6 +220,32 @@ export async function assignStripeCustomerId(
         .where(eq(accounts.id, accountId))
         .returning();
     return result[0];
+}
+
+export async function assignStripeCustomerIdIfUnchanged(
+    accountId: string,
+    expectedStripeCustomerId: string | null | undefined,
+    candidateStripeCustomerId: string,
+) {
+    return storage().transaction(async (db) => {
+        const account = await lockAccountAndAssertNotDeleting(accountId, db);
+        if (!account) {
+            return undefined;
+        }
+        const expectedCustomerId = expectedStripeCustomerId ?? null;
+        if (account.stripeCustomerId !== expectedCustomerId) {
+            return account.stripeCustomerId ?? undefined;
+        }
+        if (account.stripeCustomerId === candidateStripeCustomerId) {
+            return candidateStripeCustomerId;
+        }
+        const [updated] = await db
+            .update(accounts)
+            .set({ stripeCustomerId: candidateStripeCustomerId })
+            .where(eq(accounts.id, accountId))
+            .returning({ stripeCustomerId: accounts.stripeCustomerId });
+        return updated?.stripeCustomerId ?? undefined;
+    });
 }
 
 export async function updateAccountTimeZone(

--- a/packages/storage/src/repositories/accountsRepo.ts
+++ b/packages/storage/src/repositories/accountsRepo.ts
@@ -16,6 +16,7 @@ import {
     knownEvents,
     knownEventTypes,
 } from './eventsRepo';
+import { hasActiveStripeCheckoutAttemptForAccount } from './stripeCheckoutAttemptRepo';
 
 type StorageClient = ReturnType<typeof storage>;
 type TransactionClient = Parameters<
@@ -238,6 +239,12 @@ export async function assignStripeCustomerIdIfUnchanged(
         }
         if (account.stripeCustomerId === candidateStripeCustomerId) {
             return candidateStripeCustomerId;
+        }
+        if (
+            account.stripeCustomerId &&
+            (await hasActiveStripeCheckoutAttemptForAccount(accountId, db))
+        ) {
+            return account.stripeCustomerId;
         }
         const [updated] = await db
             .update(accounts)

--- a/packages/storage/src/repositories/gardenSandboxRepo.ts
+++ b/packages/storage/src/repositories/gardenSandboxRepo.ts
@@ -14,6 +14,7 @@ import {
 } from '../schema';
 import { raisedBedFields, raisedBedSensors } from '../schema/gardenSchema';
 import { storage } from '../storage';
+import { withCheckoutCartItemLocks } from './checkoutCartItemLock';
 import { createEvent, knownEvents, knownEventTypes } from './eventsRepo';
 import { getFarms } from './farmsRepo';
 import { removeGardenPreviewAndQueueBlobDeletionUsing } from './gardenPreviewsRepo';
@@ -22,6 +23,7 @@ import {
     deleteRaisedBedField,
     upsertRaisedBedField,
 } from './gardensRepo';
+import { lockAndAssertCartItemsMutable } from './stripeCheckoutAttemptRepo';
 
 type CreateDefaultGardenOptions = {
     accountId: string;
@@ -296,14 +298,13 @@ async function deleteSandboxShoppingCartItemBatch({
         .where(eq(shoppingCartItems.gardenId, gardenId))
         .limit(batchSize);
     if (byGarden.length > 0) {
-        await storage()
-            .delete(shoppingCartItems)
-            .where(
-                inArray(
-                    shoppingCartItems.id,
-                    byGarden.map((row) => row.id),
-                ),
-            );
+        const itemIds = byGarden.map((row) => row.id);
+        await withCheckoutCartItemLocks(itemIds, async (db) => {
+            await lockAndAssertCartItemsMutable(itemIds, db);
+            await db
+                .delete(shoppingCartItems)
+                .where(inArray(shoppingCartItems.id, itemIds));
+        });
         return byGarden.length;
     }
 
@@ -320,14 +321,13 @@ async function deleteSandboxShoppingCartItemBatch({
         return 0;
     }
 
-    await storage()
-        .delete(shoppingCartItems)
-        .where(
-            inArray(
-                shoppingCartItems.id,
-                byRaisedBed.map((row) => row.id),
-            ),
-        );
+    const itemIds = byRaisedBed.map((row) => row.id);
+    await withCheckoutCartItemLocks(itemIds, async (db) => {
+        await lockAndAssertCartItemsMutable(itemIds, db);
+        await db
+            .delete(shoppingCartItems)
+            .where(inArray(shoppingCartItems.id, itemIds));
+    });
     return byRaisedBed.length;
 }
 

--- a/packages/storage/src/repositories/outletCheckoutReservationRepo.ts
+++ b/packages/storage/src/repositories/outletCheckoutReservationRepo.ts
@@ -34,7 +34,7 @@ export async function getCheckoutOutletReservationConflict(
         cartId: number;
         cartItemIds: readonly number[];
         expectations: readonly CheckoutOutletReservationExpectation[];
-        now: Date;
+        now?: Date;
         requireActiveHolds?: boolean;
     },
     db: TransactionClient,
@@ -69,6 +69,9 @@ export async function getCheckoutOutletReservationConflict(
                   .orderBy(asc(outletOfferReservations.id))
                   .for('update')
             : [];
+    // Callers that do not inject a deterministic test time must validate
+    // expiry after every offer and reservation lock wait has completed.
+    const activeHoldValidationTime = now ?? new Date();
 
     if (reservations.length !== expectations.length) {
         return 'outlet_reservation_membership_changed' as const;
@@ -107,11 +110,12 @@ export async function getCheckoutOutletReservationConflict(
         if (
             requireActiveHolds &&
             reservation.status === 'held' &&
-            (reservation.holdExpiresAt.getTime() <= now.getTime() ||
+            (reservation.holdExpiresAt.getTime() <=
+                activeHoldValidationTime.getTime() ||
                 offer.isDeleted ||
                 offer.status !== 'published' ||
-                offer.startAt.getTime() > now.getTime() ||
-                offer.endAt.getTime() <= now.getTime() ||
+                offer.startAt.getTime() > activeHoldValidationTime.getTime() ||
+                offer.endAt.getTime() <= activeHoldValidationTime.getTime() ||
                 (expected.expiresAt !== undefined &&
                     reservation.holdExpiresAt.getTime() <
                         new Date(expected.expiresAt).getTime()))

--- a/packages/storage/src/repositories/outletCheckoutReservationRepo.ts
+++ b/packages/storage/src/repositories/outletCheckoutReservationRepo.ts
@@ -6,7 +6,6 @@ type StorageClient = ReturnType<typeof storage>;
 type TransactionClient = Parameters<
     Parameters<StorageClient['transaction']>[0]
 >[0];
-type DatabaseClient = StorageClient | TransactionClient;
 
 export type CheckoutOutletReservationExpectation = {
     cartItemId: number;
@@ -128,10 +127,27 @@ export async function releaseOutletReservationsForCheckoutAttempt(
     cartId: number,
     reservationIds: readonly number[],
     now = new Date(),
-    db: DatabaseClient,
+    db: TransactionClient,
 ) {
-    const uniqueReservationIds = [...new Set(reservationIds)];
+    const uniqueReservationIds = [...new Set(reservationIds)].sort(
+        (left, right) => left - right,
+    );
     if (uniqueReservationIds.length === 0) {
+        return;
+    }
+    const lockedReservations = await db
+        .select({ id: outletOfferReservations.id })
+        .from(outletOfferReservations)
+        .where(
+            and(
+                eq(outletOfferReservations.cartId, cartId),
+                inArray(outletOfferReservations.id, uniqueReservationIds),
+                eq(outletOfferReservations.status, 'held'),
+            ),
+        )
+        .orderBy(asc(outletOfferReservations.id))
+        .for('update');
+    if (lockedReservations.length === 0) {
         return;
     }
     await db
@@ -140,7 +156,10 @@ export async function releaseOutletReservationsForCheckoutAttempt(
         .where(
             and(
                 eq(outletOfferReservations.cartId, cartId),
-                inArray(outletOfferReservations.id, uniqueReservationIds),
+                inArray(
+                    outletOfferReservations.id,
+                    lockedReservations.map((reservation) => reservation.id),
+                ),
                 eq(outletOfferReservations.status, 'held'),
             ),
         );

--- a/packages/storage/src/repositories/outletCheckoutReservationRepo.ts
+++ b/packages/storage/src/repositories/outletCheckoutReservationRepo.ts
@@ -15,10 +15,11 @@ export type CheckoutOutletReservationExpectation = {
     id: number;
     initialPlantStatus: string;
     offerId: number;
+    plantSortId: string;
     priceCents: number;
     quantity: number;
     sowingDate: string;
-    status: 'converted' | 'held';
+    statuses: readonly ('converted' | 'held')[];
 };
 
 export async function getCheckoutOutletReservationConflict(
@@ -89,17 +90,24 @@ export async function getCheckoutOutletReservationConflict(
             reservation.cartItemId !== expected.cartItemId ||
             reservation.outletOfferId !== expected.offerId ||
             reservation.quantity !== expected.quantity ||
-            reservation.status !== expected.status ||
+            !(
+                (reservation.status === 'held' &&
+                    expected.statuses.includes('held')) ||
+                (reservation.status === 'converted' &&
+                    expected.statuses.includes('converted'))
+            ) ||
             reservation.heldOutletPriceCents !== expected.priceCents ||
             reservation.heldComparePriceCents !== expected.comparePriceCents ||
             reservation.heldSowingDate.toISOString() !== expected.sowingDate ||
-            reservation.heldInitialPlantStatus !== expected.initialPlantStatus
+            reservation.heldInitialPlantStatus !==
+                expected.initialPlantStatus ||
+            offer.plantSortId.toString() !== expected.plantSortId
         ) {
             return 'outlet_reservation_changed' as const;
         }
         if (
             requireActiveHolds &&
-            expected.status === 'held' &&
+            reservation.status === 'held' &&
             (reservation.holdExpiresAt.getTime() <= now.getTime() ||
                 offer.isDeleted ||
                 offer.status !== 'published' ||

--- a/packages/storage/src/repositories/outletCheckoutReservationRepo.ts
+++ b/packages/storage/src/repositories/outletCheckoutReservationRepo.ts
@@ -1,0 +1,139 @@
+import { and, asc, eq, inArray, ne } from 'drizzle-orm';
+import { outletOfferReservations, outletOffers } from '../schema';
+import type { storage } from '../storage';
+
+type StorageClient = ReturnType<typeof storage>;
+type TransactionClient = Parameters<
+    Parameters<StorageClient['transaction']>[0]
+>[0];
+type DatabaseClient = StorageClient | TransactionClient;
+
+export type CheckoutOutletReservationExpectation = {
+    cartItemId: number;
+    comparePriceCents: number | null;
+    expiresAt?: string;
+    id: number;
+    initialPlantStatus: string;
+    offerId: number;
+    priceCents: number;
+    quantity: number;
+    sowingDate: string;
+    status: 'converted' | 'held';
+};
+
+export async function getCheckoutOutletReservationConflict(
+    {
+        accountId,
+        cartId,
+        cartItemIds,
+        expectations,
+        now,
+        requireActiveHolds = true,
+    }: {
+        accountId: string;
+        cartId: number;
+        cartItemIds: readonly number[];
+        expectations: readonly CheckoutOutletReservationExpectation[];
+        now: Date;
+        requireActiveHolds?: boolean;
+    },
+    db: TransactionClient,
+) {
+    const uniqueCartItemIds = [...new Set(cartItemIds)];
+    const uniqueOfferIds = [
+        ...new Set(expectations.map((expectation) => expectation.offerId)),
+    ];
+    const offers =
+        uniqueOfferIds.length > 0
+            ? await db
+                  .select()
+                  .from(outletOffers)
+                  .where(inArray(outletOffers.id, uniqueOfferIds))
+                  .orderBy(asc(outletOffers.id))
+                  .for('update')
+            : [];
+    const reservations =
+        uniqueCartItemIds.length > 0
+            ? await db
+                  .select()
+                  .from(outletOfferReservations)
+                  .where(
+                      and(
+                          inArray(
+                              outletOfferReservations.cartItemId,
+                              uniqueCartItemIds,
+                          ),
+                          ne(outletOfferReservations.status, 'released'),
+                      ),
+                  )
+                  .orderBy(asc(outletOfferReservations.id))
+                  .for('update')
+            : [];
+
+    if (reservations.length !== expectations.length) {
+        return 'outlet_reservation_membership_changed' as const;
+    }
+
+    const reservationsById = new Map(
+        reservations.map((reservation) => [reservation.id, reservation]),
+    );
+    const offersById = new Map(offers.map((offer) => [offer.id, offer]));
+    for (const expected of expectations) {
+        const reservation = reservationsById.get(expected.id);
+        const offer = offersById.get(expected.offerId);
+        if (
+            !reservation ||
+            !offer ||
+            reservation.accountId !== accountId ||
+            reservation.cartId !== cartId ||
+            reservation.cartItemId !== expected.cartItemId ||
+            reservation.outletOfferId !== expected.offerId ||
+            reservation.quantity !== expected.quantity ||
+            reservation.status !== expected.status ||
+            reservation.heldOutletPriceCents !== expected.priceCents ||
+            reservation.heldComparePriceCents !== expected.comparePriceCents ||
+            reservation.heldSowingDate.toISOString() !== expected.sowingDate ||
+            reservation.heldInitialPlantStatus !== expected.initialPlantStatus
+        ) {
+            return 'outlet_reservation_changed' as const;
+        }
+        if (
+            requireActiveHolds &&
+            expected.status === 'held' &&
+            (reservation.holdExpiresAt.getTime() <= now.getTime() ||
+                offer.isDeleted ||
+                offer.status !== 'published' ||
+                offer.startAt.getTime() > now.getTime() ||
+                offer.endAt.getTime() <= now.getTime() ||
+                (expected.expiresAt !== undefined &&
+                    reservation.holdExpiresAt.getTime() <
+                        new Date(expected.expiresAt).getTime()))
+        ) {
+            return 'outlet_reservation_inactive' as const;
+        }
+    }
+
+    return undefined;
+}
+
+export async function releaseOutletReservationsForCheckoutAttempt(
+    cartId: number,
+    reservationIds: readonly number[],
+    now = new Date(),
+    db: DatabaseClient,
+) {
+    const uniqueReservationIds = [...new Set(reservationIds)];
+    if (uniqueReservationIds.length === 0) {
+        return;
+    }
+    await db
+        .update(outletOfferReservations)
+        .set({ status: 'released', releasedAt: now })
+        .where(
+            and(
+                eq(outletOfferReservations.cartId, cartId),
+                inArray(outletOfferReservations.id, uniqueReservationIds),
+                eq(outletOfferReservations.status, 'held'),
+            ),
+        );
+}

--- a/packages/storage/src/repositories/outletOffersRepo.ts
+++ b/packages/storage/src/repositories/outletOffersRepo.ts
@@ -509,6 +509,28 @@ export async function releaseOutletReservationsForCart(
         );
 }
 
+export async function releaseOutletReservationsForCheckoutAttempt(
+    cartId: number,
+    reservationIds: readonly number[],
+    now = new Date(),
+    db: DatabaseClient = storage(),
+) {
+    const uniqueReservationIds = [...new Set(reservationIds)];
+    if (uniqueReservationIds.length === 0) {
+        return;
+    }
+    await db
+        .update(outletOfferReservations)
+        .set({ status: 'released', releasedAt: now })
+        .where(
+            and(
+                eq(outletOfferReservations.cartId, cartId),
+                inArray(outletOfferReservations.id, uniqueReservationIds),
+                eq(outletOfferReservations.status, 'held'),
+            ),
+        );
+}
+
 export async function convertOutletReservationForCartItem(
     cartItemId: number,
     now = new Date(),

--- a/packages/storage/src/repositories/outletOffersRepo.ts
+++ b/packages/storage/src/repositories/outletOffersRepo.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, inArray, lte, ne, sql } from 'drizzle-orm';
+import { and, asc, eq, gt, inArray, lte, ne, sql } from 'drizzle-orm';
 import {
     type InsertOutletOffer,
     type OutletOfferReservationStatus,
@@ -12,7 +12,10 @@ import {
 } from '../schema';
 import { storage } from '../storage';
 import { withCheckoutCartItemLock } from './checkoutCartItemLock';
-import { assertNoActiveStripeCheckoutAttempt } from './stripeCheckoutAttemptRepo';
+import {
+    assertNoActiveStripeCheckoutAttempt,
+    getActiveStripeCheckoutAttempt,
+} from './stripeCheckoutAttemptRepo';
 
 type StorageClient = ReturnType<typeof storage>;
 type TransactionClient = Parameters<
@@ -33,6 +36,14 @@ export class OutletReservationUnavailableError extends Error {
     constructor(message = 'Outlet reservation is not available.') {
         super(message);
         this.name = 'OutletReservationUnavailableError';
+    }
+}
+
+export class OutletOfferIdentityImmutableError extends Error {
+    override readonly name = 'OutletOfferIdentityImmutableError';
+
+    constructor(readonly offerId: number) {
+        super('An outlet offer with reservation history cannot change plant.');
     }
 }
 
@@ -151,9 +162,35 @@ export async function updateOutletOffer(
     data: Partial<
         Omit<InsertOutletOffer, 'id' | 'createdAt' | 'updatedAt' | 'isDeleted'>
     >,
-    db: DatabaseClient = storage(),
 ) {
-    await db.update(outletOffers).set(data).where(eq(outletOffers.id, id));
+    await storage().transaction(async (db) => {
+        const [offer] = await db
+            .select({
+                id: outletOffers.id,
+                plantSortId: outletOffers.plantSortId,
+            })
+            .from(outletOffers)
+            .where(eq(outletOffers.id, id))
+            .for('update')
+            .limit(1);
+        if (!offer) {
+            return;
+        }
+        if (
+            data.plantSortId !== undefined &&
+            data.plantSortId !== offer.plantSortId
+        ) {
+            const reservation =
+                await db.query.outletOfferReservations.findFirst({
+                    columns: { id: true },
+                    where: eq(outletOfferReservations.outletOfferId, id),
+                });
+            if (reservation) {
+                throw new OutletOfferIdentityImmutableError(id);
+            }
+        }
+        await db.update(outletOffers).set(data).where(eq(outletOffers.id, id));
+    });
 }
 
 export async function getOutletOffer(
@@ -385,6 +422,26 @@ async function reserveOutletOfferInTransaction(
     if (offer.endAt.getTime() <= now.getTime()) {
         throw new OutletOfferUnavailableError('Outlet offer has expired.');
     }
+    const cartItem = await tx.query.shoppingCartItems.findFirst({
+        columns: {
+            cartId: true,
+            entityId: true,
+            entityTypeName: true,
+            isDeleted: true,
+        },
+        where: eq(shoppingCartItems.id, cartItemId),
+    });
+    if (
+        !cartItem ||
+        cartItem.isDeleted ||
+        cartItem.cartId !== cartId ||
+        cartItem.entityTypeName !== 'plantSort' ||
+        cartItem.entityId !== offer.plantSortId.toString()
+    ) {
+        throw new OutletOfferUnavailableError(
+            'Outlet offer does not match the cart item.',
+        );
+    }
 
     const existingReservation =
         await tx.query.outletOfferReservations.findFirst({
@@ -596,9 +653,9 @@ export async function releaseOutletReservationsForCart(
 export async function convertOutletReservationForCartItem(
     cartItemId: number,
     now = new Date(),
-    db?: DatabaseClient,
+    db?: TransactionClient,
 ) {
-    const convert = async (tx: DatabaseClient) => {
+    const convert = async (tx: TransactionClient) => {
         const reservation = await tx.query.outletOfferReservations.findFirst({
             where: and(
                 eq(outletOfferReservations.cartItemId, cartItemId),
@@ -621,9 +678,22 @@ export async function convertOutletReservationForCartItem(
         }
 
         if (reservation.holdExpiresAt.getTime() <= now.getTime()) {
-            throw new OutletReservationUnavailableError(
-                'Outlet reservation has expired.',
+            const activeAttempt = await getActiveStripeCheckoutAttempt(
+                reservation.cartId,
+                tx,
             );
+            const capturedByBoundAttempt =
+                Boolean(activeAttempt?.sessionId) &&
+                activeAttempt?.snapshot.items.some(
+                    (item) =>
+                        item.id === cartItemId &&
+                        item.outlet?.reservationId === reservation.id,
+                );
+            if (!capturedByBoundAttempt) {
+                throw new OutletReservationUnavailableError(
+                    'Outlet reservation has expired.',
+                );
+            }
         }
 
         const [updated] = await tx
@@ -638,28 +708,83 @@ export async function convertOutletReservationForCartItem(
         return updated;
     };
 
-    return db ? convert(db) : storage().transaction(convert);
+    return db ? convert(db) : withCheckoutCartItemLock(cartItemId, convert);
 }
 
 export async function expireOutletReservations(
     now = new Date(),
-    db: DatabaseClient = storage(),
+    db?: TransactionClient,
 ) {
-    const expired = await db
-        .update(outletOfferReservations)
-        .set({
-            status: 'released',
-            releasedAt: now,
+    const database = db ?? storage();
+    const candidates = await database
+        .select({
+            cartId: outletOfferReservations.cartId,
+            cartItemId: outletOfferReservations.cartItemId,
+            id: outletOfferReservations.id,
         })
+        .from(outletOfferReservations)
         .where(
             and(
                 eq(outletOfferReservations.status, 'held'),
                 lte(outletOfferReservations.holdExpiresAt, now),
             ),
         )
-        .returning({ id: outletOfferReservations.id });
+        .orderBy(
+            asc(outletOfferReservations.cartItemId),
+            asc(outletOfferReservations.id),
+        );
 
-    return expired.map((reservation) => reservation.id);
+    const releasedIds: number[] = [];
+    for (const candidate of candidates) {
+        const release = async (tx: TransactionClient) => {
+            const [reservation] = await tx
+                .select()
+                .from(outletOfferReservations)
+                .where(eq(outletOfferReservations.id, candidate.id))
+                .for('update')
+                .limit(1);
+            if (
+                reservation?.status !== 'held' ||
+                reservation.holdExpiresAt.getTime() > now.getTime()
+            ) {
+                return undefined;
+            }
+            const activeAttempt = await getActiveStripeCheckoutAttempt(
+                candidate.cartId,
+                tx,
+            );
+            if (
+                activeAttempt?.snapshot.items.some(
+                    (item) =>
+                        item.id === candidate.cartItemId &&
+                        item.outlet?.reservationId === candidate.id,
+                )
+            ) {
+                return undefined;
+            }
+            const [released] = await tx
+                .update(outletOfferReservations)
+                .set({ status: 'released', releasedAt: now })
+                .where(
+                    and(
+                        eq(outletOfferReservations.id, candidate.id),
+                        eq(outletOfferReservations.status, 'held'),
+                    ),
+                )
+                .returning({ id: outletOfferReservations.id });
+            return released?.id;
+        };
+        const releasedId = await withCheckoutCartItemLock(
+            candidate.cartItemId,
+            release,
+            db,
+        );
+        if (releasedId !== undefined) {
+            releasedIds.push(releasedId);
+        }
+    }
+
+    return releasedIds;
 }
 
 export async function closeExpiredOutletOffers(

--- a/packages/storage/src/repositories/outletOffersRepo.ts
+++ b/packages/storage/src/repositories/outletOffersRepo.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, inArray, lte, ne, sql } from 'drizzle-orm';
+import { and, asc, eq, gt, inArray, lte, ne } from 'drizzle-orm';
 import {
     type InsertOutletOffer,
     type OutletOfferReservationStatus,
@@ -77,20 +77,22 @@ function activeOfferWhere(now: Date) {
     );
 }
 
-function activeHeldReservationWhere(now: Date) {
-    return and(
-        eq(outletOfferReservations.status, 'held'),
-        gt(outletOfferReservations.holdExpiresAt, now),
-    );
-}
+type AvailabilityReservation = Pick<
+    SelectOutletOfferReservation,
+    | 'cartId'
+    | 'cartItemId'
+    | 'holdExpiresAt'
+    | 'id'
+    | 'outletOfferId'
+    | 'quantity'
+    | 'status'
+>;
 
 function countQuantity(
-    reservations: Pick<
-        SelectOutletOfferReservation,
-        'quantity' | 'status' | 'holdExpiresAt'
-    >[],
+    reservations: readonly AvailabilityReservation[],
     now: Date,
     status: OutletOfferReservationStatus,
+    protectedReservationIds: ReadonlySet<number> = new Set(),
 ) {
     return reservations.reduce((sum, reservation) => {
         if (reservation.status !== status) {
@@ -99,7 +101,8 @@ function countQuantity(
 
         if (
             status === 'held' &&
-            reservation.holdExpiresAt.getTime() <= now.getTime()
+            reservation.holdExpiresAt.getTime() <= now.getTime() &&
+            !protectedReservationIds.has(reservation.id)
         ) {
             return sum;
         }
@@ -110,13 +113,16 @@ function countQuantity(
 
 function withAvailability(
     offer: SelectOutletOffer,
-    reservations: Pick<
-        SelectOutletOfferReservation,
-        'quantity' | 'status' | 'holdExpiresAt'
-    >[],
+    reservations: readonly AvailabilityReservation[],
     now: Date,
+    protectedReservationIds: ReadonlySet<number>,
 ): OutletOfferWithAvailability {
-    const reservedQuantity = countQuantity(reservations, now, 'held');
+    const reservedQuantity = countQuantity(
+        reservations,
+        now,
+        'held',
+        protectedReservationIds,
+    );
     const soldQuantity = countQuantity(reservations, now, 'converted');
     return {
         ...offer,
@@ -140,6 +146,61 @@ async function getReservationsForOfferIds(
     return db.query.outletOfferReservations.findMany({
         where: inArray(outletOfferReservations.outletOfferId, offerIds),
     });
+}
+
+async function getActiveAttemptProtectedReservationIds(
+    reservations: readonly AvailabilityReservation[],
+    now: Date,
+    db: DatabaseClient,
+) {
+    const expiredHeldReservationsByCartId = new Map<
+        number,
+        Map<number, AvailabilityReservation>
+    >();
+    for (const reservation of reservations) {
+        if (
+            reservation.status !== 'held' ||
+            reservation.holdExpiresAt.getTime() > now.getTime()
+        ) {
+            continue;
+        }
+        const cartReservations =
+            expiredHeldReservationsByCartId.get(reservation.cartId) ??
+            new Map<number, AvailabilityReservation>();
+        cartReservations.set(reservation.id, reservation);
+        expiredHeldReservationsByCartId.set(
+            reservation.cartId,
+            cartReservations,
+        );
+    }
+
+    const protectedReservationIds = new Set<number>();
+    const cartIds = [...expiredHeldReservationsByCartId.keys()].sort(
+        (left, right) => left - right,
+    );
+    for (const cartId of cartIds) {
+        const activeAttempt = await getActiveStripeCheckoutAttempt(cartId, db);
+        if (!activeAttempt) {
+            continue;
+        }
+        const cartReservations = expiredHeldReservationsByCartId.get(cartId);
+        if (!cartReservations) {
+            continue;
+        }
+        for (const item of activeAttempt.snapshot.items) {
+            if (!item.outlet) {
+                continue;
+            }
+            const reservation = cartReservations.get(item.outlet.reservationId);
+            if (
+                reservation?.cartItemId === item.id &&
+                reservation.outletOfferId === item.outlet.offerId
+            ) {
+                protectedReservationIds.add(reservation.id);
+            }
+        }
+    }
+    return protectedReservationIds;
 }
 
 export async function createOutletOffer(
@@ -206,7 +267,9 @@ export async function getOutletOffer(
     }
 
     const reservations = await getReservationsForOfferIds([offer.id], db);
-    return withAvailability(offer, reservations, now);
+    const protectedReservationIds =
+        await getActiveAttemptProtectedReservationIds(reservations, now, db);
+    return withAvailability(offer, reservations, now, protectedReservationIds);
 }
 
 export async function getOutletOfferReservation(
@@ -297,6 +360,8 @@ export async function getOutletOffers({
         offers.map((offer) => offer.id),
         db,
     );
+    const protectedReservationIds =
+        await getActiveAttemptProtectedReservationIds(reservations, now, db);
     const reservationsByOfferId = new Map<
         number,
         SelectOutletOfferReservation[]
@@ -309,7 +374,12 @@ export async function getOutletOffers({
     }
 
     const offersWithAvailability = offers.map((offer) =>
-        withAvailability(offer, reservationsByOfferId.get(offer.id) ?? [], now),
+        withAvailability(
+            offer,
+            reservationsByOfferId.get(offer.id) ?? [],
+            now,
+            protectedReservationIds,
+        ),
     );
 
     return includeUnavailable || statuses?.length
@@ -335,7 +405,7 @@ async function lockOutletOffer(
     return offer ?? null;
 }
 
-async function getActiveReservedQuantity({
+async function getReservedAndConvertedQuantities({
     offerId,
     now,
     excludeReservationId,
@@ -346,49 +416,31 @@ async function getActiveReservedQuantity({
     excludeReservationId?: number;
     db: TransactionClient;
 }) {
-    const [row] = await db
-        .select({
-            quantity: sql<number>`coalesce(sum(${outletOfferReservations.quantity}), 0)::int`,
-        })
+    const reservations = await db
+        .select()
         .from(outletOfferReservations)
         .where(
             and(
                 eq(outletOfferReservations.outletOfferId, offerId),
-                activeHeldReservationWhere(now),
+                inArray(outletOfferReservations.status, ['held', 'converted']),
                 excludeReservationId
                     ? ne(outletOfferReservations.id, excludeReservationId)
                     : undefined,
             ),
-        );
-
-    return row?.quantity ?? 0;
-}
-
-async function getConvertedQuantity({
-    offerId,
-    excludeReservationId,
-    db,
-}: {
-    offerId: number;
-    excludeReservationId?: number;
-    db: TransactionClient;
-}) {
-    const [row] = await db
-        .select({
-            quantity: sql<number>`coalesce(sum(${outletOfferReservations.quantity}), 0)::int`,
-        })
-        .from(outletOfferReservations)
-        .where(
-            and(
-                eq(outletOfferReservations.outletOfferId, offerId),
-                eq(outletOfferReservations.status, 'converted'),
-                excludeReservationId
-                    ? ne(outletOfferReservations.id, excludeReservationId)
-                    : undefined,
-            ),
-        );
-
-    return row?.quantity ?? 0;
+        )
+        .orderBy(asc(outletOfferReservations.id))
+        .for('update');
+    const protectedReservationIds =
+        await getActiveAttemptProtectedReservationIds(reservations, now, db);
+    return {
+        reservedQuantity: countQuantity(
+            reservations,
+            now,
+            'held',
+            protectedReservationIds,
+        ),
+        soldQuantity: countQuantity(reservations, now, 'converted'),
+    };
 }
 
 async function reserveOutletOfferInTransaction(
@@ -472,15 +524,13 @@ async function reserveOutletOfferInTransaction(
             ? existingReservation
             : null;
     const excludeReservationId = reusableReservation?.id;
-    const [reservedQuantity, soldQuantity] = await Promise.all([
-        getActiveReservedQuantity({
+    const { reservedQuantity, soldQuantity } =
+        await getReservedAndConvertedQuantities({
             offerId,
             now,
             excludeReservationId,
             db: tx,
-        }),
-        getConvertedQuantity({ offerId, excludeReservationId, db: tx }),
-    ]);
+        });
     const remainingQuantity = offer.quantity - reservedQuantity - soldQuantity;
     if (remainingQuantity < quantity) {
         throw new OutletOfferUnavailableError('Outlet offer is sold out.');
@@ -789,21 +839,44 @@ export async function expireOutletReservations(
 
 export async function closeExpiredOutletOffers(
     now = new Date(),
-    db: DatabaseClient = storage(),
+    db?: TransactionClient,
 ) {
-    const closed = await db
-        .update(outletOffers)
-        .set({ status: 'closed' })
-        .where(
-            and(
-                eq(outletOffers.isDeleted, false),
-                eq(outletOffers.status, 'published'),
-                lte(outletOffers.endAt, now),
-            ),
-        )
-        .returning({ id: outletOffers.id });
+    const close = async (tx: TransactionClient) => {
+        const expiredOffers = await tx
+            .select({ id: outletOffers.id })
+            .from(outletOffers)
+            .where(
+                and(
+                    eq(outletOffers.isDeleted, false),
+                    eq(outletOffers.status, 'published'),
+                    lte(outletOffers.endAt, now),
+                ),
+            )
+            .orderBy(asc(outletOffers.id))
+            .for('update');
+        if (expiredOffers.length === 0) {
+            return [];
+        }
+        const expiredOfferIds = expiredOffers.map((offer) => offer.id);
+        const closed = await tx
+            .update(outletOffers)
+            .set({ status: 'closed' })
+            .where(
+                and(
+                    inArray(outletOffers.id, expiredOfferIds),
+                    eq(outletOffers.isDeleted, false),
+                    eq(outletOffers.status, 'published'),
+                    lte(outletOffers.endAt, now),
+                ),
+            )
+            .returning({ id: outletOffers.id });
 
-    return closed.map((offer) => offer.id);
+        return closed
+            .map((offer) => offer.id)
+            .sort((left, right) => left - right);
+    };
+
+    return db ? close(db) : storage().transaction(close);
 }
 
 export async function cleanupOutletLifecycle(now = new Date()) {

--- a/packages/storage/src/repositories/outletOffersRepo.ts
+++ b/packages/storage/src/repositories/outletOffersRepo.ts
@@ -7,8 +7,12 @@ import {
     outletOffers,
     type SelectOutletOffer,
     type SelectOutletOfferReservation,
+    shoppingCartItems,
+    shoppingCarts,
 } from '../schema';
 import { storage } from '../storage';
+import { withCheckoutCartItemLock } from './checkoutCartItemLock';
+import { assertNoActiveStripeCheckoutAttempt } from './stripeCheckoutAttemptRepo';
 
 type StorageClient = ReturnType<typeof storage>;
 type TransactionClient = Parameters<
@@ -461,20 +465,62 @@ async function reserveOutletOfferInTransaction(
     return created;
 }
 
+async function lockCartAndAssertOutletMutationAllowed(
+    cartId: number,
+    db: TransactionClient,
+) {
+    const [cart] = await db
+        .select({
+            accountId: shoppingCarts.accountId,
+            id: shoppingCarts.id,
+            isDeleted: shoppingCarts.isDeleted,
+            status: shoppingCarts.status,
+        })
+        .from(shoppingCarts)
+        .where(eq(shoppingCarts.id, cartId))
+        .for('update')
+        .limit(1);
+    if (!cart || cart.isDeleted || cart.status !== 'new') {
+        throw new OutletReservationUnavailableError(
+            'Outlet reservation cart is no longer mutable.',
+        );
+    }
+    await assertNoActiveStripeCheckoutAttempt(cartId, db);
+    return cart;
+}
+
 export async function reserveOutletOffer(options: ReserveOutletOfferOptions) {
     if (options.db) {
         return reserveOutletOfferInTransaction(options, options.db);
     }
 
-    return storage().transaction((tx) =>
-        reserveOutletOfferInTransaction(options, tx),
-    );
+    return withCheckoutCartItemLock(options.cartItemId, async (tx) => {
+        const cart = await lockCartAndAssertOutletMutationAllowed(
+            options.cartId,
+            tx,
+        );
+        const item = await tx.query.shoppingCartItems.findFirst({
+            columns: { cartId: true, isDeleted: true },
+            where: eq(shoppingCartItems.id, options.cartItemId),
+        });
+        if (
+            cart.accountId !== options.accountId ||
+            !item ||
+            item.cartId !== options.cartId ||
+            item.isDeleted
+        ) {
+            throw new OutletReservationUnavailableError(
+                'Outlet reservation cart is no longer mutable.',
+            );
+        }
+        return reserveOutletOfferInTransaction(options, tx);
+    });
 }
 
-export async function releaseOutletReservationForCartItem(
+async function releaseOutletReservationForCartItemInDatabase(
     cartItemId: number,
-    now = new Date(),
-    db: DatabaseClient = storage(),
+    now: Date,
+    db: DatabaseClient,
 ) {
     await db
         .update(outletOfferReservations)
@@ -490,45 +536,61 @@ export async function releaseOutletReservationForCartItem(
         );
 }
 
+export async function releaseOutletReservationForCartItem(
+    cartItemId: number,
+    now = new Date(),
+    db?: DatabaseClient,
+) {
+    if (db) {
+        return releaseOutletReservationForCartItemInDatabase(
+            cartItemId,
+            now,
+            db,
+        );
+    }
+    return withCheckoutCartItemLock(cartItemId, async (tx) => {
+        const item = await tx.query.shoppingCartItems.findFirst({
+            columns: { cartId: true },
+            where: eq(shoppingCartItems.id, cartItemId),
+        });
+        if (!item) {
+            return;
+        }
+        await lockCartAndAssertOutletMutationAllowed(item.cartId, tx);
+        await releaseOutletReservationForCartItemInDatabase(
+            cartItemId,
+            now,
+            tx,
+        );
+    });
+}
+
 export async function releaseOutletReservationsForCart(
     cartId: number,
     now = new Date(),
-    db: DatabaseClient = storage(),
+    db?: DatabaseClient,
 ) {
-    await db
-        .update(outletOfferReservations)
-        .set({
-            status: 'released',
-            releasedAt: now,
-        })
-        .where(
-            and(
-                eq(outletOfferReservations.cartId, cartId),
-                eq(outletOfferReservations.status, 'held'),
-            ),
-        );
-}
-
-export async function releaseOutletReservationsForCheckoutAttempt(
-    cartId: number,
-    reservationIds: readonly number[],
-    now = new Date(),
-    db: DatabaseClient = storage(),
-) {
-    const uniqueReservationIds = [...new Set(reservationIds)];
-    if (uniqueReservationIds.length === 0) {
+    const release = async (database: DatabaseClient) =>
+        database
+            .update(outletOfferReservations)
+            .set({
+                status: 'released',
+                releasedAt: now,
+            })
+            .where(
+                and(
+                    eq(outletOfferReservations.cartId, cartId),
+                    eq(outletOfferReservations.status, 'held'),
+                ),
+            );
+    if (db) {
+        await release(db);
         return;
     }
-    await db
-        .update(outletOfferReservations)
-        .set({ status: 'released', releasedAt: now })
-        .where(
-            and(
-                eq(outletOfferReservations.cartId, cartId),
-                inArray(outletOfferReservations.id, uniqueReservationIds),
-                eq(outletOfferReservations.status, 'held'),
-            ),
-        );
+    await storage().transaction(async (tx) => {
+        await lockCartAndAssertOutletMutationAllowed(cartId, tx);
+        await release(tx);
+    });
 }
 
 export async function convertOutletReservationForCartItem(

--- a/packages/storage/src/repositories/outletOffersRepo.ts
+++ b/packages/storage/src/repositories/outletOffersRepo.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, inArray, lte, ne } from 'drizzle-orm';
+import { and, asc, eq, gt, inArray, lte, ne, or } from 'drizzle-orm';
 import {
     type InsertOutletOffer,
     type OutletOfferReservationStatus,
@@ -387,59 +387,95 @@ export async function getOutletOffers({
         : offersWithAvailability.filter((offer) => offer.remainingQuantity > 0);
 }
 
-async function lockOutletOffer(
-    offerId: number,
+async function lockOutletOffers(
+    offerIds: readonly number[],
     db: TransactionClient,
-): Promise<SelectOutletOffer | null> {
-    const [offer] = await db
+) {
+    const uniqueOfferIds = [...new Set(offerIds)].sort(
+        (left, right) => left - right,
+    );
+    if (uniqueOfferIds.length === 0) {
+        return [];
+    }
+    return db
         .select()
         .from(outletOffers)
-        .where(
-            and(
-                eq(outletOffers.id, offerId),
-                eq(outletOffers.isDeleted, false),
-            ),
-        )
+        .where(inArray(outletOffers.id, uniqueOfferIds))
+        .orderBy(asc(outletOffers.id))
         .for('update');
+}
 
-    return offer ?? null;
+async function findCurrentOutletReservation(
+    cartItemId: number,
+    db: DatabaseClient,
+) {
+    return db.query.outletOfferReservations.findFirst({
+        where: and(
+            eq(outletOfferReservations.cartItemId, cartItemId),
+            ne(outletOfferReservations.status, 'released'),
+        ),
+        orderBy: (table, { desc }) => [desc(table.createdAt), desc(table.id)],
+    });
+}
+
+async function lockOutletReservationsForSwitch({
+    existingReservationId,
+    targetOfferId,
+    db,
+}: {
+    existingReservationId?: number;
+    targetOfferId: number;
+    db: TransactionClient;
+}) {
+    const targetCapacityWhere = and(
+        eq(outletOfferReservations.outletOfferId, targetOfferId),
+        inArray(outletOfferReservations.status, ['held', 'converted']),
+    );
+    return db
+        .select()
+        .from(outletOfferReservations)
+        .where(
+            existingReservationId
+                ? or(
+                      eq(outletOfferReservations.id, existingReservationId),
+                      targetCapacityWhere,
+                  )
+                : targetCapacityWhere,
+        )
+        .orderBy(asc(outletOfferReservations.id))
+        .for('update');
 }
 
 async function getReservedAndConvertedQuantities({
-    offerId,
+    reservations,
     now,
     excludeReservationId,
     db,
 }: {
-    offerId: number;
+    reservations: readonly AvailabilityReservation[];
     now: Date;
     excludeReservationId?: number;
     db: TransactionClient;
 }) {
-    const reservations = await db
-        .select()
-        .from(outletOfferReservations)
-        .where(
-            and(
-                eq(outletOfferReservations.outletOfferId, offerId),
-                inArray(outletOfferReservations.status, ['held', 'converted']),
-                excludeReservationId
-                    ? ne(outletOfferReservations.id, excludeReservationId)
-                    : undefined,
-            ),
-        )
-        .orderBy(asc(outletOfferReservations.id))
-        .for('update');
+    const capacityReservations = excludeReservationId
+        ? reservations.filter(
+              (reservation) => reservation.id !== excludeReservationId,
+          )
+        : reservations;
     const protectedReservationIds =
-        await getActiveAttemptProtectedReservationIds(reservations, now, db);
+        await getActiveAttemptProtectedReservationIds(
+            capacityReservations,
+            now,
+            db,
+        );
     return {
         reservedQuantity: countQuantity(
-            reservations,
+            capacityReservations,
             now,
             'held',
             protectedReservationIds,
         ),
-        soldQuantity: countQuantity(reservations, now, 'converted'),
+        soldQuantity: countQuantity(capacityReservations, now, 'converted'),
     };
 }
 
@@ -461,19 +497,6 @@ async function reserveOutletOfferInTransaction(
         );
     }
 
-    const offer = await lockOutletOffer(offerId, tx);
-    if (!offer) {
-        throw new OutletOfferUnavailableError();
-    }
-    if (offer.status !== 'published') {
-        throw new OutletOfferUnavailableError();
-    }
-    if (offer.startAt.getTime() > now.getTime()) {
-        throw new OutletOfferUnavailableError('Outlet offer has not started.');
-    }
-    if (offer.endAt.getTime() <= now.getTime()) {
-        throw new OutletOfferUnavailableError('Outlet offer has expired.');
-    }
     const cartItem = await tx.query.shoppingCartItems.findFirst({
         columns: {
             cartId: true,
@@ -487,25 +510,69 @@ async function reserveOutletOfferInTransaction(
         !cartItem ||
         cartItem.isDeleted ||
         cartItem.cartId !== cartId ||
-        cartItem.entityTypeName !== 'plantSort' ||
-        cartItem.entityId !== offer.plantSortId.toString()
+        cartItem.entityTypeName !== 'plantSort'
     ) {
         throw new OutletOfferUnavailableError(
             'Outlet offer does not match the cart item.',
         );
     }
 
+    // Discover the source before taking database row locks, then keep the
+    // global order: all touched offers by ID, followed by all reservations by
+    // ID. The outer checkout-item and cart locks stabilize this cart item.
+    const discoveredReservation = await findCurrentOutletReservation(
+        cartItemId,
+        tx,
+    );
+    const lockedOffers = await lockOutletOffers(
+        [offerId, discoveredReservation?.outletOfferId].filter(
+            (id): id is number => id !== undefined,
+        ),
+        tx,
+    );
+    const offer = lockedOffers.find((candidate) => candidate.id === offerId);
+    if (!offer || offer.isDeleted || offer.status !== 'published') {
+        throw new OutletOfferUnavailableError();
+    }
+    if (offer.startAt.getTime() > now.getTime()) {
+        throw new OutletOfferUnavailableError('Outlet offer has not started.');
+    }
+    if (offer.endAt.getTime() <= now.getTime()) {
+        throw new OutletOfferUnavailableError('Outlet offer has expired.');
+    }
+    if (cartItem.entityId !== offer.plantSortId.toString()) {
+        throw new OutletOfferUnavailableError(
+            'Outlet offer does not match the cart item.',
+        );
+    }
+
+    const lockedReservations = await lockOutletReservationsForSwitch({
+        existingReservationId: discoveredReservation?.id,
+        targetOfferId: offerId,
+        db: tx,
+    });
+    const lockedExistingReservation = discoveredReservation
+        ? lockedReservations.find(
+              (reservation) => reservation.id === discoveredReservation.id,
+          )
+        : undefined;
+    if (
+        discoveredReservation &&
+        (!lockedExistingReservation ||
+            lockedExistingReservation.accountId !== accountId ||
+            lockedExistingReservation.cartId !== cartId ||
+            lockedExistingReservation.cartItemId !== cartItemId ||
+            lockedExistingReservation.outletOfferId !==
+                discoveredReservation.outletOfferId)
+    ) {
+        throw new OutletReservationUnavailableError(
+            'Outlet reservation changed while switching offers.',
+        );
+    }
     const existingReservation =
-        await tx.query.outletOfferReservations.findFirst({
-            where: and(
-                eq(outletOfferReservations.cartItemId, cartItemId),
-                ne(outletOfferReservations.status, 'released'),
-            ),
-            orderBy: (table, { desc }) => [
-                desc(table.createdAt),
-                desc(table.id),
-            ],
-        });
+        lockedExistingReservation?.status === 'released'
+            ? undefined
+            : lockedExistingReservation;
 
     if (existingReservation?.status === 'converted') {
         throw new OutletReservationUnavailableError(
@@ -526,7 +593,9 @@ async function reserveOutletOfferInTransaction(
     const excludeReservationId = reusableReservation?.id;
     const { reservedQuantity, soldQuantity } =
         await getReservedAndConvertedQuantities({
-            offerId,
+            reservations: lockedReservations.filter(
+                (reservation) => reservation.outletOfferId === offerId,
+            ),
             now,
             excludeReservationId,
             db: tx,
@@ -624,12 +693,41 @@ export async function reserveOutletOffer(options: ReserveOutletOfferOptions) {
     });
 }
 
-async function releaseOutletReservationForCartItemInDatabase(
-    cartItemId: number,
-    now: Date,
-    db: DatabaseClient,
+async function releaseHeldOutletReservations(
+    {
+        cartId,
+        cartItemId,
+        now,
+    }: {
+        cartId?: number;
+        cartItemId?: number;
+        now: Date;
+    },
+    db: TransactionClient,
 ) {
-    await db
+    if (cartId === undefined && cartItemId === undefined) {
+        throw new TypeError('An outlet reservation release scope is required.');
+    }
+    const reservations = await db
+        .select({ id: outletOfferReservations.id })
+        .from(outletOfferReservations)
+        .where(
+            and(
+                cartId !== undefined
+                    ? eq(outletOfferReservations.cartId, cartId)
+                    : undefined,
+                cartItemId !== undefined
+                    ? eq(outletOfferReservations.cartItemId, cartItemId)
+                    : undefined,
+                eq(outletOfferReservations.status, 'held'),
+            ),
+        )
+        .orderBy(asc(outletOfferReservations.id))
+        .for('update');
+    if (reservations.length === 0) {
+        return [];
+    }
+    return db
         .update(outletOfferReservations)
         .set({
             status: 'released',
@@ -637,23 +735,23 @@ async function releaseOutletReservationForCartItemInDatabase(
         })
         .where(
             and(
-                eq(outletOfferReservations.cartItemId, cartItemId),
+                inArray(
+                    outletOfferReservations.id,
+                    reservations.map((reservation) => reservation.id),
+                ),
                 eq(outletOfferReservations.status, 'held'),
             ),
-        );
+        )
+        .returning({ id: outletOfferReservations.id });
 }
 
 export async function releaseOutletReservationForCartItem(
     cartItemId: number,
     now = new Date(),
-    db?: DatabaseClient,
+    db?: TransactionClient,
 ) {
     if (db) {
-        return releaseOutletReservationForCartItemInDatabase(
-            cartItemId,
-            now,
-            db,
-        );
+        return releaseHeldOutletReservations({ cartItemId, now }, db);
     }
     return withCheckoutCartItemLock(cartItemId, async (tx) => {
         const item = await tx.query.shoppingCartItems.findFirst({
@@ -664,39 +762,22 @@ export async function releaseOutletReservationForCartItem(
             return;
         }
         await lockCartAndAssertOutletMutationAllowed(item.cartId, tx);
-        await releaseOutletReservationForCartItemInDatabase(
-            cartItemId,
-            now,
-            tx,
-        );
+        await releaseHeldOutletReservations({ cartItemId, now }, tx);
     });
 }
 
 export async function releaseOutletReservationsForCart(
     cartId: number,
     now = new Date(),
-    db?: DatabaseClient,
+    db?: TransactionClient,
 ) {
-    const release = async (database: DatabaseClient) =>
-        database
-            .update(outletOfferReservations)
-            .set({
-                status: 'released',
-                releasedAt: now,
-            })
-            .where(
-                and(
-                    eq(outletOfferReservations.cartId, cartId),
-                    eq(outletOfferReservations.status, 'held'),
-                ),
-            );
     if (db) {
-        await release(db);
+        await releaseHeldOutletReservations({ cartId, now }, db);
         return;
     }
     await storage().transaction(async (tx) => {
         await lockCartAndAssertOutletMutationAllowed(cartId, tx);
-        await release(tx);
+        await releaseHeldOutletReservations({ cartId, now }, tx);
     });
 }
 

--- a/packages/storage/src/repositories/raisedBedsRepo.ts
+++ b/packages/storage/src/repositories/raisedBedsRepo.ts
@@ -37,6 +37,7 @@ import {
     raisedBedSensors,
     type UpdateRaisedBedSensor,
 } from '../schema/gardenSchema';
+import { withCheckoutCartItemLocks } from './checkoutCartItemLock';
 import {
     createEvent,
     getAllEvents,
@@ -55,6 +56,7 @@ import {
 } from './raisedBedFieldsRepo';
 import { processReferralRewardsForAccount } from './referralsRepo';
 import type { ScheduleTaskTransaction } from './scheduleTaskTransactionsRepo';
+import { lockAndAssertCartItemsMutable } from './stripeCheckoutAttemptRepo';
 
 const RAISED_BED_FIELDS_PER_BLOCK = 9;
 
@@ -715,8 +717,46 @@ export async function mergeRaisedBeds(
     }
 
     const db = storage();
+    const expectedMutableCartItems = await db
+        .select({ id: shoppingCartItems.id })
+        .from(shoppingCartItems)
+        .where(
+            and(
+                eq(shoppingCartItems.raisedBedId, sourceRaisedBedId),
+                eq(shoppingCartItems.isDeleted, false),
+                eq(shoppingCartItems.status, 'new'),
+            ),
+        );
+    const expectedMutableCartItemIds = expectedMutableCartItems.map(
+        (item) => item.id,
+    );
 
-    await db.transaction(async (tx) => {
+    await withCheckoutCartItemLocks(expectedMutableCartItemIds, async (tx) => {
+        const liveMutableCartItems = await tx
+            .select({ id: shoppingCartItems.id })
+            .from(shoppingCartItems)
+            .where(
+                and(
+                    eq(shoppingCartItems.raisedBedId, sourceRaisedBedId),
+                    eq(shoppingCartItems.isDeleted, false),
+                    eq(shoppingCartItems.status, 'new'),
+                ),
+            );
+        const expectedMutableCartItemIdSet = new Set(
+            expectedMutableCartItemIds,
+        );
+        if (
+            liveMutableCartItems.length !== expectedMutableCartItemIds.length ||
+            liveMutableCartItems.some(
+                (item) => !expectedMutableCartItemIdSet.has(item.id),
+            )
+        ) {
+            throw new Error(
+                'Shopping cart items changed while fencing raised bed merge.',
+            );
+        }
+        await lockAndAssertCartItemsMutable(expectedMutableCartItemIds, tx);
+
         const targetRaisedBed = await tx.query.raisedBeds.findFirst({
             where: and(
                 eq(raisedBeds.id, targetRaisedBedId),

--- a/packages/storage/src/repositories/shoppingCartRepo.ts
+++ b/packages/storage/src/repositories/shoppingCartRepo.ts
@@ -6,6 +6,7 @@ import {
     shoppingCarts,
 } from '../schema';
 import { storage } from '../storage';
+import { lockAccountAndAssertNotDeleting } from './accountDeletionFenceRepo';
 import {
     withCheckoutCartItemLock,
     withCheckoutCartItemLocks,
@@ -683,36 +684,40 @@ export async function getOrCreateShoppingCart(
     accountId: string,
     status: 'new' | 'paid' = 'new',
 ) {
-    const cart = await storage().query.shoppingCarts.findFirst({
-        where: and(
-            eq(shoppingCarts.accountId, accountId),
-            eq(shoppingCarts.isDeleted, false),
-            eq(shoppingCarts.status, status),
-        ),
-        with: {
-            items: {
-                where: and(eq(shoppingCartItems.isDeleted, false)),
-                orderBy: shoppingCartItems.createdAt,
+    return storage().transaction(async (db) => {
+        const account = await lockAccountAndAssertNotDeleting(accountId, db);
+        if (!account) {
+            throw new Error('Shopping cart account not found');
+        }
+        const cart = await db.query.shoppingCarts.findFirst({
+            where: and(
+                eq(shoppingCarts.accountId, accountId),
+                eq(shoppingCarts.isDeleted, false),
+                eq(shoppingCarts.status, status),
+            ),
+            with: {
+                items: {
+                    where: and(eq(shoppingCartItems.isDeleted, false)),
+                    orderBy: shoppingCartItems.createdAt,
+                },
             },
-        },
-    });
-    if (cart) {
-        return cart;
-    }
+        });
+        if (cart) {
+            return cart;
+        }
 
-    const createdCartId = (
-        await storage()
+        const [createdCart] = await db
             .insert(shoppingCarts)
             .values({
                 accountId,
                 status: 'new',
             })
-            .returning({
-                id: shoppingCarts.id,
-            })
-    )[0].id;
-
-    return getShoppingCart(createdCartId);
+            .returning({ id: shoppingCarts.id });
+        if (!createdCart) {
+            throw new Error('Failed to create shopping cart');
+        }
+        return getShoppingCart(createdCart.id, db);
+    });
 }
 
 export async function markCartPaidIfAllItemsPaid(cartId: number) {

--- a/packages/storage/src/repositories/shoppingCartRepo.ts
+++ b/packages/storage/src/repositories/shoppingCartRepo.ts
@@ -26,6 +26,10 @@ import {
     releaseOutletReservationsForCart,
     reserveOutletOffer,
 } from './outletOffersRepo';
+import {
+    assertNoActiveStripeCheckoutAttempt,
+    getActiveStripeCheckoutAttempt,
+} from './stripeCheckoutAttemptRepo';
 
 type StorageClient = ReturnType<typeof storage>;
 type TransactionClient = Parameters<
@@ -626,6 +630,15 @@ export async function normalizeShoppingCartScheduledDates(
 
     const itemIds = itemUpdates.map((item) => item.id);
     await withCheckoutCartItemLocks(itemIds, async (db) => {
+        const [lockedCart] = await db
+            .select({ id: shoppingCarts.id })
+            .from(shoppingCarts)
+            .where(eq(shoppingCarts.id, cartId))
+            .for('update')
+            .limit(1);
+        if (!lockedCart || (await getActiveStripeCheckoutAttempt(cartId, db))) {
+            return;
+        }
         const lockedItems = await db
             .select()
             .from(shoppingCartItems)
@@ -797,20 +810,31 @@ export async function upsertOrRemoveCartItem(
         // Re-read after taking the checkout-item lock. A checkout that won the
         // race may have committed a payment or fulfillment effect meanwhile.
         const existingItem = await findExistingItem(db, lockedItemId);
+        if (existingItem && existingItem.cartId !== cartId) {
+            throw new Error('Shopping cart item does not belong to this cart');
+        }
+        const [mutationCart] = await db
+            .select({
+                accountId: shoppingCarts.accountId,
+                id: shoppingCarts.id,
+                isDeleted: shoppingCarts.isDeleted,
+                status: shoppingCarts.status,
+            })
+            .from(shoppingCarts)
+            .where(eq(shoppingCarts.id, cartId))
+            .for('update')
+            .limit(1);
+        if (!mutationCart) {
+            throw new Error('Shopping cart not found');
+        }
+        await assertNoActiveStripeCheckoutAttempt(cartId, db);
         if (existingItem) {
-            const cart = await db.query.shoppingCarts.findFirst({
-                columns: { accountId: true },
-                where: eq(shoppingCarts.id, existingItem.cartId),
-            });
-            if (!cart) {
-                throw new Error('Shopping cart not found');
-            }
-            if (!cart.accountId) {
+            if (!mutationCart.accountId) {
                 throw new Error('Shopping cart account is missing');
             }
             const fulfillmentStartedItemIds =
                 await getCheckoutFulfillmentStartedCartItemIds(
-                    cart.accountId,
+                    mutationCart.accountId,
                     [existingItem],
                     db,
                 );
@@ -1064,6 +1088,7 @@ export async function deleteShoppingCart(accountId: string) {
                 if (lockedCart.accountId !== accountId) {
                     throw new Error('Shopping cart account mismatch');
                 }
+                await assertNoActiveStripeCheckoutAttempt(lockedCart.id, db);
 
                 const liveItems = await db.query.shoppingCartItems.findMany({
                     where: and(
@@ -1151,6 +1176,18 @@ export async function normalizeShoppingCartInventoryUsage(cartId: number) {
     }
 
     await withCheckoutCartItemLocks(inventoryItemIds, async (checkoutTx) => {
+        const [lockedCart] = await checkoutTx
+            .select({ id: shoppingCarts.id })
+            .from(shoppingCarts)
+            .where(eq(shoppingCarts.id, cartId))
+            .for('update')
+            .limit(1);
+        if (
+            !lockedCart ||
+            (await getActiveStripeCheckoutAttempt(cartId, checkoutTx))
+        ) {
+            return;
+        }
         await withInventoryAccountTransaction(
             accountId,
             async (tx) => {

--- a/packages/storage/src/repositories/stripeCheckoutAttemptRepo.ts
+++ b/packages/storage/src/repositories/stripeCheckoutAttemptRepo.ts
@@ -708,13 +708,14 @@ export async function createStripeCheckoutAttempt(
                                       initialPlantStatus:
                                           item.outlet.initialPlantStatus,
                                       offerId: item.outlet.offerId,
+                                      plantSortId: item.entityId,
                                       priceCents: item.outlet.priceCents,
                                       quantity: item.amount,
                                       sowingDate: item.outlet.sowingDate,
-                                      status:
+                                      statuses:
                                           item.status === 'paid'
-                                              ? ('converted' as const)
-                                              : ('held' as const),
+                                              ? (['converted'] as const)
+                                              : (['held'] as const),
                                   },
                               ]
                             : [],
@@ -870,6 +871,9 @@ export async function verifyStripeCheckoutAttemptLiveCart(
                 attempt.snapshot,
                 liveItems,
             );
+            const liveItemStatusById = new Map(
+                liveItems.map((item) => [item.id, item.status]),
+            );
             const outletReservationConflict =
                 await getCheckoutOutletReservationConflict(
                     {
@@ -899,13 +903,19 @@ export async function verifyStripeCheckoutAttemptLiveCart(
                                           initialPlantStatus:
                                               item.outlet.initialPlantStatus,
                                           offerId: item.outlet.offerId,
+                                          plantSortId: item.entityId,
                                           priceCents: item.outlet.priceCents,
                                           quantity: item.amount,
                                           sowingDate: item.outlet.sowingDate,
-                                          status:
-                                              item.status === 'paid'
-                                                  ? ('converted' as const)
-                                                  : ('held' as const),
+                                          statuses:
+                                              liveItemStatusById.get(
+                                                  item.id,
+                                              ) === 'paid'
+                                                  ? (['converted'] as const)
+                                                  : ([
+                                                        'held',
+                                                        'converted',
+                                                    ] as const),
                                       },
                                   ]
                                 : [],

--- a/packages/storage/src/repositories/stripeCheckoutAttemptRepo.ts
+++ b/packages/storage/src/repositories/stripeCheckoutAttemptRepo.ts
@@ -641,7 +641,7 @@ async function lockCartRow(cartId: number, db: TransactionClient) {
 
 export async function createStripeCheckoutAttempt(
     snapshot: StripeCheckoutAttemptSnapshot,
-    { accountId, now = new Date() }: { accountId: string; now?: Date },
+    { accountId, now }: { accountId: string; now?: Date },
 ) {
     parseSnapshot(snapshot);
     const itemIds = snapshot.items.map((item) => item.id);

--- a/packages/storage/src/repositories/stripeCheckoutAttemptRepo.ts
+++ b/packages/storage/src/repositories/stripeCheckoutAttemptRepo.ts
@@ -523,6 +523,28 @@ export async function getActiveStripeCheckoutAttempt(
     return activeAttempts[0];
 }
 
+export async function hasActiveStripeCheckoutAttemptForAccount(
+    accountId: string,
+    db: DatabaseClient = storage(),
+) {
+    const carts = await db
+        .select({ id: shoppingCarts.id })
+        .from(shoppingCarts)
+        .where(
+            and(
+                eq(shoppingCarts.accountId, accountId),
+                eq(shoppingCarts.isDeleted, false),
+            ),
+        )
+        .orderBy(asc(shoppingCarts.id));
+    for (const cart of carts) {
+        if (await getActiveStripeCheckoutAttempt(cart.id, db)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 export async function assertNoActiveStripeCheckoutAttempt(
     cartId: number,
     db: DatabaseClient,

--- a/packages/storage/src/repositories/stripeCheckoutAttemptRepo.ts
+++ b/packages/storage/src/repositories/stripeCheckoutAttemptRepo.ts
@@ -8,7 +8,10 @@ import {
     type CheckoutCartItemLockTransaction,
     withCheckoutCartItemLocks,
 } from './checkoutCartItemLock';
-import { releaseOutletReservationsForCheckoutAttempt } from './outletOffersRepo';
+import {
+    getCheckoutOutletReservationConflict,
+    releaseOutletReservationsForCheckoutAttempt,
+} from './outletCheckoutReservationRepo';
 
 type StorageClient = ReturnType<typeof storage>;
 type TransactionClient = CheckoutCartItemLockTransaction;
@@ -616,7 +619,7 @@ async function lockCartRow(cartId: number, db: TransactionClient) {
 
 export async function createStripeCheckoutAttempt(
     snapshot: StripeCheckoutAttemptSnapshot,
-    { accountId }: { accountId: string },
+    { accountId, now = new Date() }: { accountId: string; now?: Date },
 ) {
     parseSnapshot(snapshot);
     const itemIds = snapshot.items.map((item) => item.id);
@@ -627,6 +630,15 @@ export async function createStripeCheckoutAttempt(
         const account = await lockAccountAndAssertNotDeleting(accountId, db);
         if (!account) {
             throw new StripeCheckoutAttemptConflictError('account_inactive');
+        }
+        if (
+            !account.stripeCustomerId ||
+            fingerprintStripeCheckoutValue(account.stripeCustomerId) !==
+                snapshot.stripeSession.customerFingerprint
+        ) {
+            throw new StripeCheckoutAttemptConflictError(
+                'checkout_identity_changed',
+            );
         }
         const cart = await lockCartRow(snapshot.cartId, db);
         if (
@@ -649,6 +661,51 @@ export async function createStripeCheckoutAttempt(
             )
             .orderBy(asc(shoppingCartItems.id));
         assertStripeCheckoutAttemptSnapshotMatchesLiveCart(snapshot, liveItems);
+        const outletReservationConflict =
+            await getCheckoutOutletReservationConflict(
+                {
+                    accountId,
+                    cartId: snapshot.cartId,
+                    cartItemIds: snapshot.items.map((item) => item.id),
+                    expectations: snapshot.items.flatMap((item) =>
+                        item.outlet
+                            ? [
+                                  {
+                                      cartItemId: item.id,
+                                      comparePriceCents:
+                                          item.outlet.comparePriceCents,
+                                      ...(item.paymentKind === 'stripe' &&
+                                      snapshot.stripeSession.expiresAt
+                                          ? {
+                                                expiresAt:
+                                                    snapshot.stripeSession
+                                                        .expiresAt,
+                                            }
+                                          : {}),
+                                      id: item.outlet.reservationId,
+                                      initialPlantStatus:
+                                          item.outlet.initialPlantStatus,
+                                      offerId: item.outlet.offerId,
+                                      priceCents: item.outlet.priceCents,
+                                      quantity: item.amount,
+                                      sowingDate: item.outlet.sowingDate,
+                                      status:
+                                          item.status === 'paid'
+                                              ? ('converted' as const)
+                                              : ('held' as const),
+                                  },
+                              ]
+                            : [],
+                    ),
+                    now,
+                },
+                db,
+            );
+        if (outletReservationConflict) {
+            throw new StripeCheckoutAttemptConflictError(
+                outletReservationConflict,
+            );
+        }
         await db.insert(events).values({
             aggregateId: cartAggregateId(snapshot.cartId),
             data: snapshot,
@@ -756,35 +813,94 @@ export async function releaseStripeCheckoutAttempt({
 
 export async function verifyStripeCheckoutAttemptLiveCart(
     attempt: StripeCheckoutAttempt,
-    db: DatabaseClient = storage(),
 ) {
-    const cart = await db.query.shoppingCarts.findFirst({
-        columns: { accountId: true, id: true, isDeleted: true, status: true },
-        where: eq(shoppingCarts.id, attempt.snapshot.cartId),
-    });
-    if (
-        !cart ||
-        cart.isDeleted ||
-        (cart.status !== 'new' && cart.status !== 'paid') ||
-        !cart.accountId
-    ) {
-        throw new StripeCheckoutAttemptConflictError('cart_inactive');
-    }
-    const liveItems = await db
-        .select()
-        .from(shoppingCartItems)
-        .where(
-            and(
-                eq(shoppingCartItems.cartId, attempt.snapshot.cartId),
-                eq(shoppingCartItems.isDeleted, false),
-            ),
-        )
-        .orderBy(asc(shoppingCartItems.id));
-    assertStripeCheckoutAttemptSnapshotMatchesLiveCart(
-        attempt.snapshot,
-        liveItems,
+    return withCheckoutCartItemLocks(
+        attempt.snapshot.items.map((item) => item.id),
+        async (db) => {
+            const cart = await db.query.shoppingCarts.findFirst({
+                columns: {
+                    accountId: true,
+                    id: true,
+                    isDeleted: true,
+                    status: true,
+                },
+                where: eq(shoppingCarts.id, attempt.snapshot.cartId),
+            });
+            if (
+                !cart ||
+                cart.isDeleted ||
+                (cart.status !== 'new' && cart.status !== 'paid') ||
+                !cart.accountId
+            ) {
+                throw new StripeCheckoutAttemptConflictError('cart_inactive');
+            }
+            const liveItems = await db
+                .select()
+                .from(shoppingCartItems)
+                .where(
+                    and(
+                        eq(shoppingCartItems.cartId, attempt.snapshot.cartId),
+                        eq(shoppingCartItems.isDeleted, false),
+                    ),
+                )
+                .orderBy(asc(shoppingCartItems.id));
+            assertStripeCheckoutAttemptSnapshotMatchesLiveCart(
+                attempt.snapshot,
+                liveItems,
+            );
+            const outletReservationConflict =
+                await getCheckoutOutletReservationConflict(
+                    {
+                        accountId: cart.accountId,
+                        cartId: attempt.snapshot.cartId,
+                        cartItemIds: attempt.snapshot.items.map(
+                            (item) => item.id,
+                        ),
+                        expectations: attempt.snapshot.items.flatMap((item) =>
+                            item.outlet
+                                ? [
+                                      {
+                                          cartItemId: item.id,
+                                          comparePriceCents:
+                                              item.outlet.comparePriceCents,
+                                          ...(item.paymentKind === 'stripe' &&
+                                          attempt.snapshot.stripeSession
+                                              .expiresAt
+                                              ? {
+                                                    expiresAt:
+                                                        attempt.snapshot
+                                                            .stripeSession
+                                                            .expiresAt,
+                                                }
+                                              : {}),
+                                          id: item.outlet.reservationId,
+                                          initialPlantStatus:
+                                              item.outlet.initialPlantStatus,
+                                          offerId: item.outlet.offerId,
+                                          priceCents: item.outlet.priceCents,
+                                          quantity: item.amount,
+                                          sowingDate: item.outlet.sowingDate,
+                                          status:
+                                              item.status === 'paid'
+                                                  ? ('converted' as const)
+                                                  : ('held' as const),
+                                      },
+                                  ]
+                                : [],
+                        ),
+                        now: new Date(),
+                        requireActiveHolds: false,
+                    },
+                    db,
+                );
+            if (outletReservationConflict) {
+                throw new StripeCheckoutAttemptConflictError(
+                    outletReservationConflict,
+                );
+            }
+            return { accountId: cart.accountId, items: liveItems };
+        },
     );
-    return { accountId: cart.accountId, items: liveItems };
 }
 
 export const stripeCheckoutAttemptEventTypes = eventTypes;

--- a/packages/storage/src/repositories/stripeCheckoutAttemptRepo.ts
+++ b/packages/storage/src/repositories/stripeCheckoutAttemptRepo.ts
@@ -1,0 +1,648 @@
+import { and, asc, eq, inArray } from 'drizzle-orm';
+import { z } from 'zod';
+import { events, shoppingCartItems, shoppingCarts } from '../schema';
+import { storage } from '../storage';
+import {
+    type CheckoutCartItemLockTransaction,
+    withCheckoutCartItemLocks,
+} from './checkoutCartItemLock';
+
+type StorageClient = ReturnType<typeof storage>;
+type TransactionClient = CheckoutCartItemLockTransaction;
+type DatabaseClient = StorageClient | TransactionClient;
+
+const eventTypes = {
+    bound: 'checkout.stripeAttempt.bound',
+    created: 'checkout.stripeAttempt.created',
+    released: 'checkout.stripeAttempt.released',
+} as const;
+
+const relevantEventTypes = Object.values(eventTypes);
+
+export type StripeCheckoutAttemptReleaseReason =
+    | 'cancelled'
+    | 'completed'
+    | 'expired'
+    | 'session_binding_failed'
+    | 'session_creation_failed';
+
+export type StripeCheckoutAttemptSnapshotItem = {
+    additionalData: string | null;
+    amount: number;
+    cartId: number;
+    checkoutAdditionalData: unknown;
+    currency: string;
+    entityId: string;
+    entityTypeName: string;
+    gardenId: number | null;
+    id: number;
+    outlet?: {
+        comparePriceCents: number | null;
+        initialPlantStatus: string;
+        offerId: number;
+        priceCents: number;
+        reservationId: number;
+        sowingDate: string;
+    };
+    paymentAmount: number;
+    paymentKind: 'inventory' | 'paid' | 'stripe' | 'sunflower';
+    positionIndex: number | null;
+    raisedBedId: number | null;
+    status: 'new' | 'paid';
+};
+
+export type StripeCheckoutAttemptSnapshot = {
+    accountId: string;
+    attemptId: string;
+    cartId: number;
+    expectedNonStripeCartItemIds: number[];
+    harvestDates: Array<{
+        cartItemId: number;
+        scheduledDate: string;
+    }>;
+    items: StripeCheckoutAttemptSnapshotItem[];
+    userId: string;
+    version: 1;
+};
+
+export type StripeCheckoutAttempt = {
+    releaseReason?: StripeCheckoutAttemptReleaseReason;
+    sessionId?: string;
+    snapshot: StripeCheckoutAttemptSnapshot;
+};
+
+type AttemptBoundData = {
+    attemptId: string;
+    sessionId: string;
+};
+
+type AttemptReleasedData = {
+    attemptId: string;
+    reason: StripeCheckoutAttemptReleaseReason;
+    sessionId: string | null;
+};
+
+type AttemptEvent = {
+    data: unknown;
+    type: string;
+};
+
+export class StripeCheckoutAttemptInProgressError extends Error {
+    override readonly name = 'StripeCheckoutAttemptInProgressError';
+
+    constructor(readonly cartId: number) {
+        super('The shopping cart has an active Stripe checkout attempt.');
+    }
+}
+
+export class StripeCheckoutAttemptConflictError extends Error {
+    override readonly name = 'StripeCheckoutAttemptConflictError';
+
+    constructor(readonly category: string) {
+        super(`Stripe checkout attempt conflict (${category}).`);
+    }
+}
+
+const positiveSafeIntegerSchema = z
+    .number()
+    .int()
+    .positive()
+    .refine(Number.isSafeInteger);
+
+const nullableSafeIntegerSchema = z
+    .number()
+    .int()
+    .refine(Number.isSafeInteger)
+    .nullable();
+
+const canonicalUtcDaySchema = z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}T00:00:00\.000Z$/u)
+    .refine((value) => {
+        const date = new Date(value);
+        return !Number.isNaN(date.getTime()) && date.toISOString() === value;
+    });
+
+const snapshotItemSchema = z
+    .object({
+        additionalData: z.string().nullable(),
+        amount: positiveSafeIntegerSchema,
+        cartId: positiveSafeIntegerSchema,
+        checkoutAdditionalData: z.unknown(),
+        currency: z.string().min(1),
+        entityId: z.string().min(1),
+        entityTypeName: z.string().min(1),
+        gardenId: nullableSafeIntegerSchema,
+        id: positiveSafeIntegerSchema,
+        outlet: z
+            .object({
+                comparePriceCents: nullableSafeIntegerSchema,
+                initialPlantStatus: z.string().min(1),
+                offerId: positiveSafeIntegerSchema,
+                priceCents: positiveSafeIntegerSchema,
+                reservationId: positiveSafeIntegerSchema,
+                sowingDate: z.iso.datetime(),
+            })
+            .strict()
+            .optional(),
+        paymentAmount: z
+            .number()
+            .int()
+            .nonnegative()
+            .refine(Number.isSafeInteger),
+        paymentKind: z.enum(['inventory', 'paid', 'stripe', 'sunflower']),
+        positionIndex: nullableSafeIntegerSchema,
+        raisedBedId: nullableSafeIntegerSchema,
+        status: z.enum(['new', 'paid']),
+    })
+    .strict();
+
+const snapshotSchema = z
+    .object({
+        accountId: z.string().min(1),
+        attemptId: z.uuid(),
+        cartId: positiveSafeIntegerSchema,
+        expectedNonStripeCartItemIds: z.array(positiveSafeIntegerSchema),
+        harvestDates: z.array(
+            z
+                .object({
+                    cartItemId: positiveSafeIntegerSchema,
+                    scheduledDate: canonicalUtcDaySchema,
+                })
+                .strict(),
+        ),
+        items: z.array(snapshotItemSchema).min(1).max(100),
+        userId: z.string().min(1),
+        version: z.literal(1),
+    })
+    .strict()
+    .superRefine((snapshot, context) => {
+        const itemIds = new Set<number>();
+        const harvestDateItemIds = new Set<number>();
+        const expectedNonStripeIds = new Set(
+            snapshot.expectedNonStripeCartItemIds,
+        );
+        for (const item of snapshot.items) {
+            if (itemIds.has(item.id)) {
+                context.addIssue({
+                    code: 'custom',
+                    message: 'Duplicate snapshot cart item ID',
+                });
+            }
+            itemIds.add(item.id);
+            const isExpectedNonStripe =
+                item.paymentKind === 'inventory' ||
+                item.paymentKind === 'sunflower';
+            if (expectedNonStripeIds.has(item.id) !== isExpectedNonStripe) {
+                context.addIssue({
+                    code: 'custom',
+                    message: 'Expected non-Stripe membership mismatch',
+                });
+            }
+            if (
+                item.cartId !== snapshot.cartId ||
+                (item.paymentKind === 'stripe' && item.currency !== 'eur') ||
+                (item.paymentKind === 'sunflower' &&
+                    item.currency !== 'sunflower') ||
+                (item.paymentKind === 'inventory' &&
+                    item.currency !== 'inventory') ||
+                ((item.paymentKind === 'stripe' ||
+                    item.paymentKind === 'sunflower') &&
+                    item.paymentAmount <= 0) ||
+                ((item.paymentKind === 'inventory' ||
+                    item.paymentKind === 'paid') &&
+                    item.paymentAmount !== 0) ||
+                (item.paymentKind === 'paid') !== (item.status === 'paid')
+            ) {
+                context.addIssue({
+                    code: 'custom',
+                    message: 'Snapshot cart item invariant mismatch',
+                });
+            }
+        }
+        if (
+            expectedNonStripeIds.size !==
+                snapshot.expectedNonStripeCartItemIds.length ||
+            [...expectedNonStripeIds].some((id) => !itemIds.has(id))
+        ) {
+            context.addIssue({
+                code: 'custom',
+                message: 'Invalid expected non-Stripe item IDs',
+            });
+        }
+        for (const harvestDate of snapshot.harvestDates) {
+            if (
+                harvestDateItemIds.has(harvestDate.cartItemId) ||
+                !itemIds.has(harvestDate.cartItemId)
+            ) {
+                context.addIssue({
+                    code: 'custom',
+                    message: 'Invalid snapshot harvest date membership',
+                });
+            }
+            harvestDateItemIds.add(harvestDate.cartItemId);
+        }
+    });
+
+function parseSnapshot(value: unknown): StripeCheckoutAttemptSnapshot {
+    const parsed = snapshotSchema.safeParse(value);
+    if (!parsed.success) {
+        throw new StripeCheckoutAttemptConflictError('snapshot_malformed');
+    }
+    return parsed.data;
+}
+
+function parseBoundData(value: unknown): AttemptBoundData {
+    const parsed = z
+        .object({ attemptId: z.uuid(), sessionId: z.string().min(1) })
+        .strict()
+        .safeParse(value);
+    if (!parsed.success) {
+        throw new StripeCheckoutAttemptConflictError('binding_malformed');
+    }
+    return parsed.data;
+}
+
+function isReleaseReason(
+    value: unknown,
+): value is StripeCheckoutAttemptReleaseReason {
+    return (
+        value === 'cancelled' ||
+        value === 'completed' ||
+        value === 'expired' ||
+        value === 'session_binding_failed' ||
+        value === 'session_creation_failed'
+    );
+}
+
+function parseReleasedData(value: unknown): AttemptReleasedData {
+    const parsed = z
+        .object({
+            attemptId: z.uuid(),
+            reason: z.string().refine(isReleaseReason),
+            sessionId: z.string().min(1).nullable(),
+        })
+        .strict()
+        .safeParse(value);
+    if (!parsed.success) {
+        throw new StripeCheckoutAttemptConflictError('release_malformed');
+    }
+    return parsed.data;
+}
+
+function cartAggregateId(cartId: number) {
+    return `shoppingCart:${cartId.toString()}`;
+}
+
+async function getAttemptEvents(cartId: number, db: DatabaseClient) {
+    return db
+        .select({ data: events.data, type: events.type })
+        .from(events)
+        .where(
+            and(
+                eq(events.aggregateId, cartAggregateId(cartId)),
+                inArray(events.type, relevantEventTypes),
+            ),
+        )
+        .orderBy(asc(events.id));
+}
+
+export function foldStripeCheckoutAttemptEvents(
+    attemptId: string,
+    attemptEvents: readonly AttemptEvent[],
+): StripeCheckoutAttempt | undefined {
+    let attempt: StripeCheckoutAttempt | undefined;
+    for (const event of attemptEvents) {
+        if (event.type === eventTypes.created) {
+            const snapshot = parseSnapshot(event.data);
+            if (snapshot.attemptId !== attemptId) {
+                continue;
+            }
+            if (attempt) {
+                throw new StripeCheckoutAttemptConflictError(
+                    'duplicate_snapshot',
+                );
+            }
+            attempt = { snapshot };
+            continue;
+        }
+        if (event.type === eventTypes.bound) {
+            const binding = parseBoundData(event.data);
+            if (binding.attemptId !== attemptId) {
+                continue;
+            }
+            if (!attempt) {
+                throw new StripeCheckoutAttemptConflictError(
+                    'binding_without_snapshot',
+                );
+            }
+            if (attempt.sessionId && attempt.sessionId !== binding.sessionId) {
+                throw new StripeCheckoutAttemptConflictError(
+                    'session_binding_changed',
+                );
+            }
+            attempt.sessionId = binding.sessionId;
+            continue;
+        }
+        if (event.type === eventTypes.released) {
+            const release = parseReleasedData(event.data);
+            if (release.attemptId !== attemptId) {
+                continue;
+            }
+            if (!attempt) {
+                throw new StripeCheckoutAttemptConflictError(
+                    'release_without_snapshot',
+                );
+            }
+            if (attempt.sessionId && attempt.sessionId !== release.sessionId) {
+                throw new StripeCheckoutAttemptConflictError(
+                    'release_session_mismatch',
+                );
+            }
+            attempt.sessionId = release.sessionId ?? attempt.sessionId;
+            attempt.releaseReason = release.reason;
+        }
+    }
+    return attempt;
+}
+
+function getCreatedAttemptIds(attemptEvents: readonly AttemptEvent[]) {
+    return attemptEvents.flatMap((event) => {
+        if (event.type !== eventTypes.created) {
+            return [];
+        }
+        return [parseSnapshot(event.data).attemptId];
+    });
+}
+
+export async function getStripeCheckoutAttempt(
+    cartId: number,
+    attemptId: string,
+    db: DatabaseClient = storage(),
+) {
+    return foldStripeCheckoutAttemptEvents(
+        attemptId,
+        await getAttemptEvents(cartId, db),
+    );
+}
+
+export async function getActiveStripeCheckoutAttempt(
+    cartId: number,
+    db: DatabaseClient = storage(),
+) {
+    const attemptEvents = await getAttemptEvents(cartId, db);
+    const activeAttempts = getCreatedAttemptIds(attemptEvents)
+        .map((attemptId) =>
+            foldStripeCheckoutAttemptEvents(attemptId, attemptEvents),
+        )
+        .filter(
+            (attempt): attempt is StripeCheckoutAttempt =>
+                attempt !== undefined && attempt.releaseReason === undefined,
+        );
+    if (activeAttempts.length > 1) {
+        throw new StripeCheckoutAttemptConflictError(
+            'multiple_active_attempts',
+        );
+    }
+    return activeAttempts[0];
+}
+
+export async function assertNoActiveStripeCheckoutAttempt(
+    cartId: number,
+    db: DatabaseClient,
+) {
+    if (await getActiveStripeCheckoutAttempt(cartId, db)) {
+        throw new StripeCheckoutAttemptInProgressError(cartId);
+    }
+}
+
+export async function lockAndAssertShoppingCartsMutable(
+    cartIds: readonly number[],
+    db: TransactionClient,
+) {
+    const normalizedCartIds = [...new Set(cartIds)].sort(
+        (left, right) => left - right,
+    );
+    if (normalizedCartIds.length === 0) {
+        return;
+    }
+    const lockedCarts = await db
+        .select({ id: shoppingCarts.id })
+        .from(shoppingCarts)
+        .where(inArray(shoppingCarts.id, normalizedCartIds))
+        .orderBy(asc(shoppingCarts.id))
+        .for('update');
+    for (const cart of lockedCarts) {
+        await assertNoActiveStripeCheckoutAttempt(cart.id, db);
+    }
+}
+
+export async function lockAndAssertCartItemsMutable(
+    cartItemIds: readonly number[],
+    db: TransactionClient,
+) {
+    if (cartItemIds.length === 0) {
+        return;
+    }
+    const cartRows = await db
+        .select({ cartId: shoppingCartItems.cartId })
+        .from(shoppingCartItems)
+        .where(inArray(shoppingCartItems.id, [...new Set(cartItemIds)]));
+    await lockAndAssertShoppingCartsMutable(
+        cartRows.map((row) => row.cartId),
+        db,
+    );
+}
+
+export function assertStripeCheckoutAttemptSnapshotMatchesLiveCart(
+    snapshot: StripeCheckoutAttemptSnapshot,
+    liveItems: readonly (typeof shoppingCartItems.$inferSelect)[],
+) {
+    if (snapshot.items.length !== liveItems.length) {
+        throw new StripeCheckoutAttemptConflictError('cart_membership_changed');
+    }
+    const liveItemsById = new Map(liveItems.map((item) => [item.id, item]));
+    for (const expected of snapshot.items) {
+        const live = liveItemsById.get(expected.id);
+        if (
+            !live ||
+            live.cartId !== expected.cartId ||
+            live.entityId !== expected.entityId ||
+            live.entityTypeName !== expected.entityTypeName ||
+            live.gardenId !== expected.gardenId ||
+            live.raisedBedId !== expected.raisedBedId ||
+            live.positionIndex !== expected.positionIndex ||
+            live.additionalData !== expected.additionalData ||
+            live.amount !== expected.amount ||
+            live.currency !== expected.currency ||
+            live.isDeleted ||
+            (expected.status === 'paid'
+                ? live.status !== 'paid'
+                : live.status !== 'new' && live.status !== 'paid')
+        ) {
+            throw new StripeCheckoutAttemptConflictError('cart_item_changed');
+        }
+    }
+}
+
+async function lockCartRow(cartId: number, db: TransactionClient) {
+    const [cart] = await db
+        .select({
+            accountId: shoppingCarts.accountId,
+            id: shoppingCarts.id,
+            isDeleted: shoppingCarts.isDeleted,
+            status: shoppingCarts.status,
+        })
+        .from(shoppingCarts)
+        .where(eq(shoppingCarts.id, cartId))
+        .for('update')
+        .limit(1);
+    return cart;
+}
+
+export async function createStripeCheckoutAttempt(
+    snapshot: StripeCheckoutAttemptSnapshot,
+) {
+    parseSnapshot(snapshot);
+    const itemIds = snapshot.items.map((item) => item.id);
+    if (new Set(itemIds).size !== itemIds.length) {
+        throw new StripeCheckoutAttemptConflictError('duplicate_cart_item');
+    }
+    return withCheckoutCartItemLocks(itemIds, async (db) => {
+        const cart = await lockCartRow(snapshot.cartId, db);
+        if (
+            !cart ||
+            cart.isDeleted ||
+            cart.status !== 'new' ||
+            cart.accountId !== snapshot.accountId
+        ) {
+            throw new StripeCheckoutAttemptConflictError('cart_inactive');
+        }
+        await assertNoActiveStripeCheckoutAttempt(snapshot.cartId, db);
+        const liveItems = await db
+            .select()
+            .from(shoppingCartItems)
+            .where(
+                and(
+                    eq(shoppingCartItems.cartId, snapshot.cartId),
+                    eq(shoppingCartItems.isDeleted, false),
+                ),
+            )
+            .orderBy(asc(shoppingCartItems.id));
+        assertStripeCheckoutAttemptSnapshotMatchesLiveCart(snapshot, liveItems);
+        await db.insert(events).values({
+            aggregateId: cartAggregateId(snapshot.cartId),
+            data: snapshot,
+            type: eventTypes.created,
+            version: 1,
+        });
+        return snapshot;
+    });
+}
+
+export async function bindStripeCheckoutAttempt({
+    attemptId,
+    cartId,
+    sessionId,
+}: AttemptBoundData & { cartId: number }) {
+    return storage().transaction(async (db) => {
+        await lockCartRow(cartId, db);
+        const attempt = await getStripeCheckoutAttempt(cartId, attemptId, db);
+        if (!attempt) {
+            throw new StripeCheckoutAttemptConflictError('attempt_missing');
+        }
+        if (attempt.releaseReason) {
+            throw new StripeCheckoutAttemptConflictError('attempt_released');
+        }
+        if (attempt.sessionId) {
+            if (attempt.sessionId !== sessionId) {
+                throw new StripeCheckoutAttemptConflictError(
+                    'session_binding_changed',
+                );
+            }
+            return attempt;
+        }
+        await db.insert(events).values({
+            aggregateId: cartAggregateId(cartId),
+            data: { attemptId, sessionId },
+            type: eventTypes.bound,
+            version: 1,
+        });
+        return { ...attempt, sessionId };
+    });
+}
+
+export async function releaseStripeCheckoutAttempt({
+    attemptId,
+    cartId,
+    reason,
+    sessionId,
+}: AttemptReleasedData & { cartId: number }) {
+    return storage().transaction(async (db) => {
+        await lockCartRow(cartId, db);
+        const attempt = await getStripeCheckoutAttempt(cartId, attemptId, db);
+        if (!attempt) {
+            throw new StripeCheckoutAttemptConflictError('attempt_missing');
+        }
+        if (attempt.sessionId && attempt.sessionId !== sessionId) {
+            throw new StripeCheckoutAttemptConflictError(
+                'session_binding_changed',
+            );
+        }
+        if (attempt.releaseReason) {
+            const equivalentAbandonment =
+                (attempt.releaseReason === 'cancelled' ||
+                    attempt.releaseReason === 'expired') &&
+                (reason === 'cancelled' || reason === 'expired');
+            if (
+                (!equivalentAbandonment && attempt.releaseReason !== reason) ||
+                attempt.sessionId !== (sessionId ?? attempt.sessionId)
+            ) {
+                throw new StripeCheckoutAttemptConflictError('release_changed');
+            }
+            return attempt;
+        }
+        if (!attempt.sessionId && sessionId) {
+            await db.insert(events).values({
+                aggregateId: cartAggregateId(cartId),
+                data: { attemptId, sessionId },
+                type: eventTypes.bound,
+                version: 1,
+            });
+        }
+        await db.insert(events).values({
+            aggregateId: cartAggregateId(cartId),
+            data: { attemptId, reason, sessionId },
+            type: eventTypes.released,
+            version: 1,
+        });
+        return {
+            ...attempt,
+            releaseReason: reason,
+            sessionId: sessionId ?? attempt.sessionId,
+        };
+    });
+}
+
+export async function verifyStripeCheckoutAttemptLiveCart(
+    attempt: StripeCheckoutAttempt,
+    db: DatabaseClient = storage(),
+) {
+    const liveItems = await db
+        .select()
+        .from(shoppingCartItems)
+        .where(
+            and(
+                eq(shoppingCartItems.cartId, attempt.snapshot.cartId),
+                eq(shoppingCartItems.isDeleted, false),
+            ),
+        )
+        .orderBy(asc(shoppingCartItems.id));
+    assertStripeCheckoutAttemptSnapshotMatchesLiveCart(
+        attempt.snapshot,
+        liveItems,
+    );
+    return liveItems;
+}
+
+export const stripeCheckoutAttemptEventTypes = eventTypes;

--- a/packages/storage/src/repositories/stripeCheckoutAttemptRepo.ts
+++ b/packages/storage/src/repositories/stripeCheckoutAttemptRepo.ts
@@ -1,11 +1,14 @@
+import { createHash } from 'node:crypto';
 import { and, asc, eq, inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import { events, shoppingCartItems, shoppingCarts } from '../schema';
 import { storage } from '../storage';
+import { lockAccountAndAssertNotDeleting } from './accountDeletionFenceRepo';
 import {
     type CheckoutCartItemLockTransaction,
     withCheckoutCartItemLocks,
 } from './checkoutCartItemLock';
+import { releaseOutletReservationsForCheckoutAttempt } from './outletOffersRepo';
 
 type StorageClient = ReturnType<typeof storage>;
 type TransactionClient = CheckoutCartItemLockTransaction;
@@ -27,10 +30,10 @@ export type StripeCheckoutAttemptReleaseReason =
     | 'session_creation_failed';
 
 export type StripeCheckoutAttemptSnapshotItem = {
-    additionalData: string | null;
+    additionalDataFingerprint: string;
     amount: number;
     cartId: number;
-    checkoutAdditionalData: unknown;
+    checkoutAdditionalDataFingerprint: string;
     currency: string;
     entityId: string;
     entityTypeName: string;
@@ -51,8 +54,32 @@ export type StripeCheckoutAttemptSnapshotItem = {
     status: 'new' | 'paid';
 };
 
+export type StripeCheckoutAttemptSessionItem = {
+    cartItemId: number;
+    price: {
+        currency: 'eur';
+        valueInCents: number;
+    };
+    product: {
+        description?: string;
+        imageUrls?: string[];
+        name: string;
+    };
+    quantity: number;
+};
+
+export type StripeCheckoutAttemptSession = {
+    allowPromotionCodes: boolean;
+    customerFingerprint: string;
+    expiresAt: string | null;
+    items: StripeCheckoutAttemptSessionItem[];
+    returnUrls: {
+        cancel: string;
+        success: string;
+    };
+};
+
 export type StripeCheckoutAttemptSnapshot = {
-    accountId: string;
     attemptId: string;
     cartId: number;
     expectedNonStripeCartItemIds: number[];
@@ -61,7 +88,8 @@ export type StripeCheckoutAttemptSnapshot = {
         scheduledDate: string;
     }>;
     items: StripeCheckoutAttemptSnapshotItem[];
-    userId: string;
+    stripeSession: StripeCheckoutAttemptSession;
+    userFingerprint: string;
     version: 1;
 };
 
@@ -123,12 +151,39 @@ const canonicalUtcDaySchema = z
         return !Number.isNaN(date.getTime()) && date.toISOString() === value;
     });
 
+const fingerprintSchema = z.string().regex(/^[a-f0-9]{64}$/u);
+
+export function serializeStripeCheckoutValue(value: unknown): string {
+    if (value === undefined) {
+        return 'undefined';
+    }
+    if (Array.isArray(value)) {
+        return `[${value.map(serializeStripeCheckoutValue).join(',')}]`;
+    }
+    if (value && typeof value === 'object') {
+        return `{${Object.entries(value)
+            .sort(([left], [right]) => left.localeCompare(right))
+            .map(
+                ([key, entry]) =>
+                    `${JSON.stringify(key)}:${serializeStripeCheckoutValue(entry)}`,
+            )
+            .join(',')}}`;
+    }
+    return JSON.stringify(value);
+}
+
+export function fingerprintStripeCheckoutValue(value: unknown) {
+    return createHash('sha256')
+        .update(serializeStripeCheckoutValue(value))
+        .digest('hex');
+}
+
 const snapshotItemSchema = z
     .object({
-        additionalData: z.string().nullable(),
+        additionalDataFingerprint: fingerprintSchema,
         amount: positiveSafeIntegerSchema,
         cartId: positiveSafeIntegerSchema,
-        checkoutAdditionalData: z.unknown(),
+        checkoutAdditionalDataFingerprint: fingerprintSchema,
         currency: z.string().min(1),
         entityId: z.string().min(1),
         entityTypeName: z.string().min(1),
@@ -157,9 +212,38 @@ const snapshotItemSchema = z
     })
     .strict();
 
+const stripeSessionItemSchema = z
+    .object({
+        cartItemId: positiveSafeIntegerSchema,
+        price: z
+            .object({
+                currency: z.literal('eur'),
+                valueInCents: positiveSafeIntegerSchema,
+            })
+            .strict(),
+        product: z
+            .object({
+                description: z.string().optional(),
+                imageUrls: z.array(z.url()).optional(),
+                name: z.string().min(1),
+            })
+            .strict(),
+        quantity: positiveSafeIntegerSchema,
+    })
+    .strict();
+
+const stripeSessionSchema = z
+    .object({
+        allowPromotionCodes: z.boolean(),
+        customerFingerprint: fingerprintSchema,
+        expiresAt: z.iso.datetime().nullable(),
+        items: z.array(stripeSessionItemSchema).min(1).max(100),
+        returnUrls: z.object({ cancel: z.url(), success: z.url() }).strict(),
+    })
+    .strict();
+
 const snapshotSchema = z
     .object({
-        accountId: z.string().min(1),
         attemptId: z.uuid(),
         cartId: positiveSafeIntegerSchema,
         expectedNonStripeCartItemIds: z.array(positiveSafeIntegerSchema),
@@ -172,13 +256,15 @@ const snapshotSchema = z
                 .strict(),
         ),
         items: z.array(snapshotItemSchema).min(1).max(100),
-        userId: z.string().min(1),
+        stripeSession: stripeSessionSchema,
+        userFingerprint: fingerprintSchema,
         version: z.literal(1),
     })
     .strict()
     .superRefine((snapshot, context) => {
         const itemIds = new Set<number>();
         const harvestDateItemIds = new Set<number>();
+        const stripeSessionItemIds = new Set<number>();
         const expectedNonStripeIds = new Set(
             snapshot.expectedNonStripeCartItemIds,
         );
@@ -241,6 +327,33 @@ const snapshotSchema = z
                 });
             }
             harvestDateItemIds.add(harvestDate.cartItemId);
+        }
+        const expectedStripeItems = snapshot.items.filter(
+            (item) => item.paymentKind === 'stripe',
+        );
+        for (const sessionItem of snapshot.stripeSession.items) {
+            const cartItemId = sessionItem.cartItemId;
+            const expectedItem = expectedStripeItems.find(
+                (item) => item.id === cartItemId,
+            );
+            if (
+                !expectedItem ||
+                stripeSessionItemIds.has(cartItemId) ||
+                sessionItem.quantity !== expectedItem.amount ||
+                sessionItem.price.valueInCents !== expectedItem.paymentAmount
+            ) {
+                context.addIssue({
+                    code: 'custom',
+                    message: 'Stripe session item snapshot mismatch',
+                });
+            }
+            stripeSessionItemIds.add(cartItemId);
+        }
+        if (stripeSessionItemIds.size !== expectedStripeItems.length) {
+            context.addIssue({
+                code: 'custom',
+                message: 'Stripe session snapshot mismatch',
+            });
         }
     });
 
@@ -472,7 +585,8 @@ export function assertStripeCheckoutAttemptSnapshotMatchesLiveCart(
             live.gardenId !== expected.gardenId ||
             live.raisedBedId !== expected.raisedBedId ||
             live.positionIndex !== expected.positionIndex ||
-            live.additionalData !== expected.additionalData ||
+            fingerprintStripeCheckoutValue(live.additionalData) !==
+                expected.additionalDataFingerprint ||
             live.amount !== expected.amount ||
             live.currency !== expected.currency ||
             live.isDeleted ||
@@ -502,6 +616,7 @@ async function lockCartRow(cartId: number, db: TransactionClient) {
 
 export async function createStripeCheckoutAttempt(
     snapshot: StripeCheckoutAttemptSnapshot,
+    { accountId }: { accountId: string },
 ) {
     parseSnapshot(snapshot);
     const itemIds = snapshot.items.map((item) => item.id);
@@ -509,12 +624,16 @@ export async function createStripeCheckoutAttempt(
         throw new StripeCheckoutAttemptConflictError('duplicate_cart_item');
     }
     return withCheckoutCartItemLocks(itemIds, async (db) => {
+        const account = await lockAccountAndAssertNotDeleting(accountId, db);
+        if (!account) {
+            throw new StripeCheckoutAttemptConflictError('account_inactive');
+        }
         const cart = await lockCartRow(snapshot.cartId, db);
         if (
             !cart ||
             cart.isDeleted ||
             cart.status !== 'new' ||
-            cart.accountId !== snapshot.accountId
+            cart.accountId !== accountId
         ) {
             throw new StripeCheckoutAttemptConflictError('cart_inactive');
         }
@@ -610,6 +729,17 @@ export async function releaseStripeCheckoutAttempt({
                 version: 1,
             });
         }
+        // Cleanup commits before the release event removes the cart fence.
+        // Replays of an already released attempt intentionally skip cleanup so
+        // they cannot release reservations created by a subsequent attempt.
+        await releaseOutletReservationsForCheckoutAttempt(
+            cartId,
+            attempt.snapshot.items.flatMap((item) =>
+                item.outlet ? [item.outlet.reservationId] : [],
+            ),
+            new Date(),
+            db,
+        );
         await db.insert(events).values({
             aggregateId: cartAggregateId(cartId),
             data: { attemptId, reason, sessionId },
@@ -628,6 +758,18 @@ export async function verifyStripeCheckoutAttemptLiveCart(
     attempt: StripeCheckoutAttempt,
     db: DatabaseClient = storage(),
 ) {
+    const cart = await db.query.shoppingCarts.findFirst({
+        columns: { accountId: true, id: true, isDeleted: true, status: true },
+        where: eq(shoppingCarts.id, attempt.snapshot.cartId),
+    });
+    if (
+        !cart ||
+        cart.isDeleted ||
+        (cart.status !== 'new' && cart.status !== 'paid') ||
+        !cart.accountId
+    ) {
+        throw new StripeCheckoutAttemptConflictError('cart_inactive');
+    }
     const liveItems = await db
         .select()
         .from(shoppingCartItems)
@@ -642,7 +784,7 @@ export async function verifyStripeCheckoutAttemptLiveCart(
         attempt.snapshot,
         liveItems,
     );
-    return liveItems;
+    return { accountId: cart.accountId, items: liveItems };
 }
 
 export const stripeCheckoutAttemptEventTypes = eventTypes;

--- a/packages/storage/tests/accountDeletionFenceRepo.node.spec.ts
+++ b/packages/storage/tests/accountDeletionFenceRepo.node.spec.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    AccountDeletionInProgressError,
+    accountDeletionStartedEventType,
+    accounts,
+    deleteAccountWithDependencies,
+    events,
+    fenceAccountShoppingCartsForDeletion,
+    getOrCreateShoppingCart,
+    getShoppingCart,
+    storage,
+} from '@gredice/storage';
+import { and, eq } from 'drizzle-orm';
+import { createTestDb } from './testDb';
+
+async function getDeletionMarkers(accountId: string) {
+    return storage().query.events.findMany({
+        where: and(
+            eq(events.aggregateId, accountId),
+            eq(events.type, accountDeletionStartedEventType),
+        ),
+    });
+}
+
+test('account deletion fence remains durable until final account cleanup', async () => {
+    createTestDb();
+    const accountId = randomUUID();
+    await storage().insert(accounts).values({ id: accountId });
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart);
+
+    assert.equal(await fenceAccountShoppingCartsForDeletion(accountId), true);
+    assert.equal(await getShoppingCart(cart.id), undefined);
+    assert.equal((await getDeletionMarkers(accountId)).length, 1);
+
+    await assert.rejects(
+        () => getOrCreateShoppingCart(accountId),
+        (error) => {
+            assert.ok(error instanceof AccountDeletionInProgressError);
+            assert.equal(error.accountId, accountId);
+            return true;
+        },
+    );
+
+    assert.equal(await fenceAccountShoppingCartsForDeletion(accountId), true);
+    assert.equal((await getDeletionMarkers(accountId)).length, 1);
+
+    await deleteAccountWithDependencies(accountId, 'missing-test-user');
+    assert.equal(
+        await storage().query.accounts.findFirst({
+            where: eq(accounts.id, accountId),
+        }),
+        undefined,
+    );
+    assert.equal((await getDeletionMarkers(accountId)).length, 0);
+});

--- a/packages/storage/tests/accountsRepo.node.spec.ts
+++ b/packages/storage/tests/accountsRepo.node.spec.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
     accountUsers,
     assignStripeCustomerId,
+    assignStripeCustomerIdIfUnchanged,
     createEvent,
     earnSunflowers,
     earnSunflowersForPayment,
@@ -171,6 +172,25 @@ test('assignStripeCustomerId sets stripeCustomerId', async () => {
     const updated = await assignStripeCustomerId(accountId, stripeId);
     assert.ok(updated);
     assert.strictEqual(updated.stripeCustomerId, stripeId);
+});
+
+test('assignStripeCustomerIdIfUnchanged keeps one canonical customer under concurrency', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const assigned = await Promise.all([
+        assignStripeCustomerIdIfUnchanged(accountId, null, 'cus_first'),
+        assignStripeCustomerIdIfUnchanged(accountId, null, 'cus_second'),
+    ]);
+    const account = await getAccount(accountId);
+    assert.ok(account?.stripeCustomerId);
+    assert.deepStrictEqual(assigned, [
+        account.stripeCustomerId,
+        account.stripeCustomerId,
+    ]);
+    assert.ok(
+        account.stripeCustomerId === 'cus_first' ||
+            account.stripeCustomerId === 'cus_second',
+    );
 });
 
 test('getAccountUsers returns empty array for new account', async () => {

--- a/packages/storage/tests/outletOffersRepo.node.spec.ts
+++ b/packages/storage/tests/outletOffersRepo.node.spec.ts
@@ -22,8 +22,10 @@ import {
     releaseOutletReservationForCartItem,
     releaseStripeCheckoutAttempt,
     reserveOutletOffer,
+    StripeCheckoutAttemptConflictError,
     type StripeCheckoutAttemptSnapshot,
     setCartItemPaid,
+    storage,
     updateEntity,
     updateOutletOffer,
     upsertEntityType,
@@ -31,6 +33,8 @@ import {
     upsertOrRemoveCartItemWithOutletReservation,
     verifyStripeCheckoutAttemptLiveCart,
 } from '@gredice/storage';
+import { eq } from 'drizzle-orm';
+import { outletOffers } from '../src/schema';
 import { createTestAccount } from './helpers/testHelpers';
 import { createTestDb } from './testDb';
 
@@ -339,7 +343,87 @@ test('opposite outlet switches lock offers and reservations canonically', async 
     assert.equal(secondOffer?.remainingQuantity, 1);
 });
 
-+test('stale attempt release cannot release a later attempt reservation', async () => {
+test('checkout rechecks outlet hold expiry after waiting for the offer lock', {
+    skip: process.env.GREDICE_TEST_DB_PROVIDER === 'pglite',
+}, async (t) => {
+    createTestDb();
+    const heldAt = new Date('2026-05-01T10:00:00.000Z');
+    const checkoutStartedAt = addMinutes(heldAt, 14);
+    const reallocatedAt = new Date(addMinutes(heldAt, 15).getTime() + 1);
+    const plantSortId = await createTestPlantSort();
+    const offerId = await createPublishedOffer({ plantSortId, now: heldAt });
+    const firstAccountId = await createTestAccount();
+    const firstCartItem = await createCartItem(firstAccountId, plantSortId);
+    const firstReservation = await reserveOutletOffer({
+        accountId: firstAccountId,
+        cartId: firstCartItem.cart.id,
+        cartItemId: firstCartItem.cartItemId,
+        now: heldAt,
+        offerId,
+    });
+    const firstAttempt = outletAttemptSnapshot({
+        cartId: firstCartItem.cart.id,
+        cartItemId: firstCartItem.cartItemId,
+        entityId: plantSortId.toString(),
+        reservation: firstReservation,
+    });
+    const secondAccountId = await createTestAccount();
+    const secondCartItem = await createCartItem(secondAccountId, plantSortId);
+
+    let signalOfferLocked: (() => void) | undefined;
+    const offerLocked = new Promise<void>((resolve) => {
+        signalOfferLocked = resolve;
+    });
+    let releaseOfferLock: (() => void) | undefined;
+    const holdOfferLock = new Promise<void>((resolve) => {
+        releaseOfferLock = resolve;
+    });
+    const reallocation = storage().transaction(async (tx) => {
+        await tx
+            .select({ id: outletOffers.id })
+            .from(outletOffers)
+            .where(eq(outletOffers.id, offerId))
+            .for('update');
+        signalOfferLocked?.();
+        await holdOfferLock;
+        return reserveOutletOffer({
+            accountId: secondAccountId,
+            cartId: secondCartItem.cart.id,
+            cartItemId: secondCartItem.cartItemId,
+            db: tx,
+            now: reallocatedAt,
+            offerId,
+        });
+    });
+    await offerLocked;
+
+    t.mock.timers.enable({ apis: ['Date'], now: checkoutStartedAt });
+    const rejectedAttempt = assert.rejects(
+        createStripeCheckoutAttempt(firstAttempt, {
+            accountId: firstAccountId,
+        }),
+        (error) => {
+            assert.ok(error instanceof StripeCheckoutAttemptConflictError);
+            assert.equal(error.category, 'outlet_reservation_inactive');
+            return true;
+        },
+    );
+    t.mock.timers.setTime(reallocatedAt.getTime());
+    releaseOfferLock?.();
+
+    const secondReservation = await reallocation;
+    await rejectedAttempt;
+    assert.equal(secondReservation.cartItemId, secondCartItem.cartItemId);
+    assert.equal(
+        await getActiveStripeCheckoutAttempt(firstCartItem.cart.id),
+        undefined,
+    );
+    const offer = await getOutletOffer(offerId, reallocatedAt);
+    assert.equal(offer?.reservedQuantity, 1);
+    assert.equal(offer?.remainingQuantity, 0);
+});
+
+test('stale attempt release cannot release a later attempt reservation', async () => {
     createTestDb();
     const now = new Date('2026-05-01T10:00:00.000Z');
     const plantSortId = await createTestPlantSort();

--- a/packages/storage/tests/outletOffersRepo.node.spec.ts
+++ b/packages/storage/tests/outletOffersRepo.node.spec.ts
@@ -266,7 +266,80 @@ test('reserveOutletOffer creates a held reservation and blocks overselling', asy
     );
 });
 
-test('stale attempt release cannot release a later attempt reservation', async () => {
+test('opposite outlet switches lock offers and reservations canonically', async () => {
+    createTestDb();
+    const now = new Date('2026-05-01T10:00:00.000Z');
+    const switchedAt = addMinutes(now, 1);
+    const plantSortId = await createTestPlantSort();
+    const firstOfferId = await createPublishedOffer({
+        plantSortId,
+        quantity: 2,
+        now,
+    });
+    const secondOfferId = await createPublishedOffer({
+        plantSortId,
+        quantity: 2,
+        now,
+    });
+    const firstAccountId = await createTestAccount();
+    const secondAccountId = await createTestAccount();
+    const firstCartItem = await createCartItem(firstAccountId, plantSortId);
+    const secondCartItem = await createCartItem(secondAccountId, plantSortId);
+    const [firstReservation, secondReservation] = await Promise.all([
+        reserveOutletOffer({
+            accountId: firstAccountId,
+            cartId: firstCartItem.cart.id,
+            cartItemId: firstCartItem.cartItemId,
+            now,
+            offerId: firstOfferId,
+        }),
+        reserveOutletOffer({
+            accountId: secondAccountId,
+            cartId: secondCartItem.cart.id,
+            cartItemId: secondCartItem.cartItemId,
+            now,
+            offerId: secondOfferId,
+        }),
+    ]);
+
+    const [firstSwitch, secondSwitch] = await Promise.all([
+        reserveOutletOffer({
+            accountId: firstAccountId,
+            cartId: firstCartItem.cart.id,
+            cartItemId: firstCartItem.cartItemId,
+            now: switchedAt,
+            offerId: secondOfferId,
+        }),
+        reserveOutletOffer({
+            accountId: secondAccountId,
+            cartId: secondCartItem.cart.id,
+            cartItemId: secondCartItem.cartItemId,
+            now: switchedAt,
+            offerId: firstOfferId,
+        }),
+    ]);
+
+    assert.equal(firstSwitch.outletOfferId, secondOfferId);
+    assert.equal(secondSwitch.outletOfferId, firstOfferId);
+    assert.equal(
+        (await getOutletOfferReservation(firstReservation.id))?.status,
+        'released',
+    );
+    assert.equal(
+        (await getOutletOfferReservation(secondReservation.id))?.status,
+        'released',
+    );
+    const [firstOffer, secondOffer] = await Promise.all([
+        getOutletOffer(firstOfferId, switchedAt),
+        getOutletOffer(secondOfferId, switchedAt),
+    ]);
+    assert.equal(firstOffer?.reservedQuantity, 1);
+    assert.equal(firstOffer?.remainingQuantity, 1);
+    assert.equal(secondOffer?.reservedQuantity, 1);
+    assert.equal(secondOffer?.remainingQuantity, 1);
+});
+
++test('stale attempt release cannot release a later attempt reservation', async () => {
     createTestDb();
     const now = new Date('2026-05-01T10:00:00.000Z');
     const plantSortId = await createTestPlantSort();

--- a/packages/storage/tests/outletOffersRepo.node.spec.ts
+++ b/packages/storage/tests/outletOffersRepo.node.spec.ts
@@ -6,14 +6,18 @@ import {
     convertOutletReservationForCartItem,
     createEntity,
     createOutletOffer,
+    createStripeCheckoutAttempt,
     expireOutletReservations,
+    fingerprintStripeCheckoutValue,
     getOrCreateShoppingCart,
     getOutletOffer,
     getOutletOfferReservation,
     getOutletOffers,
     getShoppingCart,
     OutletOfferUnavailableError,
+    releaseStripeCheckoutAttempt,
     reserveOutletOffer,
+    type StripeCheckoutAttemptSnapshot,
     updateEntity,
     updateOutletOffer,
     upsertEntityType,
@@ -91,6 +95,77 @@ async function createPublishedOffer({
         status: 'published',
         adminNotes: null,
     });
+}
+
+function outletAttemptSnapshot({
+    cartId,
+    cartItemId,
+    entityId,
+    reservation,
+}: {
+    cartId: number;
+    cartItemId: number;
+    entityId: string;
+    reservation: NonNullable<
+        Awaited<ReturnType<typeof getOutletOfferReservation>>
+    >;
+}): StripeCheckoutAttemptSnapshot {
+    const attemptId = randomUUID();
+    return {
+        attemptId,
+        cartId,
+        expectedNonStripeCartItemIds: [],
+        harvestDates: [],
+        items: [
+            {
+                additionalDataFingerprint: fingerprintStripeCheckoutValue(null),
+                amount: 1,
+                cartId,
+                checkoutAdditionalDataFingerprint:
+                    fingerprintStripeCheckoutValue({}),
+                currency: 'eur',
+                entityId,
+                entityTypeName: 'plantSort',
+                gardenId: null,
+                id: cartItemId,
+                outlet: {
+                    comparePriceCents: reservation.heldComparePriceCents,
+                    initialPlantStatus: reservation.heldInitialPlantStatus,
+                    offerId: reservation.outletOfferId,
+                    priceCents: reservation.heldOutletPriceCents,
+                    reservationId: reservation.id,
+                    sowingDate: reservation.heldSowingDate.toISOString(),
+                },
+                paymentAmount: reservation.heldOutletPriceCents,
+                paymentKind: 'stripe',
+                positionIndex: null,
+                raisedBedId: null,
+                status: 'new',
+            },
+        ],
+        stripeSession: {
+            allowPromotionCodes: true,
+            customerFingerprint: fingerprintStripeCheckoutValue('cus_outlet'),
+            expiresAt: '2026-05-01T11:00:00.000Z',
+            items: [
+                {
+                    cartItemId,
+                    price: {
+                        currency: 'eur',
+                        valueInCents: reservation.heldOutletPriceCents,
+                    },
+                    product: { name: 'Outlet item' },
+                    quantity: 1,
+                },
+            ],
+            returnUrls: {
+                cancel: 'https://example.test/cancel',
+                success: 'https://example.test/success',
+            },
+        },
+        userFingerprint: fingerprintStripeCheckoutValue('user-outlet'),
+        version: 1,
+    };
 }
 
 test('getOutletOffers returns active published offers with remaining stock', async () => {
@@ -180,6 +255,66 @@ test('reserveOutletOffer creates a held reservation and blocks overselling', asy
                 now,
             }),
         OutletOfferUnavailableError,
+    );
+});
+
+test('stale attempt release cannot release a later attempt reservation', async () => {
+    createTestDb();
+    const now = new Date('2026-05-01T10:00:00.000Z');
+    const plantSortId = await createTestPlantSort();
+    const offerId = await createPublishedOffer({ plantSortId, now });
+    const accountId = await createTestAccount();
+    const { cart, cartItemId } = await createCartItem(accountId, plantSortId);
+    const firstReservation = await reserveOutletOffer({
+        accountId,
+        cartId: cart.id,
+        cartItemId,
+        offerId,
+        now,
+    });
+    const firstAttempt = outletAttemptSnapshot({
+        cartId: cart.id,
+        cartItemId,
+        entityId: plantSortId.toString(),
+        reservation: firstReservation,
+    });
+    await createStripeCheckoutAttempt(firstAttempt, { accountId });
+    await releaseStripeCheckoutAttempt({
+        attemptId: firstAttempt.attemptId,
+        cartId: cart.id,
+        reason: 'cancelled',
+        sessionId: null,
+    });
+    assert.equal(
+        (await getOutletOfferReservation(firstReservation.id))?.status,
+        'released',
+    );
+
+    const secondReservation = await reserveOutletOffer({
+        accountId,
+        cartId: cart.id,
+        cartItemId,
+        offerId,
+        now: addMinutes(now, 1),
+    });
+    assert.notEqual(secondReservation.id, firstReservation.id);
+    const secondAttempt = outletAttemptSnapshot({
+        cartId: cart.id,
+        cartItemId,
+        entityId: plantSortId.toString(),
+        reservation: secondReservation,
+    });
+    await createStripeCheckoutAttempt(secondAttempt, { accountId });
+
+    await releaseStripeCheckoutAttempt({
+        attemptId: firstAttempt.attemptId,
+        cartId: cart.id,
+        reason: 'expired',
+        sessionId: null,
+    });
+    assert.equal(
+        (await getOutletOfferReservation(secondReservation.id))?.status,
+        'held',
     );
 });
 

--- a/packages/storage/tests/outletOffersRepo.node.spec.ts
+++ b/packages/storage/tests/outletOffersRepo.node.spec.ts
@@ -340,7 +340,7 @@ test('checkout rejects an outlet switch and active attempt fences later reservat
     });
     const secondOfferId = await createPublishedOffer({
         plantSortId,
-        quantity: 2,
+        quantity: 1,
         now,
     });
     const otherPlantSortId = await createTestPlantSort();
@@ -416,13 +416,27 @@ test('checkout rejects an outlet switch and active attempt fences later reservat
         () => releaseOutletReservationForCartItem(cartItemId),
         /active Stripe checkout attempt/u,
     );
-    await bindStripeCheckoutAttempt({
-        attemptId: currentAttempt.attemptId,
-        cartId: cart.id,
-        sessionId: 'cs_delayed_outlet',
-    });
     const delayedWebhookAt = new Date(
         secondReservation.holdExpiresAt.getTime() + 1,
+    );
+    const protectedOffer = await getOutletOffer(
+        secondOfferId,
+        delayedWebhookAt,
+    );
+    assert.equal(protectedOffer?.reservedQuantity, 1);
+    assert.equal(protectedOffer?.remainingQuantity, 0);
+    const otherAccountId = await createTestAccount();
+    const otherCartItem = await createCartItem(otherAccountId, plantSortId);
+    await assert.rejects(
+        () =>
+            reserveOutletOffer({
+                accountId: otherAccountId,
+                cartId: otherCartItem.cart.id,
+                cartItemId: otherCartItem.cartItemId,
+                now: delayedWebhookAt,
+                offerId: secondOfferId,
+            }),
+        OutletOfferUnavailableError,
     );
     const releasedAtExpiry = await expireOutletReservations(delayedWebhookAt);
     assert.equal(releasedAtExpiry.includes(secondReservation.id), false);
@@ -430,6 +444,11 @@ test('checkout rejects an outlet switch and active attempt fences later reservat
         (await getOutletOfferReservation(secondReservation.id))?.status,
         'held',
     );
+    await bindStripeCheckoutAttempt({
+        attemptId: currentAttempt.attemptId,
+        cartId: cart.id,
+        sessionId: 'cs_delayed_outlet',
+    });
     assert.equal(
         (
             await convertOutletReservationForCartItem(
@@ -562,6 +581,7 @@ test('cleanupOutletLifecycle releases expired holds and closes expired offers', 
     const later = addMinutes(now, 61);
     const plantSortId = await createTestPlantSort();
     const offerId = await createPublishedOffer({ plantSortId, now });
+    const secondOfferId = await createPublishedOffer({ plantSortId, now });
     const accountId = await createTestAccount();
     const { cart, cartItemId } = await createCartItem(accountId, plantSortId);
     const reservation = await reserveOutletOffer({
@@ -576,11 +596,18 @@ test('cleanupOutletLifecycle releases expired holds and closes expired offers', 
 
     assert.ok(cleanup.releasedReservationIds.includes(reservation.id));
     assert.ok(cleanup.closedOfferIds.includes(offerId));
+    assert.ok(cleanup.closedOfferIds.includes(secondOfferId));
+    assert.deepEqual(
+        cleanup.closedOfferIds,
+        [...cleanup.closedOfferIds].sort((left, right) => left - right),
+    );
 
     const releasedReservation = await getOutletOfferReservation(reservation.id);
     const closedOffer = await getOutletOffer(offerId, later);
+    const secondClosedOffer = await getOutletOffer(secondOfferId, later);
     assert.equal(releasedReservation?.status, 'released');
     assert.equal(closedOffer?.status, 'closed');
+    assert.equal(secondClosedOffer?.status, 'closed');
 });
 
 test('removing a cart item releases its outlet reservation', async () => {

--- a/packages/storage/tests/outletOffersRepo.node.spec.ts
+++ b/packages/storage/tests/outletOffersRepo.node.spec.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
     assignStripeCustomerId,
+    bindStripeCheckoutAttempt,
     cleanupOutletLifecycle,
     convertOutletReservationForCartItem,
     createEntity,
@@ -10,21 +11,25 @@ import {
     createStripeCheckoutAttempt,
     expireOutletReservations,
     fingerprintStripeCheckoutValue,
+    getActiveStripeCheckoutAttempt,
     getOrCreateShoppingCart,
     getOutletOffer,
     getOutletOfferReservation,
     getOutletOffers,
     getShoppingCart,
+    OutletOfferIdentityImmutableError,
     OutletOfferUnavailableError,
     releaseOutletReservationForCartItem,
     releaseStripeCheckoutAttempt,
     reserveOutletOffer,
     type StripeCheckoutAttemptSnapshot,
+    setCartItemPaid,
     updateEntity,
     updateOutletOffer,
     upsertEntityType,
     upsertOrRemoveCartItem,
     upsertOrRemoveCartItemWithOutletReservation,
+    verifyStripeCheckoutAttemptLiveCart,
 } from '@gredice/storage';
 import { createTestAccount } from './helpers/testHelpers';
 import { createTestDb } from './testDb';
@@ -338,6 +343,7 @@ test('checkout rejects an outlet switch and active attempt fences later reservat
         quantity: 2,
         now,
     });
+    const otherPlantSortId = await createTestPlantSort();
     const accountId = await createTestAccount();
     const { cart, cartItemId } = await createCartItem(accountId, plantSortId);
     const firstReservation = await reserveOutletOffer({
@@ -348,6 +354,13 @@ test('checkout rejects an outlet switch and active attempt fences later reservat
         now,
         offerId: firstOfferId,
     });
+    await assert.rejects(
+        () =>
+            updateOutletOffer(firstOfferId, {
+                plantSortId: otherPlantSortId,
+            }),
+        OutletOfferIdentityImmutableError,
+    );
     const staleAttempt = outletAttemptSnapshot({
         cartId: cart.id,
         cartItemId,
@@ -403,6 +416,38 @@ test('checkout rejects an outlet switch and active attempt fences later reservat
         () => releaseOutletReservationForCartItem(cartItemId),
         /active Stripe checkout attempt/u,
     );
+    await bindStripeCheckoutAttempt({
+        attemptId: currentAttempt.attemptId,
+        cartId: cart.id,
+        sessionId: 'cs_delayed_outlet',
+    });
+    const delayedWebhookAt = new Date(
+        secondReservation.holdExpiresAt.getTime() + 1,
+    );
+    const releasedAtExpiry = await expireOutletReservations(delayedWebhookAt);
+    assert.equal(releasedAtExpiry.includes(secondReservation.id), false);
+    assert.equal(
+        (await getOutletOfferReservation(secondReservation.id))?.status,
+        'held',
+    );
+    assert.equal(
+        (
+            await convertOutletReservationForCartItem(
+                cartItemId,
+                delayedWebhookAt,
+            )
+        ).status,
+        'converted',
+    );
+    const fulfillmentCommittedAttempt = await getActiveStripeCheckoutAttempt(
+        cart.id,
+    );
+    assert.ok(fulfillmentCommittedAttempt);
+    await verifyStripeCheckoutAttemptLiveCart(fulfillmentCommittedAttempt);
+    await setCartItemPaid(cartItemId);
+    const resumableAttempt = await getActiveStripeCheckoutAttempt(cart.id);
+    assert.ok(resumableAttempt);
+    await verifyStripeCheckoutAttemptLiveCart(resumableAttempt);
 });
 
 test('outlet cart upsert rolls back when reservation fails', async () => {

--- a/packages/storage/tests/outletOffersRepo.node.spec.ts
+++ b/packages/storage/tests/outletOffersRepo.node.spec.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
+    assignStripeCustomerId,
     cleanupOutletLifecycle,
     convertOutletReservationForCartItem,
     createEntity,
@@ -15,6 +16,7 @@ import {
     getOutletOffers,
     getShoppingCart,
     OutletOfferUnavailableError,
+    releaseOutletReservationForCartItem,
     releaseStripeCheckoutAttempt,
     reserveOutletOffer,
     type StripeCheckoutAttemptSnapshot,
@@ -49,6 +51,7 @@ function addMinutes(date: Date, minutes: number) {
 }
 
 async function createCartItem(accountId: string, plantSortId: number) {
+    await assignStripeCustomerId(accountId, 'cus_outlet');
     const cart = await getOrCreateShoppingCart(accountId);
     assert.ok(cart, 'Cart should be created');
 
@@ -146,7 +149,7 @@ function outletAttemptSnapshot({
         stripeSession: {
             allowPromotionCodes: true,
             customerFingerprint: fingerprintStripeCheckoutValue('cus_outlet'),
-            expiresAt: '2026-05-01T11:00:00.000Z',
+            expiresAt: reservation.holdExpiresAt.toISOString(),
             items: [
                 {
                     cartItemId,
@@ -278,7 +281,7 @@ test('stale attempt release cannot release a later attempt reservation', async (
         entityId: plantSortId.toString(),
         reservation: firstReservation,
     });
-    await createStripeCheckoutAttempt(firstAttempt, { accountId });
+    await createStripeCheckoutAttempt(firstAttempt, { accountId, now });
     await releaseStripeCheckoutAttempt({
         attemptId: firstAttempt.attemptId,
         cartId: cart.id,
@@ -304,7 +307,10 @@ test('stale attempt release cannot release a later attempt reservation', async (
         entityId: plantSortId.toString(),
         reservation: secondReservation,
     });
-    await createStripeCheckoutAttempt(secondAttempt, { accountId });
+    await createStripeCheckoutAttempt(secondAttempt, {
+        accountId,
+        now: addMinutes(now, 1),
+    });
 
     await releaseStripeCheckoutAttempt({
         attemptId: firstAttempt.attemptId,
@@ -315,6 +321,87 @@ test('stale attempt release cannot release a later attempt reservation', async (
     assert.equal(
         (await getOutletOfferReservation(secondReservation.id))?.status,
         'held',
+    );
+});
+
+test('checkout rejects an outlet switch and active attempt fences later reservations', async () => {
+    createTestDb();
+    const now = new Date('2026-05-01T10:00:00.000Z');
+    const plantSortId = await createTestPlantSort();
+    const firstOfferId = await createPublishedOffer({
+        plantSortId,
+        quantity: 2,
+        now,
+    });
+    const secondOfferId = await createPublishedOffer({
+        plantSortId,
+        quantity: 2,
+        now,
+    });
+    const accountId = await createTestAccount();
+    const { cart, cartItemId } = await createCartItem(accountId, plantSortId);
+    const firstReservation = await reserveOutletOffer({
+        accountId,
+        cartId: cart.id,
+        cartItemId,
+        holdMinutes: 31,
+        now,
+        offerId: firstOfferId,
+    });
+    const staleAttempt = outletAttemptSnapshot({
+        cartId: cart.id,
+        cartItemId,
+        entityId: plantSortId.toString(),
+        reservation: firstReservation,
+    });
+    const switchedAt = addMinutes(now, 1);
+    const secondReservation = await reserveOutletOffer({
+        accountId,
+        cartId: cart.id,
+        cartItemId,
+        holdMinutes: 31,
+        now: switchedAt,
+        offerId: secondOfferId,
+    });
+
+    await assert.rejects(
+        () =>
+            createStripeCheckoutAttempt(staleAttempt, {
+                accountId,
+                now: switchedAt,
+            }),
+        (error) => {
+            assert.ok(error instanceof Error);
+            assert.match(error.message, /outlet_reservation/u);
+            return true;
+        },
+    );
+
+    const currentAttempt = outletAttemptSnapshot({
+        cartId: cart.id,
+        cartItemId,
+        entityId: plantSortId.toString(),
+        reservation: secondReservation,
+    });
+    await createStripeCheckoutAttempt(currentAttempt, {
+        accountId,
+        now: switchedAt,
+    });
+    await assert.rejects(
+        () =>
+            reserveOutletOffer({
+                accountId,
+                cartId: cart.id,
+                cartItemId,
+                holdMinutes: 31,
+                now: addMinutes(switchedAt, 1),
+                offerId: firstOfferId,
+            }),
+        /active Stripe checkout attempt/u,
+    );
+    await assert.rejects(
+        () => releaseOutletReservationForCartItem(cartItemId),
+        /active Stripe checkout attempt/u,
     );
 });
 

--- a/packages/storage/tests/stripeCheckoutAttemptRepo.node.spec.ts
+++ b/packages/storage/tests/stripeCheckoutAttemptRepo.node.spec.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
     accountDeletionStartedEventType,
     accounts,
+    assignStripeCustomerId,
     bindStripeCheckoutAttempt,
     createStripeCheckoutAttempt,
     deleteAccountWithDependencies,
@@ -81,6 +82,7 @@ function snapshotFromCart(
 
 async function createCartWithItem(existingAccountId?: string) {
     const accountId = existingAccountId ?? (await createTestAccount());
+    await assignStripeCustomerId(accountId, 'checkout-test-customer');
     const cart = await getOrCreateShoppingCart(accountId);
     assert.ok(cart);
     const itemId = await upsertOrRemoveCartItem(
@@ -362,6 +364,23 @@ test('snapshot creation rejects cart membership and amount changes before Stripe
         () => createStripeCheckoutAttempt(missingItemSnapshot, { accountId }),
         StripeCheckoutAttemptConflictError,
     );
+});
+
+test('snapshot creation rejects a customer that lost the canonical assignment race', async () => {
+    createTestDb();
+    const { accountId, cart } = await createCartWithItem();
+    const snapshot = snapshotFromCart(cart);
+    await assignStripeCustomerId(accountId, 'checkout-race-winner');
+
+    await assert.rejects(
+        () => createStripeCheckoutAttempt(snapshot, { accountId }),
+        (error) => {
+            assert.ok(error instanceof StripeCheckoutAttemptConflictError);
+            assert.equal(error.category, 'checkout_identity_changed');
+            return true;
+        },
+    );
+    assert.equal(await getActiveStripeCheckoutAttempt(cart.id), undefined);
 });
 
 test('an active snapshot wins account deletion before any garden mutation', async () => {

--- a/packages/storage/tests/stripeCheckoutAttemptRepo.node.spec.ts
+++ b/packages/storage/tests/stripeCheckoutAttemptRepo.node.spec.ts
@@ -1,0 +1,322 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    accounts,
+    bindStripeCheckoutAttempt,
+    createStripeCheckoutAttempt,
+    deleteAccountWithDependencies,
+    deleteShoppingCart,
+    foldStripeCheckoutAttemptEvents,
+    getActiveStripeCheckoutAttempt,
+    getGarden,
+    getOrCreateShoppingCart,
+    getShoppingCart,
+    releaseStripeCheckoutAttempt,
+    StripeCheckoutAttemptConflictError,
+    StripeCheckoutAttemptInProgressError,
+    type StripeCheckoutAttemptSnapshot,
+    storage,
+    upsertOrRemoveCartItem,
+    verifyStripeCheckoutAttemptLiveCart,
+} from '@gredice/storage';
+import {
+    createTestAccount,
+    createTestGarden,
+    ensureFarmId,
+} from './helpers/testHelpers';
+import { createTestDb } from './testDb';
+
+function snapshotFromCart(
+    cart: NonNullable<Awaited<ReturnType<typeof getShoppingCart>>>,
+): StripeCheckoutAttemptSnapshot {
+    return {
+        accountId: cart.accountId ?? '',
+        attemptId: randomUUID(),
+        cartId: cart.id,
+        expectedNonStripeCartItemIds: [],
+        harvestDates: [],
+        items: cart.items.map((item) => ({
+            additionalData: item.additionalData,
+            amount: item.amount,
+            cartId: item.cartId,
+            checkoutAdditionalData: {},
+            currency: item.currency,
+            entityId: item.entityId,
+            entityTypeName: item.entityTypeName,
+            gardenId: item.gardenId,
+            id: item.id,
+            paymentAmount: 500,
+            paymentKind: 'stripe',
+            positionIndex: item.positionIndex,
+            raisedBedId: item.raisedBedId,
+            status: 'new',
+        })),
+        userId: 'checkout-test-user',
+        version: 1,
+    };
+}
+
+async function createCartWithItem(existingAccountId?: string) {
+    const accountId = existingAccountId ?? (await createTestAccount());
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart);
+    const itemId = await upsertOrRemoveCartItem(
+        undefined,
+        cart.id,
+        'entity-1',
+        'plantSort',
+        1,
+        undefined,
+        undefined,
+        undefined,
+        null,
+        'eur',
+        true,
+    );
+    assert.ok(itemId);
+    const populatedCart = await getShoppingCart(cart.id);
+    assert.ok(populatedCart);
+    return { accountId, cart: populatedCart, itemId };
+}
+
+test('Stripe attempt events retain one immutable binding and retry-safe release', () => {
+    const snapshot = {
+        accountId: 'account-1',
+        attemptId: '79d24698-c458-45aa-b025-c311dc9a3c1a',
+        cartId: 4,
+        expectedNonStripeCartItemIds: [],
+        harvestDates: [],
+        items: [
+            {
+                additionalData: null,
+                amount: 1,
+                cartId: 4,
+                checkoutAdditionalData: {},
+                currency: 'eur',
+                entityId: 'entity-1',
+                entityTypeName: 'plantSort',
+                gardenId: null,
+                id: 5,
+                paymentAmount: 500,
+                paymentKind: 'stripe',
+                positionIndex: null,
+                raisedBedId: null,
+                status: 'new',
+            },
+        ],
+        userId: 'user-1',
+        version: 1,
+    } satisfies StripeCheckoutAttemptSnapshot;
+    const created = {
+        data: snapshot,
+        type: 'checkout.stripeAttempt.created',
+    };
+    const bound = {
+        data: { attemptId: snapshot.attemptId, sessionId: 'cs_1' },
+        type: 'checkout.stripeAttempt.bound',
+    };
+    assert.equal(
+        foldStripeCheckoutAttemptEvents(snapshot.attemptId, [created])
+            ?.sessionId,
+        undefined,
+    );
+    assert.equal(
+        foldStripeCheckoutAttemptEvents(snapshot.attemptId, [created, bound])
+            ?.sessionId,
+        'cs_1',
+    );
+    assert.throws(
+        () =>
+            foldStripeCheckoutAttemptEvents(snapshot.attemptId, [
+                created,
+                bound,
+                {
+                    data: {
+                        attemptId: snapshot.attemptId,
+                        sessionId: 'cs_changed',
+                    },
+                    type: 'checkout.stripeAttempt.bound',
+                },
+            ]),
+        StripeCheckoutAttemptConflictError,
+    );
+});
+
+test('active Stripe attempt fences insert, update, last-item removal, and cart deletion', async () => {
+    createTestDb();
+    const { cart, itemId } = await createCartWithItem();
+    const snapshot = snapshotFromCart(cart);
+    await createStripeCheckoutAttempt(snapshot);
+
+    await assert.rejects(
+        () =>
+            upsertOrRemoveCartItem(
+                itemId,
+                cart.id,
+                'entity-1',
+                'plantSort',
+                2,
+                undefined,
+                undefined,
+                undefined,
+                null,
+                'eur',
+            ),
+        StripeCheckoutAttemptInProgressError,
+    );
+    await assert.rejects(
+        () =>
+            upsertOrRemoveCartItem(
+                undefined,
+                cart.id,
+                'entity-2',
+                'plantSort',
+                1,
+                undefined,
+                undefined,
+                undefined,
+                null,
+                'eur',
+                true,
+            ),
+        StripeCheckoutAttemptInProgressError,
+    );
+    await assert.rejects(
+        () =>
+            upsertOrRemoveCartItem(itemId, cart.id, 'entity-1', 'plantSort', 0),
+        StripeCheckoutAttemptInProgressError,
+    );
+    await assert.rejects(
+        () => deleteShoppingCart(snapshot.accountId),
+        StripeCheckoutAttemptInProgressError,
+    );
+
+    const activeAttempt = await getActiveStripeCheckoutAttempt(cart.id);
+    assert.equal(activeAttempt?.snapshot.attemptId, snapshot.attemptId);
+});
+
+test('attempt binding, webhook recovery, cancellation, and a later cart mutation are idempotent', async () => {
+    createTestDb();
+    const { cart, itemId } = await createCartWithItem();
+    const snapshot = snapshotFromCart(cart);
+    await createStripeCheckoutAttempt(snapshot);
+    await bindStripeCheckoutAttempt({
+        attemptId: snapshot.attemptId,
+        cartId: cart.id,
+        sessionId: 'cs_retry',
+    });
+    await bindStripeCheckoutAttempt({
+        attemptId: snapshot.attemptId,
+        cartId: cart.id,
+        sessionId: 'cs_retry',
+    });
+    const attempt = await getActiveStripeCheckoutAttempt(cart.id);
+    assert.ok(attempt);
+    await verifyStripeCheckoutAttemptLiveCart(attempt);
+
+    await releaseStripeCheckoutAttempt({
+        attemptId: snapshot.attemptId,
+        cartId: cart.id,
+        reason: 'cancelled',
+        sessionId: 'cs_retry',
+    });
+    await releaseStripeCheckoutAttempt({
+        attemptId: snapshot.attemptId,
+        cartId: cart.id,
+        reason: 'expired',
+        sessionId: 'cs_retry',
+    });
+    assert.equal(await getActiveStripeCheckoutAttempt(cart.id), undefined);
+    assert.equal(
+        await upsertOrRemoveCartItem(
+            itemId,
+            cart.id,
+            'entity-1',
+            'plantSort',
+            2,
+            undefined,
+            undefined,
+            undefined,
+            null,
+            'eur',
+        ),
+        itemId,
+    );
+});
+
+test('snapshot creation rejects cart membership and amount changes before Stripe', async () => {
+    createTestDb();
+    const { cart, itemId } = await createCartWithItem();
+    const staleSnapshot = snapshotFromCart(cart);
+    await upsertOrRemoveCartItem(
+        itemId,
+        cart.id,
+        'entity-1',
+        'plantSort',
+        2,
+        undefined,
+        undefined,
+        undefined,
+        null,
+        'eur',
+    );
+    await assert.rejects(
+        () => createStripeCheckoutAttempt(staleSnapshot),
+        (error) => {
+            assert.ok(error instanceof StripeCheckoutAttemptConflictError);
+            assert.equal(error.category, 'cart_item_changed');
+            return true;
+        },
+    );
+
+    const currentCart = await getShoppingCart(cart.id);
+    assert.ok(currentCart);
+    const missingItemSnapshot = snapshotFromCart(currentCart);
+    missingItemSnapshot.items = [];
+    await assert.rejects(
+        () => createStripeCheckoutAttempt(missingItemSnapshot),
+        StripeCheckoutAttemptConflictError,
+    );
+});
+
+test('an active snapshot wins account deletion before any garden mutation', async () => {
+    createTestDb();
+    const { accountId, cart } = await createCartWithItem();
+    const garden = await createTestGarden({
+        accountId,
+        farmId: await ensureFarmId(),
+    });
+    const snapshot = snapshotFromCart(cart);
+    await createStripeCheckoutAttempt(snapshot);
+
+    await assert.rejects(
+        () => deleteAccountWithDependencies(accountId, 'missing-test-user'),
+        StripeCheckoutAttemptInProgressError,
+    );
+
+    const untouchedGarden = await getGarden(garden);
+    assert.equal(untouchedGarden?.accountId, accountId);
+    assert.ok(await getActiveStripeCheckoutAttempt(cart.id));
+});
+
+test('account deletion can win and remains retryable while a stale snapshot fails', async () => {
+    createTestDb();
+    const accountId = randomUUID();
+    await storage().insert(accounts).values({ id: accountId });
+    const { cart } = await createCartWithItem(accountId);
+    const snapshot = snapshotFromCart(cart);
+
+    await deleteAccountWithDependencies(accountId, 'missing-test-user');
+    await deleteAccountWithDependencies(accountId, 'missing-test-user');
+
+    assert.equal(await getShoppingCart(cart.id), undefined);
+    await assert.rejects(
+        () => createStripeCheckoutAttempt(snapshot),
+        (error) => {
+            assert.ok(error instanceof StripeCheckoutAttemptConflictError);
+            assert.equal(error.category, 'cart_inactive');
+            return true;
+        },
+    );
+});

--- a/packages/storage/tests/stripeCheckoutAttemptRepo.node.spec.ts
+++ b/packages/storage/tests/stripeCheckoutAttemptRepo.node.spec.ts
@@ -5,6 +5,7 @@ import {
     accountDeletionStartedEventType,
     accounts,
     assignStripeCustomerId,
+    assignStripeCustomerIdIfUnchanged,
     bindStripeCheckoutAttempt,
     createStripeCheckoutAttempt,
     deleteAccountWithDependencies,
@@ -381,6 +382,36 @@ test('snapshot creation rejects a customer that lost the canonical assignment ra
         },
     );
     assert.equal(await getActiveStripeCheckoutAttempt(cart.id), undefined);
+});
+
+test('an active snapshot fences replacement of its canonical Stripe customer', async () => {
+    createTestDb();
+    const { accountId, cart } = await createCartWithItem();
+    const snapshot = snapshotFromCart(cart);
+    await createStripeCheckoutAttempt(snapshot, { accountId });
+
+    assert.equal(
+        await assignStripeCustomerIdIfUnchanged(
+            accountId,
+            'checkout-test-customer',
+            'checkout-replacement-customer',
+        ),
+        'checkout-test-customer',
+    );
+    await releaseStripeCheckoutAttempt({
+        attemptId: snapshot.attemptId,
+        cartId: cart.id,
+        reason: 'cancelled',
+        sessionId: null,
+    });
+    assert.equal(
+        await assignStripeCustomerIdIfUnchanged(
+            accountId,
+            'checkout-test-customer',
+            'checkout-replacement-customer',
+        ),
+        'checkout-replacement-customer',
+    );
 });
 
 test('an active snapshot wins account deletion before any garden mutation', async () => {

--- a/packages/storage/tests/stripeCheckoutAttemptRepo.node.spec.ts
+++ b/packages/storage/tests/stripeCheckoutAttemptRepo.node.spec.ts
@@ -2,11 +2,13 @@ import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
+    accountDeletionStartedEventType,
     accounts,
     bindStripeCheckoutAttempt,
     createStripeCheckoutAttempt,
     deleteAccountWithDependencies,
     deleteShoppingCart,
+    fingerprintStripeCheckoutValue,
     foldStripeCheckoutAttemptEvents,
     getActiveStripeCheckoutAttempt,
     getGarden,
@@ -31,16 +33,19 @@ function snapshotFromCart(
     cart: NonNullable<Awaited<ReturnType<typeof getShoppingCart>>>,
 ): StripeCheckoutAttemptSnapshot {
     return {
-        accountId: cart.accountId ?? '',
         attemptId: randomUUID(),
         cartId: cart.id,
         expectedNonStripeCartItemIds: [],
         harvestDates: [],
         items: cart.items.map((item) => ({
-            additionalData: item.additionalData,
+            additionalDataFingerprint: fingerprintStripeCheckoutValue(
+                item.additionalData,
+            ),
             amount: item.amount,
             cartId: item.cartId,
-            checkoutAdditionalData: {},
+            checkoutAdditionalDataFingerprint: fingerprintStripeCheckoutValue(
+                {},
+            ),
             currency: item.currency,
             entityId: item.entityId,
             entityTypeName: item.entityTypeName,
@@ -52,7 +57,24 @@ function snapshotFromCart(
             raisedBedId: item.raisedBedId,
             status: 'new',
         })),
-        userId: 'checkout-test-user',
+        stripeSession: {
+            allowPromotionCodes: true,
+            customerFingerprint: fingerprintStripeCheckoutValue(
+                'checkout-test-customer',
+            ),
+            expiresAt: '2026-08-04T00:00:00.000Z',
+            items: cart.items.map((item) => ({
+                cartItemId: item.id,
+                price: { currency: 'eur', valueInCents: 500 },
+                product: { name: 'Checkout test item' },
+                quantity: item.amount,
+            })),
+            returnUrls: {
+                cancel: 'https://example.test/cancel',
+                success: 'https://example.test/success',
+            },
+        },
+        userFingerprint: fingerprintStripeCheckoutValue('checkout-test-user'),
         version: 1,
     };
 }
@@ -82,17 +104,17 @@ async function createCartWithItem(existingAccountId?: string) {
 
 test('Stripe attempt events retain one immutable binding and retry-safe release', () => {
     const snapshot = {
-        accountId: 'account-1',
         attemptId: '79d24698-c458-45aa-b025-c311dc9a3c1a',
         cartId: 4,
         expectedNonStripeCartItemIds: [],
         harvestDates: [],
         items: [
             {
-                additionalData: null,
+                additionalDataFingerprint: fingerprintStripeCheckoutValue(null),
                 amount: 1,
                 cartId: 4,
-                checkoutAdditionalData: {},
+                checkoutAdditionalDataFingerprint:
+                    fingerprintStripeCheckoutValue({}),
                 currency: 'eur',
                 entityId: 'entity-1',
                 entityTypeName: 'plantSort',
@@ -105,7 +127,24 @@ test('Stripe attempt events retain one immutable binding and retry-safe release'
                 status: 'new',
             },
         ],
-        userId: 'user-1',
+        stripeSession: {
+            allowPromotionCodes: true,
+            customerFingerprint: fingerprintStripeCheckoutValue('cus_1'),
+            expiresAt: '2026-08-04T00:00:00.000Z',
+            items: [
+                {
+                    cartItemId: 5,
+                    price: { currency: 'eur', valueInCents: 500 },
+                    product: { name: 'Checkout test item' },
+                    quantity: 1,
+                },
+            ],
+            returnUrls: {
+                cancel: 'https://example.test/cancel',
+                success: 'https://example.test/success',
+            },
+        },
+        userFingerprint: fingerprintStripeCheckoutValue('user-1'),
         version: 1,
     } satisfies StripeCheckoutAttemptSnapshot;
     const created = {
@@ -145,9 +184,9 @@ test('Stripe attempt events retain one immutable binding and retry-safe release'
 
 test('active Stripe attempt fences insert, update, last-item removal, and cart deletion', async () => {
     createTestDb();
-    const { cart, itemId } = await createCartWithItem();
+    const { accountId, cart, itemId } = await createCartWithItem();
     const snapshot = snapshotFromCart(cart);
-    await createStripeCheckoutAttempt(snapshot);
+    await createStripeCheckoutAttempt(snapshot, { accountId });
 
     await assert.rejects(
         () =>
@@ -188,7 +227,7 @@ test('active Stripe attempt fences insert, update, last-item removal, and cart d
         StripeCheckoutAttemptInProgressError,
     );
     await assert.rejects(
-        () => deleteShoppingCart(snapshot.accountId),
+        () => deleteShoppingCart(accountId),
         StripeCheckoutAttemptInProgressError,
     );
 
@@ -196,11 +235,56 @@ test('active Stripe attempt fences insert, update, last-item removal, and cart d
     assert.equal(activeAttempt?.snapshot.attemptId, snapshot.attemptId);
 });
 
+test('serialized attempt event omits account, user, and raw delivery data', async () => {
+    createTestDb();
+    const { accountId, cart } = await createCartWithItem();
+    const snapshot = snapshotFromCart(cart);
+    const privateUserId = 'private-user-id-never-persist';
+    const privateAddressId = 987654321;
+    const privateNotes = 'private-delivery-note-never-persist';
+    snapshot.userFingerprint = fingerprintStripeCheckoutValue(privateUserId);
+    const item = snapshot.items[0];
+    assert.ok(item);
+    item.checkoutAdditionalDataFingerprint = fingerprintStripeCheckoutValue({
+        delivery: {
+            addressId: privateAddressId,
+            mode: 'delivery',
+            notes: privateNotes,
+            slotId: 7,
+        },
+    });
+
+    await createStripeCheckoutAttempt(snapshot, { accountId });
+    const createdEvent = await storage().query.events.findFirst({
+        where: (event, { and, eq }) =>
+            and(
+                eq(event.aggregateId, `shoppingCart:${cart.id.toString()}`),
+                eq(event.type, 'checkout.stripeAttempt.created'),
+            ),
+    });
+    assert.ok(createdEvent);
+    const serialized = JSON.stringify(createdEvent.data);
+    for (const forbidden of [
+        accountId,
+        privateUserId,
+        privateAddressId.toString(),
+        privateNotes,
+        '"accountId":',
+        '"userId":',
+        '"additionalData":',
+        '"checkoutAdditionalData":',
+        '"addressId":',
+        '"notes":',
+    ]) {
+        assert.equal(serialized.includes(forbidden), false, forbidden);
+    }
+});
+
 test('attempt binding, webhook recovery, cancellation, and a later cart mutation are idempotent', async () => {
     createTestDb();
-    const { cart, itemId } = await createCartWithItem();
+    const { accountId, cart, itemId } = await createCartWithItem();
     const snapshot = snapshotFromCart(cart);
-    await createStripeCheckoutAttempt(snapshot);
+    await createStripeCheckoutAttempt(snapshot, { accountId });
     await bindStripeCheckoutAttempt({
         attemptId: snapshot.attemptId,
         cartId: cart.id,
@@ -247,7 +331,7 @@ test('attempt binding, webhook recovery, cancellation, and a later cart mutation
 
 test('snapshot creation rejects cart membership and amount changes before Stripe', async () => {
     createTestDb();
-    const { cart, itemId } = await createCartWithItem();
+    const { accountId, cart, itemId } = await createCartWithItem();
     const staleSnapshot = snapshotFromCart(cart);
     await upsertOrRemoveCartItem(
         itemId,
@@ -262,7 +346,7 @@ test('snapshot creation rejects cart membership and amount changes before Stripe
         'eur',
     );
     await assert.rejects(
-        () => createStripeCheckoutAttempt(staleSnapshot),
+        () => createStripeCheckoutAttempt(staleSnapshot, { accountId }),
         (error) => {
             assert.ok(error instanceof StripeCheckoutAttemptConflictError);
             assert.equal(error.category, 'cart_item_changed');
@@ -275,7 +359,7 @@ test('snapshot creation rejects cart membership and amount changes before Stripe
     const missingItemSnapshot = snapshotFromCart(currentCart);
     missingItemSnapshot.items = [];
     await assert.rejects(
-        () => createStripeCheckoutAttempt(missingItemSnapshot),
+        () => createStripeCheckoutAttempt(missingItemSnapshot, { accountId }),
         StripeCheckoutAttemptConflictError,
     );
 });
@@ -288,7 +372,7 @@ test('an active snapshot wins account deletion before any garden mutation', asyn
         farmId: await ensureFarmId(),
     });
     const snapshot = snapshotFromCart(cart);
-    await createStripeCheckoutAttempt(snapshot);
+    await createStripeCheckoutAttempt(snapshot, { accountId });
 
     await assert.rejects(
         () => deleteAccountWithDependencies(accountId, 'missing-test-user'),
@@ -298,6 +382,16 @@ test('an active snapshot wins account deletion before any garden mutation', asyn
     const untouchedGarden = await getGarden(garden);
     assert.equal(untouchedGarden?.accountId, accountId);
     assert.ok(await getActiveStripeCheckoutAttempt(cart.id));
+    assert.equal(
+        await storage().query.events.findFirst({
+            where: (event, { and, eq }) =>
+                and(
+                    eq(event.aggregateId, accountId),
+                    eq(event.type, accountDeletionStartedEventType),
+                ),
+        }),
+        undefined,
+    );
 });
 
 test('account deletion can win and remains retryable while a stale snapshot fails', async () => {
@@ -312,10 +406,10 @@ test('account deletion can win and remains retryable while a stale snapshot fail
 
     assert.equal(await getShoppingCart(cart.id), undefined);
     await assert.rejects(
-        () => createStripeCheckoutAttempt(snapshot),
+        () => createStripeCheckoutAttempt(snapshot, { accountId }),
         (error) => {
             assert.ok(error instanceof StripeCheckoutAttemptConflictError);
-            assert.equal(error.category, 'cart_inactive');
+            assert.equal(error.category, 'account_inactive');
             return true;
         },
     );

--- a/packages/stripe/src/lib/server/serverStripe.ts
+++ b/packages/stripe/src/lib/server/serverStripe.ts
@@ -48,7 +48,9 @@ function getValidStripeImageUrls(imageUrls?: string[]): string[] | undefined {
     return validUrls;
 }
 
-async function ensureStripeCustomer(account: UserAccount): Promise<string> {
+export async function resolveStripeCustomerId(
+    account: UserAccount,
+): Promise<string> {
     // Check if the user already has a Stripe customer ID
     // Ensure customer still exists in Stripe and is not deleted
     if (account.stripeCustomerId && account.stripeCustomerId.length > 0) {
@@ -176,9 +178,16 @@ export async function stripeCheckout(
         allowPromotionCodes?: boolean;
         metadata?: Record<string, string | number | null>;
     },
+    options: {
+        customerId?: string;
+        idempotencyKey?: string;
+        returnUrls?: StripeCheckoutReturnUrls;
+    } = {},
 ) {
     try {
-        const customerId = await ensureStripeCustomer(account);
+        const customerId =
+            options.customerId ?? (await resolveStripeCustomerId(account));
+        const returnUrls = options.returnUrls ?? getStripeCheckoutReturnUrls();
         const params: StripeCheckoutSessionCreateParams = {
             customer: customerId,
             customer_update: {
@@ -200,8 +209,8 @@ export async function stripeCheckout(
             allow_promotion_codes: data.allowPromotionCodes ?? true,
             mode: 'payment',
             locale: 'hr',
-            cancel_url: getReturnUrl({ status: 'cancel' }),
-            success_url: getReturnUrl({ status: 'success' }),
+            cancel_url: returnUrls.cancel,
+            success_url: returnUrls.success,
             metadata: data.metadata,
         };
         if (data.expiresAt) {
@@ -211,10 +220,15 @@ export async function stripeCheckout(
         // Create a checkout session in Stripe
         let session: Stripe.Checkout.Session | undefined;
         try {
-            session = await getStripe().checkout.sessions.create(params);
+            session = await getStripe().checkout.sessions.create(
+                params,
+                options.idempotencyKey
+                    ? { idempotencyKey: options.idempotencyKey }
+                    : undefined,
+            );
         } catch (err) {
             console.error(err);
-            throw new Error('Unable to create checkout session.');
+            throw err;
         }
 
         if (session) {
@@ -243,9 +257,21 @@ export async function stripeCheckout(
     }
 }
 
+export type StripeCheckoutReturnUrls = {
+    cancel: string;
+    success: string;
+};
+
+export function getStripeCheckoutReturnUrls(): StripeCheckoutReturnUrls {
+    return {
+        cancel: getReturnUrl({ status: 'cancel' }),
+        success: getReturnUrl({ status: 'success' }),
+    };
+}
+
 export async function stripeCustomerBillingInfo(account: UserAccount) {
     try {
-        const customerId = await ensureStripeCustomer(account);
+        const customerId = await resolveStripeCustomerId(account);
         const stripeCustomer = await getStripe().customers.retrieve(customerId);
         if (stripeCustomer.deleted) throw new Error('Customer not found');
 
@@ -294,7 +320,7 @@ async function stripeListAll<T extends { id: string }>(
 
 export async function stripeCustomerPaymentMethods(account: UserAccount) {
     try {
-        const customerId = await ensureStripeCustomer(account);
+        const customerId = await resolveStripeCustomerId(account);
         const stripeCustomer = await getStripe().customers.retrieve(customerId);
         if (stripeCustomer.deleted) throw new Error('Customer not found');
 
@@ -340,7 +366,7 @@ export async function stripeCustomerPaymentMethods(account: UserAccount) {
 
 export async function stripeCreatePortal(account: UserAccount) {
     try {
-        const customerId = await ensureStripeCustomer(account);
+        const customerId = await resolveStripeCustomerId(account);
         try {
             const { url, id } = await getStripe().billingPortal.sessions.create(
                 {

--- a/packages/stripe/src/lib/server/serverStripe.ts
+++ b/packages/stripe/src/lib/server/serverStripe.ts
@@ -124,6 +124,7 @@ export async function getStripeCheckoutSession(sessionId: string) {
             lineItems: line_items,
             amountTotal: session.amount_total,
             metadata: session.metadata,
+            url: session.url,
         };
     } catch (error) {
         if (error instanceof Error) {


### PR DESCRIPTION
## Outcome

- Freezes an immutable, privacy-safe cart snapshot before Stripe opens and verifies it before the first fulfillment side effect.
- Uses the attempt UUID as the Stripe idempotency key and replays the exact captured session inputs after an interrupted response.
- Fences cart, account, customer, and outlet mutations while an attempt is active.
- Reconciles zero-total and partial fulfillment retries without duplicating payment, planting, inventory, or outlet effects.
- Preserves exact outlet reservations for delayed webhooks and prevents expired active-attempt holds from being reallocated.

## Concurrency and safety

- Locks all source and target outlet offers in ascending order, then locks the complete reservation union in ascending order before any switch mutation.
- Pre-locks cart and checkout-attempt bulk reservation releases in the same canonical reservation order.
- Closes expired offers in ascending lock order to avoid verifier and cleanup deadlocks.
- Samples outlet expiry only after every offer and reservation lock wait, closing the pre-expiry validation race.
- Keeps an expired unbound attempt fail-closed: local time cannot prove that a lost Stripe create response did not create or charge a session.
- Keeps raw account, user, delivery, and Stripe customer values out of durable attempt events; only fingerprints and fulfillment inputs are retained.

## Validation

- 56 focused storage checkout tests pass on PGlite; the new deterministic two-connection PostgreSQL lock-wait regression is skipped only on PGlite and runs in repository CI.
- 389 of 389 API node tests pass, including exact replay and expired-unbound fail-closed recovery.
- API TypeScript passes.
- Scoped Biome and git diff check pass.
- Production API Next.js build passes.

## Residual verification

- PGlite cannot reproduce the exact PostgreSQL advisory and row-lock scheduler. The implementation uses one documented global offer-then-reservation lock order; GitHub CI provides the real PostgreSQL gate.
- An expired unbound attempt conservatively retains its exact outlet capacity until Stripe recovery resolves it. Stripe-authoritative autonomous discovery and two-pass release are tracked separately in #4382.

Closes #4379