### PR TITLE
fix(game): preserve raised-bed soil after material swaps

### DIFF
--- a/apps/garden/playwright.config.ts
+++ b/apps/garden/playwright.config.ts
@@ -18,7 +18,8 @@ const reporter: PlaywrightTestConfig['reporter'] = [
     ['list'],
     ['html', { open: 'never' }],
 ];
-const webglTestPattern = /(garden-preview-capture|hover-outline)\.spec\.tsx/;
+const webglTestPattern =
+    /(garden-preview-capture|hover-outline|instanced-mesh-material-swap)\.spec\.tsx/;
 
 // Plugin to intercept next/font/google before Vite's resolver
 function nextFontMockPlugin() {

--- a/apps/garden/tests/instanced-mesh-material-swap.spec.tsx
+++ b/apps/garden/tests/instanced-mesh-material-swap.spec.tsx
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { InstancedMeshMaterialSwapFixture } from '../../../packages/game/tests/InstancedMeshMaterialSwapFixture';
+
+test('preserves instance transforms when the material constructor argument changes', async ({
+    mount,
+    page,
+}) => {
+    const browserErrors: string[] = [];
+    page.on('console', (message) => {
+        if (message.type() === 'error') {
+            browserErrors.push(message.text());
+        }
+    });
+    page.on('pageerror', (error) => {
+        browserErrors.push(error.message);
+    });
+
+    const fixture = await mount(<InstancedMeshMaterialSwapFixture />);
+    await expect(fixture).toHaveAttribute('data-render-ready', 'true');
+
+    const result = JSON.parse(
+        (await fixture
+            .getByTestId('instanced-mesh-material-swap-result')
+            .textContent()) ?? '{}',
+    );
+    expect(result).toEqual({
+        positions: [
+            [2, 1, 3],
+            [4, 2, 5],
+        ],
+        status: 'ready',
+    });
+    expect(browserErrors).toEqual([]);
+});

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -1122,7 +1122,7 @@ function EntityInstancesGeometryRenderer(
     );
 }
 
