### PR TITLE
feat(skills): add plant and plant-sort population workflows

### DIFF
--- a/.agents/skills/gredice-populate-plant-sort/SKILL.md
+++ b/.agents/skills/gredice-populate-plant-sort/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: gredice-populate-plant-sort
+description: Create and fully populate brand-new Gredice plant-sort directory entities as unpublished Croatian drafts, including the published parent-plant reference, cultivar-specific sourced content, reproduction and store controls, and a realistic transparent produce-focused cover. Use when onboarding a new cultivar, hybrid, commercial line, bulb selection, or other plant sort before review and eventual publication. Route established-sort changes through supported community edits or the appropriate admin review workflow instead.
+---
+
+# Gredice Populate Plant Sort
+
+## Overview
+
+Build a complete, source-backed `plantSort` record that adds cultivar-specific value without copying the parent plant's generic content. Keep the result as a verifiable draft until publication is explicitly authorized.
+
+Read [plant-sort-field-checklist.md](references/plant-sort-field-checklist.md) in full before creating or populating a record.
+
+## Boundaries
+
+- Confirm a published parent `plant` exists. If the crop/species itself is missing, use `gredice-populate-plant` first.
+- Use this workflow only for a brand-new sort. Propose changes to an established sort through community edits where supported; use the appropriate reviewable admin workflow for unsupported core fields.
+- Confirm the target environment, host, and authenticated admin account before any mutation. Never infer that the currently open session is the intended production account.
+- Link the parent with `information.plant` (`ref:plant`). Never use `entities.parentId`; that field is only for same-entity-type hierarchy.
+- The admin reference picker exposes published plants. When a plant and its first sort are both new, complete and review the plant first; do not work around the draft-parent limitation unless the user explicitly authorizes a guarded repository-helper flow.
+- Create and populate through the authenticated admin directory workflow. Community edits cannot create a sort or set its parent, cover, store flag, reproduction type, or publication state.
+- Keep the new sort in `draft`. Publishing is a separate, explicit user decision after complete readback and preview.
+- Load active `plantSort` definitions at runtime and map them by `category.name`; never hardcode definition IDs.
+- Write Croatian copy, keep direct source URLs, and leave unsupported cultivar-level facts unset. Do not turn parent-species facts into apparently cultivar-specific claims.
+- Finish research and a locally validated cover before creating the entity. Identify unresolved commercial inputs first; proceed with an incomplete draft only when the user accepts those explicit blockers. If an earlier attempt left a partial draft, reuse and report that ID instead of creating another blank record.
+
+## Workflow
+
+1. **Resolve identity.** Establish the canonical marketed cultivar name, aliases, breeder/maintainer where known, cultivar-group or hybrid notation, exact parent plant, and reproduction type. Search both published and draft raw sort entities for case-, whitespace-, punctuation-, synonym-, vendor-spelling-, and slug-normalized collisions. Stop on an ambiguous near match rather than creating a probable duplicate. Keep aliases or breeder facts that lack a schema field in the source ledger and review handoff.
+2. **Research cultivar evidence.** Prefer variety registries, breeders, conservation bodies, extension services, trial results, and reputable seed suppliers. Separate stable cultivar traits from vendor marketing and region-dependent performance.
+3. **Inspect and preflight.** Load active definitions, required flags, visibility, data types, defaults, multiplicity, and reference targets. The runtime schema—not a remembered list—is the publication gate. Prepare the per-field source ledger, corroborate the exact produce phenotype where sources permit, generate and validate the local cover, and resolve or explicitly declare business blockers before mutation.
+4. **Create the draft.** Add one blank record in `/admin/directories/plantSort`, capture its ID, and immediately re-run the duplicate guard. If a collision appears, stop without populating or deleting the new draft, report its ID, and request explicit cleanup direction. Otherwise set the published parent through `information.plant`. If the parent is still a draft, stop at this boundary and report the dependency instead of linking the wrong plant. If an applicable field is hidden from the form, use an approved guarded server/repository path or report a blocker; do not confuse a formatted default with a persisted value.
+5. **Populate core controls.** Fill the exact name, concise Croatian short description, parent reference, `attributes.reproductionType` (`seed` or `bulb`), explicit `store.availableInStore`, and `image.cover`. Store availability is a commercial decision and must not be inferred from publication; if it is unresolved, leave the entity in draft and report the blocker rather than claiming completion. If reliable evidence does not fit the current reproduction enum, report a schema gap instead of forcing the closest value.
+6. **Add cultivar-specific content.** Fill Latin/cultivar notation, origin, full description, and only the lifecycle sections for which the sort differs meaningfully from its parent. Prefer concrete phenotype, growth habit, maturity, use, harvest cue, storage behavior, or resistance evidence. Leave generic parent guidance to the parent page.
+7. **Handle relationships conservatively.** Plant sorts inherit the parent plant's relationship baseline. Add a direct sort override only when reliable evidence shows a cultivar-specific difference; avoid duplicating inherited companions or antagonists.
+8. **Create the cover during preflight.** Load and follow the available image-generation skill (in Codex, `$imagegen`) to make a square, realistic, naturally imperfect image of the exact marketed produce phenotype. Emphasize the harvested product rather than the whole plant: fruit, root, bulb, head, flower head, pod, seed head, or harvested leaf bunch as appropriate. Use no text, labels, banners, logos, hands, packaging, props, soil bed, or CGI styling. Remove the background and export a transparent RGBA PNG.
+9. **Validate and upload the cover.** Run `node scripts/validate-directory-cover.mjs <cover.png>`, visually compare color/shape/size with the cultivar sources, then upload through `image.cover`, which attaches the returned URL immediately. Preserve the SHA-256. Fetch the CDN object with cache busting, validate the downloaded file again, and require matching content type, dimensions, alpha, and SHA-256 before accepting the attachment. If remote validation fails, clear `image.cover`, verify the raw value was removed, and report the orphaned CDN URL as a cleanup candidate. A guarded upload-only path may avoid immediate attachment, but use it only with explicit authority.
+10. **Verify and hand off.** Check raw values and the authenticated draft-formatted preview, parent linkage, required completeness, enum/control values, derived slug, absence of copied parent prose, cover URL/bytes/hash/alpha, `state = draft`, `publishedAt = null`, and absence from the public published collection. A public 404 is expected before publication. Preserve the source ledger in the durable task or review artifact and report the sort ID, state, parent ID, populated and intentionally empty fields, store decision, reproduction type, image evidence, named visual-review result, and unresolved items.
+11. **Publish only on request.** After explicit authorization, publish and verify the sort in the published list, `/biljke/{parentSlug}/sorte/{sortSlug}`, commerce/search surfaces when store-enabled, and the CDN. Account for public cache delay rather than treating it as a failed write.
+
+## Cover Prompt Template
+
+Use this base and add source-backed cultivar traits:
+
+> Realistic and naturally imperfect studio image of [CULTIVAR] [HARVESTED PRODUCT], accurately showing [CULTIVAR-SPECIFIC COLOR, SHAPE, SIZE, PATTERN, OR INTERIOR]. Centered isolated subject, square composition, plain white background for clean removal. Focus on the produce, with only minimal leaves or stems needed for identification. No text, labels, banners, logos, hands, packaging, garden props, decorative objects, or CGI look.
+
+For a leafy cultivar, the leaves are the product: show the harvested head or bunch, not a generic rooted plant. The attached asset must be a transparent PNG, not the white-background master.
+
+## Repository Anchors
+
+- Runtime definitions and draft entities: `packages/storage/src/schema/cmsSchema.ts`
+- Create/update/publish behavior: `packages/storage/src/repositories/entitiesRepo.ts`
+- Admin image upload: `apps/app/components/shared/attributes/typed/ImageInput.tsx`, `apps/app/app/(actions)/entityActions.ts`
+- Public sort contract: `packages/directory-types/src/v1.d.ts`
+- Parent and inherited relationship behavior: `packages/storage/src/helpers/plantRelationships.ts`
+- Editable-field boundary: `packages/storage/src/helpers/communityEditableFields.ts`
+
+## Validation
+
+For skill-only changes, run the skill validator and `git diff --check`. When using the skill for a real sort, validation must include the cover validator, parent-reference readback, admin raw/formatted readback, draft preview, and runtime completeness. Run storage/API/client tests only when implementation code or contracts change.

