### PR TITLE
Fix Suncokret chat stacking above field HUD

### DIFF
--- a/apps/garden/tests/SuncokretChatHudStory.tsx
+++ b/apps/garden/tests/SuncokretChatHudStory.tsx
@@ -9,6 +9,7 @@ import {
     type SuncokretChatTarget,
 } from '../../../packages/game/src/hud/SuncokretChatProvider';
 import { SuncokretChatTrigger } from '../../../packages/game/src/hud/SuncokretChatTrigger';
+import { GameModal } from '../../../packages/game/src/shared-ui/game-modal';
 import {
     createGameState,
     GameStateContext,
@@ -89,11 +90,13 @@ function createQueryClient() {
 export function SuncokretChatHudStory({
     contextTarget,
     debug = false,
+    fieldUiTarget,
     focusedRaisedBed = false,
     settingsSection,
 }: {
     contextTarget?: SuncokretChatTarget;
     debug?: boolean;
+    fieldUiTarget?: SuncokretChatTarget;
     focusedRaisedBed?: boolean;
     settingsSection?: string;
 }) {
@@ -128,12 +131,19 @@ export function SuncokretChatHudStory({
                         }}
                     >
                         <SuncokretChatProvider>
-                            {contextTarget && (
+                            {fieldUiTarget ? (
+                                <GameModal open title="Kartica biljke">
+                                    <SuncokretChatTrigger
+                                        title="Pitaj Suncokreta iz kartice biljke"
+                                        target={fieldUiTarget}
+                                    />
+                                </GameModal>
+                            ) : contextTarget ? (
                                 <SuncokretChatTrigger
                                     title="Pitaj Suncokreta u kontekstu"
                                     target={contextTarget}
                                 />
-                            )}
+                            ) : null}
                             <SuncokretChatHud />
                         </SuncokretChatProvider>
                     </GameFlagsContext.Provider>

--- a/apps/garden/tests/suncokret-chat-hud.spec.tsx
+++ b/apps/garden/tests/suncokret-chat-hud.spec.tsx
@@ -2,6 +2,8 @@ import { expect, test } from '@playwright/experimental-ct-react';
 import type { Page } from '@playwright/test';
 import { SuncokretChatHudStory } from './SuncokretChatHudStory';
 
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+
 const statusResponse = {
     enabled: true,
     debugEnabled: false,
@@ -397,6 +399,63 @@ test('raised-bed closeup uses the contextual trigger and anchored chat', async (
     await expect(
         page.locator('[data-suncokret-placement="anchored"]'),
     ).toBeVisible();
+});
+
+test('mobile chat stays above the field UI and can close independently', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await mockSuncokretRoutes(page);
+    await mount(
+        <SuncokretChatHudStory
+            focusedRaisedBed
+            fieldUiTarget={{
+                conversationLabel: 'Rajčica mini red cherry',
+                gardenId: 1,
+                positionIndex: 6,
+                raisedBedId: 11,
+                uiContext: {
+                    surface: 'plant-details',
+                    tab: 'lifecycle',
+                },
+            }}
+        />,
+    );
+
+    const fieldUi = page.getByRole('dialog', { name: 'Kartica biljke' });
+    await expect(fieldUi).toBeVisible();
+    await page
+        .getByRole('button', {
+            name: 'Pitaj Suncokreta iz kartice biljke',
+        })
+        .click();
+
+    const placement = page.locator('[data-suncokret-placement="bottom-left"]');
+    const chat = page.getByRole('dialog', {
+        name: 'Razgovor sa Suncokretom',
+    });
+    const closeButton = chat.getByRole('button', { name: 'Zatvori' });
+
+    await expect(placement).toBeVisible();
+    await expect(placement).toHaveCSS('z-index', '60');
+    await expect
+        .poll(() =>
+            closeButton.evaluate((button) => {
+                const bounds = button.getBoundingClientRect();
+                const topElement = document.elementFromPoint(
+                    bounds.left + bounds.width / 2,
+                    bounds.top + bounds.height / 2,
+                );
+
+                return topElement === button || button.contains(topElement);
+            }),
+        )
+        .toBe(true);
+
+    await closeButton.click();
+    await expect(chat).toHaveCount(0);
+    await expect(fieldUi).toBeVisible();
 });
 
 test('context selected after chat initialization is sent with the request', async ({

--- a/apps/garden/tests/suncokret-chat-hud.spec.tsx
+++ b/apps/garden/tests/suncokret-chat-hud.spec.tsx
@@ -179,6 +179,21 @@ test('production chat hides developer controls and shows visual usage', async ({
     await expect(usage).toContainText('87,5% preostalo');
     await expect(usage).toContainText('96% preostalo');
     await expect(usage).not.toContainText('iskorišteno');
+    const usagePopper = page.locator('[data-suncokret-usage-popper]');
+    await expect(usagePopper).toHaveCSS('z-index', '70');
+    await expect
+        .poll(() =>
+            usage.evaluate((element) => {
+                const bounds = element.getBoundingClientRect();
+                const topElement = document.elementFromPoint(
+                    bounds.left + bounds.width / 2,
+                    bounds.top + bounds.height / 2,
+                );
+
+                return topElement === element || element.contains(topElement);
+            }),
+        )
+        .toBe(true);
     await expect(chat).not.toContainText('USD');
     await expect(chat).not.toContainText('token');
     await expect(chat).not.toContainText('AI vrtni pomoćnik');

--- a/packages/game/src/hud/SuncokretChatHud.tsx
+++ b/packages/game/src/hud/SuncokretChatHud.tsx
@@ -45,6 +45,7 @@ import {
     useState,
     useSyncExternalStore,
 } from 'react';
+import { createPortal } from 'react-dom';
 import { useGameFlags } from '../GameFlagsContext';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useGameState } from '../useGameState';
@@ -139,7 +140,7 @@ function SuncokretChatPositioner({
         return (
             <Popper
                 align="center"
-                className="!w-[440px] max-w-[calc(100vw-var(--game-safe-area-left,0px)-var(--game-safe-area-right,0px)-1rem)] border-0 bg-transparent p-0 shadow-none"
+                className="z-[60] !w-[440px] max-w-[calc(100vw-var(--game-safe-area-left,0px)-var(--game-safe-area-right,0px)-1rem)] border-0 bg-transparent p-0 shadow-none"
                 data-suncokret-placement="anchored"
                 onOpenChange={(nextOpen) => {
                     if (!nextOpen) {
@@ -156,10 +157,10 @@ function SuncokretChatPositioner({
         );
     }
 
-    return (
+    return createPortal(
         <div
             className={cx(
-                'pointer-events-auto fixed bottom-[calc(var(--game-safe-area-bottom,0px)+0.5rem)] left-[calc(var(--game-safe-area-left,0px)+0.5rem)] right-[calc(var(--game-safe-area-right,0px)+0.5rem)] z-50 flex justify-center md:block',
+                'pointer-events-auto fixed bottom-[calc(var(--game-safe-area-bottom,0px)+0.5rem)] left-[calc(var(--game-safe-area-left,0px)+0.5rem)] right-[calc(var(--game-safe-area-right,0px)+0.5rem)] z-[60] flex justify-center md:block',
                 isCloseup
                     ? 'md:right-auto md:left-[calc(var(--game-safe-area-left,0px)+0.5rem)]'
                     : 'md:right-[calc(var(--game-safe-area-right,0px)+0.5rem)] md:left-auto',
@@ -169,7 +170,8 @@ function SuncokretChatPositioner({
             }
         >
             {children}
-        </div>
+        </div>,
+        document.body,
     );
 }
 

--- a/packages/game/src/hud/SuncokretUsageButton.tsx
+++ b/packages/game/src/hud/SuncokretUsageButton.tsx
@@ -35,7 +35,8 @@ export function SuncokretUsageButton({
             align="end"
             side="top"
             sideOffset={8}
-            className="w-72 p-3"
+            className="z-[70] w-72 p-3"
+            data-suncokret-usage-popper
             trigger={
                 <IconButton
                     aria-label={`Preostala AI upotreba: danas ${formatSuncokretUsagePercent(dayRemaining)}, ovaj tjedan ${formatSuncokretUsagePercent(weekRemaining)}`}


### PR DESCRIPTION
## What changed

- render the mobile Suncokret chat in a body-level portal so parent HUD stacking contexts cannot trap it
- place mobile and anchored desktop chat surfaces on layer 60, above standard dialogs and raised-bed HUD controls
- place the chat's usage-details popper on layer 70 so nested controls remain above the chat
- add browser regressions that verify both the chat close button and usage details win real hit-testing

## Why

The chat used the same generic layer as field dialogs and remained inside the game HUD tree on mobile. As a result, plant details and raised-bed closeup controls could cover the chat, including its close button. Raising the chat also required its nested usage popper to stay one layer higher.

## User impact

Suncokret chat now stays interactive when opened from field UI or while a raised bed is in closeup, including on mobile. Its usage details also remain visible and interactive above the chat.

## Validation

- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter @gredice/game exec biome check src/hud/SuncokretChatHud.tsx src/hud/SuncokretUsageButton.tsx ../../apps/garden/tests/SuncokretChatHudStory.tsx ../../apps/garden/tests/suncokret-chat-hud.spec.tsx`
- `pnpm --filter garden exec playwright test tests/suncokret-chat-hud.spec.tsx --project=chromium` (11 passed)
- `pnpm --filter garden run test:prepare`
- `git diff --check`