-const ChunkedInstancedMesh = memo(function ChunkedInstancedMesh({
+export const ChunkedInstancedMesh = memo(function ChunkedInstancedMesh({
     castShadow,
     chunk,
     debugName,
@@ -1156,7 +1156,10 @@ const ChunkedInstancedMesh = memo(function ChunkedInstancedMesh({
     useLayoutEffect(() => {
         const startedAt = placementAnimationProfileNow();
         const mesh = meshRef.current;
-        if (mesh) {
+        const meshUsesCurrentConstructorArguments =
+            mesh?.geometry === geometry &&
+            (material === undefined || mesh.material === material);
+        if (mesh && meshUsesCurrentConstructorArguments) {
             chunk.instances.forEach((instance, index) => {
                 mesh.setMatrixAt(
                     index,
@@ -1186,7 +1189,14 @@ const ChunkedInstancedMesh = memo(function ChunkedInstancedMesh({
                 transformedInstanceCount: chunk.instances.length,
             });
         }
-    }, [chunk.instances, localTransform, placementSignature, scale]);
+    }, [
+        chunk.instances,
+        geometry,
+        localTransform,
+        material,
+        placementSignature,
+        scale,
+    ]);
 
     if (chunk.instances.length === 0) {
         return null;

--- a/packages/game/tests/InstancedMeshMaterialSwapFixture.tsx
+++ b/packages/game/tests/InstancedMeshMaterialSwapFixture.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+    BoxGeometry,
+    InstancedMesh,
+    Matrix4,
+    MeshBasicMaterial,
+    Vector3,
+} from 'three';
+import type { MeshInstanceLocalTransform } from '../src/entities/chunkedMeshGeometry';
+import {
+    ChunkedInstancedMesh,
+    type EntityBlockInstance,
+} from '../src/entities/EntityInstancesBlock';
+
+const firstBlock = {
+    id: 'material-swap-first',
+    name: 'Material_Swap_First',
+    rotation: 0,
+};
+const secondBlock = {
+    id: 'material-swap-second',
+    name: 'Material_Swap_Second',
+    rotation: 0,
+};
+const firstStack = {
+    blocks: [firstBlock],
+    position: new Vector3(2, 1, 3),
+};
+const secondStack = {
+    blocks: [secondBlock],
+    position: new Vector3(4, 2, 5),
+};
+const instances = [
+    {
+        block: firstBlock,
+        blockIndex: 0,
+        id: firstBlock.id,
+        pickupOutlineVisible: false,
+        position: [2, 1, 3],
+        rotation: 0,
+        stack: firstStack,
+        stackHeight: 1,
+    },
+    {
+        block: secondBlock,
+        blockIndex: 0,
+        id: secondBlock.id,
+        pickupOutlineVisible: false,
+        position: [4, 2, 5],
+        rotation: 0,
+        stack: secondStack,
+        stackHeight: 1,
+    },
+] satisfies EntityBlockInstance[];
+const chunk = { instances, key: 'material-swap' };
+const localTransform: MeshInstanceLocalTransform = {
+    position: [0, 0, 0],
+    rotation: [0, 0, 0],
+};
+
+type MatrixReadback = {
+    positions: number[][];
+    status: 'ready';
+};
+
+function roundPosition(position: Vector3) {
+    return position.toArray().map((value) => Number(value.toFixed(4)));
+}
+
+function MaterialSwapScene({
+    onReadback,
+}: {
+    onReadback: (readback: MatrixReadback) => void;
+}) {
+    const scene = useThree((state) => state.scene);
+    const [swapped, setSwapped] = useState(false);
+    const renderedFrameCount = useRef(0);
+    const postSwapFrameCount = useRef(0);
+    const swapRequested = useRef(false);
+    const readbackComplete = useRef(false);
+    const geometry = useMemo(() => new BoxGeometry(1, 1, 1), []);
+    const initialMaterial = useMemo(
+        () => new MeshBasicMaterial({ color: '#8b5a2b' }),
+        [],
+    );
+    const replacementMaterial = useMemo(
+        () => new MeshBasicMaterial({ color: '#4f321c' }),
+        [],
+    );
+
+    useEffect(
+        () => () => {
+            geometry.dispose();
+            initialMaterial.dispose();
+            replacementMaterial.dispose();
+        },
+        [geometry, initialMaterial, replacementMaterial],
+    );
+
+    useFrame(() => {
+        renderedFrameCount.current += 1;
+        if (
+            !swapped &&
+            !swapRequested.current &&
+            renderedFrameCount.current >= 2
+        ) {
+            swapRequested.current = true;
+            setSwapped(true);
+            return;
+        }
+
+        if (!swapped || readbackComplete.current) {
+            return;
+        }
+
+        postSwapFrameCount.current += 1;
+        if (postSwapFrameCount.current < 3) {
+            return;
+        }
+
+        const object = scene.getObjectByName('MaterialSwapInstances');
+        if (!(object instanceof InstancedMesh)) {
+            return;
+        }
+
+        const matrix = new Matrix4();
+        const position = new Vector3();
+        const positions = instances.map((_, index) => {
+            object.getMatrixAt(index, matrix);
+            position.setFromMatrixPosition(matrix);
+            return roundPosition(position);
+        });
+        readbackComplete.current = true;
+        onReadback({ positions, status: 'ready' });
+    });
+
+    return (
+        <ChunkedInstancedMesh
+            castShadow={false}
+            chunk={chunk}
+            debugName="MaterialSwapInstances"
+            geometry={geometry}
+            localTransform={localTransform}
+            material={swapped ? replacementMaterial : initialMaterial}
+            materialNode={null}
+            placementSignature="material-swap-placement"
+            receiveShadow={false}
+            scale={undefined}
+        />
+    );
+}
+
+export function InstancedMeshMaterialSwapFixture() {
+    const [result, setResult] = useState<
+        MatrixReadback | { status: 'waiting' }
+    >({ status: 'waiting' });
+    const handleReadback = useCallback(
+        (readback: MatrixReadback) => setResult(readback),
+        [],
+    );
+
+    return (
+        <div
+            data-render-ready={result.status === 'ready' ? 'true' : 'false'}
+            data-testid="instanced-mesh-material-swap-fixture"
+            style={{ height: 240, width: 360 }}
+        >
+            <output data-testid="instanced-mesh-material-swap-result">
+                {JSON.stringify(result)}
+            </output>
+            <Canvas
+                camera={{ position: [0, 0, 10] }}
+                frameloop="always"
+                gl={{ preserveDrawingBuffer: true }}
+            >
+                <MaterialSwapScene onReadback={handleReadback} />
+            </Canvas>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

- rerun instanced-mesh matrix setup when React Three Fiber reconstructs a mesh after its geometry or material changes
- verify the current constructor arguments before applying transforms
- add a software-WebGL component regression that swaps the material and reads back two instance matrices

## Root cause

Recent watering operations change the raised-bed soil material after the operation directory loads. React Three Fiber reconstructs the `InstancedMesh` because its constructor material changes, but the matrix layout effect previously did not depend on that material. The replacement mesh therefore kept identity matrices, collapsing the soil instances to the origin while the wooden bed remained visible.

## Validation

- `pnpm --filter garden run test:prepare`
- `pnpm --filter garden exec playwright test tests/instanced-mesh-material-swap.spec.tsx --project=chromium-webgl`
- regression fails with both matrices at `[0, 0, 0]` when the new dependencies are removed, and passes with `[2, 1, 3]` / `[4, 2, 5]` after the fix
- `pnpm --filter @gredice/game test` (806 passed)
- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden lint`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
