### PR TITLE
feat(www): add catalogue creation suggestions

### DIFF
--- a/apps/api/app/api/[...route]/directoriesRoutes.ts
+++ b/apps/api/app/api/[...route]/directoriesRoutes.ts
@@ -1,6 +1,7 @@
 import {
     CommunityEditRequestError,
     createCommunityEditRequest,
+    createCommunityEntitySuggestion,
     type EntityStandardized,
     getCmsPageBySlug,
     getCmsPages,
@@ -45,6 +46,33 @@ function cmsPagePreviewSecret(requestUrl: string) {
 }
 
 const communityEditSubmittedValueSchema = z.unknown();
+const communityEntitySuggestionSchema = z.discriminatedUnion('kind', [
+    z.object({
+        kind: z.literal('plantSort'),
+        parentPlantId: z.number().int().positive(),
+        name: z.string().trim().min(1).max(200),
+        description: z.string().trim().min(1).max(2000),
+        source: z.string().max(500).nullable().optional(),
+        note: z.string().max(1000).nullable().optional(),
+        publicPath: z.string().min(1).max(500),
+    }),
+    z.object({
+        kind: z.literal('operation'),
+        plantStageId: z.number().int().positive(),
+        application: z.enum([
+            'farm',
+            'garden',
+            'plant',
+            'raisedBed1m',
+            'raisedBedFull',
+        ]),
+        name: z.string().trim().min(1).max(200),
+        description: z.string().trim().min(1).max(2000),
+        source: z.string().max(500).nullable().optional(),
+        note: z.string().max(1000).nullable().optional(),
+        publicPath: z.string().min(1).max(500),
+    }),
+]);
 
 function communityEditErrorResponse(error: CommunityEditRequestError) {
     const status: 400 | 409 = error.code === 'conflict' ? 409 : 400;
@@ -302,6 +330,50 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     sectionKey: sectionKey ?? null,
                     fields,
                 });
