### PR TITLE
fix(game): match raised-bed support and crop scale

### DIFF
--- a/packages/game/src/entities/EntityInstances.tsx
+++ b/packages/game/src/entities/EntityInstances.tsx
@@ -35,6 +35,7 @@ import {
 } from './helpers/groundPatchMaterial';
 import { MulchPatchInstances } from './raisedBed/MulchPatch';
 import { RaisedBedGeneratedPlantFieldBatches } from './raisedBed/RaisedBedGeneratedPlantFieldBatches';
+import { RAISED_BED_SUPPORT_SCALE } from './raisedBed/raisedBedDimensions';
 import { tulipBouquetStems } from './tulipBouquet';
 
 export const instancedBlockNames = [
@@ -778,6 +779,7 @@ export function EntityInstances({
                 name="Stick"
                 geometry={(gltf) => gltf.nodes.Stick.geometry}
                 material={(gltf) => gltf.nodes.Stick.material}
+                scale={RAISED_BED_SUPPORT_SCALE}
                 snow={snowPresets.tool}
                 snowLift={0.002}
                 {...commonSnowProps}

--- a/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantFieldBatches.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantFieldBatches.tsx
@@ -17,7 +17,8 @@ import { useGameSceneDetails } from '../../GameSceneDetailContext';
 import type { GeneratedPlantTaskPriority } from '../../generators/plant/hooks/generatedPlantTaskScheduler';
 import {
     calculateInGamePlantGeneration,
-    getPlantLifecycleWindowDays,
+    getInGamePlantInstanceScale,
+    getPlantMaturityWindowDays,
     type ResolvedInGamePlantPreset,
     resolveInGamePlantPreset,
 } from '../../generators/plant/lib/inGamePlantPresets';
@@ -787,7 +788,7 @@ export function RaisedBedGeneratedPlantFieldBatches({
                 const plantGeneration = calculateInGamePlantGeneration({
                     currentTime,
                     sowDate: field.plantSowDate ?? '',
-                    lifecycleWindowDays: getPlantLifecycleWindowDays({
+                    lifecycleWindowDays: getPlantMaturityWindowDays({
                         germinationWindowMax:
                             highTargetAttributes?.germinationWindowMax ??
                             sort?.information.plant.attributes
@@ -795,19 +796,13 @@ export function RaisedBedGeneratedPlantFieldBatches({
                         growthWindowMax:
                             highTargetAttributes?.growthWindowMax ??
                             sort?.information.plant.attributes?.growthWindowMax,
-                        harvestWindowMax:
-                            highTargetAttributes?.harvestWindowMax ??
-                            sort?.information.plant.attributes
-                                ?.harvestWindowMax,
                     }),
                     growthMultiplier: resolvedPlantPreset.growthMultiplier,
                 });
-                const plantInstanceScale =
-                    resolvedPlantPreset.instanceScale *
-                    Math.max(
-                        0.72,
-                        1 - Math.max(0, safePlantsPerRow - 2) * 0.12,
-                    );
+                const plantInstanceScale = getInGamePlantInstanceScale(
+                    resolvedPlantPreset,
+                    safePlantsPerRow,
+                );
                 const fieldPosition = getFieldPosition({
                     blockIndex,
                     blockPosition: block.position,

--- a/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
@@ -5,7 +5,8 @@ import type { Group } from 'three';
 import { usePlantLodState } from '../../generators/plant/hooks/usePlantLod';
 import {
     calculateInGamePlantGeneration,
-    getPlantLifecycleWindowDays,
+    getInGamePlantInstanceScale,
+    getPlantMaturityWindowDays,
     resolveInGamePlantPreset,
 } from '../../generators/plant/lib/inGamePlantPresets';
 import { getApproximatePlantHeight } from '../../generators/plant/lib/plantRenderData';
@@ -105,20 +106,18 @@ export function RaisedBedPlantField({
         sortData?.information.plant.information?.latinName,
         sortData?.information.plant.information?.name,
     ]);
-    const lifecycleWindowDays = getPlantLifecycleWindowDays({
+    const maturityWindowDays = getPlantMaturityWindowDays({
         germinationWindowMax:
             sortData?.information.plant.attributes?.germinationWindowMax,
         growthWindowMax:
             sortData?.information.plant.attributes?.growthWindowMax,
-        harvestWindowMax:
-            sortData?.information.plant.attributes?.harvestWindowMax,
     });
     const plantGeneration =
         plantSowDate && resolvedPlantPreset
             ? calculateInGamePlantGeneration({
                   currentTime,
                   sowDate: plantSowDate,
-                  lifecycleWindowDays,
+                  lifecycleWindowDays: maturityWindowDays,
                   growthMultiplier: resolvedPlantPreset.growthMultiplier,
               })
             : 0;
@@ -132,8 +131,7 @@ export function RaisedBedPlantField({
             field.plantStatus === 'ready' ||
             field.plantStatus === 'harvested');
     const plantInstanceScale = resolvedPlantPreset
-        ? resolvedPlantPreset.instanceScale *
-          Math.max(0.72, 1 - Math.max(0, safePlantsPerRow - 2) * 0.12)
+        ? getInGamePlantInstanceScale(resolvedPlantPreset, safePlantsPerRow)
         : 0;
     const approximateFieldPlantHeight = resolvedPlantPreset
         ? getApproximatePlantHeight(resolvedPlantPreset.definition) *

--- a/packages/game/src/entities/raisedBed/Stick.tsx
+++ b/packages/game/src/entities/raisedBed/Stick.tsx
@@ -5,6 +5,7 @@ import type { EntityInstanceProps } from '../../types/runtime/EntityInstanceProp
 import { useStackHeight } from '../../utils/getStackHeight';
 import { useGameGLTF } from '../../utils/useGameGLTF';
 import { useAnimatedEntityRotation } from '../helpers/useAnimatedEntityRotation';
+import { RAISED_BED_SUPPORT_SCALE } from './raisedBedDimensions';
 
 export function Stick({ stack, block, rotation }: EntityInstanceProps) {
     const { nodes } = useGameGLTF('Stick');
@@ -15,6 +16,7 @@ export function Stick({ stack, block, rotation }: EntityInstanceProps) {
         <animated.group
             position={stack.position.clone().setY(currentStackHeight)}
             rotation={animatedRotation as unknown as [number, number, number]}
+            scale={RAISED_BED_SUPPORT_SCALE}
         >
             <mesh
                 castShadow

--- a/packages/game/src/entities/raisedBed/raisedBedDimensions.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedDimensions.ts
@@ -1,0 +1,8 @@
+// Stick.glb is authored at exactly one meter from its base to its top.
+export const RAISED_BED_SUPPORT_HEIGHT_METERS = 1.2;
+
+export const RAISED_BED_SUPPORT_SCALE: [number, number, number] = [
+    1,
+    RAISED_BED_SUPPORT_HEIGHT_METERS,
+    1,
+];

--- a/packages/game/src/entities/raisedBed/raisedBedDimensions.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedDimensions.unit.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    RAISED_BED_SUPPORT_HEIGHT_METERS,
+    RAISED_BED_SUPPORT_SCALE,
+} from './raisedBedDimensions';
+
+test('raised-bed supports extend 1.2 meters above the soil surface', () => {
+    assert.equal(RAISED_BED_SUPPORT_HEIGHT_METERS, 1.2);
+    assert.deepEqual(RAISED_BED_SUPPORT_SCALE, [1, 1.2, 1]);
+});

--- a/packages/game/src/generators/plant/lib/inGamePlantPresets.ts
+++ b/packages/game/src/generators/plant/lib/inGamePlantPresets.ts
@@ -3,11 +3,14 @@ import {
     type PlantDefinition,
 } from './plant-definition-types';
 import { plantTypes } from './plant-presets';
+import { getNominalMaturePlantHeight } from './plantLodSummary';
 
 interface InGamePlantRuntimeConfig {
     aliases: string[];
+    definition: PlantDefinition;
     growthMultiplier: number;
     instanceScale: number;
+    matureHeightMeters?: number;
     plantType: keyof typeof plantTypes;
 }
 
@@ -15,6 +18,7 @@ export interface ResolvedInGamePlantPreset {
     definition: PlantDefinition;
     growthMultiplier: number;
     instanceScale: number;
+    matureHeightMeters?: number;
     plantType: keyof typeof plantTypes;
 }
 
@@ -26,8 +30,53 @@ function createRuntimeConfig(
 ): InGamePlantRuntimeConfig {
     return {
         aliases,
+        definition: plantTypes[plantType],
         growthMultiplier,
         instanceScale,
+        plantType,
+    };
+}
+
+function createHeightCalibratedRuntimeConfig(
+    plantType: keyof typeof plantTypes,
+    growthMultiplier: number,
+    instanceScale: number,
+    {
+        aliases = [],
+        leafSizeMeters,
+        matureHeightMeters,
+    }: {
+        aliases?: string[];
+        leafSizeMeters: number;
+        matureHeightMeters: number;
+    },
+): InGamePlantRuntimeConfig {
+    const sourceDefinition = plantTypes[plantType];
+    const definition = {
+        ...sourceDefinition,
+        leaf: {
+            ...sourceDefinition.leaf,
+            size: leafSizeMeters / instanceScale,
+        },
+    };
+    const targetModelHeight = matureHeightMeters / instanceScale;
+    const currentModelHeight = getNominalMaturePlantHeight(definition);
+    const verticalHeightContribution =
+        definition.development.axes.internodeLengthScale *
+        (definition.development.axes.habit === 'prostrate' ? 0.18 : 0.98);
+
+    return {
+        aliases,
+        definition: {
+            ...definition,
+            height:
+                definition.height +
+                (targetModelHeight - currentModelHeight) /
+                    verticalHeightContribution,
+        },
+        growthMultiplier,
+        instanceScale,
+        matureHeightMeters,
         plantType,
     };
 }
@@ -35,14 +84,22 @@ function createRuntimeConfig(
 const inGamePlantRuntimeConfigs = {
     strawberry: createRuntimeConfig('strawberry', 1.02, 0.28, ['jagoda']),
     blueberry: createRuntimeConfig('blueberry', 0.92, 0.34, ['borovnica']),
-    raspberry: createRuntimeConfig('raspberry', 0.98, 0.34, ['malina']),
-    tomato: createRuntimeConfig('tomato', 1, 0.34, [
-        'rajcica',
-        'rajčica',
-        'paradajz',
-        'cherry tomato',
-        'rajcica cherry',
-    ]),
+    raspberry: createHeightCalibratedRuntimeConfig('raspberry', 0.98, 0.34, {
+        aliases: ['malina'],
+        leafSizeMeters: 0.16,
+        matureHeightMeters: 1.5,
+    }),
+    tomato: createHeightCalibratedRuntimeConfig('tomato', 1, 0.34, {
+        aliases: [
+            'rajcica',
+            'rajčica',
+            'paradajz',
+            'cherry tomato',
+            'rajcica cherry',
+        ],
+        leafSizeMeters: 0.2,
+        matureHeightMeters: 1.5,
+    }),
     bellpepper: createRuntimeConfig('bellpepper', 0.96, 0.32, [
         'paprika',
         'pepper',
@@ -55,7 +112,11 @@ const inGamePlantRuntimeConfigs = {
         'aubergine',
     ]),
     artichoke: createRuntimeConfig('artichoke', 0.88, 0.36, ['artičoka']),
-    okra: createRuntimeConfig('okra', 0.92, 0.3, ['bamija']),
+    okra: createHeightCalibratedRuntimeConfig('okra', 0.92, 0.3, {
+        aliases: ['bamija'],
+        leafSizeMeters: 0.22,
+        matureHeightMeters: 1.5,
+    }),
     cucumber: createRuntimeConfig('cucumber', 1.04, 0.34, [
         'krastavac',
         'krastavci',
@@ -97,13 +158,26 @@ const inGamePlantRuntimeConfigs = {
     oregano: createRuntimeConfig('oregano', 0.96, 0.22, ['origano']),
     parsley: createRuntimeConfig('parsley', 1, 0.24, ['peršin', 'persin']),
     thyme: createRuntimeConfig('thyme', 0.92, 0.2, ['timijan']),
-    broadbean: createRuntimeConfig('broadbean', 0.94, 0.32, [
-        'bob',
-        'fava bean',
-    ]),
-    bean: createRuntimeConfig('bean', 0.98, 0.32, ['grah']),
-    pea: createRuntimeConfig('pea', 1.02, 0.28, ['grašak', 'grasak']),
-    greenbean: createRuntimeConfig('greenbean', 1, 0.3, ['mahuna']),
+    broadbean: createHeightCalibratedRuntimeConfig('broadbean', 0.94, 0.32, {
+        aliases: ['bob', 'fava bean'],
+        leafSizeMeters: 0.12,
+        matureHeightMeters: 1.2,
+    }),
+    bean: createHeightCalibratedRuntimeConfig('bean', 0.98, 0.32, {
+        aliases: ['grah'],
+        leafSizeMeters: 0.16,
+        matureHeightMeters: 1.5,
+    }),
+    pea: createHeightCalibratedRuntimeConfig('pea', 1.02, 0.28, {
+        aliases: ['grašak', 'grasak'],
+        leafSizeMeters: 0.1,
+        matureHeightMeters: 1.2,
+    }),
+    greenbean: createHeightCalibratedRuntimeConfig('greenbean', 1, 0.3, {
+        aliases: ['mahuna'],
+        leafSizeMeters: 0.16,
+        matureHeightMeters: 1.5,
+    }),
     broccoli: createRuntimeConfig('broccoli', 0.92, 0.34, ['brokula']),
     cauliflower: createRuntimeConfig('cauliflower', 0.92, 0.34, [
         'cvjetača',
@@ -169,9 +243,10 @@ export function resolveInGamePlantPreset(
 
         if (matches) {
             return {
-                definition: plantTypes[config.plantType],
+                definition: config.definition,
                 growthMultiplier: config.growthMultiplier,
                 instanceScale: config.instanceScale,
+                matureHeightMeters: config.matureHeightMeters,
                 plantType: config.plantType,
             };
         }
@@ -180,20 +255,28 @@ export function resolveInGamePlantPreset(
     return null;
 }
 
-export function getPlantLifecycleWindowDays({
+export function getPlantMaturityWindowDays({
     germinationWindowMax,
     growthWindowMax,
-    harvestWindowMax,
 }: {
     germinationWindowMax?: number;
     growthWindowMax?: number;
-    harvestWindowMax?: number;
 }) {
-    return Math.max(
-        1,
-        (germinationWindowMax ?? 0) +
-            (growthWindowMax ?? 0) +
-            (harvestWindowMax ?? 0),
+    return Math.max(1, (germinationWindowMax ?? 0) + (growthWindowMax ?? 0));
+}
+
+export function getInGamePlantInstanceScale(
+    preset: ResolvedInGamePlantPreset,
+    plantsPerRow: number,
+) {
+    const densityScale = Math.max(
+        0.72,
+        1 - Math.max(0, plantsPerRow - 2) * 0.12,
+    );
+
+    return (
+        preset.instanceScale *
+        (preset.matureHeightMeters === undefined ? densityScale : 1)
     );
 }
 

--- a/packages/game/src/generators/plant/lib/inGamePlantPresets.unit.ts
+++ b/packages/game/src/generators/plant/lib/inGamePlantPresets.unit.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    calculateInGamePlantGeneration,
+    getInGamePlantInstanceScale,
+    getPlantMaturityWindowDays,
+    resolveInGamePlantPreset,
+} from './inGamePlantPresets';
+import { getNominalMaturePlantHeight } from './plantLodSummary';
+
+test('height-calibrated crops preserve mature height and leaf size in game meters', () => {
+    for (const [label, expectedHeight, expectedLeafSize] of [
+        ['Rajčica', 1.5, 0.2],
+        ['Malina', 1.5, 0.16],
+        ['Bamija', 1.5, 0.22],
+        ['Grah', 1.5, 0.16],
+        ['Mahuna', 1.5, 0.16],
+        ['Bob', 1.2, 0.12],
+        ['Grašak', 1.2, 0.1],
+    ] as const) {
+        const preset = resolveInGamePlantPreset([label]);
+
+        assert.ok(preset);
+        assert.equal(preset.matureHeightMeters, expectedHeight);
+        assert.ok(
+            Math.abs(
+                getNominalMaturePlantHeight(preset.definition) *
+                    preset.instanceScale -
+                    expectedHeight,
+            ) < 1e-12,
+        );
+        assert.ok(
+            Math.abs(
+                preset.definition.leaf.size * preset.instanceScale -
+                    expectedLeafSize,
+            ) < 1e-12,
+        );
+    }
+});
+
+test('plants reach full generation at the end of germination and growth', () => {
+    const maturityWindowDays = getPlantMaturityWindowDays({
+        germinationWindowMax: 14,
+        growthWindowMax: 70,
+    });
+
+    assert.equal(maturityWindowDays, 84);
+    assert.equal(
+        calculateInGamePlantGeneration({
+            currentTime: new Date('2026-07-24T00:00:00.000Z'),
+            sowDate: '2026-05-01T00:00:00.000Z',
+            lifecycleWindowDays: maturityWindowDays,
+            growthMultiplier: 1,
+        }),
+        12,
+    );
+});
+
+test('planting density does not shrink height-calibrated crops', () => {
+    const tomato = resolveInGamePlantPreset(['Rajčica']);
+    const lettuce = resolveInGamePlantPreset(['Salata']);
+
+    assert.ok(tomato);
+    assert.ok(lettuce);
+    assert.equal(getInGamePlantInstanceScale(tomato, 8), tomato.instanceScale);
+    assert.equal(
+        getInGamePlantInstanceScale(lettuce, 8),
+        lettuce.instanceScale * 0.72,
+    );
+});
+
+test('missing maturity windows still produce a finite growth timeline', () => {
+    assert.equal(getPlantMaturityWindowDays({}), 1);
+});

--- a/packages/game/src/generators/plant/lib/plantLodSummary.ts
+++ b/packages/game/src/generators/plant/lib/plantLodSummary.ts
@@ -29,6 +29,33 @@ function getLifecycleGrowth(
     return THREE.MathUtils.smoothstep(generation, start, matureAt);
 }
 
+export function getNominalMaturePlantHeight(plantDefinition: PlantDefinition) {
+    const { development } = plantDefinition;
+    const isBasal =
+        development.architecture === 'rosette' ||
+        development.architecture === 'clump';
+    const isProstrate = development.axes.habit === 'prostrate';
+    const storageHeight = development.storage
+        ? plantDefinition.vegetable.baseSize *
+          development.storage.sizeScale *
+          Math.max(0.5, development.storage.aboveSoilFraction)
+        : 0;
+    const basalFoliageHeight =
+        plantDefinition.leaf.size *
+        (1.05 + development.foliage.petioleLengthScale * 0.5);
+    const axialFoliageHeight =
+        plantDefinition.height *
+            development.axes.internodeLengthScale *
+            (isProstrate ? 0.18 : 0.98) +
+        plantDefinition.leaf.size;
+
+    return Math.max(
+        isBasal ? basalFoliageHeight : axialFoliageHeight,
+        storageHeight,
+        0.16,
+    );
+}
+
 export function buildApproximatePlantLodSummary({
     flowerGrowth,
     fruitGrowth,
@@ -58,24 +85,7 @@ export function buildApproximatePlantLodSummary({
         development.architecture === 'rosette' ||
         development.architecture === 'clump';
     const isProstrate = development.axes.habit === 'prostrate';
-    const storageHeight = development.storage
-        ? plantDefinition.vegetable.baseSize *
-          development.storage.sizeScale *
-          Math.max(0.5, development.storage.aboveSoilFraction)
-        : 0;
-    const basalFoliageHeight =
-        plantDefinition.leaf.size *
-        (1.05 + development.foliage.petioleLengthScale * 0.5);
-    const axialFoliageHeight =
-        plantDefinition.height *
-            development.axes.internodeLengthScale *
-            (isProstrate ? 0.18 : 0.98) +
-        plantDefinition.leaf.size;
-    const matureHeight = Math.max(
-        isBasal ? basalFoliageHeight : axialFoliageHeight,
-        storageHeight,
-        0.16,
-    );
+    const matureHeight = getNominalMaturePlantHeight(plantDefinition);
     const minimumHeight = Math.max(
         plantDefinition.vegetable.baseSize * 1.2,
         plantDefinition.leaf.size * (isBasal ? 1.1 : 0.7),


### PR DESCRIPTION
## Summary

- scale raised-bed support sticks from their authored 1 m height to 1.2 m above the soil
- calibrate mature tomato, raspberry, okra, bean, green bean, broad bean, and pea heights in world meters without enlarging fruit
- use germination plus growth (not harvest duration) for visual plant maturity
- preserve calibrated tall-crop height in dense fields while retaining density scaling for other crops
- add regression coverage for support height, crop height/leaf scale, maturity timing, and density behavior

## Validation

- `pnpm lint --filter @gredice/game`
- `pnpm test --filter @gredice/game` (794 passing)
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
- `git diff --check`
- visually verified the Garden debug scene and calibrated tomato fixture