### PR TITLE
Enable Suncokret operation ordering

### DIFF
--- a/apps/api/app/api/[...route]/aiSuncokretRoutes.ts
+++ b/apps/api/app/api/[...route]/aiSuncokretRoutes.ts
@@ -63,6 +63,37 @@ const MAX_TOOL_STEPS = 6;
 
 type ChatVariables = AuthVariables;
 
+type McpErrorCategory =
+    | 'forbidden'
+    | 'http_error'
+    | 'invalid_params'
+    | 'invalid_response'
+    | 'network_error'
+    | 'rate_limited'
+    | 'timeout'
+    | 'tool_failure'
+    | 'unauthorized';
+
+type McpToolTelemetry = {
+    correlationId?: string;
+    errorCategory?: McpErrorCategory;
+};
+
+type SuncokretToolExecutionOptions = {
+    abortSignal?: AbortSignal;
+    toolCallId: string;
+};
+
+class SuncokretMcpToolError extends Error {
+    readonly userMessage: string;
+
+    constructor(userMessage: string) {
+        super(userMessage);
+        this.name = 'SuncokretMcpToolError';
+        this.userMessage = userMessage;
+    }
+}
+
 const FeatureFlagsSchema = z.object({
     enableSuncokretDebugFlag: z.boolean().optional().default(false),
 });
@@ -247,42 +278,132 @@ async function callMcpTool({
     accountId,
     args,
     name,
+    onTelemetry,
     origin,
+    signal,
     token,
+    toolCallId,
 }: {
     accountId: string;
     args: Record<string, unknown>;
     name: string;
+    onTelemetry: (toolCallId: string, telemetry: McpToolTelemetry) => void;
     origin: string;
+    signal?: AbortSignal;
     token: string;
+    toolCallId: string;
 }) {
-    const response = await fetch(`${origin}/api/mcp`, {
-        method: 'POST',
-        headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-Type': 'application/json',
-            'x-gredice-account-id': accountId,
-        },
-        body: JSON.stringify({
-            jsonrpc: '2.0',
-            id: crypto.randomUUID(),
-            method: 'tools/call',
-            params: {
-                name,
-                arguments: args,
+    let response: Response;
+    try {
+        response = await fetch(`${origin}/api/mcp`, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'Content-Type': 'application/json',
+                'x-gredice-account-id': accountId,
             },
-        }),
-    });
-    const payload = (await response.json()) as {
-        result?: unknown;
-        error?: { message?: string };
-    };
-
-    if (!response.ok || payload.error) {
-        throw new Error(payload.error?.message ?? `MCP tool ${name} failed`);
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                id: crypto.randomUUID(),
+                method: 'tools/call',
+                params: {
+                    name,
+                    arguments: args,
+                },
+            }),
+            signal,
+        });
+    } catch (error) {
+        onTelemetry(toolCallId, { errorCategory: 'network_error' });
+        throw new SuncokretMcpToolError(
+            error instanceof DOMException && error.name === 'AbortError'
+                ? 'Provjera podataka je prekinuta. Pokušaj ponovno.'
+                : 'Podaci trenutačno nisu dostupni. Pokušaj ponovno.',
+        );
     }
 
+    const correlationId = response.headers.get('x-correlation-id') ?? undefined;
+    let payload: {
+        result?: unknown;
+        error?: {
+            code?: number;
+            data?: { category?: string } | unknown[];
+            message?: string;
+        };
+    };
+    try {
+        payload = (await response.json()) as typeof payload;
+    } catch {
+        onTelemetry(toolCallId, {
+            correlationId,
+            errorCategory: 'invalid_response',
+        });
+        throw new SuncokretMcpToolError(
+            'Primljen je neispravan odgovor. Pokušaj ponovno.',
+        );
+    }
+
+    if (!response.ok || payload.error) {
+        const errorData = payload.error?.data;
+        const reportedCategory = Array.isArray(errorData)
+            ? undefined
+            : errorData?.category;
+        const errorCategory: McpErrorCategory =
+            reportedCategory === 'invalid_params' ||
+            reportedCategory === 'timeout' ||
+            reportedCategory === 'tool_failure'
+                ? reportedCategory
+                : payload.error?.code === -32602
+                  ? 'invalid_params'
+                  : response.status === 401
+                    ? 'unauthorized'
+                    : response.status === 403
+                      ? 'forbidden'
+                      : response.status === 429
+                        ? 'rate_limited'
+                        : response.status >= 500
+                          ? 'tool_failure'
+                          : 'http_error';
+        onTelemetry(toolCallId, { correlationId, errorCategory });
+        const userMessage =
+            errorCategory === 'timeout'
+                ? 'Provjera podataka trajala je predugo. Pokušaj ponovno.'
+                : errorCategory === 'invalid_params'
+                  ? 'Nedostaju podaci za ovu radnju. Provjeri odabir i pokušaj ponovno.'
+                  : 'Radnja trenutačno nije uspjela. Pokušaj ponovno.';
+        throw new SuncokretMcpToolError(userMessage);
+    }
+
+    onTelemetry(toolCallId, { correlationId });
     return payload.result;
