### PR TITLE
[Game] Expand Suncokret AI chat

### DIFF
--- a/apps/api/app/api/[...route]/aiSuncokretRoutes.ts
+++ b/apps/api/app/api/[...route]/aiSuncokretRoutes.ts
@@ -9,11 +9,14 @@ import {
     ensureAiChatConversation,
     finalizeAiChatUsage,
     getAiChatAccountLimitState,
+    getAiChatConversationForUser,
+    getAiChatConversationsForUser,
     getGarden,
     getRaisedBed,
     releaseAiChatUsageReservation,
     replaceAiChatMessages,
     reserveAiChatUsage,
+    updateAiChatConversationTitle,
 } from '@gredice/storage';
 import {
     consumeStream,
@@ -32,6 +35,10 @@ import {
     buildSuncokretFinalAnswerSystemPrompt,
     buildSuncokretSystemPrompt,
 } from '../../../lib/ai/suncokretContext';
+import {
+    fallbackSuncokretConversationTitle,
+    generateSuncokretConversationTitle,
+} from '../../../lib/ai/suncokretConversationTitle';
 import { visibleRaisedBedsForGarden } from '../../../lib/ai/suncokretGardenContext';
 import {
     estimateSuncokretPromptTokens,
@@ -51,12 +58,12 @@ import {
 const MIN_OUTPUT_TOKENS = 128;
 const MAX_CONTEXT_MESSAGES = 24;
 const MAX_IMAGE_URLS_PER_ANALYSIS = 6;
+const MAX_LEGACY_TITLE_BACKFILLS = 6;
 const MAX_TOOL_STEPS = 6;
 
 type ChatVariables = AuthVariables;
 
 const FeatureFlagsSchema = z.object({
-    enableSuncokretChatFlag: z.boolean().optional().default(false),
     enableSuncokretDebugFlag: z.boolean().optional().default(false),
 });
 
@@ -81,6 +88,27 @@ const SuncokretUiContextSchema = z.discriminatedUnion('surface', [
     }),
 ]);
 
+const RecommendationDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+
+const SuncokretRecommendationSchema = z.discriminatedUnion('kind', [
+    z.object({
+        kind: z.literal('operation'),
+        operationId: z.number().int().positive(),
+        gardenId: z.number().int().positive(),
+        raisedBedId: z.number().int().positive(),
+        positionIndex: z.number().int().min(0).optional(),
+        scheduledDate: RecommendationDateSchema.optional(),
+    }),
+    z.object({
+        kind: z.literal('sowing'),
+        plantSortId: z.number().int().positive(),
+        gardenId: z.number().int().positive(),
+        raisedBedId: z.number().int().positive(),
+        positionIndex: z.number().int().min(0),
+        scheduledDate: RecommendationDateSchema.optional(),
+    }),
+]);
+
 const ChatBodySchema = z.object({
     id: z.string().optional(),
     conversationId: z.string().optional(),
@@ -92,16 +120,22 @@ const ChatBodySchema = z.object({
     uiContext: SuncokretUiContextSchema.optional().nullable(),
     debug: z.boolean().optional(),
     featureFlags: FeatureFlagsSchema.optional().default({
-        enableSuncokretChatFlag: false,
         enableSuncokretDebugFlag: false,
     }),
 });
 
 const StatusQuerySchema = z.object({
     modelId: z.string().optional(),
-    enableSuncokretChatFlag: z.string().optional(),
     enableSuncokretDebugFlag: z.string().optional(),
 });
+
+const ConversationParamsSchema = z.object({
+    conversationId: z.string().trim().min(1).max(128),
+});
+
+function conversationNeedsGeneratedTitle(title: string | null) {
+    return !title || title === 'Suncokret razgovor';
+}
 
 function booleanFlag(value: string | undefined) {
     return ['1', 'true', 'yes', 'on'].includes(value?.toLowerCase() ?? '');
@@ -109,7 +143,6 @@ function booleanFlag(value: string | undefined) {
 
 function queryFeatureFlags(query: z.infer<typeof StatusQuerySchema>) {
     return {
-        enableSuncokretChatFlag: booleanFlag(query.enableSuncokretChatFlag),
         enableSuncokretDebugFlag: booleanFlag(query.enableSuncokretDebugFlag),
     };
 }
@@ -132,18 +165,6 @@ function jsonError(
         },
         status,
     };
-}
-
-function enabledOrResponse(flags: z.infer<typeof FeatureFlagsSchema>) {
-    if (flags.enableSuncokretChatFlag) {
-        return null;
-    }
-
-    return jsonError(
-        'ai_feature_disabled',
-        'Suncokret chat trenutno nije omogućen.',
-        403,
-    );
 }
 
 function usageTokens(usage: LanguageModelUsage | undefined) {
@@ -523,6 +544,17 @@ function buildTools({
                 });
             },
         }),
+        presentRecommendations: tool({
+            description:
+                'Prikaži klikabilne prijedloge za konkretne radnje ili sijanja. Pozovi tek nakon provjere kataloga i ciljne gredice/polja. Za radnju koristi operationId iz kataloga radnji. Za sijanje koristi entityId sorte iz rezultata searchProducts kao plantSortId. Ako zadaješ datum, koristi YYYY-MM-DD. Ovaj alat samo prikazuje prijedloge; ne mijenja košaricu.',
+            inputSchema: z.object({
+                recommendations: z
+                    .array(SuncokretRecommendationSchema)
+                    .min(1)
+                    .max(6),
+            }),
+            execute: (input) => input,
+        }),
         prepareCheckout: tool({
             description:
                 'Pripremi korisnika za checkout. Uvijek treba odobrenje korisnika.',
@@ -549,7 +581,6 @@ const app = new Hono<{ Variables: ChatVariables }>()
         async (context) => {
             const query = context.req.valid('query');
             const featureFlags = queryFeatureFlags(query);
-            const disabled = enabledOrResponse(featureFlags);
             const { accountId } = context.get('authContext');
             const model = getSuncokretModel(query.modelId);
             const limitState = await getAiChatAccountLimitState(accountId);
@@ -566,7 +597,7 @@ const app = new Hono<{ Variables: ChatVariables }>()
                 : undefined;
 
             return context.json({
-                enabled: !disabled,
+                enabled: true,
                 debugEnabled: featureFlags.enableSuncokretDebugFlag,
                 model: model
                     ? {
@@ -603,12 +634,6 @@ const app = new Hono<{ Variables: ChatVariables }>()
         zValidator('query', StatusQuerySchema),
         authValidator(['user', 'admin']),
         async (context) => {
-            const featureFlags = queryFeatureFlags(context.req.valid('query'));
-            const disabled = enabledOrResponse(featureFlags);
-            if (disabled) {
-                return context.json(disabled.body, disabled.status);
-            }
-
             return context.json({
                 models: getSuncokretModelRegistry()
                     .filter((model) => model.enabled)
@@ -616,6 +641,137 @@ const app = new Hono<{ Variables: ChatVariables }>()
                         id: model.id,
                         label: model.label,
                     })),
+            });
+        },
+    )
+    .get(
+        '/conversations',
+        describeRoute({
+            description: 'List the current user Suncokret AI conversations',
+            security: authSecurity,
+        }),
+        zValidator('query', StatusQuerySchema),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const auth = context.get('authContext');
+            const conversations = await getAiChatConversationsForUser({
+                accountId: auth.accountId,
+                userId: auth.userId,
+            });
+            const legacyTitleBackfillIds = new Set(
+                conversations
+                    .filter((conversation) =>
+                        conversationNeedsGeneratedTitle(conversation.title),
+                    )
+                    .slice(0, MAX_LEGACY_TITLE_BACKFILLS)
+                    .map((conversation) => conversation.id),
+            );
+            const titledConversations = await Promise.all(
+                conversations.map(async (conversation) => {
+                    if (!legacyTitleBackfillIds.has(conversation.id)) {
+                        return conversation;
+                    }
+
+                    const model =
+                        getSuncokretModel(conversation.model) ??
+                        getSuncokretModel();
+                    if (!model) {
+                        return conversation;
+                    }
+
+                    let title: string | null = null;
+                    try {
+                        title = await generateSuncokretConversationTitle({
+                            messages: conversation.messages,
+                            modelId: model.id,
+                        });
+                    } catch (error) {
+                        console.warn(
+                            'Suncokret legacy conversation title generation failed',
+                            { conversationId: conversation.id, error },
+                        );
+                        title = fallbackSuncokretConversationTitle(
+                            conversation.messages,
+                        );
+                    }
+
+                    if (!title) {
+                        return conversation;
+                    }
+
+                    try {
+                        await updateAiChatConversationTitle({
+                            accountId: auth.accountId,
+                            conversationId: conversation.id,
+                            title,
+                            userId: auth.userId,
+                        });
+                        return { ...conversation, title };
+                    } catch (error) {
+                        console.warn(
+                            'Suncokret legacy conversation title persistence failed',
+                            { conversationId: conversation.id, error },
+                        );
+                        return conversation;
+                    }
+                }),
+            );
+
+            return context.json({
+                conversations: titledConversations.map((conversation) => ({
+                    id: conversation.id,
+                    title: conversation.title,
+                    model: conversation.model,
+                    gardenId: conversation.gardenId,
+                    raisedBedId: conversation.raisedBedId,
+                    createdAt: conversation.createdAt.toISOString(),
+                    lastMessageAt: conversation.lastMessageAt?.toISOString(),
+                })),
+            });
+        },
+    )
+    .get(
+        '/conversations/:conversationId',
+        describeRoute({
+            description: 'Load a current user Suncokret AI conversation',
+            security: authSecurity,
+        }),
+        zValidator('param', ConversationParamsSchema),
+        zValidator('query', StatusQuerySchema),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const auth = context.get('authContext');
+            const { conversationId } = context.req.valid('param');
+            const conversation = await getAiChatConversationForUser({
+                accountId: auth.accountId,
+                conversationId,
+                userId: auth.userId,
+            });
+            if (!conversation) {
+                const error = jsonError(
+                    'ai_conversation_not_found',
+                    'Razgovor nije pronađen.',
+                    404,
+                );
+                return context.json(error.body, error.status);
+            }
+
+            return context.json({
+                conversation: {
+                    id: conversation.id,
+                    title: conversation.title,
+                    model: conversation.model,
+                    gardenId: conversation.gardenId,
+                    raisedBedId: conversation.raisedBedId,
+                    createdAt: conversation.createdAt.toISOString(),
+                    lastMessageAt: conversation.lastMessageAt?.toISOString(),
+                    messages: conversation.messages.map((message) => ({
+                        id: message.id,
+                        role: message.role,
+                        parts: message.parts,
+                        metadata: message.metadata ?? undefined,
+                    })),
+                },
             });
         },
     )
@@ -629,11 +785,6 @@ const app = new Hono<{ Variables: ChatVariables }>()
         authValidator(['user', 'admin']),
         async (context) => {
             const body = context.req.valid('json');
-            const disabled = enabledOrResponse(body.featureFlags);
-            if (disabled) {
-                return context.json(disabled.body, disabled.status);
-            }
-
             const debugAllowed = Boolean(
                 body.debug && body.featureFlags.enableSuncokretDebugFlag,
             );
@@ -673,7 +824,7 @@ const app = new Hono<{ Variables: ChatVariables }>()
                 gardenId: validatedGardenId,
                 raisedBedId: validatedRaisedBedId,
                 model: model.id,
-                title: 'Suncokret razgovor',
+                title: null,
             });
             if (!conversation) {
                 const error = jsonError(
@@ -683,7 +834,6 @@ const app = new Hono<{ Variables: ChatVariables }>()
                 );
                 return context.json(error.body, error.status);
             }
-
             const limitState = await getAiChatAccountLimitState(auth.accountId);
             if (limitState.blockedReason) {
                 const error = jsonError(
@@ -768,6 +918,20 @@ const app = new Hono<{ Variables: ChatVariables }>()
                 return context.json(error.body, error.status);
             }
 
+            const generatedTitlePromise = conversationNeedsGeneratedTitle(
+                conversation.title,
+            )
+                ? generateSuncokretConversationTitle({
+                      messages: body.messages,
+                      modelId: model.id,
+                  }).catch((error) => {
+                      console.warn(
+                          'Suncokret conversation title generation failed',
+                          { conversationId, error },
+                      );
+                      return fallbackSuncokretConversationTitle(body.messages);
+                  })
+                : null;
             const token = await mcpToken(auth.userId, auth.accountId);
             const origin = new URL(context.req.url).origin;
             let finalized = false;
@@ -889,6 +1053,24 @@ const app = new Hono<{ Variables: ChatVariables }>()
                             conversationId,
                             messages,
                         });
