### PR TITLE
fix(checkout): recover superseded plant cycles

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,7 @@
         "test:run": "playwright test",
         "test:node": "node --import tsx --test --conditions=react-server ./lib/**/*.node.spec.ts",
         "mcp:smoke:public": "node ./scripts/smokePublicMcp.mjs",
+        "checkout:resume-direct": "node --conditions=react-server --env-file=.env --import tsx ./scripts/resumeDirectCheckout.ts",
         "merge:raised-beds:all": "node --conditions=react-server --env-file=.env --import tsx ./scripts/mergeAllRaisedBeds.ts",
         "regenerate": "pnpm run /^regenerate:.*/",
         "regenerate:directories-api": "pnpm dlx openapi-typescript https://api.gredice.com/api/docs/directories -o ./lib/@types/directories-api/v1.d.ts"

--- a/apps/api/scripts/resumeDirectCheckout.ts
+++ b/apps/api/scripts/resumeDirectCheckout.ts
@@ -1,0 +1,273 @@
+import {
+    closeStorage,
+    events,
+    getAccount,
+    getShoppingCart,
+    knownEventTypes,
+    markCartPaidAndEnqueueOrderConfirmation,
+    setCartItemPaid,
+    storage,
+} from '@gredice/storage';
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import { getCartInfo } from '../lib/checkout/cartInfo';
+import { withDirectSunflowerCheckoutBatch } from '../lib/checkout/directSunflowerCheckout';
+import { buildCheckoutAdditionalData } from '../lib/checkout/harvestCheckout';
+import {
+    buildOrderConfirmationItems,
+    ORDER_CONFIRMATION_MANAGE_URL,
+} from '../lib/checkout/orderConfirmationEmail';
+import {
+    assertCheckoutItemFulfilled,
+    processItem,
+} from '../lib/stripe/processCheckoutSession';
+
+function readRequiredOption(argv: string[], name: string) {
+    const prefix = `--${name}=`;
+    const value = argv
+        .find((argument) => argument.startsWith(prefix))
+        ?.slice(prefix.length)
+        .trim();
+    if (!value) {
+        throw new Error(`${prefix}<value> is required.`);
+    }
+    return value;
+}
+
+function readCartId(argv: string[]) {
+    const rawCartId = readRequiredOption(argv, 'cart-id');
+    const cartId = Number(rawCartId);
+    if (!Number.isSafeInteger(cartId) || cartId <= 0) {
+        throw new Error('--cart-id must be a positive integer.');
+    }
+    return cartId;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseSpendEvent(data: unknown) {
+    if (!isRecord(data)) {
+        return null;
+    }
+    const { amount, reason } = data;
+    if (
+        typeof reason !== 'string' ||
+        typeof amount !== 'number' ||
+        !Number.isSafeInteger(amount) ||
+        amount <= 0
+    ) {
+        return null;
+    }
+    return { amount, reason };
+}
+
+async function getExistingCartItemDebits(
+    accountId: string,
+    cartItemIds: readonly number[],
+) {
+    const reasons = cartItemIds.map(
+        (cartItemId) => `shoppingCartItem:${cartItemId.toString()}`,
+    );
+    const spendEvents = await storage()
+        .select({ data: events.data, id: events.id })
+        .from(events)
+        .where(
+            and(
+                eq(events.aggregateId, accountId),
+                eq(events.type, knownEventTypes.accounts.spendSunflowers),
+                inArray(sql<string>`${events.data}->>'reason'`, reasons),
+            ),
+        );
+    const amountsByReason = new Map<string, number>();
+    for (const event of spendEvents) {
+        const parsed = parseSpendEvent(event.data);
+        if (!parsed || !reasons.includes(parsed.reason)) {
+            throw new Error(
+                `Cart debit event ${event.id.toString()} is malformed.`,
+            );
+        }
+        if (amountsByReason.has(parsed.reason)) {
+            throw new Error(`Duplicate cart debit found for ${parsed.reason}.`);
+        }
+        amountsByReason.set(parsed.reason, parsed.amount);
+    }
+
+    const missingReasons = reasons.filter(
+        (reason) => !amountsByReason.has(reason),
+    );
+    if (missingReasons.length > 0) {
+        throw new Error(
+            `Refusing to resume because original debits are missing: ${missingReasons.join(', ')}.`,
+        );
+    }
+    return amountsByReason;
+}
+
+const argv = process.argv.slice(2);
+const accountId = readRequiredOption(argv, 'account-id');
+const cartId = readCartId(argv);
+const recipient = readRequiredOption(argv, 'recipient').toLowerCase();
+const execute = argv.includes('--execute');
+
+try {
+    const [account, cart] = await Promise.all([
+        getAccount(accountId),
+        getShoppingCart(cartId),
+    ]);
+    if (!account) {
+        throw new Error(`Account ${accountId} was not found.`);
+    }
+    if (!cart || cart.accountId !== accountId) {
+        throw new Error(
+            `Cart ${cartId.toString()} does not belong to account ${accountId}.`,
+        );
+    }
+    if (cart.status !== 'new' && cart.status !== 'paid') {
+        throw new Error(
+            `Cart ${cartId.toString()} has unsupported status ${cart.status}.`,
+        );
+    }
+
+    const recipientBelongsToAccount = account.accountUsers.some(
+        ({ user }) => user.userName.toLowerCase() === recipient,
+    );
+    if (!recipientBelongsToAccount) {
+        throw new Error('Confirmation recipient is not linked to the account.');
+    }
+    if (
+        cart.items.length === 0 ||
+        cart.items.some(
+            (item) =>
+                item.entityTypeName !== 'plantSort' ||
+                item.currency !== 'sunflower' ||
+                item.isDeleted,
+        )
+    ) {
+        throw new Error(
+            'This recovery command only supports a cart of live sunflower plant items.',
+        );
+    }
+
+    const cartInfo = await getCartInfo(cart.items, accountId);
+    if (cartInfo.items.length !== cart.items.length) {
+        throw new Error('Not every cart item resolved to current shop data.');
+    }
+    if (!cartInfo.allowPurchase && cart.status !== 'paid') {
+        throw new Error(
+            `Cart is not currently purchasable: ${cartInfo.notes.join(' ')}`,
+        );
+    }
+
+    const existingDebits = await getExistingCartItemDebits(
+        accountId,
+        cartInfo.items.map((item) => item.id),
+    );
+    console.log(
+        JSON.stringify(
+            {
+                accountId,
+                cartId,
+                cartStatus: cart.status,
+                items: cartInfo.items.map((item) => ({
+                    debit: existingDebits.get(
+                        `shoppingCartItem:${item.id.toString()}`,
+                    ),
+                    entityId: item.entityId,
+                    id: item.id,
+                    positionIndex: item.positionIndex,
+                    raisedBedId: item.raisedBedId,
+                    status: item.status,
+                })),
+                mode: execute ? 'execute' : 'dry-run',
+            },
+            null,
+            2,
+        ),
+    );
+
+    if (!execute) {
+        console.log('Dry run complete; no checkout data was changed.');
+    } else if (cart.status === 'paid') {
+        console.log('Cart is already paid; no checkout data was changed.');
+    } else {
+        const result = await withDirectSunflowerCheckoutBatch({
+            accountId,
+            allCheckoutItems: cartInfo.items,
+            cartId,
+            operation: async ({
+                pendingItems,
+                resolvedAmountsByCartItemId,
+            }) => {
+                const fulfilledItemIds: number[] = [];
+                for (const item of pendingItems) {
+                    const amountTotal = resolvedAmountsByCartItemId.get(
+                        item.id,
+                    );
+                    if (amountTotal === undefined) {
+                        throw new Error(
+                            `Resolved debit is missing for cart item ${item.id.toString()}.`,
+                        );
+                    }
+                    const fulfillment = await processItem({
+                        accountId,
+                        cartItemId: item.id,
+                        ...item,
+                        additionalData: buildCheckoutAdditionalData({
+                            additionalData: item.additionalData,
+                        }),
+                        amount_total: amountTotal,
+                    });
+                    assertCheckoutItemFulfilled(fulfillment);
+                    await setCartItemPaid(item.id);
+                    fulfilledItemIds.push(item.id);
+                }
+
+                const confirmation =
+                    await markCartPaidAndEnqueueOrderConfirmation({
+                        cartId,
+                        payload: {
+                            cartId,
+                            currency: null,
+                            items: buildOrderConfirmationItems(
+                                cartInfo.items,
+                                (item) => {
+                                    const amount =
+                                        resolvedAmountsByCartItemId.get(
+                                            item.id,
+                                        );
+                                    if (amount === undefined) {
+                                        throw new Error(
+                                            `Confirmation debit is missing for cart item ${item.id.toString()}.`,
+                                        );
+                                    }
+                                    return amount;
+                                },
+                            ),
+                            manageUrl: ORDER_CONFIRMATION_MANAGE_URL,
+                            to: recipient,
+                            totalAmountCents: null,
+                        },
+                    });
+                if (
+                    confirmation.status !== 'enqueued' &&
+                    !(
+                        confirmation.status === 'already_paid' &&
+                        confirmation.emailMessageId !== null
+                    )
+                ) {
+                    throw new Error(
+                        `Cart confirmation was not recorded (${confirmation.status}).`,
+                    );
+                }
+                return { confirmation, fulfilledItemIds };
+            },
+        });
+        if (result.state !== 'processed') {
+            throw new Error('Cart became paid before recovery was processed.');
+        }
+        console.log(JSON.stringify(result.value, null, 2));
+    }
+} finally {
+    await closeStorage();
+}

--- a/apps/api/scripts/resumeDirectCheckout.ts
+++ b/apps/api/scripts/resumeDirectCheckout.ts
@@ -149,7 +149,23 @@ try {
         );
     }
 
