### PR TITLE
Fix Suncokret chat pricing with AI Gateway billing

### DIFF
--- a/apps/api/app/api/[...route]/aiSuncokretRoutes.ts
+++ b/apps/api/app/api/[...route]/aiSuncokretRoutes.ts
@@ -43,8 +43,10 @@ import { visibleRaisedBedsForGarden } from '../../../lib/ai/suncokretGardenConte
 import {
     estimateSuncokretPromptTokens,
     estimateSuncokretRequestCostMicroUsd,
+    getSuncokretGatewayBilledCostMicroUsd,
     getSuncokretModel,
     getSuncokretModelRegistry,
+    getSuncokretPricedModel,
     resolveSuncokretMaxOutputTokens,
 } from '../../../lib/ai/suncokretModels';
 import { buildSuncokretUsageStatus } from '../../../lib/ai/suncokretUsage';
@@ -170,6 +172,10 @@ function jsonError(
 function usageTokens(usage: LanguageModelUsage | undefined) {
     return {
         inputTokens: usage?.inputTokens ?? 0,
+        noCacheTokens: usage?.inputTokenDetails.noCacheTokens ?? undefined,
+        cacheReadTokens: usage?.inputTokenDetails.cacheReadTokens ?? undefined,
+        cacheWriteTokens:
+            usage?.inputTokenDetails.cacheWriteTokens ?? undefined,
         outputTokens: usage?.outputTokens ?? 0,
         totalTokens:
             usage?.totalTokens ??
@@ -582,7 +588,7 @@ const app = new Hono<{ Variables: ChatVariables }>()
             const query = context.req.valid('query');
             const featureFlags = queryFeatureFlags(query);
             const { accountId } = context.get('authContext');
-            const model = getSuncokretModel(query.modelId);
+            const model = await getSuncokretPricedModel(query.modelId);
             const limitState = await getAiChatAccountLimitState(accountId);
 
             const budget = featureFlags.enableSuncokretDebugFlag
@@ -789,7 +795,7 @@ const app = new Hono<{ Variables: ChatVariables }>()
                 body.debug && body.featureFlags.enableSuncokretDebugFlag,
             );
             const auth = context.get('authContext');
-            const model = getSuncokretModel(body.modelId);
+            const model = await getSuncokretPricedModel(body.modelId);
             if (!model) {
                 const error = jsonError(
                     'ai_model_unavailable',
@@ -979,14 +985,49 @@ const app = new Hono<{ Variables: ChatVariables }>()
                             ],
                         },
                     },
-                    onFinish: async ({ totalUsage }) => {
+                    onFinish: async ({ steps, totalUsage }) => {
                         const usage = usageTokens(totalUsage);
+                        let billedTotalMicroUsd: number | null = null;
+                        try {
+                            billedTotalMicroUsd =
+                                await getSuncokretGatewayBilledCostMicroUsd(
+                                    steps,
+                                );
+                            if (billedTotalMicroUsd === null) {
+                                console.warn(
+                                    'Suncokret AI Gateway billed cost is unavailable; using token estimate',
+                                    {
+                                        accountId: auth.accountId,
+                                        conversationId,
+                                        modelId: model.id,
+                                        requestId,
+                                    },
+                                );
+                            }
+                        } catch (error) {
+                            console.warn(
+                                'Suncokret AI Gateway billed cost lookup failed; using token estimate',
+                                {
+                                    accountId: auth.accountId,
+                                    conversationId,
+                                    modelId: model.id,
+                                    requestId,
+                                    error,
+                                },
+                            );
+                        }
                         const cost = await finalizeAiChatUsage({
                             ledgerId: reservation.ledgerId,
                             inputTokens: usage.inputTokens,
+                            noCacheTokens: usage.noCacheTokens,
+                            cacheReadTokens: usage.cacheReadTokens,
+                            cacheWriteTokens: usage.cacheWriteTokens,
                             outputTokens: usage.outputTokens,
                             totalTokens: usage.totalTokens,
                             pricing: model,
+                            ...(billedTotalMicroUsd === null
+                                ? {}
+                                : { billedTotalMicroUsd }),
                         });
                         finalized = true;
                         finishMetadata = {

--- a/apps/api/lib/ai/suncokretModels.node.spec.ts
+++ b/apps/api/lib/ai/suncokretModels.node.spec.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { getSuncokretModel } from './suncokretModels';
+import {
+    getSuncokretGatewayBilledCostMicroUsd,
+    getSuncokretModel,
+    getSuncokretPricedModel,
+    suncokretGatewayGenerationIds,
+} from './suncokretModels';
 
 function setEnvValue(name: string, value: string | undefined) {
     if (typeof value === 'string') {
@@ -47,8 +52,8 @@ test('getSuncokretModel falls back to the first enabled model for automatic sele
             const model = getSuncokretModel();
 
             assert.equal(model?.id, 'openai/gpt-5.6-luna');
-            assert.equal(model?.inputUsdPerMillionTokens, 1);
-            assert.equal(model?.outputUsdPerMillionTokens, 6);
+            assert.equal(model?.inputUsdPerMillionTokens, 0.2);
+            assert.equal(model?.outputUsdPerMillionTokens, 1.2);
         },
     );
 });
@@ -63,3 +68,110 @@ test('getSuncokretModel keeps explicit unavailable model requests invalid', () =
         },
     );
 });
