### PR TITLE
feat(news): group changelog posts by week

### DIFF
--- a/apps/news/app/sto-je-novo/page.tsx
+++ b/apps/news/app/sto-je-novo/page.tsx
@@ -6,7 +6,6 @@ import { NewsArchiveNavigation } from '../../components/NewsArchiveNavigation';
 import { NewsCard } from '../../components/NewsCard';
 import { NewsTagFilters } from '../../components/NewsTagFilters';
 import {
-    formatNewsDate,
     getChangelogEntries,
     getPrimaryNewsTags,
     uniqueNewsValues,
@@ -19,12 +18,30 @@ const monthFormatter = new Intl.DateTimeFormat('hr-HR', {
     month: 'long',
     year: 'numeric',
 });
+const dayOnlyFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: 'numeric',
+});
+const dayMonthFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: 'numeric',
+    month: 'long',
+});
+const dayMonthYearFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+});
 type ChangelogEntry = Awaited<ReturnType<typeof getChangelogEntries>>[number];
 
 type ChangelogTimelineGroup = {
-    entries: ChangelogEntry[];
     monthKey: string;
     monthLabel: string;
+    weeks: ChangelogTimelineWeek[];
+};
+
+type ChangelogTimelineWeek = {
+    entries: ChangelogEntry[];
+    weekKey: string;
+    weekLabel: string;
 };
 
 function paddedDatePart(value: number) {
@@ -44,26 +61,89 @@ function getMonthKey(date: Date) {
     return [date.getFullYear(), paddedDatePart(date.getMonth() + 1)].join('-');
 }
 
-function groupEntriesByMonth(entries: ChangelogEntry[]) {
+function getDayKey(date: Date) {
+    return [
+        date.getFullYear(),
+        paddedDatePart(date.getMonth() + 1),
+        paddedDatePart(date.getDate()),
+    ].join('-');
+}
+
+function getWeekStart(date: Date) {
+    const weekStart = new Date(date);
+    const day = weekStart.getDay();
+    const mondayOffset = day === 0 ? -6 : 1 - day;
+
+    weekStart.setDate(weekStart.getDate() + mondayOffset);
+    weekStart.setHours(0, 0, 0, 0);
+
+    return weekStart;
+}
+
+function getWeekEnd(weekStart: Date) {
+    const weekEnd = new Date(weekStart);
+    weekEnd.setDate(weekStart.getDate() + 6);
+    weekEnd.setHours(23, 59, 59, 999);
+
+    return weekEnd;
+}
+
+function formatWeekRange(weekStart: Date, weekEnd: Date) {
+    if (
+        weekStart.getFullYear() === weekEnd.getFullYear() &&
+        weekStart.getMonth() === weekEnd.getMonth()
+    ) {
+        return `${dayOnlyFormatter.format(weekStart)} - ${dayMonthYearFormatter.format(weekEnd)}`;
+    }
+
+    if (weekStart.getFullYear() === weekEnd.getFullYear()) {
+        return `${dayMonthFormatter.format(weekStart)} - ${dayMonthYearFormatter.format(weekEnd)}`;
+    }
+
+    return `${dayMonthYearFormatter.format(weekStart)} - ${dayMonthYearFormatter.format(weekEnd)}`;
+}
+
+function groupEntriesByWeek(entries: ChangelogEntry[]) {
     const groups: ChangelogTimelineGroup[] = [];
     const groupsByKey = new Map<string, ChangelogTimelineGroup>();
+    const weeksByKey = new Map<string, ChangelogTimelineWeek>();
 
     for (const entry of entries) {
         const date = getEntryDate(entry);
-        const monthKey = date ? getMonthKey(date) : 'unknown';
+        const weekStart = date ? getWeekStart(date) : null;
+        const weekEnd = weekStart ? getWeekEnd(weekStart) : null;
+        const monthKey = weekStart ? getMonthKey(weekStart) : 'unknown';
+        const weekKey = weekStart ? getDayKey(weekStart) : 'unknown';
         let group = groupsByKey.get(monthKey);
 
         if (!group) {
             group = {
-                entries: [],
                 monthKey,
-                monthLabel: date ? monthFormatter.format(date) : 'Bez datuma',
+                monthLabel: weekStart
+                    ? monthFormatter.format(weekStart)
+                    : 'Bez datuma',
+                weeks: [],
             };
             groupsByKey.set(monthKey, group);
             groups.push(group);
         }
 
-        group.entries.push(entry);
+        let week = weeksByKey.get(weekKey);
+
+        if (!week) {
+            week = {
+                entries: [],
+                weekKey,
+                weekLabel:
+                    weekStart && weekEnd
+                        ? formatWeekRange(weekStart, weekEnd)
+                        : 'Bez datuma',
+            };
+            weeksByKey.set(weekKey, week);
+            group.weeks.push(week);
+        }
+
+        week.entries.push(entry);
     }
 
     return groups;
@@ -91,9 +171,12 @@ export default async function WhatsNewPage({
     const dropdownTags = tags.filter(
         (value) => !primaryTagKeys.has(value.toLocaleLowerCase('hr-HR')),
     );
-    const timelineGroups = groupEntriesByMonth(entries);
-    const totalEntries = entries.length;
-    let entryIndex = 0;
+    const timelineGroups = groupEntriesByWeek(entries);
+    const totalWeeks = timelineGroups.reduce(
+        (total, group) => total + group.weeks.length,
+        0,
+    );
+    let weekIndex = 0;
 
     return (
         <Container className="grid gap-8 py-10">
@@ -121,41 +204,41 @@ export default async function WhatsNewPage({
                 <Timeline>
                     {timelineGroups.map((group, groupIndex) => (
                         <TimelineGroup
-                            hasItems={group.entries.length > 0}
+                            hasItems={group.weeks.length > 0}
                             isFirst={groupIndex === 0}
                             key={group.monthKey}
                             label={group.monthLabel}
                         >
-                            {group.entries.map((entry) => {
-                                const currentEntryIndex = entryIndex;
-                                const dateLabel = entry.publishedAt
-                                    ? formatNewsDate(entry.publishedAt)
-                                    : null;
-                                entryIndex += 1;
+                            {group.weeks.map((week) => {
+                                const currentWeekIndex = weekIndex;
+                                weekIndex += 1;
 
                                 return (
                                     <TimelineEntry
-                                        index={currentEntryIndex}
+                                        index={currentWeekIndex}
                                         isLast={
-                                            currentEntryIndex ===
-                                            totalEntries - 1
+                                            currentWeekIndex === totalWeeks - 1
                                         }
-                                        key={entry.id}
-                                        label={dateLabel ?? 'Bez datuma'}
+                                        key={week.weekKey}
+                                        label={week.weekLabel}
                                     >
-                                        <NewsCard
-                                            entry={entry}
-                                            href={changelogEntryPath(
-                                                entry.slug,
-                                            )}
-                                            kind="changelog"
-                                            showDate={false}
-                                            showKindLabel={false}
-                                            viewTransitionName={getNewsArticleViewTransitionName(
-                                                'changelog',
-                                                entry.slug,
-                                            )}
-                                        />
+                                        <div className="space-y-4">
+                                            {week.entries.map((entry) => (
+                                                <NewsCard
+                                                    entry={entry}
+                                                    href={changelogEntryPath(
+                                                        entry.slug,
+                                                    )}
+                                                    key={entry.id}
+                                                    kind="changelog"
+                                                    showKindLabel={false}
+                                                    viewTransitionName={getNewsArticleViewTransitionName(
+                                                        'changelog',
+                                                        entry.slug,
+                                                    )}
+                                                />
+                                            ))}
+                                        </div>
                                     </TimelineEntry>
                                 );
                             })}


### PR DESCRIPTION
## What changed

- group “Što je novo” entries into Monday-to-Sunday weeks
- alternate the timeline by week instead of by individual post
- keep month markers and show each post's publication date inside its card

## Why

Busy release periods caused every post to jump between the left and right sides of the timeline. Grouping a week's posts on one side follows the existing plant-trace timeline pattern and makes the archive calmer to scan.

## Verification

- `pnpm lint --filter news`
- `pnpm typecheck --filter news`
- `pnpm build --filter news`
- production-build browser check at desktop and mobile widths using live archive data
- verified tag filtering, no horizontal overflow, no error overlay, and no browser errors
