### PR TITLE
Fix Suncokret operation ordering and default to Luna

### DIFF
--- a/apps/api/app/api/[...route]/aiSuncokretRoutes.ts
+++ b/apps/api/app/api/[...route]/aiSuncokretRoutes.ts
@@ -678,13 +678,20 @@ function buildTools({
         }),
         addOperationToCart: tool({
             description:
-                'Dodaj dostupnu radnju za cijelu gredicu ili biljku na polju u košaricu. ID radnje dohvati iz kataloga radnji. Uvijek treba odobrenje korisnika.',
+                'Dodaj dostupnu radnju za cijelu gredicu ili biljku na polju u košaricu. ID radnje dohvati iz kataloga radnji. Za radnju cijele gredice izostavi positionIndex; navedi ga samo za radnju biljke na konkretnom polju. Uvijek treba odobrenje korisnika.',
             inputSchema: z.object({
                 operationId: z.number().int().positive(),
                 quantity: z.number().positive().default(1),
                 gardenId: z.number().int().positive().optional(),
                 raisedBedId: z.number().int().positive().optional(),
-                positionIndex: z.number().int().min(0).optional(),
+                positionIndex: z
+                    .number()
+                    .int()
+                    .min(0)
+                    .optional()
+                    .describe(
+                        'Indeks polja samo za radnju biljke; izostavi za radnju cijele gredice.',
+                    ),
                 scheduledDate: z.string().optional(),
             }),
             needsApproval: true,

--- a/apps/api/app/api/mcp/commerce/tools/call/execute.ts
+++ b/apps/api/app/api/mcp/commerce/tools/call/execute.ts
@@ -15,7 +15,10 @@ import {
     upsertOrRemoveCartItem,
 } from '@gredice/storage';
 import { z } from 'zod';
-import { assertOperationCartTarget } from '../../../../../../lib/mcp/operationCartTarget';
+import {
+    assertOperationCartTarget,
+    resolveOperationCartTarget,
+} from '../../../../../../lib/mcp/operationCartTarget';
 
 type McpAuthContext = {
     accountId: string;
@@ -404,15 +407,18 @@ export async function executeCommerceTool(
             if (!operation) {
                 throw new Error('Operation not found');
             }
-            assertOperationCartTarget(operation.attributes?.application, {
-                raisedBedId: input.raisedBedId,
-                positionIndex: input.positionIndex,
-            });
+            const operationTarget = resolveOperationCartTarget(
+                operation.attributes?.application,
+                {
+                    raisedBedId: input.raisedBedId,
+                    positionIndex: input.positionIndex,
+                },
+            );
             const location = await validateCartLocation({
                 accountId: authContext.accountId,
                 gardenId: input.gardenId,
-                raisedBedId: input.raisedBedId,
-                positionIndex: input.positionIndex,
+                raisedBedId: operationTarget.raisedBedId,
+                positionIndex: operationTarget.positionIndex,
             });
             if (!location.raisedBedId || !location.raisedBed) {
                 throw new Error('Operation requires a raised bed');

--- a/apps/api/lib/ai/suncokretContext.node.spec.ts
+++ b/apps/api/lib/ai/suncokretContext.node.spec.ts
@@ -34,6 +34,10 @@ test('buildSuncokretSystemPrompt requires a friendly gender-neutral voice', () =
     assert.match(prompt, /Uvijek koristi rodno neutralne rečenice/);
     assert.match(prompt, /trebao\/trebala/);
     assert.match(prompt, /addOperationToCart/);
+    assert.match(
+        prompt,
+        /Za radnju cijele gredice navedi gredicu, ali nikada indeks polja/,
+    );
     assert.match(prompt, /Gredice općenito ne podržavaju ili ne nude/);
 });
 

--- a/apps/api/lib/ai/suncokretContext.ts
+++ b/apps/api/lib/ai/suncokretContext.ts
@@ -120,7 +120,7 @@ export function buildSuncokretSystemPrompt(input: {
         'Korisnik nema nužno fizički pristup gredici. Kada preporuka traži rad na gredici, predloži naručivanje odgovarajuće radnje ili sijanja kroz dostupne alate.',
         'Kada u završnom odgovoru preporučiš konkretnu dostupnu Gredice radnju ili sijanje za određenu gredicu ili polje, nakon provjere kataloga pozovi presentRecommendations kako bi korisnik dobio klikabilne prijedloge. Prikaži samo stavke koje doista preporučuješ, najviše šest. Taj alat ne dodaje ništa u košaricu.',
         'Uz klikabilne prijedloge kratko reci da ih korisnik može otvoriti i ručno naručiti ili zatražiti da ih dodaš u košaricu.',
-        'Radnje za cijelu gredicu i primjenjive radnje za biljku na pojedinom polju mogu se naručiti alatom addOperationToCart nakon što iz kataloga dohvatiš ID radnje. Za biljnu radnju uvijek navedi gredicu i indeks polja.',
+        'Radnje za cijelu gredicu i primjenjive radnje za biljku na pojedinom polju mogu se naručiti alatom addOperationToCart nakon što iz kataloga dohvatiš ID radnje. Za radnju cijele gredice navedi gredicu, ali nikada indeks polja, čak ni kada je polje trenutačno u fokusu. Za biljnu radnju uvijek navedi gredicu i indeks polja.',
         'Ako neki alat ne podržava traženu promjenu, reci samo da je ne možeš izvršiti iz ovog razgovora. Nemoj iz toga zaključiti da Gredice općenito ne podržavaju ili ne nude tu radnju.',
         'Ne tvrdi da je radnja, sijanje, izmjena košarice ili checkout izvršen dok alat ne potvrdi rezultat.',
         'Za kupnju, checkout, promjene košarice, sijanje, zakazivanje, otkazivanje i druge promjene prvo sažmi što želiš napraviti i koristi alat koji traži odobrenje korisnika.',

--- a/apps/api/lib/ai/suncokretModels.node.spec.ts
+++ b/apps/api/lib/ai/suncokretModels.node.spec.ts
@@ -37,9 +37,9 @@ function withModelEnv(
     }
 }
 
-test('getSuncokretModel defaults to DeepSeek V4 Flash', () => {
+test('getSuncokretModel defaults to OpenAI GPT-5.6 Luna', () => {
     withModelEnv({}, () => {
-        assert.equal(getSuncokretModel()?.id, 'deepseek/deepseek-v4-flash');
+        assert.equal(getSuncokretModel()?.id, 'openai/gpt-5.6-luna');
     });
 });
 

--- a/apps/api/lib/ai/suncokretModels.ts
+++ b/apps/api/lib/ai/suncokretModels.ts
@@ -10,7 +10,7 @@ export type SuncokretModelConfig = AiChatPricing & {
     enabled: boolean;
 };
 
-const DEFAULT_MODEL_ID = 'deepseek/deepseek-v4-flash';
+const DEFAULT_MODEL_ID = 'openai/gpt-5.6-luna';
 
 // Used only when AI Gateway metadata cannot be loaded. Normal requests replace
 // these values with Gateway catalog pricing and persist the billed request cost.

--- a/apps/api/lib/mcp/operationCartTarget.node.spec.ts
+++ b/apps/api/lib/mcp/operationCartTarget.node.spec.ts
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { assertOperationCartTarget } from './operationCartTarget';
+import {
+    assertOperationCartTarget,
+    resolveOperationCartTarget,
+} from './operationCartTarget';
 
-test('raised-bed operations require a raised bed and no individual field', () => {
+test('raised-bed operations require a raised bed', () => {
     assert.doesNotThrow(() =>
         assertOperationCartTarget('raisedBedFull', { raisedBedId: 12 }),
     );
@@ -13,22 +16,32 @@ test('raised-bed operations require a raised bed and no individual field', () =>
         () => assertOperationCartTarget('raisedBedFull', {}),
         /requires a raised bed/,
     );
-    assert.throws(
-        () =>
-            assertOperationCartTarget('raisedBed1m', {
-                raisedBedId: 12,
-                positionIndex: 3,
-            }),
-        /cannot target an individual field/,
+});
+
+test('raised-bed operations ignore an incidental focused field', () => {
+    assert.deepStrictEqual(
+        resolveOperationCartTarget('raisedBedFull', {
+            raisedBedId: 12,
+            positionIndex: 3,
+        }),
+        { raisedBedId: 12 },
+    );
+    assert.deepStrictEqual(
+        resolveOperationCartTarget('raisedBed1m', {
+            raisedBedId: 12,
+            positionIndex: 0,
+        }),
+        { raisedBedId: 12 },
     );
 });
 
 test('plant operations require a concrete field', () => {
-    assert.doesNotThrow(() =>
-        assertOperationCartTarget('plant', {
+    assert.deepStrictEqual(
+        resolveOperationCartTarget('plant', {
             raisedBedId: 12,
             positionIndex: 0,
         }),
+        { raisedBedId: 12, positionIndex: 0 },
     );
     assert.throws(
         () => assertOperationCartTarget('plant', { raisedBedId: 12 }),

--- a/apps/api/lib/mcp/operationCartTarget.ts
+++ b/apps/api/lib/mcp/operationCartTarget.ts
@@ -3,22 +3,17 @@ export type OperationCartTarget = {
     positionIndex?: number;
 };
 
-export function assertOperationCartTarget(
+export function resolveOperationCartTarget(
     application: string | undefined,
     target: OperationCartTarget,
-) {
+): OperationCartTarget {
     switch (application) {
         case 'raisedBedFull':
         case 'raisedBed1m':
             if (!target.raisedBedId) {
                 throw new Error('Raised-bed operation requires a raised bed');
             }
-            if (typeof target.positionIndex === 'number') {
-                throw new Error(
-                    'Raised-bed operation cannot target an individual field',
-                );
-            }
-            return;
+            return { raisedBedId: target.raisedBedId };
         case 'plant':
             if (!target.raisedBedId) {
                 throw new Error('Plant operation requires a raised bed');
@@ -26,8 +21,18 @@ export function assertOperationCartTarget(
             if (typeof target.positionIndex !== 'number') {
                 throw new Error('Plant operation requires a raised-bed field');
             }
-            return;
+            return {
+                raisedBedId: target.raisedBedId,
+                positionIndex: target.positionIndex,
+            };
         default:
             throw new Error('Operation is not orderable for this target');
     }
+}
+
+export function assertOperationCartTarget(
+    application: string | undefined,
+    target: OperationCartTarget,
+) {
+    resolveOperationCartTarget(application, target);
 }

--- a/packages/storage/src/repositories/aiChatRepo.ts
+++ b/packages/storage/src/repositories/aiChatRepo.ts
@@ -306,6 +306,10 @@ function extractToolCallRows(
     conversationId: string,
     messages: AiChatMessageForStorage[],
     approvedByUserId?: string,
+    existingToolCallsById: ReadonlyMap<
+        string,
+        typeof aiChatToolCalls.$inferSelect
+    > = new Map(),
 ) {
     const rows: Array<typeof aiChatToolCalls.$inferInsert> = [];
 
@@ -325,16 +329,20 @@ function extractToolCallRows(
                 typeof part.mcpErrorCategory === 'string'
                     ? part.mcpErrorCategory
                     : null;
+            const toolCallId =
+                typeof part.toolCallId === 'string'
+                    ? part.toolCallId
+                    : typeof part.id === 'string'
+                      ? part.id
+                      : null;
+            const existingToolCall = toolCallId
+                ? existingToolCallsById.get(toolCallId)
+                : undefined;
             rows.push({
-                id: randomUUID(),
+                id: existingToolCall?.id ?? randomUUID(),
                 conversationId,
                 messageId: message.id,
-                toolCallId:
-                    typeof part.toolCallId === 'string'
-                        ? part.toolCallId
-                        : typeof part.id === 'string'
-                          ? part.id
-                          : null,
+                toolCallId,
                 toolName: type.slice('tool-'.length),
                 state:
                     typeof part.state === 'string'
@@ -347,14 +355,22 @@ function extractToolCallRows(
                     toolCallValue(part.output) ?? toolCallValue(part.result),
                 error: mcpErrorCategory
                     ? `[${mcpErrorCategory}]${errorText ? ` ${errorText}` : ''}`
-                    : errorText,
-                needsApproval: Boolean(approval),
-                approvedByUserId: approved ? approvedByUserId : undefined,
-                approvedAt: approved ? new Date() : undefined,
+                    : (existingToolCall?.error ?? errorText),
+                needsApproval:
+                    Boolean(approval) ||
+                    (existingToolCall?.needsApproval ?? false),
+                approvedByUserId: approved
+                    ? (existingToolCall?.approvedByUserId ?? approvedByUserId)
+                    : existingToolCall?.approvedByUserId,
+                approvedAt: approved
+                    ? (existingToolCall?.approvedAt ?? new Date())
+                    : existingToolCall?.approvedAt,
+                durationMs: existingToolCall?.durationMs,
                 mcpCorrelationId:
                     typeof part.mcpCorrelationId === 'string'
                         ? part.mcpCorrelationId
-                        : null,
+                        : (existingToolCall?.mcpCorrelationId ?? null),
+                createdAt: existingToolCall?.createdAt,
             });
         }
     }
@@ -790,6 +806,16 @@ export async function replaceAiChatMessages({
     const normalizedMessages = normalizeAiChatMessagesForStorage(messages);
 
     await storage().transaction(async (tx) => {
+        const existingToolCalls = await tx
+            .select()
+            .from(aiChatToolCalls)
+            .where(eq(aiChatToolCalls.conversationId, conversationId));
+        const existingToolCallsById = new Map(
+            existingToolCalls.flatMap((toolCall) =>
+                toolCall.toolCallId ? [[toolCall.toolCallId, toolCall]] : [],
+            ),
+        );
+
         await tx
             .delete(aiChatToolCalls)
             .where(eq(aiChatToolCalls.conversationId, conversationId));
@@ -813,6 +839,7 @@ export async function replaceAiChatMessages({
             conversationId,
             normalizedMessages,
             approvedByUserId,
+            existingToolCallsById,
         );
         if (toolCalls.length > 0) {
             await tx.insert(aiChatToolCalls).values(toolCalls);

--- a/packages/storage/tests/aiChatRepo.node.spec.ts
+++ b/packages/storage/tests/aiChatRepo.node.spec.ts
@@ -475,7 +475,7 @@ test('replaceAiChatMessages records MCP correlation and error category', async (
         conversationId,
         messages: [
             {
-                id: 'assistant-error',
+                id: 'assistant-telemetry-error',
                 role: 'assistant',
                 parts: [
                     {
@@ -502,6 +502,89 @@ test('replaceAiChatMessages records MCP correlation and error category', async (
     assert.strictEqual(
         toolCall.error,
         '[timeout] Provjera podataka trajala je predugo. Pokušaj ponovno.',
+    );
+});
+
+test('replaceAiChatMessages preserves server MCP telemetry on later client snapshots', async () => {
+    createTestDb();
+    const { accountId, userId } = await createAiChatTestUser();
+    const conversationId = randomUUID();
+    await ensureAiChatConversation({
+        id: conversationId,
+        accountId,
+        userId,
+        model: 'openai/gpt-5.5',
+        title: 'Suncokret MCP telemetry preservation test',
+    });
+
+    const toolPart = {
+        type: 'tool-addOperationToCart',
+        toolCallId: 'operation-call-1',
+        state: 'output-error',
+        input: { operationId: 167, raisedBedId: 498 },
+        approval: { approved: true },
+        errorText: 'Radnja trenutačno nije uspjela. Pokušaj ponovno.',
+    };
+    await replaceAiChatMessages({
+        approvedByUserId: userId,
+        conversationId,
+        messages: [
+            {
+                id: 'assistant-preserve-error',
+                role: 'assistant',
+                parts: [
+                    {
+                        ...toolPart,
+                        mcpCorrelationId: 'mcp-correlation-456',
+                        mcpErrorCategory: 'tool_failure',
+                    },
+                ],
+            },
+        ],
+    });
+
+    const initialToolCall = (
+        await storage().query.aiChatToolCalls.findMany()
+    ).find((candidate) => candidate.toolCallId === 'operation-call-1');
+    assert.ok(initialToolCall);
+
+    await replaceAiChatMessages({
+        approvedByUserId: userId,
+        conversationId,
+        messages: [
+            {
+                id: 'assistant-preserve-error',
+                role: 'assistant',
+                parts: [toolPart],
+            },
+            {
+                id: 'later-user-message',
+                role: 'user',
+                parts: [{ type: 'text', text: 'Zašto nije uspjelo?' }],
+            },
+        ],
+    });
+
+    const rewrittenToolCall = (
+        await storage().query.aiChatToolCalls.findMany()
+    ).find((candidate) => candidate.toolCallId === 'operation-call-1');
+    assert.ok(rewrittenToolCall);
+    assert.strictEqual(rewrittenToolCall.id, initialToolCall.id);
+    assert.strictEqual(
+        rewrittenToolCall.mcpCorrelationId,
+        'mcp-correlation-456',
+    );
+    assert.strictEqual(
+        rewrittenToolCall.error,
+        '[tool_failure] Radnja trenutačno nije uspjela. Pokušaj ponovno.',
+    );
+    assert.strictEqual(
+        rewrittenToolCall.approvedAt?.toISOString(),
+        initialToolCall.approvedAt?.toISOString(),
+    );
+    assert.strictEqual(
+        rewrittenToolCall.createdAt.toISOString(),
+        initialToolCall.createdAt.toISOString(),
     );
 });
 


### PR DESCRIPTION
## Summary

- normalize operation targets so whole-raised-bed actions ignore an incidental focused field while plant actions still require one
- preserve MCP correlation and categorized error telemetry when later client snapshots rewrite chat history
- make `openai/gpt-5.6-luna` the default Suncokret chat model while keeping the environment override
- strengthen tool and system instructions for whole-bed versus plant operations

## Root cause

The chat sent `positionIndex: 0` together with the whole-bed watering operation. The MCP target validator treated that focused field as an invalid individual-field target and rejected the otherwise valid raised-bed operation. Separately, full-history persistence could replace server-enriched tool parts with later client snapshots and lose diagnostic telemetry.

## Validation

- `pnpm --filter api test:node` — 465 passed
- `pnpm --filter api exec tsc --noEmit --pretty false`
- Biome checks for all 10 changed files
- focused storage AI chat suite — 18 passed
- `git diff --check`