### PR TITLE
feat(www): replace neighbor IDs with plant picker

### DIFF
--- a/apps/www/components/community-edits/CommunityEditButton.tsx
+++ b/apps/www/components/community-edits/CommunityEditButton.tsx
@@ -32,6 +32,7 @@ import dynamic from 'next/dynamic';
 import { type ReactNode, useEffect, useId, useMemo, useState } from 'react';
 import { useCurrentUser } from '../../hooks/useCurrentUser';
 import { InlineLoginDialog } from '../auth/InlineLoginDialog';
+import { PlantReferencePicker } from './PlantReferencePicker';
 
 const CommunityMarkdownInput = dynamic(
     () =>
@@ -1079,6 +1080,20 @@ function FieldInput({
     }
 
     if (field.controlType === 'reference' && field.multiple) {
+        if (field.dataType === 'ref:plant' && field.options) {
+            return (
+                <PlantReferencePicker
+                    id={id}
+                    label={field.publicLabel}
+                    onValueChange={(values) => onChange(values.join('\n'))}
+                    options={field.options}
+                    selectedValues={referenceListFromText(
+                        typeof value === 'string' ? value : '',
+                    )}
+                />
+            );
+        }
+
         return (
             <textarea
                 className={cx(textareaControlClassName, 'min-h-24')}

--- a/apps/www/components/community-edits/PlantReferencePicker.tsx
+++ b/apps/www/components/community-edits/PlantReferencePicker.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { Chip } from '@gredice/ui/Chip';
+import { Close } from '@gredice/ui/icons';
+import { SelectItems } from '@gredice/ui/SelectItems';
+import { Typography } from '@gredice/ui/Typography';
+import { useMemo } from 'react';
+
+type PlantReferenceOption = {
+    value: string;
+    label: string;
+};
+
+export function PlantReferencePicker({
+    id,
+    label,
+    onValueChange,
+    options,
+    selectedValues,
+}: {
+    id: string;
+    label: string;
+    onValueChange: (values: string[]) => void;
+    options: PlantReferenceOption[];
+    selectedValues: string[];
+}) {
+    const optionByValue = useMemo(
+        () => new Map(options.map((option) => [option.value, option])),
+        [options],
+    );
+    const selectedValueSet = useMemo(
+        () => new Set(selectedValues),
+        [selectedValues],
+    );
+    const availableOptions = options.filter(
+        (option) => !selectedValueSet.has(option.value),
+    );
+    const selectedOptions = selectedValues.map(
+        (value) =>
+            optionByValue.get(value) ?? {
+                value,
+                label: `Biljka ${value}`,
+            },
+    );
+
+    return (
+        <div className="space-y-3">
+            <SelectItems
+                disabled={availableOptions.length === 0}
+                emptySearchText="Nema biljaka za taj pojam."
+                id={id}
+                items={availableOptions}
+                onValueChange={(value) => {
+                    if (value) {
+                        onValueChange([...selectedValues, value]);
+                    }
+                }}
+                placeholder={
+                    availableOptions.length > 0
+                        ? `Dodaj biljku — ${label}`
+                        : 'Nema više dostupnih biljaka'
+                }
+                searchable
+                searchPlaceholder="Pretraži biljke..."
+                value=""
+            />
+            <fieldset className="flex min-h-9 flex-wrap items-center gap-2">
+                <legend className="sr-only">Odabrane biljke — {label}</legend>
+                {selectedOptions.length > 0 ? (
+                    selectedOptions.map((option) => (
+                        <Chip
+                            aria-label={`Ukloni biljku ${option.label}`}
+                            key={option.value}
+                            onClick={() =>
+                                onValueChange(
+                                    selectedValues.filter(
+                                        (value) => value !== option.value,
+                                    ),
+                                )
+                            }
+                            size="sm"
+                            variant="soft"
+                        >
+                            <span className="max-w-52 truncate">
+                                {option.label}
+                            </span>
+                            <Close aria-hidden className="size-3" />
+                        </Chip>
+                    ))
+                ) : (
+                    <Typography level="body3" className="text-muted-foreground">
+                        Nema odabranih biljaka.
+                    </Typography>
+                )}
+            </fieldset>
+        </div>
+    );
+}

--- a/apps/www/tests/community-edit-button.spec.tsx
+++ b/apps/www/tests/community-edit-button.spec.tsx
@@ -287,8 +287,13 @@ test('submits multiple reference edits for plant relationships', async ({
                             controlType: 'reference',
                             multiple: true,
                             publicLabel: 'Dobri susjedi',
-                            helpText:
-                                'ID-jeve biljaka unesi odvojene zarezom ili svaki u novi red.',
+                            helpText: 'Odaberi jednu ili više biljaka.',
+                            options: [
+                                { value: '12', label: 'Bosiljak' },
+                                { value: '34', label: 'Kadifica' },
+                                { value: '56', label: 'Mrkva' },
+                                { value: '78', label: 'Krumpir' },
+                            ],
                             currentValue: JSON.stringify(['12', '34']),
                             baseValueHash: 'hash-companions',
                         },
@@ -304,6 +309,13 @@ test('submits multiple reference edits for plant relationships', async ({
                             controlType: 'reference',
                             multiple: true,
                             publicLabel: 'Izbjegavati blizinu',
+                            helpText: 'Odaberi jednu ili više biljaka.',
+                            options: [
+                                { value: '12', label: 'Bosiljak' },
+                                { value: '34', label: 'Kadifica' },
+                                { value: '56', label: 'Mrkva' },
+                                { value: '78', label: 'Krumpir' },
+                            ],
                             currentValue: '[]',
                             baseValueHash: 'hash-antagonists',
                         },
@@ -356,10 +368,26 @@ test('submits multiple reference edits for plant relationships', async ({
     );
 
     await page.getByTitle('Predloži izmjenu').click();
-    await expect(page.getByLabel('Dobri susjedi')).toHaveValue('12\n34');
+    await expect(
+        page.getByRole('button', { name: 'Ukloni biljku Bosiljak' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Ukloni biljku Kadifica' }),
+    ).toBeVisible();
 
-    await page.getByLabel('Dobri susjedi').fill('12\n34\n56');
-    await page.getByLabel('Izbjegavati blizinu').fill('78');
+    await page
+        .getByRole('combobox', { name: 'Dodaj biljku — Dobri susjedi' })
+        .click();
+    await page.getByPlaceholder('Pretraži biljke...').fill('mrk');
+    await page.getByRole('option', { name: 'Mrkva' }).click();
+
+    await page
+        .getByRole('combobox', {
+            name: 'Dodaj biljku — Izbjegavati blizinu',
+        })
+        .click();
+    await page.getByPlaceholder('Pretraži biljke...').fill('krump');
+    await page.getByRole('option', { name: 'Krumpir' }).click();
     await page.getByRole('button', { name: 'Pošalji' }).click();
 
     await expect(

--- a/packages/storage/src/helpers/communityEditableFields.ts
+++ b/packages/storage/src/helpers/communityEditableFields.ts
@@ -105,15 +105,13 @@ const communityEditablePlantRelationshipFields: CommunityEditableFieldDefinition
             fieldKey: 'plant.relationships.companions',
             name: plantRelationshipAttributeNames.companions,
             publicLabel: 'Dobri susjedi',
-            helpText:
-                'ID-jeve biljaka unesi odvojene zarezom ili svaki u novi red.',
+            helpText: 'Odaberi jednu ili više biljaka.',
         },
         {
             fieldKey: 'plant.relationships.antagonists',
             name: plantRelationshipAttributeNames.antagonists,
             publicLabel: 'Izbjegavati blizinu',
-            helpText:
-                'ID-jeve biljaka unesi odvojene zarezom ili svaki u novi red.',
+            helpText: 'Odaberi jednu ili više biljaka.',
         },
     ].map((field) => ({
         entityTypeName: 'plant',
@@ -131,15 +129,13 @@ const communityEditablePlantSortRelationshipFields: CommunityEditableFieldDefini
             fieldKey: 'plant-sort.relationships.companions',
             name: plantRelationshipAttributeNames.companions,
             publicLabel: 'Dobri susjedi sorte',
-            helpText:
-                'ID-jeve biljaka unesi odvojene zarezom ili svaki u novi red.',
+            helpText: 'Odaberi jednu ili više biljaka.',
         },
         {
             fieldKey: 'plant-sort.relationships.antagonists',
             name: plantRelationshipAttributeNames.antagonists,
             publicLabel: 'Izbjegavati blizinu sorte',
-            helpText:
-                'ID-jeve biljaka unesi odvojene zarezom ili svaki u novi red.',
+            helpText: 'Odaberi jednu ili više biljaka.',
         },
     ].map((field) => ({
         entityTypeName: 'plantSort',

--- a/packages/storage/src/repositories/communityEditRequestsRepo.ts
+++ b/packages/storage/src/repositories/communityEditRequestsRepo.ts
@@ -470,18 +470,79 @@ async function operationSuggestionOptions(
         .sort((left, right) => left.label.localeCompare(right.label, 'hr'));
 }
 
+type CommunityEditableFieldOptions = NonNullable<
+    CommunityEditableFieldDefinition['options']
+>;
+
+function referenceEntityType(dataType: string) {
+    return dataType.startsWith('ref:') ? dataType.slice('ref:'.length) : null;
+}
+
+async function multipleReferenceOptions(
+    snapshot: CommunityEditableFieldSnapshot,
+    sourceEntity: EntityRaw,
+    optionsByEntityType: Map<string, Promise<CommunityEditableFieldOptions>>,
+) {
+    if (snapshot.controlType !== 'reference' || !snapshot.multiple) {
+        return snapshot.options;
+    }
+
+    const targetEntityType = referenceEntityType(snapshot.dataType);
+    if (!targetEntityType) {
+        return snapshot.options;
+    }
+
+    let options = optionsByEntityType.get(targetEntityType);
+    if (!options) {
+        options = getEntitiesRaw(targetEntityType, 'published').then(
+            (entities) =>
+                entities
+                    .filter(
+                        (entity) =>
+                            entity.entityTypeName === targetEntityType &&
+                            !(
+                                sourceEntity.entityTypeName ===
+                                    targetEntityType &&
+                                sourceEntity.id === entity.id
+                            ),
+                    )
+                    .map((entity) => ({
+                        value: String(entity.id),
+                        label: entityLabel(entity),
+                    }))
+                    .sort((left, right) =>
+                        left.label.localeCompare(right.label, 'hr'),
+                    ),
+        );
+        optionsByEntityType.set(targetEntityType, options);
+    }
+
+    return options;
+}
+
 async function resolveFieldSnapshotForResponse(
     entity: EntityRaw,
     field: CommunityEditableFieldDefinition,
-) {
+    referenceOptionsByEntityType: Map<
+        string,
+        Promise<CommunityEditableFieldOptions>
+    >,
+): Promise<CommunityEditableFieldSnapshot> {
     const snapshot = resolveFieldSnapshot(entity, field);
-    if (field.controlType !== 'operationSuggestion') {
-        return snapshot;
+    if (field.controlType === 'operationSuggestion') {
+        return {
+            ...snapshot,
+            options: await operationSuggestionOptions(field),
+        };
     }
 
     return {
         ...snapshot,
-        options: await operationSuggestionOptions(field),
+        options: await multipleReferenceOptions(
+            snapshot,
+            entity,
+            referenceOptionsByEntityType,
+        ),
     };
 }
 
@@ -494,6 +555,10 @@ export async function getCommunityEditableFieldsForEntity(input: {
         input.entityTypeName,
         input.entityId,
     );
+    const referenceOptionsByEntityType = new Map<
+        string,
+        Promise<CommunityEditableFieldOptions>
+    >();
 
     const fields = await Promise.all(
         getCommunityEditableFieldDefinitions(
@@ -501,7 +566,11 @@ export async function getCommunityEditableFieldsForEntity(input: {
             input.sectionKey,
         ).map(async (field) => {
             try {
-                return await resolveFieldSnapshotForResponse(entity, field);
+                return await resolveFieldSnapshotForResponse(
+                    entity,
+                    field,
+                    referenceOptionsByEntityType,
+                );
             } catch (error) {
                 if (error instanceof CommunityEditRequestError) {
                     return null;

--- a/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
@@ -664,13 +664,24 @@ test('community editable registry resolves allowed plant and operation fields', 
         entityId: relationshipPlantId,
         sectionKey: 'relationships',
     });
+    const companionsField = relationshipFields.find(
+        (field) => field.fieldKey === 'plant.relationships.companions',
+    );
+    assert.ok(companionsField);
+    assert.equal(companionsField.controlType, 'reference');
+    assert.ok(companionsField.multiple);
+    assert.equal(
+        companionsField.currentValue,
+        JSON.stringify([String(companionId)]),
+    );
     assert.ok(
-        relationshipFields.some(
-            (field) =>
-                field.fieldKey === 'plant.relationships.companions' &&
-                field.controlType === 'reference' &&
-                field.multiple &&
-                field.currentValue === JSON.stringify([String(companionId)]),
+        companionsField.options?.some(
+            (option) => option.value === String(companionId),
+        ),
+    );
+    assert.ok(
+        !companionsField.options?.some(
+            (option) => option.value === String(relationshipPlantId),
         ),
     );
     assert.ok(


### PR DESCRIPTION
## What changed

- replace raw plant-ID textareas in community relationship edits with searchable plant pickers
- show current selections as removable named chips and exclude the plant being edited from its own options
- populate reference options from published directory entities while preserving the existing ID-array moderation payload
- update Croatian helper copy and add repository/component coverage

## Why

People suggesting good or bad plant neighbours currently need to discover and enter internal numeric IDs. The relationship metadata already identifies these as plant references, so the edit form can present published plant names instead.

## Impact

Authenticated contributors can search and select plants by name for both good-neighbour and avoid-nearby proposals. Existing moderation and storage contracts remain unchanged.

## Validation

- `pnpm lint --filter www --filter @gredice/storage`
- `pnpm typecheck --filter www --filter @gredice/storage`
- `pnpm build --filter www`
- `pnpm --filter www exec playwright test tests/community-edit-button.spec.tsx --project=chromium` (10 passed)
- `pnpm --filter @gredice/storage test -- communityEditRequestsRepo.node.spec.ts` (16 passed)