### PR TITLE
perf(game): always merge stable block geometry

### DIFF
--- a/apps/garden/app/debug/profile/game/page.tsx
+++ b/apps/garden/app/debug/profile/game/page.tsx
@@ -293,7 +293,6 @@ export default async function GameProfilePage({
         mockGardenProfile === 'high-target' &&
         resolveGameProfileOperationVisuals(firstValue(params.operationVisuals));
     const debugGameFlags = resolveGameProfileFlags(
-        firstValue(params.blockGeometryMerging),
         firstValue(params.adaptiveHigh),
         firstValue(params.weatherSurface),
         firstValue(params.staticSceneCache),
@@ -310,7 +309,6 @@ export default async function GameProfilePage({
         firstValue(params.weatherSurface),
     );
     const adaptiveHigh = debugGameFlags.enableAdaptiveHighQualityFlag;
-    const blockGeometryMerging = debugGameFlags.enableBlockGeometryMergingFlag;
     const isOperationRewardDebug =
         isOperationVisualRewardDebugProfile(mockGardenProfile);
     const quality = resolveQuality(firstValue(params.quality));
@@ -329,9 +327,6 @@ export default async function GameProfilePage({
             data-game-profile-garden-profile={mockGardenProfile}
             data-game-profile-quality={quality ?? 'auto'}
             data-game-profile-adaptive-high={adaptiveHigh ? '1' : '0'}
-            data-game-profile-block-geometry-merging={
-                blockGeometryMerging ? '1' : '0'
-            }
             data-game-profile-closeup-raised-bed-id={
                 closeupRaisedBedId ?? undefined
             }

--- a/apps/garden/app/debug/profile/game/profileFlags.ts
+++ b/apps/garden/app/debug/profile/game/profileFlags.ts
@@ -9,12 +9,6 @@ export const highTargetOperationVisualHighlightTarget = {
     raisedBedId: 2,
 } as const;
 
-export function resolveGameProfileBlockGeometryMerging(
-    value: string | undefined,
-) {
-    return value === '1';
-}
-
 export function resolveGameProfileAdaptiveHigh(value: string | undefined) {
     return value === '1';
 }
@@ -42,7 +36,6 @@ export function resolveGameProfileWeatherSurface(
 }
 
 export function resolveGameProfileFlags(
-    blockGeometryMerging: string | undefined,
     adaptiveHigh: string | undefined,
     weatherSurface: string | undefined,
     staticSceneCache: string | undefined,
@@ -54,8 +47,6 @@ export function resolveGameProfileFlags(
     return {
         enableAdaptiveHighQualityFlag:
             resolveGameProfileAdaptiveHigh(adaptiveHigh),
-        enableBlockGeometryMergingFlag:
-            resolveGameProfileBlockGeometryMerging(blockGeometryMerging),
         enableDebugHudFlag: true,
         enableIntegratedWeatherSurfacesFlag:
             weatherSurfaceMode === 'integrated',

--- a/apps/garden/app/debug/profile/game/profileFlags.unit.ts
+++ b/apps/garden/app/debug/profile/game/profileFlags.unit.ts
@@ -3,7 +3,6 @@ import { describe, it } from 'node:test';
 import {
     highTargetOperationVisualHighlightTarget,
     resolveGameProfileAdaptiveHigh,
-    resolveGameProfileBlockGeometryMerging,
     resolveGameProfileFlags,
     resolveGameProfileOperationVisuals,
     resolveGameProfileStaticSceneCache,
@@ -17,21 +16,6 @@ describe('resolveGameProfileAdaptiveHigh', () => {
         assert.equal(resolveGameProfileAdaptiveHigh('0'), false);
         assert.equal(resolveGameProfileAdaptiveHigh('unexpected'), false);
         assert.equal(resolveGameProfileAdaptiveHigh('1'), true);
-    });
-});
-
-describe('resolveGameProfileBlockGeometryMerging', () => {
-    it('preserves the existing profiler default', () => {
-        assert.equal(resolveGameProfileBlockGeometryMerging(undefined), false);
-        assert.equal(
-            resolveGameProfileBlockGeometryMerging('unexpected'),
-            false,
-        );
-    });
-
-    it('supports explicit enabled and disabled profile comparisons', () => {
-        assert.equal(resolveGameProfileBlockGeometryMerging('1'), true);
-        assert.equal(resolveGameProfileBlockGeometryMerging('0'), false);
     });
 });
 
@@ -55,41 +39,32 @@ describe('resolveGameProfileOperationVisuals', () => {
 describe('resolveGameProfileFlags', () => {
     it('defaults production-profile weather surfaces to the integrated path', () => {
         assert.deepEqual(
-            resolveGameProfileFlags(undefined, undefined, undefined, undefined),
+            resolveGameProfileFlags(undefined, undefined, undefined),
             {
                 enableAdaptiveHighQualityFlag: false,
-                enableBlockGeometryMergingFlag: false,
                 enableDebugHudFlag: true,
                 enableIntegratedWeatherSurfacesFlag: true,
                 enableRainWetOverlayFlag: true,
                 enableStaticOpaqueSceneCacheFlag: true,
             },
         );
-        assert.deepEqual(
-            resolveGameProfileFlags('0', '1', 'integrated', 'cache'),
-            {
-                enableAdaptiveHighQualityFlag: true,
-                enableBlockGeometryMergingFlag: false,
-                enableDebugHudFlag: true,
-                enableIntegratedWeatherSurfacesFlag: true,
-                enableRainWetOverlayFlag: true,
-                enableStaticOpaqueSceneCacheFlag: true,
-            },
-        );
+        assert.deepEqual(resolveGameProfileFlags('1', 'integrated', 'cache'), {
+            enableAdaptiveHighQualityFlag: true,
+            enableDebugHudFlag: true,
+            enableIntegratedWeatherSurfacesFlag: true,
+            enableRainWetOverlayFlag: true,
+            enableStaticOpaqueSceneCacheFlag: true,
+        });
     });
 
     it('allows explicit legacy weather-surface and scene-cache comparisons', () => {
-        assert.deepEqual(
-            resolveGameProfileFlags('1', '0', 'legacy', 'legacy'),
-            {
-                enableAdaptiveHighQualityFlag: false,
-                enableBlockGeometryMergingFlag: true,
-                enableDebugHudFlag: true,
-                enableIntegratedWeatherSurfacesFlag: false,
-                enableRainWetOverlayFlag: true,
-                enableStaticOpaqueSceneCacheFlag: false,
-            },
-        );
+        assert.deepEqual(resolveGameProfileFlags('0', 'legacy', 'legacy'), {
+            enableAdaptiveHighQualityFlag: false,
+            enableDebugHudFlag: true,
+            enableIntegratedWeatherSurfacesFlag: false,
+            enableRainWetOverlayFlag: true,
+            enableStaticOpaqueSceneCacheFlag: false,
+        });
     });
 });
 

--- a/apps/garden/app/flags.ts
+++ b/apps/garden/app/flags.ts
@@ -24,13 +24,6 @@ export const rainWetOverlayFlag = flag<boolean>({
     options: booleanFlagOptions,
 });
 
-export const blockGeometryMergingFlag = flag<boolean>({
-    key: 'blockGeometryMerging',
-    description: 'Enable merged geometry chunks for stable terrain blocks.',
-    decide: () => true,
-    options: booleanFlagOptions,
-});
-
 export const adaptiveHighQualityFlag = flag<boolean>({
     key: 'adaptiveHighQuality',
     description:

--- a/apps/garden/app/getGardenGameFlags.ts
+++ b/apps/garden/app/getGardenGameFlags.ts
@@ -1,7 +1,6 @@
 import type { GameFeatureFlags } from '@gredice/game';
 import {
     adaptiveHighQualityFlag,
-    blockGeometryMergingFlag,
     enableDebugHudFlag,
     enableSuncokretChatFlag,
     enableSuncokretDebugFlag,
@@ -12,7 +11,6 @@ import {
 export async function getGardenGameFlags(): Promise<GameFeatureFlags> {
     const [
         enableAdaptiveHighQualityFlag,
-        enableBlockGeometryMergingFlag,
         enableDebugHud,
         enableRainWetOverlayFlag,
         enableStaticOpaqueSceneCacheFlag,
@@ -20,7 +18,6 @@ export async function getGardenGameFlags(): Promise<GameFeatureFlags> {
         enableSuncokretDebug,
     ] = await Promise.all([
         adaptiveHighQualityFlag(),
-        blockGeometryMergingFlag(),
         enableDebugHudFlag(),
         rainWetOverlayFlag(),
         staticOpaqueSceneCacheFlag(),
@@ -30,7 +27,6 @@ export async function getGardenGameFlags(): Promise<GameFeatureFlags> {
 
     return {
         enableAdaptiveHighQualityFlag,
-        enableBlockGeometryMergingFlag,
         enableDebugHudFlag: enableDebugHud,
         enableRainWetOverlayFlag,
         enableStaticOpaqueSceneCacheFlag,

--- a/apps/garden/scripts/profile-game-scene.mjs
+++ b/apps/garden/scripts/profile-game-scene.mjs
@@ -239,7 +239,7 @@ const denseScenarios = [
 const highTargetScenarios = [
     {
         name: 'game-high-target-clear-idle-desktop',
-        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -248,7 +248,7 @@ const highTargetScenarios = [
     },
     {
         name: 'game-high-target-camera-motion-desktop',
-        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -258,7 +258,7 @@ const highTargetScenarios = [
     },
     {
         name: 'game-high-target-hover-selection-desktop',
-        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -268,7 +268,7 @@ const highTargetScenarios = [
     },
     {
         name: 'game-high-target-placement-desktop',
-        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&placement=1',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&placement=1',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -281,7 +281,7 @@ const highTargetScenarios = [
     },
     {
         name: 'game-high-target-rain-desktop',
-        path: '/debug/profile/game?mode=rain&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1',
+        path: '/debug/profile/game?mode=rain&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -290,7 +290,7 @@ const highTargetScenarios = [
     },
     {
         name: 'game-high-target-snow-desktop',
-        path: '/debug/profile/game?mode=snow&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1',
+        path: '/debug/profile/game?mode=snow&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -302,7 +302,7 @@ const highTargetScenarios = [
 const highTargetOperationVisualScenarios = [
     {
         name: 'game-high-target-operation-visuals-desktop',
-        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&operationVisuals=1',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&operationVisuals=1',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -314,7 +314,7 @@ const highTargetOperationVisualScenarios = [
 const highTargetFoliageBudgetScenarios = [
     {
         name: 'game-high-target-foliage-unbudgeted-zoom-desktop',
-        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&foliageBudget=legacy',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&foliageBudget=legacy',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -327,7 +327,7 @@ const highTargetFoliageBudgetScenarios = [
     },
     {
         name: 'game-high-target-foliage-budget-zoom-desktop',
-        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&foliageBudget=1',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&foliageBudget=1',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -343,7 +343,7 @@ const highTargetFoliageBudgetScenarios = [
 const highTargetWeatherMaterialScenarios = [
     {
         name: 'game-high-target-rain-legacy-weather-surfaces-desktop',
-        path: '/debug/profile/game?mode=rain&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&weatherSurface=legacy',
+        path: '/debug/profile/game?mode=rain&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&weatherSurface=legacy',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -354,7 +354,7 @@ const highTargetWeatherMaterialScenarios = [
     },
     {
         name: 'game-high-target-rain-integrated-weather-surfaces-desktop',
-        path: '/debug/profile/game?mode=rain&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&weatherSurface=integrated',
+        path: '/debug/profile/game?mode=rain&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&weatherSurface=integrated',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -365,7 +365,7 @@ const highTargetWeatherMaterialScenarios = [
     },
     {
         name: 'game-high-target-snow-legacy-weather-surfaces-desktop',
-        path: '/debug/profile/game?mode=snow&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&weatherSurface=legacy',
+        path: '/debug/profile/game?mode=snow&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&weatherSurface=legacy',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -376,7 +376,7 @@ const highTargetWeatherMaterialScenarios = [
     },
     {
         name: 'game-high-target-snow-integrated-weather-surfaces-desktop',
-        path: '/debug/profile/game?mode=snow&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&weatherSurface=integrated',
+        path: '/debug/profile/game?mode=snow&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&weatherSurface=integrated',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -390,7 +390,7 @@ const highTargetWeatherMaterialScenarios = [
 const highTargetStaticSceneCacheScenarios = [
     {
         name: 'game-high-target-static-scene-cache-legacy-desktop',
-        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=0&details=1&hud=0&debugHud=0&blockGeometryMerging=1&staticSceneCache=legacy',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=0&details=1&hud=0&debugHud=0&staticSceneCache=legacy',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -403,7 +403,7 @@ const highTargetStaticSceneCacheScenarios = [
     },
     {
         name: 'game-high-target-static-scene-cache-cached-desktop',
-        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=0&details=1&hud=0&debugHud=0&blockGeometryMerging=1&staticSceneCache=cache',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=0&details=1&hud=0&debugHud=0&staticSceneCache=cache',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -416,7 +416,7 @@ const highTargetStaticSceneCacheScenarios = [
     },
     {
         name: 'game-high-target-static-scene-cache-cloudy-legacy-desktop',
-        path: '/debug/profile/game?mode=cloudy&profile=high-target&quality=high&controls=0&details=1&hud=0&debugHud=0&blockGeometryMerging=1&staticSceneCache=legacy&fixedTimeSeconds=12',
+        path: '/debug/profile/game?mode=cloudy&profile=high-target&quality=high&controls=0&details=1&hud=0&debugHud=0&staticSceneCache=legacy&fixedTimeSeconds=12',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -430,7 +430,7 @@ const highTargetStaticSceneCacheScenarios = [
     },
     {
         name: 'game-high-target-static-scene-cache-cloudy-cached-desktop',
-        path: '/debug/profile/game?mode=cloudy&profile=high-target&quality=high&controls=0&details=1&hud=0&debugHud=0&blockGeometryMerging=1&staticSceneCache=cache&fixedTimeSeconds=12',
+        path: '/debug/profile/game?mode=cloudy&profile=high-target&quality=high&controls=0&details=1&hud=0&debugHud=0&staticSceneCache=cache&fixedTimeSeconds=12',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -444,7 +444,7 @@ const highTargetStaticSceneCacheScenarios = [
     },
     {
         name: 'game-high-target-static-scene-cache-occlusion-fixture-desktop',
-        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=0&details=1&hud=0&debugHud=0&blockGeometryMerging=1&staticSceneCache=cache&staticSceneCacheOcclusionFixture=1',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=0&details=1&hud=0&debugHud=0&staticSceneCache=cache&staticSceneCacheOcclusionFixture=1',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -458,7 +458,7 @@ const highTargetStaticSceneCacheScenarios = [
 const highTargetWeatherOnsetScenarios = [
     {
         name: 'game-high-target-snow-onset-legacy-weather-surfaces-desktop',
-        path: '/debug/profile/game?mode=snow-onset&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&weatherSurface=legacy',
+        path: '/debug/profile/game?mode=snow-onset&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&weatherSurface=legacy',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -467,7 +467,7 @@ const highTargetWeatherOnsetScenarios = [
     },
     {
         name: 'game-high-target-snow-onset-integrated-weather-surfaces-desktop',
-        path: '/debug/profile/game?mode=snow-onset&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&weatherSurface=integrated',
+        path: '/debug/profile/game?mode=snow-onset&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&weatherSurface=integrated',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -476,7 +476,7 @@ const highTargetWeatherOnsetScenarios = [
     },
     {
         name: 'game-high-target-snow-threshold-transition-integrated-weather-surfaces-desktop',
-        path: '/debug/profile/game?mode=snow-onset&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&weatherSurface=integrated',
+        path: '/debug/profile/game?mode=snow-onset&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&weatherSurface=integrated',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -489,7 +489,7 @@ const highTargetWeatherOnsetScenarios = [
 const outlineScenarios = [
     {
         name: 'game-high-target-connected-raised-bed-outline-desktop',
-        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&outline=1',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&outline=1',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -505,7 +505,7 @@ const outlineScenarios = [
 const adaptiveHighScenarios = [
     {
         name: 'game-high-target-adaptive-pair-fixed-camera-motion-desktop',
-        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -517,7 +517,7 @@ const adaptiveHighScenarios = [
     },
     {
         name: 'game-high-target-adaptive-camera-motion-desktop',
-        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&adaptiveHigh=1',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&adaptiveHigh=1',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -530,7 +530,7 @@ const adaptiveHighScenarios = [
     },
     {
         name: 'game-high-target-adaptive-motion-recovery-desktop',
-        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&adaptiveHigh=1',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&adaptiveHigh=1',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -544,7 +544,7 @@ const adaptiveHighScenarios = [
     },
     {
         name: 'game-high-target-adaptive-runtime-gpu-source-desktop',
-        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&adaptiveHigh=1',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&adaptiveHigh=1',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -555,7 +555,7 @@ const adaptiveHighScenarios = [
     },
     {
         name: 'game-high-target-adaptive-placement-desktop',
-        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&placement=1&adaptiveHigh=1',
+        path: '/debug/profile/game?mode=details&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&placement=1&adaptiveHigh=1',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -569,7 +569,7 @@ const adaptiveHighScenarios = [
     },
     {
         name: 'game-high-target-adaptive-rain-desktop',
-        path: '/debug/profile/game?mode=rain&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&adaptiveHigh=1',
+        path: '/debug/profile/game?mode=rain&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&adaptiveHigh=1',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -578,7 +578,7 @@ const adaptiveHighScenarios = [
     },
     {
         name: 'game-high-target-adaptive-snow-desktop',
-        path: '/debug/profile/game?mode=snow&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&adaptiveHigh=1',
+        path: '/debug/profile/game?mode=snow&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&adaptiveHigh=1',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -587,7 +587,7 @@ const adaptiveHighScenarios = [
     },
     {
         name: 'game-high-target-adaptive-cloudy-desktop',
-        path: '/debug/profile/game?mode=cloudy&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&adaptiveHigh=1',
+        path: '/debug/profile/game?mode=cloudy&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&adaptiveHigh=1',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -596,7 +596,7 @@ const adaptiveHighScenarios = [
     },
     {
         name: 'game-high-target-adaptive-windy-plants-desktop',
-        path: '/debug/profile/game?mode=windy&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1&adaptiveHigh=1',
+        path: '/debug/profile/game?mode=windy&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&adaptiveHigh=1',
         viewport: { width: 1280, height: 720 },
         dpr: 2,
         isMobile: false,
@@ -1329,8 +1329,6 @@ function getScenarioRequest(path) {
     const url = new URL(path, 'http://profile.local');
     return {
         adaptiveHigh: url.searchParams.get('adaptiveHigh') ?? '0',
-        blockGeometryMerging:
-            url.searchParams.get('blockGeometryMerging') ?? 'default',
         controls: url.searchParams.get('controls') ?? '0',
         closeupRaisedBedId:
             Number.parseInt(
@@ -2800,8 +2798,6 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                     typeof deviceMemory === 'number' ? deviceMemory : null,
                 narrowViewport: window.innerWidth <= 640,
             },
-            blockGeometryMerging:
-                element.dataset.gameProfileBlockGeometryMerging ?? null,
             controls: element.dataset.gameProfileControls ?? null,
             closeupRaisedBedId:
                 Number.parseInt(
@@ -2887,9 +2883,6 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 autoQualityDeviceClass:
                     scenario.autoQualityDeviceClass ?? 'unspecified',
                 autoQualityMetrics: profileMetadata?.autoQualityMetrics ?? null,
-                blockGeometryMerging:
-                    profileMetadata?.blockGeometryMerging ??
-                    request.blockGeometryMerging,
                 closeupRaisedBedId:
                     profileMetadata?.closeupRaisedBedId ??
                     request.closeupRaisedBedId,
@@ -4511,9 +4504,6 @@ async function measureScenario(browser, baseUrl, scenario, options) {
         autoQualityDeviceClass:
             scenario.autoQualityDeviceClass ?? 'unspecified',
         autoQualityMetrics: profileMetadata?.autoQualityMetrics ?? null,
-        blockGeometryMerging:
-            profileMetadata?.blockGeometryMerging ??
-            request.blockGeometryMerging,
         comparisonPair: scenario.comparisonPair ?? null,
         comparisonRole: scenario.comparisonRole ?? null,
         controls: profileMetadata?.controls ?? request.controls,
@@ -4915,7 +4905,6 @@ function evaluateHighTargetAcceptance({
                   runtime?.groundDecorationVisibleCount,
                   500,
               ),
-        exact('highTargetGeometryMerging', requested.blockGeometryMerging, '1'),
         exact('highTargetCanvasClientWidth', sample.canvas?.clientWidth, 1280),
         exact('highTargetCanvasClientHeight', sample.canvas?.clientHeight, 720),
         ...(adaptiveHighRequested
@@ -8398,8 +8387,8 @@ function buildMarkdown(report) {
         '',
         `Budget status: ${report.summary.failedScenarios === 0 ? 'pass' : 'fail'}`,
         '',
-        '| Scenario | Mode | Profile | Merged | Details | Controls | HUD | Debug HUD | Motion | Quality | Canvas | Shadow | Rain/Snow | Rain off | Overlays/Decor | Browser FPS | Rendered FPS | p95 | Max | Draw/frame | Draw/render | Triangles/frame | Triangles/render | Long tasks | Heap | Run diagnostic | Screenshot |',
-        '| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |',
+        '| Scenario | Mode | Profile | Details | Controls | HUD | Debug HUD | Motion | Quality | Canvas | Shadow | Rain/Snow | Rain off | Overlays/Decor | Browser FPS | Rendered FPS | p95 | Max | Draw/frame | Draw/render | Triangles/frame | Triangles/render | Long tasks | Heap | Run diagnostic | Screenshot |',
+        '| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |',
     ];
 
     for (const scenario of report.scenarios) {
@@ -8437,7 +8426,7 @@ function buildMarkdown(report) {
             : 'n/a';
         const screenshot = scenario.screenshotPath ?? 'n/a';
         lines.push(
-            `| ${scenario.name} | ${scenario.requested.mode} | ${scenario.requested.gardenProfile} | ${scenario.requested.blockGeometryMerging} | ${scenario.requested.details} | ${scenario.requested.controls} | ${scenario.requested.hud} | ${scenario.requested.debugHud} | ${scenario.requested.motion} | ${quality} | ${canvas} | ${shadow} | ${weather} | ${rainUnmount} | ${detailCounts} | ${scenario.sample.fps} | ${scenario.sample.renderedFps} | ${scenario.sample.p95FrameMs} ms | ${scenario.sample.maxFrameMs} ms | ${scenario.sample.drawCallsPerFrame} | ${scenario.sample.drawCallsPerRenderedFrame} | ${scenario.sample.trianglesPerFrame} | ${scenario.sample.trianglesPerRenderedFrame} | ${scenario.sample.longTaskCount} | ${scenario.sample.jsHeapMb ?? 'n/a'} MB | ${scenario.budget.pass ? 'pass' : 'fail'} | ${screenshot} |`,
+            `| ${scenario.name} | ${scenario.requested.mode} | ${scenario.requested.gardenProfile} | ${scenario.requested.details} | ${scenario.requested.controls} | ${scenario.requested.hud} | ${scenario.requested.debugHud} | ${scenario.requested.motion} | ${quality} | ${canvas} | ${shadow} | ${weather} | ${rainUnmount} | ${detailCounts} | ${scenario.sample.fps} | ${scenario.sample.renderedFps} | ${scenario.sample.p95FrameMs} ms | ${scenario.sample.maxFrameMs} ms | ${scenario.sample.drawCallsPerFrame} | ${scenario.sample.drawCallsPerRenderedFrame} | ${scenario.sample.trianglesPerFrame} | ${scenario.sample.trianglesPerRenderedFrame} | ${scenario.sample.longTaskCount} | ${scenario.sample.jsHeapMb ?? 'n/a'} MB | ${scenario.budget.pass ? 'pass' : 'fail'} | ${screenshot} |`,
         );
     }
 

--- a/apps/garden/scripts/profile-game-scene.unit.mjs
+++ b/apps/garden/scripts/profile-game-scene.unit.mjs
@@ -160,7 +160,6 @@ test('high target scenario set covers representative High DPR 2 phases', () => {
         assert.equal(scenario.budget, 'gameHighTarget');
         assert.equal(scenario.dpr, 2);
         assert.equal(scenario.isMobile, false);
-        assert.equal(request.blockGeometryMerging, '1');
         assert.equal(request.controls, '1');
         assert.equal(request.debugHud, '0');
         assert.equal(request.details, '1');
@@ -189,7 +188,6 @@ test('operation-visual High scenario is isolated behind its own opt-in set', () 
     assert.equal(scenario.repeat, 3);
     assert.deepEqual(getScenarioRequest(scenario.path), {
         adaptiveHigh: '0',
-        blockGeometryMerging: '1',
         closeupRaisedBedId: null,
         controls: '1',
         debugHud: '0',
@@ -358,7 +356,6 @@ test('static scene-cache High scenarios use deterministic five-run ABBA pairs', 
         assert.equal(scenario.isMobile, false);
         assert.equal(scenario.repeat, 5);
         assert.equal(scenario.staticSceneCacheBenchmark, true);
-        assert.equal(request.blockGeometryMerging, '1');
         assert.equal(request.controls, '0');
         assert.equal(request.details, '1');
         assert.equal(request.gardenProfile, 'high-target');
@@ -692,12 +689,11 @@ test('historical dense High stays at DPR 1 while high-target uses DPR 2', () => 
 
 test('profile request parses the High target fixture contract', () => {
     const request = getScenarioRequest(
-        '/debug/profile/game?mode=snow&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0&blockGeometryMerging=1',
+        '/debug/profile/game?mode=snow&profile=high-target&quality=high&controls=1&details=1&hud=0&debugHud=0',
     );
 
     assert.deepEqual(request, {
         adaptiveHigh: '0',
-        blockGeometryMerging: '1',
         closeupRaisedBedId: null,
         controls: '1',
         debugHud: '0',
@@ -824,7 +820,6 @@ test('markdown reports per-rAF and per-render work in separate columns', () => {
                 name: 'work-columns',
                 pageErrors: [],
                 requested: {
-                    blockGeometryMerging: 'default',
                     controls: '0',
                     debugHud: '0',
                     details: '1',
@@ -899,7 +894,6 @@ test('markdown distinguishes controlled governor evidence and formats range fail
                 pageErrors: [],
                 requested: {
                     adaptiveHigh: '1',
-                    blockGeometryMerging: '1',
                     controls: '1',
                     debugHud: '0',
                     details: '1',
@@ -1210,7 +1204,6 @@ test('high target acceptance proves the intended workload rendered', () => {
         apiErrors: [],
         pageErrors: [],
         requested: {
-            blockGeometryMerging: '1',
             gardenProfile: 'high-target',
             mode: 'rain',
             motion: 'hover-scan',
@@ -1380,7 +1373,6 @@ test('operation-visual High acceptance gates batching, uploads, mulch, and highl
         apiErrors: [],
         pageErrors: [],
         requested: {
-            blockGeometryMerging: '1',
             gardenProfile: 'high-target',
             mode: 'details',
             motion: 'none',
@@ -1587,7 +1579,6 @@ test('foliage-budget High acceptance keeps normal-view foliage clustered', () =>
         apiErrors: [],
         pageErrors: [],
         requested: {
-            blockGeometryMerging: '1',
             foliageBudget: '1',
             gardenProfile: 'high-target',
             mode: 'details',
@@ -1693,7 +1684,6 @@ test('weather-surface High acceptance proves integrated work without hiding fall
             apiErrors: [],
             pageErrors: [],
             requested: {
-                blockGeometryMerging: '1',
                 gardenProfile: 'high-target',
                 mode,
                 motion: 'none',
@@ -2363,7 +2353,6 @@ test('adaptive High acceptance allows bounded effective DPR during interaction',
         pageErrors: [],
         requested: {
             adaptiveHigh: '1',
-            blockGeometryMerging: '1',
             gardenProfile: 'high-target',
             mode: 'details',
             motion: 'pan-zoom-rotate',
@@ -2723,7 +2712,6 @@ test('high target acceptance distinguishes a cached map from refreshes and reset
             apiErrors: [],
             pageErrors: [],
             requested: {
-                blockGeometryMerging: '1',
                 gardenProfile: 'high-target',
                 mode: 'details',
                 quality: 'high',
@@ -2799,7 +2787,6 @@ test('high target placement acceptance requires one deferred final shadow flush'
         apiErrors: [],
         pageErrors: [],
         requested: {
-            blockGeometryMerging: '1',
             gardenProfile: 'high-target',
             mode: 'details',
             placementProfile: 'placement-drop',
@@ -2878,7 +2865,6 @@ test('high target acceptance requires the full workload to remain visible', () =
         apiErrors: [],
         pageErrors: [],
         requested: {
-            blockGeometryMerging: '1',
             gardenProfile: 'high-target',
             mode: 'details',
             quality: 'high',
@@ -2939,7 +2925,6 @@ test('high target acceptance rejects failed API requests', () => {
         ],
         pageErrors: [],
         requested: {
-            blockGeometryMerging: '1',
             gardenProfile: 'high-target',
             mode: 'details',
             quality: 'high',
@@ -2984,7 +2969,6 @@ test('high target acceptance rejects failed API requests', () => {
 
 test('static scene-cache acceptance requires a warm, stable timed window', () => {
     const requested = {
-        blockGeometryMerging: '1',
         comparisonPair: 'static-opaque-scene-cache',
         comparisonRole: 'cache',
         gardenProfile: 'high-target',
@@ -3137,7 +3121,6 @@ test('cloudy static scene-cache acceptance proves live cloud attenuation without
         consoleMessages: [],
         pageErrors: [],
         requested: {
-            blockGeometryMerging: '1',
             comparisonPair: 'static-opaque-scene-cache-cloudy',
             comparisonRole: 'cache',
             fixedTimeSeconds: 12,
@@ -3231,7 +3214,6 @@ test('cloudy static scene-cache acceptance proves live cloud attenuation without
 
 test('static scene-cache occlusion acceptance requires cached depth and live layers on verified hits', () => {
     const requested = {
-        blockGeometryMerging: '1',
         gardenProfile: 'high-target',
         mode: 'details',
         quality: 'high',
@@ -3401,7 +3383,6 @@ test('high target acceptance rejects a demand-render scene with one frame', () =
         apiErrors: [],
         pageErrors: [],
         requested: {
-            blockGeometryMerging: '1',
             gardenProfile: 'high-target',
             mode: 'details',
             quality: 'high',
@@ -3461,7 +3442,6 @@ test('high target acceptance rejects zero work and an incomplete fixture', () =>
         ],
         pageErrors: ['render failed'],
         requested: {
-            blockGeometryMerging: '0',
             gardenProfile: 'high-target',
             mode: 'snow',
             quality: 'medium',

--- a/apps/garden/tests/GardenPreviewCaptureStory.tsx
+++ b/apps/garden/tests/GardenPreviewCaptureStory.tsx
@@ -255,7 +255,6 @@ export function GardenPreviewCaptureStory() {
                     }}
                     className="size-full"
                     deferDetails={false}
-                    enableBlockGeometryMerging
                     garden={captureGarden}
                     spriteBaseUrl={assetBaseUrl}
                 />

--- a/apps/www/app/flags.ts
+++ b/apps/www/app/flags.ts
@@ -12,13 +12,6 @@ export const lSystemPlantsFlag = flag<boolean>({
     options: booleanFlagOptions,
 });
 
-export const blockGeometryMergingFlag = flag<boolean>({
-    key: 'blockGeometryMerging',
-    description: 'Enable merged geometry chunks for stable terrain blocks.',
-    decide: () => true,
-    options: booleanFlagOptions,
-});
-
 export const recipesFlag = flag<boolean>({
     key: 'recipes',
     description: 'Enable recipes pages and recipe detail routes.',

--- a/apps/www/app/korisnici/[publicId]/ProfilePageClient.tsx
+++ b/apps/www/app/korisnici/[publicId]/ProfilePageClient.tsx
@@ -8,14 +8,10 @@ import { useState } from 'react';
 import { PublicGardenViewerDynamic } from './PublicGardenViewerDynamic';
 
 type ProfilePageClientProps = {
-    enableBlockGeometryMerging?: boolean;
     publicId: string;
 };
 
-export function ProfilePageClient({
-    enableBlockGeometryMerging = false,
-    publicId,
-}: ProfilePageClientProps) {
+export function ProfilePageClient({ publicId }: ProfilePageClientProps) {
     const profileQuery = useQuery({
         queryKey: ['public-profile', publicId],
         queryFn: async () => {
@@ -142,9 +138,6 @@ export function ProfilePageClient({
                     ) : (
                         <PublicGardenViewerDynamic
                             className="h-full"
-                            enableBlockGeometryMerging={
-                                enableBlockGeometryMerging
-                            }
                             garden={gardenQuery.data}
                         />
                     )}

--- a/apps/www/app/korisnici/[publicId]/page.tsx
+++ b/apps/www/app/korisnici/[publicId]/page.tsx
@@ -1,4 +1,3 @@
-import { blockGeometryMergingFlag } from '../../flags';
 import { ProfilePageClient } from './ProfilePageClient';
 
 type ProfilePageProps = {
@@ -8,15 +7,7 @@ type ProfilePageProps = {
 };
 
 export default async function ProfilePage({ params }: ProfilePageProps) {
-    const [{ publicId }, enableBlockGeometryMerging] = await Promise.all([
-        params,
-        blockGeometryMergingFlag(),
-    ]);
+    const { publicId } = await params;
 
-    return (
-        <ProfilePageClient
-            enableBlockGeometryMerging={enableBlockGeometryMerging}
-            publicId={publicId}
-        />
-    );
+    return <ProfilePageClient publicId={publicId} />;
 }

--- a/apps/www/app/vrtovi/PublicGardenExplorer.tsx
+++ b/apps/www/app/vrtovi/PublicGardenExplorer.tsx
@@ -9,13 +9,11 @@ import { PublicGardenViewerDynamic } from './PublicGardenViewerDynamic';
 
 export function PublicGardenExplorer({
     className,
-    enableBlockGeometryMerging = false,
     framed = true,
     garden,
     size = 'default',
 }: {
     className?: string;
-    enableBlockGeometryMerging?: boolean;
     framed?: boolean;
     garden: PublicGardenViewerProps['garden'];
     size?: 'card' | 'default';
@@ -92,7 +90,6 @@ export function PublicGardenExplorer({
                 <PublicGardenViewerDynamic
                     className="size-full"
                     deferDetails={false}
-                    enableBlockGeometryMerging={enableBlockGeometryMerging}
                     garden={garden}
                 />
                 {supportsFullscreen ? (

--- a/apps/www/app/vrtovi/PublicGardenPreviewBackfill.tsx
+++ b/apps/www/app/vrtovi/PublicGardenPreviewBackfill.tsx
@@ -300,7 +300,6 @@ export function PublicGardenPreviewBackfill({
                 }}
                 className="size-full"
                 deferDetails={false}
-                enableBlockGeometryMerging
                 garden={activeCapture.garden}
                 spriteBaseUrl={gameAssetBaseUrl}
             />

--- a/apps/www/app/vrtovi/[gardenId]/page.tsx
+++ b/apps/www/app/vrtovi/[gardenId]/page.tsx
@@ -6,7 +6,6 @@ import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { KnownPages } from '../../../src/KnownPages';
-import { blockGeometryMergingFlag } from '../../flags';
 import { PublicGardenExplorer } from '../PublicGardenExplorer';
 import { PublicGardenLikeButton } from '../PublicGardenLikeButton';
 import { PublicGardenStatsAccordion } from '../PublicGardenStatsAccordion';
@@ -93,10 +92,9 @@ export default async function PublicGardenPage({
         notFound();
     }
 
-    const [garden, blockData, enableBlockGeometryMerging] = await Promise.all([
+    const [garden, blockData] = await Promise.all([
         getPublicGardenForWww(gardenId),
         getPublicGardenBlockDataForWww(),
-        blockGeometryMergingFlag(),
     ]);
     const activePlantCount = countActivePlantsFromPublicGarden(garden);
     const gardenStats = calculatePublicGardenStats(garden, blockData);
@@ -119,7 +117,6 @@ export default async function PublicGardenPage({
                 }}
             >
                 <PublicGardenExplorer
-                    enableBlockGeometryMerging={enableBlockGeometryMerging}
                     framed={false}
                     garden={garden}
                     size="card"

--- a/packages/game/src/GameFlagsContext.tsx
+++ b/packages/game/src/GameFlagsContext.tsx
@@ -11,7 +11,6 @@ export interface GameFeatureFlags {
     enableRaisedBedFieldOperationsFlag?: boolean;
     enableRaisedBedFieldWateringFlag?: boolean;
     enableRaisedBedFieldDiaryFlag?: boolean;
-    enableBlockGeometryMergingFlag?: boolean;
     enableIntegratedWeatherSurfacesFlag?: boolean;
     enableRainWetOverlayFlag?: boolean;
     enableStaticOpaqueSceneCacheFlag?: boolean;

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -501,9 +501,6 @@ export function GameScene({
                                     </Suspense>
                                 )}
                                 <EntityInstances
-                                    enableBlockGeometryMerging={Boolean(
-                                        flags?.enableBlockGeometryMergingFlag,
-                                    )}
                                     farmId={garden?.farmId}
                                     quality={qualityProfile}
                                     renderGroundDecorations={

--- a/packages/game/src/GardenPreviewCaptureController.tsx
+++ b/packages/game/src/GardenPreviewCaptureController.tsx
@@ -333,7 +333,6 @@ export function GardenPreviewCaptureController({
                 }}
                 className="size-full"
                 deferDetails={false}
-                enableBlockGeometryMerging
                 garden={captureGarden}
                 spriteBaseUrl={spriteBaseUrl}
             />

--- a/packages/game/src/entities/AdditionalEntityInstances.tsx
+++ b/packages/game/src/entities/AdditionalEntityInstances.tsx
@@ -84,9 +84,6 @@ type CommonWeatherProps = Pick<
     EntityInstancesBlockBaseProps,
     'renderSnow' | 'snowOverlayMinCoverage'
 >;
-type BlockGeometryMergingProps = {
-    enableBlockGeometryMerging?: boolean;
-};
 
 type ScaleTuple = [number, number, number];
 type ScaleInput = number | ScaleTuple | { x: number; y: number; z: number };
@@ -363,11 +360,9 @@ function InstancedWaterSurfaceMaterial() {
 }
 
 function BlockGroundInstances({
-    enableBlockGeometryMerging = false,
     stacks,
     ...commonSnowProps
-}: { stacks: Stack[] | undefined } & CommonWeatherProps &
-    BlockGeometryMergingProps) {
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
     const { nodes } = useGameGLTF('BlockGround');
     const groundMaterial11 = useGroundPatchMaterial(
         nodes.Block_Ground_1.material,
@@ -402,7 +397,7 @@ function BlockGroundInstances({
                     slopeExponent: 3.2,
                     noiseScale: 1.7,
                 }}
-                renderStableChunksAsMergedGeometry={enableBlockGeometryMerging}
+                renderStableChunksAsMergedGeometry
                 {...commonSnowProps}
             />
             <EntityInstancesGeometry
@@ -416,7 +411,7 @@ function BlockGroundInstances({
                     slopeExponent: 3.2,
                     noiseScale: 1.7,
                 }}
-                renderStableChunksAsMergedGeometry={enableBlockGeometryMerging}
+                renderStableChunksAsMergedGeometry
                 {...commonSnowProps}
             />
         </>
@@ -2418,11 +2413,9 @@ const birdHouseRoofNodes = [
 ] satisfies (keyof GLTFResult['nodes'])[];
 
 function SimpleAdditionalInstances({
-    enableBlockGeometryMerging = false,
     stacks,
     ...commonSnowProps
-}: { stacks: Stack[] | undefined } & CommonWeatherProps &
-    BlockGeometryMergingProps) {
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
     const snowmanMaterial = useMemo(
         () =>
             new MeshStandardMaterial({
@@ -2449,7 +2442,7 @@ function SimpleAdditionalInstances({
                     slopeExponent: 2.2,
                     noiseScale: 1.8,
                 }}
-                renderStableChunksAsMergedGeometry={enableBlockGeometryMerging}
+                renderStableChunksAsMergedGeometry
                 {...commonSnowProps}
             />
             <AssetBlock
@@ -2466,7 +2459,7 @@ function SimpleAdditionalInstances({
                     slopeExponent: 2.2,
                     noiseScale: 1.8,
                 }}
-                renderStableChunksAsMergedGeometry={enableBlockGeometryMerging}
+                renderStableChunksAsMergedGeometry
                 {...commonSnowProps}
             />
             <AssetBlock
@@ -2487,7 +2480,7 @@ function SimpleAdditionalInstances({
                     slopeExponent: 2.2,
                     noiseScale: 1.8,
                 }}
-                renderStableChunksAsMergedGeometry={enableBlockGeometryMerging}
+                renderStableChunksAsMergedGeometry
                 {...commonSnowProps}
             />
             <AssetBlock
@@ -2548,23 +2541,13 @@ function SimpleAdditionalInstances({
 }
 
 export function AdditionalEntityInstances({
-    enableBlockGeometryMerging = false,
     stacks,
     ...commonSnowProps
-}: { stacks: Stack[] | undefined } & CommonWeatherProps &
-    BlockGeometryMergingProps) {
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
     return (
         <>
-            <BlockGroundInstances
-                enableBlockGeometryMerging={enableBlockGeometryMerging}
-                stacks={stacks}
-                {...commonSnowProps}
-            />
-            <SimpleAdditionalInstances
-                enableBlockGeometryMerging={enableBlockGeometryMerging}
-                stacks={stacks}
-                {...commonSnowProps}
-            />
+            <BlockGroundInstances stacks={stacks} {...commonSnowProps} />
+            <SimpleAdditionalInstances stacks={stacks} {...commonSnowProps} />
             <WaterBlockInstances stacks={stacks} />
             <RaisedBedInstances stacks={stacks} {...commonSnowProps} />
             <ShadeInstances stacks={stacks} {...commonSnowProps} />

--- a/packages/game/src/entities/EntityInstances.tsx
+++ b/packages/game/src/entities/EntityInstances.tsx
@@ -229,7 +229,6 @@ function EntityInstancesAssetBlock(props: EntityInstancesAssetBlockProps) {
 }
 
 export function EntityInstances({
-    enableBlockGeometryMerging = false,
     farmId,
     quality,
     renderGroundDecorations,
@@ -237,7 +236,6 @@ export function EntityInstances({
     renderDetails = true,
     weather,
 }: {
-    enableBlockGeometryMerging?: boolean;
     farmId?: number | null;
     quality?: GameQualityProfile;
     renderGroundDecorations?: boolean;
@@ -312,7 +310,7 @@ export function EntityInstances({
         snowOverlayMinCoverage: qualityProfile.snowOverlayMinCoverage,
     };
     const mergedTerrainChunkProps = {
-        renderStableChunksAsMergedGeometry: enableBlockGeometryMerging,
+        renderStableChunksAsMergedGeometry: true,
     };
 
     return (
@@ -799,7 +797,6 @@ export function EntityInstances({
             </Suspense>
             <Suspense fallback={null}>
                 <AdditionalEntityInstances
-                    enableBlockGeometryMerging={enableBlockGeometryMerging}
                     stacks={stacks}
                     {...commonSnowProps}
                 />

--- a/packages/game/src/viewers/PublicGardenViewer.tsx
+++ b/packages/game/src/viewers/PublicGardenViewer.tsx
@@ -101,7 +101,6 @@ export type PublicGardenViewerProps = HTMLAttributes<HTMLDivElement> & {
     stacks?: PublicGardenStack[];
     appBaseUrl?: string;
     spriteBaseUrl?: string;
-    enableBlockGeometryMerging?: boolean;
     deferDetails?: boolean;
     className?: string;
     capture?: {
@@ -280,7 +279,6 @@ function publicGardenTimeLocation(
 
 function PublicGardenScene({
     capture,
-    enableBlockGeometryMerging,
     initialView,
     className,
     garden,
@@ -290,7 +288,6 @@ function PublicGardenScene({
     renderDetails,
 }: {
     capture?: PublicGardenViewerProps['capture'];
-    enableBlockGeometryMerging: boolean;
     initialView: PublicGardenInitialView;
     className?: string;
     garden?: ReturnType<typeof publicGardenForGameState>;
@@ -373,9 +370,6 @@ function PublicGardenScene({
                                         )),
                                     )}
                                     <EntityInstances
-                                        enableBlockGeometryMerging={
-                                            enableBlockGeometryMerging
-                                        }
                                         farmId={garden?.farmId}
                                         quality={qualityProfile}
                                         renderGroundDecorations={
@@ -513,7 +507,6 @@ export function PublicGardenViewer({
     appBaseUrl,
     capture,
     spriteBaseUrl,
-    enableBlockGeometryMerging = false,
     deferDetails = true,
     garden,
     stacks,
@@ -673,9 +666,6 @@ export function PublicGardenViewer({
                                 <PublicGardenScene
                                     capture={capture}
                                     className="size-full"
-                                    enableBlockGeometryMerging={
-                                        enableBlockGeometryMerging
-                                    }
                                     garden={gameGarden}
                                     gardenCacheReady={gardenCacheReady}
                                     initialView={initialView}


### PR DESCRIPTION
## What changed

- enable stable terrain block geometry merging unconditionally in the shared game renderer
- remove the Garden and WWW feature flag, context field, and viewer/component prop plumbing
- remove the profiler query option, metadata, acceptance check, report column, and fixtures

## Why

Geometry merging is already the production default and should now apply consistently to every renderer consumer without an opt-out path.

## Validation

- `pnpm lint --filter @gredice/game --filter garden --filter www`
- `pnpm typecheck --filter @gredice/game --filter garden --filter www`
- `pnpm test --filter @gredice/game` (780 tests)
- profiler unit tests (68 tests)
- `git diff --check`