+                        if (generatedTitlePromise) {
+                            const title = await generatedTitlePromise;
+                            if (title) {
+                                try {
+                                    await updateAiChatConversationTitle({
+                                        accountId: auth.accountId,
+                                        conversationId,
+                                        title,
+                                        userId: auth.userId,
+                                    });
+                                } catch (error) {
+                                    console.warn(
+                                        'Suncokret conversation title persistence failed',
+                                        { conversationId, error },
+                                    );
+                                }
+                            }
+                        }
                         if (isAborted && !finalized) {
                             await releaseAiChatUsageReservation({
                                 ledgerId: reservation.ledgerId,

--- a/apps/api/lib/ai/suncokretContext.node.spec.ts
+++ b/apps/api/lib/ai/suncokretContext.node.spec.ts
@@ -35,6 +35,20 @@ test('buildSuncokretSystemPrompt requires a friendly gender-neutral voice', () =
     assert.match(prompt, /trebao\/trebala/);
 });
 
+test('buildSuncokretSystemPrompt requires structured actionable recommendations', () => {
+    const prompt = buildSuncokretSystemPrompt({
+        garden: { id: 12, name: 'Aleksov vrt' },
+        raisedBed: { id: 34, name: 'Sunčano Sunce', status: 'active' },
+        uiContext: { surface: 'raised-bed' },
+    });
+
+    assert.match(prompt, /pozovi presentRecommendations/);
+    assert.match(prompt, /klikabilne prijedloge/);
+    assert.match(prompt, /ne dodaje ništa u košaricu/);
+    assert.match(prompt, /ručno naručiti/);
+    assert.match(prompt, /dodaš u košaricu/);
+});
+
 test('buildSuncokretSystemPrompt describes the active settings section', () => {
     const prompt = buildSuncokretSystemPrompt({
         garden: { id: 12, name: 'Aleksov vrt' },

--- a/apps/api/lib/ai/suncokretContext.ts
+++ b/apps/api/lib/ai/suncokretContext.ts
@@ -118,6 +118,8 @@ export function buildSuncokretSystemPrompt(input: {
         'Ne zovi isti alat s istim argumentima više puta u jednom odgovoru. Nakon dohvaćanja podataka nastavi korisniku završnim odgovorom; ne završavaj razgovor samo na rezultatu alata.',
         'Kada korisnik pita što treba napraviti ovaj tjedan, odgovori s naslovom "Plan za ovaj tjedan" i 3-6 prioriteta. Za svaki prioritet navedi zašto je važan, kada ga napraviti ako podaci imaju termin i koju Gredice radnju naručiti kada postoji odgovarajuća radnja.',
         'Korisnik nema nužno fizički pristup gredici. Kada preporuka traži rad na gredici, predloži naručivanje odgovarajuće radnje ili sijanja kroz dostupne alate.',
+        'Kada u završnom odgovoru preporučiš konkretnu dostupnu Gredice radnju ili sijanje za određenu gredicu ili polje, nakon provjere kataloga pozovi presentRecommendations kako bi korisnik dobio klikabilne prijedloge. Prikaži samo stavke koje doista preporučuješ, najviše šest. Taj alat ne dodaje ništa u košaricu.',
+        'Uz klikabilne prijedloge kratko reci da ih korisnik može otvoriti i ručno naručiti ili zatražiti da ih dodaš u košaricu.',
         'Ne tvrdi da je radnja, sijanje, izmjena košarice ili checkout izvršen dok alat ne potvrdi rezultat.',
         'Za kupnju, checkout, promjene košarice, sijanje, zakazivanje, otkazivanje i druge promjene prvo sažmi što želiš napraviti i koristi alat koji traži odobrenje korisnika.',
         'Ako korisnik traži savjete iz fotografija gredice, prvo pokreni alat analyzeRaisedBedImages i nastavi razgovor iz spremljenog rezultata.',

--- a/apps/api/lib/ai/suncokretConversationTitle.node.spec.ts
+++ b/apps/api/lib/ai/suncokretConversationTitle.node.spec.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    fallbackSuncokretConversationTitle,
+    firstSuncokretUserQuestion,
+    normalizeSuncokretConversationTitle,
+} from './suncokretConversationTitle';
+
+test('extracts the first user question from UI message parts', () => {
+    assert.strictEqual(
+        firstSuncokretUserQuestion([
+            { id: 'assistant-1', role: 'assistant', parts: [] },
+            {
+                id: 'user-1',
+                role: 'user',
+                parts: [
+                    { type: 'text', text: '  Kako pripremiti ' },
+                    { type: 'file', url: 'https://example.test/image.jpg' },
+                    { type: 'text', text: 'vrt za kišu?  ' },
+                ],
+            },
+        ]),
+        'Kako pripremiti vrt za kišu?',
+    );
+});
+
+test('normalizes generated titles and bounds their length', () => {
+    assert.strictEqual(
+        normalizeSuncokretConversationTitle(
+            'Naslov: „Priprema vrta za kišu”\n',
+            'Kako pripremiti vrt?',
+        ),
+        'Priprema vrta za kišu',
+    );
+    assert.ok(
+        normalizeSuncokretConversationTitle('', 'a'.repeat(100)).length <= 72,
+    );
+    assert.strictEqual(
+        fallbackSuncokretConversationTitle([
+            {
+                role: 'user',
+                parts: [{ type: 'text', text: 'Kako pripremiti vrt?' }],
+            },
+        ]),
+        'Kako pripremiti vrt?',
+    );
+});

--- a/apps/api/lib/ai/suncokretConversationTitle.ts
+++ b/apps/api/lib/ai/suncokretConversationTitle.ts
@@ -1,0 +1,85 @@
+import { gateway, generateText } from 'ai';
+
+const MAX_TITLE_LENGTH = 72;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function firstSuncokretUserQuestion(messages: unknown[]) {
+    for (const message of messages) {
+        if (!isRecord(message) || message.role !== 'user') {
+            continue;
+        }
+
+        const parts = Array.isArray(message.parts) ? message.parts : [];
+        const text = parts
+            .flatMap((part) => {
+                if (
+                    !isRecord(part) ||
+                    part.type !== 'text' ||
+                    typeof part.text !== 'string'
+                ) {
+                    return [];
+                }
+
+                return part.text.trim();
+            })
+            .filter(Boolean)
+            .join(' ')
+            .trim();
+
+        if (text) {
+            return text;
+        }
+    }
+
+    return null;
+}
+
+export function normalizeSuncokretConversationTitle(
+    value: string,
+    fallbackQuestion: string,
+) {
+    const normalized = value
+        .replace(/^\s*(naslov|title)\s*:\s*/i, '')
+        .replace(/^\s*["'„“”]+|["'„“”]+\s*$/g, '')
+        .replace(/[\r\n]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+    const fallback = fallbackQuestion.replace(/\s+/g, ' ').trim();
+    const title = normalized || fallback || 'Novi razgovor';
+
+    if (title.length <= MAX_TITLE_LENGTH) {
+        return title;
+    }
+
+    return `${title.slice(0, MAX_TITLE_LENGTH - 1).trimEnd()}…`;
+}
+
+export function fallbackSuncokretConversationTitle(messages: unknown[]) {
+    const question = firstSuncokretUserQuestion(messages);
+    return question ? normalizeSuncokretConversationTitle('', question) : null;
+}
+
+export async function generateSuncokretConversationTitle({
+    messages,
+    modelId,
+}: {
+    messages: unknown[];
+    modelId: string;
+}) {
+    const question = firstSuncokretUserQuestion(messages);
+    if (!question) {
+        return null;
+    }
+
+    const result = await generateText({
+        model: gateway(modelId),
+        system: 'Napiši kratak, jasan naslov razgovora na hrvatskom jeziku. Vrati samo naslov, bez navodnika, dvotočke ili objašnjenja. Naslov mora opisivati temu prvog korisničkog pitanja.',
+        prompt: question,
+        maxOutputTokens: 32,
+    });
+
+    return normalizeSuncokretConversationTitle(result.text, question);
+}

--- a/apps/garden/app/flags.ts
+++ b/apps/garden/app/flags.ts
@@ -29,13 +29,6 @@ export const enableDebugHudFlag = flag<boolean>({
     options: booleanFlagOptions,
 });
 
-export const enableSuncokretChatFlag = flag<boolean>({
-    key: 'enableSuncokretChat',
-    description: 'Enable the in-game Suncokret AI chat HUD.',
-    decide: () => false,
-    options: booleanFlagOptions,
-});
-
 export const enableSuncokretDebugFlag = flag<boolean>({
     key: 'enableSuncokretDebug',
     description: 'Show Suncokret AI debug metadata in chat conversations.',

--- a/apps/garden/app/getGardenGameFlags.ts
+++ b/apps/garden/app/getGardenGameFlags.ts
@@ -1,21 +1,14 @@
 import type { GameFeatureFlags } from '@gredice/game';
-import {
-    enableDebugHudFlag,
-    enableSuncokretChatFlag,
-    enableSuncokretDebugFlag,
-} from './flags';
+import { enableDebugHudFlag, enableSuncokretDebugFlag } from './flags';
 
 export async function getGardenGameFlags(): Promise<GameFeatureFlags> {
-    const [enableDebugHud, enableSuncokretChat, enableSuncokretDebug] =
-        await Promise.all([
-            enableDebugHudFlag(),
-            enableSuncokretChatFlag(),
-            enableSuncokretDebugFlag(),
-        ]);
+    const [enableDebugHud, enableSuncokretDebug] = await Promise.all([
+        enableDebugHudFlag(),
+        enableSuncokretDebugFlag(),
+    ]);
 
     return {
         enableDebugHudFlag: enableDebugHud,
-        enableSuncokretChatFlag: enableSuncokretChat,
         enableSuncokretDebugFlag: enableSuncokretDebug,
     };
 }

--- a/apps/garden/tests/RaisedBedFieldHudStory.tsx
+++ b/apps/garden/tests/RaisedBedFieldHudStory.tsx
@@ -166,14 +166,12 @@ function createScenarioQueryClient(
 }
 
 type ProvidersProps = PropsWithChildren<{
-    enableSuncokret?: boolean;
     favorites?: FavoriteItem[];
     scenario: RaisedBedScenario;
 }>;
 
 function RaisedBedHudTestProviders({
     children,
-    enableSuncokret = false,
     scenario,
     favorites = [],
 }: ProvidersProps) {
@@ -196,11 +194,7 @@ function RaisedBedHudTestProviders({
         <NuqsTestingAdapter>
             <ReactQuery.QueryClientProvider client={queryClient}>
                 <GameStateContext.Provider value={gameStore}>
-                    <GameFlagsContext.Provider
-                        value={{
-                            enableSuncokretChatFlag: enableSuncokret,
-                        }}
-                    >
+                    <GameFlagsContext.Provider value={{}}>
                         <SuncokretChatProvider>
                             <GameAnalyticsProvider
                                 capture={(eventName, properties) => {
@@ -232,24 +226,18 @@ export function RaisedBedFieldHudStory({
     positionIndex,
     favorites = [],
     cellSize = 80,
-    enableSuncokret = false,
 }: {
     scenario: RaisedBedScenario;
     positionIndex: number;
     favorites?: FavoriteItem[];
     cellSize?: number;
-    enableSuncokret?: boolean;
 }) {
     const cartItem =
         scenario.cartItems?.find(
             (item) => item.positionIndex === positionIndex,
         ) ?? null;
     return (
-        <RaisedBedHudTestProviders
-            scenario={scenario}
-            favorites={favorites}
-            enableSuncokret={enableSuncokret}
-        >
+        <RaisedBedHudTestProviders scenario={scenario} favorites={favorites}>
             <div
                 data-testid="hud-cell"
                 className="relative"
@@ -272,34 +260,24 @@ export function RaisedBedFieldHudStory({
 }
 
 export function RaisedBedInfoModalStory({
-    enableSuncokret = false,
     scenario,
 }: {
-    enableSuncokret?: boolean;
     scenario: RaisedBedScenario;
 }) {
     return (
-        <RaisedBedHudTestProviders
-            scenario={scenario}
-            enableSuncokret={enableSuncokret}
-        >
+        <RaisedBedHudTestProviders scenario={scenario}>
             <RaisedBedInfoModalStoryContent />
         </RaisedBedHudTestProviders>
     );
 }
 
 export function RaisedBedCloseupHudStory({
-    enableSuncokret = false,
     scenario,
 }: {
-    enableSuncokret?: boolean;
     scenario: RaisedBedScenario;
 }) {
     return (
-        <RaisedBedHudTestProviders
-            scenario={scenario}
-            enableSuncokret={enableSuncokret}
-        >
+        <RaisedBedHudTestProviders scenario={scenario}>
             <RaisedBedCloseupHudStoryContent />
         </RaisedBedHudTestProviders>
     );

--- a/apps/garden/tests/SuncokretChatHudStory.tsx
+++ b/apps/garden/tests/SuncokretChatHudStory.tsx
@@ -13,6 +13,7 @@ import {
     createGameState,
     GameStateContext,
 } from '../../../packages/game/src/useGameState';
+import { allSorts, buildOperation } from './raisedBedFieldHudScenarios';
 
 const gardenId = 1;
 const raisedBedId = 11;
@@ -54,6 +55,21 @@ const garden = {
     ],
 };
 
+const wateringOperationBase = buildOperation({
+    id: 77,
+    name: 'watering-raised-bed',
+    label: 'Zalijevanje gredice',
+    stageName: 'maintenance',
+    stageLabel: 'Održavanje',
+});
+const wateringOperation = {
+    ...wateringOperationBase,
+    attributes: {
+        ...wateringOperationBase.attributes,
+        application: 'raisedBedFull' as const,
+    },
+};
+
 function createQueryClient() {
     const queryClient = new ReactQuery.QueryClient({
         defaultOptions: {
@@ -65,6 +81,8 @@ function createQueryClient() {
         [{ id: gardenId, name: garden.name, isSandbox: false }],
     );
     queryClient.setQueryData(currentGardenKeys('summer', gardenId), garden);
+    queryClient.setQueryData(['operations'], [wateringOperation]);
+    queryClient.setQueryData(['sorts'], allSorts);
     return queryClient;
 }
 
@@ -106,7 +124,6 @@ export function SuncokretChatHudStory({
                 <GameStateContext.Provider value={gameStore}>
                     <GameFlagsContext.Provider
                         value={{
-                            enableSuncokretChatFlag: true,
                             enableSuncokretDebugFlag: debug,
                         }}
                     >

--- a/apps/garden/tests/WeatherHudStory.tsx
+++ b/apps/garden/tests/WeatherHudStory.tsx
@@ -198,10 +198,8 @@ function createWeatherHudQueryClient({
 function WeatherHudTestProviders({
     alerts,
     children,
-    enableSuncokret = false,
 }: PropsWithChildren<{
     alerts?: WeatherHudAlert[];
-    enableSuncokret?: boolean;
 }>) {
     const queryClient = useMemo(
         () => createWeatherHudQueryClient({ alerts }),
@@ -222,11 +220,7 @@ function WeatherHudTestProviders({
         <ReactQuery.QueryClientProvider client={queryClient}>
             <NuqsTestingAdapter>
                 <GameStateContext.Provider value={gameStore}>
-                    <GameFlagsContext.Provider
-                        value={{
-                            enableSuncokretChatFlag: enableSuncokret,
-                        }}
-                    >
+                    <GameFlagsContext.Provider value={{}}>
                         <SuncokretChatProvider>
                             {children}
                         </SuncokretChatProvider>
@@ -238,16 +232,13 @@ function WeatherHudTestProviders({
 }
 
 export function WeatherHudStory({
-    enableSuncokret = false,
     withAlerts = false,
 }: {
-    enableSuncokret?: boolean;
     withAlerts?: boolean;
 } = {}) {
     return (
         <WeatherHudTestProviders
             alerts={withAlerts ? groupedWeatherAlerts : undefined}
-            enableSuncokret={enableSuncokret}
         >
             <div className="relative h-screen w-screen overflow-hidden">
                 <div className="absolute right-2 top-2">

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -1724,7 +1724,6 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
     }) => {
         await mount(
             <RaisedBedCloseupHudStory
-                enableSuncokret
                 scenario={plantedGrowingWithOperationHistoryScenario()}
             />,
         );
@@ -1751,7 +1750,6 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
     }) => {
         await mount(
             <RaisedBedInfoModalStory
-                enableSuncokret
                 scenario={plantedGrowingWithOperationHistoryScenario()}
             />,
         );
@@ -1776,7 +1774,6 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
     }) => {
         await mount(
             <RaisedBedFieldHudStory
-                enableSuncokret
                 scenario={plantedGrowingWithOperationHistoryScenario()}
                 positionIndex={0}
             />,

--- a/apps/garden/tests/suncokret-chat-hud.spec.tsx
+++ b/apps/garden/tests/suncokret-chat-hud.spec.tsx
@@ -23,7 +23,16 @@ function uiMessageStream(chunks: Record<string, unknown>[]) {
     return `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join('')}data: [DONE]\n\n`;
 }
 
-async function mockSuncokretRoutes(page: Page) {
+function requestRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' && !Array.isArray(value)
+        ? Object.fromEntries(Object.entries(value))
+        : null;
+}
+
+async function mockSuncokretRoutes(
+    page: Page,
+    status: typeof statusResponse = statusResponse,
+) {
     page.on('pageerror', (error) => console.error(error));
     page.on('console', (message) => {
         if (message.type() === 'error') {
@@ -31,7 +40,7 @@ async function mockSuncokretRoutes(page: Page) {
         }
     });
     await page.route('**/api/ai/suncokret/status**', (route) =>
-        route.fulfill({ json: statusResponse }),
+        route.fulfill({ json: status }),
     );
     await page.route('**/api/ai/suncokret/models**', (route) =>
         route.fulfill({
@@ -42,6 +51,101 @@ async function mockSuncokretRoutes(page: Page) {
                 ],
             },
         }),
+    );
+    await page.route('**/api/ai/suncokret/conversations?*', (route) =>
+        route.fulfill({
+            json: {
+                conversations: [
+                    {
+                        id: 'conversation-1',
+                        title: 'Priprema vrta za kišu',
+                        model: 'openai/gpt-5.5',
+                        gardenId: 1,
+                        raisedBedId: null,
+                        createdAt: '2026-07-01T09:00:00.000Z',
+                        lastMessageAt: '2026-07-01T09:05:00.000Z',
+                    },
+                ],
+            },
+        }),
+    );
+    await page.route(
+        '**/api/ai/suncokret/conversations/conversation-1?*',
+        (route) =>
+            route.fulfill({
+                json: {
+                    conversation: {
+                        id: 'conversation-1',
+                        title: 'Priprema vrta za kišu',
+                        model: 'openai/gpt-5.5',
+                        gardenId: 1,
+                        raisedBedId: null,
+                        createdAt: '2026-07-01T09:00:00.000Z',
+                        lastMessageAt: '2026-07-01T09:05:00.000Z',
+                        messages: [
+                            {
+                                id: 'user-history-1',
+                                role: 'user',
+                                parts: [
+                                    {
+                                        type: 'text',
+                                        text: 'Kako pripremiti vrt za kišu?',
+                                    },
+                                ],
+                            },
+                            {
+                                id: 'assistant-history-1',
+                                role: 'assistant',
+                                parts: [
+                                    {
+                                        type: 'text',
+                                        text: 'Provjeri odvodnju i zaštiti osjetljive biljke. Predlažem i ove korake:',
+                                    },
+                                    {
+                                        type: 'tool-presentRecommendations',
+                                        toolCallId: 'recommendations-1',
+                                        state: 'output-available',
+                                        input: {
+                                            recommendations: [
+                                                {
+                                                    kind: 'operation',
+                                                    operationId: 77,
+                                                    gardenId: 1,
+                                                    raisedBedId: 11,
+                                                },
+                                                {
+                                                    kind: 'sowing',
+                                                    plantSortId: 102,
+                                                    gardenId: 1,
+                                                    raisedBedId: 11,
+                                                    positionIndex: 0,
+                                                },
+                                            ],
+                                        },
+                                        output: {
+                                            recommendations: [
+                                                {
+                                                    kind: 'operation',
+                                                    operationId: 77,
+                                                    gardenId: 1,
+                                                    raisedBedId: 11,
+                                                },
+                                                {
+                                                    kind: 'sowing',
+                                                    plantSortId: 102,
+                                                    gardenId: 1,
+                                                    raisedBedId: 11,
+                                                    positionIndex: 0,
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            }),
     );
 }
 
@@ -65,10 +169,14 @@ test('production chat hides developer controls and shows visual usage', async ({
     });
     await expect(chat).toBeVisible();
     await expect(chat).toContainText('Razgovor za Aleksov vrt');
-    await expect(chat).toContainText('Danas');
-    await expect(chat).toContainText('Ovaj tjedan');
-    await expect(chat).toContainText('12,5% iskorišteno');
-    await expect(chat).toContainText('87,5% preostalo');
+    await expect(chat).not.toContainText('12,5% iskorišteno');
+    await page.getByRole('button', { name: /Preostala AI upotreba/ }).click();
+    const usage = page.locator('[data-suncokret-usage]');
+    await expect(usage).toContainText('Danas');
+    await expect(usage).toContainText('Ovaj tjedan');
+    await expect(usage).toContainText('87,5% preostalo');
+    await expect(usage).toContainText('96% preostalo');
+    await expect(usage).not.toContainText('iskorišteno');
     await expect(chat).not.toContainText('USD');
     await expect(chat).not.toContainText('token');
     await expect(chat).not.toContainText('AI vrtni pomoćnik');
@@ -85,11 +193,119 @@ test('production chat hides developer controls and shows visual usage', async ({
 
 test('debug chat exposes the model picker', async ({ mount, page }) => {
     await mockSuncokretRoutes(page);
+    let requestBody: Record<string, unknown> | null = null;
+    await page.route('**/api/ai/suncokret/chat', async (route) => {
+        const payload: unknown = route.request().postDataJSON();
+        requestBody = requestRecord(payload);
+        await route.fulfill({
+            status: 500,
+            json: { error: 'Test request captured' },
+        });
+    });
     await mount(<SuncokretChatHudStory debug />);
     await page.getByRole('button', { name: 'Suncokret AI' }).click();
 
     await expect(page.getByLabel('AI model')).toBeVisible();
     await expect(page.getByLabel('AI model').locator('option')).toHaveCount(2);
+    await page.getByLabel('AI model').selectOption('anthropic/claude-4');
+    await page
+        .getByRole('textbox', { name: 'Pitaj Suncokret' })
+        .fill('Koji model odgovara?');
+    await page.getByRole('button', { name: 'Pošalji' }).click();
+    await expect.poll(() => requestBody?.modelId).toBe('anthropic/claude-4');
+});
+
+test('exhausted daily and weekly usage is red and blocks sending', async ({
+    mount,
+    page,
+}) => {
+    await mockSuncokretRoutes(page, {
+        ...statusResponse,
+        usage: {
+            ...statusResponse.usage,
+            day: { usedPercent: 100, remainingPercent: 0 },
+            week: { usedPercent: 100, remainingPercent: 0 },
+        },
+    });
+    await mount(<SuncokretChatHudStory />);
+    await page.getByRole('button', { name: 'Suncokret AI' }).click();
+
+    const usageButton = page.getByRole('button', {
+        name: /Preostala AI upotreba: danas 0%, ovaj tjedan 0%/,
+    });
+    await expect(usageButton).toHaveClass(/text-red-700/);
+    await usageButton.click();
+    await expect(
+        page.locator('[data-suncokret-usage]').getByText('Iskorišteno'),
+    ).toHaveCount(2);
+    await expect(page.getByLabel('Pitaj Suncokret')).toBeDisabled();
+});
+
+test('chat lists, opens, and starts conversations', async ({ mount, page }) => {
+    await mockSuncokretRoutes(page);
+    await mount(<SuncokretChatHudStory />);
+    await page.getByRole('button', { name: 'Suncokret AI' }).click();
+
+    await page.getByRole('button', { name: 'Prijašnji razgovori' }).click();
+    await expect(page.locator('[data-suncokret-conversations]')).toContainText(
+        'Priprema vrta za kišu',
+    );
+
+    await page.getByRole('button', { name: /Priprema vrta za kišu/ }).click();
+    const chat = page.getByRole('dialog', {
+        name: 'Razgovor sa Suncokretom',
+    });
+    await expect(chat).toContainText('Kako pripremiti vrt za kišu?');
+    await expect(chat).toContainText(
+        'Provjeri odvodnju i zaštiti osjetljive biljke.',
+    );
+    await expect(chat).toContainText('Priprema vrta za kišu');
+
+    await page.getByRole('button', { name: 'Novi razgovor' }).click();
+    await expect(chat).toContainText('Kako ti mogu pomoći?');
+    await expect(chat).not.toContainText('Kako pripremiti vrt za kišu?');
+});
+
+test('saved AI recommendations open manual operation and sowing flows', async ({
+    mount,
+    page,
+}) => {
+    await mockSuncokretRoutes(page);
+    await page.route('**/api/outlet/offers**', (route) =>
+        route.fulfill({ json: { items: [] } }),
+    );
+    await mount(<SuncokretChatHudStory />);
+    await page.getByRole('button', { name: 'Suncokret AI' }).click();
+    await page.getByRole('button', { name: 'Prijašnji razgovori' }).click();
+    await page.getByRole('button', { name: /Priprema vrta za kišu/ }).click();
+
+    const recommendations = page.getByRole('group', {
+        name: 'Preporučene radnje i sijanja',
+    });
+    await expect(recommendations).toBeVisible();
+    await recommendations
+        .getByRole('button', { name: 'Zalijevanje gredice' })
+        .click();
+    await expect(
+        page.getByRole('dialog', {
+            name: 'Zakaži radnju: Zalijevanje gredice',
+        }),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Odustani' }).click();
+
+    await recommendations
+        .getByRole('button', { name: 'Klasični bosiljak - polje 1' })
+        .click();
+    const sowingDialog = page.getByRole('dialog', {
+        name: 'Sijanje biljke',
+    });
+    await expect(sowingDialog).toBeVisible();
+    await expect(
+        sowingDialog.getByText('Klasični bosiljak', { exact: true }),
+    ).toBeVisible();
+    await expect(
+        sowingDialog.getByRole('button', { name: 'Dodaj u košaru' }),
+    ).toBeEnabled();
 });
 
 test('settings context replaces the raised-bed context in the header', async ({
@@ -190,11 +406,8 @@ test('context selected after chat initialization is sent with the request', asyn
     await mockSuncokretRoutes(page);
     let requestBody: Record<string, unknown> | null = null;
     await page.route('**/api/ai/suncokret/chat', async (route) => {
-        const payload = route.request().postDataJSON() as unknown;
-        requestBody =
-            payload && typeof payload === 'object' && !Array.isArray(payload)
-                ? (payload as Record<string, unknown>)
-                : null;
+        const payload: unknown = route.request().postDataJSON();
+        requestBody = requestRecord(payload);
         await route.fulfill({
             status: 500,
             json: { error: 'Test request captured' },

--- a/apps/garden/tests/weather-hud.spec.tsx
+++ b/apps/garden/tests/weather-hud.spec.tsx
@@ -80,7 +80,7 @@ test('weather and forecast surfaces expose contextual Suncokret triggers', async
     page,
 }) => {
     await page.setViewportSize(DESKTOP_VIEWPORT);
-    await mount(<WeatherHudStory enableSuncokret />);
+    await mount(<WeatherHudStory />);
 
     await page.getByTitle('Trenutno vrijeme').click();
     await expect(

--- a/packages/game/src/GameFlagsContext.tsx
+++ b/packages/game/src/GameFlagsContext.tsx
@@ -11,7 +11,6 @@ export interface GameFeatureFlags {
     enableRaisedBedFieldWateringFlag?: boolean;
     enableRaisedBedFieldDiaryFlag?: boolean;
     enableIntegratedWeatherSurfacesFlag?: boolean;
-    enableSuncokretChatFlag?: boolean;
     enableSuncokretDebugFlag?: boolean;
 }
 

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -184,8 +184,19 @@ export function GameHud({
                     )}
                 </div>
                 {!isSandbox && <SunflowersHud />}
-                {!isSandbox && !isLocalSandbox && <SuncokretChatHud />}
             </div>
+            {!isSandbox && !isLocalSandbox && (
+                <div
+                    data-game-hud-bottom-right
+                    className={cx(
+                        'pointer-events-none absolute right-[calc(var(--game-safe-area-right,0px)+0.5rem)] bottom-[calc(var(--game-safe-area-bottom,0px)+0.5rem)] z-40',
+                        gameHudEntranceClassName,
+                        'motion-safe:slide-in-from-right-4',
+                    )}
+                >
+                    <SuncokretChatHud />
+                </div>
+            )}
             <div className={gameHudBottomBarClassName}>
                 <div
                     data-game-hud-bottom-controls

--- a/packages/game/src/hud/SuncokretChatHud.tsx
+++ b/packages/game/src/hud/SuncokretChatHud.tsx
@@ -13,9 +13,12 @@ import {
 } from '@gredice/ui/Chat';
 import { IconButton } from '@gredice/ui/IconButton';
 import {
+    Add,
     AI,
+    ArrowLeft,
     Check,
     Close,
+    History,
     LoaderSpinner,
     Send,
     Sun,
@@ -31,6 +34,7 @@ import {
     lastAssistantMessageIsCompleteWithApprovalResponses,
     type UIMessage,
 } from 'ai';
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import {
     type FormEvent,
@@ -50,10 +54,13 @@ import { HudCard } from './components/HudCard';
 import { useSuncokretChat } from './SuncokretChatProvider';
 import { SuncokretChatTrigger } from './SuncokretChatTrigger';
 import {
-    formatSuncokretUsagePercent,
+    SuncokretConversationList,
+    type SuncokretConversationSummary,
+} from './SuncokretConversationList';
+import { SuncokretUsageButton } from './SuncokretUsageButton';
+import {
     resolveSuncokretUiContext,
     resolveSuncokretVisibleUsage,
-    type SuncokretUsagePeriod,
     type SuncokretUsageStatus,
     suncokretContextSuggestions,
     suncokretConversationLabel,
@@ -78,6 +85,18 @@ type SuncokretModel = {
     id: string;
     label: string;
 };
+
+type SuncokretConversationDetail = SuncokretConversationSummary & {
+    messages: UIMessage[];
+};
+
+const SuncokretRecommendationChips = dynamic(
+    () =>
+        import('./SuncokretRecommendationChips').then(
+            (module) => module.SuncokretRecommendationChips,
+        ),
+    { ssr: false },
+);
 
 const desktopChatQuery = '(min-width: 768px)';
 
@@ -154,41 +173,6 @@ function SuncokretChatPositioner({
     );
 }
 
-function UsagePeriodIndicator({
-    label,
-    period,
-}: {
-    label: string;
-    period: SuncokretUsagePeriod;
-}) {
-    const used = formatSuncokretUsagePercent(period.usedPercent);
-    const remaining = formatSuncokretUsagePercent(period.remainingPercent);
-
-    return (
-        <div className="min-w-0 flex-1">
-            <Row justifyContent="space-between" className="gap-2 text-[11px]">
-                <span className="font-medium text-foreground">{label}</span>
-                <span className="truncate text-muted-foreground">
-                    {used} iskorišteno · {remaining} preostalo
-                </span>
-            </Row>
-            <div
-                aria-label={`${label}: ${used} iskorišteno, ${remaining} preostalo`}
-                aria-valuemax={100}
-                aria-valuemin={0}
-                aria-valuenow={Math.round(period.usedPercent)}
-                className="mt-1 h-1.5 overflow-hidden rounded-full bg-muted"
-                role="progressbar"
-            >
-                <div
-                    className="h-full rounded-full bg-amber-400 transition-[width] duration-300 dark:bg-amber-500"
-                    style={{ width: `${period.usedPercent}%` }}
-                />
-            </div>
-        </div>
-    );
-}
-
 function randomChatId() {
     return typeof crypto !== 'undefined' && 'randomUUID' in crypto
         ? crypto.randomUUID()
@@ -197,6 +181,70 @@ function randomChatId() {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isNullableNumber(value: unknown): value is number | null {
+    return value === null || typeof value === 'number';
+}
+
+function isNullableString(value: unknown): value is string | null {
+    return value === null || typeof value === 'string';
+}
+
+function isSuncokretConversationSummary(
+    value: unknown,
+): value is SuncokretConversationSummary {
+    return (
+        isRecord(value) &&
+        typeof value.id === 'string' &&
+        isNullableString(value.title) &&
+        isNullableString(value.model) &&
+        isNullableNumber(value.gardenId) &&
+        isNullableNumber(value.raisedBedId) &&
+        typeof value.createdAt === 'string' &&
+        isNullableString(value.lastMessageAt)
+    );
+}
+
+function isUiMessage(value: unknown): value is UIMessage {
+    return (
+        isRecord(value) &&
+        typeof value.id === 'string' &&
+        ['system', 'user', 'assistant'].includes(
+            typeof value.role === 'string' ? value.role : '',
+        ) &&
+        Array.isArray(value.parts)
+    );
+}
+
+function parseConversationListPayload(value: unknown) {
+    if (!isRecord(value) || !Array.isArray(value.conversations)) {
+        return null;
+    }
+
+    return value.conversations.every(isSuncokretConversationSummary)
+        ? value.conversations
+        : null;
+}
+
+function parseConversationDetailPayload(
+    value: unknown,
+): SuncokretConversationDetail | null {
+    if (!isRecord(value) || !isRecord(value.conversation)) {
+        return null;
+    }
+
+    const conversation = value.conversation;
+    const messages = conversation.messages;
+    if (
+        !isSuncokretConversationSummary(conversation) ||
+        !Array.isArray(messages) ||
+        !messages.every(isUiMessage)
+    ) {
+        return null;
+    }
+
+    return { ...conversation, messages };
 }
 
 function textPart(part: unknown) {
@@ -257,9 +305,12 @@ function toolActivityLabel(name: string) {
             return 'Pretražujem Gredice katalog';
         case 'searchProducts':
             return 'Provjeravam ponudu';
+        case 'presentRecommendations':
+            return 'Pripremam prijedloge';
         case 'getCart':
             return 'Provjeravam košaricu';
         case 'addProductToCart':
+        case 'addOperationToCart':
         case 'updateCartItem':
             return 'Pripremam košaricu';
         case 'analyzeRaisedBedImages':
@@ -352,15 +403,8 @@ function messageTextContent(message: UIMessage | undefined) {
         .trim();
 }
 
-function suncokretFlagParams({
-    debug,
-    enabled,
-}: {
-    debug: boolean;
-    enabled: boolean;
-}) {
+function suncokretFlagParams({ debug }: { debug: boolean }) {
     const params = new URLSearchParams({
-        enableSuncokretChatFlag: enabled ? 'true' : 'false',
         enableSuncokretDebugFlag: debug ? 'true' : 'false',
     });
     return params.toString();
@@ -514,6 +558,7 @@ function toolActivityScope(parts: Record<string, unknown>[]) {
                 'searchDirectory',
                 'getOperationsDirectory',
                 'searchProducts',
+                'presentRecommendations',
             ].includes(name),
         )
             ? 'katalog'
@@ -522,6 +567,7 @@ function toolActivityScope(parts: Record<string, unknown>[]) {
             [
                 'getCart',
                 'addProductToCart',
+                'addOperationToCart',
                 'updateCartItem',
                 'prepareCheckout',
             ].includes(name),
@@ -655,6 +701,31 @@ function ChatMessage({
 
                     const toolData = toolPart(part);
                     if (toolData) {
+                        if (
+                            toolName(toolData) === 'presentRecommendations' &&
+                            (toolState(toolData) === 'output-available' ||
+                                toolState(toolData) === 'result')
+                        ) {
+                            return (
+                                <div className="space-y-2" key={key}>
+                                    <SuncokretRecommendationChips
+                                        output={
+                                            toolData.output ?? toolData.result
+                                        }
+                                    />
+                                    {debug && (
+                                        <ToolPart
+                                            addToolApprovalResponse={
+                                                addToolApprovalResponse
+                                            }
+                                            debug
+                                            part={toolData}
+                                        />
+                                    )}
+                                </div>
+                            );
+                        }
+
                         if (!debug && !isToolApprovalRequested(toolData)) {
                             return null;
                         }
@@ -725,7 +796,6 @@ function ChatMessage({
 
 export function SuncokretChatHud() {
     const flags = useGameFlags();
-    const enabled = Boolean(flags.enableSuncokretChatFlag);
     const debug = Boolean(flags.enableSuncokretDebugFlag);
     const chat = useSuncokretChat();
     const open = chat?.open ?? false;
@@ -733,19 +803,38 @@ export function SuncokretChatHud() {
     const [statusInfo, setStatusInfo] = useState<SuncokretStatus | null>(null);
     const [models, setModels] = useState<SuncokretModel[]>([]);
     const [modelId, setModelId] = useState<string | null>(null);
-    const chatId = useMemo(randomChatId, []);
+    const [activeConversationId, setActiveConversationId] =
+        useState(randomChatId);
+    const [activeConversationTitle, setActiveConversationTitle] = useState<
+        string | null
+    >(null);
+    const [chatView, setChatView] = useState<'chat' | 'conversations'>('chat');
+    const [conversations, setConversations] = useState<
+        SuncokretConversationSummary[]
+    >([]);
+    const [conversationsLoading, setConversationsLoading] = useState(false);
+    const [conversationsError, setConversationsError] = useState<string | null>(
+        null,
+    );
+    const chatSessionId = useMemo(randomChatId, []);
     const apiOrigin = getBrowserGrediceAppOrigin('api');
     const featureFlags = useMemo(
         () => ({
-            enableSuncokretChatFlag: enabled,
             enableSuncokretDebugFlag: debug,
         }),
-        [debug, enabled],
+        [debug],
     );
     const featureFlagQuery = useMemo(
-        () => suncokretFlagParams({ debug, enabled }),
-        [debug, enabled],
+        () => suncokretFlagParams({ debug }),
+        [debug],
     );
+    const statusQuery = useMemo(() => {
+        const params = new URLSearchParams(featureFlagQuery);
+        if (debug && modelId) {
+            params.set('modelId', modelId);
+        }
+        return params.toString();
+    }, [debug, featureFlagQuery, modelId]);
     const { data: currentGarden } = useCurrentGarden();
     const [settingsSection] = useOverviewSectionParam();
     const view = useGameState((state) => state.view);
@@ -779,6 +868,7 @@ export function SuncokretChatHud() {
             settingsSection,
         });
     const requestContextRef = useRef({
+        conversationId: activeConversationId,
         debug,
         featureFlags,
         gardenId,
@@ -788,6 +878,7 @@ export function SuncokretChatHud() {
         uiContext,
     });
     requestContextRef.current = {
+        conversationId: activeConversationId,
         debug,
         featureFlags,
         gardenId,
@@ -807,7 +898,7 @@ export function SuncokretChatHud() {
                     return {
                         body: {
                             id,
-                            conversationId: id,
+                            conversationId: requestContext.conversationId,
                             messages,
                             gardenId: requestContext.gardenId,
                             raisedBedId: requestContext.raisedBedId,
@@ -824,24 +915,31 @@ export function SuncokretChatHud() {
         [apiOrigin],
     );
 
-    const { addToolApprovalResponse, error, messages, sendMessage, status } =
-        useChat({
-            id: chatId,
-            transport,
-            experimental_throttle: 80,
-            sendAutomaticallyWhen:
-                lastAssistantMessageIsCompleteWithApprovalResponses,
-        });
+    const {
+        addToolApprovalResponse,
+        clearError,
+        error,
+        messages,
+        sendMessage,
+        setMessages,
+        status,
+    } = useChat({
+        id: chatSessionId,
+        transport,
+        experimental_throttle: 80,
+        sendAutomaticallyWhen:
+            lastAssistantMessageIsCompleteWithApprovalResponses,
+    });
 
     const loading = status === 'submitted' || status === 'streaming';
 
     useEffect(() => {
-        if (!enabled || !open || status !== 'ready') {
+        if (!open || status !== 'ready') {
             return;
         }
 
         let cancelled = false;
-        void fetch(`${apiOrigin}/api/ai/suncokret/status?${featureFlagQuery}`, {
+        void fetch(`${apiOrigin}/api/ai/suncokret/status?${statusQuery}`, {
             credentials: 'include',
         })
             .then((response) => response.json() as Promise<SuncokretStatus>)
@@ -861,7 +959,7 @@ export function SuncokretChatHud() {
         return () => {
             cancelled = true;
         };
-    }, [apiOrigin, debug, enabled, featureFlagQuery, open, status]);
+    }, [apiOrigin, debug, open, status, statusQuery]);
 
     useEffect(() => {
         if (!debug) {
@@ -869,7 +967,7 @@ export function SuncokretChatHud() {
             setModelId(null);
             return;
         }
-        if (!enabled || !open) {
+        if (!open) {
             return;
         }
 
@@ -895,9 +993,101 @@ export function SuncokretChatHud() {
         return () => {
             cancelled = true;
         };
-    }, [apiOrigin, debug, enabled, featureFlagQuery, open]);
+    }, [apiOrigin, debug, featureFlagQuery, open]);
 
-    if (!enabled || !chat) {
+    const showConversationList = async () => {
+        if (loading) {
+            return;
+        }
+
+        setChatView('conversations');
+        setConversationsLoading(true);
+        setConversationsError(null);
+
+        try {
+            const response = await fetch(
+                `${apiOrigin}/api/ai/suncokret/conversations?${featureFlagQuery}`,
+                { credentials: 'include' },
+            );
+            if (!response.ok) {
+                throw new Error('Conversation list request failed');
+            }
+
+            const payload: unknown = await response.json();
+            const nextConversations = parseConversationListPayload(payload);
+            if (!nextConversations) {
+                throw new Error('Invalid conversation list response');
+            }
+
+            setConversations(nextConversations);
+        } catch {
+            setConversationsError(
+                'Razgovori se trenutno ne mogu učitati. Pokušaj ponovno.',
+            );
+        } finally {
+            setConversationsLoading(false);
+        }
+    };
+
+    const selectConversation = async (conversationId: string) => {
+        if (loading) {
+            return;
+        }
+
+        setConversationsLoading(true);
+        setConversationsError(null);
+
+        try {
+            const response = await fetch(
+                `${apiOrigin}/api/ai/suncokret/conversations/${encodeURIComponent(conversationId)}?${featureFlagQuery}`,
+                { credentials: 'include' },
+            );
+            if (!response.ok) {
+                throw new Error('Conversation request failed');
+            }
+
+            const payload: unknown = await response.json();
+            const conversation = parseConversationDetailPayload(payload);
+            if (!conversation) {
+                throw new Error('Invalid conversation response');
+            }
+
+            clearError();
+            setInput('');
+            setMessages(conversation.messages);
+            setActiveConversationId(conversation.id);
+            setActiveConversationTitle(conversation.title);
+            if (
+                debug &&
+                conversation.model &&
+                models.some((model) => model.id === conversation.model)
+            ) {
+                setModelId(conversation.model);
+            }
+            setChatView('chat');
+        } catch {
+            setConversationsError(
+                'Razgovor se trenutno ne može otvoriti. Pokušaj ponovno.',
+            );
+        } finally {
+            setConversationsLoading(false);
+        }
+    };
+
+    const startFreshConversation = () => {
+        if (loading) {
+            return;
+        }
+
+        clearError();
+        setInput('');
+        setMessages([]);
+        setActiveConversationId(randomChatId());
+        setActiveConversationTitle(null);
+        setChatView('chat');
+    };
+
+    if (!chat) {
         return null;
     }
 
@@ -916,7 +1106,6 @@ export function SuncokretChatHud() {
     };
 
     const limit = statusInfo?.limit;
-    const blocked = Boolean(limit?.blockedReason);
     const streamingMessage =
         status === 'streaming' &&
         messages[messages.length - 1]?.role === 'assistant'
@@ -926,6 +1115,15 @@ export function SuncokretChatHud() {
         streamingText: messageTextContent(streamingMessage),
         usage: statusInfo?.usage,
     });
+    const dailyUsageExhausted = Boolean(
+        visibleUsage && visibleUsage.day.remainingPercent <= 0,
+    );
+    const weeklyUsageExhausted = Boolean(
+        visibleUsage && visibleUsage.week.remainingPercent <= 0,
+    );
+    const blocked = Boolean(
+        limit?.blockedReason || dailyUsageExhausted || weeklyUsageExhausted,
+    );
     const contextSuggestions = suncokretContextSuggestions(uiContext);
     const isCloseup = view === 'closeup';
 
@@ -980,34 +1178,70 @@ export function SuncokretChatHud() {
                                         className="text-muted-foreground"
                                         noWrap
                                     >
-                                        <span className="mr-1.5 inline-block size-1.5 rounded-full bg-emerald-500 align-middle" />
-                                        Razgovor za {conversationLabel}
+                                        {chatView === 'chat' && (
+                                            <span className="mr-1.5 inline-block size-1.5 rounded-full bg-emerald-500 align-middle" />
+                                        )}
+                                        {chatView === 'conversations'
+                                            ? 'Prijašnji razgovori'
+                                            : (activeConversationTitle ??
+                                              `Razgovor za ${conversationLabel}`)}
                                     </Typography>
                                 </Stack>
                             </Row>
                             <Row spacing={1}>
-                                {debug && models.length > 1 && (
-                                    <select
-                                        aria-label="AI model"
-                                        data-suncokret-model-picker
-                                        value={modelId ?? ''}
-                                        onChange={(event) =>
-                                            setModelId(
-                                                event.target.value || null,
-                                            )
-                                        }
-                                        className="h-8 max-w-32 rounded-full border bg-background px-2.5 text-xs"
+                                {chatView === 'conversations' ? (
+                                    <IconButton
+                                        title="Natrag na razgovor"
+                                        variant="plain"
+                                        disabled={conversationsLoading}
+                                        onClick={() => setChatView('chat')}
                                     >
-                                        {models.map((model) => (
-                                            <option
-                                                key={model.id}
-                                                value={model.id}
-                                            >
-                                                {model.label}
-                                            </option>
-                                        ))}
-                                    </select>
+                                        <ArrowLeft className="size-4" />
+                                    </IconButton>
+                                ) : (
+                                    <IconButton
+                                        title="Prijašnji razgovori"
+                                        variant="plain"
+                                        disabled={loading}
+                                        onClick={() => {
+                                            void showConversationList();
+                                        }}
+                                    >
+                                        <History className="size-4" />
+                                    </IconButton>
                                 )}
+                                <IconButton
+                                    title="Novi razgovor"
+                                    variant="plain"
+                                    disabled={loading}
+                                    onClick={startFreshConversation}
+                                >
+                                    <Add className="size-4" />
+                                </IconButton>
+                                {chatView === 'chat' &&
+                                    debug &&
+                                    models.length > 1 && (
+                                        <select
+                                            aria-label="AI model"
+                                            data-suncokret-model-picker
+                                            value={modelId ?? ''}
+                                            onChange={(event) =>
+                                                setModelId(
+                                                    event.target.value || null,
+                                                )
+                                            }
+                                            className="h-8 max-w-32 rounded-full border bg-background px-2.5 text-xs"
+                                        >
+                                            {models.map((model) => (
+                                                <option
+                                                    key={model.id}
+                                                    value={model.id}
+                                                >
+                                                    {model.label}
+                                                </option>
+                                            ))}
+                                        </select>
+                                    )}
                                 <IconButton
                                     title="Zatvori"
                                     variant="plain"
@@ -1018,198 +1252,222 @@ export function SuncokretChatHud() {
                             </Row>
                         </Row>
 
-                        <ChatMessageScroller
-                            ariaBusy={loading}
-                            ariaLabel="Razgovor sa Suncokretom"
-                            className="flex-1"
-                            emptyContent={
-                                <Stack
-                                    alignItems="center"
-                                    spacing={4}
-                                    className="w-full px-3 text-center"
-                                >
-                                    <span className="grid size-14 place-items-center rounded-full border border-amber-200 bg-amber-50 shadow-sm dark:border-amber-900 dark:bg-amber-950">
-                                        <Sun className="size-7 text-amber-500" />
-                                    </span>
-                                    <Stack spacing={1} alignItems="center">
-                                        <Typography level="h6" semiBold>
-                                            Kako ti mogu pomoći?
-                                        </Typography>
-                                        <Typography
-                                            level="body3"
-                                            className="max-w-72 text-muted-foreground"
+                        {chatView === 'conversations' ? (
+                            <SuncokretConversationList
+                                conversations={conversations}
+                                currentConversationId={activeConversationId}
+                                error={conversationsError}
+                                loading={conversationsLoading}
+                                onSelect={(conversationId) => {
+                                    void selectConversation(conversationId);
+                                }}
+                            />
+                        ) : (
+                            <>
+                                <ChatMessageScroller
+                                    ariaBusy={loading}
+                                    ariaLabel="Razgovor sa Suncokretom"
+                                    className="flex-1"
+                                    emptyContent={
+                                        <Stack
+                                            alignItems="center"
+                                            spacing={4}
+                                            className="w-full px-3 text-center"
                                         >
-                                            Pitaj me o stanju vrta, sadnji ili
-                                            radnjama koje slijede.
-                                        </Typography>
-                                    </Stack>
-                                    <Stack spacing={2} className="w-full">
-                                        {contextSuggestions.map(
-                                            (suggestion, index) => (
-                                                <Button
-                                                    key={suggestion.prompt}
-                                                    fullWidth
-                                                    size="sm"
-                                                    variant="outlined"
-                                                    className={cx(
-                                                        'rounded-full',
-                                                        index === 0 &&
-                                                            'border-amber-200 bg-amber-50/60 hover:bg-amber-100 dark:border-amber-900 dark:bg-amber-950/40 dark:hover:bg-amber-950',
-                                                    )}
-                                                    onClick={() =>
-                                                        sendPrompt(
-                                                            suggestion.prompt,
-                                                        )
-                                                    }
+                                            <span className="grid size-14 place-items-center rounded-full border border-amber-200 bg-amber-50 shadow-sm dark:border-amber-900 dark:bg-amber-950">
+                                                <Sun className="size-7 text-amber-500" />
+                                            </span>
+                                            <Stack
+                                                spacing={1}
+                                                alignItems="center"
+                                            >
+                                                <Typography level="h6" semiBold>
+                                                    Kako ti mogu pomoći?
+                                                </Typography>
+                                                <Typography
+                                                    level="body3"
+                                                    className="max-w-72 text-muted-foreground"
                                                 >
-                                                    {suggestion.label}
-                                                </Button>
-                                            ),
-                                        )}
-                                    </Stack>
-                                </Stack>
-                            }
-                            items={[
-                                ...messages.map((message) => ({
-                                    id: message.id,
-                                    scrollAnchor: message.role === 'user',
-                                    content: (
-                                        <ChatMessage
-                                            addToolApprovalResponse={
-                                                addToolApprovalResponse
-                                            }
-                                            debug={debug}
-                                            isStreaming={
-                                                loading &&
-                                                message.role === 'assistant' &&
-                                                message.id ===
-                                                    messages[
-                                                        messages.length - 1
-                                                    ]?.id
-                                            }
-                                            message={message}
-                                        />
-                                    ),
-                                })),
-                                ...(loading
-                                    ? [
-                                          {
-                                              id: 'suncokret-loading',
-                                              content: (
-                                                  <ChatMarker
-                                                      className="px-10"
-                                                      icon={
-                                                          <LoaderSpinner className="animate-spin" />
-                                                      }
-                                                      role="status"
-                                                  >
-                                                      <span className="chat-shimmer">
-                                                          Suncokret razmišlja...
-                                                      </span>
-                                                  </ChatMarker>
-                                              ),
-                                          },
-                                      ]
-                                    : []),
-                            ]}
-                        />
-
-                        <Stack
-                            spacing={2}
-                            className="border-t bg-background/95 p-3"
-                        >
-                            {visibleUsage && (
-                                <div
-                                    className="grid gap-2 rounded-xl bg-muted/40 px-3 py-2"
-                                    data-suncokret-usage
-                                >
-                                    <UsagePeriodIndicator
-                                        label="Danas"
-                                        period={visibleUsage.day}
-                                    />
-                                    <UsagePeriodIndicator
-                                        label="Ovaj tjedan"
-                                        period={visibleUsage.week}
-                                    />
-                                </div>
-                            )}
-                            {blocked && (
-                                <div className="rounded-xl border border-amber-300 bg-amber-50 p-2.5 text-xs text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
-                                    Dnevni limit je iskorišten. Nastavak je
-                                    moguć {formatRetryAt(limit?.retryAt)}.
-                                </div>
-                            )}
-                            {error && (
-                                <div className="rounded-xl border border-red-300 bg-red-50 p-2.5 text-xs text-red-900 dark:border-red-900 dark:bg-red-950 dark:text-red-100">
-                                    {error.message}
-                                </div>
-                            )}
-                            <form
-                                onSubmit={onSubmit}
-                                className="overflow-hidden rounded-2xl border bg-card shadow-sm transition-shadow focus-within:ring-2 focus-within:ring-ring"
-                            >
-                                <textarea
-                                    aria-label="Pitaj Suncokret"
-                                    value={input}
-                                    disabled={loading || blocked}
-                                    onChange={(event) =>
-                                        setInput(event.target.value)
+                                                    Pitaj me o stanju vrta,
+                                                    sadnji ili radnjama koje
+                                                    slijede.
+                                                </Typography>
+                                            </Stack>
+                                            <Stack
+                                                spacing={2}
+                                                className="w-full"
+                                            >
+                                                {contextSuggestions.map(
+                                                    (suggestion, index) => (
+                                                        <Button
+                                                            key={
+                                                                suggestion.prompt
+                                                            }
+                                                            fullWidth
+                                                            size="sm"
+                                                            variant="outlined"
+                                                            className={cx(
+                                                                'rounded-full',
+                                                                index === 0 &&
+                                                                    'border-amber-200 bg-amber-50/60 hover:bg-amber-100 dark:border-amber-900 dark:bg-amber-950/40 dark:hover:bg-amber-950',
+                                                            )}
+                                                            onClick={() =>
+                                                                sendPrompt(
+                                                                    suggestion.prompt,
+                                                                )
+                                                            }
+                                                        >
+                                                            {suggestion.label}
+                                                        </Button>
+                                                    ),
+                                                )}
+                                            </Stack>
+                                        </Stack>
                                     }
-                                    onKeyDown={(event) => {
-                                        if (
-                                            event.key === 'Enter' &&
-                                            !event.shiftKey
-                                        ) {
-                                            event.preventDefault();
-                                            sendPrompt(input);
-                                        }
-                                    }}
-                                    className="min-h-14 max-h-28 w-full resize-none border-0 bg-transparent px-4 py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed"
-                                    placeholder="Pitaj Suncokret..."
+                                    items={[
+                                        ...messages.map((message) => ({
+                                            id: message.id,
+                                            scrollAnchor:
+                                                message.role === 'user',
+                                            content: (
+                                                <ChatMessage
+                                                    addToolApprovalResponse={
+                                                        addToolApprovalResponse
+                                                    }
+                                                    debug={debug}
+                                                    isStreaming={
+                                                        loading &&
+                                                        message.role ===
+                                                            'assistant' &&
+                                                        message.id ===
+                                                            messages[
+                                                                messages.length -
+                                                                    1
+                                                            ]?.id
+                                                    }
+                                                    message={message}
+                                                />
+                                            ),
+                                        })),
+                                        ...(loading
+                                            ? [
+                                                  {
+                                                      id: 'suncokret-loading',
+                                                      content: (
+                                                          <ChatMarker
+                                                              className="px-10"
+                                                              icon={
+                                                                  <LoaderSpinner className="animate-spin" />
+                                                              }
+                                                              role="status"
+                                                          >
+                                                              <span className="chat-shimmer">
+                                                                  Suncokret
+                                                                  razmišlja...
+                                                              </span>
+                                                          </ChatMarker>
+                                                      ),
+                                                  },
+                                              ]
+                                            : []),
+                                    ]}
                                 />
-                                <Row
-                                    justifyContent="space-between"
-                                    className="border-t border-border/60 px-2 py-2"
+
+                                <Stack
+                                    spacing={2}
+                                    className="border-t bg-background/95 p-3"
                                 >
-                                    <span
-                                        aria-live="polite"
-                                        className="px-1 text-xs text-muted-foreground"
+                                    {blocked && (
+                                        <div className="rounded-xl border border-amber-300 bg-amber-50 p-2.5 text-xs text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+                                            {weeklyUsageExhausted
+                                                ? 'Tjedni limit je iskorišten.'
+                                                : 'Dnevni limit je iskorišten.'}{' '}
+                                            Nastavak je moguć{' '}
+                                            {formatRetryAt(limit?.retryAt)}.
+                                        </div>
+                                    )}
+                                    {error && (
+                                        <div className="rounded-xl border border-red-300 bg-red-50 p-2.5 text-xs text-red-900 dark:border-red-900 dark:bg-red-950 dark:text-red-100">
+                                            {error.message}
+                                        </div>
+                                    )}
+                                    <form
+                                        onSubmit={onSubmit}
+                                        className="overflow-hidden rounded-2xl border bg-card shadow-sm transition-shadow focus-within:ring-2 focus-within:ring-ring"
                                     >
-                                        Enter šalje poruku
-                                    </span>
-                                    <IconButton
-                                        title={
-                                            loading
-                                                ? 'Suncokret odgovara'
-                                                : 'Pošalji'
-                                        }
-                                        type="submit"
-                                        disabled={
-                                            loading ||
-                                            blocked ||
-                                            input.trim().length === 0
-                                        }
-                                        className="size-9 shrink-0 rounded-full bg-emerald-700 text-white shadow-sm hover:bg-emerald-800 dark:bg-emerald-600 dark:hover:bg-emerald-500"
-                                    >
-                                        {loading ? (
-                                            <LoaderSpinner className="size-4 animate-spin" />
-                                        ) : (
-                                            <Send className="size-4" />
-                                        )}
-                                    </IconButton>
-                                </Row>
-                            </form>
-                            {debug && statusInfo && (
-                                <details className="text-xs text-muted-foreground">
-                                    <summary className="cursor-pointer">
-                                        Debug
-                                    </summary>
-                                    <pre className="mt-1 max-h-36 overflow-auto rounded-sm bg-muted p-2">
-                                        {debugJson(statusInfo)}
-                                    </pre>
-                                </details>
-                            )}
-                        </Stack>
+                                        <textarea
+                                            aria-label="Pitaj Suncokret"
+                                            value={input}
+                                            disabled={loading || blocked}
+                                            onChange={(event) =>
+                                                setInput(event.target.value)
+                                            }
+                                            onKeyDown={(event) => {
+                                                if (
+                                                    event.key === 'Enter' &&
+                                                    !event.shiftKey
+                                                ) {
+                                                    event.preventDefault();
+                                                    sendPrompt(input);
+                                                }
+                                            }}
+                                            className="min-h-14 max-h-28 w-full resize-none border-0 bg-transparent px-4 py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed"
+                                            placeholder="Pitaj Suncokret..."
+                                        />
+                                        <Row
+                                            justifyContent="space-between"
+                                            className="border-t border-border/60 px-2 py-2"
+                                        >
+                                            <span
+                                                aria-live="polite"
+                                                className="px-1 text-xs text-muted-foreground"
+                                            >
+                                                Enter šalje poruku
+                                            </span>
+                                            <Row spacing={1}>
+                                                {visibleUsage && (
+                                                    <SuncokretUsageButton
+                                                        day={visibleUsage.day}
+                                                        week={visibleUsage.week}
+                                                    />
+                                                )}
+                                                <IconButton
+                                                    title={
+                                                        loading
+                                                            ? 'Suncokret odgovara'
+                                                            : 'Pošalji'
+                                                    }
+                                                    type="submit"
+                                                    disabled={
+                                                        loading ||
+                                                        blocked ||
+                                                        input.trim().length ===
+                                                            0
+                                                    }
+                                                    className="size-9 shrink-0 rounded-full bg-emerald-700 text-white shadow-sm hover:bg-emerald-800 dark:bg-emerald-600 dark:hover:bg-emerald-500"
+                                                >
+                                                    {loading ? (
+                                                        <LoaderSpinner className="size-4 animate-spin" />
+                                                    ) : (
+                                                        <Send className="size-4" />
+                                                    )}
+                                                </IconButton>
+                                            </Row>
+                                        </Row>
+                                    </form>
+                                    {debug && statusInfo && (
+                                        <details className="text-xs text-muted-foreground">
+                                            <summary className="cursor-pointer">
+                                                Debug
+                                            </summary>
+                                            <pre className="mt-1 max-h-36 overflow-auto rounded-sm bg-muted p-2">
+                                                {debugJson(statusInfo)}
+                                            </pre>
+                                        </details>
+                                    )}
+                                </Stack>
+                            </>
+                        )}
                     </div>
                 </SuncokretChatPositioner>
             )}

--- a/packages/game/src/hud/SuncokretChatTrigger.tsx
+++ b/packages/game/src/hud/SuncokretChatTrigger.tsx
@@ -3,7 +3,6 @@
 import { IconButton } from '@gredice/ui/IconButton';
 import { cx } from '@gredice/ui/utils';
 import Image from 'next/image';
-import { useGameFlags } from '../GameFlagsContext';
 import {
     type SuncokretChatTarget,
     useSuncokretChat,
@@ -22,10 +21,9 @@ export function SuncokretChatTrigger({
     title: string;
     variant?: 'compact' | 'hud';
 }) {
-    const enabled = Boolean(useGameFlags().enableSuncokretChatFlag);
     const chat = useSuncokretChat();
 
-    if (!enabled || !chat || (action === 'open' && !target)) {
+    if (!chat || (action === 'open' && !target)) {
         return null;
     }
 

--- a/packages/game/src/hud/SuncokretConversationList.tsx
+++ b/packages/game/src/hud/SuncokretConversationList.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { History, LoaderSpinner } from '@gredice/ui/icons';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+
+export type SuncokretConversationSummary = {
+    id: string;
+    title: string | null;
+    model: string | null;
+    gardenId: number | null;
+    raisedBedId: number | null;
+    createdAt: string;
+    lastMessageAt: string | null;
+};
+
+const conversationDateFormatter = new Intl.DateTimeFormat('hr-HR', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+});
+
+function formatConversationDate(value: string | null) {
+    if (!value) {
+        return '';
+    }
+
+    const date = new Date(value);
+    return Number.isNaN(date.getTime())
+        ? ''
+        : conversationDateFormatter.format(date);
+}
+
+export function SuncokretConversationList({
+    conversations,
+    currentConversationId,
+    error,
+    loading,
+    onSelect,
+}: {
+    conversations: SuncokretConversationSummary[];
+    currentConversationId: string;
+    error: string | null;
+    loading: boolean;
+    onSelect: (conversationId: string) => void;
+}) {
+    if (loading) {
+        return (
+            <div className="grid flex-1 place-items-center" role="status">
+                <LoaderSpinner className="size-5 animate-spin text-muted-foreground" />
+                <span className="sr-only">Učitavanje razgovora</span>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="grid flex-1 place-items-center px-6 text-center">
+                <Typography
+                    level="body2"
+                    className="text-red-700 dark:text-red-400"
+                >
+                    {error}
+                </Typography>
+            </div>
+        );
+    }
+
+    if (conversations.length === 0) {
+        return (
+            <Stack
+                alignItems="center"
+                spacing={3}
+                className="flex-1 justify-center px-6 text-center"
+            >
+                <span className="grid size-12 place-items-center rounded-full bg-muted">
+                    <History className="size-5 text-muted-foreground" />
+                </span>
+                <Stack spacing={1} alignItems="center">
+                    <Typography level="body2" semiBold>
+                        Još nema razgovora
+                    </Typography>
+                    <Typography level="body3" className="text-muted-foreground">
+                        Započni novi razgovor i pronaći ćeš ga ovdje.
+                    </Typography>
+                </Stack>
+            </Stack>
+        );
+    }
+
+    return (
+        <div
+            className="flex-1 overflow-y-auto p-2"
+            data-suncokret-conversations
+        >
+            <Stack spacing={1}>
+                {conversations.map((conversation) => {
+                    const selected = conversation.id === currentConversationId;
+                    const title =
+                        conversation.title?.trim() || 'Razgovor sa Suncokretom';
+
+                    return (
+                        <button
+                            key={conversation.id}
+                            type="button"
+                            aria-current={selected ? 'true' : undefined}
+                            onClick={() => onSelect(conversation.id)}
+                            className={cx(
+                                'w-full rounded-xl px-3 py-3 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                                selected &&
+                                    'bg-amber-50 ring-1 ring-amber-200 dark:bg-amber-950/40 dark:ring-amber-900',
+                            )}
+                        >
+                            <span className="flex items-center gap-2">
+                                <span
+                                    className={cx(
+                                        'size-1.5 shrink-0 rounded-full bg-muted-foreground/35',
+                                        selected && 'bg-emerald-500',
+                                    )}
+                                />
+                                <span className="min-w-0 flex-1">
+                                    <span className="block truncate text-sm font-medium">
+                                        {title}
+                                    </span>
+                                    <span className="mt-0.5 block text-xs text-muted-foreground">
+                                        {formatConversationDate(
+                                            conversation.lastMessageAt ??
+                                                conversation.createdAt,
+                                        )}
+                                    </span>
+                                </span>
+                            </span>
+                        </button>
+                    );
+                })}
+            </Stack>
+        </div>
+    );
+}

--- a/packages/game/src/hud/SuncokretRecommendationChips.tsx
+++ b/packages/game/src/hud/SuncokretRecommendationChips.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { Chip } from '@gredice/ui/Chip';
+import { Sprout } from '@gredice/ui/icons';
+import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import { useAllSorts } from '../hooks/usePlantSorts';
+import { isRaisedBedFieldOccupied } from '../utils/raisedBedFields';
+import { RaisedBedAiOperationChip } from './raisedBed/RaisedBedAiOperationMarkdown';
+import { PlantPicker } from './raisedBed/RaisedBedPlantPicker';
+
+type OperationRecommendation = {
+    kind: 'operation';
+    operationId: number;
+    gardenId: number;
+    raisedBedId: number;
+    positionIndex?: number;
+    scheduledDate?: string;
+};
+
+type SowingRecommendation = {
+    kind: 'sowing';
+    plantSortId: number;
+    gardenId: number;
+    raisedBedId: number;
+    positionIndex: number;
+    scheduledDate?: string;
+};
+
+export type SuncokretRecommendation =
+    | OperationRecommendation
+    | SowingRecommendation;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function positiveInteger(value: unknown) {
+    return typeof value === 'number' && Number.isSafeInteger(value) && value > 0
+        ? value
+        : null;
+}
+
+function nonNegativeInteger(value: unknown) {
+    return typeof value === 'number' &&
+        Number.isSafeInteger(value) &&
+        value >= 0
+        ? value
+        : null;
+}
+
+function calendarDate(value: unknown) {
+    if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        return undefined;
+    }
+
+    const [year, month, day] = value.split('-').map(Number);
+    const date = new Date(year, month - 1, day);
+    return date.getFullYear() === year &&
+        date.getMonth() === month - 1 &&
+        date.getDate() === day
+        ? value
+        : undefined;
+}
+
+function parseRecommendation(value: unknown): SuncokretRecommendation | null {
+    if (!isRecord(value)) {
+        return null;
+    }
+
+    const gardenId = positiveInteger(value.gardenId);
+    const raisedBedId = positiveInteger(value.raisedBedId);
+    if (!gardenId || !raisedBedId) {
+        return null;
+    }
+
+    const scheduledDate = calendarDate(value.scheduledDate);
+    if (value.kind === 'operation') {
+        const operationId = positiveInteger(value.operationId);
+        const positionIndex =
+            value.positionIndex === undefined
+                ? undefined
+                : nonNegativeInteger(value.positionIndex);
+        if (!operationId || positionIndex === null) {
+            return null;
+        }
+
+        return {
+            kind: 'operation',
+            operationId,
+            gardenId,
+            raisedBedId,
+            ...(typeof positionIndex === 'number' ? { positionIndex } : {}),
+            ...(scheduledDate ? { scheduledDate } : {}),
+        };
+    }
+
+    if (value.kind === 'sowing') {
+        const plantSortId = positiveInteger(value.plantSortId);
+        const positionIndex = nonNegativeInteger(value.positionIndex);
+        if (!plantSortId || positionIndex === null) {
+            return null;
+        }
+
+        return {
+            kind: 'sowing',
+            plantSortId,
+            gardenId,
+            raisedBedId,
+            positionIndex,
+            ...(scheduledDate ? { scheduledDate } : {}),
+        };
+    }
+
+    return null;
+}
+
+export function parseSuncokretRecommendations(value: unknown) {
+    if (!isRecord(value) || !Array.isArray(value.recommendations)) {
+        return [];
+    }
+
+    return value.recommendations
+        .map(parseRecommendation)
+        .filter(
+            (recommendation): recommendation is SuncokretRecommendation =>
+                recommendation !== null,
+        )
+        .slice(0, 6);
+}
+
+function DisabledSowingChip({
+    label,
+    title,
+}: {
+    label: string;
+    title: string;
+}) {
+    return (
+        <Chip
+            color="warning"
+            data-suncokret-sowing-chip
+            disabled
+            size="sm"
+            startDecorator={<Sprout />}
+            title={title}
+            variant="outlined"
+        >
+            {label}
+        </Chip>
+    );
+}
+
+function parseScheduledDate(value: string | undefined) {
+    if (!value) {
+        return undefined;
+    }
+
+    const [year, month, day] = value.split('-').map(Number);
+    return new Date(year, month - 1, day);
+}
+
+function SowingRecommendationChip({
+    recommendation,
+}: {
+    recommendation: SowingRecommendation;
+}) {
+    const { data: garden } = useCurrentGarden();
+    const { data: plantSorts } = useAllSorts();
+    const plantSort = plantSorts?.find(
+        (candidate) => candidate.id === recommendation.plantSortId,
+    );
+    const raisedBed = garden?.raisedBeds.find(
+        (candidate) => candidate.id === recommendation.raisedBedId,
+    );
+    const field = raisedBed?.fields.find(
+        (candidate) => candidate.positionIndex === recommendation.positionIndex,
+    );
+    const fallbackLabel = `Sijanje - polje ${(
+        recommendation.positionIndex + 1
+    ).toString()}`;
+    const label = plantSort
+        ? `${plantSort.information.name} - polje ${(
+              recommendation.positionIndex + 1
+          ).toString()}`
+        : fallbackLabel;
+
+    const disabledReason = !plantSort
+        ? 'Predložena sorta više nije dostupna u katalogu.'
+        : garden?.id !== recommendation.gardenId
+          ? 'Otvori vrt iz ovog razgovora kako bi odabrao sijanje.'
+          : raisedBed?.status !== 'active'
+            ? 'Ciljna gredica nije aktivna ili više nije dostupna.'
+            : isRaisedBedFieldOccupied(field)
+              ? 'Na ciljnom polju već se nalazi biljka.'
+              : null;
+
+    if (!plantSort || !raisedBed || disabledReason) {
+        return (
+            <DisabledSowingChip label={label} title={disabledReason ?? ''} />
+        );
+    }
+
+    return (
+        <PlantPicker
+            gardenId={recommendation.gardenId}
+            positionIndex={recommendation.positionIndex}
+            raisedBedId={recommendation.raisedBedId}
+            selectedPlantId={plantSort.information.plant.id}
+            selectedPlantOptions={{
+                scheduledDate: parseScheduledDate(recommendation.scheduledDate),
+            }}
+            selectedSortId={plantSort.id}
+            trigger={
+                <Chip
+                    color="success"
+                    data-suncokret-sowing-chip
+                    size="sm"
+                    startDecorator={<Sprout />}
+                    title={`Otvori sijanje: ${label}`}
+                    variant="soft"
+                >
+                    {label}
+                </Chip>
+            }
+        />
+    );
+}
+
+export function SuncokretRecommendationChips({ output }: { output: unknown }) {
+    const recommendations = parseSuncokretRecommendations(output);
+    if (recommendations.length === 0) {
+        return null;
+    }
+
+    return (
+        <fieldset
+            className="m-0 flex min-w-0 flex-wrap gap-2 border-0 p-0"
+            data-suncokret-recommendations
+        >
+            <legend className="sr-only">Preporučene radnje i sijanja</legend>
+            {recommendations.map((recommendation) => {
+                const entityId =
+                    recommendation.kind === 'operation'
+                        ? recommendation.operationId
+                        : recommendation.plantSortId;
+                const key = [
+                    recommendation.kind,
+                    entityId,
+                    recommendation.gardenId,
+                    recommendation.raisedBedId,
+                    recommendation.positionIndex ?? 'bed',
+                ].join(':');
+
+                return (
+                    <span
+                        data-suncokret-recommendation={recommendation.kind}
+                        key={key}
+                    >
+                        {recommendation.kind === 'operation' ? (
+                            <RaisedBedAiOperationChip
+                                gardenId={recommendation.gardenId}
+                                label=""
+                                target={{
+                                    operationId: recommendation.operationId,
+                                    raisedBedId: recommendation.raisedBedId,
+                                    positionIndex: recommendation.positionIndex,
+                                    scheduledDate: recommendation.scheduledDate,
+                                }}
+                            />
+                        ) : (
+                            <SowingRecommendationChip
+                                recommendation={recommendation}
+                            />
+                        )}
+                    </span>
+                );
+            })}
+        </fieldset>
+    );
+}

--- a/packages/game/src/hud/SuncokretUsageButton.tsx
+++ b/packages/game/src/hud/SuncokretUsageButton.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { IconButton } from '@gredice/ui/IconButton';
+import { Popper } from '@gredice/ui/Popper';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import {
+    formatSuncokretUsagePercent,
+    type SuncokretUsagePeriod,
+} from './suncokretChatContext';
+
+function exhausted(period: SuncokretUsagePeriod) {
+    return period.remainingPercent <= 0;
+}
+
+export function SuncokretUsageButton({
+    day,
+    week,
+}: {
+    day: SuncokretUsagePeriod;
+    week: SuncokretUsagePeriod;
+}) {
+    const dayRemaining = Math.max(0, Math.min(100, day.remainingPercent));
+    const weekRemaining = Math.max(0, Math.min(100, week.remainingPercent));
+    const exhaustedUsage = exhausted(day) || exhausted(week);
+    const periods = [
+        { label: 'Danas', period: day, detail: 'Vanjski krug' },
+        { label: 'Ovaj tjedan', period: week, detail: 'Unutarnji krug' },
+    ];
+
+    return (
+        <Popper
+            align="end"
+            side="top"
+            sideOffset={8}
+            className="w-72 p-3"
+            trigger={
+                <IconButton
+                    aria-label={`Preostala AI upotreba: danas ${formatSuncokretUsagePercent(dayRemaining)}, ovaj tjedan ${formatSuncokretUsagePercent(weekRemaining)}`}
+                    title="Prikaži preostalu AI upotrebu"
+                    type="button"
+                    variant="plain"
+                    className={cx(
+                        'size-9 shrink-0 rounded-full text-emerald-700 hover:bg-emerald-50 dark:text-emerald-400 dark:hover:bg-emerald-950',
+                        exhaustedUsage &&
+                            'text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950',
+                    )}
+                    data-suncokret-usage-trigger
+                >
+                    <svg
+                        aria-hidden="true"
+                        className="size-5 -rotate-90"
+                        viewBox="0 0 24 24"
+                    >
+                        <circle
+                            cx="12"
+                            cy="12"
+                            r="10"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            className={cx(
+                                'text-muted-foreground/25',
+                                exhausted(day) && 'text-red-500/70',
+                            )}
+                        />
+                        {!exhausted(day) && (
+                            <circle
+                                cx="12"
+                                cy="12"
+                                r="10"
+                                fill="none"
+                                pathLength="100"
+                                stroke="currentColor"
+                                strokeDasharray={`${dayRemaining} 100`}
+                                strokeLinecap="round"
+                                strokeWidth="2"
+                                className="text-emerald-600 dark:text-emerald-400"
+                            />
+                        )}
+                        <circle
+                            cx="12"
+                            cy="12"
+                            r="5"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="10"
+                            className={cx(
+                                'text-muted-foreground/20',
+                                exhausted(week) && 'text-red-500/70',
+                            )}
+                        />
+                        {!exhausted(week) && (
+                            <circle
+                                cx="12"
+                                cy="12"
+                                r="5"
+                                fill="none"
+                                pathLength="100"
+                                stroke="currentColor"
+                                strokeDasharray={`${weekRemaining} 100`}
+                                strokeLinecap="round"
+                                strokeWidth="10"
+                                className="text-amber-400 dark:text-amber-500"
+                            />
+                        )}
+                    </svg>
+                </IconButton>
+            }
+        >
+            <Stack spacing={3} data-suncokret-usage>
+                <Stack spacing={0}>
+                    <Typography level="body2" semiBold>
+                        Preostala AI upotreba
+                    </Typography>
+                    <Typography level="body3" className="text-muted-foreground">
+                        Krugovi se prazne kako koristiš Suncokreta.
+                    </Typography>
+                </Stack>
+                {periods.map(({ detail, label, period }) => {
+                    const remaining = formatSuncokretUsagePercent(
+                        period.remainingPercent,
+                    );
+                    const periodExhausted = exhausted(period);
+
+                    return (
+                        <Stack key={label} spacing={1}>
+                            <Row
+                                justifyContent="space-between"
+                                className="gap-2 text-xs"
+                            >
+                                <span className="font-medium">{label}</span>
+                                <span
+                                    className={cx(
+                                        'text-muted-foreground',
+                                        periodExhausted &&
+                                            'font-medium text-red-700 dark:text-red-400',
+                                    )}
+                                >
+                                    {periodExhausted
+                                        ? 'Iskorišteno'
+                                        : `${remaining} preostalo`}
+                                </span>
+                            </Row>
+                            <div
+                                aria-label={`${label}: ${remaining} preostalo`}
+                                aria-valuemax={100}
+                                aria-valuemin={0}
+                                aria-valuenow={Math.round(
+                                    period.remainingPercent,
+                                )}
+                                className={cx(
+                                    'h-1.5 overflow-hidden rounded-full bg-muted',
+                                    periodExhausted &&
+                                        'bg-red-200 dark:bg-red-950',
+                                )}
+                                role="progressbar"
+                            >
+                                <div
+                                    className="h-full rounded-full bg-emerald-600 transition-[width] duration-300 dark:bg-emerald-500"
+                                    style={{
+                                        width: `${period.remainingPercent}%`,
+                                    }}
+                                />
+                            </div>
+                            <span className="text-[10px] text-muted-foreground">
+                                {detail}
+                            </span>
+                        </Stack>
+                    );
+                })}
+            </Stack>
+        </Popper>
+    );
+}

--- a/packages/game/src/hud/raisedBed/RaisedBedAiOperationMarkdown.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedAiOperationMarkdown.tsx
@@ -137,7 +137,7 @@ function DisabledOperationChip({
     );
 }
 
-function RaisedBedAiOperationChip({
+export function RaisedBedAiOperationChip({
     gardenId,
     label,
     target,

--- a/packages/storage/src/repositories/aiChatRepo.ts
+++ b/packages/storage/src/repositories/aiChatRepo.ts
@@ -600,7 +600,7 @@ export async function ensureAiChatConversation({
     });
 
     if (existing) {
-        if (existing.accountId !== accountId) {
+        if (existing.accountId !== accountId || existing.userId !== userId) {
             return null;
         }
 
@@ -631,6 +631,91 @@ export async function ensureAiChatConversation({
         .returning();
 
     return created ?? null;
+}
+
+export async function getAiChatConversationsForUser({
+    accountId,
+    limit = 50,
+    userId,
+}: {
+    accountId: string;
+    limit?: number;
+    userId: string;
+}) {
+    return storage().query.aiChatConversations.findMany({
+        columns: {
+            id: true,
+            title: true,
+            model: true,
+            gardenId: true,
+            raisedBedId: true,
+            createdAt: true,
+            lastMessageAt: true,
+        },
+        where: and(
+            eq(aiChatConversations.accountId, accountId),
+            eq(aiChatConversations.userId, userId),
+        ),
+        orderBy: desc(aiChatConversations.lastMessageAt),
+        limit: Math.min(100, Math.max(1, limit)),
+        with: {
+            messages: {
+                columns: {
+                    parts: true,
+                    role: true,
+                },
+                where: eq(aiChatMessages.role, 'user'),
+                orderBy: aiChatMessages.createdAt,
+                limit: 1,
+            },
+        },
+    });
+}
+
+export async function getAiChatConversationForUser({
+    accountId,
+    conversationId,
+    userId,
+}: {
+    accountId: string;
+    conversationId: string;
+    userId: string;
+}) {
+    return storage().query.aiChatConversations.findFirst({
+        where: and(
+            eq(aiChatConversations.id, conversationId),
+            eq(aiChatConversations.accountId, accountId),
+            eq(aiChatConversations.userId, userId),
+        ),
+        with: {
+            messages: {
+                orderBy: aiChatMessages.createdAt,
+            },
+        },
+    });
+}
+
+export async function updateAiChatConversationTitle({
+    accountId,
+    conversationId,
+    title,
+    userId,
+}: {
+    accountId: string;
+    conversationId: string;
+    title: string;
+    userId: string;
+}) {
+    await storage()
+        .update(aiChatConversations)
+        .set({ title })
+        .where(
+            and(
+                eq(aiChatConversations.id, conversationId),
+                eq(aiChatConversations.accountId, accountId),
+                eq(aiChatConversations.userId, userId),
+            ),
+        );
 }
 
 export async function replaceAiChatMessages({

--- a/packages/storage/tests/aiChatRepo.node.spec.ts
+++ b/packages/storage/tests/aiChatRepo.node.spec.ts
@@ -9,6 +9,8 @@ import {
     ensureAiChatConversation,
     getAccountGardens,
     getAiChatAccountLimitState,
+    getAiChatConversationForUser,
+    getAiChatConversationsForUser,
     getUser,
     normalizeAiChatMessagesForStorage,
     replaceAiChatMessages,
@@ -19,6 +21,7 @@ import {
     SUNCOKRET_TRIAL_DAILY_LIMIT_MICRO_USD,
     storage,
     updateAccountTimeZone,
+    updateAiChatConversationTitle,
     updateRaisedBed,
 } from '@gredice/storage';
 import { ensureFarmId } from './helpers/testHelpers';
@@ -385,6 +388,50 @@ test('replaceAiChatMessages records approved tool requests for audit', async () 
     assert.strictEqual(toolCall.needsApproval, true);
     assert.strictEqual(toolCall.approvedByUserId, userId);
     assert.ok(toolCall.approvedAt instanceof Date);
+});
+
+test('lists and restores user-scoped AI conversations', async () => {
+    createTestDb();
+    const { accountId, userId } = await createAiChatTestUser();
+    const conversationId = randomUUID();
+    await ensureAiChatConversation({
+        id: conversationId,
+        accountId,
+        userId,
+        model: 'openai/gpt-5.5',
+    });
+    await replaceAiChatMessages({
+        conversationId,
+        messages: [
+            {
+                id: 'user-history',
+                role: 'user',
+                parts: [{ type: 'text', text: 'Kako je vrt?' }],
+            },
+        ],
+    });
+    await updateAiChatConversationTitle({
+        accountId,
+        conversationId,
+        title: 'Stanje vrta',
+        userId,
+    });
+
+    const conversations = await getAiChatConversationsForUser({
+        accountId,
+        userId,
+    });
+    assert.strictEqual(conversations[0]?.id, conversationId);
+    assert.strictEqual(conversations[0]?.title, 'Stanje vrta');
+    assert.strictEqual(conversations[0]?.messages[0]?.role, 'user');
+
+    const restored = await getAiChatConversationForUser({
+        accountId,
+        conversationId,
+        userId,
+    });
+    assert.strictEqual(restored?.messages[0]?.id, 'user-history');
+    assert.strictEqual(restored?.messages[0]?.role, 'user');
 });
 
 test('normalizeAiChatMessagesForStorage does not persist provider tool protocol text', () => {


### PR DESCRIPTION
## What

- add user-scoped Suncokret conversation history with restore navigation and AI-generated titles from the first user interaction
- add new-chat and history navigation, move the top-level launcher to the bottom-right safe area, and remove the chat feature flag so chat is enabled for eligible Garden sessions by default
- keep the Suncokret debug flag disabled by default and expose model selection only in debug mode
- replace always-visible usage details with a remaining-usage popover and daily/weekly circular indicator
- render validated AI operation and sowing recommendations as actionable chips that open the existing manual order flows

## Why

This makes the in-game assistant easier to return to, keeps production chat focused, and connects AI recommendations to the existing commerce flows without forcing cart mutations.

## Impact

- Suncokret chat is now always available outside sandbox/local-sandbox sessions
- `enableSuncokretDebugFlag` remains the only Suncokret feature flag and still defaults to `false`
- conversation reads, title updates, and restores are scoped to both account and user
- no storage migration or new dependency is required

## Checks

- `pnpm build --filter api --filter garden`
- API, Garden, and Game TypeScript checks
- Biome checks for all changed files
- 786 Game unit tests
- 14 AI chat storage tests
- 11 focused Suncokret API tests
- 14 Garden Suncokret component tests