### PR TITLE
[Game] Enable optimized plant rendering

### DIFF
--- a/apps/garden/app/debug/animals/page.tsx
+++ b/apps/garden/app/debug/animals/page.tsx
@@ -6,7 +6,6 @@ const animalDebugStorageKey = 'gredice.debug.sandbox.animals.v1';
 
 const animalDebugFlags = {
     enableDebugHudFlag: true,
-    enableRainWetOverlayFlag: true,
 } satisfies NonNullable<ComponentProps<typeof GameScene>['flags']>;
 
 const animalDebugFreezeTime = new Date('2026-06-02T10:00:00+02:00');

--- a/apps/garden/app/debug/profile/game/page.tsx
+++ b/apps/garden/app/debug/profile/game/page.tsx
@@ -7,6 +7,7 @@ import {
 import { ProfileGameScene } from './ProfileGameScene';
 import {
     highTargetOperationVisualHighlightTarget,
+    resolveGameProfileAdaptiveHigh,
     resolveGameProfileFlags,
     resolveGameProfileOperationVisuals,
     resolveGameProfileStaticSceneCache,
@@ -293,9 +294,7 @@ export default async function GameProfilePage({
         mockGardenProfile === 'high-target' &&
         resolveGameProfileOperationVisuals(firstValue(params.operationVisuals));
     const debugGameFlags = resolveGameProfileFlags(
-        firstValue(params.adaptiveHigh),
         firstValue(params.weatherSurface),
-        firstValue(params.staticSceneCache),
     );
     const staticSceneCacheMode = resolveGameProfileStaticSceneCache(
         firstValue(params.staticSceneCache),
@@ -308,7 +307,9 @@ export default async function GameProfilePage({
     const weatherSurfaceMode = resolveGameProfileWeatherSurface(
         firstValue(params.weatherSurface),
     );
-    const adaptiveHigh = debugGameFlags.enableAdaptiveHighQualityFlag;
+    const adaptiveHigh = resolveGameProfileAdaptiveHigh(
+        firstValue(params.adaptiveHigh),
+    );
     const isOperationRewardDebug =
         isOperationVisualRewardDebugProfile(mockGardenProfile);
     const quality = resolveQuality(firstValue(params.quality));
@@ -355,6 +356,7 @@ export default async function GameProfilePage({
             }
         >
             <ProfileGameScene
+                adaptiveHighQuality={adaptiveHigh}
                 key={mode}
                 className="h-full w-full"
                 dayNightCycleDisabled={false}
@@ -379,6 +381,7 @@ export default async function GameProfilePage({
                 noControls={!enableControls}
                 noSound
                 renderDetails={renderDetails}
+                staticOpaqueSceneCache={staticSceneCacheMode === 'cache'}
                 weather={weather}
                 winterMode={mode === 'snow' ? 'winter' : 'summer'}
                 zoom={isOperationRewardDebug ? 'far' : 'normal'}

--- a/apps/garden/app/debug/profile/game/profileFlags.ts
+++ b/apps/garden/app/debug/profile/game/profileFlags.ts
@@ -35,22 +35,12 @@ export function resolveGameProfileWeatherSurface(
     return value === 'legacy' ? 'legacy' : 'integrated';
 }
 
-export function resolveGameProfileFlags(
-    adaptiveHigh: string | undefined,
-    weatherSurface: string | undefined,
-    staticSceneCache: string | undefined,
-) {
+export function resolveGameProfileFlags(weatherSurface: string | undefined) {
     const weatherSurfaceMode = resolveGameProfileWeatherSurface(weatherSurface);
-    const staticSceneCacheMode =
-        resolveGameProfileStaticSceneCache(staticSceneCache);
 
     return {
-        enableAdaptiveHighQualityFlag:
-            resolveGameProfileAdaptiveHigh(adaptiveHigh),
         enableDebugHudFlag: true,
         enableIntegratedWeatherSurfacesFlag:
             weatherSurfaceMode === 'integrated',
-        enableRainWetOverlayFlag: true,
-        enableStaticOpaqueSceneCacheFlag: staticSceneCacheMode === 'cache',
     } satisfies NonNullable<GameSceneProps['flags']>;
 }

--- a/apps/garden/app/debug/profile/game/profileFlags.unit.ts
+++ b/apps/garden/app/debug/profile/game/profileFlags.unit.ts
@@ -38,32 +38,20 @@ describe('resolveGameProfileOperationVisuals', () => {
 
 describe('resolveGameProfileFlags', () => {
     it('defaults production-profile weather surfaces to the integrated path', () => {
-        assert.deepEqual(
-            resolveGameProfileFlags(undefined, undefined, undefined),
-            {
-                enableAdaptiveHighQualityFlag: false,
-                enableDebugHudFlag: true,
-                enableIntegratedWeatherSurfacesFlag: true,
-                enableRainWetOverlayFlag: true,
-                enableStaticOpaqueSceneCacheFlag: true,
-            },
-        );
-        assert.deepEqual(resolveGameProfileFlags('1', 'integrated', 'cache'), {
-            enableAdaptiveHighQualityFlag: true,
+        assert.deepEqual(resolveGameProfileFlags(undefined), {
             enableDebugHudFlag: true,
             enableIntegratedWeatherSurfacesFlag: true,
-            enableRainWetOverlayFlag: true,
-            enableStaticOpaqueSceneCacheFlag: true,
+        });
+        assert.deepEqual(resolveGameProfileFlags('integrated'), {
+            enableDebugHudFlag: true,
+            enableIntegratedWeatherSurfacesFlag: true,
         });
     });
 
-    it('allows explicit legacy weather-surface and scene-cache comparisons', () => {
-        assert.deepEqual(resolveGameProfileFlags('0', 'legacy', 'legacy'), {
-            enableAdaptiveHighQualityFlag: false,
+    it('allows explicit legacy weather-surface comparisons', () => {
+        assert.deepEqual(resolveGameProfileFlags('legacy'), {
             enableDebugHudFlag: true,
             enableIntegratedWeatherSurfacesFlag: false,
-            enableRainWetOverlayFlag: true,
-            enableStaticOpaqueSceneCacheFlag: false,
         });
     });
 });

--- a/apps/garden/app/debug/sandbox/page.tsx
+++ b/apps/garden/app/debug/sandbox/page.tsx
@@ -4,7 +4,6 @@ import { SandboxDebugActions } from './SandboxDebugActions';
 
 const debugSandboxFlags = {
     enableDebugHudFlag: true,
-    enableRainWetOverlayFlag: true,
 } satisfies NonNullable<ComponentProps<typeof GameScene>['flags']>;
 
 export default function DebugSandboxPage() {

--- a/apps/garden/app/flags.ts
+++ b/apps/garden/app/flags.ts
@@ -17,29 +17,6 @@ export const addressDistanceVerificationFlag = flag<boolean>({
     options: booleanFlagOptions,
 });
 
-export const rainWetOverlayFlag = flag<boolean>({
-    key: 'rainWetOverlay',
-    description: 'Enable rain wetness overlays on exposed garden entities.',
-    decide: () => false,
-    options: booleanFlagOptions,
-});
-
-export const adaptiveHighQualityFlag = flag<boolean>({
-    key: 'adaptiveHighQuality',
-    description:
-        'Adapt the runtime ceiling of manually selected High game quality.',
-    decide: () => true,
-    options: booleanFlagOptions,
-});
-
-export const staticOpaqueSceneCacheFlag = flag<boolean>({
-    key: 'staticOpaqueSceneCache',
-    description:
-        'Cache stable opaque terrain while rendering the game at High quality.',
-    decide: () => true,
-    options: booleanFlagOptions,
-});
-
 export const enableDebugCloseupFlag = flag<boolean>({
     key: 'enableDebugCloseup',
     decide: () => false,

--- a/apps/garden/app/getGardenGameFlags.ts
+++ b/apps/garden/app/getGardenGameFlags.ts
@@ -1,35 +1,20 @@
 import type { GameFeatureFlags } from '@gredice/game';
 import {
-    adaptiveHighQualityFlag,
     enableDebugHudFlag,
     enableSuncokretChatFlag,
     enableSuncokretDebugFlag,
-    rainWetOverlayFlag,
-    staticOpaqueSceneCacheFlag,
 } from './flags';
 
 export async function getGardenGameFlags(): Promise<GameFeatureFlags> {
-    const [
-        enableAdaptiveHighQualityFlag,
-        enableDebugHud,
-        enableRainWetOverlayFlag,
-        enableStaticOpaqueSceneCacheFlag,
-        enableSuncokretChat,
-        enableSuncokretDebug,
-    ] = await Promise.all([
-        adaptiveHighQualityFlag(),
-        enableDebugHudFlag(),
-        rainWetOverlayFlag(),
-        staticOpaqueSceneCacheFlag(),
-        enableSuncokretChatFlag(),
-        enableSuncokretDebugFlag(),
-    ]);
+    const [enableDebugHud, enableSuncokretChat, enableSuncokretDebug] =
+        await Promise.all([
+            enableDebugHudFlag(),
+            enableSuncokretChatFlag(),
+            enableSuncokretDebugFlag(),
+        ]);
 
     return {
-        enableAdaptiveHighQualityFlag,
         enableDebugHudFlag: enableDebugHud,
-        enableRainWetOverlayFlag,
-        enableStaticOpaqueSceneCacheFlag,
         enableSuncokretChatFlag: enableSuncokretChat,
         enableSuncokretDebugFlag: enableSuncokretDebug,
     };

--- a/apps/garden/scripts/profile-game-scene.mjs
+++ b/apps/garden/scripts/profile-game-scene.mjs
@@ -29,7 +29,7 @@ const highTargetOperationVisualHighlightObjectCount = 2;
 const highTargetOperationVisualLegacyObjectCount = 452;
 const highTargetOperationVisualRenderedObjectLimit = 64;
 const highTargetGeneratedPlantDetailInstanceBudget = 179;
-const highTargetExpectedGeneratedPlantClusterTriangleCount = 3_354;
+const highTargetBudgetedGeneratedPlantClusterTriangleCount = 2_740;
 const highTargetWeatherSurfaceExpectations = {
     rain: {
         avoidedOverlaySubmissionCount: 16,
@@ -2753,20 +2753,57 @@ async function measureScenario(browser, baseUrl, scenario, options) {
                 { timeout: 90_000 },
             );
         } else {
-            await page.waitForFunction(
-                (expected) => {
+            try {
+                await page.waitForFunction(
+                    ({ expectedClusterCount, expectedDetailCount }) => {
+                        const profile = globalThis.__grediceGameProfile;
+                        return (
+                            profile?.generatedPlantClusterInstanceCount ===
+                                expectedClusterCount &&
+                            profile.generatedPlantRenderNearInstanceCount ===
+                                expectedDetailCount &&
+                            profile.generatedPlantDetailedInstanceCount ===
+                                expectedDetailCount &&
+                            profile.generatedPlantPendingDetailInstanceCount ===
+                                0
+                        );
+                    },
+                    {
+                        expectedClusterCount:
+                            highTargetExpectedGeneratedPlantInstanceCount -
+                            highTargetGeneratedPlantDetailInstanceBudget,
+                        expectedDetailCount:
+                            highTargetGeneratedPlantDetailInstanceBudget,
+                    },
+                    { timeout: 90_000 },
+                );
+            } catch (error) {
+                const readiness = await page.evaluate(() => {
                     const profile = globalThis.__grediceGameProfile;
-                    return (
-                        profile?.generatedPlantClusterInstanceCount ===
-                            expected &&
-                        profile.generatedPlantRenderNearInstanceCount === 0 &&
-                        profile.generatedPlantDetailedInstanceCount === 0 &&
-                        profile.generatedPlantPendingDetailInstanceCount === 0
-                    );
-                },
-                highTargetExpectedGeneratedPlantInstanceCount,
-                { timeout: 90_000 },
-            );
+                    return {
+                        admittedBeds:
+                            profile?.generatedPlantDetailAdmittedBedCount,
+                        admittedInstances:
+                            profile?.generatedPlantDetailAdmittedInstanceCount,
+                        clusterInstances:
+                            profile?.generatedPlantClusterInstanceCount,
+                        detailedInstances:
+                            profile?.generatedPlantDetailedInstanceCount,
+                        nearInstances:
+                            profile?.generatedPlantRenderNearInstanceCount,
+                        pendingInstances:
+                            profile?.generatedPlantPendingDetailInstanceCount,
+                        requestedBeds:
+                            profile?.generatedPlantDetailRequestedBedCount,
+                        requestedInstances:
+                            profile?.generatedPlantDetailRequestedInstanceCount,
+                    };
+                });
+                throw new Error(
+                    `Budgeted foliage detail did not become ready: ${JSON.stringify(readiness)}`,
+                    { cause: error },
+                );
+            }
         }
     }
     const adaptiveHighProfileControlStarted = scenario.profileControl
@@ -4927,32 +4964,32 @@ function evaluateHighTargetAcceptance({
                   exact(
                       'highTargetFoliageRequestedBeds',
                       runtime?.generatedPlantDetailRequestedBedCount,
-                      0,
+                      3,
                   ),
                   exact(
                       'highTargetFoliageRequestedInstances',
                       runtime?.generatedPlantDetailRequestedInstanceCount,
-                      0,
+                      highTargetExpectedGeneratedPlantInstanceCount,
                   ),
                   exact(
                       'highTargetFoliageAdmittedBeds',
                       runtime?.generatedPlantDetailAdmittedBedCount,
-                      0,
+                      1,
                   ),
                   exact(
                       'highTargetFoliageAdmittedInstances',
                       runtime?.generatedPlantDetailAdmittedInstanceCount,
-                      0,
+                      highTargetGeneratedPlantDetailInstanceBudget,
                   ),
                   exact(
                       'highTargetFoliageUsedBudget',
                       runtime?.generatedPlantDetailUsedBudgetInstanceCount,
-                      0,
+                      highTargetGeneratedPlantDetailInstanceBudget,
                   ),
                   exact(
                       'highTargetFoliageDemotedBeds',
                       runtime?.generatedPlantDetailDemotedBedCount,
-                      0,
+                      2,
                   ),
                   exact(
                       'highTargetFoliageSelectedOverflow',
@@ -4962,29 +4999,30 @@ function evaluateHighTargetAcceptance({
                   exact(
                       'highTargetFoliageNearFields',
                       runtime?.generatedPlantNearFieldCount,
-                      0,
+                      18,
                   ),
                   exact(
                       'highTargetFoliageNearInstances',
                       runtime?.generatedPlantNearInstanceCount,
-                      0,
+                      highTargetGeneratedPlantDetailInstanceBudget,
                   ),
                   exact(
                       'highTargetFoliageClusterFields',
                       (runtime?.generatedPlantMidFieldCount ?? 0) +
                           (runtime?.generatedPlantFarFieldCount ?? 0),
-                      highTargetExpectedGeneratedPlantFieldCount,
+                      highTargetExpectedGeneratedPlantFieldCount - 18,
                   ),
                   exact(
                       'highTargetFoliageClusterLodInstances',
                       (runtime?.generatedPlantMidInstanceCount ?? 0) +
                           (runtime?.generatedPlantFarInstanceCount ?? 0),
-                      highTargetExpectedGeneratedPlantInstanceCount,
+                      highTargetExpectedGeneratedPlantInstanceCount -
+                          highTargetGeneratedPlantDetailInstanceBudget,
                   ),
                   exact(
                       'highTargetFoliageDetailedRenderInstances',
                       runtime?.generatedPlantDetailedInstanceCount,
-                      0,
+                      highTargetGeneratedPlantDetailInstanceBudget,
                   ),
                   exact(
                       'highTargetFoliagePendingDetailInstances',
@@ -4994,18 +5032,19 @@ function evaluateHighTargetAcceptance({
                   exact(
                       'highTargetFoliageClusterInstances',
                       runtime?.generatedPlantClusterInstanceCount,
-                      highTargetExpectedGeneratedPlantInstanceCount,
+                      highTargetExpectedGeneratedPlantInstanceCount -
+                          highTargetGeneratedPlantDetailInstanceBudget,
                   ),
                   exact(
                       'highTargetFoliageClusterPrimitiveTriangles',
                       runtime?.generatedPlantClusterPrimitiveTriangleCount,
-                      highTargetExpectedGeneratedPlantClusterTriangleCount,
+                      highTargetBudgetedGeneratedPlantClusterTriangleCount,
                   ),
                   range(
                       'highTargetFoliageRenderBatches',
                       runtime?.generatedPlantRenderBatchCount,
                       3,
-                      6,
+                      12,
                   ),
               ]
             : []),

--- a/apps/garden/scripts/profile-game-scene.unit.mjs
+++ b/apps/garden/scripts/profile-game-scene.unit.mjs
@@ -1574,7 +1574,7 @@ test('operation-visual High acceptance gates batching, uploads, mulch, and highl
     );
 });
 
-test('foliage-budget High acceptance keeps normal-view foliage clustered', () => {
+test('foliage-budget High acceptance admits one normal-view detail bed', () => {
     const input = {
         apiErrors: [],
         pageErrors: [],
@@ -1592,27 +1592,27 @@ test('foliage-budget High acceptance keeps normal-view foliage clustered', () =>
             actorGroundingShadowPrimaryCasterCount: 0,
             actorGroundingShadowVisibleCount: 5,
             animatedCasterShadowRefreshCount: 0,
-            generatedPlantClusterInstanceCount: 537,
-            generatedPlantClusterPrimitiveTriangleCount: 3_354,
-            generatedPlantDetailedInstanceCount: 0,
-            generatedPlantDetailAdmittedBedCount: 0,
-            generatedPlantDetailAdmittedInstanceCount: 0,
+            generatedPlantClusterInstanceCount: 358,
+            generatedPlantClusterPrimitiveTriangleCount: 2_740,
+            generatedPlantDetailedInstanceCount: 179,
+            generatedPlantDetailAdmittedBedCount: 1,
+            generatedPlantDetailAdmittedInstanceCount: 179,
             generatedPlantDetailBudgetInstanceCount: 179,
-            generatedPlantDetailDemotedBedCount: 0,
+            generatedPlantDetailDemotedBedCount: 2,
             generatedPlantDetailOverflowInstanceCount: 0,
-            generatedPlantDetailRequestedBedCount: 0,
-            generatedPlantDetailRequestedInstanceCount: 0,
+            generatedPlantDetailRequestedBedCount: 3,
+            generatedPlantDetailRequestedInstanceCount: 537,
             generatedPlantDetailTransitionCount: 0,
-            generatedPlantDetailUsedBudgetInstanceCount: 0,
+            generatedPlantDetailUsedBudgetInstanceCount: 179,
             generatedPlantExpectedInstanceCount: 537,
             generatedPlantFarFieldCount: 9,
             generatedPlantFarInstanceCount: 81,
             generatedPlantFieldCount: 54,
             generatedPlantInstanceCount: 537,
-            generatedPlantMidFieldCount: 45,
-            generatedPlantMidInstanceCount: 456,
-            generatedPlantNearFieldCount: 0,
-            generatedPlantNearInstanceCount: 0,
+            generatedPlantMidFieldCount: 27,
+            generatedPlantMidInstanceCount: 277,
+            generatedPlantNearFieldCount: 18,
+            generatedPlantNearInstanceCount: 179,
             generatedPlantPendingDetailInstanceCount: 0,
             generatedPlantRenderBatchCount: 6,
             generatedPlantVisibleFieldCount: 54,
@@ -1643,16 +1643,16 @@ test('foliage-budget High acceptance keeps normal-view foliage clustered', () =>
     };
 
     assert.equal(evaluateHighTargetAcceptance(input).pass, true);
-    const exactLeak = evaluateHighTargetAcceptance({
+    const missingDetail = evaluateHighTargetAcceptance({
         ...input,
         runtime: {
             ...input.runtime,
-            generatedPlantDetailedInstanceCount: 179,
+            generatedPlantDetailedInstanceCount: 0,
         },
     });
-    assert.equal(exactLeak.pass, false);
+    assert.equal(missingDetail.pass, false);
     assert.equal(
-        exactLeak.checks.find(
+        missingDetail.checks.find(
             (check) =>
                 check.name === 'highTargetFoliageDetailedRenderInstances',
         )?.pass,

--- a/apps/www/app/blokovi/BlockGallery.tsx
+++ b/apps/www/app/blokovi/BlockGallery.tsx
@@ -8,7 +8,6 @@ import { Row } from '@gredice/ui/Row';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import { ItemCard } from '../../components/shared/ItemCard';
-import { useClientSearchParam } from '../../hooks/useClientSearchParam';
 import { normalizeSearchText } from '../../lib/search/normalizeSearchText';
 import { KnownPages } from '../../src/KnownPages';
 
@@ -49,9 +48,15 @@ function BlockGalleryItem(
     );
 }
 
-export function BlockGallery({ blocks }: { blocks: BlockData[] | undefined }) {
-    const [search] = useClientSearchParam('pretraga');
-    const normalizedSearch = normalizeSearchText(search);
+export function BlockGallery({
+    blocks,
+    hasMatchingPlant,
+    normalizedSearch,
+}: {
+    blocks: BlockData[] | undefined;
+    hasMatchingPlant: boolean;
+    normalizedSearch: string;
+}) {
     const filteredBlocks = orderBy(blocks ?? [], (a, b) =>
         a.information.name.localeCompare(b.information.label),
     )
@@ -66,9 +71,9 @@ export function BlockGallery({ blocks }: { blocks: BlockData[] | undefined }) {
 
     return (
         <>
-            {filteredBlocks.length === 0 && (
+            {filteredBlocks.length === 0 && !hasMatchingPlant ? (
                 <Typography level="body2">Nema rezultata pretrage.</Typography>
-            )}
+            ) : null}
             <Gallery
                 gridHeader={''}
                 items={filteredBlocks}

--- a/apps/www/app/blokovi/BlockPlantGalleries.tsx
+++ b/apps/www/app/blokovi/BlockPlantGalleries.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import type { BlockData, PlantData } from '@gredice/client';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { useClientSearchParam } from '../../hooks/useClientSearchParam';
+import { normalizeSearchText } from '../../lib/search/normalizeSearchText';
+import { BlockGallery } from './BlockGallery';
+import { PlantBlockGalleryResults } from './PlantBlockGallery';
+import { plantMatchesBlockSearch } from './plantBlockSearch';
+
+export function BlockPlantGalleries({
+    blocks,
+    plants,
+}: {
+    blocks: BlockData[] | undefined;
+    plants: PlantData[] | undefined;
+}) {
+    const [search] = useClientSearchParam('pretraga');
+    const normalizedSearch = normalizeSearchText(search);
+    const hasMatchingPlant = (plants ?? []).some((plant) =>
+        plantMatchesBlockSearch(plant, normalizedSearch),
+    );
+
+    return (
+        <>
+            <BlockGallery
+                blocks={blocks}
+                hasMatchingPlant={hasMatchingPlant}
+                normalizedSearch={normalizedSearch}
+            />
+            <Stack spacing={4} className="mt-8">
+                <Typography level="h3" className="px-2">
+                    Biljke
+                </Typography>
+                <PlantBlockGalleryResults
+                    plants={plants}
+                    normalizedSearch={normalizedSearch}
+                />
+            </Stack>
+        </>
+    );
+}

--- a/apps/www/app/blokovi/PlantBlockGallery.tsx
+++ b/apps/www/app/blokovi/PlantBlockGallery.tsx
@@ -7,11 +7,10 @@ import { Row } from '@gredice/ui/Row';
 import { Typography } from '@gredice/ui/Typography';
 import { ItemCard } from '../../components/shared/ItemCard';
 import { useClientSearchParam } from '../../hooks/useClientSearchParam';
-import { plantMatchesSearch } from '../../lib/plants/plantSearch';
 import { normalizeSearchText } from '../../lib/search/normalizeSearchText';
 import { KnownPages } from '../../src/KnownPages';
 import { PlantBlockImage } from './PlantBlockImage';
-import { plantNamesWithProceduralModels } from './plantNamesWithProceduralModels';
+import { plantMatchesBlockSearch } from './plantBlockSearch';
 
 function PlantBlockGalleryItem(props: Omit<PlantData, 'id'> & { id: string }) {
     return (
@@ -39,15 +38,26 @@ export function PlantBlockGallery({
 }) {
     const [search] = useClientSearchParam('pretraga');
     const normalizedSearch = normalizeSearchText(search);
+
+    return (
+        <PlantBlockGalleryResults
+            plants={plants}
+            normalizedSearch={normalizedSearch}
+        />
+    );
+}
+
+export function PlantBlockGalleryResults({
+    plants,
+    normalizedSearch,
+}: {
+    plants: PlantData[] | undefined;
+    normalizedSearch: string;
+}) {
     const filteredPlants = orderBy(plants ?? [], (a, b) =>
         a.information.name.localeCompare(b.information.name),
     )
-        .filter((plant) =>
-            plantNamesWithProceduralModels.has(
-                plant.information.name.toLowerCase(),
-            ),
-        )
-        .filter((plant) => plantMatchesSearch(plant, normalizedSearch))
+        .filter((plant) => plantMatchesBlockSearch(plant, normalizedSearch))
         .map((plant) => ({ ...plant, id: plant.id.toString() }));
 
     if (filteredPlants.length === 0) {

--- a/apps/www/app/blokovi/page.tsx
+++ b/apps/www/app/blokovi/page.tsx
@@ -1,13 +1,11 @@
 import { directoriesClient } from '@gredice/client';
 import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
-import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import { PageFilterInputNoSSR } from '../../components/shared/PageFilterInputNoSSR';
 import { getPlantsData } from '../../lib/plants/getPlantsData';
-import { BlockGallery } from './BlockGallery';
-import { PlantBlockGallery } from './PlantBlockGallery';
+import { BlockPlantGalleries } from './BlockPlantGalleries';
 
 export const revalidate = 3600; // 1 hour
 export const metadata: Metadata = {
@@ -52,16 +50,8 @@ export default async function BlocksPage() {
                 </Suspense>
             </PageHeader>
             <Suspense>
-                <BlockGallery blocks={blocks} />
+                <BlockPlantGalleries blocks={blocks} plants={plants} />
             </Suspense>
-            <Stack spacing={4} className="mt-8">
-                <Typography level="h3" className="px-2">
-                    Biljke
-                </Typography>
-                <Suspense>
-                    <PlantBlockGallery plants={plants} />
-                </Suspense>
-            </Stack>
         </Stack>
     );
 }

--- a/apps/www/app/blokovi/page.tsx
+++ b/apps/www/app/blokovi/page.tsx
@@ -6,7 +6,6 @@ import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import { PageFilterInputNoSSR } from '../../components/shared/PageFilterInputNoSSR';
 import { getPlantsData } from '../../lib/plants/getPlantsData';
-import { proceduralPlantsFlag } from '../flags';
 import { BlockGallery } from './BlockGallery';
 import { PlantBlockGallery } from './PlantBlockGallery';
 
@@ -33,10 +32,9 @@ async function getBlocksData() {
 }
 
 export default async function BlocksPage() {
-    const proceduralPlants = await proceduralPlantsFlag();
     const [blocks, plants] = await Promise.all([
         getBlocksData(),
-        proceduralPlants ? getPlantsData() : Promise.resolve([]),
+        getPlantsData(),
     ]);
     return (
         <Stack>
@@ -56,16 +54,14 @@ export default async function BlocksPage() {
             <Suspense>
                 <BlockGallery blocks={blocks} />
             </Suspense>
-            {proceduralPlants && (
-                <Stack spacing={4} className="mt-8">
-                    <Typography level="h3" className="px-2">
-                        Biljke
-                    </Typography>
-                    <Suspense>
-                        <PlantBlockGallery plants={plants} />
-                    </Suspense>
-                </Stack>
-            )}
+            <Stack spacing={4} className="mt-8">
+                <Typography level="h3" className="px-2">
+                    Biljke
+                </Typography>
+                <Suspense>
+                    <PlantBlockGallery plants={plants} />
+                </Suspense>
+            </Stack>
         </Stack>
     );
 }

--- a/apps/www/app/blokovi/plantBlockSearch.ts
+++ b/apps/www/app/blokovi/plantBlockSearch.ts
@@ -1,0 +1,14 @@
+import type { PlantData } from '@gredice/client';
+import { plantMatchesSearch } from '../../lib/plants/plantSearch';
+import { plantNamesWithProceduralModels } from './plantNamesWithProceduralModels';
+
+export function plantMatchesBlockSearch(
+    plant: PlantData,
+    normalizedSearch: string,
+) {
+    return (
+        plantNamesWithProceduralModels.has(
+            plant.information.name.toLowerCase(),
+        ) && plantMatchesSearch(plant, normalizedSearch)
+    );
+}

--- a/apps/www/app/flags.ts
+++ b/apps/www/app/flags.ts
@@ -5,13 +5,6 @@ function isDevelopmentEnvironment() {
     return process.env.NODE_ENV === 'development';
 }
 
-export const proceduralPlantsFlag = flag<boolean>({
-    key: 'proceduralPlants',
-    description: 'Enable procedural plant content rendering.',
-    decide: () => false,
-    options: booleanFlagOptions,
-});
-
 export const recipesFlag = flag<boolean>({
     key: 'recipes',
     description: 'Enable recipes pages and recipe detail routes.',

--- a/apps/www/tests/landing.spec.ts
+++ b/apps/www/tests/landing.spec.ts
@@ -210,6 +210,7 @@ test('navbar floats on scroll and landing game frame is rounded', async ({
                     const profile = (
                         window as Window & {
                             __grediceGameProfile?: {
+                                adaptiveHighEnabled?: boolean;
                                 dprCap?: number;
                                 qualityTier?: string;
                             };
@@ -217,13 +218,21 @@ test('navbar floats on scroll and landing game frame is rounded', async ({
                     ).__grediceGameProfile;
 
                     return {
-                        dprCap: profile?.dprCap,
+                        adaptiveHighEnabled: profile?.adaptiveHighEnabled,
+                        dprCapIsSupported:
+                            typeof profile?.dprCap === 'number' &&
+                            profile.dprCap >= 1 &&
+                            profile.dprCap <= 2,
                         qualityTier: profile?.qualityTier,
                     };
                 }),
             { timeout: 15_000 },
         )
-        .toEqual({ dprCap: 2, qualityTier: 'high' });
+        .toEqual({
+            adaptiveHighEnabled: true,
+            dprCapIsSupported: true,
+            qualityTier: 'high',
+        });
 
     const canvas = page.locator('canvas');
     const countVisibleCanvasPixels = async () => {

--- a/apps/www/tests/search.spec.ts
+++ b/apps/www/tests/search.spec.ts
@@ -439,6 +439,15 @@ test.describe('public search filters', () => {
         await expect(page.getByText('Nema rezultata pretrage.')).toBeHidden();
     });
 
+    test('block search suppresses its empty state when a plant matches', async ({
+        page,
+    }) => {
+        await page.goto('/blokovi?pretraga=rajcica', { waitUntil: 'load' });
+
+        await expect(page.getByText('Rajčica', { exact: true })).toBeVisible();
+        await expect(page.getByText('Nema rezultata pretrage.')).toBeHidden();
+    });
+
     test('plant search clear button resets input, URL and list', async ({
         page,
     }) => {

--- a/docs/game-performance-optimization-results.md
+++ b/docs/game-performance-optimization-results.md
@@ -710,14 +710,14 @@ contract, R8 pipeline, kernel bound, and pass alignment.
 
 ### Global generated-foliage detail budget
 
-Issue `#4322` reserves exact generated L-system geometry for the raised bed
-that the player explicitly opens in close-up. Normal High-quality garden view
-uses deterministic bed-level mid/far clusters instead of independently
-promoting every visible field to exact detail. The selected bed is pinned,
-admitted atomically, and may overflow the global 179-instance budget rather
-than rendering only part of a bed. Interaction priority, projected
-benefit-per-instance ranking, an 8% incumbent hysteresis bias, and stable
-raised-bed IDs keep future competing detail requests deterministic.
+Issue `#4322` introduced a global exact-plant budget for High quality. After the
+developmental plant renderer replaced L-systems, normal High-quality garden
+view may admit nearby raised beds to exact detail when their plants occupy at
+least 8% of the viewport. Admission remains atomic and capped at 179 plant
+instances, while the explicitly selected close-up bed stays pinned and may
+overflow the budget rather than rendering only part of a bed. Interaction
+priority, projected benefit-per-instance ranking, an 8% incumbent hysteresis
+bias, and stable raised-bed IDs keep competing detail requests deterministic.
 
 Mid clusters retain per-plant height, canopy width, dominant foliage and
 accent colors, Lambert scene lighting, and deterministic wind sway. Two
@@ -727,11 +727,13 @@ instance uploads. Front-facing foliage cards submit one transparent pass
 instead of Three's default two-pass double-sided path. Far clusters are
 unchanged. Non-High profiles retain their shared plant-type/LOD background
 batches and original normal-view exact policy. A profiler-only `legacy` query
-keeps that old High policy available for a same-commit comparison; production
-High always reserves exact work for selected close-up.
+bypasses the High detail budget for a same-commit comparison; production High
+admits at most one typical full raised bed in normal view and always preserves
+selected close-up detail.
 
-The three-repeat DPR-2 comparison passed every structural gate on Chromium 149
-using ANGLE/Metal on an Apple M4 Pro:
+The pre-rollout three-repeat DPR-2 comparison that established the budget
+passed every structural gate on Chromium 149 using ANGLE/Metal on an Apple M4
+Pro:
 
 | Normal-view median | Legacy exact | Budgeted clusters | Change |
 | --- | ---: | ---: | ---: |
@@ -743,12 +745,27 @@ using ANGLE/Metal on an Apple M4 Pro:
 | p95 frame | 26.6 ms | 26.2 ms | -1.5% |
 | GPU timer p95 | 19.59 ms | 20.16 ms | neutral/noisy |
 
-All three filled beds and all 537 plants remained visible in both variants.
-The budgeted runs used six bed/LOD cluster batches, reported zero exact or
-pending instances after camera zoom, and submitted 3,354 cluster primitive
-triangles. The hardware GPU p95 ranges overlapped (`19.01-20.61 ms` legacy and
-`19.66-20.35 ms` budgeted), so the measured claim is the large geometry and
-heap reduction rather than a GPU-time win on this machine.
+The 2026-08-05 rollout calibration repeated the same comparison after widening
+High detail to the 8% viewport threshold. All six runs passed on Chromium 149
+using ANGLE/Metal on an Apple M3 Pro:
+
+| Rollout median | Unbudgeted exact | 179-instance budget | Change |
+| --- | ---: | ---: | ---: |
+| Exact generated plants | 537 | 179 | -66.7% |
+| Clustered generated plants | 0 | 358 | remaining plants retained |
+| Draws/render, full scene | 88.1 | 92.0 | +4.4% |
+| Triangles/render, full scene | 250,298 | 89,980 | -64.1% |
+| Sampled JS heap | 77.6 MB | 64.8 MB | -16.5% |
+| p95 frame | 9.4 ms | 8.9 ms | -5.3% |
+| GPU timer p95 | 6.47 ms | 5.48 ms | -15.3% |
+
+All three filled beds and all 537 plants remained visible in both variants. In
+the pre-rollout comparison, the budgeted runs used six bed/LOD cluster batches,
+reported zero exact or pending instances after camera zoom, and submitted 3,354
+cluster primitive triangles. The hardware GPU p95 ranges overlapped
+(`19.01-20.61 ms` legacy and `19.66-20.35 ms` budgeted), so the measured claim
+is the large geometry and heap reduction rather than a GPU-time win on this
+machine.
 
 The selected-bed validation separately opened High-target bed `2`. It retained
 all 179 exact plants across 18 fields, reached fully detailed in `256 ms`,

--- a/packages/game/src/GameFlagsContext.tsx
+++ b/packages/game/src/GameFlagsContext.tsx
@@ -3,7 +3,6 @@
 import { createContext, useContext } from 'react';
 
 export interface GameFeatureFlags {
-    enableAdaptiveHighQualityFlag?: boolean;
     enableDebugHudFlag?: boolean;
     enableRaisedBedWateringFlag?: boolean;
     enableRaisedBedDiaryFlag?: boolean;
@@ -12,8 +11,6 @@ export interface GameFeatureFlags {
     enableRaisedBedFieldWateringFlag?: boolean;
     enableRaisedBedFieldDiaryFlag?: boolean;
     enableIntegratedWeatherSurfacesFlag?: boolean;
-    enableRainWetOverlayFlag?: boolean;
-    enableStaticOpaqueSceneCacheFlag?: boolean;
     enableSuncokretChatFlag?: boolean;
     enableSuncokretDebugFlag?: boolean;
 }

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -110,9 +110,11 @@ export type GameSceneProps = HTMLAttributes<HTMLDivElement> & {
     initialQualitySetting?: GameQualitySetting;
 
     // Development purposes
+    adaptiveHighQuality?: boolean;
     enableGameProfileController?: boolean;
     enableStaticOpaqueSceneCacheOcclusionFixture?: boolean;
     flags?: GameFeatureFlags;
+    staticOpaqueSceneCache?: boolean;
 };
 
 type GameSceneInnerProps = Omit<GameSceneProps, 'initialQualitySetting'>;
@@ -300,9 +302,11 @@ export function GameScene({
     weather,
     deferDetails,
     renderDetails: renderDetailsOverride,
+    adaptiveHighQuality = true,
     enableGameProfileController,
     enableStaticOpaqueSceneCacheOcclusionFixture,
     fixedTimeSeconds,
+    staticOpaqueSceneCache = true,
     ...rest
 }: GameSceneInnerProps) {
     useFocusPlacedBlock();
@@ -348,14 +352,13 @@ export function GameScene({
         quality,
     ]);
     const adaptiveHighEnabled = Boolean(
-        flags?.enableAdaptiveHighQualityFlag &&
+        adaptiveHighQuality &&
             qualityProfile.tier === 'high' &&
             (quality === 'high' ||
                 (quality === undefined && gameQualitySetting === 'high')),
     );
     const staticOpaqueCacheEnabled = Boolean(
-        flags?.enableStaticOpaqueSceneCacheFlag &&
-            qualityProfile.tier === 'high',
+        staticOpaqueSceneCache && qualityProfile.tier === 'high',
     );
     const adaptiveHighInteractionActive = useAdaptiveHighInteractionActivity(
         adaptiveHighEnabled || staticOpaqueCacheEnabled,

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -496,7 +496,6 @@ function IntegratedWeatherEntityInstancesGeometry({
     >[0];
     weatherSurfaceMode: WeatherSurfaceMode;
 } & EntityInstancesGeometryProps) {
-    const flags = useGameFlags();
     const {
         geometry,
         renderRainWetOverlay = false,
@@ -513,9 +512,7 @@ function IntegratedWeatherEntityInstancesGeometry({
     const puddleStrengthUniform = useRainSurfacePuddleStrengthUniform();
     const rainOverlayVisible = useRainWetOverlayVisible();
     const rainSurfaceActive =
-        renderRainWetOverlay &&
-        Boolean(flags.enableRainWetOverlayFlag) &&
-        Boolean(rainOverlayVisible);
+        renderRainWetOverlay && Boolean(rainOverlayVisible);
     const snowOverlayVisible = useSnowOverlayVisible({
         coverageMultiplier: snow?.coverageMultiplier,
         minCoverage: snowOverlayMinCoverage,
@@ -650,7 +647,6 @@ function EntityInstancesGeometryRenderer(
         weatherSurfaceMode: WeatherSurfaceMode;
     },
 ) {
-    const flags = useGameFlags();
     const {
         instanceKey,
         instances: incomingInstances,
@@ -798,8 +794,7 @@ function EntityInstancesGeometryRenderer(
     );
     const weatherRegistryId = useId();
     const rainOverlayVisible = useRainWetOverlayVisible();
-    const rainOverlayEnabled =
-        renderRainWetOverlay && Boolean(flags.enableRainWetOverlayFlag);
+    const rainOverlayEnabled = renderRainWetOverlay;
     const rainWetnessActive = useRainSurfaceWetnessActive({
         drySpeed: 1.8,
         enabled: rainOverlayEnabled,

--- a/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantFieldBatches.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantFieldBatches.tsx
@@ -67,6 +67,8 @@ import {
 import {
     buildGeneratedPlantRaisedBedBounds,
     getGeneratedPlantBatchKey,
+    HIGH_QUALITY_PLANT_NEAR_HYSTERESIS,
+    HIGH_QUALITY_PLANT_NEAR_THRESHOLD,
     isGeneratedPlantRaisedBedGroupVisible,
     resolveGeneratedPlantFieldLod,
 } from './generatedPlantFieldLod';
@@ -271,18 +273,20 @@ function resolveGeneratedFieldVisibility({
 }
 
 function useGeneratedPlantFieldLods({
-    allowNormalViewNear,
     detailInstanceBudget,
     focusActive,
     generatedFields,
     interactingRaisedBedId,
+    nearHysteresis,
+    nearThreshold,
     selectedRaisedBedId,
 }: {
-    allowNormalViewNear: boolean;
     detailInstanceBudget: number;
     focusActive: boolean;
     generatedFields: GeneratedPlantField[];
     interactingRaisedBedId: number | null;
+    nearHysteresis?: number;
+    nearThreshold?: number;
     selectedRaisedBedId: number | null;
 }) {
     const camera = useThree((state) => state.camera);
@@ -458,11 +462,12 @@ function useGeneratedPlantFieldLods({
                     lodByFieldKeyRef.current.get(field.fieldKey)
                         ?.requestedLevel ?? 'far';
                 const requestedLevel = resolveGeneratedPlantFieldLod({
-                    allowNormalViewNear,
                     cameraZoom: getOrthographicCameraZoom(camera),
                     currentLevel: previousLevel,
                     focusActive,
                     isSelectedRaisedBed,
+                    nearHysteresis,
+                    nearThreshold,
                     screenOccupancy,
                 });
 
@@ -585,13 +590,14 @@ function useGeneratedPlantFieldLods({
             return current;
         });
     }, [
-        allowNormalViewNear,
         camera,
         detailInstanceBudget,
         focusActive,
         frustum,
         generatedFields.length,
         interactingRaisedBedId,
+        nearHysteresis,
+        nearThreshold,
         projectedPosition,
         projectionViewMatrix,
         raisedBedGroups,
@@ -904,12 +910,18 @@ export function RaisedBedGeneratedPlantFieldBatches({
     const detailInstanceBudget = globalDetailBudgetActive
         ? HIGH_GENERATED_PLANT_DETAIL_INSTANCE_BUDGET
         : generatedPlantInstanceCount;
+    const expandedHighQualityDetail = quality.tier === 'high';
     const { detailBudget, lodByFieldKey: lods } = useGeneratedPlantFieldLods({
-        allowNormalViewNear: !globalDetailBudgetActive,
         detailInstanceBudget,
         focusActive,
         generatedFields,
         interactingRaisedBedId,
+        nearHysteresis: expandedHighQualityDetail
+            ? HIGH_QUALITY_PLANT_NEAR_HYSTERESIS
+            : undefined,
+        nearThreshold: expandedHighQualityDetail
+            ? HIGH_QUALITY_PLANT_NEAR_THRESHOLD
+            : undefined,
         selectedRaisedBedId,
     });
     const detailTransitionTotalsRef = useRef({

--- a/packages/game/src/entities/raisedBed/generatedPlantFieldLod.ts
+++ b/packages/game/src/entities/raisedBed/generatedPlantFieldLod.ts
@@ -6,6 +6,8 @@ import {
 
 const FIELD_HORIZONTAL_BOUNDS_MARGIN = 0.4;
 const MINIMUM_PLANT_HEIGHT = 0.25;
+export const HIGH_QUALITY_PLANT_NEAR_THRESHOLD = 0.08;
+export const HIGH_QUALITY_PLANT_NEAR_HYSTERESIS = 0.008;
 
 export type GeneratedPlantFieldBoundsInput = {
     approximatePlantHeight: number;
@@ -29,18 +31,20 @@ export function getGeneratedPlantBatchKey({
 }
 
 export function resolveGeneratedPlantFieldLod({
-    allowNormalViewNear,
     cameraZoom,
     currentLevel,
     focusActive,
     isSelectedRaisedBed,
+    nearHysteresis,
+    nearThreshold,
     screenOccupancy,
 }: {
-    allowNormalViewNear: boolean;
     cameraZoom: number;
     currentLevel: PlantLodLevel;
     focusActive: boolean;
     isSelectedRaisedBed: boolean;
+    nearHysteresis?: number;
+    nearThreshold?: number;
     screenOccupancy: number;
 }): PlantLodLevel {
     if (focusActive && isSelectedRaisedBed) {
@@ -50,10 +54,12 @@ export function resolveGeneratedPlantFieldLod({
     const resolvedLevel = resolvePlantLodLevelWithHysteresis({
         cameraZoom,
         currentLevel,
+        nearHysteresis,
+        nearThreshold,
         screenOccupancy,
     });
 
-    if (resolvedLevel === 'near' && (focusActive || !allowNormalViewNear)) {
+    if (resolvedLevel === 'near' && focusActive) {
         return 'mid';
     }
 

--- a/packages/game/src/entities/raisedBed/generatedPlantFieldLod.unit.ts
+++ b/packages/game/src/entities/raisedBed/generatedPlantFieldLod.unit.ts
@@ -4,6 +4,8 @@ import * as THREE from 'three';
 import {
     buildGeneratedPlantRaisedBedBounds,
     getGeneratedPlantBatchKey,
+    HIGH_QUALITY_PLANT_NEAR_HYSTERESIS,
+    HIGH_QUALITY_PLANT_NEAR_THRESHOLD,
     isGeneratedPlantRaisedBedGroupVisible,
     resolveGeneratedPlantFieldLod,
 } from './generatedPlantFieldLod';
@@ -11,7 +13,6 @@ import {
 test('selected raised beds keep exact near detail throughout close-up', () => {
     assert.equal(
         resolveGeneratedPlantFieldLod({
-            allowNormalViewNear: false,
             cameraZoom: 20,
             currentLevel: 'far',
             focusActive: true,
@@ -25,7 +26,6 @@ test('selected raised beds keep exact near detail throughout close-up', () => {
 test('close-up zoom cannot promote a background raised bed to near', () => {
     assert.equal(
         resolveGeneratedPlantFieldLod({
-            allowNormalViewNear: false,
             cameraZoom: 300,
             currentLevel: 'near',
             focusActive: true,
@@ -36,21 +36,19 @@ test('close-up zoom cannot promote a background raised bed to near', () => {
     );
 });
 
-test('normal view reserves exact detail for an explicit close-up selection', () => {
+test('normal view can request exact detail within the global budget', () => {
     assert.equal(
         resolveGeneratedPlantFieldLod({
-            allowNormalViewNear: false,
             cameraZoom: 180,
             currentLevel: 'far',
             focusActive: false,
             isSelectedRaisedBed: false,
             screenOccupancy: 0.001,
         }),
-        'mid',
+        'near',
     );
     assert.equal(
         resolveGeneratedPlantFieldLod({
-            allowNormalViewNear: false,
             cameraZoom: 0,
             currentLevel: 'far',
             focusActive: false,
@@ -61,15 +59,26 @@ test('normal view reserves exact detail for an explicit close-up selection', () 
     );
 });
 
-test('the profiler can opt into the legacy normal-view exact policy', () => {
+test('High quality requests detail from a wider normal-view range', () => {
     assert.equal(
         resolveGeneratedPlantFieldLod({
-            allowNormalViewNear: true,
-            cameraZoom: 180,
+            cameraZoom: 0,
             currentLevel: 'far',
             focusActive: false,
             isSelectedRaisedBed: false,
-            screenOccupancy: 0.001,
+            screenOccupancy: 0.095,
+        }),
+        'mid',
+    );
+    assert.equal(
+        resolveGeneratedPlantFieldLod({
+            cameraZoom: 0,
+            currentLevel: 'far',
+            focusActive: false,
+            isSelectedRaisedBed: false,
+            nearHysteresis: HIGH_QUALITY_PLANT_NEAR_HYSTERESIS,
+            nearThreshold: HIGH_QUALITY_PLANT_NEAR_THRESHOLD,
+            screenOccupancy: 0.095,
         }),
         'near',
     );

--- a/packages/game/src/generators/plant/lib/plantLod.ts
+++ b/packages/game/src/generators/plant/lib/plantLod.ts
@@ -21,10 +21,14 @@ export function resolvePlantLodLevel(screenOccupancy: number): PlantLodLevel {
 export function resolvePlantLodLevelWithHysteresis({
     cameraZoom,
     currentLevel,
+    nearHysteresis = HYSTERESIS,
+    nearThreshold = NEAR_THRESHOLD,
     screenOccupancy,
 }: {
     cameraZoom: number;
     currentLevel: PlantLodLevel;
+    nearHysteresis?: number;
+    nearThreshold?: number;
     screenOccupancy: number;
 }): PlantLodLevel {
     if (
@@ -36,14 +40,14 @@ export function resolvePlantLodLevelWithHysteresis({
     }
 
     if (currentLevel === 'near') {
-        if (screenOccupancy >= NEAR_THRESHOLD - HYSTERESIS) {
+        if (screenOccupancy >= nearThreshold - nearHysteresis) {
             return 'near';
         }
         return screenOccupancy >= FAR_THRESHOLD - HYSTERESIS ? 'mid' : 'far';
     }
 
     if (currentLevel === 'mid') {
-        if (screenOccupancy >= NEAR_THRESHOLD + HYSTERESIS) {
+        if (screenOccupancy >= nearThreshold + nearHysteresis) {
             return 'near';
         }
         if (screenOccupancy < FAR_THRESHOLD - HYSTERESIS) {
@@ -52,7 +56,7 @@ export function resolvePlantLodLevelWithHysteresis({
         return 'mid';
     }
 
-    if (screenOccupancy >= NEAR_THRESHOLD + HYSTERESIS) {
+    if (screenOccupancy >= nearThreshold + nearHysteresis) {
         return 'near';
     }
 

--- a/packages/game/src/generators/plant/lib/plantLod.unit.ts
+++ b/packages/game/src/generators/plant/lib/plantLod.unit.ts
@@ -40,3 +40,26 @@ test('plant LOD keeps close geometry through zoom hysteresis', () => {
         'far',
     );
 });
+
+test('plant LOD supports a wider High-quality detail range', () => {
+    assert.equal(
+        resolvePlantLodLevelWithHysteresis({
+            cameraZoom: 0,
+            currentLevel: 'far',
+            nearHysteresis: 0.01,
+            nearThreshold: 0.1,
+            screenOccupancy: 0.115,
+        }),
+        'near',
+    );
+    assert.equal(
+        resolvePlantLodLevelWithHysteresis({
+            cameraZoom: 0,
+            currentLevel: 'near',
+            nearHysteresis: 0.01,
+            nearThreshold: 0.1,
+            screenOccupancy: 0.091,
+        }),
+        'near',
+    );
+});

--- a/packages/game/src/rain/RainWetOverlay.tsx
+++ b/packages/game/src/rain/RainWetOverlay.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import type { BufferGeometry, IUniform, Vector3Tuple } from 'three';
 import { ShaderMaterial, UniformsLib, UniformsUtils, Vector3 } from 'three';
-import { useGameFlags } from '../GameFlagsContext';
 import {
     useRainSurfacePuddleStrengthUniform,
     useRainSurfaceWetnessState,
@@ -88,12 +87,6 @@ void main() {
 `;
 
 export function RainWetOverlay(props: RainWetOverlayProps) {
-    const flags = useGameFlags();
-
-    if (!flags.enableRainWetOverlayFlag) {
-        return null;
-    }
-
     return <RainWetOverlayEffect {...props} />;
 }
 
@@ -101,13 +94,9 @@ export function useRainWetOverlayVisible({
     intensityMultiplier = 1,
     minRain = 0.08,
 }: Pick<RainWetOverlayProps, 'intensityMultiplier' | 'minRain'> = {}) {
-    const flags = useGameFlags();
     const rainAmount = useGameState((state) => state.rainSurfaceIntensity);
 
-    return (
-        flags.enableRainWetOverlayFlag &&
-        rainAmount * intensityMultiplier >= minRain
-    );
+    return rainAmount * intensityMultiplier >= minRain;
 }
 
 export function useRainWetOverlayMaterial({

--- a/packages/game/src/viewers/EntitySandboxViewer.tsx
+++ b/packages/game/src/viewers/EntitySandboxViewer.tsx
@@ -97,7 +97,6 @@ export function EntitySandboxViewer({
             deferDetails={false}
             flags={{
                 enableDebugHudFlag: debugHud,
-                enableRainWetOverlayFlag: debugHud,
             }}
             key={storageKey}
             localSandboxInitialStacks={stacks}

--- a/packages/game/src/viewers/EntityViewer.tsx
+++ b/packages/game/src/viewers/EntityViewer.tsx
@@ -155,7 +155,6 @@ export function EntityViewer({
                 <GameFlagsContext.Provider
                     value={{
                         enableDebugHudFlag: debugHud,
-                        enableRainWetOverlayFlag: debugHud,
                     }}
                 >
                     <GameSceneDetailContext.Provider

--- a/packages/game/src/viewers/OperationCoverSnapshotViewer.tsx
+++ b/packages/game/src/viewers/OperationCoverSnapshotViewer.tsx
@@ -587,7 +587,6 @@ export function OperationCoverSnapshotViewer({
                 <GameFlagsContext.Provider
                     value={{
                         enableDebugHudFlag: false,
-                        enableRainWetOverlayFlag: false,
                     }}
                 >
                     <GameSceneDetailContext.Provider

--- a/packages/game/src/viewers/PlantPerformanceViewer.tsx
+++ b/packages/game/src/viewers/PlantPerformanceViewer.tsx
@@ -9,7 +9,6 @@ export interface PlantPerformanceViewerProps {
 
 const plantDebugFlags = {
     enableDebugHudFlag: true,
-    enableRainWetOverlayFlag: true,
 };
 
 const plantDebugFreezeTime = new Date('2026-06-02T12:00:00+02:00');
@@ -27,11 +26,7 @@ export function PlantPerformanceViewer({
     className,
     debugHud,
 }: PlantPerformanceViewerProps) {
-    const flags = debugHud
-        ? plantDebugFlags
-        : {
-              enableRainWetOverlayFlag: true,
-          };
+    const flags = debugHud ? plantDebugFlags : undefined;
 
     return (
         <GameSceneDynamic


### PR DESCRIPTION
## Summary

- remove the WWW procedural-plant rollout flag and always expose the plant block gallery
- remove the Garden adaptive High, static opaque scene cache, and rain wetness flags; enable the optimized production paths by default while retaining explicit profiler overrides
- extend High-quality exact plant detail to an 8% viewport threshold, guarded by the existing atomic 179-instance global budget
- update LOD/profiler contracts, timeout diagnostics, unit coverage, and the performance results documentation

## Validation

- `pnpm --filter @gredice/game lint`
- `pnpm --filter garden lint`
- `pnpm --filter www lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter @gredice/game test` — 787 passed
- `pnpm --filter garden test:profile` — 70 passed
- `pnpm --filter www test:prepare:routes`
- `pnpm build --filter=garden`
- `pnpm build --filter=www`
- paired production profile: `GAME_PROFILE_SCENARIO_SET=high-target-foliage-budget GAME_PROFILE_FAIL_ON_BUDGET=1 pnpm --dir apps/garden run profile:game:start` — 6/6 accepted, budget passed

## Performance

Apple M3 Pro, Chromium 149, ANGLE/Metal, three runs per variant:

| Median | Unbudgeted exact | 179-instance budget |
| --- | ---: | ---: |
| Exact / clustered plants | 537 / 0 | 179 / 358 |
| Triangles per rendered frame | 250,298 | 89,980 |
| Sampled JS heap | 77.6 MB | 64.8 MB |
| p95 frame | 9.4 ms | 8.9 ms |
| GPU timer p95 | 6.47 ms | 5.48 ms |