--- a/.agents/skills/gredice-populate-plant-sort/agents/openai.yaml
+++ b/.agents/skills/gredice-populate-plant-sort/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gredice Plant Sort Population"
+  short_description: "Create complete draft cultivar records"
+  default_prompt: "Use $gredice-populate-plant-sort to create and fully populate a new unpublished Gredice plant-sort record."

--- a/.agents/skills/gredice-populate-plant-sort/references/plant-sort-field-checklist.md
+++ b/.agents/skills/gredice-populate-plant-sort/references/plant-sort-field-checklist.md
@@ -1,0 +1,51 @@
+# Plant-sort field checklist
+
+Use active runtime definitions as the source of truth. A sort should contain the complete commercial identity and only source-backed cultivar-specific editorial differences; its parent supplies general crop guidance.
+
+## Core record
+
+| Path | Rule |
+| --- | --- |
+| `information.plant` | Numeric `ref:plant` pointing to the correct published parent plant. Never use `entities.parentId`. |
+| `information.name` | Canonical marketed cultivar/sort name in Gredice naming style. Preserve registered capitalization and hybrid notation. |
+| `information.shortDescription` | One concise Croatian sentence distinguishing the product phenotype or use. |
+| `attributes.reproductionType` | Exact current value `seed` or `bulb`. |
+| `store.availableInStore` | Explicit commercial boolean; do not derive it from publication. |
+| `image.cover` | Admin-uploaded JSON `{ "url": "..." }` for the exact cultivar phenotype. |
+
+All six are present on the current published catalogue and should be treated as the normal minimum even if runtime required flags later change.
+
+## Cultivar-specific editorial fields
+
+| Path | Rule |
+| --- | --- |
+| `information.latinName` | Botanical name plus cultivar/group notation when the identity is certain; do not force a cultivar epithet onto generic trade labels. |
+| `information.origin` | Breeding, selection, or geographic origin only when directly documented for this cultivar. |
+| `information.description` | Croatian description of stable distinguishing traits: phenotype, habit, maturity, culinary/production use, and documented resistance where relevant. |
+| `information.soilPreparation` | Only a cultivar-specific soil difference; otherwise inherit the parent. |
+| `information.sowing` | Cultivar-specific sowing timing, seed treatment, or emergence behavior. |
+| `information.planting` | Cultivar-specific spacing, support, or transplant behavior. |
+| `information.growth` | Habit, vigor, height/spread, determinacy, maturity class, or climate response. |
+| `information.maintenance` | Cultivar-specific training, pruning, feeding, or protection. |
+| `information.watering` | A documented cultivar-specific moisture sensitivity. |
+| `information.flowering` | Flowering/pollination trait meaningful to production. |
+| `information.harvest` | Produce-specific maturity cues, size/color, picking stage, and repeat-harvest behavior. |
+| `information.storage` | Cultivar-specific curing, shelf life, or storage behavior. |
+
+Do not copy the parent plant prose into empty sort fields. Empty means “use the parent baseline,” while a populated field should add a meaningful override or supplement. Generic/type records must disclose that they are not a uniquely identified cultivar and avoid invented Latin names or origins.
+
+## Relationships and operations
+
+- Sorts inherit the parent plant's companions and antagonists. Add direct sort relationship rows only for a reliable cultivar-specific difference, and never duplicate the inherited set.
+- Operation applicability comes from the parent plant and global operation rules. Do not create or link a sort-specific harvest operation merely because the produce looks different. Expand/reuse the generic harvest operation unless the work itself is genuinely different.
+
+## Cover acceptance
+
+- Show the exact harvested product phenotype: cultivar-accurate color, shape, size, striping, head form, pod form, bulb form, root form, or leaf habit.
+- Focus on produce rather than foliage or a whole plant. Minimal identifying stems/leaves are acceptable. For leafy cultivars, show the harvested head or bunch because the leaves are the product.
+- Use a square PNG at least 1000×1000, RGBA, with genuinely transparent background and corners, natural imperfections, and no text, banners, logos, hands, packaging, props, or CGI look.
+- Run `node scripts/validate-directory-cover.mjs <cover.png>` before upload; visually inspect what automation cannot detect. After upload, compare CDN bytes/hash, dimensions, alpha, and the attached URL.
+
+## Final evidence
+
+The handoff must include sort ID/state/slug, parent ID/slug, source URLs, every core field, populated cultivar-specific paths, intentionally inherited paths, store decision, reproduction type, cover dimensions/SHA-256/CDN URL, preview result, unresolved decisions, and whether publication was explicitly requested.

