### PR TITLE
fix(game): preserve public garden plant models

### DIFF
--- a/packages/game/src/hooks/currentGardenQueryPolicy.ts
+++ b/packages/game/src/hooks/currentGardenQueryPolicy.ts
@@ -1,0 +1,18 @@
+export function getCurrentGardenQueryPolicy({
+    authenticatedGardenQueriesEnabled,
+    isLocalSandbox,
+    isMock,
+}: {
+    authenticatedGardenQueriesEnabled: boolean;
+    isLocalSandbox: boolean;
+    isMock: boolean;
+}) {
+    const accountGardenQueriesEnabled =
+        authenticatedGardenQueriesEnabled && !isLocalSandbox && !isMock;
+
+    return {
+        accountGardenQueriesEnabled,
+        currentGardenQueryEnabled:
+            accountGardenQueriesEnabled || isLocalSandbox || isMock,
+    };
+}

--- a/packages/game/src/hooks/currentGardenQueryPolicy.unit.ts
+++ b/packages/game/src/hooks/currentGardenQueryPolicy.unit.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { getCurrentGardenQueryPolicy } from './currentGardenQueryPolicy';
+
+describe('getCurrentGardenQueryPolicy', () => {
+    it('keeps seeded public-garden data isolated from authenticated queries', () => {
+        assert.deepEqual(
+            getCurrentGardenQueryPolicy({
+                authenticatedGardenQueriesEnabled: false,
+                isLocalSandbox: false,
+                isMock: false,
+            }),
+            {
+                accountGardenQueriesEnabled: false,
+                currentGardenQueryEnabled: false,
+            },
+        );
+    });
+
+    it('loads authenticated garden data in the customer game', () => {
+        assert.deepEqual(
+            getCurrentGardenQueryPolicy({
+                authenticatedGardenQueriesEnabled: true,
+                isLocalSandbox: false,
+                isMock: false,
+            }),
+            {
+                accountGardenQueriesEnabled: true,
+                currentGardenQueryEnabled: true,
+            },
+        );
+    });
+
+    it('keeps local and mock garden loaders enabled without account queries', () => {
+        for (const mode of [
+            { isLocalSandbox: true, isMock: false },
+            { isLocalSandbox: false, isMock: true },
+        ]) {
+            assert.deepEqual(
+                getCurrentGardenQueryPolicy({
+                    authenticatedGardenQueriesEnabled: true,
+                    ...mode,
+                }),
+                {
+                    accountGardenQueriesEnabled: false,
+                    currentGardenQueryEnabled: true,
+                },
+            );
+        }
+    });
+});

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -33,6 +33,7 @@ import {
     type WinterMode,
 } from '../useGameState';
 import { useCurrentGardenIdParam } from '../useUrlState';