+}
+
+function attachMcpToolTelemetry(
+    messages: UIMessage[],
+    telemetryByToolCallId: ReadonlyMap<string, McpToolTelemetry>,
+) {
+    return messages.map((message) => ({
+        ...message,
+        parts: message.parts.map((part) => {
+            if (!('toolCallId' in part)) {
+                return part;
+            }
+            const telemetry = telemetryByToolCallId.get(part.toolCallId);
+            return telemetry
+                ? {
+                      ...part,
+                      mcpCorrelationId: telemetry.correlationId,
+                      mcpErrorCategory: telemetry.errorCategory,
+                  }
+                : part;
+        }),
+    }));
+}
+
+function suncokretStreamErrorMessage(error: unknown) {
+    return error instanceof SuncokretMcpToolError
+        ? error.userMessage
+        : 'Suncokret trenutačno ne može dovršiti radnju. Pokušaj ponovno.';
 }
 
 async function callPublicJson(url: URL) {
@@ -345,21 +466,41 @@ function buildTools({
     accountId,
     contextFarmId,
     contextGardenId,
+    contextPositionIndex,
     contextRaisedBedId,
     origin,
+    reportMcpTelemetry,
     token,
     userId,
 }: {
     accountId: string;
     contextFarmId?: number | null;
     contextGardenId?: number | null;
+    contextPositionIndex?: number | null;
     contextRaisedBedId?: number | null;
     origin: string;
+    reportMcpTelemetry: (
+        toolCallId: string,
+        telemetry: McpToolTelemetry,
+    ) => void;
     token: string;
     userId: string;
 }) {
-    const mcp = (name: string, args: Record<string, unknown>) =>
-        callMcpTool({ accountId, args, name, origin, token });
+    const mcp = (
+        name: string,
+        args: Record<string, unknown>,
+        options: SuncokretToolExecutionOptions,
+    ) =>
+        callMcpTool({
+            accountId,
+            args,
+            name,
+            onTelemetry: reportMcpTelemetry,
+            origin,
+            signal: options.abortSignal,
+            token,
+            toolCallId: options.toolCallId,
+        });
 
     const raisedBedDetailsTool = tool({
         description:
@@ -368,11 +509,15 @@ function buildTools({
             gardenId: z.number().int().positive().optional(),
             raisedBedId: z.number().int().positive().optional(),
         }),
-        execute: ({ gardenId, raisedBedId }) =>
-            mcp('gardens/get-raised-bed-fields', {
-                gardenId: gardenId ?? contextGardenId,
-                raisedBedId: raisedBedId ?? contextRaisedBedId,
-            }),
+        execute: ({ gardenId, raisedBedId }, options) =>
+            mcp(
+                'gardens/get-raised-bed-fields',
+                {
+                    gardenId: gardenId ?? contextGardenId,
+                    raisedBedId: raisedBedId ?? contextRaisedBedId,
+                },
+                options,
+            ),
     });
 
     return {
@@ -381,18 +526,22 @@ function buildTools({
             inputSchema: z.object({
                 limit: z.number().int().min(1).max(20).default(10),
             }),
-            execute: ({ limit }) =>
-                mcp('gardens/list-gardens', { limit, offset: 0 }),
+            execute: ({ limit }, options) =>
+                mcp('gardens/list-gardens', { limit, offset: 0 }, options),
         }),
         listRaisedBeds: tool({
             description: 'Dohvati gredice za vrt.',
             inputSchema: z.object({
                 gardenId: z.number().int().positive().optional(),
             }),
-            execute: ({ gardenId }) =>
-                mcp('gardens/list-raised-beds', {
-                    gardenId: gardenId ?? contextGardenId,
-                }),
+            execute: ({ gardenId }, options) =>
+                mcp(
+                    'gardens/list-raised-beds',
+                    {
+                        gardenId: gardenId ?? contextGardenId,
+                    },
+                    options,
+                ),
         }),
         getRaisedBedFields: raisedBedDetailsTool,
         getRaisedBedDetails: raisedBedDetailsTool,
@@ -430,13 +579,17 @@ function buildTools({
                 raisedBedId: z.number().int().positive().optional(),
                 limit: z.number().int().min(1).max(30).default(12),
             }),
-            execute: ({ gardenId, limit, raisedBedId }) =>
-                mcp('gardens/list-operations', {
-                    gardenId: gardenId ?? contextGardenId,
-                    raisedBedId: raisedBedId ?? contextRaisedBedId,
-                    limit,
-                    offset: 0,
-                }),
+            execute: ({ gardenId, limit, raisedBedId }, options) =>
+                mcp(
+                    'gardens/list-operations',
+                    {
+                        gardenId: gardenId ?? contextGardenId,
+                        raisedBedId: raisedBedId ?? contextRaisedBedId,
+                        limit,
+                        offset: 0,
+                    },
+                    options,
+                ),
         }),
         getRaisedBedAiHistory: tool({
             description: 'Dohvati već spremljene AI savjete za gredicu.',
@@ -445,12 +598,16 @@ function buildTools({
                 raisedBedId: z.number().int().positive().optional(),
                 limit: z.number().int().min(1).max(10).default(5),
             }),
-            execute: ({ gardenId, limit, raisedBedId }) =>
-                mcp('gardens/get-raised-bed-ai-history', {
-                    gardenId: gardenId ?? contextGardenId,
-                    raisedBedId: raisedBedId ?? contextRaisedBedId,
-                    limit,
-                }),
+            execute: ({ gardenId, limit, raisedBedId }, options) =>
+                mcp(
+                    'gardens/get-raised-bed-ai-history',
+                    {
+                        gardenId: gardenId ?? contextGardenId,
+                        raisedBedId: raisedBedId ?? contextRaisedBedId,
+                        limit,
+                    },
+                    options,
+                ),
         }),
         searchDirectory: tool({
             description: 'Pretraži Gredice katalog biljaka, sorti i radnji.',
@@ -459,7 +616,8 @@ function buildTools({
                 entityTypes: z.array(z.string()).optional(),
                 limit: z.number().int().min(1).max(20).default(8),
             }),
-            execute: (input) => mcp('directories/search-entities', input),
+            execute: (input, options) =>
+                mcp('directories/search-entities', input, options),
         }),
         getOperationsDirectory: tool({
             description: 'Dohvati katalog dostupnih vrtlarskih radnji.',
@@ -467,12 +625,16 @@ function buildTools({
                 category: z.string().optional(),
                 limit: z.number().int().min(1).max(30).default(12),
             }),
-            execute: ({ category, limit }) =>
-                mcp('directories/get-operations', {
-                    category,
-                    limit,
-                    offset: 0,
-                }),
+            execute: ({ category, limit }, options) =>
+                mcp(
+                    'directories/get-operations',
+                    {
+                        category,
+                        limit,
+                        offset: 0,
+                    },
+                    options,
+                ),
         }),
         searchProducts: tool({
             description: 'Pretraži proizvode koje je moguće dodati u košaricu.',
@@ -480,13 +642,18 @@ function buildTools({
                 query: z.string().optional(),
                 limit: z.number().int().min(1).max(20).default(8),
             }),
-            execute: ({ limit, query }) =>
-                mcp('commerce/search-products', { query, limit, offset: 0 }),
+            execute: ({ limit, query }, options) =>
+                mcp(
+                    'commerce/search-products',
+                    { query, limit, offset: 0 },
+                    options,
+                ),
         }),
         getCart: tool({
             description: 'Dohvati trenutnu košaricu korisnika.',
             inputSchema: z.object({}),
-            execute: () => mcp('commerce/get-cart', { userId }),
+            execute: (_input, options) =>
+                mcp('commerce/get-cart', { userId }, options),
         }),
         addProductToCart: tool({
             description:
@@ -500,8 +667,42 @@ function buildTools({
                 scheduledDate: z.string().optional(),
             }),
             needsApproval: true,
-            execute: (input) =>
-                mcp('commerce/add-to-cart', { ...input, userId }),
+            execute: (input, options) =>
+                mcp('commerce/add-to-cart', { ...input, userId }, options),
+        }),
+        addOperationToCart: tool({
+            description:
+                'Dodaj dostupnu radnju za cijelu gredicu ili biljku na polju u košaricu. ID radnje dohvati iz kataloga radnji. Uvijek treba odobrenje korisnika.',
+            inputSchema: z.object({
+                operationId: z.number().int().positive(),
+                quantity: z.number().positive().default(1),
+                gardenId: z.number().int().positive().optional(),
+                raisedBedId: z.number().int().positive().optional(),
+                positionIndex: z.number().int().min(0).optional(),
+                scheduledDate: z.string().optional(),
+            }),
+            needsApproval: true,
+            execute: (input, options) => {
+                const raisedBedId =
+                    input.raisedBedId ?? contextRaisedBedId ?? undefined;
+                const positionIndex =
+                    input.positionIndex ??
+                    (raisedBedId === contextRaisedBedId
+                        ? (contextPositionIndex ?? undefined)
+                        : undefined);
+                return mcp(
+                    'commerce/add-operation-to-cart',
+                    {
+                        ...input,
+                        gardenId:
+                            input.gardenId ?? contextGardenId ?? undefined,
+                        raisedBedId,
+                        positionIndex,
+                        userId,
+                    },
+                    options,
+                );
+            },
         }),
         updateCartItem: tool({
             description:
@@ -511,8 +712,8 @@ function buildTools({
                 quantity: z.number().min(0),
             }),
             needsApproval: true,
-            execute: (input) =>
-                mcp('commerce/update-cart-item', { ...input, userId }),
+            execute: (input, options) =>
+                mcp('commerce/update-cart-item', { ...input, userId }, options),
         }),
         analyzeRaisedBedImages: tool({
             description:
@@ -936,6 +1137,10 @@ const app = new Hono<{ Variables: ChatVariables }>()
             const origin = new URL(context.req.url).origin;
             let finalized = false;
             let finishMetadata: Record<string, unknown> | null = null;
+            const mcpTelemetryByToolCallId = new Map<
+                string,
+                McpToolTelemetry
+            >();
 
             try {
                 const modelMessages = await convertToModelMessages(
@@ -949,8 +1154,12 @@ const app = new Hono<{ Variables: ChatVariables }>()
                         accountId: auth.accountId,
                         contextFarmId: gardenContext.garden?.farmId,
                         contextGardenId: validatedGardenId,
+                        contextPositionIndex: body.positionIndex,
                         contextRaisedBedId: validatedRaisedBedId,
                         origin,
+                        reportMcpTelemetry: (toolCallId, telemetry) => {
+                            mcpTelemetryByToolCallId.set(toolCallId, telemetry);
+                        },
                         token,
                         userId: auth.userId,
                     }),
@@ -1020,6 +1229,7 @@ const app = new Hono<{ Variables: ChatVariables }>()
                 return result.toUIMessageStreamResponse({
                     originalMessages: body.messages as UIMessage[],
                     consumeSseStream: consumeStream,
+                    onError: suncokretStreamErrorMessage,
                     messageMetadata: ({ part }) => {
                         if (part.type !== 'finish') {
                             return undefined;
@@ -1051,7 +1261,10 @@ const app = new Hono<{ Variables: ChatVariables }>()
                         await replaceAiChatMessages({
                             approvedByUserId: auth.userId,
                             conversationId,
-                            messages,
+                            messages: attachMcpToolTelemetry(
+                                messages,
+                                mcpTelemetryByToolCallId,
+                            ),
                         });
                         if (generatedTitlePromise) {
                             const title = await generatedTitlePromise;

--- a/apps/api/app/api/mcp/catalog.ts
+++ b/apps/api/app/api/mcp/catalog.ts
@@ -281,6 +281,24 @@ const TOOL_CATALOG: readonly McpToolCatalogEntry[] = [
         },
     },
     {
+        name: 'commerce/add-operation-to-cart',
+        description:
+            'Add an applicable raised-bed or plant-field operation to the authenticated account cart.',
+        domain: 'commerce',
+        exposure: 'auth-mutation',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                operationId: { type: 'number' },
+                quantity: { type: 'number' },
+                gardenId: { type: 'number' },
+                raisedBedId: { type: 'number' },
+                positionIndex: { type: 'number' },
+                scheduledDate: { type: 'string' },
+            },
+        },
+    },
+    {
         name: 'commerce/update-cart-item',
         description: 'Update or remove an authenticated account cart item.',
         domain: 'commerce',

--- a/apps/api/app/api/mcp/commerce/tools/call/execute.ts
+++ b/apps/api/app/api/mcp/commerce/tools/call/execute.ts
@@ -1,3 +1,4 @@
+import { isOperationApplicableToPlant } from '@gredice/js/operations';
 import {
     isRaisedBedAbandoned,
     RAISED_BED_ABANDONED_ACTIONS_DISABLED_MESSAGE,
@@ -14,6 +15,7 @@ import {
     upsertOrRemoveCartItem,
 } from '@gredice/storage';
 import { z } from 'zod';
+import { assertOperationCartTarget } from '../../../../../../lib/mcp/operationCartTarget';
 
 type McpAuthContext = {
     accountId: string;
@@ -24,6 +26,20 @@ type McpAuthContext = {
 type CommerceEntity = EntityStandardized & {
     description?: string;
     name?: string;
+};
+
+type PlantEntity = EntityStandardized & {
+    information?: EntityStandardized['information'] & {
+        operations?: Array<{
+            information?: { name?: string };
+        }>;
+    };
+};
+
+type PlantSortEntity = EntityStandardized & {
+    information?: EntityStandardized['information'] & {
+        plant?: PlantEntity | null;
+    };
 };
 
 const GetProductsSchema = z.object({
@@ -39,6 +55,16 @@ const GetCartSchema = z.object({
 const AddToCartSchema = z.object({
     userId: z.string().optional(),
     productId: z.string().min(1),
+    quantity: z.number().positive().default(1),
+    gardenId: z.number().int().positive().optional(),
+    raisedBedId: z.number().int().positive().optional(),
+    positionIndex: z.number().int().min(0).optional(),
+    scheduledDate: z.string().optional(),
+});
+
+const AddOperationToCartSchema = z.object({
+    userId: z.string().optional(),
+    operationId: z.coerce.number().int().positive(),
     quantity: z.number().positive().default(1),
     gardenId: z.number().int().positive().optional(),
     raisedBedId: z.number().int().positive().optional(),
@@ -167,6 +193,7 @@ async function validateCartLocation({
     if (!raisedBedId) {
         return {
             gardenId: gardenId ?? undefined,
+            raisedBed: undefined,
             raisedBedId: undefined,
             positionIndex: positionIndex ?? undefined,
         };
@@ -208,9 +235,70 @@ async function validateCartLocation({
 
     return {
         gardenId: finalGardenId,
+        raisedBed,
         raisedBedId: raisedBed.id,
         positionIndex: positionIndex ?? undefined,
     };
+}
+
+function linkedOperationNames(plantSort: PlantSortEntity) {
+    return new Set(
+        plantSort.information?.plant?.information?.operations
+            ?.map((operation) => operation.information?.name)
+            .filter((name): name is string => Boolean(name)) ?? [],
+    );
+}
+
+async function validateOperationTarget({
+    operation,
+    positionIndex,
+    raisedBed,
+}: {
+    operation: CommerceEntity;
+    positionIndex?: number;
+    raisedBed: NonNullable<Awaited<ReturnType<typeof getRaisedBed>>>;
+}) {
+    const application = operation.attributes?.application;
+    assertOperationCartTarget(application, {
+        raisedBedId: raisedBed.id,
+        positionIndex,
+    });
+
+    if (application !== 'plant') {
+        return;
+    }
+
+    const field = raisedBed.fields.find(
+        (candidate) => candidate.positionIndex === positionIndex,
+    );
+    if (!field?.plantSortId) {
+        throw new Error('Raised-bed field does not contain a plant');
+    }
+
+    const plantSort = await getEntityFormatted<PlantSortEntity>(
+        field.plantSortId,
+    );
+    const operationName = operation.information?.name;
+    if (!plantSort || !operationName) {
+        throw new Error('Plant operation applicability could not be verified');
+    }
+
+    const applicable = isOperationApplicableToPlant(
+        {
+            attributes: {
+                application,
+                appliesToAllTargets:
+                    operation.attributes?.appliesToAllTargets === true,
+            },
+            information: { name: operationName },
+        },
+        linkedOperationNames(plantSort),
+    );
+    if (!applicable) {
+        throw new Error(
+            'Operation is not applicable to the plant in this field',
+        );
+    }
 }
 
 export async function executeCommerceTool(
@@ -282,6 +370,70 @@ export async function executeCommerceTool(
                 cart.id,
                 entityId.toString(),
                 'plantSort',
+                input.quantity,
+                location.gardenId,
+                location.raisedBedId,
+                location.positionIndex,
+                additionalData,
+            );
+            const refreshedCart = await getOrCreateShoppingCart(
+                authContext.accountId,
+            );
+            if (!refreshedCart) {
+                throw new Error('Cart could not be loaded');
+            }
+            return {
+                cartItemId,
+                cart: formatCart(refreshedCart),
+            };
+        }
+        case 'commerce/add-operation-to-cart': {
+            const authContext = requireCommerceAuth(auth);
+            const input = AddOperationToCartSchema.parse(args);
+            assertUser(input.userId, authContext);
+            const operationRaw = await getEntityRaw(input.operationId);
+            if (
+                operationRaw?.state !== 'published' ||
+                operationRaw.entityType?.name !== 'operation'
+            ) {
+                throw new Error('Operation not found');
+            }
+            const operation = await getEntityFormatted<CommerceEntity>(
+                input.operationId,
+            );
+            if (!operation) {
+                throw new Error('Operation not found');
+            }
+            assertOperationCartTarget(operation.attributes?.application, {
+                raisedBedId: input.raisedBedId,
+                positionIndex: input.positionIndex,
+            });
+            const location = await validateCartLocation({
+                accountId: authContext.accountId,
+                gardenId: input.gardenId,
+                raisedBedId: input.raisedBedId,
+                positionIndex: input.positionIndex,
+            });
+            if (!location.raisedBedId || !location.raisedBed) {
+                throw new Error('Operation requires a raised bed');
+            }
+            await validateOperationTarget({
+                operation,
+                positionIndex: location.positionIndex,
+                raisedBed: location.raisedBed,
+            });
+            const cart = await getOrCreateShoppingCart(authContext.accountId);
+            if (!cart) {
+                throw new Error('Cart could not be created');
+            }
+            const additionalData = input.scheduledDate
+                ? JSON.stringify({ scheduledDate: input.scheduledDate })
+                : null;
+            const cartItemId = await upsertOrRemoveCartItem(
+                null,
+                cart.id,
+                input.operationId.toString(),
+                'operation',
                 input.quantity,
                 location.gardenId,
                 location.raisedBedId,

--- a/apps/api/app/api/mcp/server.ts
+++ b/apps/api/app/api/mcp/server.ts
@@ -559,17 +559,26 @@ export async function handleMcpRequest(request: NextRequest) {
             } catch (error) {
                 const isInvalidParams = error instanceof z.ZodError;
                 const isTimeout = error instanceof ToolExecutionTimeoutError;
+                const errorType = isInvalidParams
+                    ? 'invalid_params'
+                    : isTimeout
+                      ? 'timeout'
+                      : 'tool_failure';
                 logger.error('mcp.request.error', {
                     correlationId,
                     method,
                     toolName: name,
                     latencyMs: Math.round(performance.now() - requestStart),
                     status: 'error',
-                    errorType: isInvalidParams
-                        ? 'invalid_params'
-                        : isTimeout
-                          ? 'timeout'
-                          : 'tool_failure',
+                    errorType,
+                    error:
+                        error instanceof Error
+                            ? {
+                                  name: error.name,
+                                  message: error.message.slice(0, 1_000),
+                                  stack: error.stack?.slice(0, 4_000),
+                              }
+                            : String(error),
                 });
                 return NextResponse.json(
                     {
@@ -584,7 +593,9 @@ export async function handleMcpRequest(request: NextRequest) {
                                   : error instanceof Error
                                     ? error.message
                                     : 'Tool execution failed',
-                            data: isInvalidParams ? error.issues : undefined,
+                            data: isInvalidParams
+                                ? error.issues
+                                : { category: errorType },
                         },
                     },
                     {

--- a/apps/api/lib/ai/suncokretContext.node.spec.ts
+++ b/apps/api/lib/ai/suncokretContext.node.spec.ts
@@ -33,6 +33,8 @@ test('buildSuncokretSystemPrompt requires a friendly gender-neutral voice', () =
     assert.match(prompt, /Obraćaj se korisniku s "ti"/);
     assert.match(prompt, /Uvijek koristi rodno neutralne rečenice/);
     assert.match(prompt, /trebao\/trebala/);
+    assert.match(prompt, /addOperationToCart/);
+    assert.match(prompt, /Gredice općenito ne podržavaju ili ne nude/);
 });
 
 test('buildSuncokretSystemPrompt requires structured actionable recommendations', () => {

--- a/apps/api/lib/ai/suncokretContext.ts
+++ b/apps/api/lib/ai/suncokretContext.ts
@@ -120,6 +120,8 @@ export function buildSuncokretSystemPrompt(input: {
         'Korisnik nema nužno fizički pristup gredici. Kada preporuka traži rad na gredici, predloži naručivanje odgovarajuće radnje ili sijanja kroz dostupne alate.',
         'Kada u završnom odgovoru preporučiš konkretnu dostupnu Gredice radnju ili sijanje za određenu gredicu ili polje, nakon provjere kataloga pozovi presentRecommendations kako bi korisnik dobio klikabilne prijedloge. Prikaži samo stavke koje doista preporučuješ, najviše šest. Taj alat ne dodaje ništa u košaricu.',
         'Uz klikabilne prijedloge kratko reci da ih korisnik može otvoriti i ručno naručiti ili zatražiti da ih dodaš u košaricu.',
+        'Radnje za cijelu gredicu i primjenjive radnje za biljku na pojedinom polju mogu se naručiti alatom addOperationToCart nakon što iz kataloga dohvatiš ID radnje. Za biljnu radnju uvijek navedi gredicu i indeks polja.',
+        'Ako neki alat ne podržava traženu promjenu, reci samo da je ne možeš izvršiti iz ovog razgovora. Nemoj iz toga zaključiti da Gredice općenito ne podržavaju ili ne nude tu radnju.',
         'Ne tvrdi da je radnja, sijanje, izmjena košarice ili checkout izvršen dok alat ne potvrdi rezultat.',
         'Za kupnju, checkout, promjene košarice, sijanje, zakazivanje, otkazivanje i druge promjene prvo sažmi što želiš napraviti i koristi alat koji traži odobrenje korisnika.',
         'Ako korisnik traži savjete iz fotografija gredice, prvo pokreni alat analyzeRaisedBedImages i nastavi razgovor iz spremljenog rezultata.',

--- a/apps/api/lib/mcp/catalog.node.spec.ts
+++ b/apps/api/lib/mcp/catalog.node.spec.ts
@@ -59,6 +59,10 @@ describe('MCP catalog contract scaffold', () => {
 
         assert.equal(exposures.get('commerce/add-to-cart'), 'auth-mutation');
         assert.equal(
+            exposures.get('commerce/add-operation-to-cart'),
+            'auth-mutation',
+        );
+        assert.equal(
             exposures.get('commerce/update-cart-item'),
             'auth-mutation',
         );
@@ -72,9 +76,11 @@ describe('MCP catalog contract scaffold', () => {
             assert.equal(tool.annotations.openWorldHint, false);
             assert.equal(
                 tool.annotations.readOnlyHint,
-                !['commerce/add-to-cart', 'commerce/update-cart-item'].includes(
-                    tool.name,
-                ),
+                ![
+                    'commerce/add-to-cart',
+                    'commerce/add-operation-to-cart',
+                    'commerce/update-cart-item',
+                ].includes(tool.name),
             );
             assert.equal(
                 tool.annotations.destructiveHint,
@@ -87,6 +93,7 @@ describe('MCP catalog contract scaffold', () => {
         for (const toolName of [
             'commerce/get-cart',
             'commerce/add-to-cart',
+            'commerce/add-operation-to-cart',
             'commerce/update-cart-item',
         ]) {
             const tool = getMcpTools().find(

--- a/apps/api/lib/mcp/operationCartTarget.node.spec.ts
+++ b/apps/api/lib/mcp/operationCartTarget.node.spec.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { assertOperationCartTarget } from './operationCartTarget';
+
+test('raised-bed operations require a raised bed and no individual field', () => {
+    assert.doesNotThrow(() =>
+        assertOperationCartTarget('raisedBedFull', { raisedBedId: 12 }),
+    );
+    assert.doesNotThrow(() =>
+        assertOperationCartTarget('raisedBed1m', { raisedBedId: 12 }),
+    );
+    assert.throws(
+        () => assertOperationCartTarget('raisedBedFull', {}),
+        /requires a raised bed/,
+    );
+    assert.throws(
+        () =>
+            assertOperationCartTarget('raisedBed1m', {
+                raisedBedId: 12,
+                positionIndex: 3,
+            }),
+        /cannot target an individual field/,
+    );
+});
+
+test('plant operations require a concrete field', () => {
+    assert.doesNotThrow(() =>
+        assertOperationCartTarget('plant', {
+            raisedBedId: 12,
+            positionIndex: 0,
+        }),
+    );
+    assert.throws(
+        () => assertOperationCartTarget('plant', { raisedBedId: 12 }),
+        /requires a raised-bed field/,
+    );
+});
+
+test('other operation applications cannot be ordered through a raised-bed target', () => {
+    assert.throws(
+        () => assertOperationCartTarget('garden', { raisedBedId: 12 }),
+        /not orderable for this target/,
+    );
+});

--- a/apps/api/lib/mcp/operationCartTarget.ts
+++ b/apps/api/lib/mcp/operationCartTarget.ts
@@ -1,0 +1,33 @@
+export type OperationCartTarget = {
+    raisedBedId?: number;
+    positionIndex?: number;
+};
+
+export function assertOperationCartTarget(
+    application: string | undefined,
+    target: OperationCartTarget,
+) {
+    switch (application) {
+        case 'raisedBedFull':
+        case 'raisedBed1m':
+            if (!target.raisedBedId) {
+                throw new Error('Raised-bed operation requires a raised bed');
+            }
+            if (typeof target.positionIndex === 'number') {
+                throw new Error(
+                    'Raised-bed operation cannot target an individual field',
+                );
+            }
+            return;
+        case 'plant':
+            if (!target.raisedBedId) {
+                throw new Error('Plant operation requires a raised bed');
+            }
+            if (typeof target.positionIndex !== 'number') {
+                throw new Error('Plant operation requires a raised-bed field');
+            }
+            return;
+        default:
+            throw new Error('Operation is not orderable for this target');
+    }
+}

--- a/packages/game/src/hud/suncokretChatContext.unit.ts
+++ b/packages/game/src/hud/suncokretChatContext.unit.ts
@@ -122,3 +122,23 @@ test('provider tool protocol variants are replaced with a friendly retry message
         assert.match(sanitized, /Pokušaj ponovno/);
     }
 });
+
+test('english model planning preamble is not displayed before a Croatian answer', () => {
+    const sanitized = sanitizeSuncokretAssistantText(
+        "Confirmed: watering is available. I'll explain briefly.Nažalost, prethodni odgovor nije bio točan. Zalijevanje se može naručiti.",
+    );
+
+    assert.strictEqual(
+        sanitized,
+        'Nažalost, prethodni odgovor nije bio točan. Zalijevanje se može naručiti.',
+    );
+});
+
+test('english model planning without a Croatian answer uses the retry fallback', () => {
+    const sanitized = sanitizeSuncokretAssistantText(
+        'I should inspect the tool output before answering.',
+    );
+
+    assert.doesNotMatch(sanitized, /I should|tool output/);
+    assert.match(sanitized, /Pokušaj ponovno/);
+});

--- a/packages/js/src/ai/index.ts
+++ b/packages/js/src/ai/index.ts
@@ -95,19 +95,35 @@ export type SuncokretUiContext =
 
 const SUNCOKRET_TOOL_PROTOCOL_PATTERN =
     /<\s*(?:[|｜]\s*){1,2}DSML(?:\s*[|｜]){1,2}/iu;
+const SUNCOKRET_ENGLISH_META_PREAMBLE_PATTERN =
+    /^\s*(?:Confirmed\b|I(?:'|’)ll\b|I\s+(?:can|cannot|can't|found|must|need|should|will)\b|Let me\b|The user\b|We need\b)/iu;
+const SUNCOKRET_CROATIAN_ANSWER_START_PATTERN =
+    /\b(?:Da|Evo|Gotovo|Mogu|Možeš|Nažalost|Naravno|Ne|Nisam|Prema|Radnja|Razumijem|U Gredicama|Za ovu|Za tu|Zalijevanje)\b/iu;
 
 export const SUNCOKRET_TOOL_PROTOCOL_FALLBACK =
     'Nisam uspio dovršiti odgovor. Pokušaj ponovno — ne moraš mijenjati pitanje.';
 
 export function sanitizeSuncokretAssistantText(value: string) {
     const protocolStart = value.search(SUNCOKRET_TOOL_PROTOCOL_PATTERN);
-    if (protocolStart === -1) {
-        return value;
+    const protocolSafeText =
+        protocolStart === -1
+            ? value
+            : (() => {
+                  const visibleText = value.slice(0, protocolStart).trimEnd();
+                  return visibleText
+                      ? `${visibleText}\n\n${SUNCOKRET_TOOL_PROTOCOL_FALLBACK}`
+                      : SUNCOKRET_TOOL_PROTOCOL_FALLBACK;
+              })();
+
+    if (!SUNCOKRET_ENGLISH_META_PREAMBLE_PATTERN.test(protocolSafeText)) {
+        return protocolSafeText;
     }
 
-    const visibleText = value.slice(0, protocolStart).trimEnd();
-    return visibleText
-        ? `${visibleText}\n\n${SUNCOKRET_TOOL_PROTOCOL_FALLBACK}`
+    const answerStart =
+        SUNCOKRET_CROATIAN_ANSWER_START_PATTERN.exec(protocolSafeText);
+
+    return answerStart?.index !== undefined
+        ? protocolSafeText.slice(answerStart.index).trimStart()
         : SUNCOKRET_TOOL_PROTOCOL_FALLBACK;
 }
 

--- a/packages/storage/src/repositories/aiChatRepo.ts
+++ b/packages/storage/src/repositories/aiChatRepo.ts
@@ -290,6 +290,12 @@ function extractToolCallRows(
             const approval = toolCallValue(part.approval);
             const approved =
                 approval?.approved === true || approval?.state === 'approved';
+            const errorText =
+                typeof part.errorText === 'string' ? part.errorText : null;
+            const mcpErrorCategory =
+                typeof part.mcpErrorCategory === 'string'
+                    ? part.mcpErrorCategory
+                    : null;
             rows.push({
                 id: randomUUID(),
                 conversationId,
@@ -310,11 +316,16 @@ function extractToolCallRows(
                 input: toolCallValue(part.input) ?? toolCallValue(part.args),
                 output:
                     toolCallValue(part.output) ?? toolCallValue(part.result),
-                error:
-                    typeof part.errorText === 'string' ? part.errorText : null,
+                error: mcpErrorCategory
+                    ? `[${mcpErrorCategory}]${errorText ? ` ${errorText}` : ''}`
+                    : errorText,
                 needsApproval: Boolean(approval),
                 approvedByUserId: approved ? approvedByUserId : undefined,
                 approvedAt: approved ? new Date() : undefined,
+                mcpCorrelationId:
+                    typeof part.mcpCorrelationId === 'string'
+                        ? part.mcpCorrelationId
+                        : null,
             });
         }
     }

--- a/packages/storage/tests/aiChatRepo.node.spec.ts
+++ b/packages/storage/tests/aiChatRepo.node.spec.ts
@@ -382,7 +382,10 @@ test('replaceAiChatMessages records approved tool requests for audit', async () 
         ],
     });
 
-    const toolCall = await storage().query.aiChatToolCalls.findFirst();
+    const toolCalls = await storage().query.aiChatToolCalls.findMany();
+    const toolCall = toolCalls.find(
+        (candidate) => candidate.toolCallId === 'cart-call-1',
+    );
     assert.ok(toolCall);
     assert.strictEqual(toolCall.state, 'approval-responded');
     assert.strictEqual(toolCall.needsApproval, true);
@@ -434,6 +437,52 @@ test('lists and restores user-scoped AI conversations', async () => {
     assert.strictEqual(restored?.messages[0]?.role, 'user');
 });
 
+test('replaceAiChatMessages records MCP correlation and error category', async () => {
+    createTestDb();
+    const { accountId, userId } = await createAiChatTestUser();
+    const conversationId = randomUUID();
+    await ensureAiChatConversation({
+        id: conversationId,
+        accountId,
+        userId,
+        model: 'openai/gpt-5.5',
+        title: 'Suncokret MCP error test',
+    });
+
+    await replaceAiChatMessages({
+        conversationId,
+        messages: [
+            {
+                id: 'assistant-error',
+                role: 'assistant',
+                parts: [
+                    {
+                        type: 'tool-listGardenOperations',
+                        toolCallId: 'operations-call-1',
+                        state: 'output-error',
+                        input: { gardenId: 1 },
+                        errorText:
+                            'Provjera podataka trajala je predugo. Pokušaj ponovno.',
+                        mcpCorrelationId: 'mcp-correlation-123',
+                        mcpErrorCategory: 'timeout',
+                    },
+                ],
+            },
+        ],
+    });
+
+    const toolCalls = await storage().query.aiChatToolCalls.findMany();
+    const toolCall = toolCalls.find(
+        (candidate) => candidate.toolCallId === 'operations-call-1',
+    );
+    assert.ok(toolCall);
+    assert.strictEqual(toolCall.mcpCorrelationId, 'mcp-correlation-123');
+    assert.strictEqual(
+        toolCall.error,
+        '[timeout] Provjera podataka trajala je predugo. Pokušaj ponovno.',
+    );
+});
+
 test('normalizeAiChatMessagesForStorage does not persist provider tool protocol text', () => {
     const [message] = normalizeAiChatMessagesForStorage([
         {
@@ -453,6 +502,29 @@ test('normalizeAiChatMessagesForStorage does not persist provider tool protocol 
         {
             type: 'text',
             text: 'Nisam uspio dovršiti odgovor. Pokušaj ponovno — ne moraš mijenjati pitanje.',
+        },
+    ]);
+});
+
+test('normalizeAiChatMessagesForStorage removes English model planning preambles', () => {
+    const [message] = normalizeAiChatMessagesForStorage([
+        {
+            id: 'assistant-message',
+            role: 'assistant',
+            parts: [
+                {
+                    type: 'text',
+                    text: "Confirmed: watering can be ordered. I'll answer briefly.Nažalost, prethodni odgovor nije bio točan.",
+                },
+            ],
+        },
+    ]);
+
+    assert.ok(message);
+    assert.deepStrictEqual(message.parts, [
+        {
+            type: 'text',
+            text: 'Nažalost, prethodni odgovor nije bio točan.',
         },
     ]);
 });


### PR DESCRIPTION
## Summary

- add an approval-gated Suncokret tool for ordering applicable raised-bed and plant-field operations
- validate account ownership, raised-bed targets, field targets, published operation entities, and plant applicability before cart mutation
- persist MCP correlation IDs and categorized failures while returning safe Croatian error messages
- filter leaked English planning/tool-protocol text before display and persistence
- clarify the Croatian system prompt so tool limitations are not described as product limitations

## Root cause

Suncokret could enumerate operation entities but its commerce bridge only accepted `plantSort` products, so it incorrectly concluded that raised-bed watering could not be ordered. MCP tool errors also lost their response correlation/category in the persisted chat audit, and model planning text was rendered as ordinary assistant text.

## Impact

Users can now approve ordering every applicable operation offered by the existing raised-bed and plant-field UIs. Failures are traceable without exposing internal details, and English planning preambles are suppressed.

## Validation

- API Node suite: 462 passed
- focused AI chat storage suite: 16 passed
- Suncokret chat rendering tests: 7 passed
- API TypeScript check
- game TypeScript check
- Biome checks and `git diff --check`