--- a/.agents/skills/gredice-populate-plant/SKILL.md
+++ b/.agents/skills/gredice-populate-plant/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: gredice-populate-plant
+description: Create and fully populate brand-new Gredice plant directory entities as unpublished Croatian drafts, including sourced lifecycle content, agronomic attributes, calendars, relationships, operations, health coverage, commerce data, and a realistic transparent produce-focused cover. Use when onboarding a new crop or species to the plant catalogue or completing a newly created plant record before editorial review and eventual publication. Route established-plant changes through supported community edits or the appropriate admin review workflow instead.
+---
+
+# Gredice Populate Plant
+
+## Overview
+
+Build a complete, source-backed `plant` directory record without publishing it implicitly. Treat the active runtime attribute definitions as the schema and leave a verifiable draft for review.
+
+Read [plant-field-checklist.md](references/plant-field-checklist.md) in full before creating or populating a record.
+
+## Boundaries
+
+- Confirm the target is a crop/species-level plant. Use `gredice-populate-plant-sort` for a named cultivar, hybrid, commercial line, or marketed sort of an existing plant.
+- Use this workflow only to create or finish a brand-new entity. Propose changes to an established plant through community edits where supported; use the appropriate reviewable admin workflow for unsupported fields.
+- Confirm the target environment, host, and authenticated admin account before any mutation. Never infer that the currently open session is the intended production account.
+- Create through the authenticated admin directory workflow so revisions, cache invalidation, and search refreshes remain intact. Do not write production rows ad hoc unless the user explicitly requests a guarded script.
+- Keep the entity in `draft`. Publishing is a separate, explicit user decision after complete readback and preview.
+- Load current `plant` attribute definitions and address them by `category.name`. Never hardcode definition IDs or assume the checked-in generated type contains newer runtime fields.
+- Use Croatian customer-facing copy and retain a source ledger with direct URLs. Do not add unsupported origin, health, resistance, yield, or cultivation claims.
+- Finish research and a locally validated cover before creating the entity. Identify unresolved commercial/editorial inputs first; proceed with an incomplete draft only when the user accepts those explicit blockers. If an earlier attempt left a partial draft, reuse and report that ID instead of creating another blank record.
+- Never run `pnpm db-push`, expose environment values, or log credentials.
+
+## Workflow
+
+1. **Define the record.** Resolve the accepted Croatian common name, botanical name, synonyms, edible product, reproduction method, and whether the target is truly new. Search both published and draft raw plant and plant-sort entities for case-, whitespace-, punctuation-, botanical-name-, and slug-normalized collisions before the first mutation. Stop on an ambiguous near match rather than creating a probable duplicate.
+2. **Research the dossier.** Prefer botanical institutions, extension services, government/agricultural guidance, breeders, registries, and reputable seed suppliers. Reconcile conflicting values; keep region-dependent calendars appropriate for Croatian conditions and label uncertain values instead of averaging them.
+3. **Inspect and preflight.** Load active `plant` definitions, required flags, visibility, data types, defaults, multiplicity, and reference targets. Produce a dry-run checklist covering every active required field and every field in the reference checklist. Prepare the per-field source ledger, generate and validate the local cover, and resolve or explicitly declare business/editorial blockers before mutation.
+4. **Create the draft.** In `/admin/directories/plant`, add one blank record and capture its ID. Re-run the duplicate guard after creation. If a collision appears, stop without populating or deleting the new draft, report its ID, and request explicit cleanup direction. Populate through the detail form; avoid the generic JSON importer for complex JSON, repeated references, or fields whose names could collide. If an applicable field is hidden from the form, use an approved guarded server/repository path or report a blocker; do not confuse a formatted default with a persisted value.
+5. **Populate all applicable data.** Fill identity, lifecycle copy, calendars, agronomic attributes, tips, relationships, operation applicability, price/store controls, delivery freshness, and the cover; prepare inverse health coverage proposals for the adjacent-change step. Use actual `false` and `0` values where meaningful; do not replace them with blanks. Never infer price, store availability, or editorial verification from horticultural sources; if a required business decision is unavailable, leave the entity in draft and report the blocker rather than claiming completion.
+6. **Reuse operations and stage adjacent changes.** Inventory existing published operations before linking anything. Do not create crop-specific variants of a generic harvest operation when the existing operation can be expanded. Do not add redundant links for operations with `appliesToAllTargets = true`. If genuinely new behavior is required, propose the separate unpublished operation and plant association first; create that draft only with explicit authority. Likewise, treat inverse health coverage as reviewable changes to existing disease/pest records: stage or propose them unless the user explicitly authorized those adjacent mutations.
+7. **Create the cover during preflight.** Load and follow the available image-generation skill (in Codex, `$imagegen`) to make a square, realistic, naturally imperfect image centered on the harvested edible product. Use only minimal leaves or stems needed for identification; for leafy crops, show a harvested head or bunch rather than a rooted whole plant. Use no text, labels, banners, logos, hands, packaging, props, soil bed, or CGI styling. Remove the background and export a transparent RGBA PNG.
+8. **Validate and upload the cover.** Run `node scripts/validate-directory-cover.mjs <cover.png>`, visually confirm the produce focus and absence of text, then upload through the record's `image.cover` control, which attaches the returned URL immediately. Preserve the reported SHA-256. Fetch the CDN object with cache busting, validate the downloaded file again, and require matching content type, dimensions, alpha, and SHA-256 before accepting the attachment. If remote validation fails, clear `image.cover`, verify the raw value was removed, and report the orphaned CDN URL as a cleanup candidate. A guarded upload-only path may avoid immediate attachment, but use it only with explicit authority.
+9. **Verify the draft.** Compare raw stored values and the authenticated draft-formatted admin preview against the dossier. Check required completeness, JSON shapes, enum values, numeric units, duplicate multiple rows, references to published targets, relationship conflicts, operation applicability, inverse health links, cover URL/bytes/hash/alpha, and the derived slug. Confirm `state = draft`, `publishedAt = null`, and absence from the public published collection; a public 404 is expected before publication.
+10. **Hand off for review.** Preserve the source ledger in the durable task or review artifact and report the entity ID, draft state, slug, populated paths, intentionally inapplicable fields, unresolved decisions, cover dimensions/hash, and named visual-review result. Publish only when the user separately authorizes it; then verify the published list endpoint, public `/biljke/{slug}` page, search result, and CDN asset while accounting for public cache delay.
+
+## Cover Prompt Template
+
+Use this base and add species-specific phenotype details:
+
+> Realistic and naturally imperfect studio image of the harvested edible product of [PLANT], showing [IDENTIFYING COLOR, SHAPE, SIZE, OR INTERIOR]. Centered isolated subject, square composition, plain white background for clean removal. Focus on the produce, with only minimal leaves or stems needed for identification. No text, labels, banners, logos, hands, packaging, garden props, decorative objects, or CGI look.
+
+The white-background master is only an intermediate. The attached asset must pass the transparent-PNG validator.
+
+## Repository Anchors
+
+- Runtime definitions and values: `packages/storage/src/schema/cmsSchema.ts`
+- Creation, revisions, and publication gate: `packages/storage/src/repositories/entitiesRepo.ts`
+- Admin create/save/upload actions: `apps/app/app/(actions)/entityActions.ts`
+- Public contract baseline: `packages/directory-types/src/v1.d.ts`
+- Lifecycle order: `packages/js/src/plants/plantStages.ts`
+- Relationships and inverse health assembly: `packages/storage/src/helpers/plantRelationships.ts`, `packages/storage/src/helpers/plantHealth.ts`
+- Operation applicability: `packages/js/src/operations/index.ts`
+
+## Validation
+
+For skill-only changes, run the skill validator and `git diff --check`. When using the skill for a real plant, validation must include the cover validator, admin raw/formatted readback, draft preview, and runtime completeness. Run storage/API/client tests only when implementation code or contracts change.