-    const cartInfo = await getCartInfo(cart.items, accountId);
+    const existingDebits = await getExistingCartItemDebits(
+        accountId,
+        cart.items.map((item) => item.id),
+    );
+    let cartInfo = await getCartInfo(cart.items, accountId);
+    if (!cartInfo.allowPurchase && cart.status !== 'paid') {
+        // The durable item debits above prove payment already started. Mirror
+        // normal direct-checkout recovery by exempting those pending items from
+        // cart-state blockers that are only valid before payment begins.
+        cartInfo = await getCartInfo(cart.items, accountId, {
+            resumableCartItemIds: new Set(
+                cart.items
+                    .filter((item) => item.status !== 'paid')
+                    .map((item) => item.id),
+            ),
+        });
+    }
     if (cartInfo.items.length !== cart.items.length) {
         throw new Error('Not every cart item resolved to current shop data.');
     }
@@ -159,10 +175,6 @@ try {
         );
     }
 
-    const existingDebits = await getExistingCartItemDebits(
-        accountId,
-        cartInfo.items.map((item) => item.id),
-    );
     console.log(
         JSON.stringify(
             {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -35,6 +35,7 @@
         "plant-relationships:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/backfillPlantRelationships.ts",
         "plant-health:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/backfillPlantHealthDirectory.ts",
         "plants:max-harvest-days:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/backfillPlantMaxHarvestDaysBeforeDelivery.ts",
+        "plant-cycles:superseded-repair": "tsx --conditions=react-server --env-file=.env ./scripts/repairSupersededPlantCycles.ts",
         "operations:all-targets:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/backfillOperationAppliesToAllTargets.ts",
         "plant-health:operations-backfill": "tsx --conditions=react-server --env-file=.env ./scripts/backfillPlantHealthOperations.ts",
         "generated-images:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/upsertGeneratedImageAttributes.ts",

--- a/packages/storage/scripts/lib/supersededPlantCycles.ts
+++ b/packages/storage/scripts/lib/supersededPlantCycles.ts
@@ -1,0 +1,185 @@
+export type PlantCycleRepairEvent = {
+    aggregateId: string;
+    createdAt: Date;
+    data: unknown;
+    id: number;
+    type: string;
+};
+
+export type SupersededPlantCycleRepair = {
+    aggregateId: string;
+    nextPlantPlaceEventId: number;
+    positionIndex: number;
+    raisedBedId: number;
+    repairCreatedAt: Date;
+    repairKey: string;
+    supersededPlantPlaceEventId: number;
+};
+
+export type UnsafeSupersededPlantCycleRepair = {
+    aggregateId: string;
+    nextPlantPlaceEventId: number;
+    reason: string;
+    supersededPlantPlaceEventId: number;
+};
+
+const activePlantStatuses = new Set([
+    'firstFlowers',
+    'firstFruitSet',
+    'new',
+    'pendingVerification',
+    'planned',
+    'ready',
+    'sowed',
+    'sprouted',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function compareEvents(
+    left: PlantCycleRepairEvent,
+    right: PlantCycleRepairEvent,
+) {
+    const timeDifference = left.createdAt.getTime() - right.createdAt.getTime();
+    return timeDifference === 0 ? left.id - right.id : timeDifference;
+}
+
+function parseAggregateId(aggregateId: string) {
+    const match =
+        /^(?<raisedBedId>[1-9]\d*)\|(?<positionIndex>0|[1-9]\d*)$/u.exec(
+            aggregateId,
+        );
+    if (!match?.groups) {
+        return null;
+    }
+
+    const raisedBedId = Number.parseInt(match.groups.raisedBedId ?? '', 10);
+    const positionIndex = Number.parseInt(match.groups.positionIndex ?? '', 10);
+    if (
+        !Number.isSafeInteger(raisedBedId) ||
+        raisedBedId <= 0 ||
+        !Number.isSafeInteger(positionIndex) ||
+        positionIndex < 0
+    ) {
+        return null;
+    }
+
+    return { positionIndex, raisedBedId };
+}
+
+function plantCycleIsActive(events: PlantCycleRepairEvent[]) {
+    let active = true;
+
+    for (const event of events) {
+        if (event.type === 'raisedBedField.delete') {
+            active = false;
+            continue;
+        }
+        if (event.type !== 'raisedBedField.plantUpdate') {
+            continue;
+        }
+
+        const status = isRecord(event.data) ? event.data.status : undefined;
+        if (status === 'removed') {
+            active = false;
+        } else if (
+            typeof status === 'string' &&
+            activePlantStatuses.has(status)
+        ) {
+            active = true;
+        }
+    }
+
+    return active;
+}
+
+export function planSupersededPlantCycleRepairs(
+    events: PlantCycleRepairEvent[],
+) {
+    const eventsByAggregateId = new Map<string, PlantCycleRepairEvent[]>();
+    for (const event of events) {
+        const aggregateEvents = eventsByAggregateId.get(event.aggregateId);
+        if (aggregateEvents) {
+            aggregateEvents.push(event);
+        } else {
+            eventsByAggregateId.set(event.aggregateId, [event]);
+        }
+    }
+
+    const repairs: SupersededPlantCycleRepair[] = [];
+    const unsafe: UnsafeSupersededPlantCycleRepair[] = [];
+
+    for (const [aggregateId, aggregateEvents] of eventsByAggregateId) {
+        const aggregate = parseAggregateId(aggregateId);
+        if (!aggregate) {
+            continue;
+        }
+
+        const sortedEvents = [...aggregateEvents].sort(compareEvents);
+        const plantPlaceIndexes = sortedEvents.flatMap((event, index) =>
+            event.type === 'raisedBedField.plantPlace' ? [index] : [],
+        );
+
+        for (let index = 0; index < plantPlaceIndexes.length - 1; index += 1) {
+            const cycleStartIndex = plantPlaceIndexes[index];
+            const nextCycleStartIndex = plantPlaceIndexes[index + 1];
+            if (
+                cycleStartIndex === undefined ||
+                nextCycleStartIndex === undefined
+            ) {
+                continue;
+            }
+
+            const cycleEvents = sortedEvents.slice(
+                cycleStartIndex,
+                nextCycleStartIndex,
+            );
+            if (!plantCycleIsActive(cycleEvents)) {
+                continue;
+            }
+
+            const plantPlaceEvent = sortedEvents[cycleStartIndex];
+            const nextPlantPlaceEvent = sortedEvents[nextCycleStartIndex];
+            const previousEvent = sortedEvents[nextCycleStartIndex - 1];
+            if (!plantPlaceEvent || !nextPlantPlaceEvent || !previousEvent) {
+                continue;
+            }
+
+            const repairCreatedAt = new Date(
+                nextPlantPlaceEvent.createdAt.getTime() - 1,
+            );
+            if (
+                repairCreatedAt.getTime() <= previousEvent.createdAt.getTime()
+            ) {
+                unsafe.push({
+                    aggregateId,
+                    nextPlantPlaceEventId: nextPlantPlaceEvent.id,
+                    reason: 'No safe millisecond exists before the next placement event.',
+                    supersededPlantPlaceEventId: plantPlaceEvent.id,
+                });
+                continue;
+            }
+
+            repairs.push({
+                aggregateId,
+                nextPlantPlaceEventId: nextPlantPlaceEvent.id,
+                positionIndex: aggregate.positionIndex,
+                raisedBedId: aggregate.raisedBedId,
+                repairCreatedAt,
+                repairKey: `superseded-plant-cycle:${plantPlaceEvent.id.toString()}:${nextPlantPlaceEvent.id.toString()}`,
+                supersededPlantPlaceEventId: plantPlaceEvent.id,
+            });
+        }
+    }
+
+    return {
+        repairs: repairs.sort((left, right) =>
+            left.aggregateId.localeCompare(right.aggregateId),
+        ),
+        unsafe: unsafe.sort((left, right) =>
+            left.aggregateId.localeCompare(right.aggregateId),
+        ),
+    };
+}

--- a/packages/storage/scripts/repairSupersededPlantCycles.ts
+++ b/packages/storage/scripts/repairSupersededPlantCycles.ts
@@ -1,0 +1,189 @@
+import { and, asc, eq, inArray } from 'drizzle-orm';
+import {
+    acquirePlantingScheduleTaskLock,
+    bustScheduleCache,
+    closeStorage,
+    events,
+    raisedBedFields,
+    raisedBeds,
+    storage,
+} from '../src/index';
+import {
+    type PlantCycleRepairEvent,
+    planSupersededPlantCycleRepairs,
+} from './lib/supersededPlantCycles';
+
+const plantCycleEventTypes = [
+    'raisedBedField.delete',
+    'raisedBedField.plantBlock',
+    'raisedBedField.plantPlace',
+    'raisedBedField.plantReplaceSort',
+    'raisedBedField.plantSchedule',
+    'raisedBedField.plantUpdate',
+] as const;
+
+function readAccountId(argv: string[]) {
+    const option = argv.find((argument) =>
+        argument.startsWith('--account-id='),
+    );
+    const accountId = option?.slice('--account-id='.length).trim();
+    if (!accountId) {
+        throw new Error('--account-id is required.');
+    }
+    return accountId;
+}
+
+async function getAccountAggregateIds(accountId: string) {
+    const fields = await storage()
+        .select({
+            positionIndex: raisedBedFields.positionIndex,
+            raisedBedId: raisedBedFields.raisedBedId,
+        })
+        .from(raisedBedFields)
+        .innerJoin(raisedBeds, eq(raisedBeds.id, raisedBedFields.raisedBedId))
+        .where(
+            and(
+                eq(raisedBeds.accountId, accountId),
+                eq(raisedBeds.isDeleted, false),
+                eq(raisedBedFields.isDeleted, false),
+            ),
+        );
+
+    return [
+        ...new Set(
+            fields.map(
+                (field) =>
+                    `${field.raisedBedId.toString()}|${field.positionIndex.toString()}`,
+            ),
+        ),
+    ];
+}
+
+async function getPlantCycleEvents(aggregateIds: string[]) {
+    if (aggregateIds.length === 0) {
+        return [];
+    }
+
+    return storage()
+        .select({
+            aggregateId: events.aggregateId,
+            createdAt: events.createdAt,
+            data: events.data,
+            id: events.id,
+            type: events.type,
+        })
+        .from(events)
+        .where(
+            and(
+                inArray(events.aggregateId, aggregateIds),
+                inArray(events.type, [...plantCycleEventTypes]),
+            ),
+        )
+        .orderBy(asc(events.createdAt), asc(events.id));
+}
+
+async function getRepairPlan(accountId: string) {
+    const aggregateIds = await getAccountAggregateIds(accountId);
+    const plantCycleEvents = await getPlantCycleEvents(aggregateIds);
+    return planSupersededPlantCycleRepairs(plantCycleEvents);
+}
+
+const execute = process.argv.includes('--execute');
+const accountId = readAccountId(process.argv.slice(2));
+
+try {
+    const plan = await getRepairPlan(accountId);
+    console.log(
+        JSON.stringify(
+            {
+                accountId,
+                mode: execute ? 'execute' : 'dry-run',
+                repairs: plan.repairs,
+                unsafe: plan.unsafe,
+            },
+            null,
+            2,
+        ),
+    );
+
+    if (plan.unsafe.length > 0) {
+        throw new Error(
+            'Unsafe superseded plant-cycle repairs require review.',
+        );
+    }
+
+    if (execute && plan.repairs.length > 0) {
+        const database = storage();
+        await database.transaction(async (transaction) => {
+            for (const repair of plan.repairs) {
+                await acquirePlantingScheduleTaskLock(
+                    transaction,
+                    repair.raisedBedId,
+                    repair.positionIndex,
+                );
+
+                const currentEvents: PlantCycleRepairEvent[] = await transaction
+                    .select({
+                        aggregateId: events.aggregateId,
+                        createdAt: events.createdAt,
+                        data: events.data,
+                        id: events.id,
+                        type: events.type,
+                    })
+                    .from(events)
+                    .where(
+                        and(
+                            eq(events.aggregateId, repair.aggregateId),
+                            inArray(events.type, [...plantCycleEventTypes]),
+                        ),
+                    )
+                    .orderBy(asc(events.createdAt), asc(events.id));
+                const currentPlan =
+                    planSupersededPlantCycleRepairs(currentEvents);
+                const currentRepair = currentPlan.repairs.find(
+                    (candidate) => candidate.repairKey === repair.repairKey,
+                );
+                if (!currentRepair) {
+                    continue;
+                }
+                if (currentPlan.unsafe.length > 0) {
+                    throw new Error(
+                        `Repair became unsafe for ${repair.aggregateId}.`,
+                    );
+                }
+
+                await transaction.insert(events).values({
+                    aggregateId: repair.aggregateId,
+                    createdAt: currentRepair.repairCreatedAt,
+                    data: {
+                        effectiveDate: new Date(
+                            currentRepair.repairCreatedAt.getTime() + 1,
+                        ).toISOString(),
+                        repairKey: currentRepair.repairKey,
+                        repairKind: 'superseded_plant_cycle',
+                        status: 'removed',
+                        supersededByPlantPlaceEventId:
+                            currentRepair.nextPlantPlaceEventId,
+                        supersededPlantPlaceEventId:
+                            currentRepair.supersededPlantPlaceEventId,
+                    },
+                    type: 'raisedBedField.plantUpdate',
+                    version: 1,
+                });
+            }
+        });
+        await bustScheduleCache();
+
+        const verification = await getRepairPlan(accountId);
+        if (verification.repairs.length > 0 || verification.unsafe.length > 0) {
+            throw new Error(
+                'Superseded plant-cycle repair verification failed.',
+            );
+        }
+        console.log(
+            `Repaired and verified ${plan.repairs.length.toString()} superseded plant cycles.`,
+        );
+    }
+} finally {
+    await closeStorage();
+}

--- a/packages/storage/src/repositories/raisedBedFieldsRepo.ts
+++ b/packages/storage/src/repositories/raisedBedFieldsRepo.ts
@@ -1110,13 +1110,30 @@ function summarizePlantCycles(
     positionIndex: number,
     plantEvents: RaisedBedFieldPlantCycleEvent[],
 ) {
-    return splitPlantCycleEvents(plantEvents)
+    const plantCycles = splitPlantCycleEvents(plantEvents)
         .map((plantCycleEvents) =>
             summarizePlantCycle(aggregateId, positionIndex, plantCycleEvents),
         )
         .filter((plantCycle): plantCycle is RaisedBedFieldPlantCycle =>
             Boolean(plantCycle),
         );
+
+    return plantCycles.map((plantCycle, index) => {
+        const nextPlantCycle = plantCycles[index + 1];
+        if (!nextPlantCycle || !plantCycle.active) {
+            return plantCycle;
+        }
+
+        // A later placement is an authoritative lifecycle boundary. Historical
+        // data can contain a missing terminal update before that boundary, but
+        // the superseded cycle must not remain active and block a field that the
+        // current field projection correctly reports as empty or replanted.
+        return {
+            ...plantCycle,
+            active: false,
+            stoppedDate: nextPlantCycle.startedAt,
+        };
+    });
 }
 
 function eventDataRecord(event: RaisedBedFieldPlantCycleEvent) {

--- a/packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts
+++ b/packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts
@@ -893,6 +893,54 @@ test('getRaisedBed returns the latest plant cycle after a field is removed and r
     );
 });
 
+test('a later placement supersedes an unterminated historical plant cycle', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'block-superseded-cycle');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+    const aggregateId = `${raisedBedId.toString()}|0`;
+
+    await upsertRaisedBedField({
+        raisedBedId,
+        positionIndex: 0,
+    });
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(aggregateId, {
+            plantSortId: '101',
+            scheduledDate: '2026-01-01T00:00:00.000Z',
+        }),
+    );
+    const replacement = await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(aggregateId, {
+            plantSortId: '202',
+            scheduledDate: '2026-02-01T00:00:00.000Z',
+        }),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+            status: 'removed',
+        }),
+    );
+
+    const [field] = await getRaisedBedFieldsWithEvents(raisedBedId);
+    assert.ok(field);
+    assert.strictEqual(field.active, false);
+    assert.deepStrictEqual(
+        field.plantCycles.map((plantCycle) => plantCycle.plantSortId),
+        [101, 202],
+    );
+    assert.deepStrictEqual(
+        field.plantCycles.map((plantCycle) => plantCycle.active),
+        [false, false],
+    );
+    assert.strictEqual(
+        field.plantCycles[0]?.stoppedDate?.getTime(),
+        replacement.createdAt.getTime(),
+    );
+});
+
 test('raised bed field sowing location is projected from schedule events', async () => {
     createTestDb();
     const accountId = await createAccount();

--- a/packages/storage/tests/supersededPlantCyclesBackfill.node.spec.ts
+++ b/packages/storage/tests/supersededPlantCyclesBackfill.node.spec.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    type PlantCycleRepairEvent,
+    planSupersededPlantCycleRepairs,
+} from '../scripts/lib/supersededPlantCycles';
+
+function event(
+    id: number,
+    type: string,
+    createdAt: string,
+    data: unknown = null,
+): PlantCycleRepairEvent {
+    return {
+        aggregateId: '12|2',
+        createdAt: new Date(createdAt),
+        data,
+        id,
+        type,
+    };
+}
+
+test('plans a terminal event for an active cycle superseded by a placement', () => {
+    const plan = planSupersededPlantCycleRepairs([
+        event(1, 'raisedBedField.plantPlace', '2026-01-01T00:00:00.000Z'),
+        event(2, 'raisedBedField.plantUpdate', '2026-01-02T00:00:00.000Z', {
+            status: 'planned',
+        }),
+        event(3, 'raisedBedField.plantPlace', '2026-02-01T00:00:00.000Z'),
+    ]);
+
+    assert.deepStrictEqual(plan.unsafe, []);
+    assert.strictEqual(plan.repairs.length, 1);
+    assert.deepStrictEqual(plan.repairs[0], {
+        aggregateId: '12|2',
+        nextPlantPlaceEventId: 3,
+        positionIndex: 2,
+        raisedBedId: 12,
+        repairCreatedAt: new Date('2026-01-31T23:59:59.999Z'),
+        repairKey: 'superseded-plant-cycle:1:3',
+        supersededPlantPlaceEventId: 1,
+    });
+});
+
+test('does not repair a cycle with an existing terminal event', () => {
+    const plan = planSupersededPlantCycleRepairs([
+        event(1, 'raisedBedField.plantPlace', '2026-01-01T00:00:00.000Z'),
+        event(2, 'raisedBedField.plantUpdate', '2026-01-02T00:00:00.000Z', {
+            status: 'removed',
+        }),
+        event(3, 'raisedBedField.plantPlace', '2026-02-01T00:00:00.000Z'),
+    ]);
+
+    assert.deepStrictEqual(plan, { repairs: [], unsafe: [] });
+});
+
+test('a planned repair is idempotent after its synthetic removal is present', () => {
+    const plan = planSupersededPlantCycleRepairs([
+        event(1, 'raisedBedField.plantPlace', '2026-01-01T00:00:00.000Z'),
+        event(4, 'raisedBedField.plantUpdate', '2026-01-31T23:59:59.999Z', {
+            repairKey: 'superseded-plant-cycle:1:3',
+            status: 'removed',
+        }),
+        event(3, 'raisedBedField.plantPlace', '2026-02-01T00:00:00.000Z'),
+    ]);
+
+    assert.deepStrictEqual(plan, { repairs: [], unsafe: [] });
+});


### PR DESCRIPTION
## What changed

- Treat a later plant placement as the authoritative lifecycle boundary for an unterminated older cycle.
- Add a dry-run-first, account-scoped repair command that inserts audited terminal events under the planting lock.
- Add a guarded direct-checkout recovery command that requires existing item debits before fulfilling pending plantings.
- Cover the projection and idempotent repair planner with regression tests.

## Root cause

Historical field event streams could contain a second placement without a terminal update for the prior cycle. The current field appeared empty after the latest plant was removed, but checkout searched every projected cycle and found the stale older cycle still marked active. The affected shop/AI item metadata was complete.

## Impact

Replanting a field after its plant was removed works as intended, and historical orphan cycles can be repaired safely without replaying checkout charges. The production incident was repaired and the affected cart was recovered using its original durable debits.

## Validation

- `bash ./tests/runNodeTests.sh gardensRepo.raisedBedFields.node.spec.ts supersededPlantCyclesBackfill.node.spec.ts` — 18 passed
- `./node_modules/.bin/tsc --noEmit --pretty false` in `apps/api` — passed
- Targeted Biome checks in `packages/storage` and `apps/api` — passed
- `git diff --check` — passed