### PR TITLE
[Checkout] Reconcile orphaned Stripe attempts

### DIFF
--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -69,6 +69,7 @@ import {
     buildOrderConfirmationItems,
     ORDER_CONFIRMATION_MANAGE_URL,
 } from '../../../lib/checkout/orderConfirmationEmail';
+import { recoverStripeCheckoutAttemptAfterCreateRace } from '../../../lib/checkout/stripeCheckoutCreateRace';
 import { recoverStripeCheckoutAttemptSession } from '../../../lib/checkout/stripeCheckoutRecovery';
 import {
     buildStripeCheckoutAttemptSnapshot,
@@ -1004,20 +1005,39 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                     });
                 } catch (error) {
                     if (error instanceof StripeCheckoutAttemptInProgressError) {
-                        const activeAttempt =
-                            await getActiveStripeCheckoutAttempt(cart.id);
-                        if (activeAttempt) {
-                            const recovery = await recoverAttempt(
-                                activeAttempt,
-                                cart.items,
-                                canonicalCustomerId,
+                        const concurrentRecovery =
+                            await recoverStripeCheckoutAttemptAfterCreateRace({
+                                getActiveAttempt: () =>
+                                    getActiveStripeCheckoutAttempt(cart.id),
+                                recoverAttempt: (activeAttempt) =>
+                                    recoverAttempt(
+                                        activeAttempt,
+                                        cart.items,
+                                        canonicalCustomerId,
+                                    ),
+                            });
+                        if (concurrentRecovery.status === 'cart_changed') {
+                            checkoutTiming.setErrorCategory(
+                                'cart_validation_failed',
                             );
-                            if (recovery.status === 'open' && recovery.url) {
-                                return context.json({
-                                    sessionId: recovery.sessionId,
-                                    url: recovery.url,
-                                });
-                            }
+                            return context.json(
+                                {
+                                    code: 'CHECKOUT_CART_CHANGED',
+                                    error: 'Košarica se promijenila. Osvježi je i pokušaj ponovno.',
+                                },
+                                409,
+                            );
+                        }
+                        if (
+                            concurrentRecovery.status === 'recovered' &&
+                            concurrentRecovery.recovery.status === 'open' &&
+                            concurrentRecovery.recovery.url
+                        ) {
+                            return context.json({
+                                sessionId:
+                                    concurrentRecovery.recovery.sessionId,
+                                url: concurrentRecovery.recovery.url,
+                            });
                         }
                         return context.json(
                             {

--- a/apps/api/app/api/internal/cron/outlet-lifecycle/route.ts
+++ b/apps/api/app/api/internal/cron/outlet-lifecycle/route.ts
@@ -1,34 +1,84 @@
 import { cleanupOutletLifecycle } from '@gredice/storage';
 import type { NextRequest } from 'next/server';
+import { reconcileStripeCheckoutOrphanAttempts } from '../../../../../lib/checkout/stripeCheckoutOrphanReconciliation';
 
 export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+function failureCategory(error: unknown) {
+    return error instanceof Error ? error.name : 'unknown';
+}
+
+async function runOutletCleanup() {
+    try {
+        return {
+            status: 'fulfilled' as const,
+            value: await cleanupOutletLifecycle(),
+        };
+    } catch (error) {
+        const category = failureCategory(error);
+        console.error('Outlet lifecycle cleanup failed', { category });
+        return { category, status: 'rejected' as const };
+    }
+}
+
+async function runStripeAttemptReconciliation() {
+    try {
+        return {
+            status: 'fulfilled' as const,
+            value: await reconcileStripeCheckoutOrphanAttempts(),
+        };
+    } catch (error) {
+        const category = failureCategory(error);
+        console.error('Stripe checkout attempt reconciliation failed', {
+            category,
+        });
+        return { category, status: 'rejected' as const };
+    }
+}
 
 export async function GET(request: NextRequest) {
+    const cronSecret = process.env.CRON_SECRET?.trim();
     const authHeader = request.headers.get('authorization');
-    if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
         return new Response('Unauthorized', {
             status: 401,
         });
     }
 
-    try {
-        const cleanup = await cleanupOutletLifecycle();
+    // Keep the established cleanup job independent from Stripe availability
+    // and from malformed recovery candidates.
+    const cleanup = await runOutletCleanup();
+    const reconciliation = await runStripeAttemptReconciliation();
+    const healthy =
+        cleanup.status === 'fulfilled' &&
+        reconciliation.status === 'fulfilled' &&
+        reconciliation.value.failedCount === 0 &&
+        !reconciliation.value.truncated;
 
-        return Response.json({
-            success: true,
-            releasedReservationsCount: cleanup.releasedReservationIds.length,
-            closedOffersCount: cleanup.closedOfferIds.length,
+    return Response.json(
+        {
+            success: healthy,
+            reconciliation:
+                reconciliation.status === 'fulfilled'
+                    ? reconciliation.value
+                    : null,
+            reconciliationFailureCategory:
+                reconciliation.status === 'rejected'
+                    ? reconciliation.category
+                    : null,
+            releasedReservationsCount:
+                cleanup.status === 'fulfilled'
+                    ? cleanup.value.releasedReservationIds.length
+                    : 0,
+            closedOffersCount:
+                cleanup.status === 'fulfilled'
+                    ? cleanup.value.closedOfferIds.length
+                    : 0,
+            cleanupFailureCategory:
+                cleanup.status === 'rejected' ? cleanup.category : null,
             timestamp: new Date().toISOString(),
-        });
-    } catch (error) {
-        console.error('Failed to clean up outlet lifecycle:', error);
-        return Response.json(
-            {
-                success: false,
-                error: error instanceof Error ? error.message : 'Unknown error',
-                timestamp: new Date().toISOString(),
-            },
-            { status: 500 },
-        );
-    }
+        },
+        { status: healthy ? 200 : 503 },
+    );
 }

--- a/apps/api/lib/checkout/stripeCheckoutAttemptValidation.node.spec.ts
+++ b/apps/api/lib/checkout/stripeCheckoutAttemptValidation.node.spec.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    fingerprintStripeCheckoutValue,
+    type StripeCheckoutAttempt,
+    StripeCheckoutAttemptConflictError,
+} from '@gredice/storage';
+import { encodeHarvestDatesMetadata } from './harvestCheckout';
+import {
+    type StripeCheckoutAttemptValidationDependencies,
+    type StripeCheckoutSessionForReconciliation,
+    validateStripeCheckoutSessionAgainstAttempt,
+} from './stripeCheckoutAttemptValidation';
+import { encodeStripeCheckoutAttemptMetadata } from './stripeCheckoutSnapshot';
+
+const attempt = {
+    snapshot: {
+        attemptId: '93b43108-696d-48ca-92ef-9990c0a84d43',
+        cartId: 12,
+        expectedNonStripeCartItemIds: [],
+        harvestDates: [],
+        items: [],
+        stripeSession: {
+            allowPromotionCodes: true,
+            customerFingerprint: fingerprintStripeCheckoutValue('cus_1'),
+            expiresAt: '2026-08-04T00:00:00.000Z',
+            items: [],
+            returnUrls: {
+                cancel: 'https://example.test/cancel',
+                success: 'https://example.test/success',
+            },
+        },
+        userFingerprint: fingerprintStripeCheckoutValue('user-1'),
+        version: 1,
+    },
+} satisfies StripeCheckoutAttempt;
+
+function metadata() {
+    return Object.fromEntries(
+        Object.entries({
+            ...encodeStripeCheckoutAttemptMetadata(attempt.snapshot),
+            ...encodeHarvestDatesMetadata([], []),
+        }).map(([key, value]) => [key, String(value)]),
+    );
+}
+
+function dependencies({
+    customerId = 'cus_1',
+    userIds = ['user-1'],
+}: {
+    customerId?: string;
+    userIds?: string[];
+} = {}): StripeCheckoutAttemptValidationDependencies {
+    return {
+        getAccount: async () => ({ stripeCustomerId: customerId }),
+        getAccountUsers: async () => userIds.map((userId) => ({ userId })),
+        verifyLiveCart: async () => ({ accountId: 'account-1' }),
+    };
+}
+
+function session(
+    sessionMetadata = metadata(),
+): StripeCheckoutSessionForReconciliation {
+    return {
+        amountTotal: 0,
+        customerId: 'cus_1',
+        id: 'cs_1',
+        lineItems: { data: [] },
+        metadata: sessionMetadata,
+        paymentStatus: 'unpaid',
+        status: 'open',
+        url: 'https://stripe.test/session',
+    };
+}
+
+test('validates canonical cart, customer, user, metadata, and line items', async () => {
+    const identity = await validateStripeCheckoutSessionAgainstAttempt({
+        attempt,
+        dependencies: dependencies(),
+        session: session(),
+    });
+
+    assert.deepEqual(identity, {
+        accountId: 'account-1',
+        customerId: 'cus_1',
+        userId: 'user-1',
+    });
+});
+
+test('fails closed before binding when identity or metadata changed', async () => {
+    await assert.rejects(
+        validateStripeCheckoutSessionAgainstAttempt({
+            attempt,
+            dependencies: dependencies({ customerId: 'cus_changed' }),
+            session: session(),
+        }),
+        (error) =>
+            error instanceof StripeCheckoutAttemptConflictError &&
+            error.category === 'checkout_identity_changed',
+    );
+
+    await assert.rejects(
+        validateStripeCheckoutSessionAgainstAttempt({
+            attempt,
+            dependencies: dependencies({ userIds: [] }),
+            session: session(),
+        }),
+        (error) =>
+            error instanceof StripeCheckoutAttemptConflictError &&
+            error.category === 'checkout_user_inactive',
+    );
+
+    await assert.rejects(
+        validateStripeCheckoutSessionAgainstAttempt({
+            attempt,
+            dependencies: dependencies(),
+            session: session({ ...metadata(), checkoutCartId: '13' }),
+        }),
+        (error) =>
+            error instanceof StripeCheckoutAttemptConflictError &&
+            error.category === 'snapshot_identity_changed',
+    );
+});

--- a/apps/api/lib/checkout/stripeCheckoutAttemptValidation.ts
+++ b/apps/api/lib/checkout/stripeCheckoutAttemptValidation.ts
@@ -1,0 +1,161 @@
+import {
+    fingerprintStripeCheckoutValue,
+    getAccount,
+    getAccountUsers,
+    type StripeCheckoutAttempt,
+    StripeCheckoutAttemptConflictError,
+    verifyStripeCheckoutAttemptLiveCart,
+} from '@gredice/storage';
+import {
+    decodeExpectedNonStripeCartItemIdsMetadata,
+    decodeHarvestDatesMetadata,
+} from './harvestCheckout';
+import {
+    assertStripeSessionMatchesCheckoutAttempt,
+    decodeStripeCheckoutAttemptMetadata,
+    type StripeCheckoutSessionForSnapshot,
+} from './stripeCheckoutSnapshot';
+
+export type StripeCheckoutSessionForReconciliation =
+    StripeCheckoutSessionForSnapshot & {
+        metadata: Record<string, string> | null;
+        paymentStatus: 'no_payment_required' | 'paid' | 'unpaid';
+        status: 'complete' | 'expired' | 'open' | null;
+        url: string | null;
+    };
+
+export type StripeCheckoutAttemptIdentity = {
+    accountId: string;
+    customerId: string;
+    userId: string;
+};
+
+export type StripeCheckoutAttemptValidationDependencies = {
+    getAccount: (
+        accountId: string,
+    ) => Promise<{ stripeCustomerId: string | null } | undefined>;
+    getAccountUsers: (
+        accountId: string,
+    ) => Promise<readonly { userId: string }[]>;
+    verifyLiveCart: (
+        attempt: StripeCheckoutAttempt,
+    ) => Promise<{ accountId: string }>;
+};
+
+const realDependencies: StripeCheckoutAttemptValidationDependencies = {
+    getAccount,
+    getAccountUsers,
+    verifyLiveCart: verifyStripeCheckoutAttemptLiveCart,
+};
+
+export async function resolveStripeCheckoutAttemptIdentity(
+    attempt: StripeCheckoutAttempt,
+    dependencies: StripeCheckoutAttemptValidationDependencies = realDependencies,
+): Promise<StripeCheckoutAttemptIdentity> {
+    const liveCart = await dependencies.verifyLiveCart(attempt);
+    const account = await dependencies.getAccount(liveCart.accountId);
+    const customerId = account?.stripeCustomerId;
+    if (
+        !customerId ||
+        fingerprintStripeCheckoutValue(customerId) !==
+            attempt.snapshot.stripeSession.customerFingerprint
+    ) {
+        throw new StripeCheckoutAttemptConflictError(
+            'checkout_identity_changed',
+        );
+    }
+
+    const matchingUsers = (
+        await dependencies.getAccountUsers(liveCart.accountId)
+    )
+        .map((accountUser) => accountUser.userId)
+        .filter(
+            (userId) =>
+                fingerprintStripeCheckoutValue(userId) ===
+                attempt.snapshot.userFingerprint,
+        );
+    const userId = matchingUsers[0];
+    if (matchingUsers.length !== 1 || !userId) {
+        throw new StripeCheckoutAttemptConflictError('checkout_user_inactive');
+    }
+
+    return { accountId: liveCart.accountId, customerId, userId };
+}
+
+function assertSessionMetadataMatchesAttempt(
+    session: StripeCheckoutSessionForReconciliation,
+    attempt: StripeCheckoutAttempt,
+) {
+    const metadata = decodeStripeCheckoutAttemptMetadata(session.metadata);
+    if (
+        !metadata ||
+        metadata.attemptId !== attempt.snapshot.attemptId ||
+        metadata.cartId !== attempt.snapshot.cartId
+    ) {
+        throw new StripeCheckoutAttemptConflictError(
+            'snapshot_identity_changed',
+        );
+    }
+
+    let nonStripeItemIds: Set<number> | null;
+    try {
+        nonStripeItemIds = decodeExpectedNonStripeCartItemIdsMetadata(
+            session.metadata,
+        );
+    } catch {
+        throw new StripeCheckoutAttemptConflictError(
+            'non_stripe_metadata_changed',
+        );
+    }
+    if (
+        nonStripeItemIds === null ||
+        nonStripeItemIds.size !==
+            attempt.snapshot.expectedNonStripeCartItemIds.length ||
+        attempt.snapshot.expectedNonStripeCartItemIds.some(
+            (itemId) => !nonStripeItemIds?.has(itemId),
+        )
+    ) {
+        throw new StripeCheckoutAttemptConflictError(
+            'non_stripe_metadata_changed',
+        );
+    }
+
+    let harvestDates: Map<number, string>;
+    try {
+        harvestDates = decodeHarvestDatesMetadata(session.metadata);
+    } catch {
+        throw new StripeCheckoutAttemptConflictError(
+            'harvest_metadata_changed',
+        );
+    }
+    if (
+        harvestDates.size !== attempt.snapshot.harvestDates.length ||
+        attempt.snapshot.harvestDates.some(
+            (selection) =>
+                harvestDates.get(selection.cartItemId) !==
+                selection.scheduledDate,
+        )
+    ) {
+        throw new StripeCheckoutAttemptConflictError(
+            'harvest_metadata_changed',
+        );
+    }
+}
+
+export async function validateStripeCheckoutSessionAgainstAttempt({
+    attempt,
+    dependencies = realDependencies,
+    session,
+}: {
+    attempt: StripeCheckoutAttempt;
+    dependencies?: StripeCheckoutAttemptValidationDependencies;
+    session: StripeCheckoutSessionForReconciliation;
+}): Promise<StripeCheckoutAttemptIdentity> {
+    assertSessionMetadataMatchesAttempt(session, attempt);
+    const identity = await resolveStripeCheckoutAttemptIdentity(
+        attempt,
+        dependencies,
+    );
+    assertStripeSessionMatchesCheckoutAttempt(session, attempt, identity);
+    return identity;
+}

--- a/apps/api/lib/checkout/stripeCheckoutCreateRace.node.spec.ts
+++ b/apps/api/lib/checkout/stripeCheckoutCreateRace.node.spec.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { StripeCheckoutAttemptConflictError } from '@gredice/storage';
+import { recoverStripeCheckoutAttemptAfterCreateRace } from './stripeCheckoutCreateRace';
+
+test('maps a conflicting concurrent attempt recovery to cart changed', async () => {
+    const result = await recoverStripeCheckoutAttemptAfterCreateRace({
+        getActiveAttempt: async () => ({ attemptId: 'attempt-1' }),
+        recoverAttempt: async () => {
+            throw new StripeCheckoutAttemptConflictError(
+                'checkout_identity_changed',
+            );
+        },
+    });
+
+    assert.deepEqual(result, { status: 'cart_changed' });
+});
+
+test('returns a recovered concurrent attempt', async () => {
+    const result = await recoverStripeCheckoutAttemptAfterCreateRace({
+        getActiveAttempt: async () => ({ attemptId: 'attempt-1' }),
+        recoverAttempt: async (attempt) => ({
+            sessionId: `${attempt.attemptId}-session`,
+        }),
+    });
+
+    assert.deepEqual(result, {
+        recovery: { sessionId: 'attempt-1-session' },
+        status: 'recovered',
+    });
+});
+
+test('keeps unexpected concurrent recovery failures visible', async () => {
+    await assert.rejects(
+        recoverStripeCheckoutAttemptAfterCreateRace({
+            getActiveAttempt: async () => ({ attemptId: 'attempt-1' }),
+            recoverAttempt: async () => {
+                throw new Error('storage unavailable');
+            },
+        }),
+        /storage unavailable/,
+    );
+});

--- a/apps/api/lib/checkout/stripeCheckoutCreateRace.ts
+++ b/apps/api/lib/checkout/stripeCheckoutCreateRace.ts
@@ -1,0 +1,34 @@
+import { StripeCheckoutAttemptConflictError } from '@gredice/storage';
+
+export type StripeCheckoutCreateRaceRecovery<TRecovery> =
+    | { status: 'cart_changed' }
+    | { status: 'no_active_attempt' }
+    | { recovery: TRecovery; status: 'recovered' };
+
+export async function recoverStripeCheckoutAttemptAfterCreateRace<
+    TAttempt,
+    TRecovery,
+>({
+    getActiveAttempt,
+    recoverAttempt,
+}: {
+    getActiveAttempt: () => Promise<TAttempt | undefined>;
+    recoverAttempt: (attempt: TAttempt) => Promise<TRecovery>;
+}): Promise<StripeCheckoutCreateRaceRecovery<TRecovery>> {
+    const activeAttempt = await getActiveAttempt();
+    if (!activeAttempt) {
+        return { status: 'no_active_attempt' };
+    }
+
+    try {
+        return {
+            recovery: await recoverAttempt(activeAttempt),
+            status: 'recovered',
+        };
+    } catch (error) {
+        if (error instanceof StripeCheckoutAttemptConflictError) {
+            return { status: 'cart_changed' };
+        }
+        throw error;
+    }
+}

--- a/apps/api/lib/checkout/stripeCheckoutOrphanReconciliation.node.spec.ts
+++ b/apps/api/lib/checkout/stripeCheckoutOrphanReconciliation.node.spec.ts
@@ -99,6 +99,7 @@ function dependencies({
     listedItems = [{ id: 'cs_1', metadata: stringMetadata(attempt) }],
     now = beforeDeadline,
     onCall,
+    onFailure,
 }: {
     attempt?: StripeCheckoutAttempt;
     fullSession?: Session;
@@ -108,6 +109,11 @@ function dependencies({
     }>;
     now?: Date;
     onCall?: (name: string) => void;
+    onFailure?: (
+        diagnostic: Parameters<
+            StripeCheckoutOrphanReconciliationDependencies['reportFailure']
+        >[0],
+    ) => void;
 } = {}): StripeCheckoutOrphanReconciliationDependencies {
     let processed = false;
     return {
@@ -147,6 +153,7 @@ function dependencies({
             onCall?.('process');
             processed = true;
         },
+        reportFailure: (diagnostic) => onFailure?.(diagnostic),
         recordMiss: async ({ observedAt }) => {
             onCall?.('miss');
             return {
@@ -221,6 +228,11 @@ test('binds and processes a paid completed session', async () => {
 
 test('retries a bound completed attempt after transient processing failure', async () => {
     const firstCalls: string[] = [];
+    const failures: Array<
+        Parameters<
+            StripeCheckoutOrphanReconciliationDependencies['reportFailure']
+        >[0]
+    > = [];
     const completed = checkoutSession({
         paymentStatus: 'paid',
         status: 'complete',
@@ -228,6 +240,7 @@ test('retries a bound completed attempt after transient processing failure', asy
     const firstDependencies = dependencies({
         fullSession: completed,
         onCall: (name) => firstCalls.push(name),
+        onFailure: (diagnostic) => failures.push(diagnostic),
     });
     firstDependencies.processSession = async () => {
         firstCalls.push('process');
@@ -238,6 +251,15 @@ test('retries a bound completed attempt after transient processing failure', asy
     });
     assert.equal(first.failedCount, 1);
     assert.equal(first.failureCategories.unexpected, 1);
+    assert.deepEqual(failures, [
+        {
+            attemptId,
+            cartId,
+            category: 'unexpected',
+            causeName: 'Error',
+            stage: 'discovered_session_reconcile',
+        },
+    ]);
     assert.deepEqual(firstCalls, [
         'list',
         'retrieve',

--- a/apps/api/lib/checkout/stripeCheckoutOrphanReconciliation.node.spec.ts
+++ b/apps/api/lib/checkout/stripeCheckoutOrphanReconciliation.node.spec.ts
@@ -478,3 +478,94 @@ test('rotates the durable cursor so candidate 51 is reached on the next run', as
     assert.equal(cursor, undefined);
     assert.equal(processedLast, true);
 });
+
+test('advances per candidate so a long fulfillment cannot starve its page peer', async () => {
+    const candidates = [
+        {
+            ...candidate({
+                attempt: { ...checkoutAttempt(), sessionId: 'cs_1' },
+            }),
+            createdEventId: 1,
+        },
+        {
+            ...candidate({
+                attempt: { ...checkoutAttempt(), sessionId: 'cs_2' },
+            }),
+            createdEventId: 2,
+        },
+    ];
+    let cursor: number | undefined;
+    let signalFirstStarted: (() => void) | undefined;
+    let releaseFirst: (() => void) | undefined;
+    const firstStarted = new Promise<void>((resolve) => {
+        signalFirstStarted = resolve;
+    });
+    const firstCanFinish = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+    });
+    const sharedDependencies = dependencies();
+    sharedDependencies.getCursor = async () => cursor;
+    sharedDependencies.setCursor = async (afterCreatedEventId) => {
+        cursor = afterCreatedEventId ?? undefined;
+        return cursor;
+    };
+    sharedDependencies.listAttempts = async ({
+        afterCreatedEventId,
+        limit = 25,
+    } = {}) => {
+        const remaining = candidates.filter(
+            (entry) =>
+                afterCreatedEventId === undefined ||
+                entry.createdEventId > afterCreatedEventId,
+        );
+        const items = remaining.slice(0, limit);
+        const hasMore = remaining.length > items.length;
+        const lastItem = items.at(-1);
+        return {
+            hasMore,
+            items,
+            ...(hasMore && lastItem
+                ? { nextCreatedEventId: lastItem.createdEventId }
+                : {}),
+        };
+    };
+    sharedDependencies.getSession = async (sessionId) =>
+        sessionId === 'cs_1'
+            ? checkoutSession({
+                  id: sessionId,
+                  paymentStatus: 'paid',
+                  status: 'complete',
+              })
+            : checkoutSession({ id: sessionId, status: 'open' });
+    sharedDependencies.processSession = async (sessionId) => {
+        assert.equal(sessionId, 'cs_1');
+        signalFirstStarted?.();
+        await firstCanFinish;
+    };
+    sharedDependencies.getAttempt = async () => ({
+        ...checkoutAttempt(),
+        releaseReason: 'completed',
+        sessionId: 'cs_1',
+    });
+
+    const firstRun = reconcileStripeCheckoutOrphanAttempts({
+        dependencies: sharedDependencies,
+        maxAttempts: 2,
+        pageSize: 2,
+    });
+    await firstStarted;
+    assert.equal(cursor, 1);
+
+    const secondRun = await reconcileStripeCheckoutOrphanAttempts({
+        dependencies: sharedDependencies,
+        maxAttempts: 2,
+        pageSize: 2,
+    });
+    assert.equal(secondRun.scannedCount, 1);
+    assert.equal(secondRun.retainedCount, 1);
+    assert.equal(cursor, undefined);
+
+    releaseFirst?.();
+    const completedFirstRun = await firstRun;
+    assert.equal(completedFirstRun.scannedCount, 2);
+});

--- a/apps/api/lib/checkout/stripeCheckoutOrphanReconciliation.node.spec.ts
+++ b/apps/api/lib/checkout/stripeCheckoutOrphanReconciliation.node.spec.ts
@@ -1,0 +1,480 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    fingerprintStripeCheckoutValue,
+    type StripeCheckoutAttempt,
+} from '@gredice/storage';
+import {
+    reconcileStripeCheckoutOrphanAttempts,
+    STRIPE_CHECKOUT_ORPHAN_MISS_GRACE_MS,
+    type StripeCheckoutOrphanReconciliationDependencies,
+} from './stripeCheckoutOrphanReconciliation';
+import { encodeStripeCheckoutAttemptMetadata } from './stripeCheckoutSnapshot';
+
+const attemptId = '93b43108-696d-48ca-92ef-9990c0a84d43';
+const cartId = 12;
+const beforeDeadline = new Date('2026-08-03T23:00:00.000Z');
+const afterDeadline = new Date('2026-08-04T00:05:00.000Z');
+
+function checkoutAttempt(
+    expiresAt: string | null = '2026-08-04T00:00:00.000Z',
+) {
+    return {
+        snapshot: {
+            attemptId,
+            cartId,
+            expectedNonStripeCartItemIds: [],
+            harvestDates: [],
+            items: [],
+            stripeSession: {
+                allowPromotionCodes: true,
+                customerFingerprint: fingerprintStripeCheckoutValue('cus_1'),
+                expiresAt,
+                items: [],
+                returnUrls: {
+                    cancel: 'https://example.test/cancel',
+                    success: 'https://example.test/success',
+                },
+            },
+            userFingerprint: fingerprintStripeCheckoutValue('user-1'),
+            version: 1,
+        },
+    } satisfies StripeCheckoutAttempt;
+}
+
+type Session = Awaited<
+    ReturnType<StripeCheckoutOrphanReconciliationDependencies['getSession']>
+>;
+
+function checkoutSession({
+    amountTotal = 500,
+    id = 'cs_1',
+    paymentStatus = 'unpaid',
+    status = 'open',
+}: {
+    amountTotal?: number;
+    id?: string;
+    paymentStatus?: 'no_payment_required' | 'paid' | 'unpaid';
+    status?: 'complete' | 'expired' | 'open' | null;
+} = {}): Session {
+    return {
+        amountTotal,
+        customerId: 'cus_1',
+        id,
+        lineItems: {
+            data: [],
+        },
+        metadata: stringMetadata(checkoutAttempt()),
+        paymentStatus,
+        status,
+        url: status === 'open' ? 'https://stripe.test/session' : null,
+    };
+}
+
+function candidate({
+    attempt = checkoutAttempt(),
+    lastReconciliationMissAt,
+}: {
+    attempt?: StripeCheckoutAttempt;
+    lastReconciliationMissAt?: Date;
+} = {}) {
+    return {
+        attempt,
+        createdAt: new Date('2026-08-03T22:00:00.000Z'),
+        createdEventId: 101,
+        ...(lastReconciliationMissAt ? { lastReconciliationMissAt } : {}),
+    };
+}
+
+function stringMetadata(attempt: StripeCheckoutAttempt) {
+    const metadata = encodeStripeCheckoutAttemptMetadata(attempt.snapshot);
+    return Object.fromEntries(
+        Object.entries(metadata).map(([key, value]) => [key, String(value)]),
+    );
+}
+
+function dependencies({
+    attempt = checkoutAttempt(),
+    fullSession = checkoutSession(),
+    listedItems = [{ id: 'cs_1', metadata: stringMetadata(attempt) }],
+    now = beforeDeadline,
+    onCall,
+}: {
+    attempt?: StripeCheckoutAttempt;
+    fullSession?: Session;
+    listedItems?: Array<{
+        id: string;
+        metadata: Record<string, string> | null;
+    }>;
+    now?: Date;
+    onCall?: (name: string) => void;
+} = {}): StripeCheckoutOrphanReconciliationDependencies {
+    let processed = false;
+    return {
+        bindAttempt: async ({ sessionId }) => {
+            onCall?.('bind');
+            return { ...attempt, sessionId };
+        },
+        getAttempt: async () => {
+            onCall?.('get_attempt');
+            return processed
+                ? {
+                      ...attempt,
+                      releaseReason: 'completed',
+                      sessionId: fullSession.id,
+                  }
+                : attempt;
+        },
+        getCursor: async () => undefined,
+        getSession: async () => {
+            onCall?.('retrieve');
+            return fullSession;
+        },
+        listAttempts: async () => ({
+            hasMore: false,
+            items: [candidate({ attempt })],
+        }),
+        listSessions: async () => {
+            onCall?.('list');
+            return {
+                items: listedItems,
+                pageCount: 1,
+                status: 'exhaustive',
+            };
+        },
+        now: () => new Date(now),
+        processSession: async () => {
+            onCall?.('process');
+            processed = true;
+        },
+        recordMiss: async ({ observedAt }) => {
+            onCall?.('miss');
+            return {
+                createdAt: observedAt,
+                observedAt,
+                status: 'recorded',
+            };
+        },
+        releaseAfterMisses: async () => {
+            onCall?.('absence_release');
+            return { attempt, status: 'released' };
+        },
+        releaseAttempt: async ({ sessionId }) => {
+            onCall?.('release');
+            return {
+                ...attempt,
+                releaseReason: 'expired',
+                sessionId: sessionId ?? undefined,
+            };
+        },
+        resolveIdentity: async () => ({
+            accountId: 'account-1',
+            customerId: 'cus_1',
+            userId: 'user-1',
+        }),
+        setCursor: async (afterCreatedEventId) =>
+            afterCreatedEventId ?? undefined,
+        validateSession: async () => {
+            onCall?.('validate');
+            return {
+                accountId: 'account-1',
+                customerId: 'cus_1',
+                userId: 'user-1',
+            };
+        },
+    };
+}
+
+test('validates before binding an open discovered session', async () => {
+    const calls: string[] = [];
+    const summary = await reconcileStripeCheckoutOrphanAttempts({
+        dependencies: dependencies({ onCall: (name) => calls.push(name) }),
+    });
+
+    assert.equal(summary.boundCount, 1);
+    assert.equal(summary.failedCount, 0);
+    assert.deepEqual(calls, ['list', 'retrieve', 'validate', 'bind']);
+});
+
+test('binds and processes a paid completed session', async () => {
+    const calls: string[] = [];
+    const summary = await reconcileStripeCheckoutOrphanAttempts({
+        dependencies: dependencies({
+            fullSession: checkoutSession({
+                paymentStatus: 'paid',
+                status: 'complete',
+            }),
+            onCall: (name) => calls.push(name),
+        }),
+    });
+
+    assert.equal(summary.processedCount, 1);
+    assert.deepEqual(calls, [
+        'list',
+        'retrieve',
+        'validate',
+        'bind',
+        'process',
+        'get_attempt',
+    ]);
+});
+
+test('retries a bound completed attempt after transient processing failure', async () => {
+    const firstCalls: string[] = [];
+    const completed = checkoutSession({
+        paymentStatus: 'paid',
+        status: 'complete',
+    });
+    const firstDependencies = dependencies({
+        fullSession: completed,
+        onCall: (name) => firstCalls.push(name),
+    });
+    firstDependencies.processSession = async () => {
+        firstCalls.push('process');
+        throw new Error('transient fulfillment failure');
+    };
+    const first = await reconcileStripeCheckoutOrphanAttempts({
+        dependencies: firstDependencies,
+    });
+    assert.equal(first.failedCount, 1);
+    assert.equal(first.failureCategories.unexpected, 1);
+    assert.deepEqual(firstCalls, [
+        'list',
+        'retrieve',
+        'validate',
+        'bind',
+        'process',
+    ]);
+
+    const secondCalls: string[] = [];
+    const boundAttempt = { ...checkoutAttempt(), sessionId: 'cs_1' };
+    const secondDependencies = dependencies({
+        attempt: boundAttempt,
+        fullSession: completed,
+        onCall: (name) => secondCalls.push(name),
+    });
+    secondDependencies.listSessions = async () => {
+        throw new Error('bound attempts must not scan Stripe session lists');
+    };
+    const second = await reconcileStripeCheckoutOrphanAttempts({
+        dependencies: secondDependencies,
+    });
+    assert.equal(second.processedCount, 1);
+    assert.deepEqual(secondCalls, [
+        'retrieve',
+        'validate',
+        'process',
+        'get_attempt',
+    ]);
+});
+
+test('releases an authoritative expired session after validation', async () => {
+    const calls: string[] = [];
+    const summary = await reconcileStripeCheckoutOrphanAttempts({
+        dependencies: dependencies({
+            fullSession: checkoutSession({ status: 'expired' }),
+            onCall: (name) => calls.push(name),
+        }),
+    });
+
+    assert.equal(summary.releasedCount, 1);
+    assert.deepEqual(calls, ['list', 'retrieve', 'validate', 'release']);
+});
+
+test('binds but fails healthy status for an overdue open session', async () => {
+    const calls: string[] = [];
+    const overdueOpen = checkoutSession({ status: 'open' });
+    const overdueDependencies = dependencies({
+        fullSession: overdueOpen,
+        now: afterDeadline,
+        onCall: (name) => calls.push(name),
+    });
+
+    const summary = await reconcileStripeCheckoutOrphanAttempts({
+        dependencies: overdueDependencies,
+    });
+
+    assert.equal(summary.failedCount, 1);
+    assert.equal(summary.failureCategories.session_overdue_open, 1);
+    assert.deepEqual(calls, ['list', 'retrieve', 'validate', 'bind']);
+});
+
+test('records first absence and releases only after a later exhaustive scan', async () => {
+    const firstCalls: string[] = [];
+    const noSessions: Array<{
+        id: string;
+        metadata: Record<string, string> | null;
+    }> = [];
+    const first = await reconcileStripeCheckoutOrphanAttempts({
+        dependencies: dependencies({
+            listedItems: noSessions,
+            now: afterDeadline,
+            onCall: (name) => firstCalls.push(name),
+        }),
+    });
+    assert.equal(first.missRecordedCount, 1);
+    assert.deepEqual(firstCalls, ['list', 'miss']);
+
+    const secondCalls: string[] = [];
+    const secondDependencies = dependencies({
+        listedItems: noSessions,
+        now: new Date(
+            afterDeadline.getTime() + STRIPE_CHECKOUT_ORPHAN_MISS_GRACE_MS + 1,
+        ),
+        onCall: (name) => secondCalls.push(name),
+    });
+    secondDependencies.listAttempts = async () => ({
+        hasMore: false,
+        items: [candidate({ lastReconciliationMissAt: afterDeadline })],
+    });
+    const second = await reconcileStripeCheckoutOrphanAttempts({
+        dependencies: secondDependencies,
+    });
+    assert.equal(second.releasedCount, 1);
+    assert.deepEqual(secondCalls, ['list', 'miss', 'absence_release']);
+});
+
+test('never records absence for a null deadline or partial Stripe scan', async () => {
+    const nullDeadlineCalls: string[] = [];
+    const nullDeadline = checkoutAttempt(null);
+    const nullDeadlineSummary = await reconcileStripeCheckoutOrphanAttempts({
+        dependencies: dependencies({
+            attempt: nullDeadline,
+            listedItems: [],
+            now: afterDeadline,
+            onCall: (name) => nullDeadlineCalls.push(name),
+        }),
+    });
+    assert.equal(nullDeadlineSummary.failedCount, 1);
+    assert.equal(
+        nullDeadlineSummary.failureCategories.session_deadline_missing,
+        1,
+    );
+    assert.deepEqual(nullDeadlineCalls, ['list']);
+
+    const partialCalls: string[] = [];
+    const partialDependencies = dependencies({
+        listedItems: [],
+        now: afterDeadline,
+        onCall: (name) => partialCalls.push(name),
+    });
+    partialDependencies.listSessions = async () => ({
+        pageCount: 1,
+        reason: 'request_failed',
+        status: 'partial',
+    });
+    const partial = await reconcileStripeCheckoutOrphanAttempts({
+        dependencies: partialDependencies,
+    });
+    assert.equal(partial.failedCount, 1);
+    assert.equal(partial.failureCategories.stripe_scan_request_failed, 1);
+    assert.deepEqual(partialCalls, []);
+});
+
+test('fails closed for duplicate sessions and unpaid completion', async () => {
+    const duplicate = await reconcileStripeCheckoutOrphanAttempts({
+        dependencies: dependencies({
+            listedItems: [
+                { id: 'cs_1', metadata: stringMetadata(checkoutAttempt()) },
+                { id: 'cs_2', metadata: stringMetadata(checkoutAttempt()) },
+            ],
+        }),
+    });
+    assert.equal(duplicate.failedCount, 1);
+    assert.equal(duplicate.failureCategories.multiple_stripe_sessions, 1);
+
+    const unpaid = await reconcileStripeCheckoutOrphanAttempts({
+        dependencies: dependencies({
+            fullSession: checkoutSession({
+                paymentStatus: 'unpaid',
+                status: 'complete',
+            }),
+        }),
+    });
+    assert.equal(unpaid.failedCount, 1);
+    assert.equal(unpaid.failureCategories.session_unpaid, 1);
+});
+
+test('rotates the durable cursor so candidate 51 is reached on the next run', async () => {
+    const candidates = Array.from({ length: 51 }, (_, index) => ({
+        ...candidate({
+            attempt: {
+                ...checkoutAttempt(),
+                sessionId: `cs_${(index + 1).toString()}`,
+            },
+        }),
+        createdEventId: index + 1,
+    }));
+    let cursor: number | undefined;
+    let processedLast = false;
+    const rotatingDependencies = dependencies();
+    rotatingDependencies.getCursor = async () => cursor;
+    rotatingDependencies.setCursor = async (afterCreatedEventId) => {
+        cursor = afterCreatedEventId ?? undefined;
+        return cursor;
+    };
+    rotatingDependencies.listAttempts = async ({
+        afterCreatedEventId,
+        limit = 25,
+    } = {}) => {
+        const remaining = candidates.filter(
+            (entry) =>
+                afterCreatedEventId === undefined ||
+                entry.createdEventId > afterCreatedEventId,
+        );
+        const items = remaining.slice(0, limit);
+        const hasMore = remaining.length > items.length;
+        const lastItem = items.at(-1);
+        return {
+            hasMore,
+            items,
+            ...(hasMore && lastItem
+                ? { nextCreatedEventId: lastItem.createdEventId }
+                : {}),
+        };
+    };
+    rotatingDependencies.listSessions = async () => {
+        throw new Error('bound candidates do not need a customer scan');
+    };
+    rotatingDependencies.getSession = async (sessionId) =>
+        sessionId === 'cs_51'
+            ? checkoutSession({
+                  id: sessionId,
+                  paymentStatus: 'paid',
+                  status: 'complete',
+              })
+            : checkoutSession({ id: sessionId, status: 'open' });
+    rotatingDependencies.processSession = async (sessionId) => {
+        assert.equal(sessionId, 'cs_51');
+        processedLast = true;
+    };
+    rotatingDependencies.getAttempt = async () =>
+        processedLast
+            ? {
+                  ...checkoutAttempt(),
+                  releaseReason: 'completed',
+                  sessionId: 'cs_51',
+              }
+            : { ...checkoutAttempt(), sessionId: 'cs_51' };
+
+    const first = await reconcileStripeCheckoutOrphanAttempts({
+        dependencies: rotatingDependencies,
+        maxAttempts: 50,
+        pageSize: 25,
+    });
+    assert.equal(first.scannedCount, 50);
+    assert.equal(first.truncated, true);
+    assert.equal(cursor, 50);
+    assert.equal(processedLast, false);
+
+    const second = await reconcileStripeCheckoutOrphanAttempts({
+        dependencies: rotatingDependencies,
+        maxAttempts: 50,
+        pageSize: 25,
+    });
+    assert.equal(second.scannedCount, 1);
+    assert.equal(second.processedCount, 1);
+    assert.equal(second.truncated, false);
+    assert.equal(cursor, undefined);
+    assert.equal(processedLast, true);
+});

--- a/apps/api/lib/checkout/stripeCheckoutOrphanReconciliation.ts
+++ b/apps/api/lib/checkout/stripeCheckoutOrphanReconciliation.ts
@@ -406,11 +406,6 @@ export async function reconcileStripeCheckoutOrphanAttempts({
             return summary;
         }
 
-        // Lease this page before external work. A hard function timeout can
-        // skip it for one cycle, but cannot pin every later attempt forever.
-        await dependencies.setCursor(
-            page.hasMore ? (page.nextCreatedEventId ?? null) : null,
-        );
         for (const candidate of page.items) {
             if (
                 summary.scannedCount >= maxAttempts ||
@@ -419,6 +414,9 @@ export async function reconcileStripeCheckoutOrphanAttempts({
                 summary.truncated = true;
                 return summary;
             }
+            // Advance immediately before external work so a hard timeout on
+            // this candidate cannot pin later peers in the same page.
+            await dependencies.setCursor(candidate.createdEventId);
             summary.scannedCount += 1;
             const outcome = await reconcileCandidate(candidate, dependencies);
             recordOutcome(summary, outcome);
@@ -431,8 +429,10 @@ export async function reconcileStripeCheckoutOrphanAttempts({
             }
         }
         if (!page.hasMore) {
+            await dependencies.setCursor(null);
             return summary;
         }
+        await dependencies.setCursor(page.nextCreatedEventId ?? null);
         afterCreatedEventId = page.nextCreatedEventId;
         if (
             summary.scannedCount >= maxAttempts ||

--- a/apps/api/lib/checkout/stripeCheckoutOrphanReconciliation.ts
+++ b/apps/api/lib/checkout/stripeCheckoutOrphanReconciliation.ts
@@ -68,6 +68,7 @@ export type StripeCheckoutOrphanReconciliationDependencies = {
     }) => Promise<StripeSessionListResult>;
     now: () => Date;
     processSession: typeof processCheckoutSessionForReconciliation;
+    reportFailure: (diagnostic: AttemptFailureDiagnostic) => void;
     recordMiss: typeof recordStripeCheckoutAttemptReconciliationMiss;
     releaseAfterMisses: typeof releaseStripeCheckoutAttemptAfterReconciliationMisses;
     releaseAttempt: typeof releaseStripeCheckoutAttempt;
@@ -85,6 +86,12 @@ const realDependencies: StripeCheckoutOrphanReconciliationDependencies = {
     listSessions: listStripeCheckoutSessionsForCustomerExhaustively,
     now: () => new Date(),
     processSession: processCheckoutSessionForReconciliation,
+    reportFailure: (diagnostic) => {
+        console.error(
+            'Stripe checkout orphan reconciliation failed',
+            diagnostic,
+        );
+    },
     recordMiss: recordStripeCheckoutAttemptReconciliationMiss,
     releaseAfterMisses: releaseStripeCheckoutAttemptAfterReconciliationMisses,
     releaseAttempt: releaseStripeCheckoutAttempt,
@@ -102,7 +109,31 @@ type AttemptOutcome =
               | 'released'
               | 'retained';
       }
-    | { category: string; status: 'failed' };
+    | {
+          category: string;
+          causeName?: string;
+          stage?: AttemptFailureStage;
+          status: 'failed';
+      };
+
+type AttemptFailureStage =
+    | 'absence_reconcile'
+    | 'bound_session_fetch'
+    | 'bound_session_reconcile'
+    | 'candidate_start'
+    | 'discovered_session_fetch'
+    | 'discovered_session_reconcile'
+    | 'identity_resolve'
+    | 'session_correlate'
+    | 'session_scan';
+
+type AttemptFailureDiagnostic = {
+    attemptId: string;
+    cartId: number;
+    category: string;
+    causeName?: string;
+    stage?: AttemptFailureStage;
+};
 
 export type StripeCheckoutOrphanReconciliationSummary = {
     boundCount: number;
@@ -120,6 +151,11 @@ function attemptFailureCategory(error: unknown) {
     return error instanceof StripeCheckoutAttemptConflictError
         ? error.category
         : 'unexpected';
+}
+
+function safeErrorName(error: unknown) {
+    const name = error instanceof Error ? error.name : 'unknown';
+    return /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/.test(name) ? name : 'unknown';
 }
 
 function deadlineForAttempt(attempt: StripeCheckoutAttempt) {
@@ -291,19 +327,24 @@ async function reconcileCandidate(
     candidate: ActiveStripeCheckoutAttemptReconciliationCandidate,
     dependencies: StripeCheckoutOrphanReconciliationDependencies,
 ): Promise<AttemptOutcome> {
+    let stage: AttemptFailureStage = 'candidate_start';
     try {
         if (candidate.attempt.sessionId) {
+            stage = 'bound_session_fetch';
             const session = await dependencies.getSession(
                 candidate.attempt.sessionId,
             );
+            stage = 'bound_session_reconcile';
             return await reconcileAuthoritativeSession(
                 candidate.attempt,
                 session,
                 dependencies,
             );
         }
+        stage = 'identity_resolve';
         const identity = await dependencies.resolveIdentity(candidate.attempt);
         const deadline = deadlineForAttempt(candidate.attempt);
+        stage = 'session_scan';
         const listed = await dependencies.listSessions({
             createdAt: candidate.createdAt,
             customerId: identity.customerId,
@@ -315,22 +356,31 @@ async function reconcileCandidate(
                 status: 'failed',
             };
         }
+        stage = 'session_correlate';
         const matchingSessions = correlatedSessions(
             listed.items,
             candidate.attempt,
         );
         const matchingSession = matchingSessions[0];
         if (!matchingSession) {
+            stage = 'absence_reconcile';
             return await reconcileProvenAbsentSession(candidate, dependencies);
         }
+        stage = 'discovered_session_fetch';
         const session = await dependencies.getSession(matchingSession.id);
+        stage = 'discovered_session_reconcile';
         return await reconcileAuthoritativeSession(
             candidate.attempt,
             session,
             dependencies,
         );
     } catch (error) {
-        return { category: attemptFailureCategory(error), status: 'failed' };
+        return {
+            category: attemptFailureCategory(error),
+            causeName: safeErrorName(error),
+            stage,
+            status: 'failed',
+        };
     }
 }
 
@@ -421,10 +471,14 @@ export async function reconcileStripeCheckoutOrphanAttempts({
             const outcome = await reconcileCandidate(candidate, dependencies);
             recordOutcome(summary, outcome);
             if (outcome.status === 'failed') {
-                console.error('Stripe checkout orphan reconciliation failed', {
+                dependencies.reportFailure({
                     attemptId: candidate.attempt.snapshot.attemptId,
                     cartId: candidate.attempt.snapshot.cartId,
                     category: outcome.category,
+                    ...(outcome.causeName
+                        ? { causeName: outcome.causeName }
+                        : {}),
+                    ...(outcome.stage ? { stage: outcome.stage } : {}),
                 });
             }
         }

--- a/apps/api/lib/checkout/stripeCheckoutOrphanReconciliation.ts
+++ b/apps/api/lib/checkout/stripeCheckoutOrphanReconciliation.ts
@@ -1,0 +1,448 @@
+import {
+    type ActiveStripeCheckoutAttemptReconciliationCandidate,
+    bindStripeCheckoutAttempt,
+    getStripeCheckoutAttempt,
+    getStripeCheckoutAttemptReconciliationCursor,
+    listActiveStripeCheckoutAttemptsForReconciliation,
+    recordStripeCheckoutAttemptReconciliationMiss,
+    releaseStripeCheckoutAttempt,
+    releaseStripeCheckoutAttemptAfterReconciliationMisses,
+    type StripeCheckoutAttempt,
+    StripeCheckoutAttemptConflictError,
+    setStripeCheckoutAttemptReconciliationCursor,
+} from '@gredice/storage';
+import {
+    getStripeCheckoutSessionForReconciliation,
+    listStripeCheckoutSessionsForCustomerExhaustively,
+} from '@gredice/stripe/server';
+import { processCheckoutSessionForReconciliation } from '../stripe/processCheckoutSession';
+import {
+    resolveStripeCheckoutAttemptIdentity,
+    type StripeCheckoutSessionForReconciliation,
+    validateStripeCheckoutSessionAgainstAttempt,
+} from './stripeCheckoutAttemptValidation';
+import {
+    decodeStripeCheckoutAttemptMetadata,
+    stripeCheckoutAttemptMetadataKeys,
+} from './stripeCheckoutSnapshot';
+
+const RECONCILIATION_PAGE_SIZE = 25;
+const RECONCILIATION_MAX_PAGES = 20;
+const RECONCILIATION_MAX_ATTEMPTS = 50;
+const RECONCILIATION_TIME_BUDGET_MS = 15_000;
+export const STRIPE_CHECKOUT_ORPHAN_MISS_GRACE_MS = 2 * 60 * 1000;
+
+type ListedStripeCheckoutSession = {
+    id: string;
+    metadata: Record<string, string> | null;
+};
+
+type StripeSessionListResult =
+    | {
+          items: ListedStripeCheckoutSession[];
+          pageCount: number;
+          status: 'exhaustive';
+      }
+    | {
+          pageCount: number;
+          reason:
+              | 'invalid_pagination'
+              | 'page_limit'
+              | 'request_failed'
+              | 'time_limit';
+          status: 'partial';
+      };
+
+export type StripeCheckoutOrphanReconciliationDependencies = {
+    bindAttempt: typeof bindStripeCheckoutAttempt;
+    getAttempt: typeof getStripeCheckoutAttempt;
+    getSession: (
+        sessionId: string,
+    ) => Promise<StripeCheckoutSessionForReconciliation>;
+    getCursor: typeof getStripeCheckoutAttemptReconciliationCursor;
+    listAttempts: typeof listActiveStripeCheckoutAttemptsForReconciliation;
+    listSessions: (input: {
+        createdAt: Date;
+        customerId: string;
+        expiresAt: Date | null;
+    }) => Promise<StripeSessionListResult>;
+    now: () => Date;
+    processSession: typeof processCheckoutSessionForReconciliation;
+    recordMiss: typeof recordStripeCheckoutAttemptReconciliationMiss;
+    releaseAfterMisses: typeof releaseStripeCheckoutAttemptAfterReconciliationMisses;
+    releaseAttempt: typeof releaseStripeCheckoutAttempt;
+    resolveIdentity: typeof resolveStripeCheckoutAttemptIdentity;
+    setCursor: typeof setStripeCheckoutAttemptReconciliationCursor;
+    validateSession: typeof validateStripeCheckoutSessionAgainstAttempt;
+};
+
+const realDependencies: StripeCheckoutOrphanReconciliationDependencies = {
+    bindAttempt: bindStripeCheckoutAttempt,
+    getAttempt: getStripeCheckoutAttempt,
+    getCursor: getStripeCheckoutAttemptReconciliationCursor,
+    getSession: getStripeCheckoutSessionForReconciliation,
+    listAttempts: listActiveStripeCheckoutAttemptsForReconciliation,
+    listSessions: listStripeCheckoutSessionsForCustomerExhaustively,
+    now: () => new Date(),
+    processSession: processCheckoutSessionForReconciliation,
+    recordMiss: recordStripeCheckoutAttemptReconciliationMiss,
+    releaseAfterMisses: releaseStripeCheckoutAttemptAfterReconciliationMisses,
+    releaseAttempt: releaseStripeCheckoutAttempt,
+    resolveIdentity: resolveStripeCheckoutAttemptIdentity,
+    setCursor: setStripeCheckoutAttemptReconciliationCursor,
+    validateSession: validateStripeCheckoutSessionAgainstAttempt,
+};
+
+type AttemptOutcome =
+    | {
+          status:
+              | 'bound'
+              | 'miss_recorded'
+              | 'processed'
+              | 'released'
+              | 'retained';
+      }
+    | { category: string; status: 'failed' };
+
+export type StripeCheckoutOrphanReconciliationSummary = {
+    boundCount: number;
+    failedCount: number;
+    failureCategories: Record<string, number>;
+    missRecordedCount: number;
+    processedCount: number;
+    releasedCount: number;
+    retainedCount: number;
+    scannedCount: number;
+    truncated: boolean;
+};
+
+function attemptFailureCategory(error: unknown) {
+    return error instanceof StripeCheckoutAttemptConflictError
+        ? error.category
+        : 'unexpected';
+}
+
+function deadlineForAttempt(attempt: StripeCheckoutAttempt) {
+    const value = attempt.snapshot.stripeSession.expiresAt;
+    if (!value) {
+        return null;
+    }
+    const deadline = new Date(value);
+    if (Number.isNaN(deadline.getTime())) {
+        throw new StripeCheckoutAttemptConflictError(
+            'session_deadline_invalid',
+        );
+    }
+    return deadline;
+}
+
+function correlatedSessions(
+    sessions: readonly ListedStripeCheckoutSession[],
+    attempt: StripeCheckoutAttempt,
+) {
+    const correlated = sessions.filter(
+        (session) =>
+            session.metadata?.[stripeCheckoutAttemptMetadataKeys.attemptId] ===
+            attempt.snapshot.attemptId,
+    );
+    for (const session of correlated) {
+        const metadata = decodeStripeCheckoutAttemptMetadata(session.metadata);
+        if (
+            !metadata ||
+            metadata.attemptId !== attempt.snapshot.attemptId ||
+            metadata.cartId !== attempt.snapshot.cartId
+        ) {
+            throw new StripeCheckoutAttemptConflictError(
+                'snapshot_identity_changed',
+            );
+        }
+    }
+    if (correlated.length > 1) {
+        throw new StripeCheckoutAttemptConflictError(
+            'multiple_stripe_sessions',
+        );
+    }
+    return correlated;
+}
+
+async function reconcileProvenAbsentSession(
+    candidate: ActiveStripeCheckoutAttemptReconciliationCandidate,
+    dependencies: StripeCheckoutOrphanReconciliationDependencies,
+): Promise<AttemptOutcome> {
+    const { attempt } = candidate;
+    const deadline = deadlineForAttempt(attempt);
+    if (!deadline) {
+        return { category: 'session_deadline_missing', status: 'failed' };
+    }
+    const observedAt = dependencies.now();
+    if (deadline.getTime() > observedAt.getTime()) {
+        return { status: 'retained' };
+    }
+
+    const missBefore = new Date(
+        observedAt.getTime() - STRIPE_CHECKOUT_ORPHAN_MISS_GRACE_MS,
+    );
+    const recorded = await dependencies.recordMiss({
+        attemptId: attempt.snapshot.attemptId,
+        cartId: attempt.snapshot.cartId,
+        observedAt,
+    });
+    if (recorded.status === 'released' || recorded.status === 'bound') {
+        return { status: 'retained' };
+    }
+    if (recorded.status === 'attempt_missing') {
+        return { category: 'attempt_missing', status: 'failed' };
+    }
+
+    if (
+        candidate.lastReconciliationMissAt &&
+        candidate.lastReconciliationMissAt.getTime() <= missBefore.getTime()
+    ) {
+        const released = await dependencies.releaseAfterMisses({
+            attemptId: attempt.snapshot.attemptId,
+            cartId: attempt.snapshot.cartId,
+            missBefore,
+            now: observedAt,
+        });
+        if (released.status === 'released') {
+            return { status: 'released' };
+        }
+        if (
+            released.status === 'already_released' ||
+            released.status === 'bound'
+        ) {
+            return { status: 'retained' };
+        }
+        if (
+            released.status === 'too_soon' ||
+            released.status === 'not_expired'
+        ) {
+            return { status: 'miss_recorded' };
+        }
+        return {
+            category: `absence_release_${released.status}`,
+            status: 'failed',
+        };
+    }
+    return { status: 'miss_recorded' };
+}
+
+async function reconcileAuthoritativeSession(
+    attempt: StripeCheckoutAttempt,
+    initialSession: StripeCheckoutSessionForReconciliation,
+    dependencies: StripeCheckoutOrphanReconciliationDependencies,
+): Promise<AttemptOutcome> {
+    await dependencies.validateSession({ attempt, session: initialSession });
+    const deadline = deadlineForAttempt(attempt);
+
+    if (initialSession.status === 'open') {
+        if (!attempt.sessionId) {
+            await dependencies.bindAttempt({
+                attemptId: attempt.snapshot.attemptId,
+                cartId: attempt.snapshot.cartId,
+                sessionId: initialSession.id,
+            });
+        }
+        if (deadline && deadline.getTime() <= dependencies.now().getTime()) {
+            return { category: 'session_overdue_open', status: 'failed' };
+        }
+        return { status: attempt.sessionId ? 'retained' : 'bound' };
+    }
+
+    if (initialSession.status === 'expired') {
+        await dependencies.releaseAttempt({
+            attemptId: attempt.snapshot.attemptId,
+            cartId: attempt.snapshot.cartId,
+            reason: 'expired',
+            sessionId: initialSession.id,
+        });
+        return { status: 'released' };
+    }
+
+    if (initialSession.status === 'complete') {
+        const isPaid = initialSession.paymentStatus === 'paid';
+        const isZeroTotal =
+            initialSession.paymentStatus === 'no_payment_required' &&
+            initialSession.amountTotal === 0;
+        if (!isPaid && !isZeroTotal) {
+            return { category: 'session_unpaid', status: 'failed' };
+        }
+        if (!attempt.sessionId) {
+            await dependencies.bindAttempt({
+                attemptId: attempt.snapshot.attemptId,
+                cartId: attempt.snapshot.cartId,
+                sessionId: initialSession.id,
+            });
+        }
+        await dependencies.processSession(initialSession.id);
+        const processedAttempt = await dependencies.getAttempt(
+            attempt.snapshot.cartId,
+            attempt.snapshot.attemptId,
+        );
+        return processedAttempt?.releaseReason === 'completed'
+            ? { status: 'processed' }
+            : { category: 'fulfillment_incomplete', status: 'failed' };
+    }
+
+    return { category: 'session_status_unknown', status: 'failed' };
+}
+
+async function reconcileCandidate(
+    candidate: ActiveStripeCheckoutAttemptReconciliationCandidate,
+    dependencies: StripeCheckoutOrphanReconciliationDependencies,
+): Promise<AttemptOutcome> {
+    try {
+        if (candidate.attempt.sessionId) {
+            const session = await dependencies.getSession(
+                candidate.attempt.sessionId,
+            );
+            return await reconcileAuthoritativeSession(
+                candidate.attempt,
+                session,
+                dependencies,
+            );
+        }
+        const identity = await dependencies.resolveIdentity(candidate.attempt);
+        const deadline = deadlineForAttempt(candidate.attempt);
+        const listed = await dependencies.listSessions({
+            createdAt: candidate.createdAt,
+            customerId: identity.customerId,
+            expiresAt: deadline,
+        });
+        if (listed.status === 'partial') {
+            return {
+                category: `stripe_scan_${listed.reason}`,
+                status: 'failed',
+            };
+        }
+        const matchingSessions = correlatedSessions(
+            listed.items,
+            candidate.attempt,
+        );
+        const matchingSession = matchingSessions[0];
+        if (!matchingSession) {
+            return await reconcileProvenAbsentSession(candidate, dependencies);
+        }
+        const session = await dependencies.getSession(matchingSession.id);
+        return await reconcileAuthoritativeSession(
+            candidate.attempt,
+            session,
+            dependencies,
+        );
+    } catch (error) {
+        return { category: attemptFailureCategory(error), status: 'failed' };
+    }
+}
+
+function emptySummary(): StripeCheckoutOrphanReconciliationSummary {
+    return {
+        boundCount: 0,
+        failedCount: 0,
+        failureCategories: {},
+        missRecordedCount: 0,
+        processedCount: 0,
+        releasedCount: 0,
+        retainedCount: 0,
+        scannedCount: 0,
+        truncated: false,
+    };
+}
+
+function recordOutcome(
+    summary: StripeCheckoutOrphanReconciliationSummary,
+    outcome: AttemptOutcome,
+) {
+    if (outcome.status === 'failed') {
+        summary.failedCount += 1;
+        summary.failureCategories[outcome.category] =
+            (summary.failureCategories[outcome.category] ?? 0) + 1;
+        return;
+    }
+    if (outcome.status === 'bound') {
+        summary.boundCount += 1;
+    } else if (outcome.status === 'miss_recorded') {
+        summary.missRecordedCount += 1;
+    } else if (outcome.status === 'processed') {
+        summary.processedCount += 1;
+    } else if (outcome.status === 'released') {
+        summary.releasedCount += 1;
+    } else {
+        summary.retainedCount += 1;
+    }
+}
+
+export async function reconcileStripeCheckoutOrphanAttempts({
+    dependencies = realDependencies,
+    maxAttempts = RECONCILIATION_MAX_ATTEMPTS,
+    maxPages = RECONCILIATION_MAX_PAGES,
+    pageSize = RECONCILIATION_PAGE_SIZE,
+    timeBudgetMs = RECONCILIATION_TIME_BUDGET_MS,
+}: {
+    dependencies?: StripeCheckoutOrphanReconciliationDependencies;
+    maxAttempts?: number;
+    maxPages?: number;
+    pageSize?: number;
+    timeBudgetMs?: number;
+} = {}): Promise<StripeCheckoutOrphanReconciliationSummary> {
+    const summary = emptySummary();
+    const startedAt = Date.now();
+    let afterCreatedEventId = await dependencies.getCursor();
+
+    for (let pageIndex = 0; pageIndex < maxPages; pageIndex += 1) {
+        const remainingAttempts = maxAttempts - summary.scannedCount;
+        if (remainingAttempts <= 0 || Date.now() - startedAt >= timeBudgetMs) {
+            summary.truncated = true;
+            return summary;
+        }
+        const page = await dependencies.listAttempts({
+            afterCreatedEventId,
+            limit: Math.min(pageSize, remainingAttempts),
+        });
+        if (page.hasMore && !page.nextCreatedEventId) {
+            summary.truncated = true;
+            summary.failedCount += 1;
+            summary.failureCategories.local_cursor_missing =
+                (summary.failureCategories.local_cursor_missing ?? 0) + 1;
+            return summary;
+        }
+
+        // Lease this page before external work. A hard function timeout can
+        // skip it for one cycle, but cannot pin every later attempt forever.
+        await dependencies.setCursor(
+            page.hasMore ? (page.nextCreatedEventId ?? null) : null,
+        );
+        for (const candidate of page.items) {
+            if (
+                summary.scannedCount >= maxAttempts ||
+                Date.now() - startedAt >= timeBudgetMs
+            ) {
+                summary.truncated = true;
+                return summary;
+            }
+            summary.scannedCount += 1;
+            const outcome = await reconcileCandidate(candidate, dependencies);
+            recordOutcome(summary, outcome);
+            if (outcome.status === 'failed') {
+                console.error('Stripe checkout orphan reconciliation failed', {
+                    attemptId: candidate.attempt.snapshot.attemptId,
+                    cartId: candidate.attempt.snapshot.cartId,
+                    category: outcome.category,
+                });
+            }
+        }
+        if (!page.hasMore) {
+            return summary;
+        }
+        afterCreatedEventId = page.nextCreatedEventId;
+        if (
+            summary.scannedCount >= maxAttempts ||
+            Date.now() - startedAt >= timeBudgetMs
+        ) {
+            summary.truncated = true;
+            return summary;
+        }
+    }
+
+    summary.truncated = true;
+    return summary;
+}

--- a/apps/api/lib/checkout/stripeCheckoutSessionPagination.node.spec.ts
+++ b/apps/api/lib/checkout/stripeCheckoutSessionPagination.node.spec.ts
@@ -1,6 +1,33 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { collectStripePagesExhaustively } from '@gredice/stripe/server';
+import {
+    collectStripePagesExhaustively,
+    getStripeCheckoutSessionCreationRange,
+} from '@gredice/stripe/server';
+
+test('bounds a customer scan to the checkout creation window', () => {
+    const createdAt = new Date('2026-08-03T20:00:00.000Z');
+    assert.deepEqual(
+        getStripeCheckoutSessionCreationRange({
+            createdAt,
+            expiresAt: new Date('2026-08-03T20:30:00.000Z'),
+        }),
+        {
+            gte: Date.parse('2026-08-03T19:55:00.000Z') / 1000,
+            lte: Date.parse('2026-08-03T20:35:00.000Z') / 1000,
+        },
+    );
+    assert.deepEqual(
+        getStripeCheckoutSessionCreationRange({
+            createdAt,
+            expiresAt: null,
+        }),
+        {
+            gte: Date.parse('2026-08-03T19:55:00.000Z') / 1000,
+            lte: Date.parse('2026-08-03T20:05:20.000Z') / 1000,
+        },
+    );
+});
 
 test('collects every Stripe page with a stable forward cursor', async () => {
     const cursors: Array<string | undefined> = [];
@@ -62,6 +89,21 @@ test('fails closed for invalid, truncated, and failed pagination', async () => {
     assert.deepEqual(requestFailure, {
         pageCount: 0,
         reason: 'request_failed',
+        status: 'partial',
+    });
+
+    let now = 0;
+    const timeLimit = await collectStripePagesExhaustively({
+        fetchPage: async () => {
+            now += 10;
+            return { data: [{ id: `cs_${now.toString()}` }], hasMore: true };
+        },
+        maxDurationMs: 10,
+        now: () => now,
+    });
+    assert.deepEqual(timeLimit, {
+        pageCount: 1,
+        reason: 'time_limit',
         status: 'partial',
     });
 });

--- a/apps/api/lib/checkout/stripeCheckoutSessionPagination.node.spec.ts
+++ b/apps/api/lib/checkout/stripeCheckoutSessionPagination.node.spec.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { collectStripePagesExhaustively } from '@gredice/stripe/server';
+
+test('collects every Stripe page with a stable forward cursor', async () => {
+    const cursors: Array<string | undefined> = [];
+    const result = await collectStripePagesExhaustively({
+        fetchPage: async (startingAfter) => {
+            cursors.push(startingAfter);
+            if (!startingAfter) {
+                return {
+                    data: [{ id: 'cs_2' }, { id: 'cs_1' }],
+                    hasMore: true,
+                };
+            }
+            return { data: [{ id: 'cs_0' }], hasMore: false };
+        },
+    });
+
+    assert.deepEqual(cursors, [undefined, 'cs_1']);
+    assert.deepEqual(result, {
+        items: [{ id: 'cs_2' }, { id: 'cs_1' }, { id: 'cs_0' }],
+        pageCount: 2,
+        status: 'exhaustive',
+    });
+});
+
+test('fails closed for invalid, truncated, and failed pagination', async () => {
+    const emptyPage = await collectStripePagesExhaustively({
+        fetchPage: async () => ({ data: [], hasMore: true }),
+    });
+    assert.deepEqual(emptyPage, {
+        pageCount: 1,
+        reason: 'invalid_pagination',
+        status: 'partial',
+    });
+
+    const repeatedCursor = await collectStripePagesExhaustively({
+        fetchPage: async () => ({ data: [{ id: 'cs_same' }], hasMore: true }),
+    });
+    assert.deepEqual(repeatedCursor, {
+        pageCount: 2,
+        reason: 'invalid_pagination',
+        status: 'partial',
+    });
+
+    const pageLimit = await collectStripePagesExhaustively({
+        fetchPage: async () => ({ data: [{ id: 'cs_more' }], hasMore: true }),
+        maxPages: 1,
+    });
+    assert.deepEqual(pageLimit, {
+        pageCount: 1,
+        reason: 'page_limit',
+        status: 'partial',
+    });
+
+    const requestFailure = await collectStripePagesExhaustively({
+        fetchPage: async () => {
+            throw new Error('Stripe unavailable');
+        },
+    });
+    assert.deepEqual(requestFailure, {
+        pageCount: 0,
+        reason: 'request_failed',
+        status: 'partial',
+    });
+});

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -66,7 +66,10 @@ import {
     withPlantingScheduleTaskTransaction,
     withStripePaymentProcessingLock,
 } from '@gredice/storage';
-import { getStripeCheckoutSession } from '@gredice/stripe/server';
+import {
+    getStripeCheckoutSession,
+    getStripeCheckoutSessionForReconciliation,
+} from '@gredice/stripe/server';
 import { isBillingAutomationEnabled } from '../billing/automationFlag';
 import { notifyBillingDocumentsEmail } from '../billing/billingDocumentEmail';
 import {
@@ -1047,6 +1050,15 @@ export async function processCheckoutSession(
     return dependencies.withStripePaymentProcessingLock(session.id, () =>
         processPaidCheckoutSession(checkoutSessionId, session, dependencies),
     );
+}
+
+export function processCheckoutSessionForReconciliation(
+    checkoutSessionId: string,
+) {
+    return processCheckoutSession(checkoutSessionId, {
+        ...realDependencies,
+        getStripeCheckoutSession: getStripeCheckoutSessionForReconciliation,
+    });
 }
 
 async function recordSunflowerPackageFulfillmentFailure({

--- a/packages/storage/src/repositories/stripeCheckoutAttemptRepo.ts
+++ b/packages/storage/src/repositories/stripeCheckoutAttemptRepo.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
-import { and, asc, eq, inArray } from 'drizzle-orm';
+import { and, asc, desc, eq, gt, inArray, notExists, sql } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 import { z } from 'zod';
 import { events, shoppingCartItems, shoppingCarts } from '../schema';
 import { storage } from '../storage';
@@ -20,10 +21,18 @@ type DatabaseClient = StorageClient | TransactionClient;
 const eventTypes = {
     bound: 'checkout.stripeAttempt.bound',
     created: 'checkout.stripeAttempt.created',
+    reconciliationMiss: 'checkout.stripeAttempt.reconciliationMiss',
     released: 'checkout.stripeAttempt.released',
 } as const;
 
 const relevantEventTypes = Object.values(eventTypes);
+
+const reconciliationCursorAggregateId =
+    'checkout:stripeAttemptReconciliationCursor';
+const reconciliationCursorEventTypes = {
+    advanced: 'checkout.stripeAttempt.reconciliationCursor.advanced',
+    reset: 'checkout.stripeAttempt.reconciliationCursor.reset',
+} as const;
 
 export type StripeCheckoutAttemptReleaseReason =
     | 'cancelled'
@@ -113,10 +122,55 @@ type AttemptReleasedData = {
     sessionId: string | null;
 };
 
+type AttemptReconciliationMissData = {
+    attemptId: string;
+    observedAt: string;
+};
+
 type AttemptEvent = {
+    createdAt?: Date;
     data: unknown;
     type: string;
 };
+
+type StripeCheckoutAttemptReconciliationMiss = {
+    createdAt: Date;
+    observedAt: Date;
+};
+
+type StripeCheckoutAttemptEventState = {
+    attempt?: StripeCheckoutAttempt;
+    reconciliationMisses: StripeCheckoutAttemptReconciliationMiss[];
+};
+
+export type ActiveStripeCheckoutAttemptReconciliationCandidate = {
+    attempt: StripeCheckoutAttempt;
+    createdAt: Date;
+    createdEventId: number;
+    lastReconciliationMissAt?: Date;
+};
+
+export type RecordStripeCheckoutAttemptReconciliationMissResult =
+    | {
+          createdAt: Date;
+          observedAt: Date;
+          status: 'existing' | 'recorded';
+      }
+    | { releaseReason: StripeCheckoutAttemptReleaseReason; status: 'released' }
+    | { sessionId: string; status: 'bound' }
+    | { status: 'attempt_missing' };
+
+export type ReleaseStripeCheckoutAttemptAfterReconciliationMissesResult =
+    | { attempt: StripeCheckoutAttempt; status: 'released' }
+    | {
+          releaseReason: StripeCheckoutAttemptReleaseReason;
+          status: 'already_released';
+      }
+    | { sessionId: string; status: 'bound' }
+    | { expiresAt: Date; status: 'not_expired' }
+    | { status: 'null_deadline' }
+    | { lastReconciliationMissAt?: Date; status: 'too_soon' }
+    | { status: 'attempt_missing' };
 
 export class StripeCheckoutAttemptInProgressError extends Error {
     override readonly name = 'StripeCheckoutAttemptInProgressError';
@@ -406,13 +460,68 @@ function parseReleasedData(value: unknown): AttemptReleasedData {
     return parsed.data;
 }
 
+function parseReconciliationMissData(
+    value: unknown,
+): AttemptReconciliationMissData {
+    const parsed = z
+        .object({ attemptId: z.uuid(), observedAt: z.iso.datetime() })
+        .strict()
+        .safeParse(value);
+    if (!parsed.success) {
+        throw new StripeCheckoutAttemptConflictError(
+            'reconciliation_miss_malformed',
+        );
+    }
+    return parsed.data;
+}
+
+function parseStripeCheckoutAttemptReconciliationCursorEvent({
+    data,
+    type,
+}: {
+    data: unknown;
+    type: string;
+}) {
+    if (type === reconciliationCursorEventTypes.advanced) {
+        const parsed = z
+            .object({ afterCreatedEventId: positiveSafeIntegerSchema })
+            .strict()
+            .safeParse(data);
+        if (parsed.success) {
+            return parsed.data.afterCreatedEventId;
+        }
+    }
+    if (type === reconciliationCursorEventTypes.reset) {
+        const parsed = z
+            .object({ afterCreatedEventId: z.null() })
+            .strict()
+            .safeParse(data);
+        if (parsed.success) {
+            return undefined;
+        }
+    }
+    throw new StripeCheckoutAttemptConflictError(
+        'reconciliation_cursor_malformed',
+    );
+}
+
+function assertValidDate(value: Date, field: string) {
+    if (Number.isNaN(value.getTime())) {
+        throw new StripeCheckoutAttemptConflictError(`${field}_invalid`);
+    }
+}
+
 function cartAggregateId(cartId: number) {
     return `shoppingCart:${cartId.toString()}`;
 }
 
 async function getAttemptEvents(cartId: number, db: DatabaseClient) {
     return db
-        .select({ data: events.data, type: events.type })
+        .select({
+            createdAt: events.createdAt,
+            data: events.data,
+            type: events.type,
+        })
         .from(events)
         .where(
             and(
@@ -423,11 +532,12 @@ async function getAttemptEvents(cartId: number, db: DatabaseClient) {
         .orderBy(asc(events.id));
 }
 
-export function foldStripeCheckoutAttemptEvents(
+function foldStripeCheckoutAttemptEventState(
     attemptId: string,
     attemptEvents: readonly AttemptEvent[],
-): StripeCheckoutAttempt | undefined {
+): StripeCheckoutAttemptEventState {
     let attempt: StripeCheckoutAttempt | undefined;
+    const reconciliationMisses: StripeCheckoutAttemptReconciliationMiss[] = [];
     for (const event of attemptEvents) {
         if (event.type === eventTypes.created) {
             const snapshot = parseSnapshot(event.data);
@@ -477,9 +587,38 @@ export function foldStripeCheckoutAttemptEvents(
             }
             attempt.sessionId = release.sessionId ?? attempt.sessionId;
             attempt.releaseReason = release.reason;
+            continue;
+        }
+        if (event.type === eventTypes.reconciliationMiss) {
+            const miss = parseReconciliationMissData(event.data);
+            if (miss.attemptId !== attemptId) {
+                continue;
+            }
+            if (!attempt) {
+                throw new StripeCheckoutAttemptConflictError(
+                    'reconciliation_miss_without_snapshot',
+                );
+            }
+            if (!event.createdAt) {
+                throw new StripeCheckoutAttemptConflictError(
+                    'reconciliation_miss_created_at_missing',
+                );
+            }
+            reconciliationMisses.push({
+                createdAt: event.createdAt,
+                observedAt: new Date(miss.observedAt),
+            });
         }
     }
-    return attempt;
+    return { attempt, reconciliationMisses };
+}
+
+export function foldStripeCheckoutAttemptEvents(
+    attemptId: string,
+    attemptEvents: readonly AttemptEvent[],
+): StripeCheckoutAttempt | undefined {
+    return foldStripeCheckoutAttemptEventState(attemptId, attemptEvents)
+        .attempt;
 }
 
 function getCreatedAttemptIds(attemptEvents: readonly AttemptEvent[]) {
@@ -521,6 +660,200 @@ export async function getActiveStripeCheckoutAttempt(
         );
     }
     return activeAttempts[0];
+}
+
+function getLastReconciliationMiss(
+    reconciliationMisses: readonly StripeCheckoutAttemptReconciliationMiss[],
+) {
+    return reconciliationMisses.reduce<
+        StripeCheckoutAttemptReconciliationMiss | undefined
+    >(
+        (latest, miss) =>
+            !latest || miss.createdAt.getTime() > latest.createdAt.getTime()
+                ? miss
+                : latest,
+        undefined,
+    );
+}
+
+export async function listActiveStripeCheckoutAttemptsForReconciliation({
+    afterCreatedEventId,
+    limit = 25,
+}: {
+    afterCreatedEventId?: number;
+    limit?: number;
+} = {}) {
+    if (!Number.isInteger(limit) || limit <= 0) {
+        throw new StripeCheckoutAttemptConflictError(
+            'reconciliation_page_limit_invalid',
+        );
+    }
+    if (
+        afterCreatedEventId !== undefined &&
+        (!Number.isSafeInteger(afterCreatedEventId) || afterCreatedEventId <= 0)
+    ) {
+        throw new StripeCheckoutAttemptConflictError(
+            'reconciliation_page_cursor_invalid',
+        );
+    }
+
+    const boundedLimit = Math.min(limit, 100);
+    const db = storage();
+    const terminalEvents = alias(
+        events,
+        'stripe_checkout_attempt_terminal_events',
+    );
+    const createdRows = await db
+        .select({
+            aggregateId: events.aggregateId,
+            createdAt: events.createdAt,
+            data: events.data,
+            id: events.id,
+        })
+        .from(events)
+        .where(
+            and(
+                eq(events.type, eventTypes.created),
+                afterCreatedEventId === undefined
+                    ? undefined
+                    : gt(events.id, afterCreatedEventId),
+                notExists(
+                    db
+                        .select({ id: terminalEvents.id })
+                        .from(terminalEvents)
+                        .where(
+                            and(
+                                eq(
+                                    terminalEvents.aggregateId,
+                                    events.aggregateId,
+                                ),
+                                eq(terminalEvents.type, eventTypes.released),
+                                eq(
+                                    sql<string>`${terminalEvents.data}->>'attemptId'`,
+                                    sql<string>`${events.data}->>'attemptId'`,
+                                ),
+                            ),
+                        ),
+                ),
+            ),
+        )
+        .orderBy(asc(events.id))
+        .limit(boundedLimit + 1);
+    const hasMore = createdRows.length > boundedLimit;
+    const pageRows = createdRows.slice(0, boundedLimit);
+    if (pageRows.length === 0) {
+        return {
+            hasMore: false,
+            items: [] satisfies ActiveStripeCheckoutAttemptReconciliationCandidate[],
+        };
+    }
+
+    const aggregateIds = [...new Set(pageRows.map((row) => row.aggregateId))];
+    const relatedEvents = await db
+        .select({
+            aggregateId: events.aggregateId,
+            createdAt: events.createdAt,
+            data: events.data,
+            type: events.type,
+        })
+        .from(events)
+        .where(
+            and(
+                inArray(events.aggregateId, aggregateIds),
+                inArray(events.type, relevantEventTypes),
+            ),
+        )
+        .orderBy(asc(events.id));
+    const eventsByAggregateId = Map.groupBy(
+        relatedEvents,
+        (event) => event.aggregateId,
+    );
+    const items =
+        pageRows.flatMap<ActiveStripeCheckoutAttemptReconciliationCandidate>(
+            (createdRow) => {
+                const snapshot = parseSnapshot(createdRow.data);
+                const state = foldStripeCheckoutAttemptEventState(
+                    snapshot.attemptId,
+                    eventsByAggregateId.get(createdRow.aggregateId) ?? [],
+                );
+                if (!state.attempt || state.attempt.releaseReason) {
+                    return [];
+                }
+                const lastReconciliationMiss = getLastReconciliationMiss(
+                    state.reconciliationMisses,
+                );
+                return [
+                    {
+                        attempt: state.attempt,
+                        createdAt: createdRow.createdAt,
+                        createdEventId: createdRow.id,
+                        ...(lastReconciliationMiss
+                            ? {
+                                  lastReconciliationMissAt:
+                                      lastReconciliationMiss.createdAt,
+                              }
+                            : {}),
+                    },
+                ];
+            },
+        );
+    const lastPageRow = pageRows.at(-1);
+    return {
+        hasMore,
+        items,
+        ...(hasMore && lastPageRow
+            ? { nextCreatedEventId: lastPageRow.id }
+            : {}),
+    };
+}
+
+export async function getStripeCheckoutAttemptReconciliationCursor(): Promise<
+    number | undefined
+> {
+    const [latestEvent] = await storage()
+        .select({ data: events.data, type: events.type })
+        .from(events)
+        .where(eq(events.aggregateId, reconciliationCursorAggregateId))
+        .orderBy(desc(events.id))
+        .limit(1);
+    return latestEvent
+        ? parseStripeCheckoutAttemptReconciliationCursorEvent(latestEvent)
+        : undefined;
+}
+
+export async function setStripeCheckoutAttemptReconciliationCursor(
+    afterCreatedEventId: number | null,
+): Promise<number | undefined> {
+    if (
+        afterCreatedEventId !== null &&
+        (!Number.isSafeInteger(afterCreatedEventId) || afterCreatedEventId <= 0)
+    ) {
+        throw new StripeCheckoutAttemptConflictError(
+            'reconciliation_cursor_invalid',
+        );
+    }
+    // This append-only cursor schedules at-least-once scans; it is not a
+    // correctness lease. Attempt transitions still re-fold under their cart
+    // lock, so overlapping workers may duplicate work but cannot bypass the
+    // checkout attempt fence.
+    await storage()
+        .insert(events)
+        .values(
+            afterCreatedEventId === null
+                ? {
+                      aggregateId: reconciliationCursorAggregateId,
+                      data: { afterCreatedEventId: null },
+                      type: reconciliationCursorEventTypes.reset,
+                      version: 1,
+                  }
+                : {
+                      aggregateId: reconciliationCursorAggregateId,
+                      data: { afterCreatedEventId },
+                      type: reconciliationCursorEventTypes.advanced,
+                      version: 1,
+                  },
+        );
+    return afterCreatedEventId ?? undefined;
 }
 
 export async function hasActiveStripeCheckoutAttemptForAccount(
@@ -771,6 +1104,129 @@ export async function bindStripeCheckoutAttempt({
     });
 }
 
+export async function recordStripeCheckoutAttemptReconciliationMiss({
+    attemptId,
+    cartId,
+    observedAt,
+}: {
+    attemptId: string;
+    cartId: number;
+    observedAt: Date;
+}): Promise<RecordStripeCheckoutAttemptReconciliationMissResult> {
+    assertValidDate(observedAt, 'reconciliation_observed_at');
+    return storage().transaction(async (db) => {
+        await lockCartRow(cartId, db);
+        const state = foldStripeCheckoutAttemptEventState(
+            attemptId,
+            await getAttemptEvents(cartId, db),
+        );
+        const attempt = state.attempt;
+        if (!attempt) {
+            return { status: 'attempt_missing' };
+        }
+        if (attempt.releaseReason) {
+            return {
+                releaseReason: attempt.releaseReason,
+                status: 'released',
+            };
+        }
+        if (attempt.sessionId) {
+            return { sessionId: attempt.sessionId, status: 'bound' };
+        }
+        const existing = state.reconciliationMisses.find(
+            (miss) => miss.observedAt.getTime() === observedAt.getTime(),
+        );
+        if (existing) {
+            return {
+                createdAt: existing.createdAt,
+                observedAt: existing.observedAt,
+                status: 'existing',
+            };
+        }
+        const [recorded] = await db
+            .insert(events)
+            .values({
+                aggregateId: cartAggregateId(cartId),
+                data: { attemptId, observedAt: observedAt.toISOString() },
+                type: eventTypes.reconciliationMiss,
+                version: 1,
+            })
+            .returning({ createdAt: events.createdAt });
+        if (!recorded) {
+            throw new StripeCheckoutAttemptConflictError(
+                'reconciliation_miss_not_recorded',
+            );
+        }
+        return {
+            createdAt: recorded.createdAt,
+            observedAt,
+            status: 'recorded',
+        };
+    });
+}
+
+async function releaseLockedStripeCheckoutAttempt({
+    attempt,
+    attemptId,
+    cartId,
+    db,
+    now,
+    reason,
+    sessionId,
+}: AttemptReleasedData & {
+    attempt: StripeCheckoutAttempt;
+    cartId: number;
+    db: TransactionClient;
+    now: Date;
+}) {
+    if (attempt.sessionId && attempt.sessionId !== sessionId) {
+        throw new StripeCheckoutAttemptConflictError('session_binding_changed');
+    }
+    if (attempt.releaseReason) {
+        const equivalentAbandonment =
+            (attempt.releaseReason === 'cancelled' ||
+                attempt.releaseReason === 'expired') &&
+            (reason === 'cancelled' || reason === 'expired');
+        if (
+            (!equivalentAbandonment && attempt.releaseReason !== reason) ||
+            attempt.sessionId !== (sessionId ?? attempt.sessionId)
+        ) {
+            throw new StripeCheckoutAttemptConflictError('release_changed');
+        }
+        return attempt;
+    }
+    if (!attempt.sessionId && sessionId) {
+        await db.insert(events).values({
+            aggregateId: cartAggregateId(cartId),
+            data: { attemptId, sessionId },
+            type: eventTypes.bound,
+            version: 1,
+        });
+    }
+    // Cleanup commits before the release event removes the cart fence.
+    // Replays of an already released attempt intentionally skip cleanup so
+    // they cannot release reservations created by a subsequent attempt.
+    await releaseOutletReservationsForCheckoutAttempt(
+        cartId,
+        attempt.snapshot.items.flatMap((item) =>
+            item.outlet ? [item.outlet.reservationId] : [],
+        ),
+        now,
+        db,
+    );
+    await db.insert(events).values({
+        aggregateId: cartAggregateId(cartId),
+        data: { attemptId, reason, sessionId },
+        type: eventTypes.released,
+        version: 1,
+    });
+    return {
+        ...attempt,
+        releaseReason: reason,
+        sessionId: sessionId ?? attempt.sessionId,
+    };
+}
+
 export async function releaseStripeCheckoutAttempt({
     attemptId,
     cartId,
@@ -783,54 +1239,102 @@ export async function releaseStripeCheckoutAttempt({
         if (!attempt) {
             throw new StripeCheckoutAttemptConflictError('attempt_missing');
         }
-        if (attempt.sessionId && attempt.sessionId !== sessionId) {
-            throw new StripeCheckoutAttemptConflictError(
-                'session_binding_changed',
-            );
+        return releaseLockedStripeCheckoutAttempt({
+            attempt,
+            attemptId,
+            cartId,
+            db,
+            now: new Date(),
+            reason,
+            sessionId,
+        });
+    });
+}
+
+export async function releaseStripeCheckoutAttemptAfterReconciliationMisses({
+    attemptId,
+    cartId,
+    missBefore,
+    now,
+}: {
+    attemptId: string;
+    cartId: number;
+    missBefore: Date;
+    now: Date;
+}): Promise<ReleaseStripeCheckoutAttemptAfterReconciliationMissesResult> {
+    assertValidDate(now, 'reconciliation_now');
+    assertValidDate(missBefore, 'reconciliation_miss_before');
+    return storage().transaction(async (db) => {
+        await lockCartRow(cartId, db);
+        const state = foldStripeCheckoutAttemptEventState(
+            attemptId,
+            await getAttemptEvents(cartId, db),
+        );
+        const attempt = state.attempt;
+        if (!attempt) {
+            return { status: 'attempt_missing' };
         }
         if (attempt.releaseReason) {
-            const equivalentAbandonment =
-                (attempt.releaseReason === 'cancelled' ||
-                    attempt.releaseReason === 'expired') &&
-                (reason === 'cancelled' || reason === 'expired');
-            if (
-                (!equivalentAbandonment && attempt.releaseReason !== reason) ||
-                attempt.sessionId !== (sessionId ?? attempt.sessionId)
-            ) {
-                throw new StripeCheckoutAttemptConflictError('release_changed');
-            }
-            return attempt;
+            return {
+                releaseReason: attempt.releaseReason,
+                status: 'already_released',
+            };
         }
-        if (!attempt.sessionId && sessionId) {
-            await db.insert(events).values({
-                aggregateId: cartAggregateId(cartId),
-                data: { attemptId, sessionId },
-                type: eventTypes.bound,
-                version: 1,
-            });
+        if (attempt.sessionId) {
+            return { sessionId: attempt.sessionId, status: 'bound' };
         }
-        // Cleanup commits before the release event removes the cart fence.
-        // Replays of an already released attempt intentionally skip cleanup so
-        // they cannot release reservations created by a subsequent attempt.
-        await releaseOutletReservationsForCheckoutAttempt(
-            cartId,
-            attempt.snapshot.items.flatMap((item) =>
-                item.outlet ? [item.outlet.reservationId] : [],
+        const deadlineValue = attempt.snapshot.stripeSession.expiresAt;
+        if (!deadlineValue) {
+            return { status: 'null_deadline' };
+        }
+        const expiresAt = new Date(deadlineValue);
+        if (expiresAt.getTime() > now.getTime()) {
+            return { expiresAt, status: 'not_expired' };
+        }
+
+        const graceMs = now.getTime() - missBefore.getTime();
+        const currentMiss = getLastReconciliationMiss(
+            state.reconciliationMisses.filter(
+                (miss) =>
+                    miss.observedAt.getTime() === now.getTime() &&
+                    miss.createdAt.getTime() >= expiresAt.getTime(),
             ),
-            new Date(),
-            db,
         );
-        await db.insert(events).values({
-            aggregateId: cartAggregateId(cartId),
-            data: { attemptId, reason, sessionId },
-            type: eventTypes.released,
-            version: 1,
+        const previousMiss = currentMiss
+            ? getLastReconciliationMiss(
+                  state.reconciliationMisses.filter(
+                      (miss) =>
+                          miss.createdAt.getTime() >= expiresAt.getTime() &&
+                          miss.createdAt.getTime() <=
+                              currentMiss.createdAt.getTime() - graceMs,
+                  ),
+              )
+            : undefined;
+        if (graceMs <= 0 || !currentMiss || !previousMiss) {
+            const lastReconciliationMiss = getLastReconciliationMiss(
+                state.reconciliationMisses,
+            );
+            return {
+                ...(lastReconciliationMiss
+                    ? {
+                          lastReconciliationMissAt:
+                              lastReconciliationMiss.createdAt,
+                      }
+                    : {}),
+                status: 'too_soon',
+            };
+        }
+
+        const releasedAttempt = await releaseLockedStripeCheckoutAttempt({
+            attempt,
+            attemptId,
+            cartId,
+            db,
+            now,
+            reason: 'expired',
+            sessionId: null,
         });
-        return {
-            ...attempt,
-            releaseReason: reason,
-            sessionId: sessionId ?? attempt.sessionId,
-        };
+        return { attempt: releasedAttempt, status: 'released' };
     });
 }
 

--- a/packages/storage/tests/outletOffersRepo.node.spec.ts
+++ b/packages/storage/tests/outletOffersRepo.node.spec.ts
@@ -19,8 +19,10 @@ import {
     getShoppingCart,
     OutletOfferIdentityImmutableError,
     OutletOfferUnavailableError,
+    recordStripeCheckoutAttemptReconciliationMiss,
     releaseOutletReservationForCartItem,
     releaseStripeCheckoutAttempt,
+    releaseStripeCheckoutAttemptAfterReconciliationMisses,
     reserveOutletOffer,
     StripeCheckoutAttemptConflictError,
     type StripeCheckoutAttemptSnapshot,
@@ -33,8 +35,8 @@ import {
     upsertOrRemoveCartItemWithOutletReservation,
     verifyStripeCheckoutAttemptLiveCart,
 } from '@gredice/storage';
-import { eq } from 'drizzle-orm';
-import { outletOffers } from '../src/schema';
+import { and, eq } from 'drizzle-orm';
+import { events, outletOfferReservations, outletOffers } from '../src/schema';
 import { createTestAccount } from './helpers/testHelpers';
 import { createTestDb } from './testDb';
 
@@ -482,6 +484,89 @@ test('stale attempt release cannot release a later attempt reservation', async (
     });
     assert.equal(
         (await getOutletOfferReservation(secondReservation.id))?.status,
+        'held',
+    );
+});
+
+test('orphan reconciliation releases only the reservation captured by the attempt snapshot', async () => {
+    createTestDb();
+    const now = new Date('2026-05-01T10:00:00.000Z');
+    const plantSortId = await createTestPlantSort();
+    const offerId = await createPublishedOffer({
+        plantSortId,
+        quantity: 3,
+        now,
+    });
+    const accountId = await createTestAccount();
+    const { cart, cartItemId } = await createCartItem(accountId, plantSortId);
+    const attemptReservation = await reserveOutletOffer({
+        accountId,
+        cartId: cart.id,
+        cartItemId,
+        offerId,
+        now,
+    });
+    const attempt = outletAttemptSnapshot({
+        cartId: cart.id,
+        cartItemId,
+        entityId: plantSortId.toString(),
+        reservation: attemptReservation,
+    });
+    await createStripeCheckoutAttempt(attempt, { accountId, now });
+
+    const [unrelatedReservation] = await storage()
+        .insert(outletOfferReservations)
+        .values({
+            accountId,
+            cartId: cart.id,
+            cartItemId,
+            heldComparePriceCents: attemptReservation.heldComparePriceCents,
+            heldInitialPlantStatus: attemptReservation.heldInitialPlantStatus,
+            heldOutletPriceCents: attemptReservation.heldOutletPriceCents,
+            heldSowingDate: attemptReservation.heldSowingDate,
+            holdExpiresAt: addMinutes(now, 120),
+            outletOfferId: offerId,
+            quantity: 1,
+            status: 'held',
+        })
+        .returning();
+    assert.ok(unrelatedReservation);
+
+    const firstObservedAt = addMinutes(attemptReservation.holdExpiresAt, 1);
+    await recordStripeCheckoutAttemptReconciliationMiss({
+        attemptId: attempt.attemptId,
+        cartId: cart.id,
+        observedAt: firstObservedAt,
+    });
+    await storage()
+        .update(events)
+        .set({ createdAt: firstObservedAt })
+        .where(
+            and(
+                eq(events.aggregateId, `shoppingCart:${cart.id.toString()}`),
+                eq(events.type, 'checkout.stripeAttempt.reconciliationMiss'),
+            ),
+        );
+    const secondObservedAt = addMinutes(firstObservedAt, 61);
+    await recordStripeCheckoutAttemptReconciliationMiss({
+        attemptId: attempt.attemptId,
+        cartId: cart.id,
+        observedAt: secondObservedAt,
+    });
+    const result = await releaseStripeCheckoutAttemptAfterReconciliationMisses({
+        attemptId: attempt.attemptId,
+        cartId: cart.id,
+        missBefore: addMinutes(secondObservedAt, -60),
+        now: secondObservedAt,
+    });
+
+    assert.equal(result.status, 'released');
+    assert.equal(
+        (await getOutletOfferReservation(attemptReservation.id))?.status,
+        'released',
+    );
+    assert.equal(
+        (await getOutletOfferReservation(unrelatedReservation.id))?.status,
         'held',
     );
 });

--- a/packages/storage/tests/stripeCheckoutAttemptRepo.node.spec.ts
+++ b/packages/storage/tests/stripeCheckoutAttemptRepo.node.spec.ts
@@ -16,14 +16,21 @@ import {
     getGarden,
     getOrCreateShoppingCart,
     getShoppingCart,
+    getStripeCheckoutAttemptReconciliationCursor,
+    listActiveStripeCheckoutAttemptsForReconciliation,
+    recordStripeCheckoutAttemptReconciliationMiss,
     releaseStripeCheckoutAttempt,
+    releaseStripeCheckoutAttemptAfterReconciliationMisses,
     StripeCheckoutAttemptConflictError,
     StripeCheckoutAttemptInProgressError,
     type StripeCheckoutAttemptSnapshot,
+    setStripeCheckoutAttemptReconciliationCursor,
     storage,
     upsertOrRemoveCartItem,
     verifyStripeCheckoutAttemptLiveCart,
 } from '@gredice/storage';
+import { and, eq } from 'drizzle-orm';
+import { events } from '../src/schema';
 import {
     createTestAccount,
     createTestGarden,
@@ -463,4 +470,371 @@ test('account deletion can win and remains retryable while a stale snapshot fail
             return true;
         },
     );
+});
+
+test('active Stripe reconciliation pages include bound attempts and skip released history before the keyset limit', async () => {
+    createTestDb();
+    const attempts = [];
+    for (let index = 0; index < 5; index += 1) {
+        const { accountId, cart } = await createCartWithItem();
+        const snapshot = snapshotFromCart(cart);
+        await createStripeCheckoutAttempt(snapshot, { accountId });
+        attempts.push({ cart, snapshot });
+    }
+    const boundAttempt = attempts[0];
+    const firstReleasedAttempt = attempts[1];
+    const secondReleasedAttempt = attempts[2];
+    const firstActiveAttempt = attempts[3];
+    assert.ok(boundAttempt);
+    assert.ok(firstReleasedAttempt);
+    assert.ok(secondReleasedAttempt);
+    assert.ok(firstActiveAttempt);
+    const listedMiss = await recordStripeCheckoutAttemptReconciliationMiss({
+        attemptId: firstActiveAttempt.snapshot.attemptId,
+        cartId: firstActiveAttempt.cart.id,
+        observedAt: new Date('2026-08-03T09:00:00.000Z'),
+    });
+    assert.equal(listedMiss.status, 'recorded');
+    await bindStripeCheckoutAttempt({
+        attemptId: boundAttempt.snapshot.attemptId,
+        cartId: boundAttempt.cart.id,
+        sessionId: 'cs_reconciliation_bound',
+    });
+    await releaseStripeCheckoutAttempt({
+        attemptId: firstReleasedAttempt.snapshot.attemptId,
+        cartId: firstReleasedAttempt.cart.id,
+        reason: 'session_creation_failed',
+        sessionId: null,
+    });
+    await releaseStripeCheckoutAttempt({
+        attemptId: secondReleasedAttempt.snapshot.attemptId,
+        cartId: secondReleasedAttempt.cart.id,
+        reason: 'session_creation_failed',
+        sessionId: null,
+    });
+
+    const firstCreatedEvent = await storage().query.events.findFirst({
+        where: (event, { and: all, eq: equal }) =>
+            all(
+                equal(
+                    event.aggregateId,
+                    `shoppingCart:${boundAttempt.cart.id.toString()}`,
+                ),
+                equal(event.type, 'checkout.stripeAttempt.created'),
+            ),
+    });
+    assert.ok(firstCreatedEvent);
+
+    let cursor = firstCreatedEvent.id - 1;
+    const seenAttemptIds: string[] = [];
+    const pageItemCounts: number[] = [];
+    for (let pageIndex = 0; pageIndex < 3; pageIndex += 1) {
+        const page = await listActiveStripeCheckoutAttemptsForReconciliation({
+            afterCreatedEventId: cursor,
+            limit: 1,
+        });
+        pageItemCounts.push(page.items.length);
+        if (pageIndex === 0) {
+            assert.equal(
+                page.items[0]?.attempt.sessionId,
+                'cs_reconciliation_bound',
+            );
+        }
+        if (pageIndex === 1 && listedMiss.status === 'recorded') {
+            assert.equal(
+                page.items[0]?.lastReconciliationMissAt?.toISOString(),
+                listedMiss.createdAt.toISOString(),
+            );
+        }
+        seenAttemptIds.push(
+            ...page.items.map((item) => item.attempt.snapshot.attemptId),
+        );
+        if (pageIndex < 2) {
+            assert.equal(page.hasMore, true);
+            assert.ok(page.nextCreatedEventId);
+            assert.ok(page.nextCreatedEventId > cursor);
+            cursor = page.nextCreatedEventId;
+        } else {
+            assert.equal(page.hasMore, false);
+            assert.equal(page.nextCreatedEventId, undefined);
+        }
+    }
+
+    assert.deepEqual(pageItemCounts, [1, 1, 1]);
+    assert.deepEqual(seenAttemptIds, [
+        attempts[0]?.snapshot.attemptId,
+        attempts[3]?.snapshot.attemptId,
+        attempts[4]?.snapshot.attemptId,
+    ]);
+});
+
+test('released paging correlation keeps a later active attempt on the same cart', async () => {
+    createTestDb();
+    const { accountId, cart } = await createCartWithItem();
+    const releasedSnapshot = snapshotFromCart(cart);
+    await createStripeCheckoutAttempt(releasedSnapshot, { accountId });
+    await releaseStripeCheckoutAttempt({
+        attemptId: releasedSnapshot.attemptId,
+        cartId: cart.id,
+        reason: 'session_creation_failed',
+        sessionId: null,
+    });
+    const activeSnapshot = snapshotFromCart(cart);
+    await createStripeCheckoutAttempt(activeSnapshot, { accountId });
+
+    const [firstCreatedEvent] = await storage()
+        .select({ id: events.id })
+        .from(events)
+        .where(
+            and(
+                eq(events.aggregateId, `shoppingCart:${cart.id.toString()}`),
+                eq(events.type, 'checkout.stripeAttempt.created'),
+            ),
+        )
+        .orderBy(events.id)
+        .limit(1);
+    assert.ok(firstCreatedEvent);
+    const page = await listActiveStripeCheckoutAttemptsForReconciliation({
+        afterCreatedEventId: firstCreatedEvent.id - 1,
+        limit: 1,
+    });
+
+    assert.equal(page.items.length, 1);
+    assert.equal(
+        page.items[0]?.attempt.snapshot.attemptId,
+        activeSnapshot.attemptId,
+    );
+    assert.equal(page.hasMore, false);
+});
+
+test('Stripe checkout reconciliation cursor persists append-only advances and reset', async () => {
+    createTestDb();
+    await setStripeCheckoutAttemptReconciliationCursor(null);
+    assert.equal(
+        await getStripeCheckoutAttemptReconciliationCursor(),
+        undefined,
+    );
+    assert.equal(await setStripeCheckoutAttemptReconciliationCursor(41), 41);
+    assert.equal(await getStripeCheckoutAttemptReconciliationCursor(), 41);
+    assert.equal(await setStripeCheckoutAttemptReconciliationCursor(88), 88);
+    assert.equal(await getStripeCheckoutAttemptReconciliationCursor(), 88);
+    assert.equal(
+        await setStripeCheckoutAttemptReconciliationCursor(null),
+        undefined,
+    );
+    assert.equal(
+        await getStripeCheckoutAttemptReconciliationCursor(),
+        undefined,
+    );
+
+    const cursorEvents = await storage()
+        .select({ data: events.data, type: events.type })
+        .from(events)
+        .where(
+            eq(
+                events.aggregateId,
+                'checkout:stripeAttemptReconciliationCursor',
+            ),
+        )
+        .orderBy(events.id);
+    assert.deepEqual(cursorEvents, [
+        {
+            data: { afterCreatedEventId: null },
+            type: 'checkout.stripeAttempt.reconciliationCursor.reset',
+        },
+        {
+            data: { afterCreatedEventId: 41 },
+            type: 'checkout.stripeAttempt.reconciliationCursor.advanced',
+        },
+        {
+            data: { afterCreatedEventId: 88 },
+            type: 'checkout.stripeAttempt.reconciliationCursor.advanced',
+        },
+        {
+            data: { afterCreatedEventId: null },
+            type: 'checkout.stripeAttempt.reconciliationCursor.reset',
+        },
+    ]);
+    await assert.rejects(
+        () => setStripeCheckoutAttemptReconciliationCursor(0),
+        (error) => {
+            assert.ok(error instanceof StripeCheckoutAttemptConflictError);
+            assert.equal(error.category, 'reconciliation_cursor_invalid');
+            return true;
+        },
+    );
+});
+
+test('Stripe checkout reconciliation cursor rejects malformed latest evidence', async () => {
+    createTestDb();
+    await storage()
+        .insert(events)
+        .values({
+            aggregateId: 'checkout:stripeAttemptReconciliationCursor',
+            data: { afterCreatedEventId: 'private-or-invalid-value' },
+            type: 'checkout.stripeAttempt.reconciliationCursor.advanced',
+            version: 1,
+        });
+
+    await assert.rejects(
+        () => getStripeCheckoutAttemptReconciliationCursor(),
+        (error) => {
+            assert.ok(error instanceof StripeCheckoutAttemptConflictError);
+            assert.equal(error.category, 'reconciliation_cursor_malformed');
+            return true;
+        },
+    );
+});
+
+test('reconciliation miss evidence is append-only, idempotent, and releases only after a database-timed grace', async () => {
+    createTestDb();
+    const { accountId, cart } = await createCartWithItem();
+    const snapshot = snapshotFromCart(cart);
+    snapshot.stripeSession.expiresAt = '2020-01-01T00:00:00.000Z';
+    await createStripeCheckoutAttempt(snapshot, { accountId });
+
+    const firstObservedAt = new Date('2026-08-03T10:00:00.000Z');
+    const firstMiss = await recordStripeCheckoutAttemptReconciliationMiss({
+        attemptId: snapshot.attemptId,
+        cartId: cart.id,
+        observedAt: firstObservedAt,
+    });
+    assert.equal(firstMiss.status, 'recorded');
+    const duplicateFirstMiss =
+        await recordStripeCheckoutAttemptReconciliationMiss({
+            attemptId: snapshot.attemptId,
+            cartId: cart.id,
+            observedAt: firstObservedAt,
+        });
+    assert.deepEqual(duplicateFirstMiss, {
+        ...firstMiss,
+        status: 'existing',
+    });
+
+    const tooSoon = await releaseStripeCheckoutAttemptAfterReconciliationMisses(
+        {
+            attemptId: snapshot.attemptId,
+            cartId: cart.id,
+            missBefore: new Date(firstObservedAt.getTime() - 60 * 60 * 1000),
+            now: firstObservedAt,
+        },
+    );
+    assert.equal(tooSoon.status, 'too_soon');
+    assert.ok(await getActiveStripeCheckoutAttempt(cart.id));
+
+    await storage()
+        .update(events)
+        .set({ createdAt: new Date('2020-01-02T00:00:00.000Z') })
+        .where(
+            and(
+                eq(events.aggregateId, `shoppingCart:${cart.id.toString()}`),
+                eq(events.type, 'checkout.stripeAttempt.reconciliationMiss'),
+            ),
+        );
+    const secondObservedAt = new Date('2026-08-03T12:00:00.000Z');
+    const secondMiss = await recordStripeCheckoutAttemptReconciliationMiss({
+        attemptId: snapshot.attemptId,
+        cartId: cart.id,
+        observedAt: secondObservedAt,
+    });
+    assert.equal(secondMiss.status, 'recorded');
+    const released =
+        await releaseStripeCheckoutAttemptAfterReconciliationMisses({
+            attemptId: snapshot.attemptId,
+            cartId: cart.id,
+            missBefore: new Date(secondObservedAt.getTime() - 60 * 60 * 1000),
+            now: secondObservedAt,
+        });
+    assert.equal(released.status, 'released');
+    assert.equal(await getActiveStripeCheckoutAttempt(cart.id), undefined);
+
+    const repeatedRelease =
+        await releaseStripeCheckoutAttemptAfterReconciliationMisses({
+            attemptId: snapshot.attemptId,
+            cartId: cart.id,
+            missBefore: new Date(secondObservedAt.getTime() - 60 * 60 * 1000),
+            now: secondObservedAt,
+        });
+    assert.deepEqual(repeatedRelease, {
+        releaseReason: 'expired',
+        status: 'already_released',
+    });
+
+    const attemptEvents = await storage()
+        .select({ type: events.type })
+        .from(events)
+        .where(eq(events.aggregateId, `shoppingCart:${cart.id.toString()}`));
+    assert.equal(
+        attemptEvents.filter(
+            (event) =>
+                event.type === 'checkout.stripeAttempt.reconciliationMiss',
+        ).length,
+        2,
+    );
+    assert.equal(
+        attemptEvents.filter(
+            (event) => event.type === 'checkout.stripeAttempt.released',
+        ).length,
+        1,
+    );
+});
+
+test('reconciliation never releases an unbound attempt without a session deadline', async () => {
+    createTestDb();
+    const { accountId, cart } = await createCartWithItem();
+    const snapshot = snapshotFromCart(cart);
+    snapshot.stripeSession.expiresAt = null;
+    await createStripeCheckoutAttempt(snapshot, { accountId });
+    const firstObservedAt = new Date('2026-08-03T10:00:00.000Z');
+    const secondObservedAt = new Date('2026-08-03T12:00:00.000Z');
+    await recordStripeCheckoutAttemptReconciliationMiss({
+        attemptId: snapshot.attemptId,
+        cartId: cart.id,
+        observedAt: firstObservedAt,
+    });
+    await recordStripeCheckoutAttemptReconciliationMiss({
+        attemptId: snapshot.attemptId,
+        cartId: cart.id,
+        observedAt: secondObservedAt,
+    });
+
+    assert.deepEqual(
+        await releaseStripeCheckoutAttemptAfterReconciliationMisses({
+            attemptId: snapshot.attemptId,
+            cartId: cart.id,
+            missBefore: new Date(secondObservedAt.getTime() - 60 * 60 * 1000),
+            now: secondObservedAt,
+        }),
+        { status: 'null_deadline' },
+    );
+    assert.ok(await getActiveStripeCheckoutAttempt(cart.id));
+});
+
+test('reconciliation never releases an unbound attempt before its session deadline', async () => {
+    createTestDb();
+    const { accountId, cart } = await createCartWithItem();
+    const snapshot = snapshotFromCart(cart);
+    snapshot.stripeSession.expiresAt = '2030-01-01T00:00:00.000Z';
+    await createStripeCheckoutAttempt(snapshot, { accountId });
+    const observedAt = new Date('2026-08-03T12:00:00.000Z');
+    await recordStripeCheckoutAttemptReconciliationMiss({
+        attemptId: snapshot.attemptId,
+        cartId: cart.id,
+        observedAt,
+    });
+
+    const result = await releaseStripeCheckoutAttemptAfterReconciliationMisses({
+        attemptId: snapshot.attemptId,
+        cartId: cart.id,
+        missBefore: new Date(observedAt.getTime() - 60 * 60 * 1000),
+        now: observedAt,
+    });
+    assert.equal(result.status, 'not_expired');
+    if (result.status === 'not_expired') {
+        assert.equal(
+            result.expiresAt.toISOString(),
+            '2030-01-01T00:00:00.000Z',
+        );
+    }
+    assert.ok(await getActiveStripeCheckoutAttempt(cart.id));
 });

--- a/packages/stripe/src/lib/config.ts
+++ b/packages/stripe/src/lib/config.ts
@@ -4,7 +4,6 @@ import Stripe from 'stripe';
 let stripe: Stripe | null = null;
 
 export const STRIPE_REQUEST_TIMEOUT_MS = 20_000;
-const STRIPE_DEFAULT_MAX_NETWORK_RETRIES = 1;
 
 export function getPublishableKey() {
     const key = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE;
@@ -57,10 +56,7 @@ export function getReturnUrl(params?: Record<string, string> | string) {
 
 export function getStripe() {
     if (!stripe) {
-        stripe = new Stripe(getSecretKey(), {
-            maxNetworkRetries: STRIPE_DEFAULT_MAX_NETWORK_RETRIES,
-            timeout: STRIPE_REQUEST_TIMEOUT_MS,
-        });
+        stripe = new Stripe(getSecretKey(), {});
     }
     return stripe;
 }

--- a/packages/stripe/src/lib/config.ts
+++ b/packages/stripe/src/lib/config.ts
@@ -3,6 +3,9 @@ import Stripe from 'stripe';
 
 let stripe: Stripe | null = null;
 
+export const STRIPE_REQUEST_TIMEOUT_MS = 20_000;
+const STRIPE_DEFAULT_MAX_NETWORK_RETRIES = 1;
+
 export function getPublishableKey() {
     const key = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE;
     if (!key) {
@@ -54,7 +57,10 @@ export function getReturnUrl(params?: Record<string, string> | string) {
 
 export function getStripe() {
     if (!stripe) {
-        stripe = new Stripe(getSecretKey(), {});
+        stripe = new Stripe(getSecretKey(), {
+            maxNetworkRetries: STRIPE_DEFAULT_MAX_NETWORK_RETRIES,
+            timeout: STRIPE_REQUEST_TIMEOUT_MS,
+        });
     }
     return stripe;
 }

--- a/packages/stripe/src/lib/server/index.ts
+++ b/packages/stripe/src/lib/server/index.ts
@@ -1,1 +1,2 @@
+export { STRIPE_REQUEST_TIMEOUT_MS } from '../config';
 export * from './serverStripe';

--- a/packages/stripe/src/lib/server/serverStripe.ts
+++ b/packages/stripe/src/lib/server/serverStripe.ts
@@ -6,6 +6,13 @@ const STRIPE_CHECKOUT_SESSION_PAGE_SIZE = 100;
 const STRIPE_CHECKOUT_SESSION_MAX_PAGES = 100;
 const STRIPE_CHECKOUT_SESSION_CLOCK_SKEW_MS = 5 * 60 * 1000;
 const STRIPE_RECONCILIATION_MAX_NETWORK_RETRIES = 0;
+const STRIPE_RECONCILIATION_REQUEST_TIMEOUT_MS = 5_000;
+const STRIPE_RECONCILIATION_SCAN_BUDGET_MS = 10_000;
+
+const stripeReconciliationRequestOptions = {
+    maxNetworkRetries: STRIPE_RECONCILIATION_MAX_NETWORK_RETRIES,
+    timeout: STRIPE_RECONCILIATION_REQUEST_TIMEOUT_MS,
+} satisfies Stripe.RequestOptions;
 
 export type UserAccount = {
     id: string;
@@ -118,27 +125,53 @@ export type ExhaustiveStripePageResult<T> =
     | {
           status: 'partial';
           pageCount: number;
-          reason: 'invalid_pagination' | 'page_limit' | 'request_failed';
+          reason:
+              | 'invalid_pagination'
+              | 'page_limit'
+              | 'request_failed'
+              | 'time_limit';
       };
 
 export async function collectStripePagesExhaustively<T extends { id: string }>({
     fetchPage,
+    maxDurationMs,
     maxPages = STRIPE_CHECKOUT_SESSION_MAX_PAGES,
+    now = Date.now,
 }: {
     fetchPage: (startingAfter?: string) => Promise<{
         data: T[];
         hasMore: boolean;
     }>;
+    maxDurationMs?: number;
     maxPages?: number;
+    now?: () => number;
 }): Promise<ExhaustiveStripePageResult<T>> {
     if (!Number.isSafeInteger(maxPages) || maxPages <= 0) {
         throw new RangeError('Stripe page limit must be a positive integer.');
     }
+    if (
+        maxDurationMs !== undefined &&
+        (!Number.isSafeInteger(maxDurationMs) || maxDurationMs <= 0)
+    ) {
+        throw new RangeError('Stripe time limit must be a positive integer.');
+    }
 
     const items: T[] = [];
     const cursors = new Set<string>();
+    const startedAt = now();
     let startingAfter: string | undefined;
     for (let pageCount = 1; pageCount <= maxPages; pageCount += 1) {
+        if (
+            pageCount > 1 &&
+            maxDurationMs !== undefined &&
+            now() - startedAt >= maxDurationMs
+        ) {
+            return {
+                status: 'partial',
+                pageCount: pageCount - 1,
+                reason: 'time_limit',
+            };
+        }
         let page: { data: T[]; hasMore: boolean };
         try {
             page = await fetchPage(startingAfter);
@@ -176,60 +209,99 @@ export async function collectStripePagesExhaustively<T extends { id: string }>({
     };
 }
 
+export function getStripeCheckoutSessionCreationRange({
+    createdAt,
+    expiresAt,
+}: {
+    createdAt: Date;
+    expiresAt: Date | null;
+}) {
+    const createdAtMs = createdAt.getTime();
+    const expiresAtMs = expiresAt?.getTime();
+    if (
+        !Number.isFinite(createdAtMs) ||
+        (expiresAtMs !== undefined &&
+            (!Number.isFinite(expiresAtMs) || expiresAtMs < createdAtMs))
+    ) {
+        throw new RangeError('Stripe checkout creation window is invalid.');
+    }
+    const createdGte = Math.floor(
+        (createdAtMs - STRIPE_CHECKOUT_SESSION_CLOCK_SKEW_MS) / 1000,
+    );
+    const latestCreationTime =
+        expiresAtMs ?? createdAtMs + STRIPE_REQUEST_TIMEOUT_MS;
+    const createdLte = Math.ceil(
+        (latestCreationTime + STRIPE_CHECKOUT_SESSION_CLOCK_SKEW_MS) / 1000,
+    );
+    return { gte: createdGte, lte: createdLte };
+}
+
 export function listStripeCheckoutSessionsForCustomerExhaustively({
     createdAt,
     customerId,
+    expiresAt,
 }: {
     createdAt: Date;
     customerId: string;
+    expiresAt: Date | null;
 }) {
-    const createdGte = Math.floor(
-        (createdAt.getTime() - STRIPE_CHECKOUT_SESSION_CLOCK_SKEW_MS) / 1000,
-    );
+    const created = getStripeCheckoutSessionCreationRange({
+        createdAt,
+        expiresAt,
+    });
     return collectStripePagesExhaustively<Stripe.Checkout.Session>({
         fetchPage: async (startingAfter) => {
             const page = await getStripe().checkout.sessions.list(
                 {
-                    created: { gte: createdGte },
+                    created,
                     customer: customerId,
                     limit: STRIPE_CHECKOUT_SESSION_PAGE_SIZE,
                     ...(startingAfter ? { starting_after: startingAfter } : {}),
                 },
-                {
-                    maxNetworkRetries:
-                        STRIPE_RECONCILIATION_MAX_NETWORK_RETRIES,
-                    timeout: STRIPE_REQUEST_TIMEOUT_MS,
-                },
+                stripeReconciliationRequestOptions,
             );
             return { data: page.data, hasMore: page.has_more };
         },
+        maxDurationMs: STRIPE_RECONCILIATION_SCAN_BUDGET_MS,
     });
+}
+
+async function retrieveStripeCheckoutSession(
+    sessionId: string,
+    requestOptions?: Stripe.RequestOptions,
+) {
+    const session = await getStripe().checkout.sessions.retrieve(
+        sessionId,
+        {},
+        requestOptions,
+    );
+    const line_items = await getStripe().checkout.sessions.listLineItems(
+        sessionId,
+        {
+            expand: ['data.price.product'],
+            limit: 100,
+        },
+        requestOptions,
+    );
+    return {
+        id: session.id,
+        customerId: session.customer,
+        status: session.status,
+        paymentId:
+            typeof session.payment_link === 'string'
+                ? session.payment_link
+                : session.payment_link?.id,
+        paymentStatus: session.payment_status,
+        lineItems: line_items,
+        amountTotal: session.amount_total,
+        metadata: session.metadata,
+        url: session.url,
+    };
 }
 
 export async function getStripeCheckoutSession(sessionId: string) {
     try {
-        const session = await getStripe().checkout.sessions.retrieve(sessionId);
-        const line_items = await getStripe().checkout.sessions.listLineItems(
-            sessionId,
-            {
-                expand: ['data.price.product'],
-                limit: 100,
-            },
-        );
-        return {
-            id: session.id,
-            customerId: session.customer,
-            status: session.status,
-            paymentId:
-                typeof session.payment_link === 'string'
-                    ? session.payment_link
-                    : session.payment_link?.id,
-            paymentStatus: session.payment_status,
-            lineItems: line_items,
-            amountTotal: session.amount_total,
-            metadata: session.metadata,
-            url: session.url,
-        };
+        return await retrieveStripeCheckoutSession(sessionId);
     } catch (error) {
         if (error instanceof Error) {
             console.error(
@@ -245,6 +317,13 @@ export async function getStripeCheckoutSession(sessionId: string) {
         }
         throw error;
     }
+}
+
+export function getStripeCheckoutSessionForReconciliation(sessionId: string) {
+    return retrieveStripeCheckoutSession(
+        sessionId,
+        stripeReconciliationRequestOptions,
+    );
 }
 
 export async function stripeSessionCancel(sessionId: string) {

--- a/packages/stripe/src/lib/server/serverStripe.ts
+++ b/packages/stripe/src/lib/server/serverStripe.ts
@@ -1,6 +1,11 @@
 import 'server-only';
 import type Stripe from 'stripe';
-import { getReturnUrl, getStripe } from '../config';
+import { getReturnUrl, getStripe, STRIPE_REQUEST_TIMEOUT_MS } from '../config';
+
+const STRIPE_CHECKOUT_SESSION_PAGE_SIZE = 100;
+const STRIPE_CHECKOUT_SESSION_MAX_PAGES = 100;
+const STRIPE_CHECKOUT_SESSION_CLOCK_SKEW_MS = 5 * 60 * 1000;
+const STRIPE_RECONCILIATION_MAX_NETWORK_RETRIES = 0;
 
 export type UserAccount = {
     id: string;
@@ -102,6 +107,103 @@ export async function getStripeCheckoutSessions(lastDateTime: Date) {
         console.error('Error fetching checkout sessions:', error);
         throw error;
     }
+}
+
+export type ExhaustiveStripePageResult<T> =
+    | {
+          status: 'exhaustive';
+          items: T[];
+          pageCount: number;
+      }
+    | {
+          status: 'partial';
+          pageCount: number;
+          reason: 'invalid_pagination' | 'page_limit' | 'request_failed';
+      };
+
+export async function collectStripePagesExhaustively<T extends { id: string }>({
+    fetchPage,
+    maxPages = STRIPE_CHECKOUT_SESSION_MAX_PAGES,
+}: {
+    fetchPage: (startingAfter?: string) => Promise<{
+        data: T[];
+        hasMore: boolean;
+    }>;
+    maxPages?: number;
+}): Promise<ExhaustiveStripePageResult<T>> {
+    if (!Number.isSafeInteger(maxPages) || maxPages <= 0) {
+        throw new RangeError('Stripe page limit must be a positive integer.');
+    }
+
+    const items: T[] = [];
+    const cursors = new Set<string>();
+    let startingAfter: string | undefined;
+    for (let pageCount = 1; pageCount <= maxPages; pageCount += 1) {
+        let page: { data: T[]; hasMore: boolean };
+        try {
+            page = await fetchPage(startingAfter);
+        } catch {
+            return {
+                status: 'partial',
+                pageCount: pageCount - 1,
+                reason: 'request_failed',
+            };
+        }
+        items.push(...page.data);
+        if (!page.hasMore) {
+            return { status: 'exhaustive', items, pageCount };
+        }
+
+        const cursor = page.data.at(-1)?.id;
+        if (!cursor || cursor === startingAfter || cursors.has(cursor)) {
+            return {
+                status: 'partial',
+                pageCount,
+                reason: 'invalid_pagination',
+            };
+        }
+        if (pageCount === maxPages) {
+            return { status: 'partial', pageCount, reason: 'page_limit' };
+        }
+        cursors.add(cursor);
+        startingAfter = cursor;
+    }
+
+    return {
+        status: 'partial',
+        pageCount: maxPages,
+        reason: 'page_limit',
+    };
+}
+
+export function listStripeCheckoutSessionsForCustomerExhaustively({
+    createdAt,
+    customerId,
+}: {
+    createdAt: Date;
+    customerId: string;
+}) {
+    const createdGte = Math.floor(
+        (createdAt.getTime() - STRIPE_CHECKOUT_SESSION_CLOCK_SKEW_MS) / 1000,
+    );
+    return collectStripePagesExhaustively<Stripe.Checkout.Session>({
+        fetchPage: async (startingAfter) => {
+            const page = await getStripe().checkout.sessions.list(
+                {
+                    created: { gte: createdGte },
+                    customer: customerId,
+                    limit: STRIPE_CHECKOUT_SESSION_PAGE_SIZE,
+                    ...(startingAfter ? { starting_after: startingAfter } : {}),
+                },
+                {
+                    maxNetworkRetries:
+                        STRIPE_RECONCILIATION_MAX_NETWORK_RETRIES,
+                    timeout: STRIPE_REQUEST_TIMEOUT_MS,
+                },
+            );
+            return { data: page.data, hasMore: page.has_more };
+        },
+    });
 }
 
 export async function getStripeCheckoutSession(sessionId: string) {
@@ -220,12 +322,13 @@ export async function stripeCheckout(
         // Create a checkout session in Stripe
         let session: Stripe.Checkout.Session | undefined;
         try {
-            session = await getStripe().checkout.sessions.create(
-                params,
-                options.idempotencyKey
+            session = await getStripe().checkout.sessions.create(params, {
+                ...(options.idempotencyKey
                     ? { idempotencyKey: options.idempotencyKey }
-                    : undefined,
-            );
+                    : {}),
+                maxNetworkRetries: STRIPE_RECONCILIATION_MAX_NETWORK_RETRIES,
+                timeout: STRIPE_REQUEST_TIMEOUT_MS,
+            });
         } catch (err) {
             console.error(err);
             throw err;


### PR DESCRIPTION
## Summary

- recover Stripe checkout attempts whose session creation response was lost
- reconcile both unbound and bound-but-unfinished attempts from the existing five-minute outlet lifecycle cron
- prove session absence with customer-scoped, exhaustively paged, bounded Stripe creation windows before recording two database-timed misses
- keep every transition fail-closed: validate immutable metadata, live cart, canonical customer/user, line items, totals, and session state before binding, fulfilling, or releasing
- rotate a durable append-only cursor per attempt so retained, slow, or malformed candidates cannot starve later paid checkouts
- retry bound fulfillment until the attempt records terminal `completed`
- map concurrent create-race snapshot conflicts to the existing cart-changed 409 instead of an internal error
- keep outlet cleanup independent from Stripe failures and harden cron authentication

## Safety

- no schema migration; reconciliation evidence and cursor state use privacy-safe append-only events
- partial, timed-out, malformed, duplicate, or ambiguous Stripe scans never release an attempt
- autonomous release requires a non-null expired deadline plus two exhaustive no-match scans separated by two minutes and rechecked under the cart lock
- only the exact outlet reservations captured by the immutable attempt snapshot are released
- Stripe create/list/retrieve requests use scoped timeouts and zero automatic retries where ambiguity matters
- this PR follows merged snapshot foundation #4381

## Validation

- `pnpm --filter api test:node` — 407 passed
- focused storage reconciliation/outlet suite — 29 passed, 1 expected PGlite-only skip; the real-PostgreSQL race runs in CI
- focused concurrent create-race tests — 3 passed
- API and Stripe TypeScript checks — passed
- scoped API/storage/Stripe Biome checks — passed
- `git diff --check` — passed
- `pnpm --filter api build` — passed

Closes #4382