--- a/.agents/skills/gredice-populate-plant/agents/openai.yaml
+++ b/.agents/skills/gredice-populate-plant/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gredice Plant Population"
+  short_description: "Create complete draft plant records"
+  default_prompt: "Use $gredice-populate-plant to create and fully populate a new unpublished Gredice plant record."

--- a/.agents/skills/gredice-populate-plant/references/plant-field-checklist.md
+++ b/.agents/skills/gredice-populate-plant/references/plant-field-checklist.md
@@ -1,0 +1,78 @@
+# Plant field checklist
+
+Use active runtime definitions as the source of truth. This checklist is the expected coverage baseline, not permission to invent values or bypass newly added required fields.
+
+## Identity and editorial content
+
+| Path | Rule |
+| --- | --- |
+| `information.name` | Canonical Croatian customer-facing name; duplicate-check normalized names and slugs. |
+| `information.alternativeName` | One genuine Croatian regional/common synonym per multiple raw value row; the formatted/public value is an array. Do not repeat the canonical name. |
+| `information.latinName` | Accepted botanical name with author only when useful; verify taxonomy. |
+| `information.origin` | Concise domestication/geographic origin supported by strong sources. |
+| `information.description` | Practical introduction: crop type, harvested part, habit, and notable use; avoid health claims. |
+| `information.verified` | Set only according to the current editorial policy; do not infer it from confidence. |
+
+## Lifecycle content
+
+Cover the nine canonical stages in `packages/js/src/plants/plantStages.ts`:
+
+- `soilPreparation`: soil structure, drainage, pH, and restrained fertility guidance.
+- `sowing`: direct/indoor method, timing, depth context, emergence, and thinning.
+- `planting`: transplant readiness, hardening, placement, and support where relevant.
+- `growth`: habit, temperature/season response, maturity pattern, and space use.
+- `maintenance`: weed, mulch, training, pruning, protection, and feeding practices that actually apply.
+- `watering`: establishment and production-stage moisture needs; avoid rigid schedules independent of weather.
+- `flowering`: pollination or bolting guidance only when meaningful to the harvested crop.
+- `harvest`: observable readiness cues, careful picking method, and repeat-harvest behavior.
+- `storage`: immediate cooling/curing, realistic short storage, and preservation where supported.
+
+Do not fill a biologically inapplicable section with generic filler. Record it as intentionally inapplicable in the handoff. Add `information.tip` entries only for useful, distinct advice; persist each tip as a separate multiple JSON value with `header` and Markdown `content`, while the formatted/public value is an array.
+
+## Calendar
+
+Persist each calendar window as a separate multiple JSON value `{ "start": month, "end": month }`; the formatted/public value is an array. Fractional values such as `3.5` mean mid-month. Declare the climate baseline in the handoff: default to continental lowland Croatian outdoor production, and document coastal or protected-production alternatives separately instead of blending them into one range.
+
+- `calendar.propagating`: indoor/protected propagation windows when used.
+- `calendar.sowing`: direct outdoor sowing windows when used.
+- `calendar.planting`: outdoor transplanting or planting windows when used.
+- `calendar.harvest`: all realistic harvest windows; required in the current public contract.
+
+Use Croatian growing conditions as the default context. Preserve multiple windows instead of stretching one interval across a summer pause.
+
+## Agronomic attributes
+
+| Path | Unit or allowed values | Validation rule |
+| --- | --- | --- |
+| `attributes.seedingDistance` | cm | Plant-to-plant spacing used by the 30×30 cm field calculation; values over 30 cm still resolve to one plant per field. |
+| `attributes.seedingDepth` | cm | Use `0` only for true surface sowing. |
+| `attributes.germinationType` | `Klijanje pod svijetlosti` or `Klijanje u mraku` | Preserve the current exact vocabulary. |
+| `attributes.gernimationTemperature` | °C | The misspelling is the canonical key. Record a seed-germination optimum, not growing-season temperature. |
+| `attributes.germinationWindowMin/Max` | days | Min must not exceed max; reflect normal viable seed under suitable conditions. |
+| `attributes.light` | `0`, `0.5`, or `1` | Shade, partial shade, or sun. |
+| `attributes.soil` | `Lagano (pješčano)`, `Srednje (ilovasto)`, or `Teško (glineno)` | Choose the closest supported category; explain nuance in prose. |
+| `attributes.nutrients` | `Niske potrebe`, `Srednje potrebe`, or `Visoke potrebe` | Avoid equating high need with unrestricted nitrogen. |
+| `attributes.growthWindowMin/Max` | days | Inspect current definition descriptions, catalogue examples, and consumers; define the same start/end event for both values before assigning them. |
+| `attributes.water` | `Suho tlo`, `Vlažno tlo`, or `Mokro tlo` | Choose the supported moisture category; put stage nuance in watering prose. |
+| `attributes.harvestWindowMin/Max` | days | Inspect current definition descriptions, catalogue examples, and consumers; use the application's established start/end events consistently. |
+| `attributes.yieldMin/Max` | grams | Min must not exceed max and must match `yieldType`. |
+| `attributes.yieldType` | `perPlant` or `perField` | `perField` means one 30×30 cm field. |
+| `attributes.cleanHarvest` | boolean | True only when normal harvest leaves no plant-removal task. |
+| `attributes.maxHarvestDaysBeforeDelivery` | whole days, `>= 0` | Freshness policy, not harvest duration; `0` means same-day harvest. |
+
+## Commerce and cover
+
+- `prices.perPlant`: current EUR price for one transplant or one 30×30 cm sowing unit. Do not invent pricing; obtain the commercial decision. `0` means explicitly confirmed free, never “unknown.”
+- `store.availableInStore`: explicit boolean independent of publication state.
+- `image.cover`: JSON `{ "url": "..." }` created by the admin upload. Validate the local PNG before upload and the CDN bytes after upload.
+
+## Relationships, health, and operations
+
+- Store `relationships.companions` and `relationships.antagonists` as separate multiple `ref:plant` rows; the formatted/public values are arrays. Relationships render reciprocally, so add each pair once. Skip disputed broad folklore and any companion/antagonist contradiction.
+- Plant health is inverse-derived. Do not write a `health` attribute on the plant. Review published disease and pest records and propose adding the plant to their `relationships.affectedPlants` references only when supported; this changes existing records and requires its own authorization/readback. Keep source/review notes on the health record.
+- Link only applicable published directory operations. A plant operation is relevant when `application = plant` and it is explicitly linked or globally enabled with `appliesToAllTargets = true`.
+- Reuse existing harvest and maintenance operations. If behavior is genuinely absent, propose one unpublished operation draft with full information, stage/application/frequency/duration/delivery/condition/price/image fields and a proposed association. Create it only after explicit authorization.
+
+## Final evidence
+
+The handoff must state every checklist path as populated, intentionally inapplicable, awaiting a commercial/editorial decision, or blocked by missing evidence. Include source URLs, entity ID/state/slug, cover dimensions and SHA-256, preview result, unresolved references, and whether publication was requested.

