### PR TITLE
Refine supported plant canopies and LODs

### DIFF
--- a/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
@@ -709,6 +709,10 @@ export function RaisedBedFields({
                             harvestedVisual:
                                 harvestPositionSet.has(localPositionIndex),
                             positionIndex: localPositionIndex,
+                            supportedVisual:
+                                visibleSupportPositions.includes(
+                                    localPositionIndex,
+                                ),
                         }}
                         blockIndex={blockIndex}
                         orientation={orientation}

--- a/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantClusterBatch.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantClusterBatch.tsx
@@ -22,6 +22,7 @@ export interface RaisedBedGeneratedPlantClusterField {
     definition: PlantDefinition;
     fieldKey: string;
     instances: RaisedBedGeneratedPlantBatchInstance[];
+    renderVariant: string;
 }
 
 export function RaisedBedGeneratedPlantClusterBatch({

--- a/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantFieldBatches.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantFieldBatches.tsx
@@ -17,6 +17,7 @@ import { useGameSceneDetails } from '../../GameSceneDetailContext';
 import type { GeneratedPlantTaskPriority } from '../../generators/plant/hooks/generatedPlantTaskScheduler';
 import {
     calculateInGamePlantGeneration,
+    getInGamePlantDefinition,
     getInGamePlantInstanceScale,
     getPlantMaturityWindowDays,
     type ResolvedInGamePlantPreset,
@@ -83,6 +84,7 @@ import {
 } from './RaisedBedGeneratedPlantClusterBatch';
 import { mockPlantPresetLabelsBySortId } from './RaisedBedPlantField';
 import { resolveRaisedBedProtectiveCoverPositions } from './raisedBedAgrotextileRewards';
+import { resolveRaisedBedSupportPositions } from './raisedBedSupportRewards';
 
 export interface RaisedBedGeneratedPlantFieldBatchBlock {
     blockId: string;
@@ -103,9 +105,9 @@ type GeneratedPlantField = {
     definition: ResolvedInGamePlantPreset['definition'];
     fieldKey: string;
     instances: RaisedBedGeneratedPlantBatchInstance[];
-    plantType: ResolvedInGamePlantPreset['plantType'];
     position: readonly [number, number, number];
     raisedBedId: number;
+    renderVariant: string;
 };
 
 type GeneratedPlantBatch = {
@@ -113,7 +115,6 @@ type GeneratedPlantBatch = {
     definition: ResolvedInGamePlantPreset['definition'];
     instances: RaisedBedGeneratedPlantBatchInstance[];
     lodLevel: 'near';
-    plantType: ResolvedInGamePlantPreset['plantType'];
     signature: string;
     taskPriority: GeneratedPlantTaskPriority;
 };
@@ -703,6 +704,15 @@ export function RaisedBedGeneratedPlantFieldBatches({
                         visualRewardsByRaisedBedId.get(raisedBed.id) ?? [],
                 }),
             );
+            const supportPositionSet = new Set(
+                resolveRaisedBedSupportPositions({
+                    blockOffset,
+                    fields: raisedBed.fields,
+                    raisedBedId: raisedBed.id,
+                    visualRewards:
+                        visualRewardsByRaisedBedId.get(raisedBed.id) ?? [],
+                }),
+            );
             const cartItems = cart?.items.filter(
                 (item) =>
                     item.gardenId === currentGarden.id &&
@@ -803,6 +813,13 @@ export function RaisedBedGeneratedPlantFieldBatches({
                     resolvedPlantPreset,
                     safePlantsPerRow,
                 );
+                const supported = supportPositionSet.has(
+                    field.positionIndex - blockOffset,
+                );
+                const plantDefinition = getInGamePlantDefinition(
+                    resolvedPlantPreset,
+                    supported,
+                );
                 const fieldPosition = getFieldPosition({
                     blockIndex,
                     blockPosition: block.position,
@@ -810,7 +827,7 @@ export function RaisedBedGeneratedPlantFieldBatches({
                     positionIndex: field.positionIndex - blockOffset,
                 });
                 const approximatePlantHeight =
-                    getApproximatePlantHeight(resolvedPlantPreset.definition) *
+                    getApproximatePlantHeight(plantDefinition) *
                     plantInstanceScale;
                 const instances: RaisedBedGeneratedPlantBatchInstance[] = [];
 
@@ -840,12 +857,12 @@ export function RaisedBedGeneratedPlantFieldBatches({
                 fields.push({
                     approximatePlantHeight,
                     blockId: block.blockId,
-                    definition: resolvedPlantPreset.definition,
+                    definition: plantDefinition,
                     fieldKey: getFieldRenderKey(block.blockId, field),
                     instances,
-                    plantType: resolvedPlantPreset.plantType,
                     position: fieldPosition,
                     raisedBedId: raisedBed.id,
+                    renderVariant: `${resolvedPlantPreset.plantType}:${supported ? 'supported' : 'free'}`,
                 });
             }
         }
@@ -992,7 +1009,7 @@ export function RaisedBedGeneratedPlantFieldBatches({
                     : getGeneratedPlantBatchKey({
                           focused: false,
                           lodLevel: lod.level,
-                          plantType: field.plantType,
+                          plantType: field.renderVariant,
                           raisedBedId: field.raisedBedId,
                       });
                 const clusterBatch = clusterBatchMap.get(batchKey);
@@ -1000,6 +1017,7 @@ export function RaisedBedGeneratedPlantFieldBatches({
                     definition: field.definition,
                     fieldKey: field.fieldKey,
                     instances: field.instances,
+                    renderVariant: field.renderVariant,
                 } satisfies RaisedBedGeneratedPlantClusterField;
 
                 if (clusterBatch) {
@@ -1018,7 +1036,7 @@ export function RaisedBedGeneratedPlantFieldBatches({
             const batchKey = getGeneratedPlantBatchKey({
                 focused,
                 lodLevel: 'near',
-                plantType: field.plantType,
+                plantType: field.renderVariant,
                 raisedBedId: field.raisedBedId,
             });
             let batch = detailedBatchMap.get(batchKey);
@@ -1029,7 +1047,6 @@ export function RaisedBedGeneratedPlantFieldBatches({
                     definition: field.definition,
                     instances: [],
                     lodLevel: 'near',
-                    plantType: field.plantType,
                     signature: '',
                     taskPriority: focused
                         ? 'focused'
@@ -1051,6 +1068,7 @@ export function RaisedBedGeneratedPlantFieldBatches({
                     ...batch.fields.flatMap((field) => [
                         field.fieldKey,
                         field.definition.name,
+                        field.renderVariant,
                         ...field.instances.map(
                             getGeneratedPlantInstanceSignature,
                         ),

--- a/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
@@ -5,6 +5,7 @@ import type { Group } from 'three';
 import { usePlantLodState } from '../../generators/plant/hooks/usePlantLod';
 import {
     calculateInGamePlantGeneration,
+    getInGamePlantDefinition,
     getInGamePlantInstanceScale,
     getPlantMaturityWindowDays,
     resolveInGamePlantPreset,
@@ -43,11 +44,18 @@ export function RaisedBedPlantField({
         plantSortId: number | null | undefined;
         plantStatus?: string | null;
         plantSowDate?: string | null;
+        supportedVisual?: boolean;
     };
     orientation: RaisedBedOrientation;
     blockIndex: number;
 }) {
-    const { harvestedVisual, positionIndex, plantSortId, plantSowDate } = field;
+    const {
+        harvestedVisual,
+        positionIndex,
+        plantSortId,
+        plantSowDate,
+        supportedVisual,
+    } = field;
     const fieldGroupRef = useRef<Group | null>(null);
     const { data: sortData } = usePlantSort(plantSortId);
     const isMock = useGameState((state) => state.isMock);
@@ -133,9 +141,14 @@ export function RaisedBedPlantField({
     const plantInstanceScale = resolvedPlantPreset
         ? getInGamePlantInstanceScale(resolvedPlantPreset, safePlantsPerRow)
         : 0;
-    const approximateFieldPlantHeight = resolvedPlantPreset
-        ? getApproximatePlantHeight(resolvedPlantPreset.definition) *
-          plantInstanceScale
+    const plantDefinition = resolvedPlantPreset
+        ? getInGamePlantDefinition(
+              resolvedPlantPreset,
+              supportedVisual === true,
+          )
+        : null;
+    const approximateFieldPlantHeight = plantDefinition
+        ? getApproximatePlantHeight(plantDefinition) * plantInstanceScale
         : 0.25;
     const fieldLod = usePlantLodState(
         fieldGroupRef,
@@ -195,7 +208,9 @@ export function RaisedBedPlantField({
             {fieldLod.visible ? (
                 shouldRenderGeneratedPlants && resolvedPlantPreset ? (
                     <RaisedBedGeneratedPlantBatch
-                        definition={resolvedPlantPreset.definition}
+                        definition={
+                            plantDefinition ?? resolvedPlantPreset.definition
+                        }
                         flowerGrowth={harvestedVisual ? 0.35 : 1}
                         fruitGrowth={harvestedVisual ? 0.1 : 1}
                         instances={generatedPlantInstances}

--- a/packages/game/src/generators/plant/developmental/developmentalPlantGraph.ts
+++ b/packages/game/src/generators/plant/developmental/developmentalPlantGraph.ts
@@ -316,6 +316,7 @@ function getAxisStep(
         Math.max(nodeCount, 1);
     const segmentLength = baseLength * rng.nextRange(0.92, 1.08);
     const alternating = index % 2 === 0 ? 1 : -1;
+    const supportedHorizontalScale = axes.mainStemHorizontalScale;
 
     switch (axes.habit) {
         case 'prostrate':
@@ -327,19 +328,19 @@ function getAxisStep(
         case 'climbing':
             return radial(
                 azimuth + alternating * 0.08,
-                segmentLength * 0.28,
+                segmentLength * (supportedHorizontalScale ?? 0.28),
                 segmentLength * 0.9,
             );
         case 'woody':
             return radial(
                 azimuth + alternating * 0.08,
-                segmentLength * 0.1,
+                segmentLength * (supportedHorizontalScale ?? 0.1),
                 segmentLength * 0.98,
             );
         case 'upright':
             return radial(
                 azimuth + alternating * 0.11,
-                segmentLength * 0.12,
+                segmentLength * (supportedHorizontalScale ?? 0.12),
                 segmentLength * 0.98,
             );
         case 'basal':

--- a/packages/game/src/generators/plant/developmental/developmentalPlantGraph.unit.ts
+++ b/packages/game/src/generators/plant/developmental/developmentalPlantGraph.unit.ts
@@ -453,6 +453,23 @@ test('builds tomato phytomers and transitions flowers into fruit', () => {
     assert.ok(fruit.transform.position[1] < flower.transform.position[1]);
 });
 
+test('supported main stems keep their height while reducing horizontal lean', () => {
+    const supportedTomato = structuredClone(plantTypes.tomato);
+    supportedTomato.development.axes.mainStemHorizontalScale = 0.04;
+    const freeGraph = buildGraph(plantTypes.tomato, 12, 'supported-stem');
+    const supportedGraph = buildGraph(supportedTomato, 12, 'supported-stem');
+    const freeTop = getOrgan(freeGraph, 'internode:0:9');
+    const supportedTop = getOrgan(supportedGraph, 'internode:0:9');
+
+    assert.equal(freeTop.type, 'internode');
+    assert.equal(supportedTop.type, 'internode');
+    assert.equal(supportedTop.end[1], freeTop.end[1]);
+    assert.ok(
+        Math.hypot(supportedTop.end[0], supportedTop.end[2]) <
+            Math.hypot(freeTop.end[0], freeTop.end[2]) * 0.5,
+    );
+});
+
 test('builds carrot with one below-soil storage root and crown leaves', () => {
     const graph = buildGraph(plantTypes.carrot, 12, 'mature-carrot');
     const roots = graph.organs.filter((organ) => organ.type === 'root');

--- a/packages/game/src/generators/plant/lib/inGamePlantPresets.ts
+++ b/packages/game/src/generators/plant/lib/inGamePlantPresets.ts
@@ -43,10 +43,12 @@ function createHeightCalibratedRuntimeConfig(
     instanceScale: number,
     {
         aliases = [],
+        foliageCountMultiplier,
         leafSizeMeters,
         matureHeightMeters,
     }: {
         aliases?: string[];
+        foliageCountMultiplier: number;
         leafSizeMeters: number;
         matureHeightMeters: number;
     },
@@ -54,6 +56,16 @@ function createHeightCalibratedRuntimeConfig(
     const sourceDefinition = plantTypes[plantType];
     const definition = {
         ...sourceDefinition,
+        development: {
+            ...sourceDefinition.development,
+            foliage: {
+                ...sourceDefinition.development.foliage,
+                count: Math.round(
+                    sourceDefinition.development.foliage.count *
+                        foliageCountMultiplier,
+                ),
+            },
+        },
         leaf: {
             ...sourceDefinition.leaf,
             size: leafSizeMeters / instanceScale,
@@ -86,6 +98,7 @@ const inGamePlantRuntimeConfigs = {
     blueberry: createRuntimeConfig('blueberry', 0.92, 0.34, ['borovnica']),
     raspberry: createHeightCalibratedRuntimeConfig('raspberry', 0.98, 0.34, {
         aliases: ['malina'],
+        foliageCountMultiplier: 1.35,
         leafSizeMeters: 0.16,
         matureHeightMeters: 1.5,
     }),
@@ -97,6 +110,7 @@ const inGamePlantRuntimeConfigs = {
             'cherry tomato',
             'rajcica cherry',
         ],
+        foliageCountMultiplier: 1.55,
         leafSizeMeters: 0.2,
         matureHeightMeters: 1.5,
     }),
@@ -114,6 +128,7 @@ const inGamePlantRuntimeConfigs = {
     artichoke: createRuntimeConfig('artichoke', 0.88, 0.36, ['artičoka']),
     okra: createHeightCalibratedRuntimeConfig('okra', 0.92, 0.3, {
         aliases: ['bamija'],
+        foliageCountMultiplier: 1.45,
         leafSizeMeters: 0.22,
         matureHeightMeters: 1.5,
     }),
@@ -160,21 +175,25 @@ const inGamePlantRuntimeConfigs = {
     thyme: createRuntimeConfig('thyme', 0.92, 0.2, ['timijan']),
     broadbean: createHeightCalibratedRuntimeConfig('broadbean', 0.94, 0.32, {
         aliases: ['bob', 'fava bean'],
+        foliageCountMultiplier: 1.35,
         leafSizeMeters: 0.12,
         matureHeightMeters: 1.2,
     }),
     bean: createHeightCalibratedRuntimeConfig('bean', 0.98, 0.32, {
         aliases: ['grah'],
+        foliageCountMultiplier: 1.5,
         leafSizeMeters: 0.16,
         matureHeightMeters: 1.5,
     }),
     pea: createHeightCalibratedRuntimeConfig('pea', 1.02, 0.28, {
         aliases: ['grašak', 'grasak'],
+        foliageCountMultiplier: 1.4,
         leafSizeMeters: 0.1,
         matureHeightMeters: 1.2,
     }),
     greenbean: createHeightCalibratedRuntimeConfig('greenbean', 1, 0.3, {
         aliases: ['mahuna'],
+        foliageCountMultiplier: 1.5,
         leafSizeMeters: 0.16,
         matureHeightMeters: 1.5,
     }),
@@ -278,6 +297,43 @@ export function getInGamePlantInstanceScale(
         preset.instanceScale *
         (preset.matureHeightMeters === undefined ? densityScale : 1)
     );
+}
+
+const supportedPlantDefinitionCache = new WeakMap<
+    PlantDefinition,
+    PlantDefinition
+>();
+
+export function getInGamePlantDefinition(
+    preset: ResolvedInGamePlantPreset,
+    supported: boolean,
+) {
+    const { definition } = preset;
+    const { habit } = definition.development.axes;
+    if (
+        !supported ||
+        (habit !== 'climbing' && habit !== 'upright' && habit !== 'woody')
+    ) {
+        return definition;
+    }
+
+    const cachedDefinition = supportedPlantDefinitionCache.get(definition);
+    if (cachedDefinition) {
+        return cachedDefinition;
+    }
+
+    const supportedDefinition: PlantDefinition = {
+        ...definition,
+        development: {
+            ...definition.development,
+            axes: {
+                ...definition.development.axes,
+                mainStemHorizontalScale: habit === 'climbing' ? 0.07 : 0.04,
+            },
+        },
+    };
+    supportedPlantDefinitionCache.set(definition, supportedDefinition);
+    return supportedDefinition;
 }
 
 export function calculateInGamePlantGeneration({

--- a/packages/game/src/generators/plant/lib/inGamePlantPresets.unit.ts
+++ b/packages/game/src/generators/plant/lib/inGamePlantPresets.unit.ts
@@ -2,10 +2,12 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
     calculateInGamePlantGeneration,
+    getInGamePlantDefinition,
     getInGamePlantInstanceScale,
     getPlantMaturityWindowDays,
     resolveInGamePlantPreset,
 } from './inGamePlantPresets';
+import { plantTypes } from './plant-definitions';
 import { getNominalMaturePlantHeight } from './plantLodSummary';
 
 test('height-calibrated crops preserve mature height and leaf size in game meters', () => {
@@ -36,6 +38,52 @@ test('height-calibrated crops preserve mature height and leaf size in game meter
             ) < 1e-12,
         );
     }
+});
+
+test('height-calibrated crops grow denser canopies', () => {
+    for (const [label, plantType, expectedLeafCount] of [
+        ['Rajčica', 'tomato', 20],
+        ['Malina', 'raspberry', 41],
+        ['Bamija', 'okra', 16],
+        ['Grah', 'bean', 21],
+        ['Mahuna', 'greenbean', 21],
+        ['Bob', 'broadbean', 19],
+        ['Grašak', 'pea', 21],
+    ] as const) {
+        const preset = resolveInGamePlantPreset([label]);
+
+        assert.ok(preset);
+        assert.equal(
+            preset.definition.development.foliage.count,
+            expectedLeafCount,
+        );
+        assert.ok(
+            expectedLeafCount > plantTypes[plantType].development.foliage.count,
+        );
+    }
+});
+
+test('supported climbing and upright crops use a straighter main stem', () => {
+    const tomato = resolveInGamePlantPreset(['Rajčica']);
+    const cucumber = resolveInGamePlantPreset(['Krastavac']);
+
+    assert.ok(tomato);
+    assert.ok(cucumber);
+    assert.equal(getInGamePlantDefinition(tomato, false), tomato.definition);
+    assert.equal(
+        getInGamePlantDefinition(tomato, true).development.axes
+            .mainStemHorizontalScale,
+        0.04,
+    );
+    assert.equal(
+        getInGamePlantDefinition(cucumber, true).development.axes
+            .mainStemHorizontalScale,
+        0.07,
+    );
+    assert.equal(
+        getInGamePlantDefinition(cucumber, true),
+        getInGamePlantDefinition(cucumber, true),
+    );
 });
 
 test('plants reach full generation at the end of germination and growth', () => {

--- a/packages/game/src/generators/plant/lib/plant-definition-types.ts
+++ b/packages/game/src/generators/plant/lib/plant-definition-types.ts
@@ -88,6 +88,7 @@ export interface PlantDevelopmentAxes {
     branchingPattern: PlantBranchingPattern;
     habit: PlantAxisHabit;
     internodeLengthScale: number;
+    mainStemHorizontalScale?: number;
     nodeCount: number;
     pitchDegrees: number;
     spread: number;

--- a/packages/game/src/generators/plant/lib/plantMidBillboardMaterial.ts
+++ b/packages/game/src/generators/plant/lib/plantMidBillboardMaterial.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 
 export const LEGACY_MID_BILLBOARD_CIRCLE_TRIANGLE_COUNT = 18;
 export const MID_BILLBOARD_CARD_TRIANGLE_COUNT = 2;
+export const MID_BILLBOARD_CANOPY_CARD_COUNT = 3;
 export const MID_BILLBOARD_SHADER_VARIANT_COUNT = 2;
 export const PLANT_BILLBOARD_PLANE_TRIANGLE_COUNT = 2;
 
@@ -20,7 +21,10 @@ export function getPlantBillboardPrimitiveTriangleCount(
         (total, summary) =>
             total +
             PLANT_BILLBOARD_PLANE_TRIANGLE_COUNT +
-            (summary.hasFoliage ? MID_BILLBOARD_CARD_TRIANGLE_COUNT * 2 : 0) +
+            (summary.hasFoliage
+                ? MID_BILLBOARD_CARD_TRIANGLE_COUNT *
+                  MID_BILLBOARD_CANOPY_CARD_COUNT
+                : 0) +
             (summary.accentColor ? MID_BILLBOARD_CARD_TRIANGLE_COUNT : 0),
         0,
     );
@@ -31,6 +35,73 @@ export function getPlantBillboardPrimitiveTriangleCount(
  * canopy used an 18-segment circle for every lobe and accent.
  */
 export const midBillboardCardGeometry = new THREE.PlaneGeometry(2, 2);
+
+export interface MidBillboardCanopyCard {
+    centerY: number;
+    halfHeight: number;
+    halfWidth: number;
+    id: 'lower' | 'middle' | 'upper';
+    offsetX: number;
+    offsetZ: number;
+    opacity: number;
+}
+
+export function getMidBillboardCanopyCards({
+    canopyCenterY,
+    canopyWidth,
+    height,
+}: {
+    canopyCenterY: number;
+    canopyWidth: number;
+    height: number;
+}): MidBillboardCanopyCard[] {
+    const safeHeight = Math.max(height, 0.16);
+    const lowerCenter = THREE.MathUtils.clamp(
+        canopyCenterY - safeHeight * 0.2,
+        safeHeight * 0.08,
+        safeHeight * 0.76,
+    );
+    const middleCenter = THREE.MathUtils.clamp(
+        canopyCenterY,
+        Math.min(lowerCenter + safeHeight * 0.12, safeHeight * 0.84),
+        safeHeight * 0.84,
+    );
+    const upperCenter = THREE.MathUtils.clamp(
+        canopyCenterY + safeHeight * 0.2,
+        Math.min(middleCenter + safeHeight * 0.12, safeHeight * 0.92),
+        safeHeight * 0.92,
+    );
+
+    return [
+        {
+            centerY: lowerCenter,
+            halfHeight: Math.max(safeHeight * 0.1, 0.08),
+            halfWidth: Math.max(canopyWidth * 0.22, 0.11),
+            id: 'lower',
+            offsetX: -canopyWidth * 0.06,
+            offsetZ: -0.01,
+            opacity: 0.74,
+        },
+        {
+            centerY: middleCenter,
+            halfHeight: Math.max(safeHeight * 0.12, 0.1),
+            halfWidth: Math.max(canopyWidth * 0.3, 0.14),
+            id: 'middle',
+            offsetX: canopyWidth * 0.04,
+            offsetZ: 0,
+            opacity: 0.88,
+        },
+        {
+            centerY: upperCenter,
+            halfHeight: Math.max(safeHeight * 0.1, 0.08),
+            halfWidth: Math.max(canopyWidth * 0.24, 0.12),
+            id: 'upper',
+            offsetX: -canopyWidth * 0.03,
+            offsetZ: 0.01,
+            opacity: 0.8,
+        },
+    ];
+}
 
 export function getMidBillboardSwayPhase(
     position: readonly [number, number, number],

--- a/packages/game/src/generators/plant/lib/plantMidBillboardMaterial.unit.ts
+++ b/packages/game/src/generators/plant/lib/plantMidBillboardMaterial.unit.ts
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+    getMidBillboardCanopyCards,
     getMidBillboardSwayPhase,
     getPlantBillboardPrimitiveTriangleCount,
     LEGACY_MID_BILLBOARD_CIRCLE_TRIANGLE_COUNT,
+    MID_BILLBOARD_CANOPY_CARD_COUNT,
     MID_BILLBOARD_CARD_TRIANGLE_COUNT,
     MID_BILLBOARD_SHADER_VARIANT_COUNT,
     midBillboardCardGeometry,
@@ -44,13 +46,34 @@ describe('mid plant billboard material', () => {
         );
     });
 
+    it('distributes elliptical canopy cards along the plant height', () => {
+        const cards = getMidBillboardCanopyCards({
+            canopyCenterY: 0.93,
+            canopyWidth: 0.7,
+            height: 1.5,
+        });
+
+        assert.equal(cards.length, MID_BILLBOARD_CANOPY_CARD_COUNT);
+        assert.deepEqual(
+            cards.map((card) => card.id),
+            ['lower', 'middle', 'upper'],
+        );
+        assert.ok(cards[0]);
+        assert.ok(cards[1]);
+        assert.ok(cards[2]);
+        assert.ok(cards[0].centerY < cards[1].centerY);
+        assert.ok(cards[1].centerY < cards[2].centerY);
+        assert.ok(cards[2].centerY <= 1.5 * 0.92);
+        assert.ok(cards.every((card) => card.halfWidth > card.halfHeight));
+    });
+
     it('counts one stem and only the foliage cards each mid summary needs', () => {
         assert.equal(
             getPlantBillboardPrimitiveTriangleCount('mid', [
                 { accentColor: '#f00', hasFoliage: true },
                 { hasFoliage: false },
             ]),
-            10,
+            12,
         );
         assert.equal(
             getPlantBillboardPrimitiveTriangleCount('far', [

--- a/packages/game/src/generators/plant/parts/PlantBillboard.tsx
+++ b/packages/game/src/generators/plant/parts/PlantBillboard.tsx
@@ -20,6 +20,7 @@ import {
 } from '../lib/plantInstanceBuffers';
 import type { PlantLodLevel } from '../lib/plantLod';
 import {
+    getMidBillboardCanopyCards,
     getMidBillboardSwayPhase,
     midBillboardCardGeometry,
     midBillboardFragmentShader,
@@ -377,50 +378,28 @@ export function PlantBillboardBatch({
             }),
         );
     }, [billboards, level]);
-    const midCanopyPrimaryItems = useMemo(() => {
+    const midCanopyItems = useMemo(() => {
         if (level !== 'mid') {
             return [];
         }
 
         return billboards
             .filter((billboard) => billboard.summary.hasFoliage)
-            .map(({ position, scale, summary }) =>
-                createBillboardItem({
-                    color: summary.foliageColor,
-                    height: 1,
-                    position: [
-                        position[0] - summary.canopyWidth * 0.08 * scale,
-                        position[1] + summary.canopyCenterY * scale,
-                        position[2],
-                    ],
-                    opacity: 0.88,
-                    radius: Math.max(summary.canopyWidth * 0.28, 0.16) * scale,
-                    swayPosition: position,
-                }),
-            );
-    }, [billboards, level]);
-    const midCanopySecondaryItems = useMemo(() => {
-        if (level !== 'mid') {
-            return [];
-        }
-
-        return billboards
-            .filter((billboard) => billboard.summary.hasFoliage)
-            .map(({ position, scale, summary }) =>
-                createBillboardItem({
-                    color: summary.foliageColor,
-                    height: 1,
-                    position: [
-                        position[0] + summary.canopyWidth * 0.1 * scale,
-                        position[1] +
-                            (summary.canopyCenterY + summary.height * 0.06) *
-                                scale,
-                        position[2] + 0.01 * scale,
-                    ],
-                    opacity: 0.78,
-                    radius: Math.max(summary.canopyWidth * 0.24, 0.14) * scale,
-                    swayPosition: position,
-                }),
+            .flatMap(({ position, scale, summary }) =>
+                getMidBillboardCanopyCards(summary).map((card) =>
+                    createBillboardItem({
+                        color: summary.foliageColor,
+                        height: card.halfHeight * scale,
+                        position: [
+                            position[0] + card.offsetX * scale,
+                            position[1] + card.centerY * scale,
+                            position[2] + card.offsetZ * scale,
+                        ],
+                        opacity: card.opacity,
+                        swayPosition: position,
+                        width: card.halfWidth * scale,
+                    }),
+                ),
             );
     }, [billboards, level]);
     const midAccentItems = useMemo(() => {
@@ -452,12 +431,8 @@ export function PlantBillboardBatch({
             );
     }, [billboards, level]);
     const midFoliageItems = useMemo(
-        () => [
-            ...midCanopyPrimaryItems,
-            ...midCanopySecondaryItems,
-            ...midAccentItems,
-        ],
-        [midAccentItems, midCanopyPrimaryItems, midCanopySecondaryItems],
+        () => [...midCanopyItems, ...midAccentItems],
+        [midAccentItems, midCanopyItems],
     );
 
     if (billboards.length === 0) {
@@ -509,6 +484,18 @@ function MidPlantBillboard({
         enabled: animate,
         speed: 1.1,
     });
+    const canopyCards = useMemo(
+        () =>
+            getMidBillboardCanopyCards(summary).map((card) => ({
+                ...card,
+                uniforms: {
+                    ...swayUniforms,
+                    uOpacity: { value: card.opacity },
+                    uTint: { value: new THREE.Color(summary.foliageColor) },
+                },
+            })),
+        [summary, swayUniforms],
+    );
     const uniforms = useMemo(
         () => ({
             accent: {
@@ -518,18 +505,8 @@ function MidPlantBillboard({
                     value: new THREE.Color(summary.accentColor ?? '#ffffff'),
                 },
             },
-            primary: {
-                ...swayUniforms,
-                uOpacity: { value: 0.88 },
-                uTint: { value: new THREE.Color(summary.foliageColor) },
-            },
-            secondary: {
-                ...swayUniforms,
-                uOpacity: { value: 0.78 },
-                uTint: { value: new THREE.Color(summary.foliageColor) },
-            },
         }),
-        [summary.accentColor, summary.foliageColor, swayUniforms],
+        [summary.accentColor, swayUniforms],
     );
 
     return (
@@ -550,52 +527,29 @@ function MidPlantBillboard({
             </mesh>
             {summary.hasFoliage ? (
                 <group>
-                    <mesh
-                        position={[
-                            -summary.canopyWidth * 0.08,
-                            summary.canopyCenterY,
-                            0,
-                        ]}
-                    >
-                        <planeGeometry
-                            args={[
-                                Math.max(summary.canopyWidth * 0.28, 0.16) * 2,
-                                Math.max(summary.canopyWidth * 0.28, 0.16) * 2,
+                    {canopyCards.map((card) => (
+                        <mesh
+                            key={card.id}
+                            position={[
+                                card.offsetX,
+                                card.centerY,
+                                card.offsetZ,
                             ]}
-                        />
-                        <CSM
-                            baseMaterial={THREE.MeshLambertMaterial}
-                            depthWrite={false}
-                            fragmentShader={midBillboardFragmentShader}
-                            side={THREE.FrontSide}
-                            transparent
-                            uniforms={uniforms.primary}
-                            vertexShader={midBillboardVertexShader}
-                        />
-                    </mesh>
-                    <mesh
-                        position={[
-                            summary.canopyWidth * 0.1,
-                            summary.canopyCenterY + summary.height * 0.06,
-                            0.01,
-                        ]}
-                    >
-                        <planeGeometry
-                            args={[
-                                Math.max(summary.canopyWidth * 0.24, 0.14) * 2,
-                                Math.max(summary.canopyWidth * 0.24, 0.14) * 2,
-                            ]}
-                        />
-                        <CSM
-                            baseMaterial={THREE.MeshLambertMaterial}
-                            depthWrite={false}
-                            fragmentShader={midBillboardFragmentShader}
-                            side={THREE.FrontSide}
-                            transparent
-                            uniforms={uniforms.secondary}
-                            vertexShader={midBillboardVertexShader}
-                        />
-                    </mesh>
+                        >
+                            <planeGeometry
+                                args={[card.halfWidth * 2, card.halfHeight * 2]}
+                            />
+                            <CSM
+                                baseMaterial={THREE.MeshLambertMaterial}
+                                depthWrite={false}
+                                fragmentShader={midBillboardFragmentShader}
+                                side={THREE.FrontSide}
+                                transparent
+                                uniforms={card.uniforms}
+                                vertexShader={midBillboardVertexShader}
+                            />
+                        </mesh>
+                    ))}
                 </group>
             ) : null}
             {summary.accentColor ? (


### PR DESCRIPTION
## What changed

- increase foliage density for height-calibrated tomato, raspberry, okra, bean, green bean, broad bean, and pea presets
- replace the two top-heavy mid-LOD canopy circles with three vertically distributed foliage cards
- straighten the main stem only for raised-bed plants that have an active support visual
- keep supported and unsupported plant definitions separated across detailed and clustered render batches

## Why

After calibrating tall crops to real-world heights, their original foliage counts left the canopy sparse. The mid-LOD representation also collapsed foliage into circles near the plant top, and supported plants could lean unrealistically away from their sticks.

## Impact

Mature tall crops now read as properly filled-out plants at near and mid distances. Supported plants align more naturally with their sticks while unsupported plants retain their normal growth habit.

## Validation

- `pnpm lint --filter @gredice/game`
- `pnpm test --filter @gredice/game` (800 tests)
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
- visual verification in the high-target Garden debug scene at detailed and billboard distances; no runtime errors