### PR TITLE
fix(garden): render mature plants across lifecycle stages

### DIFF
--- a/packages/game/src/entities/raisedBed/RaisedBedFieldVisualBatches.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFieldVisualBatches.tsx
@@ -63,6 +63,7 @@ import {
     type RaisedBedFieldVisualTransform,
     type RaisedBedFieldVisualVector3,
 } from './raisedBedFieldVisualLayout';
+import { shouldRenderRaisedBedPlant } from './raisedBedPlantVisualStatus';
 import { resolveRaisedBedSupportPositions } from './raisedBedSupportRewards';
 import { resolveRaisedBedFieldWeedLevel } from './raisedBedWeedState';
 
@@ -203,15 +204,6 @@ function addCoverPrimitives({
     }
 }
 
-function shouldRenderGeneratedPlantField(field: DisplayedField) {
-    return (
-        Boolean(field.plantSowDate) &&
-        (field.plantStatus === 'sprouted' ||
-            field.plantStatus === 'ready' ||
-            field.plantStatus === 'harvested')
-    );
-}
-
 function addSeedInstances({
     batches,
     blockIndex,
@@ -255,7 +247,7 @@ function addSeedInstances({
             ? mockPlantPresetLabelsBySortId[plantSortId]
             : undefined,
     ]);
-    if (resolvedPlantPreset && shouldRenderGeneratedPlantField(field)) {
+    if (resolvedPlantPreset && shouldRenderRaisedBedPlant(field)) {
         return;
     }
 

--- a/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantFieldBatches.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantFieldBatches.tsx
@@ -84,6 +84,7 @@ import {
 } from './RaisedBedGeneratedPlantClusterBatch';
 import { mockPlantPresetLabelsBySortId } from './RaisedBedPlantField';
 import { resolveRaisedBedProtectiveCoverPositions } from './raisedBedAgrotextileRewards';
+import { shouldRenderRaisedBedPlant } from './raisedBedPlantVisualStatus';
 import { resolveRaisedBedSupportPositions } from './raisedBedSupportRewards';
 
 export interface RaisedBedGeneratedPlantFieldBatchBlock {
@@ -202,15 +203,6 @@ function getGeneratedPlantInstanceSignature(
         instance.scale,
         ...instance.position,
     ].join(':');
-}
-
-function shouldRenderGeneratedPlantField(field: DisplayedRaisedBedField) {
-    return (
-        Boolean(field.plantSowDate) &&
-        (field.plantStatus === 'sprouted' ||
-            field.plantStatus === 'ready' ||
-            field.plantStatus === 'harvested')
-    );
 }
 
 function getFieldPosition({
@@ -780,7 +772,7 @@ export function RaisedBedGeneratedPlantFieldBatches({
                 if (
                     !plantSortId ||
                     !resolvedPlantPreset ||
-                    !shouldRenderGeneratedPlantField(field)
+                    !shouldRenderRaisedBedPlant(field)
                 ) {
                     continue;
                 }

--- a/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../utils/raisedBedOrientation';
 import { useGameGLTF } from '../../utils/useGameGLTF';
 import { RaisedBedGeneratedPlantBatch } from './RaisedBedGeneratedPlantBatch';
+import { shouldRenderRaisedBedPlant } from './raisedBedPlantVisualStatus';
 
 export const mockPlantPresetLabelsBySortId: Record<number, string> = {
     219: 'pepper',
@@ -134,10 +135,10 @@ export function RaisedBedPlantField({
         : plantGeneration;
     const shouldRenderGeneratedPlants =
         Boolean(resolvedPlantPreset) &&
-        Boolean(plantSowDate) &&
-        (field.plantStatus === 'sprouted' ||
-            field.plantStatus === 'ready' ||
-            field.plantStatus === 'harvested');
+        shouldRenderRaisedBedPlant({
+            plantSowDate,
+            plantStatus: field.plantStatus,
+        });
     const plantInstanceScale = resolvedPlantPreset
         ? getInGamePlantInstanceScale(resolvedPlantPreset, safePlantsPerRow)
         : 0;

--- a/packages/game/src/entities/raisedBed/raisedBedPlantVisualStatus.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedPlantVisualStatus.ts
@@ -1,0 +1,21 @@
+const visibleRaisedBedPlantStatuses = new Set([
+    'sprouted',
+    'firstFlowers',
+    'firstFruitSet',
+    'ready',
+    'harvested',
+]);
+
+export function shouldRenderRaisedBedPlant({
+    plantSowDate,
+    plantStatus,
+}: {
+    plantSowDate?: string | null;
+    plantStatus?: string | null;
+}) {
+    return Boolean(
+        plantSowDate &&
+            plantStatus &&
+            visibleRaisedBedPlantStatuses.has(plantStatus),
+    );
+}

--- a/packages/game/src/entities/raisedBed/raisedBedPlantVisualStatus.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedPlantVisualStatus.unit.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { shouldRenderRaisedBedPlant } from './raisedBedPlantVisualStatus';
+
+const sowDate = '2026-05-23T19:19:50.074Z';
+
+test('raised-bed plants stay visible throughout above-ground lifecycle stages', () => {
+    for (const plantStatus of [
+        'sprouted',
+        'firstFlowers',
+        'firstFruitSet',
+        'ready',
+        'harvested',
+    ]) {
+        assert.equal(
+            shouldRenderRaisedBedPlant({ plantSowDate: sowDate, plantStatus }),
+            true,
+            plantStatus,
+        );
+    }
+});
+
+test('raised-bed plants stay as seed visuals before sprouting or after failure', () => {
+    for (const plantStatus of [
+        undefined,
+        'new',
+        'planned',
+        'pendingVerification',
+        'sowed',
+        'notSprouted',
+        'died',
+        'removed',
+    ]) {
+        assert.equal(
+            shouldRenderRaisedBedPlant({ plantSowDate: sowDate, plantStatus }),
+            false,
+            plantStatus,
+        );
+    }
+});
+
+test('raised-bed plants require a sow date before rendering', () => {
+    assert.equal(
+        shouldRenderRaisedBedPlant({ plantStatus: 'firstFlowers' }),
+        false,
+    );
+});


### PR DESCRIPTION
## What changed

- centralize the raised-bed plant visibility rule across individual and batched render paths
- render healthy above-ground lifecycle stages including `firstFlowers` and `firstFruitSet`
- keep seed visuals for pre-sprout and failed states
- add focused regression coverage for every supported visibility stage

## Root cause

The generated-plant renderer only admitted `sprouted`, `ready`, and `harvested`. In Aleksov vrt, two tomato fields had advanced from `sprouted` to `firstFlowers`, so the renderer incorrectly replaced those mature plants with seed markers while the other two tomatoes remained visible.

## Impact

All active plants remain visible as they advance through first flowers and first fruit set, consistently across the normal per-field renderer and both optimized batch render paths.

## Validation

- `pnpm test --filter @gredice/game` (803 tests)
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
- targeted Biome check for all changed files
- `git diff --check`