--- a/scripts/validate-directory-cover.mjs
+++ b/scripts/validate-directory-cover.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "..");
+const requireFromApp = createRequire(
+	path.join(repositoryRoot, "apps/app/package.json"),
+);
+let sharpModule;
+try {
+	sharpModule = requireFromApp("sharp");
+} catch (error) {
+	console.error(
+		"Unable to load sharp from apps/app. Install workspace dependencies before validating covers.",
+	);
+	throw error;
+}
+const sharp = sharpModule.default ?? sharpModule;
+
+const minimumDimension = 1000;
+const transparentAlphaMaximum = 8;
+const opaqueAlphaMinimum = 247;
+const minimumTransparentFraction = 0.15;
+const minimumOpaqueFraction = 0.01;
+
+function usage() {
+	return "Usage: node scripts/validate-directory-cover.mjs <cover.png> [more.png ...]";
+}
+
+function roundFraction(value) {
+	return Number(value.toFixed(6));
+}
+
+function alphaAt(data, width, x, y) {
+	return data[(y * width + x) * 4 + 3];
+}
+
+async function inspectCover(filePath) {
+	const absolutePath = path.resolve(filePath);
+	const bytes = await readFile(absolutePath);
+	const metadata = await sharp(bytes, { failOn: "error" }).metadata();
+	const errors = [];
+	const warnings = [];
+
+	if (metadata.format !== "png") {
+		errors.push(`Expected PNG, found ${metadata.format ?? "unknown"}.`);
+	}
+	if (!metadata.width || !metadata.height) {
+		errors.push("Image dimensions are unavailable.");
+	}
+	if (metadata.width !== metadata.height) {
+		errors.push(
+			`Expected a square image, found ${metadata.width ?? 0}x${metadata.height ?? 0}.`,
+		);
+	}
+	if (
+		(metadata.width ?? 0) < minimumDimension ||
+		(metadata.height ?? 0) < minimumDimension
+	) {
+		errors.push(
+			`Expected dimensions of at least ${minimumDimension}x${minimumDimension}.`,
+		);
+	}
+	if (!metadata.hasAlpha || metadata.channels !== 4) {
+		errors.push(
+			`Expected a four-channel RGBA image, found ${metadata.channels ?? 0} channels.`,
+		);
+	}
+
+	const { data, info } = await sharp(bytes, { failOn: "error" })
+		.ensureAlpha()
+		.raw()
+		.toBuffer({ resolveWithObject: true });
+	const pixelCount = info.width * info.height;
+	let transparentPixels = 0;
+	let fullyTransparentPixels = 0;
+	let transparentRgbResiduePixels = 0;
+	let opaquePixels = 0;
+	let minX = info.width;
+	let minY = info.height;
+	let maxX = -1;
+	let maxY = -1;
+
+	for (let index = 0; index < pixelCount; index += 1) {
+		const red = data[index * 4];
+		const green = data[index * 4 + 1];
+		const blue = data[index * 4 + 2];
+		const alpha = data[index * 4 + 3];
+		if (alpha <= transparentAlphaMaximum) {
+			transparentPixels += 1;
+		}
+		if (alpha === 0) {
+			fullyTransparentPixels += 1;
+			if (red !== 0 || green !== 0 || blue !== 0) {
+				transparentRgbResiduePixels += 1;
+			}
+		}
+		if (alpha >= opaqueAlphaMinimum) {
+			opaquePixels += 1;
+		}
+		if (alpha > transparentAlphaMaximum) {
+			const x = index % info.width;
+			const y = Math.floor(index / info.width);
+			minX = Math.min(minX, x);
+			minY = Math.min(minY, y);
+			maxX = Math.max(maxX, x);
+			maxY = Math.max(maxY, y);
+		}
+	}
+
+	const cornerAlpha = [
+		alphaAt(data, info.width, 0, 0),
+		alphaAt(data, info.width, info.width - 1, 0),
+		alphaAt(data, info.width, 0, info.height - 1),
+		alphaAt(data, info.width, info.width - 1, info.height - 1),
+	];
+	if (cornerAlpha.some((alpha) => alpha > transparentAlphaMaximum)) {
+		errors.push(
+			`Expected transparent corners with alpha <= ${transparentAlphaMaximum}; found ${cornerAlpha.join(", ")}.`,
+		);
+	}
+
+	const transparentFraction = transparentPixels / pixelCount;
+	const opaqueFraction = opaquePixels / pixelCount;
+	if (transparentFraction < minimumTransparentFraction) {
+		errors.push(
+			`Transparent coverage ${roundFraction(transparentFraction)} is below ${minimumTransparentFraction}.`,
+		);
+	}
+	if (opaqueFraction < minimumOpaqueFraction) {
+		errors.push(
+			`Opaque subject coverage ${roundFraction(opaqueFraction)} is below ${minimumOpaqueFraction}.`,
+		);
+	}
+	if (transparentRgbResiduePixels > 0) {
+		errors.push(
+			`Found RGB color data in ${transparentRgbResiduePixels} fully transparent pixels; clear hidden background color to prevent resize halos.`,
+		);
+	}
+	if (maxX < 0 || maxY < 0) {
+		errors.push("No visible subject was detected.");
+	}
+
+	if (
+		minX === 0 ||
+		minY === 0 ||
+		maxX === info.width - 1 ||
+		maxY === info.height - 1
+	) {
+		warnings.push(
+			"The visible subject touches an image edge; visually check for clipping.",
+		);
+	}
+
+	return {
+		file: absolutePath,
+		valid: errors.length === 0,
+		sha256: createHash("sha256").update(bytes).digest("hex"),
+		format: metadata.format ?? null,
+		width: metadata.width ?? null,
+		height: metadata.height ?? null,
+		channels: metadata.channels ?? null,
+		hasAlpha: metadata.hasAlpha ?? false,
+		cornerAlpha,
+		transparentFraction: roundFraction(transparentFraction),
+		fullyTransparentFraction: roundFraction(
+			fullyTransparentPixels / pixelCount,
+		),
+		transparentRgbResiduePixels,
+		opaqueFraction: roundFraction(opaqueFraction),
+		subjectBounds: maxX < 0 || maxY < 0 ? null : { minX, minY, maxX, maxY },
+		visualChecksRequired: [
+			"Cultivar or species phenotype matches the sources.",
+			"The harvested edible product is the visual focus.",
+			"No text, label, banner, logo, hand, packaging, prop, or CGI styling is visible.",
+			"Edges are clean and free of white-background halos.",
+		],
+		warnings,
+		errors,
+	};
+}
+
+const filePaths = process.argv.slice(2).filter((value) => value !== "--");
+if (filePaths.length === 0) {
+	console.error(usage());
+	process.exitCode = 2;
+} else {
+	const results = [];
+	for (const filePath of filePaths) {
+		try {
+			results.push(await inspectCover(filePath));
+		} catch (error) {
+			results.push({
+				file: path.resolve(filePath),
+				valid: false,
+				errors: [error instanceof Error ? error.message : String(error)],
+			});
+		}
+	}
+
+	console.log(JSON.stringify(results, null, 2));
+	if (results.some((result) => !result.valid)) {
+		process.exitCode = 1;
+	}
+}


