### PR TITLE
[Game] Refine Suncokret usage meter

### DIFF
--- a/packages/game/src/hud/SuncokretUsageButton.tsx
+++ b/packages/game/src/hud/SuncokretUsageButton.tsx
@@ -26,8 +26,18 @@ export function SuncokretUsageButton({
     const weekRemaining = Math.max(0, Math.min(100, week.remainingPercent));
     const exhaustedUsage = exhausted(day) || exhausted(week);
     const periods = [
-        { label: 'Danas', period: day, detail: 'Vanjski krug' },
-        { label: 'Ovaj tjedan', period: week, detail: 'Unutarnji krug' },
+        {
+            label: 'Danas',
+            period: day,
+            detail: 'Vanjski krug',
+            tone: 'day',
+        },
+        {
+            label: 'Ovaj tjedan',
+            period: week,
+            detail: 'Unutarnji krug',
+            tone: 'week',
+        },
     ];
 
     return (
@@ -43,69 +53,73 @@ export function SuncokretUsageButton({
                     type="button"
                     variant="plain"
                     className={cx(
-                        'size-9 shrink-0 rounded-full text-emerald-700 hover:bg-emerald-50 dark:text-emerald-400 dark:hover:bg-emerald-950',
+                        'group size-9 shrink-0 rounded-full border border-border/70 bg-background/85 text-muted-foreground shadow-sm transition-colors hover:border-emerald-200 hover:bg-emerald-50/80 dark:bg-background/70 dark:hover:border-emerald-900 dark:hover:bg-emerald-950/60',
                         exhaustedUsage &&
-                            'text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950',
+                            'border-red-200 bg-red-50/80 text-red-700 hover:border-red-300 hover:bg-red-50 dark:border-red-950 dark:bg-red-950/40 dark:text-red-400 dark:hover:border-red-900 dark:hover:bg-red-950/60',
                     )}
                     data-suncokret-usage-trigger
                 >
                     <svg
                         aria-hidden="true"
-                        className="size-5 -rotate-90"
+                        className="size-[22px] -rotate-90 overflow-visible"
                         viewBox="0 0 24 24"
                     >
-                        <circle
-                            cx="12"
-                            cy="12"
-                            r="10"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                            className={cx(
-                                'text-muted-foreground/25',
-                                exhausted(day) && 'text-red-500/70',
-                            )}
-                        />
-                        {!exhausted(day) && (
+                        <g data-suncokret-usage-ring="day">
                             <circle
                                 cx="12"
                                 cy="12"
-                                r="10"
+                                r="9.25"
                                 fill="none"
-                                pathLength="100"
                                 stroke="currentColor"
-                                strokeDasharray={`${dayRemaining} 100`}
-                                strokeLinecap="round"
-                                strokeWidth="2"
-                                className="text-emerald-600 dark:text-emerald-400"
+                                strokeWidth="2.5"
+                                className={cx(
+                                    'text-muted-foreground/20',
+                                    exhausted(day) && 'text-red-500/80',
+                                )}
                             />
-                        )}
-                        <circle
-                            cx="12"
-                            cy="12"
-                            r="5"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="10"
-                            className={cx(
-                                'text-muted-foreground/20',
-                                exhausted(week) && 'text-red-500/70',
+                            {!exhausted(day) && (
+                                <circle
+                                    cx="12"
+                                    cy="12"
+                                    r="9.25"
+                                    fill="none"
+                                    pathLength="100"
+                                    stroke="currentColor"
+                                    strokeDasharray={`${dayRemaining} ${100 - dayRemaining}`}
+                                    strokeLinecap="round"
+                                    strokeWidth="2.5"
+                                    className="text-emerald-600 transition-colors group-hover:text-emerald-700 dark:text-emerald-400 dark:group-hover:text-emerald-300"
+                                />
                             )}
-                        />
-                        {!exhausted(week) && (
+                        </g>
+                        <g data-suncokret-usage-ring="week">
                             <circle
                                 cx="12"
                                 cy="12"
                                 r="5"
                                 fill="none"
-                                pathLength="100"
                                 stroke="currentColor"
-                                strokeDasharray={`${weekRemaining} 100`}
-                                strokeLinecap="round"
-                                strokeWidth="10"
-                                className="text-amber-400 dark:text-amber-500"
+                                strokeWidth="2.5"
+                                className={cx(
+                                    'text-muted-foreground/20',
+                                    exhausted(week) && 'text-red-500/80',
+                                )}
                             />
-                        )}
+                            {!exhausted(week) && (
+                                <circle
+                                    cx="12"
+                                    cy="12"
+                                    r="5"
+                                    fill="none"
+                                    pathLength="100"
+                                    stroke="currentColor"
+                                    strokeDasharray={`${weekRemaining} ${100 - weekRemaining}`}
+                                    strokeLinecap="round"
+                                    strokeWidth="2.5"
+                                    className="text-amber-400 transition-colors group-hover:text-amber-500 dark:text-amber-500 dark:group-hover:text-amber-400"
+                                />
+                            )}
+                        </g>
                     </svg>
                 </IconButton>
             }
@@ -119,10 +133,13 @@ export function SuncokretUsageButton({
                         Krugovi se prazne kako koristiš Suncokreta.
                     </Typography>
                 </Stack>
-                {periods.map(({ detail, label, period }) => {
-                    const remaining = formatSuncokretUsagePercent(
-                        period.remainingPercent,
+                {periods.map(({ detail, label, period, tone }) => {
+                    const remainingPercent = Math.max(
+                        0,
+                        Math.min(100, period.remainingPercent),
                     );
+                    const remaining =
+                        formatSuncokretUsagePercent(remainingPercent);
                     const periodExhausted = exhausted(period);
 
                     return (
@@ -131,7 +148,20 @@ export function SuncokretUsageButton({
                                 justifyContent="space-between"
                                 className="gap-2 text-xs"
                             >
-                                <span className="font-medium">{label}</span>
+                                <span className="flex items-center gap-1.5 font-medium">
+                                    <span
+                                        aria-hidden="true"
+                                        className={cx(
+                                            'size-1.5 rounded-full',
+                                            periodExhausted
+                                                ? 'bg-red-500'
+                                                : tone === 'day'
+                                                  ? 'bg-emerald-600 dark:bg-emerald-400'
+                                                  : 'bg-amber-400 dark:bg-amber-500',
+                                        )}
+                                    />
+                                    {label}
+                                </span>
                                 <span
                                     className={cx(
                                         'text-muted-foreground',
@@ -148,9 +178,7 @@ export function SuncokretUsageButton({
                                 aria-label={`${label}: ${remaining} preostalo`}
                                 aria-valuemax={100}
                                 aria-valuemin={0}
-                                aria-valuenow={Math.round(
-                                    period.remainingPercent,
-                                )}
+                                aria-valuenow={Math.round(remainingPercent)}
                                 className={cx(
                                     'h-1.5 overflow-hidden rounded-full bg-muted',
                                     periodExhausted &&
@@ -159,9 +187,16 @@ export function SuncokretUsageButton({
                                 role="progressbar"
                             >
                                 <div
-                                    className="h-full rounded-full bg-emerald-600 transition-[width] duration-300 dark:bg-emerald-500"
+                                    className={cx(
+                                        'h-full rounded-full transition-[width] duration-300',
+                                        periodExhausted
+                                            ? 'bg-red-500'
+                                            : tone === 'day'
+                                              ? 'bg-emerald-600 dark:bg-emerald-500'
+                                              : 'bg-amber-400 dark:bg-amber-500',
+                                    )}
                                     style={{
-                                        width: `${period.remainingPercent}%`,
+                                        width: `${remainingPercent}%`,
                                     }}
                                 />
                             </div>


### PR DESCRIPTION
## What changed

- replace the solid-looking weekly usage dot with two balanced concentric progress rings
- give daily and weekly limits distinct emerald and amber tones
- add a subtle bordered surface and hover state to the usage button
- align the popover legend and progress bars with the icon colors
- keep exhausted limits full and red while clamping displayed percentages

## Why

The weekly ring used a stroke as wide as its diameter, making the icon read as a flat yellow disk instead of a useful two-period meter.

## Impact

Visual-only refinement. Usage calculations, labels, popover behavior, and exhaustion rules remain unchanged.

## Validation

- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm exec biome check src/hud/SuncokretUsageButton.tsx`
- focused Garden Playwright component tests (normal and exhausted usage)
- `pnpm build --filter garden`