+import { getCurrentGardenQueryPolicy } from './currentGardenQueryPolicy';
 import { shareCurrentGardenQueryData } from './currentGardenStructuralSharing';
 import { resolveCurrentAccountGardenId } from './gardenSelection';
 import {
@@ -1252,6 +1253,9 @@ function isHighTargetOperationVisualsProfile(profile: MockGardenProfile) {
 }
 
 export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | null> {
+    const authenticatedGardenQueriesEnabled = useGameState(
+        (state) => state.authenticatedGardenQueriesEnabled,
+    );
     const isMock = useGameState((state) => state.isMock);
     const localSandboxStorageKey = useGameState(
         (state) => state.localSandboxStorageKey,
@@ -1262,11 +1266,18 @@ export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | nu
     const mockGardenProfile = useGameState((state) => state.mockGardenProfile);
     const winterMode = useGameState((state) => state.winterMode);
     const isLocalSandbox = localSandboxStorageKey !== null;
+    const queryPolicy = getCurrentGardenQueryPolicy({
+        authenticatedGardenQueriesEnabled,
+        isLocalSandbox,
+        isMock,
+    });
     const highTargetOperationVisuals =
         isMock && isHighTargetOperationVisualsProfile(mockGardenProfile);
-    const { data: gardens } = useGardens(isMock || isLocalSandbox);
+    const { data: gardens } = useGardens(
+        !queryPolicy.accountGardenQueriesEnabled,
+    );
     const { data: accountGroups } = useGardenAccountGroups(
-        isMock || isLocalSandbox,
+        !queryPolicy.accountGardenQueriesEnabled,
     );
     let selectedGardenId: number | null = null;
     if (!isMock && !isLocalSandbox) {
@@ -1393,10 +1404,11 @@ export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | nu
         retry: false,
         staleTime: 1000 * 60, // 1m
         enabled:
-            isLocalSandbox ||
-            isMock ||
-            (gardens !== null &&
-                (currentGardenId !== null || gardens !== undefined)),
+            queryPolicy.currentGardenQueryEnabled &&
+            (isLocalSandbox ||
+                isMock ||
+                (gardens !== null &&
+                    (currentGardenId !== null || gardens !== undefined))),
     });
 }
 

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -337,6 +337,7 @@ type BackgroundPaletteCycle = {
 
 export type GameState = {
     // General
+    authenticatedGardenQueriesEnabled: boolean;
     isMock: boolean;
     mockGardenProfile: MockGardenProfile;
     winterMode: WinterMode;
@@ -485,6 +486,7 @@ export type GameState = {
 
 export function createGameState({
     appBaseUrl,
+    authenticatedGardenQueriesEnabled = true,
     spriteBaseUrl,
     dayNightCycleDisabled: initialDayNightCycleDisabled,
     freezeTime,
@@ -499,6 +501,7 @@ export function createGameState({
     winterMode,
 }: {
     appBaseUrl: string;
+    authenticatedGardenQueriesEnabled?: boolean;
     spriteBaseUrl?: string;
     dayNightCycleDisabled?: boolean;
     freezeTime: Date | null;
@@ -533,6 +536,7 @@ export function createGameState({
     const { sunrise, sunset } = getGameSunriseSunset(timeLocation, now);
     let nextBlockPlacementDropAnimationRenderId = 0;
     return createStore<GameState>((set, get) => ({
+        authenticatedGardenQueriesEnabled,
         isMock: isMock,
         mockGardenProfile: mockGardenProfile ?? 'default',
         winterMode: winterMode ?? 'summer',

--- a/packages/game/src/viewers/PublicGardenViewer.tsx
+++ b/packages/game/src/viewers/PublicGardenViewer.tsx
@@ -519,6 +519,7 @@ export function PublicGardenViewer({
     if (!storeRef.current) {
         storeRef.current = createGameState({
             appBaseUrl: resolvedAppBaseUrl,
+            authenticatedGardenQueriesEnabled: false,
             spriteBaseUrl: resolvedSpriteBaseUrl,
             freezeTime: capture ? getPublicGardenCaptureDate() : null,
             isMock: false,


### PR DESCRIPTION
## What changed

- mark the public garden viewer as using seeded garden data
- disable authenticated account/current-garden queries for that viewer while preserving mock, sandbox, and customer-game loaders
- add regression coverage for the query policy

## Root cause

The public viewer seeds its public garden response into a private React Query cache. After the one-minute current-garden freshness window, returning focus to the tab refetched the authenticated `/api/gredice/api/gardens/:id` flow. For anonymous visitors or viewers without access to that garden, the request returned `401` and replaced the seeded garden with `null`, removing generated plant batches and raised-bed details.

## User impact

Public garden plant models and raised-bed details now remain visible when the tab becomes stale and regains focus.

## Validation

- reproduced production failure on `/vrtovi/145`: forced stale focus produced `GET /api/gredice/api/gardens/145` -> `401`, then removed plants
- verified production-built local fix with the same forced stale focus: zero authenticated current-garden requests and plants remained visible
- `pnpm --filter @gredice/game test` (806 passed)
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter www build`
- focused Biome check and `git diff --check`
