### PR TITLE
fix(storage): clear stale terminal plant dates

### DIFF
--- a/packages/storage/src/repositories/raisedBedFieldsRepo.ts
+++ b/packages/storage/src/repositories/raisedBedFieldsRepo.ts
@@ -986,9 +986,24 @@ function summarizePlantCycle(
                 plantStatus === 'pendingVerification' ||
                 plantStatus === 'sowed'
             ) {
+                active = true;
+                toBeRemoved = false;
+                stoppedDate = undefined;
                 plantSowDate = plantSowDate ?? statusEventDate;
+                plantGrowthDate = undefined;
+                plantReadyDate = undefined;
+                plantDeadDate = undefined;
+                plantHarvestedDate = undefined;
+                plantRemovedDate = undefined;
             } else if (plantStatus === 'sprouted') {
+                active = true;
+                toBeRemoved = false;
+                stoppedDate = undefined;
                 plantGrowthDate = statusEventDate;
+                plantReadyDate = undefined;
+                plantDeadDate = undefined;
+                plantHarvestedDate = undefined;
+                plantRemovedDate = undefined;
             } else if (plantStatus === 'notSprouted') {
                 plantDeadDate = statusEventDate;
                 stoppedDate = statusEventDate;
@@ -997,11 +1012,31 @@ function summarizePlantCycle(
                 plantDeadDate = statusEventDate;
                 stoppedDate = statusEventDate;
             } else if (plantStatus === 'firstFlowers') {
+                active = true;
+                toBeRemoved = false;
+                stoppedDate = undefined;
                 plantGrowthDate = plantGrowthDate ?? statusEventDate;
+                plantReadyDate = undefined;
+                plantDeadDate = undefined;
+                plantHarvestedDate = undefined;
+                plantRemovedDate = undefined;
             } else if (plantStatus === 'firstFruitSet') {
+                active = true;
+                toBeRemoved = false;
+                stoppedDate = undefined;
                 plantGrowthDate = plantGrowthDate ?? statusEventDate;
+                plantReadyDate = undefined;
+                plantDeadDate = undefined;
+                plantHarvestedDate = undefined;
+                plantRemovedDate = undefined;
             } else if (plantStatus === 'ready') {
+                active = true;
+                toBeRemoved = false;
+                stoppedDate = undefined;
                 plantReadyDate = statusEventDate;
+                plantDeadDate = undefined;
+                plantHarvestedDate = undefined;
+                plantRemovedDate = undefined;
             } else if (plantStatus === 'harvested') {
                 plantHarvestedDate = statusEventDate;
                 stoppedDate = statusEventDate;
@@ -1572,9 +1607,24 @@ function reduceRaisedBedFieldWithEvents(
                 plantStatus === 'pendingVerification' ||
                 plantStatus === 'sowed'
             ) {
+                active = true;
+                toBeRemoved = false;
+                stoppedDate = undefined;
                 plantSowDate = plantSowDate ?? statusEventDate;
+                plantGrowthDate = undefined;
+                plantReadyDate = undefined;
+                plantDeadDate = undefined;
+                plantHarvestedDate = undefined;
+                plantRemovedDate = undefined;
             } else if (plantStatus === 'sprouted') {
+                active = true;
+                toBeRemoved = false;
+                stoppedDate = undefined;
                 plantGrowthDate = statusEventDate;
+                plantReadyDate = undefined;
+                plantDeadDate = undefined;
+                plantHarvestedDate = undefined;
+                plantRemovedDate = undefined;
             } else if (plantStatus === 'notSprouted') {
                 plantDeadDate = statusEventDate;
                 stoppedDate = statusEventDate;
@@ -1583,11 +1633,31 @@ function reduceRaisedBedFieldWithEvents(
                 plantDeadDate = statusEventDate;
                 stoppedDate = statusEventDate;
             } else if (plantStatus === 'firstFlowers') {
+                active = true;
+                toBeRemoved = false;
+                stoppedDate = undefined;
                 plantGrowthDate = plantGrowthDate ?? statusEventDate;
+                plantReadyDate = undefined;
+                plantDeadDate = undefined;
+                plantHarvestedDate = undefined;
+                plantRemovedDate = undefined;
             } else if (plantStatus === 'firstFruitSet') {
+                active = true;
+                toBeRemoved = false;
+                stoppedDate = undefined;
                 plantGrowthDate = plantGrowthDate ?? statusEventDate;
+                plantReadyDate = undefined;
+                plantDeadDate = undefined;
+                plantHarvestedDate = undefined;
+                plantRemovedDate = undefined;
             } else if (plantStatus === 'ready') {
+                active = true;
+                toBeRemoved = false;
+                stoppedDate = undefined;
                 plantReadyDate = statusEventDate;
+                plantDeadDate = undefined;
+                plantHarvestedDate = undefined;
+                plantRemovedDate = undefined;
             } else if (plantStatus === 'harvested') {
                 plantHarvestedDate = statusEventDate;
                 stoppedDate = statusEventDate;

--- a/packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts
+++ b/packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts
@@ -1003,6 +1003,82 @@ test('greenhouse outlet seedlings preserve effective sowing date', async () => {
     );
 });
 
+test('live status correction clears stale terminal plant dates', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(
+        gardenId,
+        'block-live-status-correction',
+    );
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+    const aggregateId = `${raisedBedId.toString()}|0`;
+
+    await upsertRaisedBedField({
+        raisedBedId,
+        positionIndex: 0,
+    });
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(aggregateId, {
+            plantSortId: '101',
+            scheduledDate: '2026-06-26T00:00:00.000Z',
+            sowingLocation: 'greenhouse',
+        }),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+            status: 'sowed',
+        }),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+            status: 'sprouted',
+            effectiveDate: '2026-07-13T10:00:00.000Z',
+        }),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+            status: 'died',
+            effectiveDate: '2026-08-02T16:11:19.314Z',
+        }),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+            status: 'sprouted',
+            effectiveDate: '2026-08-02T10:00:00.000Z',
+        }),
+    );
+
+    const [field] = await getRaisedBedFieldsWithEvents(raisedBedId);
+    assert.strictEqual(field?.active, true);
+    assert.strictEqual(field?.plantStatus, 'sprouted');
+    assert.strictEqual(field?.sowingLocation, 'greenhouse');
+    assert.strictEqual(
+        field?.plantGrowthDate?.toISOString(),
+        '2026-08-02T10:00:00.000Z',
+    );
+    assert.strictEqual(field?.plantDeadDate, undefined);
+    assert.strictEqual(field?.plantHarvestedDate, undefined);
+    assert.strictEqual(field?.plantRemovedDate, undefined);
+    assert.strictEqual(field?.stoppedDate, undefined);
+    assert.strictEqual(field?.toBeRemoved, false);
+
+    const [plantCycle] = await getRaisedBedFieldPlantCycles(raisedBedId);
+    assert.strictEqual(plantCycle?.active, true);
+    assert.strictEqual(plantCycle?.plantStatus, 'sprouted');
+    assert.strictEqual(plantCycle?.sowingLocation, 'greenhouse');
+    assert.strictEqual(
+        plantCycle?.plantGrowthDate?.toISOString(),
+        '2026-08-02T10:00:00.000Z',
+    );
+    assert.strictEqual(plantCycle?.plantDeadDate, undefined);
+    assert.strictEqual(plantCycle?.plantHarvestedDate, undefined);
+    assert.strictEqual(plantCycle?.plantRemovedDate, undefined);
+    assert.strictEqual(plantCycle?.stoppedDate, undefined);
+    assert.strictEqual(plantCycle?.toBeRemoved, false);
+});
+
 test('raised bed field assignment metadata is projected for assign and unassign updates', async () => {
     createTestDb();
     const accountId = await createAccount();


### PR DESCRIPTION
## Summary

- Clear stale terminal plant dates when a raised-bed field status is corrected back to a live status.
- Apply the same lifecycle reset to both the current field projection and plant-cycle summaries.
- Add a regression test for a greenhouse-sown plant corrected from `died` back to `sprouted`.

## Root Cause

Raised bed 328, field 10 had one live field row, but its event history included a `died` status followed by a correction back to `sprouted` and `sowingLocation: greenhouse`. The reducer updated `plantStatus` but kept the earlier `plantDeadDate` and `stoppedDate`, causing the admin greenhouse eligibility check to render the plant as being in the raised bed.

## Validation

- `pnpm --dir packages/storage run test:node gardensRepo.raisedBedFields.node.spec.ts`
- `pnpm --filter @gredice/storage lint`
- Verified raised bed 328 field 10 projects as active, sprouted, greenhouse-sown, and greenhouse-eligible with the patched reducer.