### PR TITLE
feat(garden): improve 2D navigation and raised beds

### DIFF
--- a/apps/garden/tests/landing.spec.ts
+++ b/apps/garden/tests/landing.spec.ts
@@ -557,6 +557,58 @@ test('renders the shared HUD over a React-only 2D garden overview', async ({
         (finalScrollBounds?.x ?? 0) + (finalScrollBounds?.width ?? 0) + 1,
     );
 
+    const dragStartScrollLeft = await overviewScrollport.evaluate(
+        (element, scrollRange) => {
+            element.scrollLeft = scrollRange / 2;
+            return element.scrollLeft;
+        },
+        horizontalScrollRange,
+    );
+    const panBounds = await overviewScrollport.boundingBox();
+    expect(panBounds).not.toBeNull();
+    const panStartX = (panBounds?.x ?? 0) + (panBounds?.width ?? 0) * 0.7;
+    const panStartY = (panBounds?.y ?? 0) + (panBounds?.height ?? 0) * 0.7;
+    await page.mouse.move(panStartX, panStartY);
+    await page.mouse.down();
+    await page.mouse.move(panStartX - 100, panStartY, { steps: 5 });
+    await expect(overviewScrollport).toHaveAttribute('data-panning', 'true');
+    await page.mouse.up();
+    await expect
+        .poll(() =>
+            overviewScrollport.evaluate((element) => element.scrollLeft),
+        )
+        .toBeGreaterThan(dragStartScrollLeft + 60);
+    await expect(overviewScrollport).toHaveAttribute('data-panning', 'false');
+
+    const touchStartScrollLeft = await overviewScrollport.evaluate(
+        (element, scrollRange) => {
+            element.scrollLeft = scrollRange / 2;
+            return element.scrollLeft;
+        },
+        horizontalScrollRange,
+    );
+    const cdpSession = await page.context().newCDPSession(page);
+    await cdpSession.send('Input.dispatchTouchEvent', {
+        touchPoints: [{ x: panStartX, y: panStartY }],
+        type: 'touchStart',
+    });
+    await cdpSession.send('Input.dispatchTouchEvent', {
+        touchPoints: [{ x: panStartX - 100, y: panStartY }],
+        type: 'touchMove',
+    });
+    await expect(overviewScrollport).toHaveAttribute('data-panning', 'true');
+    await cdpSession.send('Input.dispatchTouchEvent', {
+        touchPoints: [],
+        type: 'touchEnd',
+    });
+    await cdpSession.detach();
+    await expect
+        .poll(() =>
+            overviewScrollport.evaluate((element) => element.scrollLeft),
+        )
+        .toBeGreaterThan(touchStartScrollLeft + 60);
+    await expect(overviewScrollport).toHaveAttribute('data-panning', 'false');
+
     await expect(overview).toHaveAttribute('data-world-rotation', '0');
     await expect(
         overview.locator('img[src*="Raised_Bed_1"]').first(),
@@ -590,6 +642,16 @@ test('renders the shared HUD over a React-only 2D garden overview', async ({
             name: 'Podignuta gredica Testna gredica',
         }),
     ).toBeVisible();
+    const raisedBedPlaceholder = page.locator(
+        '[data-raised-bed-2d-placeholder]',
+    );
+    await expect(raisedBedPlaceholder).toBeVisible();
+    await expect(
+        raisedBedPlaceholder.locator('[data-raised-bed-soil]'),
+    ).toBeVisible();
+    await expect(
+        raisedBedPlaceholder.locator('[data-raised-bed-plank]'),
+    ).toHaveCount(4);
     await expectNoImmediateRuntimeFailures(page, failures);
     await expect(page.locator('canvas')).toHaveCount(0);
     expect(modelRequests).toEqual([]);

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -238,7 +238,10 @@ export function GameHud({
                 </div>
             </div>
             {!isLocalSandbox && (
-                <RaisedBedFieldHud instantTransition={viewMode === '2d'} />
+                <RaisedBedFieldHud
+                    instantTransition={viewMode === '2d'}
+                    show2DPlaceholder={viewMode === '2d'}
+                />
             )}
             {!isLocalSandbox && <OverviewModal />}
             {!isLocalSandbox && <AdventModal />}

--- a/packages/game/src/GardenOverview2DMap.tsx
+++ b/packages/game/src/GardenOverview2DMap.tsx
@@ -2,7 +2,13 @@
 
 import type { BlockData } from '@gredice/client';
 import { cx } from '@gredice/ui/utils';
-import { type CSSProperties, useMemo, useRef } from 'react';
+import {
+    type CSSProperties,
+    type PointerEvent as ReactPointerEvent,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import { useHudPlacementPreview } from './controls/useHudPlacementPreview';
 import { GardenOverview2DBlockImage } from './GardenOverview2DBlockImage';
 import {
@@ -18,6 +24,16 @@ import { useSetRaisedBedCloseupParam } from './useRaisedBedCloseup';
 import { getRaisedBedBlockIds } from './utils/raisedBedBlocks';
 
 const gridPositionSelector = '[data-garden-grid-position="true"]';
+const panStartThreshold = 4;
+
+type PanSession = {
+    hasMoved: boolean;
+    pointerId: number;
+    scrollLeft: number;
+    scrollTop: number;
+    x: number;
+    y: number;
+};
 
 function gridAreaStyle(
     area: GardenOverview2DGridArea,
@@ -43,6 +59,9 @@ export function GardenOverview2DMap({
     garden: CurrentGarden;
 }) {
     const gridRef = useRef<HTMLElement>(null);
+    const panSessionRef = useRef<PanSession | null>(null);
+    const suppressClickRef = useRef(false);
+    const [isPanning, setIsPanning] = useState(false);
     const worldRotation = useGameState((state) => state.worldRotation);
     const activeView = useGameState((state) => state.view);
     const hudPlacementDrag = useGameState((state) => state.hudPlacementDrag);
@@ -161,15 +180,112 @@ export function GardenOverview2DMap({
         gridTemplateRows: `repeat(${gridRowCount}, clamp(2.75rem, 7vw, 4.5rem))`,
     };
 
+    function handlePointerDown(event: ReactPointerEvent<HTMLDivElement>) {
+        if (
+            !event.isPrimary ||
+            event.button !== 0 ||
+            hudPlacementDrag !== null
+        ) {
+            return;
+        }
+
+        panSessionRef.current = {
+            hasMoved: false,
+            pointerId: event.pointerId,
+            scrollLeft: event.currentTarget.scrollLeft,
+            scrollTop: event.currentTarget.scrollTop,
+            x: event.clientX,
+            y: event.clientY,
+        };
+        suppressClickRef.current = false;
+    }
+
+    function handlePointerMove(event: ReactPointerEvent<HTMLDivElement>) {
+        const panSession = panSessionRef.current;
+        if (!panSession || panSession.pointerId !== event.pointerId) {
+            return;
+        }
+
+        const deltaX = event.clientX - panSession.x;
+        const deltaY = event.clientY - panSession.y;
+        if (
+            !panSession.hasMoved &&
+            Math.hypot(deltaX, deltaY) < panStartThreshold
+        ) {
+            return;
+        }
+
+        if (!panSession.hasMoved) {
+            panSession.hasMoved = true;
+            suppressClickRef.current = true;
+            setIsPanning(true);
+            event.currentTarget.setPointerCapture(event.pointerId);
+        }
+
+        event.preventDefault();
+        event.currentTarget.scrollLeft = panSession.scrollLeft - deltaX;
+        event.currentTarget.scrollTop = panSession.scrollTop - deltaY;
+    }
+
+    function finishPointerPan(event: ReactPointerEvent<HTMLDivElement>) {
+        const panSession = panSessionRef.current;
+        if (!panSession || panSession.pointerId !== event.pointerId) {
+            return;
+        }
+
+        panSessionRef.current = null;
+        setIsPanning(false);
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+            event.currentTarget.releasePointerCapture(event.pointerId);
+        }
+
+        if (panSession.hasMoved) {
+            window.setTimeout(() => {
+                suppressClickRef.current = false;
+            }, 0);
+        }
+    }
+
+    function cancelPointerPan(event: ReactPointerEvent<HTMLDivElement>) {
+        suppressClickRef.current = false;
+        finishPointerPan(event);
+    }
+
+    function abandonUncapturedPointer(
+        event: ReactPointerEvent<HTMLDivElement>,
+    ) {
+        const panSession = panSessionRef.current;
+        if (panSession?.pointerId === event.pointerId && !panSession.hasMoved) {
+            panSessionRef.current = null;
+        }
+    }
+
     return (
-        <div
+        <section
             data-garden-overview-2d
+            data-panning={isPanning ? 'true' : 'false'}
+            aria-label="Pomicanje tlocrta vrta"
             className={cx(
-                'absolute inset-0 overflow-auto overscroll-contain bg-[radial-gradient(circle_at_top,#dcfce7_0%,#bbf7d0_38%,#86efac_100%)] transition-[opacity,transform] duration-300 dark:bg-[radial-gradient(circle_at_top,#163522_0%,#10271a_45%,#07150d_100%)]',
+                'absolute inset-0 touch-none cursor-grab overflow-auto overscroll-contain bg-[radial-gradient(circle_at_top,#dcfce7_0%,#bbf7d0_38%,#86efac_100%)] transition-[opacity,transform] duration-300 dark:bg-[radial-gradient(circle_at_top,#163522_0%,#10271a_45%,#07150d_100%)]',
+                isPanning && 'cursor-grabbing',
                 isCloseup && 'pointer-events-none scale-95 opacity-0',
             )}
             aria-hidden={isCloseup ? 'true' : 'false'}
             inert={isCloseup ? true : undefined}
+            tabIndex={isCloseup ? -1 : 0}
+            onClickCapture={(event) => {
+                if (!suppressClickRef.current) {
+                    return;
+                }
+                event.preventDefault();
+                event.stopPropagation();
+                suppressClickRef.current = false;
+            }}
+            onPointerCancel={cancelPointerPan}
+            onPointerDown={handlePointerDown}
+            onPointerLeave={abandonUncapturedPointer}
+            onPointerMove={handlePointerMove}
+            onPointerUp={finishPointerPan}
         >
             <div
                 className="flex min-h-full min-w-full items-center justify-start"
@@ -303,6 +419,6 @@ export function GardenOverview2DMap({
                     ) : null}
                 </section>
             </div>
-        </div>
+        </section>
     );
 }

--- a/packages/game/src/hud/RaisedBedFieldHud.tsx
+++ b/packages/game/src/hud/RaisedBedFieldHud.tsx
@@ -19,6 +19,7 @@ import {
     findRaisedBedByBlockId,
     getRaisedBedBlockIds,
 } from '../utils/raisedBedBlocks';
+import { RaisedBed2DPlaceholder } from './raisedBed/RaisedBed2DPlaceholder';
 import { RaisedBedField } from './raisedBed/RaisedBedField';
 import { RaisedBedFieldSuggestions } from './raisedBed/RaisedBedFieldSuggestions';
 import { RaisedBedGreenhouseSuggestion } from './raisedBed/RaisedBedGreenhouseSuggestion';
@@ -43,8 +44,10 @@ function centerOffset(offset: number) {
 
 export function RaisedBedFieldHud({
     instantTransition = false,
+    show2DPlaceholder = false,
 }: {
     instantTransition?: boolean;
+    show2DPlaceholder?: boolean;
 }) {
     const { data: currentGarden } = useCurrentGarden();
     const isSandbox = useIsSandboxGarden();
@@ -174,13 +177,21 @@ export function RaisedBedFieldHud({
                     </div>
                 </div>
             )}
-            <div className="absolute z-0 top-[calc(50%-1px)] left-1/2 -translate-x-1/2 -translate-y-1/2 w-[var(--raised-bed-grid-size)] h-[var(--raised-bed-grid-height)]">
-                {view === 'closeup' && currentGarden && raisedBed && (
-                    <RaisedBedField
-                        gardenId={currentGarden.id}
-                        raisedBedId={raisedBed.id}
-                    />
-                )}
+            <div
+                data-raised-bed-field-grid
+                className="absolute z-0 top-[calc(50%-1px)] left-1/2 -translate-x-1/2 -translate-y-1/2 w-[var(--raised-bed-grid-size)] h-[var(--raised-bed-grid-height)]"
+            >
+                {view === 'closeup' && currentGarden && raisedBed ? (
+                    <>
+                        {show2DPlaceholder ? <RaisedBed2DPlaceholder /> : null}
+                        <div className="relative z-10 size-full">
+                            <RaisedBedField
+                                gardenId={currentGarden.id}
+                                raisedBedId={raisedBed.id}
+                            />
+                        </div>
+                    </>
+                ) : null}
             </div>
             <Stack
                 className="absolute z-40 md:left-[calc(50%+var(--raised-bed-side-panel-left))] top-[var(--raised-bed-ui-top-mobile)] md:top-[var(--raised-bed-ui-top)] left-[var(--raised-bed-close-button-left)]"

--- a/packages/game/src/hud/raisedBed/RaisedBed2DPlaceholder.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBed2DPlaceholder.tsx
@@ -1,0 +1,35 @@
+const horizontalPlankClassName =
+    'absolute right-0 left-0 z-10 h-3 rounded-[0.3rem] border border-[#5b341d] bg-[repeating-linear-gradient(90deg,#a96d42_0,#a96d42_20px,#8a512f_21px,#8a512f_23px)] shadow-[inset_0_1px_0_rgb(255_255_255_/_0.22),0_2px_4px_rgb(48_25_12_/_0.35)]';
+const verticalPlankClassName =
+    'absolute top-0 bottom-0 w-3 rounded-[0.3rem] border border-[#5b341d] bg-[repeating-linear-gradient(180deg,#a96d42_0,#a96d42_20px,#8a512f_21px,#8a512f_23px)] shadow-[inset_1px_0_0_rgb(255_255_255_/_0.18),0_2px_4px_rgb(48_25_12_/_0.3)]';
+
+export function RaisedBed2DPlaceholder() {
+    return (
+        <div
+            aria-hidden="true"
+            data-raised-bed-2d-placeholder
+            className="pointer-events-none absolute -inset-3 z-0 drop-shadow-[0_10px_12px_rgb(48_25_12_/_0.24)]"
+        >
+            <div
+                data-raised-bed-soil
+                className="absolute inset-2.5 rounded-[0.4rem] border border-[#4e2f20]/70 bg-[radial-gradient(circle_at_28%_22%,#8a6346_0_1px,transparent_1.5px),radial-gradient(circle_at_70%_65%,#4f3427_0_1px,transparent_1.5px),#6f4b35] bg-[size:15px_17px,19px_21px,auto] shadow-[inset_0_3px_8px_rgb(38_21_14_/_0.5)]"
+            />
+            <div
+                data-raised-bed-plank="top"
+                className={`${horizontalPlankClassName} top-0`}
+            />
+            <div
+                data-raised-bed-plank="right"
+                className={`${verticalPlankClassName} right-0`}
+            />
+            <div
+                data-raised-bed-plank="bottom"
+                className={`${horizontalPlankClassName} bottom-0`}
+            />
+            <div
+                data-raised-bed-plank="left"
+                className={`${verticalPlankClassName} left-0`}
+            />
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

- add mouse and touch drag panning to the renderer-free 2D garden overview
- preserve normal raised-bed clicks with a four-pixel drag threshold and disable panning during item placement
- render a 2D-only raised-bed shell from four HTML planks and a textured soil layer behind the field HUD
- extend the focused Garden browser test with real mouse and CDP touch input plus raised-bed structure checks

## Why

The 2D overview could only be navigated through native scrollbars or wheel input, which made large gardens awkward on mouse and touch devices. Raised-bed close-up also rendered the field controls without a top-down bed frame, leaving the HUD visually detached from the garden.

## Validation

- `pnpm --filter @gredice/game test` (806 passed)
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden build`
- focused Chromium production-server Playwright coverage for mouse panning, touch panning, click-to-open, and the four-plank/soil frame
- Biome checks and `git diff --check`
- renderer-free 2D bundle boundary test