+
+test('getSuncokretPricedModel uses current AI Gateway catalog pricing', async () => {
+    await withModelEnvAsync(
+        {
+            allowlist: 'openai/gpt-5.6-luna',
+        },
+        async () => {
+            const model = await getSuncokretPricedModel(
+                'openai/gpt-5.6-luna',
+                async () => ({
+                    models: [
+                        {
+                            id: 'openai/gpt-5.6-luna',
+                            name: 'GPT 5.6 Luna',
+                            pricing: {
+                                input: '0.00000015',
+                                output: '0.0000009',
+                                cachedInputTokens: '0.000000015',
+                                cacheCreationInputTokens: '0.00000019',
+                            },
+                            specification: {
+                                specificationVersion: 'v4',
+                                provider: 'gateway',
+                                modelId: 'openai/gpt-5.6-luna',
+                            },
+                            modelType: 'language',
+                        },
+                    ],
+                }),
+            );
+
+            assert.equal(model?.inputUsdPerMillionTokens, 0.15);
+            assert.equal(model?.outputUsdPerMillionTokens, 0.9);
+            assert.equal(model?.cachedInputUsdPerMillionTokens, 0.015);
+            assert.equal(model?.cacheWriteInputUsdPerMillionTokens, 0.19);
+        },
+    );
+});
+
+test('Suncokret Gateway billed cost sums unique generation costs', async () => {
+    const steps = [
+        {
+            providerMetadata: {
+                gateway: { generationId: 'gen_one' },
+            },
+        },
+        {
+            providerMetadata: {
+                gateway: { generationId: 'gen_two' },
+            },
+        },
+        {
+            providerMetadata: {
+                gateway: { generationId: 'gen_one' },
+            },
+        },
+    ];
+
+    assert.deepStrictEqual(suncokretGatewayGenerationIds(steps), [
+        'gen_one',
+        'gen_two',
+    ]);
+    assert.equal(
+        await getSuncokretGatewayBilledCostMicroUsd(steps, async (id) => ({
+            id,
+            totalCost: id === 'gen_one' ? 0.0123451 : 0.0000001,
+            upstreamInferenceCost: 0,
+            usage: 0,
+            createdAt: '2026-08-05T00:00:00.000Z',
+            model: 'openai/gpt-5.6-luna',
+            isByok: false,
+            providerName: 'openai',
+            streamed: true,
+            finishReason: 'stop',
+            latency: 1,
+            generationTime: 1,
+            promptTokens: 1,
+            completionTokens: 1,
+            reasoningTokens: 0,
+            cachedTokens: 0,
+            cacheCreationTokens: 0,
+            billableWebSearchCalls: 0,
+        })),
+        12_345,
+    );
+});
+
+async function withModelEnvAsync(
+    env: {
+        defaultModel?: string;
+        allowlist?: string;
+    },
+    callback: () => Promise<void>,
+) {
+    const previousDefault = process.env.SUNCOKRET_AI_DEFAULT_MODEL;
+    const previousAllowlist = process.env.SUNCOKRET_AI_MODEL_ALLOWLIST;
+
+    setEnvValue('SUNCOKRET_AI_DEFAULT_MODEL', env.defaultModel);
+    setEnvValue('SUNCOKRET_AI_MODEL_ALLOWLIST', env.allowlist);
+
+    try {
+        await callback();
+    } finally {
+        setEnvValue('SUNCOKRET_AI_DEFAULT_MODEL', previousDefault);
+        setEnvValue('SUNCOKRET_AI_MODEL_ALLOWLIST', previousAllowlist);
+    }
+}

