### PR TITLE
fix(game): ripen produce colors by maturity

### DIFF
--- a/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantFieldBatches.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantFieldBatches.tsx
@@ -800,6 +800,7 @@ export function RaisedBedGeneratedPlantFieldBatches({
                             sort?.information.plant.attributes?.growthWindowMax,
                     }),
                     growthMultiplier: resolvedPlantPreset.growthMultiplier,
+                    plantStatus: field.plantStatus,
                 });
                 const plantInstanceScale = getInGamePlantInstanceScale(
                     resolvedPlantPreset,

--- a/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
@@ -128,6 +128,7 @@ export function RaisedBedPlantField({
                   sowDate: plantSowDate,
                   lifecycleWindowDays: maturityWindowDays,
                   growthMultiplier: resolvedPlantPreset.growthMultiplier,
+                  plantStatus: field.plantStatus,
               })
             : 0;
     const visualPlantGeneration = harvestedVisual

--- a/packages/game/src/generators/plant/developmental/buildDevelopmentalPlantRenderData.ts
+++ b/packages/game/src/generators/plant/developmental/buildDevelopmentalPlantRenderData.ts
@@ -156,7 +156,16 @@ export function buildDevelopmentalPlantRenderData({
     let foliageSumY = 0;
     let accentSamples = 0;
     let accentSumY = 0;
-    let accentColor: string | undefined;
+    const accentColorSum = new THREE.Color(0, 0, 0);
+    let accentColorWeight = 0;
+
+    const trackAccentColor = (color: THREE.Color, radius: number) => {
+        const weight = Math.max(radius * radius, Number.EPSILON);
+        accentColorSum.r += color.r * weight;
+        accentColorSum.g += color.g * weight;
+        accentColorSum.b += color.b * weight;
+        accentColorWeight += weight;
+    };
 
     const trackPosition = (position: THREE.Vector3, radius = 0) => {
         maxHeight = Math.max(maxHeight, position.y + radius);
@@ -254,7 +263,10 @@ export function buildDevelopmentalPlantRenderData({
                     getTransformRadius(organ.transform) * flowerGrowth;
                 accentSamples += 1;
                 accentSumY += position.y;
-                accentColor = plantDefinition.flower.color;
+                trackAccentColor(
+                    new THREE.Color(plantDefinition.flower.color),
+                    radius,
+                );
                 trackPosition(position, radius);
                 if (renderDetailedGeometry) {
                     flowers.push(
@@ -278,16 +290,19 @@ export function buildDevelopmentalPlantRenderData({
 
                 const radius =
                     getTransformRadius(organ.transform) * visibleGrowth;
+                const color = new THREE.Color(
+                    resolveVegetableColor(
+                        organ.produceType,
+                        organ.developmentStage,
+                    ),
+                );
                 accentSamples += 1;
                 accentSumY += Math.max(0.04, position.y);
-                accentColor = resolveVegetableColor(
-                    organ.produceType,
-                    organ.developmentStage,
-                );
+                trackAccentColor(color, radius);
                 trackPosition(position, radius);
                 if (renderDetailedGeometry) {
                     vegetables.push({
-                        color: new THREE.Color(accentColor),
+                        color,
                         growth: visibleGrowth,
                         matrix: toMatrix(organ.transform, position),
                         type: organ.produceType,
@@ -325,6 +340,13 @@ export function buildDevelopmentalPlantRenderData({
             }
         }
     }
+
+    const accentColor =
+        accentColorWeight > 0
+            ? `#${accentColorSum
+                  .multiplyScalar(1 / accentColorWeight)
+                  .getHexString()}`
+            : undefined;
 
     dominantColor.lerp(baseLeafColor, showLeaves ? 0.68 : 0.2);
     if (accentColor) {

--- a/packages/game/src/generators/plant/developmental/buildDevelopmentalPlantRenderData.ts
+++ b/packages/game/src/generators/plant/developmental/buildDevelopmentalPlantRenderData.ts
@@ -6,7 +6,7 @@ import type {
     PlantStemSegment,
 } from '../lib/plantRenderData';
 import { SeededRNG } from '../lib/rng';
-import { vegetableMaterialProps } from '../lib/vegetableRenderMetadata';
+import { resolveVegetableColor } from '../lib/vegetableRenderMetadata';
 import type {
     DevelopmentalPlantGraph,
     PlantOrgan,
@@ -280,10 +280,14 @@ export function buildDevelopmentalPlantRenderData({
                     getTransformRadius(organ.transform) * visibleGrowth;
                 accentSamples += 1;
                 accentSumY += Math.max(0.04, position.y);
-                accentColor = vegetableMaterialProps[organ.produceType].color;
+                accentColor = resolveVegetableColor(
+                    organ.produceType,
+                    organ.developmentStage,
+                );
                 trackPosition(position, radius);
                 if (renderDetailedGeometry) {
                     vegetables.push({
+                        color: new THREE.Color(accentColor),
                         growth: visibleGrowth,
                         matrix: toMatrix(organ.transform, position),
                         type: organ.produceType,

--- a/packages/game/src/generators/plant/developmental/buildDevelopmentalPlantRenderData.unit.ts
+++ b/packages/game/src/generators/plant/developmental/buildDevelopmentalPlantRenderData.unit.ts
@@ -65,6 +65,9 @@ function assertValidRenderData(renderData: PlantRenderData) {
     }
 
     for (const vegetable of renderData.vegetables) {
+        assert.ok(Number.isFinite(vegetable.color.r));
+        assert.ok(Number.isFinite(vegetable.color.g));
+        assert.ok(Number.isFinite(vegetable.color.b));
         assert.ok(Number.isFinite(vegetable.growth));
         assert.ok(vegetable.growth > 0);
     }
@@ -267,6 +270,26 @@ test('renders tomato flowers before their sites transition to produce', () => {
     assertValidRenderData(floweringTomato);
     assert.ok(floweringTomato.flowers.length > 0);
     assert.equal(floweringTomato.vegetables.length, 0);
+});
+
+test('gradually ripens tomato produce to deep red at maturity', () => {
+    const ripeningTomato = renderPlant(plantTypes.tomato, 10);
+    const ripeTomato = renderPlant(plantTypes.tomato, 12);
+    const ripeningColors = new Set(
+        ripeningTomato.vegetables.map((vegetable) =>
+            vegetable.color.getHexString(),
+        ),
+    );
+    const ripeColors = new Set(
+        ripeTomato.vegetables.map((vegetable) =>
+            vegetable.color.getHexString(),
+        ),
+    );
+
+    assert.ok(ripeningColors.size > 1);
+    assert.ok([...ripeningColors].every((color) => color !== 'd62828'));
+    assert.deepEqual([...ripeColors], ['d62828']);
+    assert.equal(ripeTomato.lodSummary.accentColor, '#d62828');
 });
 
 test('keeps existing leaf colors stable as new leaves emerge', () => {

--- a/packages/game/src/generators/plant/developmental/buildDevelopmentalPlantRenderData.unit.ts
+++ b/packages/game/src/generators/plant/developmental/buildDevelopmentalPlantRenderData.unit.ts
@@ -288,6 +288,10 @@ test('gradually ripens tomato produce to deep red at maturity', () => {
 
     assert.ok(ripeningColors.size > 1);
     assert.ok([...ripeningColors].every((color) => color !== 'd62828'));
+    assert.notEqual(
+        ripeningTomato.lodSummary.accentColor,
+        `#${ripeningTomato.vegetables.at(-1)?.color.getHexString()}`,
+    );
     assert.deepEqual([...ripeColors], ['d62828']);
     assert.equal(ripeTomato.lodSummary.accentColor, '#d62828');
 });

--- a/packages/game/src/generators/plant/lib/inGamePlantPresets.ts
+++ b/packages/game/src/generators/plant/lib/inGamePlantPresets.ts
@@ -341,12 +341,18 @@ export function calculateInGamePlantGeneration({
     sowDate,
     lifecycleWindowDays,
     growthMultiplier,
+    plantStatus,
 }: {
     currentTime: Date;
     sowDate: string;
     lifecycleWindowDays: number;
     growthMultiplier: number;
+    plantStatus?: string | null;
 }) {
+    if (plantStatus === 'ready') {
+        return MAX_PLANT_GENERATION;
+    }
+
     const elapsedDays = Math.max(
         0,
         (currentTime.getTime() - new Date(sowDate).getTime()) /

--- a/packages/game/src/generators/plant/lib/inGamePlantPresets.unit.ts
+++ b/packages/game/src/generators/plant/lib/inGamePlantPresets.unit.ts
@@ -104,6 +104,19 @@ test('plants reach full generation at the end of germination and growth', () => 
     );
 });
 
+test('ready plants render fully mature despite inconsistent sowing dates', () => {
+    assert.equal(
+        calculateInGamePlantGeneration({
+            currentTime: new Date('2026-05-02T00:00:00.000Z'),
+            sowDate: '2026-05-01T00:00:00.000Z',
+            lifecycleWindowDays: 84,
+            growthMultiplier: 1,
+            plantStatus: 'ready',
+        }),
+        12,
+    );
+});
+
 test('planting density does not shrink height-calibrated crops', () => {
     const tomato = resolveInGamePlantPreset(['Rajčica']);
     const lettuce = resolveInGamePlantPreset(['Salata']);

--- a/packages/game/src/generators/plant/lib/packedPlantRenderData.ts
+++ b/packages/game/src/generators/plant/lib/packedPlantRenderData.ts
@@ -1,7 +1,7 @@
 import type { VegetableType } from './plant-definitions';
 import type { PlantLodSummary, PlantRenderData } from './plantRenderData';
 
-export const PACKED_PLANT_RENDER_DATA_VERSION = 1 as const;
+export const PACKED_PLANT_RENDER_DATA_VERSION = 2 as const;
 
 export interface PackedPlantMatrixInstances {
     count: number;
@@ -19,6 +19,7 @@ export interface PackedPlantLeafInstances extends PackedPlantMatrixInstances {
 
 export interface PackedPlantVegetableInstances
     extends PackedPlantMatrixInstances {
+    colors: Float32Array;
     growth: Float32Array;
     type: VegetableType;
 }
@@ -323,6 +324,11 @@ function assertPackedPlantRenderData(packed: PackedPlantRenderData) {
     for (const vegetable of packed.vegetables) {
         assertPackedMatrixInstances(vegetable, `${vegetable.type} vegetable`);
         assertMatchingCount({
+            actual: vegetable.colors.length,
+            expected: vegetable.count * 3,
+            label: `${vegetable.type} vegetable color component`,
+        });
+        assertMatchingCount({
             actual: vegetable.growth.length,
             expected: vegetable.count,
             label: `${vegetable.type} vegetable growth`,
@@ -467,6 +473,13 @@ export function packPlantRenderData(
     const vegetables = Array.from(
         vegetablesByType,
         ([type, groupedVegetables]) => ({
+            colors: Float32Array.from(
+                groupedVegetables.flatMap((vegetable) => [
+                    vegetable.color.r,
+                    vegetable.color.g,
+                    vegetable.color.b,
+                ]),
+            ),
             count: groupedVegetables.length,
             growth: Float32Array.from(
                 groupedVegetables,
@@ -665,6 +678,9 @@ export function mergePackedPlantRenderDataBatches(
             ),
         },
         vegetables: Array.from(vegetableBatches, ([type, grouped]) => ({
+            colors: concatenatePackedFloat32Arrays(
+                grouped.map((vegetable) => vegetable.colors),
+            ),
             count: grouped.reduce(
                 (total, vegetable) => total + vegetable.count,
                 0,
@@ -827,6 +843,7 @@ export function mergePackedPlantRenderDataInstances(
     for (const [type, count] of vegetableCounts) {
         vegetableTargets.set(type, {
             data: {
+                colors: new Float32Array(count * 3),
                 count,
                 growth: new Float32Array(count),
                 matrices: new Float32Array(count * 16),
@@ -933,6 +950,7 @@ export function mergePackedPlantRenderDataInstances(
                 targetMatrixOffset: target.matrixOffset,
                 transform,
             });
+            target.data.colors.set(vegetable.colors, target.matrixOffset * 3);
             target.data.growth.fill(
                 1,
                 target.matrixOffset,
@@ -983,6 +1001,7 @@ function getPackedPlantRenderDataViews(
         packed.thorns.swayPhases,
         ...packed.vegetables.flatMap((vegetable) => [
             vegetable.matrices,
+            vegetable.colors,
             vegetable.growth,
             vegetable.swayPhases,
         ]),

--- a/packages/game/src/generators/plant/lib/packedPlantRenderData.unit.ts
+++ b/packages/game/src/generators/plant/lib/packedPlantRenderData.unit.ts
@@ -228,6 +228,15 @@ function assertPackedRenderDataEqual(
             `${vegetableGroup.type} vegetable`,
         );
         assertPackedValuesEqual(
+            vegetableGroup.colors,
+            expected.flatMap((vegetable) => [
+                vegetable.color.r,
+                vegetable.color.g,
+                vegetable.color.b,
+            ]),
+            `${vegetableGroup.type} color`,
+        );
+        assertPackedValuesEqual(
             vegetableGroup.growth,
             expected.map((vegetable) => vegetable.growth),
             `${vegetableGroup.type} growth`,
@@ -252,6 +261,7 @@ function getExpectedTransferByteLength(packed: PackedPlantRenderData) {
             (total, vegetable) =>
                 total +
                 vegetable.matrices.byteLength +
+                vegetable.colors.byteLength +
                 vegetable.growth.byteLength +
                 vegetable.swayPhases.byteLength,
             0,
@@ -476,6 +486,10 @@ test('composes root transforms and bakes vegetable growth like the current rende
         Array.from(composedTomatoes.growth),
         Array.from({ length: composedTomatoes.count }, () => 1),
     );
+    assert.deepEqual(
+        Array.from(composedTomatoes.colors),
+        Array.from(packed.vegetables[0]?.colors ?? []),
+    );
     assert.ok(
         packed.vegetables.some((vegetable) =>
             Array.from(vegetable.growth).some((growth) => growth !== 1),
@@ -645,18 +659,30 @@ test('merges exact template instances while preserving channel and produce order
         ),
     );
 
-    const expectedVegetables = new Map<VegetableType, THREE.Matrix4[]>();
+    const expectedVegetables = new Map<
+        VegetableType,
+        { colors: number[]; matrices: THREE.Matrix4[] }
+    >();
     for (const source of sources) {
         for (const vegetable of source.exact.vegetables) {
-            const matrices = expectedVegetables.get(vegetable.type);
+            const expected = expectedVegetables.get(vegetable.type);
             const matrix = bakeReferenceVegetableGrowth(
                 vegetable,
                 source.transform,
             );
-            if (matrices) {
-                matrices.push(matrix);
+            const color = [
+                vegetable.color.r,
+                vegetable.color.g,
+                vegetable.color.b,
+            ];
+            if (expected) {
+                expected.matrices.push(matrix);
+                expected.colors.push(...color);
             } else {
-                expectedVegetables.set(vegetable.type, [matrix]);
+                expectedVegetables.set(vegetable.type, {
+                    colors: color,
+                    matrices: [matrix],
+                });
             }
         }
     }
@@ -667,11 +693,16 @@ test('merges exact template instances while preserving channel and produce order
     for (const vegetable of merged.vegetables) {
         const expected = expectedVegetables.get(vegetable.type);
         assert.ok(expected);
-        assert.equal(vegetable.count, expected.length);
+        assert.equal(vegetable.count, expected.matrices.length);
         assertPackedMatricesClose(
             vegetable.matrices,
-            expected,
+            expected.matrices,
             `merged ${vegetable.type}`,
+        );
+        assertPackedValuesEqual(
+            vegetable.colors,
+            expected.colors,
+            `merged ${vegetable.type} color`,
         );
         assert.ok(Array.from(vegetable.growth).every((growth) => growth === 1));
     }

--- a/packages/game/src/generators/plant/lib/plant-render-worker-types.ts
+++ b/packages/game/src/generators/plant/lib/plant-render-worker-types.ts
@@ -4,7 +4,7 @@ import type {
 } from './packedPlantRenderData';
 import type { PlantDefinition } from './plant-definitions';
 
-export const PACKED_PLANT_RENDER_WORKER_PROTOCOL_VERSION = 3 as const;
+export const PACKED_PLANT_RENDER_WORKER_PROTOCOL_VERSION = 4 as const;
 export const PACKED_PLANT_RENDER_WORKER_REQUEST_KIND =
     'packed-plant-render-request' as const;
 export const PACKED_PLANT_RENDER_WORKER_RESPONSE_KIND =

--- a/packages/game/src/generators/plant/lib/plantLodSummary.ts
+++ b/packages/game/src/generators/plant/lib/plantLodSummary.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import type { PlantDefinition } from './plant-definitions';
 import type { PlantLodSummary } from './plantRenderData';
 import { SeededRNG } from './rng';
-import { vegetableMaterialProps } from './vegetableRenderMetadata';
+import { resolveVegetableColor } from './vegetableRenderMetadata';
 
 interface BuildApproximatePlantLodSummaryOptions {
     flowerGrowth: number;
@@ -133,15 +133,15 @@ export function buildApproximatePlantLodSummary({
     const reproduction = development.reproduction;
     const storage = development.storage;
     const fruitStart = storage?.birthGeneration ?? reproduction.fruitStart;
-    const produceGrowth =
+    const produceMaturity =
         fruitStart === undefined
             ? 0
-            : fruitGrowth *
-              getLifecycleGrowth(
+            : getLifecycleGrowth(
                   generation,
                   fruitStart,
                   storage?.matureGeneration ?? fruitStart + 2.2,
               );
+    const produceGrowth = fruitGrowth * produceMaturity;
     const flowerStageGrowth =
         flowerGrowth *
         getLifecycleGrowth(
@@ -163,8 +163,10 @@ export function buildApproximatePlantLodSummary({
         plantDefinition.vegetable.enabled &&
         produceGrowth > 0.01
     ) {
-        accentColor =
-            vegetableMaterialProps[plantDefinition.vegetable.type].color;
+        accentColor = resolveVegetableColor(
+            plantDefinition.vegetable.type,
+            produceMaturity,
+        );
         if (storage) {
             accentCenterY = Math.max(
                 plantDefinition.vegetable.baseSize * storage.aboveSoilFraction,

--- a/packages/game/src/generators/plant/lib/plantShaderPrewarm.ts
+++ b/packages/game/src/generators/plant/lib/plantShaderPrewarm.ts
@@ -25,6 +25,10 @@ import {
     createPlantStemGeometryShell,
     disposePlantStemGeometryShell,
 } from './plantStemGeometry';
+import {
+    vegetableColorFragmentShader,
+    vegetableColorVertexShader,
+} from './plantVegetableMaterial';
 
 export const GENERATED_PLANT_SHADER_PREWARM_COMPILE_TIMEOUT_MS = 4_000;
 
@@ -33,6 +37,7 @@ export const generatedPlantShaderPrewarmVariants = [
     'leaf',
     'flower',
     'standard-sway',
+    'vegetable',
     'billboard',
     'mid-billboard',
     'shadow-proxy',
@@ -43,6 +48,7 @@ export const generatedPlantInstancedSwayShaderPrewarmVariants = [
     'leaf',
     'flower',
     'standard-sway',
+    'vegetable',
     'mid-billboard',
 ] as const;
 
@@ -248,6 +254,28 @@ export function createGeneratedPlantShaderPrewarmResources(): GeneratedPlantShad
     );
     standardSway.name = 'GeneratedPlantShaderPrewarm:standard-sway';
 
+    const vegetableGeometry = new THREE.ConeGeometry(0.5, 1, 6);
+    vegetableGeometry.setAttribute(
+        'vegetableInstanceColor',
+        new THREE.InstancedBufferAttribute(
+            new Float32Array([0.84, 0.16, 0.16]),
+            3,
+        ),
+    );
+    const vegetableMaterial = new CustomShaderMaterial({
+        baseMaterial: THREE.MeshStandardMaterial,
+        fragmentShader: vegetableColorFragmentShader,
+        vertexShader: vegetableColorVertexShader,
+        uniforms: createSwayUniforms(),
+        color: '#ffffff',
+        roughness: 0.7,
+    });
+    const vegetable = initializeWarmupMesh(
+        new THREE.InstancedMesh(vegetableGeometry, vegetableMaterial, 1),
+        { usesSway: true },
+    );
+    vegetable.name = 'GeneratedPlantShaderPrewarm:vegetable';
+
     const billboardGeometry = new THREE.PlaneGeometry(1, 1);
     billboardGeometry.setAttribute(
         'instanceTint',
@@ -321,6 +349,7 @@ export function createGeneratedPlantShaderPrewarmResources(): GeneratedPlantShad
         leaf,
         flower,
         standardSway,
+        vegetable,
         billboard,
         midBillboard,
         shadowProxy,
@@ -340,6 +369,7 @@ export function createGeneratedPlantShaderPrewarmResources(): GeneratedPlantShad
             leafGeometry.dispose();
             flowerGeometry.dispose();
             standardSwayGeometry.dispose();
+            vegetableGeometry.dispose();
             billboardGeometry.dispose();
             midBillboardGeometry.dispose();
             shadowProxyGeometry.dispose();
@@ -347,6 +377,7 @@ export function createGeneratedPlantShaderPrewarmResources(): GeneratedPlantShad
             leafMaterial.dispose();
             flowerMaterial.dispose();
             standardSwayMaterial.dispose();
+            vegetableMaterial.dispose();
             billboardMaterial.dispose();
             midBillboardMaterial.dispose();
             shadowProxyColorMaterial.dispose();

--- a/packages/game/src/generators/plant/lib/plantShaderPrewarm.unit.ts
+++ b/packages/game/src/generators/plant/lib/plantShaderPrewarm.unit.ts
@@ -56,6 +56,11 @@ describe('generated plant shader prewarm', () => {
                 .get('leaf')
                 ?.geometry.hasAttribute('leafInstanceColor'),
         );
+        assert.ok(
+            meshesByVariant
+                .get('vegetable')
+                ?.geometry.hasAttribute('vegetableInstanceColor'),
+        );
         for (const variant of generatedPlantInstancedSwayShaderPrewarmVariants) {
             assert.ok(
                 meshesByVariant

--- a/packages/game/src/generators/plant/lib/plantVegetableMaterial.ts
+++ b/packages/game/src/generators/plant/lib/plantVegetableMaterial.ts
@@ -1,0 +1,22 @@
+import { plantSwayVertexShader } from '../hooks/usePlantSway';
+
+export const vegetableColorVertexShader = /* glsl */ `
+    attribute vec3 vegetableInstanceColor;
+    varying vec3 vVegetableInstanceColor;
+
+    ${plantSwayVertexShader.replace(
+        'void main() {',
+        `
+        void main() {
+            vVegetableInstanceColor = vegetableInstanceColor;
+        `,
+    )}
+`;
+
+export const vegetableColorFragmentShader = /* glsl */ `
+    varying vec3 vVegetableInstanceColor;
+
+    void main() {
+        csm_DiffuseColor = vec4(vVegetableInstanceColor, 1.0);
+    }
+`;

--- a/packages/game/src/generators/plant/lib/vegetableRenderMetadata.ts
+++ b/packages/game/src/generators/plant/lib/vegetableRenderMetadata.ts
@@ -1,10 +1,18 @@
-import type { Matrix4 } from 'three';
+import type { Color, Matrix4 } from 'three';
 import type { VegetableType } from './plant-definitions';
 
 export interface VegetableData {
+    color: Color;
     growth: number;
     matrix: Matrix4;
     type: VegetableType;
+}
+
+interface VegetableMaterialProps {
+    color: string;
+    ripeningStart?: number;
+    roughness: number;
+    unripeColor?: string;
 }
 
 /**
@@ -14,19 +22,54 @@ export interface VegetableData {
  */
 export const vegetableMaterialProps: Record<
     VegetableType,
-    { color: string; roughness: number }
+    VegetableMaterialProps
 > = {
-    strawberry: { color: '#cf3f4c', roughness: 0.52 },
-    blueberry: { color: '#5366bd', roughness: 0.58 },
-    raspberry: { color: '#c33b62', roughness: 0.5 },
-    tomato: { color: '#ff4500', roughness: 0.5 },
+    strawberry: {
+        color: '#cf3f4c',
+        ripeningStart: 0.5,
+        roughness: 0.52,
+        unripeColor: '#a2b85b',
+    },
+    blueberry: {
+        color: '#5366bd',
+        ripeningStart: 0.55,
+        roughness: 0.58,
+        unripeColor: '#8fad62',
+    },
+    raspberry: {
+        color: '#c33b62',
+        ripeningStart: 0.5,
+        roughness: 0.5,
+        unripeColor: '#9aad55',
+    },
+    tomato: {
+        color: '#d62828',
+        ripeningStart: 0.55,
+        roughness: 0.5,
+        unripeColor: '#6f8135',
+    },
     cucumber: { color: '#2e591a', roughness: 0.6 },
-    bellpepper: { color: '#d42a00', roughness: 0.4 },
+    bellpepper: {
+        color: '#c72f1e',
+        ripeningStart: 0.55,
+        roughness: 0.4,
+        unripeColor: '#4f7d32',
+    },
     carrot: { color: '#e56a1f', roughness: 0.7 },
     onion: { color: '#d1b28a', roughness: 0.8 },
-    eggplant: { color: '#5f3478', roughness: 0.45 },
+    eggplant: {
+        color: '#5f3478',
+        ripeningStart: 0.5,
+        roughness: 0.45,
+        unripeColor: '#87a45e',
+    },
     zucchini: { color: '#3f6a2a', roughness: 0.6 },
-    pumpkin: { color: '#d8771e', roughness: 0.72 },
+    pumpkin: {
+        color: '#d8771e',
+        ripeningStart: 0.45,
+        roughness: 0.72,
+        unripeColor: '#5d7931',
+    },
     melon: { color: '#a7bf69', roughness: 0.7 },
     beet: { color: '#8c2444', roughness: 0.6 },
     radish: { color: '#d04258', roughness: 0.6 },
@@ -43,3 +86,37 @@ export const vegetableMaterialProps: Record<
     fennel: { color: '#d6e5a3', roughness: 0.75 },
     kohlrabi: { color: '#9fc46f', roughness: 0.74 },
 };
+
+function clamp01(value: number) {
+    return Math.min(1, Math.max(0, value));
+}
+
+function mixHexColors(from: string, to: string, amount: number) {
+    const fromValue = Number.parseInt(from.slice(1), 16);
+    const toValue = Number.parseInt(to.slice(1), 16);
+    const progress = clamp01(amount);
+    const mixChannel = (shift: number) => {
+        const fromChannel = (fromValue >> shift) & 0xff;
+        const toChannel = (toValue >> shift) & 0xff;
+        return Math.round(fromChannel + (toChannel - fromChannel) * progress);
+    };
+    const mixed = (mixChannel(16) << 16) | (mixChannel(8) << 8) | mixChannel(0);
+
+    return `#${mixed.toString(16).padStart(6, '0')}`;
+}
+
+export function resolveVegetableColor(type: VegetableType, maturity: number) {
+    const material = vegetableMaterialProps[type];
+    if (!material.unripeColor) {
+        return material.color;
+    }
+
+    const ripeningStart = material.ripeningStart ?? 0;
+    const linearProgress = clamp01(
+        (clamp01(maturity) - ripeningStart) / (1 - ripeningStart),
+    );
+    const easedProgress =
+        linearProgress * linearProgress * (3 - 2 * linearProgress);
+
+    return mixHexColors(material.unripeColor, material.color, easedProgress);
+}

--- a/packages/game/src/generators/plant/lib/vegetableRenderMetadata.unit.ts
+++ b/packages/game/src/generators/plant/lib/vegetableRenderMetadata.unit.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    resolveVegetableColor,
+    vegetableMaterialProps,
+} from './vegetableRenderMetadata';
+
+test('keeps tomatoes green before ripening and deep red at maturity', () => {
+    assert.equal(resolveVegetableColor('tomato', 0), '#6f8135');
+    assert.equal(resolveVegetableColor('tomato', 0.55), '#6f8135');
+    assert.equal(resolveVegetableColor('tomato', 1), '#d62828');
+    assert.equal(vegetableMaterialProps.tomato.color, '#d62828');
+
+    const turningColor = resolveVegetableColor('tomato', 0.8);
+    assert.notEqual(turningColor, '#6f8135');
+    assert.notEqual(turningColor, '#d62828');
+});
+
+test('ripens color-changing produce while preserving fixed-color produce', () => {
+    for (const type of [
+        'strawberry',
+        'blueberry',
+        'raspberry',
+        'bellpepper',
+        'eggplant',
+        'pumpkin',
+    ] as const) {
+        assert.notEqual(
+            resolveVegetableColor(type, 0),
+            resolveVegetableColor(type, 1),
+        );
+        assert.equal(
+            resolveVegetableColor(type, 1),
+            vegetableMaterialProps[type].color,
+        );
+    }
+
+    assert.equal(resolveVegetableColor('cucumber', 0), '#2e591a');
+    assert.equal(resolveVegetableColor('cucumber', 0.5), '#2e591a');
+    assert.equal(resolveVegetableColor('cucumber', 1), '#2e591a');
+});
+
+test('clamps produce maturity outside the lifecycle range', () => {
+    assert.equal(
+        resolveVegetableColor('tomato', -1),
+        resolveVegetableColor('tomato', 0),
+    );
+    assert.equal(
+        resolveVegetableColor('tomato', 2),
+        resolveVegetableColor('tomato', 1),
+    );
+});

--- a/packages/game/src/generators/plant/parts/vegetables.tsx
+++ b/packages/game/src/generators/plant/parts/vegetables.tsx
@@ -4,7 +4,7 @@ import React, { useLayoutEffect, useMemo } from 'react';
 import * as THREE from 'three';
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import CSM from 'three-custom-shader-material';
-import { plantSwayVertexShader, usePlantSway } from '../hooks/usePlantSway';
+import { usePlantSway } from '../hooks/usePlantSway';
 import type {
     PackedPlantBounds,
     PackedPlantVegetableInstances,
@@ -23,6 +23,10 @@ import {
 } from '../lib/plantInstanceBuffers';
 import { resolvePlantPartCastShadow } from '../lib/plantPartRendering';
 import {
+    vegetableColorFragmentShader,
+    vegetableColorVertexShader,
+} from '../lib/plantVegetableMaterial';
+import {
     type VegetableData,
     vegetableMaterialProps,
 } from '../lib/vegetableRenderMetadata';
@@ -38,6 +42,7 @@ interface VegetablesProps {
 
 interface VegetableInstanceGroup {
     type: VegetableType;
+    color: THREE.InstancedBufferAttribute;
     count: number;
     data?: VegetableData[];
     geometry: THREE.BufferGeometry;
@@ -291,6 +296,7 @@ export function Vegetables({
         if (packed.length > 0) {
             return packed.map(
                 (data): VegetableInstanceGroup => ({
+                    color: createStaticInstancedBufferAttribute(data.count, 3),
                     count: data.count,
                     geometry: createPlantGeometryShell(
                         vegetableGeometries[data.type],
@@ -334,6 +340,7 @@ export function Vegetables({
             instanceMap.values(),
             (group): VegetableInstanceGroup => ({
                 ...group,
+                color: createStaticInstancedBufferAttribute(group.count, 3),
                 geometry: createPlantGeometryShell(
                     vegetableGeometries[group.type],
                 ),
@@ -363,6 +370,14 @@ export function Vegetables({
             }
 
             mesh.geometry.setAttribute('instanceSwayPhase', group.swayPhase);
+            mesh.geometry.setAttribute('vegetableInstanceColor', group.color);
+            if (group.packed) {
+                copyPackedStaticInstancedAttribute(
+                    group.color,
+                    group.packed.colors,
+                    group.packed.count,
+                );
+            }
             const packedGrowthIsBaked = group.packed?.growth.every(
                 (growth) => growth === 1,
             );
@@ -397,13 +412,15 @@ export function Vegetables({
                 );
             } else {
                 group.data?.forEach((veg, index) => {
-                    const { matrix, growth } = veg;
+                    const { color, matrix, growth } = veg;
                     matrix.decompose(tempPosition, tempQuaternion, tempScale);
                     tempScale.multiplyScalar(growth);
                     tempMatrix.compose(tempPosition, tempQuaternion, tempScale);
                     mesh.setMatrixAt(index, tempMatrix);
+                    group.color.setXYZ(index, color.r, color.g, color.b);
                 });
                 finalizeStaticInstanceMatrixUpload(mesh, group.count);
+                markStaticInstancedAttributeForUpload(group.color, group.count);
                 markStaticInstancedAttributeForUpload(
                     group.swayPhase,
                     group.count,
@@ -419,6 +436,7 @@ export function Vegetables({
                 generatedPlantInstanceBufferMetrics.register({
                     allocatedBytes:
                         mesh.instanceMatrix.array.byteLength +
+                        group.color.array.byteLength +
                         group.swayPhase.array.byteLength,
                     capacity: mesh.instanceMatrix.count,
                     kind: 'vegetable',
@@ -468,9 +486,10 @@ export function Vegetables({
                 >
                     <CSM
                         baseMaterial={THREE.MeshStandardMaterial}
-                        vertexShader={plantSwayVertexShader}
+                        fragmentShader={vegetableColorFragmentShader}
+                        vertexShader={vegetableColorVertexShader}
                         uniforms={swayUniforms}
-                        color={vegetableMaterialProps[group.type].color}
+                        color="#ffffff"
                         roughness={vegetableMaterialProps[group.type].roughness}
                     />
                 </instancedMesh>

--- a/packages/game/src/generators/plant/workers/plant-render-worker-handler.ts
+++ b/packages/game/src/generators/plant/workers/plant-render-worker-handler.ts
@@ -90,6 +90,7 @@ function clonePackedPlantRenderData(
             swayPhases: template.thorns.swayPhases.slice(),
         },
         vegetables: template.vegetables.map((vegetable) => ({
+            colors: vegetable.colors.slice(),
             count: vegetable.count,
             growth: vegetable.growth.slice(),
             matrices: vegetable.matrices.slice(),

--- a/packages/game/src/generators/plant/workers/plant-render-worker-handler.unit.ts
+++ b/packages/game/src/generators/plant/workers/plant-render-worker-handler.unit.ts
@@ -52,14 +52,14 @@ function createRequest(): PackedPlantRenderWorkerRequest {
     };
 }
 
-test('requires the graph-only packed plant protocol v3', () => {
+test('requires the graph-only packed plant protocol v4', () => {
     const request = createRequest();
     const unsupportedKind = { ...request };
     const unsupportedVersion = { ...request };
     Reflect.set(unsupportedKind, 'kind', 'unsupported-kind');
-    Reflect.set(unsupportedVersion, 'version', 2);
+    Reflect.set(unsupportedVersion, 'version', 3);
 
-    assert.equal(PACKED_PLANT_RENDER_WORKER_PROTOCOL_VERSION, 3);
+    assert.equal(PACKED_PLANT_RENDER_WORKER_PROTOCOL_VERSION, 4);
     assert.throws(
         () => handlePlantRenderWorkerRequest(unsupportedKind),
         /Unsupported packed plant worker protocol/,


### PR DESCRIPTION
## What changed

- derive produce color from each organ's developmental maturity
- keep tomatoes green before ripening and render mature tomatoes deep red instead of orange
- add gradual unripe-to-ripe transitions for strawberries, blueberries, raspberries, peppers, eggplants, and pumpkins
- force fields explicitly marked ready to use the fully mature visual state
- carry per-instance produce colors through direct, billboard, packed worker, and batched render paths

## Why

Produce previously used one fixed material color at every growth stage. Tomato's fixed `#ff4500` value was orange-red, so young fruit appeared ripe and harvest-ready fruit still looked orange.

## Impact

Garden produce now communicates maturity visually. Date-driven growth progressively changes ripening crops, while ready fields always show their harvest color across near and far LODs.

## Validation

- `pnpm --filter @gredice/game test` (811/811)
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm build --filter garden`
- production-build runtime check of `/debug/plants?catalog=1&labels=1` in Chromium