### PR TITLE
[Checkout] Skip redundant delivery lookup

### DIFF
--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -59,6 +59,7 @@ import {
 } from '../../../lib/checkout/checkoutTiming';
 import {
     CheckoutDeliverySelectionError,
+    resolveCheckoutRequiresDelivery,
     validateCheckoutDeliverySelection,
 } from '../../../lib/checkout/deliverySelection';
 import { getDirectCheckoutPaymentErrorResponse } from '../../../lib/checkout/directCheckoutErrors';
@@ -377,11 +378,13 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
             }> = [];
 
             try {
-                const requiresDelivery = await cartContainsDeliverableItems(
-                    cart.id,
-                    {
-                        excludeCartItemIds: [...mappedOperationCartItemIds],
-                    },
+                const requiresDelivery = await resolveCheckoutRequiresDelivery(
+                    cart.items,
+                    mappedOperationCartItemIds,
+                    () =>
+                        cartContainsDeliverableItems(cart.id, {
+                            excludeCartItemIds: [...mappedOperationCartItemIds],
+                        }),
                 );
                 const requiresMutableDeliveryPreflight =
                     mappedOperationCartItemIds.size === 0 || requiresDelivery;

--- a/apps/api/lib/checkout/deliverySelection.node.spec.ts
+++ b/apps/api/lib/checkout/deliverySelection.node.spec.ts
@@ -3,6 +3,8 @@ import { describe, it } from 'node:test';
 import {
     CheckoutDeliverySelectionError,
     checkoutDeliverySelectionErrorCodes,
+    hasCheckoutDeliveryLookupCandidate,
+    resolveCheckoutRequiresDelivery,
     validateCheckoutDeliverySelection,
 } from './deliverySelection';
 
@@ -15,6 +17,105 @@ const deliverySlot = {
     effectiveClosesAt: new Date('2026-07-26T08:00:00.000Z'),
     locationId: 3,
 };
+
+describe('hasCheckoutDeliveryLookupCandidate', () => {
+    const operationItem = {
+        entityTypeName: 'operation',
+        id: 42,
+        isDeleted: false,
+        status: 'new',
+    };
+
+    it('skips lookup for non-operation items', () => {
+        assert.equal(
+            hasCheckoutDeliveryLookupCandidate(
+                [{ ...operationItem, entityTypeName: 'sunflowerPackage' }],
+                new Set(),
+            ),
+            false,
+        );
+    });
+
+    it('skips lookup for paid operation items', () => {
+        assert.equal(
+            hasCheckoutDeliveryLookupCandidate(
+                [{ ...operationItem, status: 'paid' }],
+                new Set(),
+            ),
+            false,
+        );
+    });
+
+    it('skips lookup for deleted operation items', () => {
+        assert.equal(
+            hasCheckoutDeliveryLookupCandidate(
+                [{ ...operationItem, isDeleted: true }],
+                new Set(),
+            ),
+            false,
+        );
+    });
+
+    it('skips lookup for mapped operation items', () => {
+        assert.equal(
+            hasCheckoutDeliveryLookupCandidate(
+                [operationItem],
+                new Set([operationItem.id]),
+            ),
+            false,
+        );
+    });
+
+    it('requires the authoritative lookup for an eligible operation', () => {
+        assert.equal(
+            hasCheckoutDeliveryLookupCandidate([operationItem], new Set()),
+            true,
+        );
+    });
+});
+
+describe('resolveCheckoutRequiresDelivery', () => {
+    const operationItem = {
+        entityTypeName: 'operation',
+        id: 42,
+        isDeleted: false,
+        status: 'new',
+    };
+
+    it('does not call the authoritative lookup for an ineligible cart', async () => {
+        let lookupCalls = 0;
+
+        const requiresDelivery = await resolveCheckoutRequiresDelivery(
+            [{ ...operationItem, entityTypeName: 'sunflowerPackage' }],
+            new Set(),
+            async () => {
+                lookupCalls += 1;
+                return true;
+            },
+        );
+
+        assert.equal(requiresDelivery, false);
+        assert.equal(lookupCalls, 0);
+    });
+
+    for (const authoritativeResult of [false, true]) {
+        it(`calls the authoritative lookup once and returns ${authoritativeResult.toString()}`, async () => {
+            let lookupCalls = 0;
+
+            const requiresDelivery = await resolveCheckoutRequiresDelivery(
+                [operationItem],
+                new Set(),
+                async () => {
+                    lookupCalls += 1;
+                    return authoritativeResult;
+                },
+            );
+
+            assert.equal(requiresDelivery, authoritativeResult);
+            assert.equal(lookupCalls, 1);
+        });
+    }
+});
 
 describe('validateCheckoutDeliverySelection', () => {
     it('requires a selection for a cart with deliverable items', () => {

--- a/apps/api/lib/checkout/deliverySelection.ts
+++ b/apps/api/lib/checkout/deliverySelection.ts
@@ -24,6 +24,13 @@ interface CheckoutPickupLocation {
     isActive: boolean;
 }
 
+interface CheckoutDeliveryLookupCartItem {
+    entityTypeName: string;
+    id: number;
+    isDeleted: boolean;
+    status: string;
+}
+
 export const checkoutDeliverySelectionErrorCodes = {
     REQUIRED: 'delivery-selection-required',
     SLOT_UNAVAILABLE: 'delivery-slot-unavailable',
@@ -45,6 +52,33 @@ export class CheckoutDeliverySelectionError extends Error {
     ) {
         super(message);
     }
+}
+
+export function hasCheckoutDeliveryLookupCandidate(
+    items: readonly CheckoutDeliveryLookupCartItem[],
+    mappedOperationCartItemIds: ReadonlySet<number>,
+) {
+    return items.some(
+        (item) =>
+            item.entityTypeName === 'operation' &&
+            item.status === 'new' &&
+            !item.isDeleted &&
+            !mappedOperationCartItemIds.has(item.id),
+    );
+}
+
+export async function resolveCheckoutRequiresDelivery(
+    items: readonly CheckoutDeliveryLookupCartItem[],
+    mappedOperationCartItemIds: ReadonlySet<number>,
+    lookupDeliverableItems: () => Promise<boolean>,
+) {
+    if (
+        !hasCheckoutDeliveryLookupCandidate(items, mappedOperationCartItemIds)
+    ) {
+        return false;
+    }
+
+    return lookupDeliverableItems();
 }
 
 export function validateCheckoutDeliverySelection({


### PR DESCRIPTION
## Summary

- skip the deliverable-item repository lookup when the normalized cart has no pending, non-deleted, unmapped operation item
- retain the authoritative repository lookup and all existing delivery/harvest validation when a candidate operation exists
- cover predicate parity, zero-call short-circuiting, exactly-once lookup, and authoritative boolean propagation

Closes #4399.

## Validation

- focused delivery selection tests: 12/12 passed
- full API Node suite: 456/456 passed
- API typecheck passed
- API production build passed
- Biome check on the three changed files passed
- `git diff --check` passed
- combined `pnpm test --filter api`: build passed and 18 Playwright cases passed; 4 unrelated landing cases could not start locally because the managed Chromium launch is denied and `POSTGRES_URL` is unavailable in this worktree. CI remains authoritative for the browser suite.

## Deployment

- no schema, migration, dependency, or environment-variable changes
- existing privacy-safe checkout phase telemetry is unchanged