+            } catch (error) {
+                if (error instanceof CommunityEditRequestError) {
+                    const response = communityEditErrorResponse(error);
+                    return context.json(response.body, response.status);
+                }
+                throw error;
+            }
+        },
+    )
+    .post(
+        '/community-edits/entity-suggestions',
+        describeRoute({
+            description:
+                'Submit a pending suggestion for a new plant sort or operation. No directory entity is created or published by this endpoint.',
+            security: authSecurity,
+        }),
+        authValidator(['user', 'admin']),
+        zValidator('json', communityEntitySuggestionSchema),
+        async (context) => {
+            const authContext = context.get('authContext');
+            const user = await getUser(authContext.userId);
+            const body = context.req.valid('json');
+
+            try {
+                const request = await createCommunityEntitySuggestion({
+                    ...body,
+                    submitter: {
+                        id: authContext.userId,
+                        name:
+                            user?.displayName ??
+                            user?.userName ??
+                            authContext.userId,
+                    },
+                });
+
+                return context.json(
+                    {
+                        status: 'pending_admin_approval',
+                        requestId: request.id,
+                        requestStatus: request.status,
+                        suggestionKind: body.kind,
+                    },
+                    { status: 201 },
+                );
             } catch (error) {
                 if (error instanceof CommunityEditRequestError) {
                     const response = communityEditErrorResponse(error);

--- a/apps/app/app/admin/community-edits/[requestId]/page.tsx
+++ b/apps/app/app/admin/community-edits/[requestId]/page.tsx
@@ -2,7 +2,7 @@ import {
     type CommunityEditRequestStatus,
     type CommunityEntitySuggestionValue,
     getCommunityEditRequest,
-    parseCommunityEntitySuggestion,
+    parseCommunityEntitySuggestionRequest,
 } from '@gredice/storage';
 import { Button } from '@gredice/ui/Button';
 import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
@@ -591,9 +591,7 @@ export default async function CommunityEditDetailPage({
     if (!request) {
         notFound();
     }
-    const entitySuggestion = parseCommunityEntitySuggestion(
-        request.submitterNote,
-    );
+    const entitySuggestion = parseCommunityEntitySuggestionRequest(request);
 
     return (
         <Stack spacing={4}>

--- a/apps/app/app/admin/community-edits/[requestId]/page.tsx
+++ b/apps/app/app/admin/community-edits/[requestId]/page.tsx
@@ -1,6 +1,8 @@
 import {
     type CommunityEditRequestStatus,
+    type CommunityEntitySuggestionValue,
     getCommunityEditRequest,
+    parseCommunityEntitySuggestion,
 } from '@gredice/storage';
 import { Button } from '@gredice/ui/Button';
 import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
@@ -340,6 +342,96 @@ function OperationSuggestionBlock({
     );
 }
 
+function operationApplicationLabel(
+    application: Extract<
+        CommunityEntitySuggestionValue,
+        { kind: 'operation' }
+    >['application'],
+) {
+    switch (application) {
+        case 'plant':
+            return 'Biljka';
+        case 'raisedBedFull':
+            return 'Cijela gredica';
+        case 'raisedBed1m':
+            return 'Gredica 1 m²';
+        case 'garden':
+            return 'Vrt';
+        case 'farm':
+            return 'Farma';
+    }
+}
+
+function EntitySuggestionBlock({
+    suggestion,
+}: {
+    suggestion: CommunityEntitySuggestionValue;
+}) {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="text-lg">
+                    {suggestion.kind === 'plantSort'
+                        ? 'Nova sorta biljke'
+                        : 'Nova radnja'}
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                <Stack spacing={4}>
+                    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+                        <DetailItem label="Naziv">
+                            <Typography>{suggestion.name}</Typography>
+                        </DetailItem>
+                        {suggestion.kind === 'plantSort' ? (
+                            <DetailItem label="Biljka">
+                                <Typography>
+                                    {suggestion.parentPlantName} #
+                                    {suggestion.parentPlantId}
+                                </Typography>
+                            </DetailItem>
+                        ) : (
+                            <>
+                                <DetailItem label="Stadij">
+                                    <Typography>
+                                        {suggestion.stageLabel} #
+                                        {suggestion.plantStageId}
+                                    </Typography>
+                                </DetailItem>
+                                <DetailItem label="Primjena">
+                                    <Typography>
+                                        {operationApplicationLabel(
+                                            suggestion.application,
+                                        )}
+                                    </Typography>
+                                </DetailItem>
+                            </>
+                        )}
+                    </div>
+                    <DetailItem label="Opis prijedloga">
+                        <Typography className="whitespace-pre-line break-words">
+                            {suggestion.description}
+                        </Typography>
+                    </DetailItem>
+                    {suggestion.source ? (
+                        <DetailItem label="Izvor">
+                            <Typography className="whitespace-pre-line break-words">
+                                {suggestion.source}
+                            </Typography>
+                        </DetailItem>
+                    ) : null}
+                    {suggestion.note ? (
+                        <DetailItem label="Napomena pošiljatelja">
+                            <Typography className="whitespace-pre-line break-words">
+                                {suggestion.note}
+                            </Typography>
+                        </DetailItem>
+                    ) : null}
+                </Stack>
+            </CardContent>
+        </Card>
+    );
+}
+
 function DiffBlock({ change }: { change: CommunityEditChange }) {
     const diff = parseCompactTextDiff(change.reviewDiff);
     if (!diff) {
@@ -426,7 +518,13 @@ function ReviewNote() {
     );
 }
 
-function ReviewActions({ request }: { request: CommunityEditRequest }) {
+function ReviewActions({
+    isEntitySuggestion,
+    request,
+}: {
+    isEntitySuggestion: boolean;
+    request: CommunityEditRequest;
+}) {
     const canReview =
         request.status === 'pending' || request.status === 'approved';
     if (!canReview) {
@@ -448,7 +546,9 @@ function ReviewActions({ request }: { request: CommunityEditRequest }) {
             >
                 <ReviewNote />
                 <Button color="success" type="submit">
-                    Odobri i primijeni
+                    {isEntitySuggestion
+                        ? 'Označi obrađenim'
+                        : 'Odobri i primijeni'}
                 </Button>
             </form>
             <form
@@ -491,6 +591,9 @@ export default async function CommunityEditDetailPage({
     if (!request) {
         notFound();
     }
+    const entitySuggestion = parseCommunityEntitySuggestion(
+        request.submitterNote,
+    );
 
     return (
         <Stack spacing={4}>
@@ -512,20 +615,27 @@ export default async function CommunityEditDetailPage({
             <Card>
                 <CardHeader>
                     <CardTitle>
-                        {entityTypeLabel(request.entityTypeName)} #
-                        {request.entityId}
+                        {entitySuggestion
+                            ? `Prijedlog nove ${entitySuggestion.kind === 'plantSort' ? 'sorte' : 'radnje'}`
+                            : `${entityTypeLabel(request.entityTypeName)} #${request.entityId}`}
                     </CardTitle>
                 </CardHeader>
                 <CardContent>
                     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-                        <DetailItem label="Admin zapis">
+                        <DetailItem
+                            label={
+                                entitySuggestion ? 'Kontekst' : 'Admin zapis'
+                            }
+                        >
                             <Link
                                 href={KnownPages.DirectoryEntity(
                                     request.entityTypeName,
                                     request.entityId,
                                 )}
                             >
-                                Otvori zapis
+                                {entitySuggestion
+                                    ? 'Otvori kontekst'
+                                    : 'Otvori zapis'}
                             </Link>
                         </DetailItem>
                         <DetailItem label="Javna stranica">
@@ -541,7 +651,12 @@ export default async function CommunityEditDetailPage({
                         </DetailItem>
                         <DetailItem label="Sekcija">
                             <Typography>
-                                {request.sectionKey ?? 'Cijela stranica'}
+                                {entitySuggestion?.kind === 'plantSort'
+                                    ? 'Nova sorta'
+                                    : entitySuggestion?.kind === 'operation'
+                                      ? 'Nova radnja'
+                                      : (request.sectionKey ??
+                                        'Cijela stranica')}
                             </Typography>
                         </DetailItem>
                         <DetailItem label="Kreirano">
@@ -595,7 +710,7 @@ export default async function CommunityEditDetailPage({
                             )}
                         </DetailItem>
                     </div>
-                    {request.submitterNote ? (
+                    {request.submitterNote && !entitySuggestion ? (
                         <Stack spacing={1} className="mt-4">
                             <Typography
                                 level="body2"
@@ -630,37 +745,50 @@ export default async function CommunityEditDetailPage({
                 </CardContent>
             </Card>
 
-            <Stack spacing={3}>
-                <Typography level="h2" className="text-xl">
-                    Promjene
-                </Typography>
-                {request.changes.map((change) => (
-                    <Card key={change.id}>
-                        <CardHeader>
-                            <CardTitle className="text-lg">
-                                {change.attributeDefinition.label ??
-                                    change.fieldKey}
-                            </CardTitle>
-                            <Typography
-                                level="body3"
-                                className="text-muted-foreground"
-                            >
-                                {change.attributePath} · {change.dataType}
-                            </Typography>
-                        </CardHeader>
-                        <CardContent>
-                            <ChangeBody change={change} />
-                        </CardContent>
-                    </Card>
-                ))}
-            </Stack>
+            {entitySuggestion ? (
+                <Stack spacing={3}>
+                    <EntitySuggestionBlock suggestion={entitySuggestion} />
+                    <Typography level="body2" className="text-muted-foreground">
+                        Nakon provjere izradi novi zapis u katalogu, a zatim
+                        označi ovaj prijedlog obrađenim.
+                    </Typography>
+                </Stack>
+            ) : (
+                <Stack spacing={3}>
+                    <Typography level="h2" className="text-xl">
+                        Promjene
+                    </Typography>
+                    {request.changes.map((change) => (
+                        <Card key={change.id}>
+                            <CardHeader>
+                                <CardTitle className="text-lg">
+                                    {change.attributeDefinition.label ??
+                                        change.fieldKey}
+                                </CardTitle>
+                                <Typography
+                                    level="body3"
+                                    className="text-muted-foreground"
+                                >
+                                    {change.attributePath} · {change.dataType}
+                                </Typography>
+                            </CardHeader>
+                            <CardContent>
+                                <ChangeBody change={change} />
+                            </CardContent>
+                        </Card>
+                    ))}
+                </Stack>
+            )}
 
             <Card>
                 <CardHeader>
                     <CardTitle>Moderiranje</CardTitle>
                 </CardHeader>
                 <CardContent>
-                    <ReviewActions request={request} />
+                    <ReviewActions
+                        isEntitySuggestion={Boolean(entitySuggestion)}
+                        request={request}
+                    />
                 </CardContent>
             </Card>
         </Stack>

--- a/apps/app/app/admin/community-edits/page.tsx
+++ b/apps/app/app/admin/community-edits/page.tsx
@@ -1,6 +1,7 @@
 import {
     type CommunityEditRequestStatus,
     listCommunityEditRequests,
+    parseCommunityEntitySuggestion,
 } from '@gredice/storage';
 import { Button } from '@gredice/ui/Button';
 import { Card, CardOverflow } from '@gredice/ui/Card';
@@ -152,6 +153,13 @@ function publicPageUrl(publicPath: string) {
     return `https://www.gredice.com${publicPath.startsWith('/') ? '' : '/'}${publicPath}`;
 }
 
+function requestTargetEntityType(request: CommunityEditRequestListItem) {
+    return (
+        parseCommunityEntitySuggestion(request.submitterNote)?.kind ??
+        request.entityTypeName
+    );
+}
+
 export default async function CommunityEditsPage({
     searchParams,
 }: {
@@ -180,7 +188,7 @@ export default async function CommunityEditsPage({
         (request) =>
             (selectedStatus === 'all' || request.status === selectedStatus) &&
             (selectedEntityType === 'all' ||
-                request.entityTypeName === selectedEntityType) &&
+                requestTargetEntityType(request) === selectedEntityType) &&
             requestMatchesAge(request, selectedAge) &&
             requestMatchesSubmitter(request, submitter, exactSubmitterIds),
     );
@@ -213,6 +221,10 @@ export default async function CommunityEditsPage({
                                             : null;
                                     const displayName =
                                         submitterDisplayName(request);
+                                    const entitySuggestion =
+                                        parseCommunityEntitySuggestion(
+                                            request.submitterNote,
+                                        );
 
                                     return (
                                         <li
@@ -234,17 +246,22 @@ export default async function CommunityEditsPage({
                                                             )}
                                                             className="block min-w-0 truncate text-sm font-medium text-primary underline-offset-4 hover:underline"
                                                         >
-                                                            {entityTypeLabel(
-                                                                request.entityTypeName,
-                                                            )}{' '}
-                                                            #{request.entityId}
+                                                            {entitySuggestion
+                                                                ? `Nova ${entitySuggestion.kind === 'plantSort' ? 'sorta' : 'radnja'}: ${entitySuggestion.name}`
+                                                                : `${entityTypeLabel(request.entityTypeName)} #${request.entityId}`}
                                                         </Link>
                                                         <Typography
                                                             level="body3"
                                                             className="text-muted-foreground"
                                                         >
-                                                            {request.sectionKey ??
-                                                                'Cijela stranica'}
+                                                            {entitySuggestion?.kind ===
+                                                            'plantSort'
+                                                                ? `Biljka: ${entitySuggestion.parentPlantName}`
+                                                                : entitySuggestion?.kind ===
+                                                                    'operation'
+                                                                  ? `Stadij: ${entitySuggestion.stageLabel}`
+                                                                  : (request.sectionKey ??
+                                                                    'Cijela stranica')}
                                                         </Typography>
                                                     </Stack>
                                                     <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
@@ -327,11 +344,9 @@ export default async function CommunityEditsPage({
                                                             size="sm"
                                                             variant="soft"
                                                         >
-                                                            {
-                                                                request.changes
-                                                                    .length
-                                                            }{' '}
-                                                            promjena
+                                                            {entitySuggestion
+                                                                ? 'Novi zapis'
+                                                                : `${request.changes.length} promjena`}
                                                         </Chip>
                                                     </div>
 
@@ -382,7 +397,9 @@ export default async function CommunityEditsPage({
                                                             size="xs"
                                                             variant="outlined"
                                                         >
-                                                            Admin zapis
+                                                            {entitySuggestion
+                                                                ? 'Kontekst'
+                                                                : 'Admin zapis'}
                                                         </Button>
                                                         <Button
                                                             endDecorator={

--- a/apps/app/app/admin/community-edits/page.tsx
+++ b/apps/app/app/admin/community-edits/page.tsx
@@ -1,7 +1,7 @@
 import {
     type CommunityEditRequestStatus,
     listCommunityEditRequests,
-    parseCommunityEntitySuggestion,
+    parseCommunityEntitySuggestionRequest,
 } from '@gredice/storage';
 import { Button } from '@gredice/ui/Button';
 import { Card, CardOverflow } from '@gredice/ui/Card';
@@ -155,7 +155,7 @@ function publicPageUrl(publicPath: string) {
 
 function requestTargetEntityType(request: CommunityEditRequestListItem) {
     return (
-        parseCommunityEntitySuggestion(request.submitterNote)?.kind ??
+        parseCommunityEntitySuggestionRequest(request)?.kind ??
         request.entityTypeName
     );
 }
@@ -222,8 +222,8 @@ export default async function CommunityEditsPage({
                                     const displayName =
                                         submitterDisplayName(request);
                                     const entitySuggestion =
-                                        parseCommunityEntitySuggestion(
-                                            request.submitterNote,
+                                        parseCommunityEntitySuggestionRequest(
+                                            request,
                                         );
 
                                     return (

--- a/apps/www/app/biljke/[alias]/PlantSortsList.tsx
+++ b/apps/www/app/biljke/[alias]/PlantSortsList.tsx
@@ -5,8 +5,36 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { Suspense } from 'react';
+import { CommunityEntitySuggestionButton } from '../../../components/community-edits/CommunityEntitySuggestionButton';
 import { getPlantSortsData } from '../../../lib/plants/getPlantSortsData';
 import { KnownPages } from '../../../src/KnownPages';
+
+function PlantSortsHeading({
+    basePlantId,
+    basePlantName,
+}: {
+    basePlantId: number;
+    basePlantName: string;
+}) {
+    return (
+        <Row
+            alignItems="center"
+            justifyContent="between"
+            spacing={3}
+            className="flex-wrap"
+        >
+            <Typography level="h2" className="text-2xl" id={slug('Sorte')}>
+                Sorte
+            </Typography>
+            <CommunityEntitySuggestionButton
+                kind="plantSort"
+                parentPlantId={basePlantId}
+                parentPlantName={basePlantName}
+                publicPath={KnownPages.Plant(basePlantName)}
+            />
+        </Row>
+    );
+}
 
 async function PlantSortsListContent({
     basePlantName,
@@ -24,9 +52,10 @@ async function PlantSortsListContent({
     if (!sorts.length) {
         return (
             <Stack spacing={4}>
-                <Typography level="h2" className="text-2xl" id={slug('Sorte')}>
-                    Sorte
-                </Typography>
+                <PlantSortsHeading
+                    basePlantId={basePlantId}
+                    basePlantName={basePlantName}
+                />
                 <Typography level="body2" className="text-gray-500 italic">
                     Nema dostupnih sorti
                 </Typography>
@@ -35,9 +64,10 @@ async function PlantSortsListContent({
     }
     return (
         <Stack spacing={4}>
-            <Typography level="h2" className="text-2xl" id={slug('Sorte')}>
-                Sorte
-            </Typography>
+            <PlantSortsHeading
+                basePlantId={basePlantId}
+                basePlantName={basePlantName}
+            />
             <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
                 {sorts.map((sort) => {
                     const isAvailable =

--- a/apps/www/app/radnje/page.tsx
+++ b/apps/www/app/radnje/page.tsx
@@ -1,9 +1,11 @@
+import { PLANT_STAGES } from '@gredice/js/plants';
 import { PageHeader } from '@gredice/ui/PageHeader';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
+import { CommunityEntitySuggestionButton } from '../../components/community-edits/CommunityEntitySuggestionButton';
 import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { PageFilterInput } from '../../components/shared/PageFilterInput';
 import { StructuredDataScript } from '../../components/shared/seo/StructuredDataScript';
@@ -39,6 +41,21 @@ export default async function OperationsPage({
         (operation) => operation.attributes.internal !== true,
     );
     const availableStages = getAvailableOperationStages(publicOperations);
+    const suggestionStages = PLANT_STAGES.flatMap((stageDefinition) => {
+        const stage = operationsData.find(
+            (operation) =>
+                operation.attributes.stage?.information?.name ===
+                stageDefinition.name,
+        )?.attributes.stage;
+        return stage
+            ? [
+                  {
+                      id: stage.id,
+                      label: stage.information.label,
+                  },
+              ]
+            : [];
+    });
     const orderedOperations = availableStages.flatMap((stage) =>
         publicOperations
             .filter(
@@ -87,14 +104,21 @@ export default async function OperationsPage({
                 }}
             />
             <PageHeader header="Radnje" subHeader={pageDescription} padded>
-                <Suspense>
-                    <PageFilterInput
-                        searchParamName="pretraga"
-                        fieldName="operation-search"
-                        initialValue={search}
-                        className="lg:flex items-start justify-end w-full"
+                <div className="flex w-full flex-col items-start gap-3 md:items-end">
+                    <CommunityEntitySuggestionButton
+                        kind="operation"
+                        publicPath={KnownPages.Operations}
+                        stages={suggestionStages}
                     />
-                </Suspense>
+                    <Suspense>
+                        <PageFilterInput
+                            searchParamName="pretraga"
+                            fieldName="operation-search"
+                            initialValue={search}
+                            className="lg:flex items-start justify-end w-full"
+                        />
+                    </Suspense>
+                </div>
             </PageHeader>
             <OperationsList
                 operationsData={operationsData}

--- a/apps/www/components/community-edits/CommunityEntitySuggestionButton.tsx
+++ b/apps/www/components/community-edits/CommunityEntitySuggestionButton.tsx
@@ -1,0 +1,488 @@
+'use client';
+
+import { clientAuthenticated } from '@gredice/client';
+import { Button } from '@gredice/ui/Button';
+import { Input } from '@gredice/ui/Input';
+import { Add, Check, Send } from '@gredice/ui/icons';
+import { Modal } from '@gredice/ui/Modal';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import { type FormEvent, useEffect, useId, useMemo, useState } from 'react';
+import { useCurrentUser } from '../../hooks/useCurrentUser';
+import { InlineLoginDialog } from '../auth/InlineLoginDialog';
+
+const communitySuggestionParam = 'communitySuggestion';
+const selectControlClassName =
+    'h-10 w-full rounded-md border border-border/80 bg-card px-3 text-sm text-foreground shadow-sm ring-offset-background transition-colors hover:border-primary/40 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-muted/70 disabled:text-muted-foreground';
+const textareaControlClassName =
+    'w-full rounded-md border border-border/80 bg-card px-3 py-2 text-sm text-foreground shadow-sm ring-offset-background transition-colors placeholder:text-muted-foreground/70 hover:border-primary/40 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-muted/70 disabled:text-muted-foreground';
+
+type OperationApplication =
+    | 'farm'
+    | 'garden'
+    | 'plant'
+    | 'raisedBed1m'
+    | 'raisedBedFull';
+
+export type CommunityOperationSuggestionStage = {
+    id: number;
+    label: string;
+};
+
+type CommonProps = {
+    className?: string;
+    publicPath: string;
+};
+
+export type CommunityEntitySuggestionButtonProps = CommonProps &
+    (
+        | {
+              kind: 'plantSort';
+              parentPlantId: number;
+              parentPlantName: string;
+          }
+        | {
+              kind: 'operation';
+              stages: CommunityOperationSuggestionStage[];
+          }
+    );
+
+const applicationOptions: {
+    value: OperationApplication;
+    label: string;
+}[] = [
+    { value: 'plant', label: 'Biljka' },
+    { value: 'raisedBedFull', label: 'Cijela gredica' },
+    { value: 'raisedBed1m', label: 'Gredica 1 m²' },
+    { value: 'garden', label: 'Vrt' },
+    { value: 'farm', label: 'Farma' },
+];
+
+function isOperationApplication(value: string): value is OperationApplication {
+    return applicationOptions.some((option) => option.value === value);
+}
+
+function errorMessage(value: unknown) {
+    if (
+        typeof value === 'object' &&
+        value !== null &&
+        'message' in value &&
+        typeof value.message === 'string'
+    ) {
+        return value.message;
+    }
+    if (value instanceof Error) {
+        return value.message;
+    }
+    return 'Slanje prijedloga nije uspjelo.';
+}
+
+function isSubmitResponse(value: unknown): value is { requestId: number } {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'requestId' in value &&
+        typeof value.requestId === 'number'
+    );
+}
+
+function suggestionReturnPath(contextKey: string, fallbackPath: string) {
+    const url =
+        typeof window === 'undefined'
+            ? new URL(fallbackPath, 'https://www.gredice.com')
+            : new URL(window.location.href);
+    url.searchParams.set(communitySuggestionParam, contextKey);
+    return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function consumeSuggestionReturn(contextKey: string) {
+    if (typeof window === 'undefined') {
+        return false;
+    }
+    const url = new URL(window.location.href);
+    if (url.searchParams.get(communitySuggestionParam) !== contextKey) {
+        return false;
+    }
+    url.searchParams.delete(communitySuggestionParam);
+    window.history.replaceState(
+        window.history.state,
+        '',
+        `${url.pathname}${url.search}${url.hash}`,
+    );
+    return true;
+}
+
+export function CommunityEntitySuggestionButton(
+    props: CommunityEntitySuggestionButtonProps,
+) {
+    const [open, setOpen] = useState(false);
+    const [loginOpen, setLoginOpen] = useState(false);
+    const [name, setName] = useState('');
+    const [description, setDescription] = useState('');
+    const [source, setSource] = useState('');
+    const [note, setNote] = useState('');
+    const [plantStageId, setPlantStageId] = useState('');
+    const [application, setApplication] =
+        useState<OperationApplication>('plant');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [successRequestId, setSuccessRequestId] = useState<number | null>(
+        null,
+    );
+    const fieldIdPrefix = useId();
+    const { data: user, isLoading: isLoadingUser } = useCurrentUser();
+    const contextKey =
+        props.kind === 'plantSort'
+            ? `plantSort:${props.parentPlantId}`
+            : 'operation';
+    const returnTo = useMemo(
+        () => suggestionReturnPath(contextKey, props.publicPath),
+        [contextKey, props.publicPath],
+    );
+
+    const labels =
+        props.kind === 'plantSort'
+            ? {
+                  trigger: 'Predloži novu sortu',
+                  title: 'Predloži novu sortu',
+                  name: 'Naziv sorte',
+                  description: 'Po čemu je sorta posebna?',
+              }
+            : {
+                  trigger: 'Predloži novu radnju',
+                  title: 'Predloži novu radnju',
+                  name: 'Naziv radnje',
+                  description: 'Što se radnjom radi?',
+              };
+
+    useEffect(() => {
+        if (consumeSuggestionReturn(contextKey)) {
+            setOpen(true);
+            setLoginOpen(false);
+        }
+    }, [contextKey]);
+
+    useEffect(() => {
+        if (!open) {
+            setLoginOpen(false);
+        }
+    }, [open]);
+
+    function resetForm() {
+        setName('');
+        setDescription('');
+        setSource('');
+        setNote('');
+        setPlantStageId('');
+        setApplication('plant');
+        setError(null);
+        setSuccessRequestId(null);
+    }
+
+    function handleOpenChange(nextOpen: boolean) {
+        if (nextOpen && successRequestId) {
+            resetForm();
+        }
+        setOpen(nextOpen);
+    }
+
+    async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        setError(null);
+        setIsSubmitting(true);
+
+        try {
+            const trimmedName = name.trim();
+            const trimmedDescription = description.trim();
+            if (!trimmedName || !trimmedDescription) {
+                throw new Error('Unesi naziv i opis prijedloga.');
+            }
+
+            const suggestions =
+                clientAuthenticated().api.directories['community-edits'][
+                    'entity-suggestions'
+                ];
+            const response =
+                props.kind === 'plantSort'
+                    ? await suggestions.$post({
+                          json: {
+                              kind: props.kind,
+                              parentPlantId: props.parentPlantId,
+                              name: trimmedName,
+                              description: trimmedDescription,
+                              source: source.trim() || null,
+                              note: note.trim() || null,
+                              publicPath: props.publicPath,
+                          },
+                      })
+                    : await suggestions.$post({
+                          json: {
+                              kind: props.kind,
+                              plantStageId: Number.parseInt(plantStageId, 10),
+                              application,
+                              name: trimmedName,
+                              description: trimmedDescription,
+                              source: source.trim() || null,
+                              note: note.trim() || null,
+                              publicPath: props.publicPath,
+                          },
+                      });
+
+            if (!response.ok) {
+                const body: unknown = await response.json().catch(() => null);
+                throw new Error(errorMessage(body));
+            }
+
+            const result: unknown = await response.json();
+            if (!isSubmitResponse(result)) {
+                throw new Error('Slanje prijedloga nije uspjelo.');
+            }
+            setSuccessRequestId(result.requestId);
+        } catch (submitError) {
+            setError(errorMessage(submitError));
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    return (
+        <Modal
+            className="max-w-2xl border-border/70 shadow-xl"
+            onOpenChange={handleOpenChange}
+            open={open}
+            title={labels.title}
+            trigger={
+                <Button
+                    className={props.className}
+                    size="sm"
+                    startDecorator={<Add className="size-4" />}
+                    type="button"
+                    variant="outlined"
+                >
+                    {labels.trigger}
+                </Button>
+            }
+        >
+            <Stack spacing={5}>
+                <Row spacing={2} className="items-start justify-between gap-4">
+                    <Stack spacing={1}>
+                        <Typography level="h3">{labels.title}</Typography>
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
+                            Prijedlog ide na administratorski pregled prije
+                            stvaranja novog zapisa.
+                        </Typography>
+                    </Stack>
+                    {successRequestId ? (
+                        <Check className="size-5 shrink-0 text-green-700" />
+                    ) : null}
+                </Row>
+
+                {isLoadingUser ? (
+                    <Typography level="body2">
+                        Provjeravam prijavu...
+                    </Typography>
+                ) : !user ? (
+                    <Stack
+                        spacing={3}
+                        className="rounded-lg border border-border/70 bg-muted/30 p-4"
+                    >
+                        <Typography level="body2">
+                            Za slanje prijedloga treba se prijaviti.
+                        </Typography>
+                        <Button
+                            onClick={() => setLoginOpen(true)}
+                            type="button"
+                            variant="outlined"
+                        >
+                            Prijavi se i nastavi
+                        </Button>
+                        <InlineLoginDialog
+                            description="Prijavi se za slanje prijedloga i nastavi ispunjavati obrazac."
+                            onAuthenticated={() => {
+                                setLoginOpen(false);
+                                setOpen(true);
+                            }}
+                            onOpenChange={setLoginOpen}
+                            open={loginOpen}
+                            returnTo={returnTo}
+                        />
+                    </Stack>
+                ) : successRequestId ? (
+                    <Stack
+                        spacing={2}
+                        className="rounded-lg border border-green-700/20 bg-green-700/10 p-4"
+                    >
+                        <Typography>
+                            Prijedlog #{successRequestId} je poslan na pregled.
+                        </Typography>
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
+                            Hvala ti. Novi zapis neće biti javno dostupan bez
+                            administratorske obrade i objave.
+                        </Typography>
+                    </Stack>
+                ) : (
+                    <form className="space-y-4" onSubmit={handleSubmit}>
+                        {props.kind === 'plantSort' ? (
+                            <Typography
+                                level="body2"
+                                className="rounded-lg border border-border/70 bg-muted/30 p-3"
+                            >
+                                Biljka: {props.parentPlantName}
+                            </Typography>
+                        ) : (
+                            <div className="grid gap-4 sm:grid-cols-2">
+                                <label
+                                    className="space-y-1"
+                                    htmlFor={`${fieldIdPrefix}-stage`}
+                                >
+                                    <Typography level="body2" semiBold>
+                                        Stadij biljke
+                                    </Typography>
+                                    <select
+                                        className={selectControlClassName}
+                                        id={`${fieldIdPrefix}-stage`}
+                                        onChange={(event) =>
+                                            setPlantStageId(
+                                                event.currentTarget.value,
+                                            )
+                                        }
+                                        required
+                                        value={plantStageId}
+                                    >
+                                        <option value="">Odaberi stadij</option>
+                                        {props.stages.map((stage) => (
+                                            <option
+                                                key={stage.id}
+                                                value={stage.id}
+                                            >
+                                                {stage.label}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </label>
+                                <label
+                                    className="space-y-1"
+                                    htmlFor={`${fieldIdPrefix}-application`}
+                                >
+                                    <Typography level="body2" semiBold>
+                                        Primjena
+                                    </Typography>
+                                    <select
+                                        className={selectControlClassName}
+                                        id={`${fieldIdPrefix}-application`}
+                                        onChange={(event) => {
+                                            const nextApplication =
+                                                event.currentTarget.value;
+                                            if (
+                                                isOperationApplication(
+                                                    nextApplication,
+                                                )
+                                            ) {
+                                                setApplication(nextApplication);
+                                            }
+                                        }}
+                                        value={application}
+                                    >
+                                        {applicationOptions.map((option) => (
+                                            <option
+                                                key={option.value}
+                                                value={option.value}
+                                            >
+                                                {option.label}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </label>
+                            </div>
+                        )}
+
+                        <Input
+                            fullWidth
+                            label={labels.name}
+                            maxLength={200}
+                            onChange={(event) =>
+                                setName(event.currentTarget.value)
+                            }
+                            required
+                            value={name}
+                        />
+                        <label
+                            className="space-y-1"
+                            htmlFor={`${fieldIdPrefix}-description`}
+                        >
+                            <Typography level="body2" semiBold>
+                                {labels.description}
+                            </Typography>
+                            <textarea
+                                className={cx(
+                                    textareaControlClassName,
+                                    'min-h-28',
+                                )}
+                                id={`${fieldIdPrefix}-description`}
+                                maxLength={2000}
+                                onChange={(event) =>
+                                    setDescription(event.currentTarget.value)
+                                }
+                                required
+                                value={description}
+                            />
+                        </label>
+                        <Input
+                            fullWidth
+                            label="Izvor ili poveznica (opcionalno)"
+                            maxLength={500}
+                            onChange={(event) =>
+                                setSource(event.currentTarget.value)
+                            }
+                            value={source}
+                        />
+                        <label
+                            className="space-y-1"
+                            htmlFor={`${fieldIdPrefix}-note`}
+                        >
+                            <Typography level="body2">
+                                Napomena za administratora (opcionalno)
+                            </Typography>
+                            <textarea
+                                className={cx(
+                                    textareaControlClassName,
+                                    'min-h-20',
+                                )}
+                                id={`${fieldIdPrefix}-note`}
+                                maxLength={1000}
+                                onChange={(event) =>
+                                    setNote(event.currentTarget.value)
+                                }
+                                value={note}
+                            />
+                        </label>
+
+                        {error ? (
+                            <Typography level="body2" className="text-red-700">
+                                {error}
+                            </Typography>
+                        ) : null}
+
+                        <Row justifyContent="end">
+                            <Button
+                                disabled={isSubmitting}
+                                endDecorator={<Send className="size-4" />}
+                                type="submit"
+                            >
+                                {isSubmitting ? 'Šaljem...' : 'Pošalji'}
+                            </Button>
+                        </Row>
+                    </form>
+                )}
+            </Stack>
+        </Modal>
+    );
+}

--- a/apps/www/tests/CommunityEntitySuggestionButtonHarness.tsx
+++ b/apps/www/tests/CommunityEntitySuggestionButtonHarness.tsx
@@ -1,0 +1,22 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from 'next-themes';
+import {
+    CommunityEntitySuggestionButton,
+    type CommunityEntitySuggestionButtonProps,
+} from '../components/community-edits/CommunityEntitySuggestionButton';
+
+export function CommunityEntitySuggestionButtonHarness(
+    props: CommunityEntitySuggestionButtonProps,
+) {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+
+    return (
+        <QueryClientProvider client={queryClient}>
+            <ThemeProvider attribute="class">
+                <CommunityEntitySuggestionButton {...props} />
+            </ThemeProvider>
+        </QueryClientProvider>
+    );
+}

--- a/apps/www/tests/community-entity-suggestion-button.spec.tsx
+++ b/apps/www/tests/community-entity-suggestion-button.spec.tsx
@@ -1,0 +1,146 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Page } from '@playwright/test';
+import { CommunityEntitySuggestionButtonHarness } from './CommunityEntitySuggestionButtonHarness';
+import '../app/globals.css';
+
+function mockAuthenticatedUser(page: Page) {
+    return page.route('**/api/gredice/api/auth/current-claims', (route) =>
+        route.fulfill({
+            status: 200,
+            json: {
+                id: 'user-1',
+                userName: 'ana',
+                displayName: 'Ana',
+                role: 'user',
+            },
+        }),
+    );
+}
+
+test('submits a new plant sort suggestion for the current plant', async ({
+    mount,
+    page,
+}) => {
+    await mockAuthenticatedUser(page);
+    let submittedBody: unknown;
+    await page.route(
+        '**/api/gredice/api/directories/community-edits/entity-suggestions',
+        async (route) => {
+            submittedBody = route.request().postDataJSON();
+            await route.fulfill({
+                status: 201,
+                json: { requestId: 42, status: 'pending_admin_approval' },
+            });
+        },
+    );
+
+    await mount(
+        <CommunityEntitySuggestionButtonHarness
+            kind="plantSort"
+            parentPlantId={7}
+            parentPlantName="Blitva"
+            publicPath="/biljke/blitva"
+        />,
+    );
+
+    await page.getByRole('button', { name: 'Predloži novu sortu' }).click();
+    await expect(page.getByText('Biljka: Blitva')).toBeVisible();
+    await page.getByLabel('Naziv sorte').fill('Blitva rubin');
+    await page
+        .getByLabel('Po čemu je sorta posebna?')
+        .fill('Sorta s izraženim crvenim peteljkama.');
+    await page
+        .getByLabel('Izvor ili poveznica (opcionalno)')
+        .fill('https://example.com/blitva-rubin');
+    await page.getByRole('button', { name: 'Pošalji' }).click();
+
+    await expect(page.getByText('Prijedlog #42 je poslan')).toBeVisible();
+    expect(submittedBody).toEqual({
+        kind: 'plantSort',
+        parentPlantId: 7,
+        name: 'Blitva rubin',
+        description: 'Sorta s izraženim crvenim peteljkama.',
+        source: 'https://example.com/blitva-rubin',
+        note: null,
+        publicPath: '/biljke/blitva',
+    });
+});
+
+test('submits a new operation with stage and application', async ({
+    mount,
+    page,
+}) => {
+    await mockAuthenticatedUser(page);
+    let submittedBody: unknown;
+    await page.route(
+        '**/api/gredice/api/directories/community-edits/entity-suggestions',
+        async (route) => {
+            submittedBody = route.request().postDataJSON();
+            await route.fulfill({
+                status: 201,
+                json: { requestId: 43, status: 'pending_admin_approval' },
+            });
+        },
+    );
+
+    await mount(
+        <CommunityEntitySuggestionButtonHarness
+            kind="operation"
+            publicPath="/radnje"
+            stages={[
+                { id: 10, label: 'Održavanje' },
+                { id: 11, label: 'Zalijevanje' },
+            ]}
+        />,
+    );
+
+    await page.getByRole('button', { name: 'Predloži novu radnju' }).click();
+    await page.getByLabel('Stadij biljke').selectOption('10');
+    await page.getByLabel('Primjena').selectOption('raisedBedFull');
+    await page.getByLabel('Naziv radnje').fill('Provjera drenaže');
+    await page
+        .getByLabel('Što se radnjom radi?')
+        .fill('Provjeriti odvodi li se višak vode iz cijele gredice.');
+    await page.getByRole('button', { name: 'Pošalji' }).click();
+
+    await expect(page.getByText('Prijedlog #43 je poslan')).toBeVisible();
+    expect(submittedBody).toEqual({
+        kind: 'operation',
+        plantStageId: 10,
+        application: 'raisedBedFull',
+        name: 'Provjera drenaže',
+        description: 'Provjeriti odvodi li se višak vode iz cijele gredice.',
+        source: null,
+        note: null,
+        publicPath: '/radnje',
+    });
+});
+
+test('requires sign-in before opening a suggestion form', async ({
+    mount,
+    page,
+}) => {
+    await page.route('**/api/gredice/api/auth/current-claims', (route) =>
+        route.fulfill({ status: 401, json: { error: 'Unauthorized' } }),
+    );
+    await page.route('**/api/gredice/api/auth/last-login', (route) =>
+        route.fulfill({ status: 200, json: { provider: null } }),
+    );
+
+    await mount(
+        <CommunityEntitySuggestionButtonHarness
+            kind="plantSort"
+            parentPlantId={7}
+            parentPlantName="Blitva"
+            publicPath="/biljke/blitva"
+        />,
+    );
+
+    await page.getByRole('button', { name: 'Predloži novu sortu' }).click();
+    await expect(
+        page.getByText('Za slanje prijedloga treba se prijaviti.'),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Prijavi se i nastavi' }),
+    ).toBeVisible();
+});

--- a/packages/storage/src/repositories/communityEditRequestsRepo.ts
+++ b/packages/storage/src/repositories/communityEditRequestsRepo.ts
@@ -336,6 +336,37 @@ export function parseCommunityEntitySuggestion(
     }
 }
 
+export function parseCommunityEntitySuggestionRequest(request: {
+    submitterNote: string | null;
+    sectionKey: string | null;
+    entityTypeName: string;
+    entityId: number;
+    changes: readonly unknown[];
+}): CommunityEntitySuggestionValue | null {
+    if (request.changes.length !== 0) {
+        return null;
+    }
+
+    const suggestion = parseCommunityEntitySuggestion(request.submitterNote);
+    if (!suggestion) {
+        return null;
+    }
+
+    if (suggestion.kind === 'plantSort') {
+        return request.sectionKey === 'new-plant-sort' &&
+            request.entityTypeName === 'plant' &&
+            request.entityId === suggestion.parentPlantId
+            ? suggestion
+            : null;
+    }
+
+    return request.sectionKey === 'new-operation' &&
+        request.entityTypeName === 'plantStage' &&
+        request.entityId === suggestion.plantStageId
+        ? suggestion
+        : null;
+}
+
 function isPlantStageName(value: unknown): value is PlantStageName {
     return typeof value === 'string' && value in PLANT_STAGE_LABELS;
 }

--- a/packages/storage/src/repositories/communityEditRequestsRepo.ts
+++ b/packages/storage/src/repositories/communityEditRequestsRepo.ts
@@ -129,6 +129,63 @@ export type CommunityOperationSuggestionValue =
           newOperationDescription: string;
       });
 
+export type CommunityEntitySuggestionValue =
+    | {
+          format: 'community-entity-suggestion-v1';
+          kind: 'plantSort';
+          name: string;
+          description: string;
+          parentPlantId: number;
+          parentPlantName: string;
+          note?: string;
+          source?: string;
+      }
+    | {
+          format: 'community-entity-suggestion-v1';
+          kind: 'operation';
+          name: string;
+          description: string;
+          application:
+              | 'farm'
+              | 'garden'
+              | 'plant'
+              | 'raisedBed1m'
+              | 'raisedBedFull';
+          plantStageId: number;
+          stageName: string;
+          stageLabel: string;
+          note?: string;
+          source?: string;
+      };
+
+export type CreateCommunityEntitySuggestionInput =
+    | {
+          kind: 'plantSort';
+          parentPlantId: number;
+          name: string;
+          description: string;
+          source?: string | null;
+          note?: string | null;
+          publicPath: string;
+          submitter: CommunityEditActor;
+      }
+    | {
+          kind: 'operation';
+          plantStageId: number;
+          application:
+              | 'farm'
+              | 'garden'
+              | 'plant'
+              | 'raisedBed1m'
+              | 'raisedBedFull';
+          name: string;
+          description: string;
+          source?: string | null;
+          note?: string | null;
+          publicPath: string;
+          submitter: CommunityEditActor;
+      };
+
 type ResolvedCommunityEditChange = {
     fieldKey: string;
     sectionKey: string;
@@ -179,6 +236,104 @@ function stableValueHash(value: string | null) {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null;
+}
+
+function isCommunitySuggestionApplication(
+    value: unknown,
+): value is Extract<
+    CommunityEntitySuggestionValue,
+    { kind: 'operation' }
+>['application'] {
+    return (
+        value === 'farm' ||
+        value === 'garden' ||
+        value === 'plant' ||
+        value === 'raisedBed1m' ||
+        value === 'raisedBedFull'
+    );
+}
+
+export function parseCommunityEntitySuggestion(
+    value: string | null,
+): CommunityEntitySuggestionValue | null {
+    if (!value) {
+        return null;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(value);
+        if (
+            !isRecord(parsed) ||
+            parsed.format !== 'community-entity-suggestion-v1' ||
+            typeof parsed.name !== 'string' ||
+            typeof parsed.description !== 'string' ||
+            ('note' in parsed &&
+                typeof parsed.note !== 'undefined' &&
+                typeof parsed.note !== 'string') ||
+            ('source' in parsed &&
+                typeof parsed.source !== 'undefined' &&
+                typeof parsed.source !== 'string')
+        ) {
+            return null;
+        }
+
+        if (parsed.kind === 'plantSort') {
+            if (
+                typeof parsed.parentPlantId !== 'number' ||
+                !Number.isInteger(parsed.parentPlantId) ||
+                typeof parsed.parentPlantName !== 'string'
+            ) {
+                return null;
+            }
+
+            const suggestion: CommunityEntitySuggestionValue = {
+                format: parsed.format,
+                kind: parsed.kind,
+                name: parsed.name,
+                description: parsed.description,
+                parentPlantId: parsed.parentPlantId,
+                parentPlantName: parsed.parentPlantName,
+            };
+            if (typeof parsed.note === 'string') {
+                suggestion.note = parsed.note;
+            }
+            if (typeof parsed.source === 'string') {
+                suggestion.source = parsed.source;
+            }
+            return suggestion;
+        }
+
+        if (
+            parsed.kind !== 'operation' ||
+            !isCommunitySuggestionApplication(parsed.application) ||
+            typeof parsed.plantStageId !== 'number' ||
+            !Number.isInteger(parsed.plantStageId) ||
+            typeof parsed.stageName !== 'string' ||
+            typeof parsed.stageLabel !== 'string'
+        ) {
+            return null;
+        }
+
+        const suggestion: CommunityEntitySuggestionValue = {
+            format: parsed.format,
+            kind: parsed.kind,
+            name: parsed.name,
+            description: parsed.description,
+            application: parsed.application,
+            plantStageId: parsed.plantStageId,
+            stageName: parsed.stageName,
+            stageLabel: parsed.stageLabel,
+        };
+        if (typeof parsed.note === 'string') {
+            suggestion.note = parsed.note;
+        }
+        if (typeof parsed.source === 'string') {
+            suggestion.source = parsed.source;
+        }
+        return suggestion;
+    } catch {
+        return null;
+    }
 }
 
 function isPlantStageName(value: unknown): value is PlantStageName {
@@ -1490,6 +1645,122 @@ export async function createCommunityEditRequest(
         throw new CommunityEditRequestError(
             'not_found',
             'Community edit request was created but could not be loaded.',
+        );
+    }
+    return request;
+}
+
+async function getPublishedSuggestionContext(
+    entityTypeName: 'plant' | 'plantStage',
+    entityId: number,
+) {
+    const entity = await getCommunityEditableEntity(entityTypeName, entityId);
+    if (entity.state !== 'published') {
+        throw new CommunityEditRequestError(
+            'invalid_value',
+            `Entity ${entityTypeName}#${entityId} is not published.`,
+        );
+    }
+    return entity;
+}
+
+export async function createCommunityEntitySuggestion(
+    input: CreateCommunityEntitySuggestionInput,
+) {
+    const name = normalizeRequiredSuggestionText(
+        input.name,
+        'Suggestion name',
+        200,
+    );
+    const description = normalizeRequiredSuggestionText(
+        input.description,
+        'Suggestion description',
+        2000,
+    );
+    const source = normalizeOptionalSuggestionText(input.source, 'Source', 500);
+    const note = normalizeOptionalSuggestionText(input.note, 'Note', 1000);
+    const publicPath = normalizeRequiredSuggestionText(
+        input.publicPath,
+        'Public path',
+        500,
+    );
+
+    let contextEntityTypeName: 'plant' | 'plantStage';
+    let contextEntityId: number;
+    let sectionKey: 'new-operation' | 'new-plant-sort';
+    let suggestion: CommunityEntitySuggestionValue;
+
+    if (input.kind === 'plantSort') {
+        const plant = await getPublishedSuggestionContext(
+            'plant',
+            input.parentPlantId,
+        );
+        contextEntityTypeName = 'plant';
+        contextEntityId = plant.id;
+        sectionKey = 'new-plant-sort';
+        suggestion = {
+            format: 'community-entity-suggestion-v1',
+            kind: input.kind,
+            name,
+            description,
+            parentPlantId: plant.id,
+            parentPlantName: entityLabel(plant),
+        };
+    } else {
+        if (!isCommunitySuggestionApplication(input.application)) {
+            throw new CommunityEditRequestError(
+                'invalid_value',
+                'Operation suggestion has an unsupported application.',
+            );
+        }
+        const plantStage = await getPublishedSuggestionContext(
+            'plantStage',
+            input.plantStageId,
+        );
+        contextEntityTypeName = 'plantStage';
+        contextEntityId = plantStage.id;
+        sectionKey = 'new-operation';
+        suggestion = {
+            format: 'community-entity-suggestion-v1',
+            kind: input.kind,
+            name,
+            description,
+            application: input.application,
+            plantStageId: plantStage.id,
+            stageName:
+                rawAttributeValue(plantStage, 'information', 'name') ??
+                String(plantStage.id),
+            stageLabel: entityLabel(plantStage),
+        };
+    }
+
+    if (note) {
+        suggestion.note = note;
+    }
+    if (source) {
+        suggestion.source = source;
+    }
+
+    const [createdRequest] = await storage()
+        .insert(communityEditRequests)
+        .values({
+            status: 'pending',
+            entityTypeName: contextEntityTypeName,
+            entityId: contextEntityId,
+            publicPath,
+            sectionKey,
+            submitterUserId: input.submitter.id,
+            submitterName: input.submitter.name,
+            submitterEmail: input.submitter.email,
+            submitterNote: JSON.stringify(suggestion),
+        })
+        .returning();
+
+    const request = await getCommunityEditRequest(createdRequest.id);
+    if (!request) {
+        throw new CommunityEditRequestError(
+            'not_found',
+            'Community entity suggestion was created but could not be loaded.',
         );
     }
     return request;

--- a/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
@@ -19,6 +19,7 @@ import {
     getEntityRaw,
     getEntityRevisions,
     parseCommunityEntitySuggestion,
+    parseCommunityEntitySuggestionRequest,
     rejectCommunityEditRequest,
     storage,
     updateEntity,
@@ -814,6 +815,23 @@ test('community entity suggestions store a reviewable new plant sort proposal', 
         note: 'Provjeriti dostupnost sjemena.',
         source: 'https://example.com/blitva-rubin',
     });
+    assert.equal(
+        parseCommunityEntitySuggestionRequest(request)?.kind,
+        'plantSort',
+    );
+
+    assert.equal(
+        parseCommunityEntitySuggestionRequest({
+            ...request,
+            sectionKey: 'overview',
+            changes: [
+                {
+                    fieldKey: 'plant.description',
+                },
+            ],
+        }),
+        null,
+    );
 
     const approved = await approveCommunityEditRequest({
         id: request.id,

--- a/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
@@ -9,6 +9,7 @@ import {
     createAccount,
     createAttributeDefinition,
     createCommunityEditRequest,
+    createCommunityEntitySuggestion,
     createEntity,
     getAccountAchievements,
     getCommunityEditableFieldsForEntity,
@@ -17,6 +18,7 @@ import {
     getEntityFormatted,
     getEntityRaw,
     getEntityRevisions,
+    parseCommunityEntitySuggestion,
     rejectCommunityEditRequest,
     storage,
     updateEntity,
@@ -780,6 +782,77 @@ test('community editable registry resolves allowed plant and operation fields', 
                 field.options?.some((option) => option.value === 'garden'),
         ),
     );
+});
+
+test('community entity suggestions store a reviewable new plant sort proposal', async () => {
+    const data = await fixture();
+    const plantId = await createPublishedPlant();
+
+    const request = await createCommunityEntitySuggestion({
+        kind: 'plantSort',
+        parentPlantId: plantId,
+        name: 'Blitva rubin',
+        description: 'Sorta s izraženim crvenim peteljkama.',
+        source: 'https://example.com/blitva-rubin',
+        note: 'Provjeriti dostupnost sjemena.',
+        publicPath: '/biljke/blitva',
+        submitter: { id: data.submitterId, name: 'Community Submitter' },
+    });
+
+    assert.equal(request.status, 'pending');
+    assert.equal(request.entityTypeName, 'plant');
+    assert.equal(request.entityId, plantId);
+    assert.equal(request.sectionKey, 'new-plant-sort');
+    assert.equal(request.changes.length, 0);
+    assert.deepEqual(parseCommunityEntitySuggestion(request.submitterNote), {
+        format: 'community-entity-suggestion-v1',
+        kind: 'plantSort',
+        name: 'Blitva rubin',
+        description: 'Sorta s izraženim crvenim peteljkama.',
+        parentPlantId: plantId,
+        parentPlantName: `Biljka ${plantId}`,
+        note: 'Provjeriti dostupnost sjemena.',
+        source: 'https://example.com/blitva-rubin',
+    });
+
+    const approved = await approveCommunityEditRequest({
+        id: request.id,
+        reviewer: { id: data.reviewerId, name: 'Community Reviewer' },
+    });
+    assert.equal(approved.status, 'applied');
+});
+
+test('community entity suggestions store operation context and application', async () => {
+    const data = await fixture();
+    const plantStageId = await createPublishedPlantStage({
+        name: 'maintenance',
+        label: 'Održavanje',
+    });
+
+    const request = await createCommunityEntitySuggestion({
+        kind: 'operation',
+        plantStageId,
+        application: 'raisedBedFull',
+        name: 'Provjera drenaže',
+        description: 'Provjeriti odvodi li se višak vode iz cijele gredice.',
+        publicPath: '/radnje',
+        submitter: { id: data.submitterId, name: 'Community Submitter' },
+    });
+
+    assert.equal(request.status, 'pending');
+    assert.equal(request.entityTypeName, 'plantStage');
+    assert.equal(request.entityId, plantStageId);
+    assert.equal(request.sectionKey, 'new-operation');
+    assert.deepEqual(parseCommunityEntitySuggestion(request.submitterNote), {
+        format: 'community-entity-suggestion-v1',
+        kind: 'operation',
+        name: 'Provjera drenaže',
+        description: 'Provjeriti odvodi li se višak vode iz cijele gredice.',
+        application: 'raisedBedFull',
+        plantStageId,
+        stageName: 'maintenance',
+        stageLabel: 'Održavanje',
+    });
 });
 
 test('community edit requests submit storage content and operation suggestions together', async () => {


### PR DESCRIPTION
## What changed

- add signed-in Croatian forms for suggesting a new plant sort from a plant page and a new operation from the operations catalogue
- validate suggestions against a published parent plant or lifecycle stage and store them as pending, versioned community-edit proposals
- show structured sort and operation proposals in the admin moderation queue, without auto-creating or publishing incomplete catalogue records
- add repository coverage and Chromium component tests for both submission flows and the anonymous sign-in gate

## Why

Users could suggest edits to existing catalogue records, but there was no clear public path for proposing an entirely new sort or operation.

## Impact

Community members can now submit complete, attributable proposals while administrators retain the existing review and publication boundary.

## Validation

- `pnpm lint --filter www --filter api --filter app --filter @gredice/storage`
- `pnpm typecheck --filter www --filter api --filter app --filter @gredice/storage`
- `pnpm --filter @gredice/storage test -- communityEditRequestsRepo.node.spec.ts` (18 passed)
- `pnpm --filter www exec playwright test tests/community-entity-suggestion-button.spec.tsx tests/community-edit-button.spec.tsx --project=chromium` (13 passed)
- `pnpm build --filter api`
- `pnpm build --filter www --filter app`