--- a/apps/api/lib/ai/suncokretModels.ts
+++ b/apps/api/lib/ai/suncokretModels.ts
@@ -2,6 +2,7 @@ import {
     type AiChatPricing,
     calculateAiChatUsageCostMicroUsd,
 } from '@gredice/storage';
+import { gateway } from 'ai';
 
 export type SuncokretModelConfig = AiChatPricing & {
     id: string;
@@ -11,22 +12,94 @@ export type SuncokretModelConfig = AiChatPricing & {
 
 const DEFAULT_MODEL_ID = 'deepseek/deepseek-v4-flash';
 
+// Used only when AI Gateway metadata cannot be loaded. Normal requests replace
+// these values with Gateway catalog pricing and persist the billed request cost.
 const MODEL_REGISTRY: SuncokretModelConfig[] = [
     {
         id: 'openai/gpt-5.6-luna',
         label: 'OpenAI GPT-5.6 Luna',
-        inputUsdPerMillionTokens: 1,
-        outputUsdPerMillionTokens: 6,
+        inputUsdPerMillionTokens: 0.2,
+        outputUsdPerMillionTokens: 1.2,
+        cachedInputUsdPerMillionTokens: 0.02,
+        cacheWriteInputUsdPerMillionTokens: 0.25,
         enabled: true,
     },
     {
         id: 'deepseek/deepseek-v4-flash',
         label: 'DeepSeek V4 Flash',
-        inputUsdPerMillionTokens: 0.14,
-        outputUsdPerMillionTokens: 0.28,
+        inputUsdPerMillionTokens: 0.2,
+        outputUsdPerMillionTokens: 0.4,
+        cachedInputUsdPerMillionTokens: 0.04,
         enabled: true,
     },
 ];
+
+const USD_PER_TOKEN_TO_USD_PER_MILLION = 1_000_000;
+const USD_TO_MICRO_USD = 1_000_000;
+
+type GatewayModelMetadata = Awaited<
+    ReturnType<typeof gateway.getAvailableModels>
+>;
+
+type GatewayGenerationInfo = Awaited<
+    ReturnType<typeof gateway.getGenerationInfo>
+>;
+
+type SuncokretGatewayStep = {
+    providerMetadata?: {
+        gateway?: {
+            generationId?: unknown;
+        };
+    };
+};
+
+function usdPerTokenToUsdPerMillion(value: string | undefined) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0
+        ? Number((parsed * USD_PER_TOKEN_TO_USD_PER_MILLION).toPrecision(12))
+        : null;
+}
+
+function gatewayPricing(
+    model: SuncokretModelConfig,
+    metadata: GatewayModelMetadata,
+) {
+    const pricing = metadata.models.find(
+        (candidate) => candidate.id === model.id,
+    )?.pricing;
+    const inputUsdPerMillionTokens = usdPerTokenToUsdPerMillion(pricing?.input);
+    const outputUsdPerMillionTokens = usdPerTokenToUsdPerMillion(
+        pricing?.output,
+    );
+
+    if (
+        inputUsdPerMillionTokens === null ||
+        outputUsdPerMillionTokens === null
+    ) {
+        return null;
+    }
+
+    const cachedInputUsdPerMillionTokens = usdPerTokenToUsdPerMillion(
+        pricing?.cachedInputTokens,
+    );
+    const cacheWriteInputUsdPerMillionTokens = usdPerTokenToUsdPerMillion(
+        pricing?.cacheCreationInputTokens,
+    );
+
+    return {
+        id: model.id,
+        label: model.label,
+        enabled: model.enabled,
+        inputUsdPerMillionTokens,
+        outputUsdPerMillionTokens,
+        ...(cachedInputUsdPerMillionTokens === null
+            ? {}
+            : { cachedInputUsdPerMillionTokens }),
+        ...(cacheWriteInputUsdPerMillionTokens === null
+            ? {}
+            : { cacheWriteInputUsdPerMillionTokens }),
+    };
+}
 
 function envModelAllowlist() {
     return (process.env.SUNCOKRET_AI_MODEL_ALLOWLIST ?? '')
@@ -69,6 +142,73 @@ export function getSuncokretModel(modelId?: string | null) {
         registry.find((model) => model.enabled) ??
         null
     );
+}
+
+export async function getSuncokretPricedModel(
+    modelId?: string | null,
+    loadModels: () => Promise<GatewayModelMetadata> = () =>
+        gateway.getAvailableModels(),
+) {
+    const model = getSuncokretModel(modelId);
+    if (!model) {
+        return null;
+    }
+
+    try {
+        const resolved = gatewayPricing(model, await loadModels());
+        if (resolved) {
+            return resolved;
+        }
+
+        console.warn(
+            'Suncokret AI Gateway model pricing is unavailable; using fallback pricing',
+            { modelId: model.id },
+        );
+    } catch (error) {
+        console.warn(
+            'Suncokret AI Gateway pricing lookup failed; using fallback pricing',
+            { modelId: model.id, error },
+        );
+    }
+
+    return model;
+}
+
+export function suncokretGatewayGenerationIds(
+    steps: readonly SuncokretGatewayStep[],
+) {
+    return Array.from(
+        new Set(
+            steps.flatMap((step) => {
+                const generationId =
+                    step.providerMetadata?.gateway?.generationId;
+                return typeof generationId === 'string' && generationId
+                    ? [generationId]
+                    : [];
+            }),
+        ),
+    );
+}
+
+export async function getSuncokretGatewayBilledCostMicroUsd(
+    steps: readonly SuncokretGatewayStep[],
+    loadGeneration: (id: string) => Promise<GatewayGenerationInfo> = (id) =>
+        gateway.getGenerationInfo({ id }),
+) {
+    const generationIds = suncokretGatewayGenerationIds(steps);
+    if (generationIds.length === 0) {
+        return null;
+    }
+
+    const generations = await Promise.all(generationIds.map(loadGeneration));
+    const totalCostUsd = generations.reduce(
+        (sum, generation) => sum + generation.totalCost,
+        0,
+    );
+
+    return Number.isFinite(totalCostUsd) && totalCostUsd >= 0
+        ? Math.round(totalCostUsd * USD_TO_MICRO_USD)
+        : null;
 }
 
 export function estimateSuncokretPromptTokens(value: unknown) {

--- a/packages/storage/src/repositories/aiChatRepo.ts
+++ b/packages/storage/src/repositories/aiChatRepo.ts
@@ -22,6 +22,8 @@ export const SUNCOKRET_FALLBACK_TIME_ZONE = 'Europe/Zagreb';
 export type AiChatPricing = {
     inputUsdPerMillionTokens: number;
     outputUsdPerMillionTokens: number;
+    cachedInputUsdPerMillionTokens?: number;
+    cacheWriteInputUsdPerMillionTokens?: number;
 };
 
 export type AiChatUsageCost = {
@@ -169,18 +171,45 @@ function finiteNonNegativeInteger(value: number) {
 }
 
 export function calculateAiChatUsageCostMicroUsd({
+    cacheReadTokens,
+    cacheWriteTokens,
     inputTokens,
+    noCacheTokens,
     outputTokens,
     pricing,
 }: {
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
     inputTokens: number;
+    noCacheTokens?: number;
     outputTokens: number;
     pricing: AiChatPricing;
 }): AiChatUsageCost {
     const normalizedInputTokens = finiteNonNegativeInteger(inputTokens);
     const normalizedOutputTokens = finiteNonNegativeInteger(outputTokens);
+    const normalizedCacheReadTokens = finiteNonNegativeInteger(
+        cacheReadTokens ?? 0,
+    );
+    const normalizedCacheWriteTokens = finiteNonNegativeInteger(
+        cacheWriteTokens ?? 0,
+    );
+    const normalizedNoCacheTokens =
+        noCacheTokens == null
+            ? Math.max(
+                  0,
+                  normalizedInputTokens -
+                      normalizedCacheReadTokens -
+                      normalizedCacheWriteTokens,
+              )
+            : finiteNonNegativeInteger(noCacheTokens);
     const inputMicroUsd = finiteNonNegativeInteger(
-        normalizedInputTokens * pricing.inputUsdPerMillionTokens,
+        normalizedNoCacheTokens * pricing.inputUsdPerMillionTokens +
+            normalizedCacheReadTokens *
+                (pricing.cachedInputUsdPerMillionTokens ??
+                    pricing.inputUsdPerMillionTokens) +
+            normalizedCacheWriteTokens *
+                (pricing.cacheWriteInputUsdPerMillionTokens ??
+                    pricing.inputUsdPerMillionTokens),
     );
     const outputMicroUsd = finiteNonNegativeInteger(
         normalizedOutputTokens * pricing.outputUsdPerMillionTokens,
@@ -521,23 +550,43 @@ export async function reserveAiChatUsage({
 }
 
 export async function finalizeAiChatUsage({
+    billedTotalMicroUsd,
+    cacheReadTokens,
+    cacheWriteTokens,
     inputTokens,
     ledgerId,
+    noCacheTokens,
     outputTokens,
     pricing,
     totalTokens,
 }: {
+    billedTotalMicroUsd?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
     inputTokens: number;
     ledgerId: string;
+    noCacheTokens?: number;
     outputTokens: number;
     pricing: AiChatPricing;
     totalTokens?: number;
 }) {
-    const cost = calculateAiChatUsageCostMicroUsd({
+    const estimatedCost = calculateAiChatUsageCostMicroUsd({
+        cacheReadTokens,
+        cacheWriteTokens,
         inputTokens,
+        noCacheTokens,
         outputTokens,
         pricing,
     });
+    const cost = {
+        ...estimatedCost,
+        // The component amounts remain useful diagnostics, while the total is
+        // the authoritative Gateway charge when it is available.
+        totalMicroUsd:
+            billedTotalMicroUsd == null
+                ? estimatedCost.totalMicroUsd
+                : finiteNonNegativeInteger(billedTotalMicroUsd),
+    };
 
     await storage()
         .update(aiUsageLedger)

--- a/packages/storage/tests/aiChatRepo.node.spec.ts
+++ b/packages/storage/tests/aiChatRepo.node.spec.ts
@@ -321,6 +321,28 @@ test('calculateAiChatUsageCostMicroUsd rounds input and output token costs', () 
     });
 });
 
+test('calculateAiChatUsageCostMicroUsd applies cached input token pricing', () => {
+    const cost = calculateAiChatUsageCostMicroUsd({
+        inputTokens: 1200,
+        noCacheTokens: 700,
+        cacheReadTokens: 400,
+        cacheWriteTokens: 100,
+        outputTokens: 300,
+        pricing: {
+            inputUsdPerMillionTokens: 2,
+            outputUsdPerMillionTokens: 10,
+            cachedInputUsdPerMillionTokens: 0.2,
+            cacheWriteInputUsdPerMillionTokens: 2.5,
+        },
+    });
+
+    assert.deepStrictEqual(cost, {
+        inputMicroUsd: 1730,
+        outputMicroUsd: 3000,
+        totalMicroUsd: 4730,
+    });
+});
+
 test('normalizeAiChatMessagesForStorage keeps valid UI message payloads', () => {
     const messages = normalizeAiChatMessagesForStorage([
         null,


### PR DESCRIPTION
## What changed

- replace stale Suncokret fallback prices (Luna was 5× too high)
- resolve current model and cache pricing from the Vercel AI Gateway catalog for request budgeting
- retrieve and sum the authoritative AI Gateway billed cost for every generation in a multi-step chat request
- persist that billed total in the existing usage ledger so historical requests remain immutable snapshots
- retain cache-aware token calculation as a resilient fallback when Gateway billing metadata is unavailable

## Root cause

Suncokret chat used a hardcoded model registry for both quota reservation and final cost calculation. Luna was fixed at $1/M input and $6/M output, while the current Gateway catalog is $0.20/M and $1.20/M. Provider price changes therefore required a deploy and the admin total could drift from actual billing.

## Impact

New chat requests use current catalog pricing for limits and store the actual per-request Gateway charge, including provider routing, cached tokens, tiers, and future price changes. Existing ledger rows are intentionally not repriced because they are historical snapshots and do not contain the Gateway generation IDs needed for an authoritative backfill.

## Validation

- `pnpm lint --filter api --filter @gredice/storage`
- `pnpm --filter api test:node` (461 passed)
- `pnpm --filter @gredice/storage test:node aiChatRepo.node.spec.ts` (15 passed)
- `pnpm --dir apps/api exec tsc --noEmit --pretty false`
- `pnpm --dir apps/api exec next build --webpack` compiled successfully; the final type phase is blocked by the existing `app/api/[...route]/route.ts` exported `app` error
