### PR TITLE
fix(schedule): match bulk photo operation identity

### DIFF
--- a/apps/app/app/admin/schedule/ScheduleDayOperationsSection.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayOperationsSection.tsx
@@ -1,13 +1,14 @@
 import {
     getAssignableFarmUsersByOperationIds,
     getFarms,
+    RAISED_BED_PHOTO_OPERATION_NAME,
 } from '@gredice/storage';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import {
     type BulkPhotoOperationTarget,
-    isRaisedBedPhotoOperationLabel,
+    isRaisedBedPhotoOperationInformation,
 } from './bulkPhotoOperationImportModel';
 import { FarmOperationsScheduleSection } from './FarmOperationsScheduleSection';
 import { RaisedBedOperationsScheduleSection } from './RaisedBedOperationsScheduleSection';
@@ -83,14 +84,11 @@ export async function ScheduleDayOperationsSection({
 
     const photoOperationEntityIds = new Set(
         (operationsData ?? [])
-            .filter(
-                (operationData) =>
-                    isRaisedBedPhotoOperationLabel(
-                        operationData.information?.label,
-                    ) ||
-                    isRaisedBedPhotoOperationLabel(
-                        operationData.information?.name,
-                    ),
+            .filter((operationData) =>
+                isRaisedBedPhotoOperationInformation(
+                    operationData.information,
+                    RAISED_BED_PHOTO_OPERATION_NAME,
+                ),
             )
             .map((operationData) => operationData.id),
     );

--- a/apps/app/app/admin/schedule/bulkPhotoOperationImportModel.ts
+++ b/apps/app/app/admin/schedule/bulkPhotoOperationImportModel.ts
@@ -66,6 +66,19 @@ export function isRaisedBedPhotoOperationLabel(value?: string | null) {
     );
 }
 
+export function isRaisedBedPhotoOperationInformation(
+    information:
+        | { label?: string | null; name?: string | null }
+        | null
+        | undefined,
+    stableOperationName: string,
+) {
+    return (
+        information?.name === stableOperationName ||
+        isRaisedBedPhotoOperationLabel(information?.label)
+    );
+}
+
 function matchSelectionToTarget(
     item: BulkPhotoSelectionItem,
     targets: BulkPhotoOperationTarget[],

--- a/apps/app/app/admin/schedule/bulkPhotoOperationImportModel.unit.ts
+++ b/apps/app/app/admin/schedule/bulkPhotoOperationImportModel.unit.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
     type BulkPhotoOperationTarget,
     buildBulkPhotoImportPreview,
+    isRaisedBedPhotoOperationInformation,
     isRaisedBedPhotoOperationLabel,
     MAX_BULK_PHOTO_OPERATION_COUNT,
     MAX_PHOTOS_PER_OPERATION,
@@ -30,6 +31,23 @@ test('recognizes the raised-bed photo operation label consistently', () => {
         true,
     );
     assert.equal(isRaisedBedPhotoOperationLabel('Zalijevanje gredice'), false);
+});
+
+test('recognizes the raised-bed photo operation by its stable name', () => {
+    assert.equal(
+        isRaisedBedPhotoOperationInformation(
+            { name: 'raisedBedFullPhoto' },
+            'raisedBedFullPhoto',
+        ),
+        true,
+    );
+    assert.equal(
+        isRaisedBedPhotoOperationInformation(
+            { name: 'renamedOperation' },
+            'raisedBedFullPhoto',
+        ),
+        false,
+    );
 });
 
 test('groups supported filename variants by the scheduled physical identifier', () => {


### PR DESCRIPTION
## Summary

- match scheduled raised-bed photo operations by the exported stable technical name
- retain the Croatian display-label fallback for existing operation data
- add regression coverage for missing or renamed display labels

Follow-up to #4416 and the post-merge review finding in discussion_r3728094172.

## Validation

- `npm run test:unit` — 172 passed
- focused bulk photo model test — 7 passed
- targeted Biome check — passed
- `git diff --check` — passed
- full app TypeScript check still reports unrelated existing diagnostics; none reference these changed files