### PR DESCRIPTION
## What

- add a Gredice skill for creating complete new `plant` records as unpublished Croatian drafts
- add a separate skill for creating cultivar-specific `plantSort` drafts linked through `information.plant`
- document the normal plant and plant-sort field coverage, raw repeated-value shapes, source and commerce boundaries, operation reuse, inverse health proposals, and draft readback
- add a shared cover validator for square transparent RGBA PNGs, including alpha coverage, transparent corners, hidden RGB residue, subject bounds, SHA-256, and mandatory visual checks

## Safety and workflow

- searches published and draft entities before mutation and stops on ambiguous duplicates
- keeps creation separate from established-record community edits
- never publishes implicitly or infers price, availability, verification, or unsupported cultivar claims
- reuses the generic harvest operation and requires explicit authority for new operation drafts or adjacent health-record changes
- generates realistic produce-focused covers with no text, logos, hands, packaging, props, or opaque background
- verifies local and CDN image bytes and clears an attached cover if remote validation fails

## Validation

- `quick_validate.py .agents/skills/gredice-populate-plant`
- `quick_validate.py .agents/skills/gredice-populate-plant-sort`
- parsed both `agents/openai.yaml` files with PyYAML
- `biome check scripts/validate-directory-cover.mjs`
- `node --check scripts/validate-directory-cover.mjs`
- cover-validator fixture matrix: accepted valid 1024px RGBA cutout; rejected opaque/undersized input, transparent RGB residue, and missing input with the expected exit codes
- forward-tested the plant workflow with a duplicate-prone okra/Bamija request and unknown price
- forward-tested the sort workflow with San Marzano 2 under published Rajčica

No directory records or images were created or published while preparing this PR.
