### PR TITLE
feat(www): add plant health community editing

### DIFF
--- a/apps/api/app/api/[...route]/directoriesRoutes.ts
+++ b/apps/api/app/api/[...route]/directoriesRoutes.ts
@@ -46,6 +46,17 @@ function cmsPagePreviewSecret(requestUrl: string) {
 }
 
 const communityEditSubmittedValueSchema = z.unknown();
+const communityPlantHealthSuggestionFields = {
+    affectedPlantIds: z.array(z.number().int().positive()).min(1).max(50),
+    name: z.string().trim().min(1).max(200),
+    description: z.string().trim().min(1).max(2000),
+    symptoms: z.string().trim().min(1).max(4000),
+    favorableConditions: z.string().trim().min(1).max(4000),
+    severity: z.string().max(1000).nullable().optional(),
+    source: z.string().max(500).nullable().optional(),
+    note: z.string().max(1000).nullable().optional(),
+    publicPath: z.string().min(1).max(500),
+};
 const communityEntitySuggestionSchema = z.discriminatedUnion('kind', [
     z.object({
         kind: z.literal('plantSort'),
@@ -71,6 +82,14 @@ const communityEntitySuggestionSchema = z.discriminatedUnion('kind', [
         source: z.string().max(500).nullable().optional(),
         note: z.string().max(1000).nullable().optional(),
         publicPath: z.string().min(1).max(500),
+    }),
+    z.object({
+        kind: z.literal('disease'),
+        ...communityPlantHealthSuggestionFields,
+    }),
+    z.object({
+        kind: z.literal('pest'),
+        ...communityPlantHealthSuggestionFields,
     }),
 ]);
 
@@ -343,7 +362,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
         '/community-edits/entity-suggestions',
         describeRoute({
             description:
-                'Submit a pending suggestion for a new plant sort or operation. No directory entity is created or published by this endpoint.',
+                'Submit a pending suggestion for a new plant sort, operation, disease, or pest. No directory entity is created or published by this endpoint.',
             security: authSecurity,
         }),
         authValidator(['user', 'admin']),

--- a/apps/app/app/admin/community-edits/[requestId]/page.tsx
+++ b/apps/app/app/admin/community-edits/[requestId]/page.tsx
@@ -103,6 +103,10 @@ function entityTypeLabel(entityTypeName: string) {
             return 'Biljka';
         case 'plantSort':
             return 'Sorta';
+        case 'plantDisease':
+            return 'Bolest';
+        case 'plantPest':
+            return 'Štetnik';
         case 'operation':
             return 'Radnja';
         case 'block':
@@ -362,6 +366,35 @@ function operationApplicationLabel(
     }
 }
 
+function entitySuggestionLabels(suggestion: CommunityEntitySuggestionValue) {
+    switch (suggestion.kind) {
+        case 'plantSort':
+            return {
+                cardTitle: 'Nova sorta biljke',
+                pageTitle: 'Prijedlog nove sorte',
+                section: 'Nova sorta',
+            };
+        case 'operation':
+            return {
+                cardTitle: 'Nova radnja',
+                pageTitle: 'Prijedlog nove radnje',
+                section: 'Nova radnja',
+            };
+        case 'disease':
+            return {
+                cardTitle: 'Nova bolest biljke',
+                pageTitle: 'Prijedlog nove bolesti',
+                section: 'Nova bolest',
+            };
+        case 'pest':
+            return {
+                cardTitle: 'Novi štetnik biljke',
+                pageTitle: 'Prijedlog novog štetnika',
+                section: 'Novi štetnik',
+            };
+    }
+}
+
 function EntitySuggestionBlock({
     suggestion,
 }: {
@@ -371,9 +404,7 @@ function EntitySuggestionBlock({
         <Card>
             <CardHeader>
                 <CardTitle className="text-lg">
-                    {suggestion.kind === 'plantSort'
-                        ? 'Nova sorta biljke'
-                        : 'Nova radnja'}
+                    {entitySuggestionLabels(suggestion).cardTitle}
                 </CardTitle>
             </CardHeader>
             <CardContent>
@@ -389,7 +420,7 @@ function EntitySuggestionBlock({
                                     {suggestion.parentPlantId}
                                 </Typography>
                             </DetailItem>
-                        ) : (
+                        ) : suggestion.kind === 'operation' ? (
                             <>
                                 <DetailItem label="Stadij">
                                     <Typography>
@@ -405,13 +436,53 @@ function EntitySuggestionBlock({
                                     </Typography>
                                 </DetailItem>
                             </>
+                        ) : (
+                            <DetailItem label="Pogođene biljke">
+                                <Typography>
+                                    {suggestion.affectedPlants
+                                        .map(
+                                            (plant) =>
+                                                `${plant.name} #${plant.id}`,
+                                        )
+                                        .join(', ')}
+                                </Typography>
+                            </DetailItem>
                         )}
                     </div>
-                    <DetailItem label="Opis prijedloga">
+                    <DetailItem
+                        label={
+                            suggestion.kind === 'disease' ||
+                            suggestion.kind === 'pest'
+                                ? 'Kratki opis'
+                                : 'Opis prijedloga'
+                        }
+                    >
                         <Typography className="whitespace-pre-line break-words">
                             {suggestion.description}
                         </Typography>
                     </DetailItem>
+                    {suggestion.kind === 'disease' ||
+                    suggestion.kind === 'pest' ? (
+                        <>
+                            <DetailItem label="Simptomi">
+                                <Typography className="whitespace-pre-line break-words">
+                                    {suggestion.symptoms}
+                                </Typography>
+                            </DetailItem>
+                            <DetailItem label="Uvjeti pojave">
+                                <Typography className="whitespace-pre-line break-words">
+                                    {suggestion.favorableConditions}
+                                </Typography>
+                            </DetailItem>
+                            {suggestion.severity ? (
+                                <DetailItem label="Ozbiljnost">
+                                    <Typography className="whitespace-pre-line break-words">
+                                        {suggestion.severity}
+                                    </Typography>
+                                </DetailItem>
+                            ) : null}
+                        </>
+                    ) : null}
                     {suggestion.source ? (
                         <DetailItem label="Izvor">
                             <Typography className="whitespace-pre-line break-words">
@@ -614,7 +685,7 @@ export default async function CommunityEditDetailPage({
                 <CardHeader>
                     <CardTitle>
                         {entitySuggestion
-                            ? `Prijedlog nove ${entitySuggestion.kind === 'plantSort' ? 'sorte' : 'radnje'}`
+                            ? entitySuggestionLabels(entitySuggestion).pageTitle
                             : `${entityTypeLabel(request.entityTypeName)} #${request.entityId}`}
                     </CardTitle>
                 </CardHeader>
@@ -649,12 +720,10 @@ export default async function CommunityEditDetailPage({
                         </DetailItem>
                         <DetailItem label="Sekcija">
                             <Typography>
-                                {entitySuggestion?.kind === 'plantSort'
-                                    ? 'Nova sorta'
-                                    : entitySuggestion?.kind === 'operation'
-                                      ? 'Nova radnja'
-                                      : (request.sectionKey ??
-                                        'Cijela stranica')}
+                                {entitySuggestion
+                                    ? entitySuggestionLabels(entitySuggestion)
+                                          .section
+                                    : (request.sectionKey ?? 'Cijela stranica')}
                             </Typography>
                         </DetailItem>
                         <DetailItem label="Kreirano">

--- a/apps/app/app/admin/community-edits/communityEditLabels.ts
+++ b/apps/app/app/admin/community-edits/communityEditLabels.ts
@@ -14,6 +14,8 @@ export const ENTITY_TYPE_OPTIONS = [
     'all',
     'plant',
     'plantSort',
+    'plantDisease',
+    'plantPest',
     'operation',
     'block',
 ] as const;
@@ -52,6 +54,10 @@ export function entityTypeLabel(entityTypeName: string) {
             return 'Biljka';
         case 'plantSort':
             return 'Sorta';
+        case 'plantDisease':
+            return 'Bolest';
+        case 'plantPest':
+            return 'Štetnik';
         case 'operation':
             return 'Radnja';
         case 'block':

--- a/apps/app/app/admin/community-edits/page.tsx
+++ b/apps/app/app/admin/community-edits/page.tsx
@@ -1,5 +1,6 @@
 import {
     type CommunityEditRequestStatus,
+    type CommunityEntitySuggestionValue,
     listCommunityEditRequests,
     parseCommunityEntitySuggestionRequest,
 } from '@gredice/storage';
@@ -32,6 +33,33 @@ export const dynamic = 'force-dynamic';
 type CommunityEditRequestListItem = Awaited<
     ReturnType<typeof listCommunityEditRequests>
 >[number];
+
+function entitySuggestionTitle(suggestion: CommunityEntitySuggestionValue) {
+    switch (suggestion.kind) {
+        case 'plantSort':
+            return `Nova sorta: ${suggestion.name}`;
+        case 'operation':
+            return `Nova radnja: ${suggestion.name}`;
+        case 'disease':
+            return `Nova bolest: ${suggestion.name}`;
+        case 'pest':
+            return `Novi štetnik: ${suggestion.name}`;
+    }
+}
+
+function entitySuggestionContext(suggestion: CommunityEntitySuggestionValue) {
+    switch (suggestion.kind) {
+        case 'plantSort':
+            return `Biljka: ${suggestion.parentPlantName}`;
+        case 'operation':
+            return `Stadij: ${suggestion.stageLabel}`;
+        case 'disease':
+        case 'pest':
+            return `Pogođene biljke: ${suggestion.affectedPlants
+                .map((plant) => plant.name)
+                .join(', ')}`;
+    }
+}
 
 const REQUEST_STATUS_VALUES: readonly string[] = [
     'applied',
@@ -247,21 +275,21 @@ export default async function CommunityEditsPage({
                                                             className="block min-w-0 truncate text-sm font-medium text-primary underline-offset-4 hover:underline"
                                                         >
                                                             {entitySuggestion
-                                                                ? `Nova ${entitySuggestion.kind === 'plantSort' ? 'sorta' : 'radnja'}: ${entitySuggestion.name}`
+                                                                ? entitySuggestionTitle(
+                                                                      entitySuggestion,
+                                                                  )
                                                                 : `${entityTypeLabel(request.entityTypeName)} #${request.entityId}`}
                                                         </Link>
                                                         <Typography
                                                             level="body3"
                                                             className="text-muted-foreground"
                                                         >
-                                                            {entitySuggestion?.kind ===
-                                                            'plantSort'
-                                                                ? `Biljka: ${entitySuggestion.parentPlantName}`
-                                                                : entitySuggestion?.kind ===
-                                                                    'operation'
-                                                                  ? `Stadij: ${entitySuggestion.stageLabel}`
-                                                                  : (request.sectionKey ??
-                                                                    'Cijela stranica')}
+                                                            {entitySuggestion
+                                                                ? entitySuggestionContext(
+                                                                      entitySuggestion,
+                                                                  )
+                                                                : (request.sectionKey ??
+                                                                  'Cijela stranica')}
                                                         </Typography>
                                                     </Stack>
                                                     <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">

--- a/apps/www/app/bolesti/page.tsx
+++ b/apps/www/app/bolesti/page.tsx
@@ -4,6 +4,7 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
+import { CommunityEntitySuggestionButton } from '../../components/community-edits/CommunityEntitySuggestionButton';
 import { PlantHealthIssueDirectory } from '../../components/plant-health/PlantHealthIssueDirectory';
 import {
     plantHealthIssueShortDescription,
@@ -13,6 +14,7 @@ import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { PageFilterInput } from '../../components/shared/PageFilterInput';
 import { StructuredDataScript } from '../../components/shared/seo/StructuredDataScript';
 import { getPlantDiseasesData } from '../../lib/plants/getPlantHealthIssuesData';
+import { getPlantsData } from '../../lib/plants/getPlantsData';
 import { KnownPages } from '../../src/KnownPages';
 
 const pageDescription =
@@ -34,7 +36,16 @@ export default async function PlantDiseasesPage({
     const search = Array.isArray(params.pretraga)
         ? (params.pretraga[0] ?? '')
         : (params.pretraga ?? '');
-    const issues = await getPlantDiseasesData();
+    const [issues, plants] = await Promise.all([
+        getPlantDiseasesData(),
+        getPlantsData(),
+    ]);
+    const suggestionPlants = plants
+        .map((plant) => ({
+            value: String(plant.id),
+            label: plant.information.name,
+        }))
+        .sort((left, right) => left.label.localeCompare(right.label, 'hr'));
     const orderedIssues = issues.toSorted((left, right) =>
         plantHealthIssueTitle(left).localeCompare(
             plantHealthIssueTitle(right),
@@ -70,15 +81,22 @@ export default async function PlantDiseasesPage({
                 subHeader={pageDescription}
                 padded
             >
-                <Suspense>
-                    <PageFilterInput
-                        searchParamName="pretraga"
-                        fieldName="plant-disease-search"
-                        initialValue={search}
-                        navigateOnChange
-                        className="lg:flex items-start justify-end w-full"
+                <div className="flex w-full flex-col items-start gap-3 md:items-end">
+                    <CommunityEntitySuggestionButton
+                        kind="disease"
+                        plants={suggestionPlants}
+                        publicPath={KnownPages.PlantDiseases}
                     />
-                </Suspense>
+                    <Suspense>
+                        <PageFilterInput
+                            searchParamName="pretraga"
+                            fieldName="plant-disease-search"
+                            initialValue={search}
+                            navigateOnChange
+                            className="lg:flex items-start justify-end w-full"
+                        />
+                    </Suspense>
+                </div>
             </PageHeader>
             <PlantHealthIssueDirectory
                 issues={orderedIssues}

--- a/apps/www/app/stetnici/page.tsx
+++ b/apps/www/app/stetnici/page.tsx
@@ -4,6 +4,7 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
+import { CommunityEntitySuggestionButton } from '../../components/community-edits/CommunityEntitySuggestionButton';
 import { PlantHealthIssueDirectory } from '../../components/plant-health/PlantHealthIssueDirectory';
 import {
     plantHealthIssueShortDescription,
@@ -13,6 +14,7 @@ import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { PageFilterInput } from '../../components/shared/PageFilterInput';
 import { StructuredDataScript } from '../../components/shared/seo/StructuredDataScript';
 import { getPlantPestsData } from '../../lib/plants/getPlantHealthIssuesData';
+import { getPlantsData } from '../../lib/plants/getPlantsData';
 import { KnownPages } from '../../src/KnownPages';
 
 const pageDescription =
@@ -34,7 +36,16 @@ export default async function PlantPestsPage({
     const search = Array.isArray(params.pretraga)
         ? (params.pretraga[0] ?? '')
         : (params.pretraga ?? '');
-    const issues = await getPlantPestsData();
+    const [issues, plants] = await Promise.all([
+        getPlantPestsData(),
+        getPlantsData(),
+    ]);
+    const suggestionPlants = plants
+        .map((plant) => ({
+            value: String(plant.id),
+            label: plant.information.name,
+        }))
+        .sort((left, right) => left.label.localeCompare(right.label, 'hr'));
     const orderedIssues = issues.toSorted((left, right) =>
         plantHealthIssueTitle(left).localeCompare(
             plantHealthIssueTitle(right),
@@ -70,15 +81,22 @@ export default async function PlantPestsPage({
                 subHeader={pageDescription}
                 padded
             >
-                <Suspense>
-                    <PageFilterInput
-                        searchParamName="pretraga"
-                        fieldName="plant-pest-search"
-                        initialValue={search}
-                        navigateOnChange
-                        className="lg:flex items-start justify-end w-full"
+                <div className="flex w-full flex-col items-start gap-3 md:items-end">
+                    <CommunityEntitySuggestionButton
+                        kind="pest"
+                        plants={suggestionPlants}
+                        publicPath={KnownPages.PlantPests}
                     />
-                </Suspense>
+                    <Suspense>
+                        <PageFilterInput
+                            searchParamName="pretraga"
+                            fieldName="plant-pest-search"
+                            initialValue={search}
+                            navigateOnChange
+                            className="lg:flex items-start justify-end w-full"
+                        />
+                    </Suspense>
+                </div>
             </PageHeader>
             <PlantHealthIssueDirectory
                 issues={orderedIssues}

--- a/apps/www/components/community-edits/CommunityEditButton.tsx
+++ b/apps/www/components/community-edits/CommunityEditButton.tsx
@@ -32,7 +32,10 @@ import dynamic from 'next/dynamic';
 import { type ReactNode, useEffect, useId, useMemo, useState } from 'react';
 import { useCurrentUser } from '../../hooks/useCurrentUser';
 import { InlineLoginDialog } from '../auth/InlineLoginDialog';
-import { PlantReferencePicker } from './PlantReferencePicker';
+import {
+    PlantReferencePicker,
+    type ReferencePickerNoun,
+} from './PlantReferencePicker';
 
 const CommunityMarkdownInput = dynamic(
     () =>
@@ -134,7 +137,13 @@ type SubmitValue =
 type ButtonStyle = 'button' | 'icon';
 
 export type CommunityEditButtonProps = {
-    entityTypeName: 'block' | 'operation' | 'plant' | 'plantSort';
+    entityTypeName:
+        | 'block'
+        | 'operation'
+        | 'plant'
+        | 'plantDisease'
+        | 'plantPest'
+        | 'plantSort';
     entityId: number;
     publicPath: string;
     sectionKey?: string;
@@ -169,7 +178,10 @@ const communityEditFieldGroups = [
 function communityEditFieldGroup(
     field: CommunityEditableField,
 ): CommunityEditFieldGroup {
-    if (field.controlType === 'operationSuggestion') {
+    if (
+        field.controlType === 'operationSuggestion' ||
+        field.attributePath.startsWith('operations.')
+    ) {
         return 'operations';
     }
 
@@ -184,14 +196,20 @@ function communityEditFieldGroup(
     return 'content';
 }
 
-function communityEditFieldGroupLabel(group: CommunityEditFieldGroup) {
+function communityEditFieldGroupLabel(
+    group: CommunityEditFieldGroup,
+    entityTypeName: CommunityEditButtonProps['entityTypeName'],
+) {
     switch (group) {
         case 'attributes':
             return 'Svojstva';
         case 'operations':
             return 'Radnje';
         case 'relationships':
-            return 'Biljni susjedi';
+            return entityTypeName === 'plantDisease' ||
+                entityTypeName === 'plantPest'
+                ? 'Pogođene biljke'
+                : 'Biljni susjedi';
         case 'content':
             return 'Sadržaj';
     }
@@ -1080,11 +1098,12 @@ function FieldInput({
     }
 
     if (field.controlType === 'reference' && field.multiple) {
-        if (field.dataType === 'ref:plant' && field.options) {
+        if (field.options) {
             return (
                 <PlantReferencePicker
                     id={id}
                     label={field.publicLabel}
+                    noun={referencePickerNoun(field.dataType)}
                     onValueChange={(values) => onChange(values.join('\n'))}
                     options={field.options}
                     selectedValues={referenceListFromText(
@@ -1186,6 +1205,31 @@ function FieldInput({
             value={typeof value === 'string' ? value : ''}
         />
     );
+}
+
+function referencePickerNoun(dataType: string): ReferencePickerNoun {
+    if (dataType === 'ref:plant') {
+        return {
+            nominative: 'Biljka',
+            accusative: 'biljku',
+            accusativePlural: 'biljke',
+            genitivePlural: 'biljaka',
+        };
+    }
+    if (dataType === 'ref:operation') {
+        return {
+            nominative: 'Radnja',
+            accusative: 'radnju',
+            accusativePlural: 'radnje',
+            genitivePlural: 'radnji',
+        };
+    }
+    return {
+        nominative: 'Zapis',
+        accusative: 'zapis',
+        accusativePlural: 'zapise',
+        genitivePlural: 'zapisa',
+    };
 }
 
 export function CommunityEditButton({
@@ -1475,7 +1519,7 @@ export function CommunityEditButton({
                 key={group}
             >
                 <Typography id={headingId} level="body2" semiBold>
-                    {communityEditFieldGroupLabel(group)}
+                    {communityEditFieldGroupLabel(group, entityTypeName)}
                 </Typography>
                 <div
                     className={

--- a/apps/www/components/community-edits/CommunityEntitySuggestionButton.tsx
+++ b/apps/www/components/community-edits/CommunityEntitySuggestionButton.tsx
@@ -12,6 +12,7 @@ import { cx } from '@gredice/ui/utils';
 import { type FormEvent, useEffect, useId, useMemo, useState } from 'react';
 import { useCurrentUser } from '../../hooks/useCurrentUser';
 import { InlineLoginDialog } from '../auth/InlineLoginDialog';
+import { PlantReferencePicker } from './PlantReferencePicker';
 
 const communitySuggestionParam = 'communitySuggestion';
 const selectControlClassName =
@@ -31,6 +32,11 @@ export type CommunityOperationSuggestionStage = {
     label: string;
 };
 
+export type CommunitySuggestionPlantOption = {
+    value: string;
+    label: string;
+};
+
 type CommonProps = {
     className?: string;
     publicPath: string;
@@ -47,6 +53,10 @@ export type CommunityEntitySuggestionButtonProps = CommonProps &
               kind: 'operation';
               stages: CommunityOperationSuggestionStage[];
           }
+        | {
+              kind: 'disease' | 'pest';
+              plants: CommunitySuggestionPlantOption[];
+          }
     );
 
 const applicationOptions: {
@@ -62,6 +72,45 @@ const applicationOptions: {
 
 function isOperationApplication(value: string): value is OperationApplication {
     return applicationOptions.some((option) => option.value === value);
+}
+
+function isPlantHealthSuggestionKind(
+    kind: CommunityEntitySuggestionButtonProps['kind'],
+): kind is 'disease' | 'pest' {
+    return kind === 'disease' || kind === 'pest';
+}
+
+function suggestionLabels(kind: CommunityEntitySuggestionButtonProps['kind']) {
+    switch (kind) {
+        case 'plantSort':
+            return {
+                trigger: 'Predloži novu sortu',
+                title: 'Predloži novu sortu',
+                name: 'Naziv sorte',
+                description: 'Po čemu je sorta posebna?',
+            };
+        case 'operation':
+            return {
+                trigger: 'Predloži novu radnju',
+                title: 'Predloži novu radnju',
+                name: 'Naziv radnje',
+                description: 'Što se radnjom radi?',
+            };
+        case 'disease':
+            return {
+                trigger: 'Predloži novu bolest',
+                title: 'Predloži novu bolest',
+                name: 'Naziv bolesti',
+                description: 'Kratki opis bolesti',
+            };
+        case 'pest':
+            return {
+                trigger: 'Predloži novog štetnika',
+                title: 'Predloži novog štetnika',
+                name: 'Naziv štetnika',
+                description: 'Kratki opis štetnika',
+            };
+    }
 }
 
 function errorMessage(value: unknown) {
@@ -124,6 +173,10 @@ export function CommunityEntitySuggestionButton(
     const [source, setSource] = useState('');
     const [note, setNote] = useState('');
     const [plantStageId, setPlantStageId] = useState('');
+    const [affectedPlantIds, setAffectedPlantIds] = useState<string[]>([]);
+    const [symptoms, setSymptoms] = useState('');
+    const [favorableConditions, setFavorableConditions] = useState('');
+    const [severity, setSeverity] = useState('');
     const [application, setApplication] =
         useState<OperationApplication>('plant');
     const [isSubmitting, setIsSubmitting] = useState(false);
@@ -136,26 +189,13 @@ export function CommunityEntitySuggestionButton(
     const contextKey =
         props.kind === 'plantSort'
             ? `plantSort:${props.parentPlantId}`
-            : 'operation';
+            : props.kind;
     const returnTo = useMemo(
         () => suggestionReturnPath(contextKey, props.publicPath),
         [contextKey, props.publicPath],
     );
 
-    const labels =
-        props.kind === 'plantSort'
-            ? {
-                  trigger: 'Predloži novu sortu',
-                  title: 'Predloži novu sortu',
-                  name: 'Naziv sorte',
-                  description: 'Po čemu je sorta posebna?',
-              }
-            : {
-                  trigger: 'Predloži novu radnju',
-                  title: 'Predloži novu radnju',
-                  name: 'Naziv radnje',
-                  description: 'Što se radnjom radi?',
-              };
+    const labels = suggestionLabels(props.kind);
 
     useEffect(() => {
         if (consumeSuggestionReturn(contextKey)) {
@@ -176,6 +216,10 @@ export function CommunityEntitySuggestionButton(
         setSource('');
         setNote('');
         setPlantStageId('');
+        setAffectedPlantIds([]);
+        setSymptoms('');
+        setFavorableConditions('');
+        setSeverity('');
         setApplication('plant');
         setError(null);
         setSuccessRequestId(null);
@@ -199,36 +243,70 @@ export function CommunityEntitySuggestionButton(
             if (!trimmedName || !trimmedDescription) {
                 throw new Error('Unesi naziv i opis prijedloga.');
             }
+            const trimmedSymptoms = symptoms.trim();
+            const trimmedFavorableConditions = favorableConditions.trim();
+            if (
+                isPlantHealthSuggestionKind(props.kind) &&
+                (!trimmedSymptoms || !trimmedFavorableConditions)
+            ) {
+                throw new Error('Unesi simptome i uvjete pojave.');
+            }
+            if (
+                isPlantHealthSuggestionKind(props.kind) &&
+                affectedPlantIds.length === 0
+            ) {
+                throw new Error('Odaberi barem jednu pogođenu biljku.');
+            }
 
             const suggestions =
                 clientAuthenticated().api.directories['community-edits'][
                     'entity-suggestions'
                 ];
-            const response =
-                props.kind === 'plantSort'
-                    ? await suggestions.$post({
-                          json: {
-                              kind: props.kind,
-                              parentPlantId: props.parentPlantId,
-                              name: trimmedName,
-                              description: trimmedDescription,
-                              source: source.trim() || null,
-                              note: note.trim() || null,
-                              publicPath: props.publicPath,
-                          },
-                      })
-                    : await suggestions.$post({
-                          json: {
-                              kind: props.kind,
-                              plantStageId: Number.parseInt(plantStageId, 10),
-                              application,
-                              name: trimmedName,
-                              description: trimmedDescription,
-                              source: source.trim() || null,
-                              note: note.trim() || null,
-                              publicPath: props.publicPath,
-                          },
-                      });
+            const response = await (async () => {
+                if (props.kind === 'plantSort') {
+                    return await suggestions.$post({
+                        json: {
+                            kind: props.kind,
+                            parentPlantId: props.parentPlantId,
+                            name: trimmedName,
+                            description: trimmedDescription,
+                            source: source.trim() || null,
+                            note: note.trim() || null,
+                            publicPath: props.publicPath,
+                        },
+                    });
+                }
+                if (props.kind === 'operation') {
+                    return await suggestions.$post({
+                        json: {
+                            kind: props.kind,
+                            plantStageId: Number.parseInt(plantStageId, 10),
+                            application,
+                            name: trimmedName,
+                            description: trimmedDescription,
+                            source: source.trim() || null,
+                            note: note.trim() || null,
+                            publicPath: props.publicPath,
+                        },
+                    });
+                }
+                return await suggestions.$post({
+                    json: {
+                        kind: props.kind,
+                        affectedPlantIds: affectedPlantIds.map((value) =>
+                            Number.parseInt(value, 10),
+                        ),
+                        name: trimmedName,
+                        description: trimmedDescription,
+                        symptoms: trimmedSymptoms,
+                        favorableConditions: trimmedFavorableConditions,
+                        severity: severity.trim() || null,
+                        source: source.trim() || null,
+                        note: note.trim() || null,
+                        publicPath: props.publicPath,
+                    },
+                });
+            })();
 
             if (!response.ok) {
                 const body: unknown = await response.json().catch(() => null);
@@ -337,7 +415,7 @@ export function CommunityEntitySuggestionButton(
                             >
                                 Biljka: {props.parentPlantName}
                             </Typography>
-                        ) : (
+                        ) : props.kind === 'operation' ? (
                             <div className="grid gap-4 sm:grid-cols-2">
                                 <label
                                     className="space-y-1"
@@ -402,6 +480,30 @@ export function CommunityEntitySuggestionButton(
                                     </select>
                                 </label>
                             </div>
+                        ) : (
+                            <div className="space-y-1">
+                                <label
+                                    htmlFor={`${fieldIdPrefix}-affected-plants`}
+                                >
+                                    <Typography level="body2" semiBold>
+                                        Pogođene biljke
+                                    </Typography>
+                                </label>
+                                <Typography
+                                    level="body3"
+                                    className="text-muted-foreground"
+                                >
+                                    Odaberi barem jednu biljku na kojoj se
+                                    problem pojavljuje.
+                                </Typography>
+                                <PlantReferencePicker
+                                    id={`${fieldIdPrefix}-affected-plants`}
+                                    label="Pogođene biljke"
+                                    onValueChange={setAffectedPlantIds}
+                                    options={props.plants}
+                                    selectedValues={affectedPlantIds}
+                                />
+                            </div>
                         )}
 
                         <Input
@@ -435,6 +537,65 @@ export function CommunityEntitySuggestionButton(
                                 value={description}
                             />
                         </label>
+                        {isPlantHealthSuggestionKind(props.kind) ? (
+                            <>
+                                <label
+                                    className="space-y-1"
+                                    htmlFor={`${fieldIdPrefix}-symptoms`}
+                                >
+                                    <Typography level="body2" semiBold>
+                                        Simptomi
+                                    </Typography>
+                                    <textarea
+                                        className={cx(
+                                            textareaControlClassName,
+                                            'min-h-28',
+                                        )}
+                                        id={`${fieldIdPrefix}-symptoms`}
+                                        maxLength={4000}
+                                        onChange={(event) =>
+                                            setSymptoms(
+                                                event.currentTarget.value,
+                                            )
+                                        }
+                                        required
+                                        value={symptoms}
+                                    />
+                                </label>
+                                <label
+                                    className="space-y-1"
+                                    htmlFor={`${fieldIdPrefix}-conditions`}
+                                >
+                                    <Typography level="body2" semiBold>
+                                        Uvjeti pojave
+                                    </Typography>
+                                    <textarea
+                                        className={cx(
+                                            textareaControlClassName,
+                                            'min-h-28',
+                                        )}
+                                        id={`${fieldIdPrefix}-conditions`}
+                                        maxLength={4000}
+                                        onChange={(event) =>
+                                            setFavorableConditions(
+                                                event.currentTarget.value,
+                                            )
+                                        }
+                                        required
+                                        value={favorableConditions}
+                                    />
+                                </label>
+                                <Input
+                                    fullWidth
+                                    label="Ozbiljnost (opcionalno)"
+                                    maxLength={1000}
+                                    onChange={(event) =>
+                                        setSeverity(event.currentTarget.value)
+                                    }
+                                    value={severity}
+                                />
+                            </>
+                        ) : null}
                         <Input
                             fullWidth
                             label="Izvor ili poveznica (opcionalno)"

--- a/apps/www/components/community-edits/PlantReferencePicker.tsx
+++ b/apps/www/components/community-edits/PlantReferencePicker.tsx
@@ -11,18 +11,34 @@ type PlantReferenceOption = {
     label: string;
 };
 
+export type ReferencePickerNoun = {
+    nominative: string;
+    accusative: string;
+    accusativePlural: string;
+    genitivePlural: string;
+};
+
+const plantNoun: ReferencePickerNoun = {
+    nominative: 'Biljka',
+    accusative: 'biljku',
+    accusativePlural: 'biljke',
+    genitivePlural: 'biljaka',
+};
+
 export function PlantReferencePicker({
     id,
     label,
     onValueChange,
     options,
     selectedValues,
+    noun = plantNoun,
 }: {
     id: string;
     label: string;
     onValueChange: (values: string[]) => void;
     options: PlantReferenceOption[];
     selectedValues: string[];
+    noun?: ReferencePickerNoun;
 }) {
     const optionByValue = useMemo(
         () => new Map(options.map((option) => [option.value, option])),
@@ -39,7 +55,7 @@ export function PlantReferencePicker({
         (value) =>
             optionByValue.get(value) ?? {
                 value,
-                label: `Biljka ${value}`,
+                label: `${noun.nominative} ${value}`,
             },
     );
 
@@ -47,7 +63,7 @@ export function PlantReferencePicker({
         <div className="space-y-3">
             <SelectItems
                 disabled={availableOptions.length === 0}
-                emptySearchText="Nema biljaka za taj pojam."
+                emptySearchText={`Nema ${noun.genitivePlural} za taj pojam.`}
                 id={id}
                 items={availableOptions}
                 onValueChange={(value) => {
@@ -57,19 +73,21 @@ export function PlantReferencePicker({
                 }}
                 placeholder={
                     availableOptions.length > 0
-                        ? `Dodaj biljku — ${label}`
-                        : 'Nema više dostupnih biljaka'
+                        ? `Dodaj ${noun.accusative} — ${label}`
+                        : `Nema više dostupnih ${noun.genitivePlural}`
                 }
                 searchable
-                searchPlaceholder="Pretraži biljke..."
+                searchPlaceholder={`Pretraži ${noun.accusativePlural}...`}
                 value=""
             />
             <fieldset className="flex min-h-9 flex-wrap items-center gap-2">
-                <legend className="sr-only">Odabrane biljke — {label}</legend>
+                <legend className="sr-only">
+                    Odabrane {noun.accusativePlural} — {label}
+                </legend>
                 {selectedOptions.length > 0 ? (
                     selectedOptions.map((option) => (
                         <Chip
-                            aria-label={`Ukloni biljku ${option.label}`}
+                            aria-label={`Ukloni ${noun.accusative} ${option.label}`}
                             key={option.value}
                             onClick={() =>
                                 onValueChange(
@@ -89,7 +107,7 @@ export function PlantReferencePicker({
                     ))
                 ) : (
                     <Typography level="body3" className="text-muted-foreground">
-                        Nema odabranih biljaka.
+                        Nema odabranih {noun.genitivePlural}.
                     </Typography>
                 )}
             </fieldset>

--- a/apps/www/components/plant-health/PlantHealthIssueDetail.tsx
+++ b/apps/www/components/plant-health/PlantHealthIssueDetail.tsx
@@ -10,6 +10,7 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
 import { KnownPages } from '../../src/KnownPages';
+import { CommunityEditButton } from '../community-edits/CommunityEditButton';
 import { FeedbackModal } from '../shared/feedback/FeedbackModal';
 import { PlantHealthIssueOperations } from './PlantHealthIssueOperations';
 import {
@@ -26,8 +27,8 @@ type PlantHealthIssueData = PlantDiseaseData | PlantPestData;
 function issueIcon(kind: PlantHealthIssueKind) {
     const Icon = kind === 'disease' ? Shield : Bug;
     return (
-        <span className="flex size-24 items-center justify-center rounded-md bg-primary/10 text-primary">
-            <Icon className="size-10" />
+        <span className="inline-flex size-48 items-center justify-center overflow-hidden text-primary">
+            <Icon className="size-14" />
         </span>
     );
 }
@@ -44,6 +45,7 @@ export function PlantHealthIssueDetail({
     const title = plantHealthIssueTitle(issue);
     const affectedPlants = issue.relationships?.affectedPlants ?? [];
     const sources = issue.review?.sources ?? [];
+    const entityTypeName = kind === 'disease' ? 'plantDisease' : 'plantPest';
 
     return (
         <Stack spacing={8} className="py-8">
@@ -60,6 +62,14 @@ export function PlantHealthIssueDetail({
                 visual={issueIcon(kind)}
                 header={title}
                 subHeader={plantHealthIssueShortDescription(issue)}
+                headerChildren={
+                    <CommunityEditButton
+                        entityId={issue.id}
+                        entityTypeName={entityTypeName}
+                        publicPath={path}
+                        sectionKey="overview"
+                    />
+                }
             />
             {issue.information.description && (
                 <div className="max-w-2xl">
@@ -70,9 +80,22 @@ export function PlantHealthIssueDetail({
                 <Stack spacing={6}>
                     {issue.symptoms?.symptoms && (
                         <Stack spacing={2}>
-                            <Typography level="h2" className="text-2xl">
-                                Simptomi
-                            </Typography>
+                            <Row
+                                alignItems="center"
+                                justifyContent="between"
+                                spacing={3}
+                                className="flex-wrap"
+                            >
+                                <Typography level="h2" className="text-2xl">
+                                    Simptomi
+                                </Typography>
+                                <CommunityEditButton
+                                    entityId={issue.id}
+                                    entityTypeName={entityTypeName}
+                                    publicPath={path}
+                                    sectionKey="symptoms"
+                                />
+                            </Row>
                             <div className="max-w-2xl">
                                 <Markdown>{issue.symptoms.symptoms}</Markdown>
                             </div>
@@ -80,9 +103,22 @@ export function PlantHealthIssueDetail({
                     )}
                     {issue.conditions?.favorableConditions && (
                         <Stack spacing={2}>
-                            <Typography level="h2" className="text-2xl">
-                                Uvjeti
-                            </Typography>
+                            <Row
+                                alignItems="center"
+                                justifyContent="between"
+                                spacing={3}
+                                className="flex-wrap"
+                            >
+                                <Typography level="h2" className="text-2xl">
+                                    Uvjeti
+                                </Typography>
+                                <CommunityEditButton
+                                    entityId={issue.id}
+                                    entityTypeName={entityTypeName}
+                                    publicPath={path}
+                                    sectionKey="conditions"
+                                />
+                            </Row>
                             <div className="max-w-2xl">
                                 <Markdown>
                                     {issue.conditions.favorableConditions}
@@ -96,20 +132,46 @@ export function PlantHealthIssueDetail({
                         </Stack>
                     )}
                     <Stack spacing={3}>
-                        <Typography level="h2" className="text-2xl">
-                            Preporučene radnje
-                        </Typography>
+                        <Row
+                            alignItems="center"
+                            justifyContent="between"
+                            spacing={3}
+                            className="flex-wrap"
+                        >
+                            <Typography level="h2" className="text-2xl">
+                                Preporučene radnje
+                            </Typography>
+                            <CommunityEditButton
+                                entityId={issue.id}
+                                entityTypeName={entityTypeName}
+                                publicPath={path}
+                                sectionKey="operations"
+                            />
+                        </Row>
                         <PlantHealthIssueOperations
                             operations={issue.operations}
                         />
                     </Stack>
                 </Stack>
                 <Stack spacing={6}>
-                    {affectedPlants.length > 0 && (
-                        <Stack spacing={3}>
+                    <Stack spacing={3}>
+                        <Row
+                            alignItems="center"
+                            justifyContent="between"
+                            spacing={3}
+                            className="flex-wrap"
+                        >
                             <Typography level="h2" className="text-2xl">
                                 Pogođene biljke
                             </Typography>
+                            <CommunityEditButton
+                                entityId={issue.id}
+                                entityTypeName={entityTypeName}
+                                publicPath={path}
+                                sectionKey="relationships"
+                            />
+                        </Row>
+                        {affectedPlants.length > 0 ? (
                             <div className="grid grid-cols-1 gap-2">
                                 {affectedPlants.map((plant) => (
                                     <Link
@@ -152,8 +214,12 @@ export function PlantHealthIssueDetail({
                                     </Link>
                                 ))}
                             </div>
-                        </Stack>
-                    )}
+                        ) : (
+                            <Typography level="body2" secondary>
+                                Trenutno nema navedenih pogođenih biljaka.
+                            </Typography>
+                        )}
+                    </Stack>
                     {sources.length > 0 && (
                         <Stack spacing={2}>
                             <Typography level="h2" className="text-2xl">

--- a/apps/www/components/plant-health/PlantHealthIssueOperations.tsx
+++ b/apps/www/components/plant-health/PlantHealthIssueOperations.tsx
@@ -36,7 +36,11 @@ export function PlantHealthIssueOperations({
     );
 
     if (entries.length === 0) {
-        return null;
+        return (
+            <Typography level="body2" secondary>
+                Trenutno nema preporučenih radnji.
+            </Typography>
+        );
     }
 
     return (

--- a/apps/www/tests/community-entity-suggestion-button.spec.tsx
+++ b/apps/www/tests/community-entity-suggestion-button.spec.tsx
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import type { Page } from '@playwright/test';
+import { PlantHealthIssueOperations } from '../components/plant-health/PlantHealthIssueOperations';
 import { CommunityEntitySuggestionButtonHarness } from './CommunityEntitySuggestionButtonHarness';
 import '../app/globals.css';
 
@@ -114,6 +115,81 @@ test('submits a new operation with stage and application', async ({
         note: null,
         publicPath: '/radnje',
     });
+});
+
+test('submits a new disease with named affected plants', async ({
+    mount,
+    page,
+}) => {
+    await mockAuthenticatedUser(page);
+    let submittedBody: unknown;
+    await page.route(
+        '**/api/gredice/api/directories/community-edits/entity-suggestions',
+        async (route) => {
+            submittedBody = route.request().postDataJSON();
+            await route.fulfill({
+                status: 201,
+                json: { requestId: 44, status: 'pending_admin_approval' },
+            });
+        },
+    );
+
+    await mount(
+        <CommunityEntitySuggestionButtonHarness
+            kind="disease"
+            plants={[
+                { value: '7', label: 'Blitva' },
+                { value: '11', label: 'Špinat' },
+            ]}
+            publicPath="/bolesti"
+        />,
+    );
+
+    await page.getByRole('button', { name: 'Predloži novu bolest' }).click();
+    await page
+        .getByRole('combobox', {
+            name: 'Dodaj biljku — Pogođene biljke',
+        })
+        .click();
+    await page.getByPlaceholder('Pretraži biljke...').fill('blit');
+    await page.getByRole('option', { name: 'Blitva' }).click();
+    await page.getByLabel('Naziv bolesti').fill('Nova pjegavost blitve');
+    await page
+        .getByLabel('Kratki opis bolesti')
+        .fill('Bolest koja stvara sitne pjege na listovima.');
+    await page
+        .getByLabel('Simptomi')
+        .fill('Sitne tamne pjege i postupno žućenje listova.');
+    await page
+        .getByLabel('Uvjeti pojave')
+        .fill('Dugotrajno vlažno i toplo vrijeme.');
+    await page.getByLabel('Ozbiljnost (opcionalno)').fill('Srednje');
+    await page.getByRole('button', { name: 'Pošalji' }).click();
+
+    await expect(page.getByText('Prijedlog #44 je poslan')).toBeVisible();
+    expect(submittedBody).toEqual({
+        kind: 'disease',
+        affectedPlantIds: [7],
+        name: 'Nova pjegavost blitve',
+        description: 'Bolest koja stvara sitne pjege na listovima.',
+        symptoms: 'Sitne tamne pjege i postupno žućenje listova.',
+        favorableConditions: 'Dugotrajno vlažno i toplo vrijeme.',
+        severity: 'Srednje',
+        source: null,
+        note: null,
+        publicPath: '/bolesti',
+    });
+});
+
+test('shows a placeholder when there are no recommended operations', async ({
+    mount,
+    page,
+}) => {
+    await mount(<PlantHealthIssueOperations operations={null} />);
+
+    await expect(
+        page.getByText('Trenutno nema preporučenih radnji.'),
+    ).toBeVisible();
 });
 
 test('requires sign-in before opening a suggestion form', async ({

--- a/packages/storage/src/helpers/communityEditableFields.ts
+++ b/packages/storage/src/helpers/communityEditableFields.ts
@@ -3,6 +3,11 @@ import {
     PLANT_STAGES,
     type PlantStageName,
 } from '@gredice/js/plants';
+import {
+    plantHealthAffectedPlantsAttributeName,
+    plantHealthIssueTypeNames,
+    plantHealthOperationAttributeNames,
+} from './plantHealth';
 import { plantRelationshipAttributeNames } from './plantRelationships';
 
 export type CommunityEditControlType =
@@ -146,6 +151,126 @@ const communityEditablePlantSortRelationshipFields: CommunityEditableFieldDefini
         inline: true,
         ...field,
     }));
+
+const communityEditablePlantHealthFields: CommunityEditableFieldDefinition[] =
+    Object.values(plantHealthIssueTypeNames).flatMap((entityTypeName) => [
+        {
+            entityTypeName,
+            fieldKey: `${entityTypeName}.name`,
+            sectionKey: 'overview',
+            category: 'information',
+            name: 'name',
+            publicLabel: 'Naziv',
+            controlType: 'text',
+            pageLevel: true,
+            inline: true,
+            maxLength: 200,
+        },
+        {
+            entityTypeName,
+            fieldKey: `${entityTypeName}.label`,
+            sectionKey: 'overview',
+            category: 'information',
+            name: 'label',
+            publicLabel: 'Javni naziv',
+            helpText: 'Ako je prazno, prikazuje se naziv zapisa.',
+            controlType: 'text',
+            pageLevel: true,
+            inline: true,
+            maxLength: 200,
+        },
+        {
+            entityTypeName,
+            fieldKey: `${entityTypeName}.short-description`,
+            sectionKey: 'overview',
+            category: 'information',
+            name: 'shortDescription',
+            publicLabel: 'Kratki opis',
+            controlType: 'text',
+            pageLevel: true,
+            inline: true,
+            maxLength: 500,
+        },
+        {
+            entityTypeName,
+            fieldKey: `${entityTypeName}.description`,
+            sectionKey: 'overview',
+            category: 'information',
+            name: 'description',
+            publicLabel: 'Opis',
+            controlType: 'markdown',
+            pageLevel: true,
+            inline: true,
+            maxLength: 16000,
+        },
+        {
+            entityTypeName,
+            fieldKey: `${entityTypeName}.symptoms`,
+            sectionKey: 'symptoms',
+            category: 'symptoms',
+            name: 'symptoms',
+            publicLabel: 'Simptomi',
+            controlType: 'markdown',
+            pageLevel: true,
+            inline: true,
+            maxLength: 16000,
+        },
+        {
+            entityTypeName,
+            fieldKey: `${entityTypeName}.favorable-conditions`,
+            sectionKey: 'conditions',
+            category: 'conditions',
+            name: 'favorableConditions',
+            publicLabel: 'Povoljni uvjeti',
+            controlType: 'markdown',
+            pageLevel: true,
+            inline: true,
+            maxLength: 16000,
+        },
+        {
+            entityTypeName,
+            fieldKey: `${entityTypeName}.severity`,
+            sectionKey: 'conditions',
+            category: 'conditions',
+            name: 'severity',
+            publicLabel: 'Ozbiljnost',
+            controlType: 'text',
+            pageLevel: true,
+            inline: true,
+            maxLength: 1000,
+        },
+        {
+            entityTypeName,
+            fieldKey: `${entityTypeName}.affected-plants`,
+            sectionKey: 'relationships',
+            category: 'relationships',
+            name: plantHealthAffectedPlantsAttributeName,
+            publicLabel: 'Pogođene biljke',
+            helpText: 'Odaberi jednu ili više biljaka.',
+            controlType: 'reference',
+            pageLevel: true,
+            inline: true,
+        },
+        ...Object.entries(plantHealthOperationAttributeNames).map(
+            ([intent, name]) => ({
+                entityTypeName,
+                fieldKey: `${entityTypeName}.operations.${intent}`,
+                sectionKey: 'operations',
+                category: 'operations',
+                name,
+                publicLabel:
+                    intent === 'prevention'
+                        ? 'Prevencija'
+                        : intent === 'reduction'
+                          ? 'Smanjenje pritiska'
+                          : 'Ublažavanje i oporavak',
+                helpText: 'Odaberi jednu ili više postojećih radnji.',
+                controlType: 'reference' as const,
+                pageLevel: true,
+                inline: true,
+            }),
+        ),
+    ]);
 
 const communityEditableFieldRegistry: CommunityEditableFieldDefinition[] = [
     {
@@ -511,6 +636,7 @@ const communityEditableFieldRegistry: CommunityEditableFieldDefinition[] = [
     },
     ...communityEditablePlantSortStageInformationFields,
     ...communityEditablePlantSortRelationshipFields,
+    ...communityEditablePlantHealthFields,
     {
         entityTypeName: 'operation',
         fieldKey: 'operation.label',
@@ -708,7 +834,7 @@ export function getCommunityEditableSections(entityTypeName: string) {
     return Array.from(sections.entries()).map(
         ([key, fields]): CommunityEditableSection => ({
             key,
-            label: communityEditableSectionLabel(key),
+            label: communityEditableSectionLabel(key, entityTypeName),
             fields,
         }),
     );
@@ -718,7 +844,10 @@ function isPlantStageName(sectionKey: string): sectionKey is PlantStageName {
     return sectionKey in PLANT_STAGE_LABELS;
 }
 
-export function communityEditableSectionLabel(sectionKey: string) {
+export function communityEditableSectionLabel(
+    sectionKey: string,
+    entityTypeName?: string,
+) {
     if (isPlantStageName(sectionKey)) {
         return PLANT_STAGE_LABELS[sectionKey];
     }
@@ -728,12 +857,21 @@ export function communityEditableSectionLabel(sectionKey: string) {
             return 'Svojstva';
         case 'description':
             return 'Opis';
+        case 'conditions':
+            return 'Uvjeti';
         case 'instructions':
             return 'Postupak';
+        case 'operations':
+            return 'Preporučene radnje';
         case 'overview':
             return 'Pregled';
         case 'relationships':
-            return 'Biljni susjedi';
+            return entityTypeName === 'plantDisease' ||
+                entityTypeName === 'plantPest'
+                ? 'Pogođene biljke'
+                : 'Biljni susjedi';
+        case 'symptoms':
+            return 'Simptomi';
         default:
             return sectionKey;
     }

--- a/packages/storage/src/repositories/communityEditRequestsRepo.ts
+++ b/packages/storage/src/repositories/communityEditRequestsRepo.ts
@@ -156,6 +156,21 @@ export type CommunityEntitySuggestionValue =
           stageLabel: string;
           note?: string;
           source?: string;
+      }
+    | {
+          format: 'community-entity-suggestion-v1';
+          kind: 'disease' | 'pest';
+          name: string;
+          description: string;
+          symptoms: string;
+          favorableConditions: string;
+          severity?: string;
+          affectedPlants: {
+              id: number;
+              name: string;
+          }[];
+          note?: string;
+          source?: string;
       };
 
 export type CreateCommunityEntitySuggestionInput =
@@ -180,6 +195,19 @@ export type CreateCommunityEntitySuggestionInput =
               | 'raisedBedFull';
           name: string;
           description: string;
+          source?: string | null;
+          note?: string | null;
+          publicPath: string;
+          submitter: CommunityEditActor;
+      }
+    | {
+          kind: 'disease' | 'pest';
+          affectedPlantIds: number[];
+          name: string;
+          description: string;
+          symptoms: string;
+          favorableConditions: string;
+          severity?: string | null;
           source?: string | null;
           note?: string | null;
           publicPath: string;
@@ -253,6 +281,27 @@ function isCommunitySuggestionApplication(
     );
 }
 
+function parseCommunitySuggestionAffectedPlants(value: unknown) {
+    if (!Array.isArray(value) || value.length === 0) {
+        return null;
+    }
+
+    const plants: { id: number; name: string }[] = [];
+    for (const entry of value) {
+        if (
+            !isRecord(entry) ||
+            typeof entry.id !== 'number' ||
+            !Number.isInteger(entry.id) ||
+            entry.id <= 0 ||
+            typeof entry.name !== 'string'
+        ) {
+            return null;
+        }
+        plants.push({ id: entry.id, name: entry.name });
+    }
+    return plants;
+}
+
 export function parseCommunityEntitySuggestion(
     value: string | null,
 ): CommunityEntitySuggestionValue | null {
@@ -294,6 +343,42 @@ export function parseCommunityEntitySuggestion(
                 parentPlantId: parsed.parentPlantId,
                 parentPlantName: parsed.parentPlantName,
             };
+            if (typeof parsed.note === 'string') {
+                suggestion.note = parsed.note;
+            }
+            if (typeof parsed.source === 'string') {
+                suggestion.source = parsed.source;
+            }
+            return suggestion;
+        }
+
+        if (parsed.kind === 'disease' || parsed.kind === 'pest') {
+            const affectedPlants = parseCommunitySuggestionAffectedPlants(
+                parsed.affectedPlants,
+            );
+            if (
+                !affectedPlants ||
+                typeof parsed.symptoms !== 'string' ||
+                typeof parsed.favorableConditions !== 'string' ||
+                ('severity' in parsed &&
+                    typeof parsed.severity !== 'undefined' &&
+                    typeof parsed.severity !== 'string')
+            ) {
+                return null;
+            }
+
+            const suggestion: CommunityEntitySuggestionValue = {
+                format: parsed.format,
+                kind: parsed.kind,
+                name: parsed.name,
+                description: parsed.description,
+                symptoms: parsed.symptoms,
+                favorableConditions: parsed.favorableConditions,
+                affectedPlants,
+            };
+            if (typeof parsed.severity === 'string') {
+                suggestion.severity = parsed.severity;
+            }
             if (typeof parsed.note === 'string') {
                 suggestion.note = parsed.note;
             }
@@ -358,6 +443,20 @@ export function parseCommunityEntitySuggestionRequest(request: {
             request.entityId === suggestion.parentPlantId
             ? suggestion
             : null;
+    }
+
+    if (suggestion.kind === 'disease' || suggestion.kind === 'pest') {
+        const contextPlant = suggestion.affectedPlants[0];
+        return contextPlant &&
+            request.sectionKey === `new-${suggestion.kind}` &&
+            request.entityTypeName === 'plant' &&
+            request.entityId === contextPlant.id
+            ? suggestion
+            : null;
+    }
+
+    if (suggestion.kind !== 'operation') {
+        return null;
     }
 
     return request.sectionKey === 'new-operation' &&
@@ -686,6 +785,16 @@ async function multipleReferenceOptions(
                     .filter(
                         (entity) =>
                             entity.entityTypeName === targetEntityType &&
+                            !(
+                                targetEntityType === 'operation' &&
+                                booleanAttributeValue(
+                                    rawAttributeValue(
+                                        entity,
+                                        'attributes',
+                                        'internal',
+                                    ),
+                                )
+                            ) &&
                             !(
                                 sourceEntity.entityTypeName ===
                                     targetEntityType &&
@@ -1695,6 +1804,26 @@ async function getPublishedSuggestionContext(
     return entity;
 }
 
+async function getPublishedSuggestionPlants(plantIds: number[]) {
+    const uniquePlantIds = Array.from(new Set(plantIds));
+    if (uniquePlantIds.length === 0) {
+        throw new CommunityEditRequestError(
+            'invalid_value',
+            'At least one affected plant is required.',
+        );
+    }
+
+    return await Promise.all(
+        uniquePlantIds.map(async (plantId) => {
+            const plant = await getPublishedSuggestionContext('plant', plantId);
+            return {
+                id: plant.id,
+                name: entityLabel(plant),
+            };
+        }),
+    );
+}
+
 export async function createCommunityEntitySuggestion(
     input: CreateCommunityEntitySuggestionInput,
 ) {
@@ -1718,7 +1847,11 @@ export async function createCommunityEntitySuggestion(
 
     let contextEntityTypeName: 'plant' | 'plantStage';
     let contextEntityId: number;
-    let sectionKey: 'new-operation' | 'new-plant-sort';
+    let sectionKey:
+        | 'new-disease'
+        | 'new-operation'
+        | 'new-pest'
+        | 'new-plant-sort';
     let suggestion: CommunityEntitySuggestionValue;
 
     if (input.kind === 'plantSort') {
@@ -1737,7 +1870,7 @@ export async function createCommunityEntitySuggestion(
             parentPlantId: plant.id,
             parentPlantName: entityLabel(plant),
         };
-    } else {
+    } else if (input.kind === 'operation') {
         if (!isCommunitySuggestionApplication(input.application)) {
             throw new CommunityEditRequestError(
                 'invalid_value',
@@ -1763,6 +1896,48 @@ export async function createCommunityEntitySuggestion(
                 String(plantStage.id),
             stageLabel: entityLabel(plantStage),
         };
+    } else {
+        const affectedPlants = await getPublishedSuggestionPlants(
+            input.affectedPlantIds,
+        );
+        const symptoms = normalizeRequiredSuggestionText(
+            input.symptoms,
+            'Symptoms',
+            4000,
+        );
+        const favorableConditions = normalizeRequiredSuggestionText(
+            input.favorableConditions,
+            'Favorable conditions',
+            4000,
+        );
+        const severity = normalizeOptionalSuggestionText(
+            input.severity,
+            'Severity',
+            1000,
+        );
+        const contextPlant = affectedPlants[0];
+        if (!contextPlant) {
+            throw new CommunityEditRequestError(
+                'invalid_value',
+                'At least one affected plant is required.',
+            );
+        }
+
+        contextEntityTypeName = 'plant';
+        contextEntityId = contextPlant.id;
+        sectionKey = input.kind === 'disease' ? 'new-disease' : 'new-pest';
+        suggestion = {
+            format: 'community-entity-suggestion-v1',
+            kind: input.kind,
+            name,
+            description,
+            symptoms,
+            favorableConditions,
+            affectedPlants,
+        };
+        if (severity) {
+            suggestion.severity = severity;
+        }
     }
 
     if (note) {

--- a/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
@@ -570,6 +570,38 @@ test('community editable registry resolves allowed plant and operation fields', 
                 (field) => field.fieldKey === 'operation.application',
             ),
     );
+    for (const entityTypeName of ['plantDisease', 'plantPest']) {
+        const healthSections = getCommunityEditableSections(entityTypeName);
+        assert.ok(
+            healthSections
+                .find((section) => section.key === 'overview')
+                ?.fields.some(
+                    (field) =>
+                        field.fieldKey ===
+                        `${entityTypeName}.short-description`,
+                ),
+        );
+        assert.ok(
+            healthSections
+                .find((section) => section.key === 'symptoms')
+                ?.fields.some(
+                    (field) => field.fieldKey === `${entityTypeName}.symptoms`,
+                ),
+        );
+        assert.ok(
+            healthSections
+                .find((section) => section.key === 'relationships')
+                ?.fields.some(
+                    (field) =>
+                        field.fieldKey === `${entityTypeName}.affected-plants`,
+                ),
+        );
+        assert.equal(
+            healthSections.find((section) => section.key === 'operations')
+                ?.fields.length,
+            3,
+        );
+    }
 
     const plantId = await createPublishedPlant();
     const plantFields = await getCommunityEditableFieldsForEntity({
@@ -785,6 +817,104 @@ test('community editable registry resolves allowed plant and operation fields', 
     );
 });
 
+test('community editing resolves disease content, affected plants, and public operations', async () => {
+    await fixture();
+    await upsertEntityType({ name: 'plantDisease', label: 'Bolest' });
+    const nameDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        name: 'name',
+        label: 'Naziv',
+        entityTypeName: 'plantDisease',
+        dataType: 'text',
+    });
+    const symptomsDefinitionId = await createAttributeDefinition({
+        category: 'symptoms',
+        name: 'symptoms',
+        label: 'Simptomi',
+        entityTypeName: 'plantDisease',
+        dataType: 'markdown',
+    });
+    const affectedPlantsDefinitionId = await createAttributeDefinition({
+        category: 'relationships',
+        name: 'affectedPlants',
+        label: 'Pogođene biljke',
+        entityTypeName: 'plantDisease',
+        dataType: 'ref:plant',
+        multiple: true,
+    });
+    const preventionDefinitionId = await createAttributeDefinition({
+        category: 'operations',
+        name: 'prevention',
+        label: 'Prevencija',
+        entityTypeName: 'plantDisease',
+        dataType: 'ref:operation',
+        multiple: true,
+    });
+    const plantId = await createPublishedPlant();
+    const operationId = await createPublishedPlantOperation({
+        name: 'Preventivni pregled',
+    });
+    const diseaseId = await createEntity('plantDisease');
+    await updateEntity({ id: diseaseId, state: 'published' });
+    await upsertAttributeValue({
+        attributeDefinitionId: nameDefinitionId,
+        entityTypeName: 'plantDisease',
+        entityId: diseaseId,
+        value: 'Probna bolest',
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: symptomsDefinitionId,
+        entityTypeName: 'plantDisease',
+        entityId: diseaseId,
+        value: 'Pjege na listu.',
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: affectedPlantsDefinitionId,
+        entityTypeName: 'plantDisease',
+        entityId: diseaseId,
+        value: String(plantId),
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: preventionDefinitionId,
+        entityTypeName: 'plantDisease',
+        entityId: diseaseId,
+        value: String(operationId),
+    });
+
+    const symptomFields = await getCommunityEditableFieldsForEntity({
+        entityTypeName: 'plantDisease',
+        entityId: diseaseId,
+        sectionKey: 'symptoms',
+    });
+    assert.equal(symptomFields[0]?.currentValue, 'Pjege na listu.');
+
+    const relationshipFields = await getCommunityEditableFieldsForEntity({
+        entityTypeName: 'plantDisease',
+        entityId: diseaseId,
+        sectionKey: 'relationships',
+    });
+    assert.equal(relationshipFields[0]?.currentValue, `["${plantId}"]`);
+    assert.ok(
+        relationshipFields[0]?.options?.some(
+            (option) => option.value === String(plantId),
+        ),
+    );
+
+    const operationFields = await getCommunityEditableFieldsForEntity({
+        entityTypeName: 'plantDisease',
+        entityId: diseaseId,
+        sectionKey: 'operations',
+    });
+    assert.equal(operationFields[0]?.currentValue, `["${operationId}"]`);
+    assert.ok(
+        operationFields[0]?.options?.some(
+            (option) =>
+                option.value === String(operationId) &&
+                option.label === 'Preventivni pregled',
+        ),
+    );
+});
+
 test('community entity suggestions store a reviewable new plant sort proposal', async () => {
     const data = await fixture();
     const plantId = await createPublishedPlant();
@@ -871,6 +1001,55 @@ test('community entity suggestions store operation context and application', asy
         stageName: 'maintenance',
         stageLabel: 'Održavanje',
     });
+});
+
+test('community entity suggestions store disease and pest details against affected plant context', async () => {
+    const data = await fixture();
+    const firstPlantId = await createPublishedPlant();
+    const secondPlantId = await createPublishedPlant();
+
+    for (const kind of ['disease', 'pest'] as const) {
+        const request = await createCommunityEntitySuggestion({
+            kind,
+            affectedPlantIds: [firstPlantId, secondPlantId, firstPlantId],
+            name: kind === 'disease' ? 'Nova pjegavost' : 'Novi kukac',
+            description: 'Kratki javni opis problema.',
+            symptoms: 'Na listovima se pojavljuju vidljivi znakovi.',
+            favorableConditions: 'Problem se češće javlja za toplog vremena.',
+            severity: 'Srednje',
+            source: 'https://example.com/plant-health',
+            publicPath: kind === 'disease' ? '/bolesti' : '/stetnici',
+            submitter: { id: data.submitterId },
+        });
+
+        assert.equal(request.entityTypeName, 'plant');
+        assert.equal(request.entityId, firstPlantId);
+        assert.equal(request.sectionKey, `new-${kind}`);
+        assert.equal(request.changes.length, 0);
+
+        const suggestion = parseCommunityEntitySuggestionRequest(request);
+        assert.equal(suggestion?.kind, kind);
+        if (suggestion?.kind !== 'disease' && suggestion?.kind !== 'pest') {
+            assert.fail('Expected a plant health suggestion.');
+        }
+        assert.deepEqual(suggestion.affectedPlants, [
+            { id: firstPlantId, name: `Biljka ${firstPlantId}` },
+            { id: secondPlantId, name: `Biljka ${secondPlantId}` },
+        ]);
+        assert.equal(
+            suggestion.symptoms,
+            'Na listovima se pojavljuju vidljivi znakovi.',
+        );
+        assert.equal(suggestion.severity, 'Srednje');
+
+        assert.equal(
+            parseCommunityEntitySuggestionRequest({
+                ...request,
+                entityId: secondPlantId,
+            }),
+            null,
+        );
+    }
 });
 
 test('community edit requests submit storage content and operation suggestions together', async () => {

--- a/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
@@ -817,104 +817,6 @@ test('community editable registry resolves allowed plant and operation fields', 
     );
 });
 
-test('community editing resolves disease content, affected plants, and public operations', async () => {
-    await fixture();
-    await upsertEntityType({ name: 'plantDisease', label: 'Bolest' });
-    const nameDefinitionId = await createAttributeDefinition({
-        category: 'information',
-        name: 'name',
-        label: 'Naziv',
-        entityTypeName: 'plantDisease',
-        dataType: 'text',
-    });
-    const symptomsDefinitionId = await createAttributeDefinition({
-        category: 'symptoms',
-        name: 'symptoms',
-        label: 'Simptomi',
-        entityTypeName: 'plantDisease',
-        dataType: 'markdown',
-    });
-    const affectedPlantsDefinitionId = await createAttributeDefinition({
-        category: 'relationships',
-        name: 'affectedPlants',
-        label: 'Pogođene biljke',
-        entityTypeName: 'plantDisease',
-        dataType: 'ref:plant',
-        multiple: true,
-    });
-    const preventionDefinitionId = await createAttributeDefinition({
-        category: 'operations',
-        name: 'prevention',
-        label: 'Prevencija',
-        entityTypeName: 'plantDisease',
-        dataType: 'ref:operation',
-        multiple: true,
-    });
-    const plantId = await createPublishedPlant();
-    const operationId = await createPublishedPlantOperation({
-        name: 'Preventivni pregled',
-    });
-    const diseaseId = await createEntity('plantDisease');
-    await updateEntity({ id: diseaseId, state: 'published' });
-    await upsertAttributeValue({
-        attributeDefinitionId: nameDefinitionId,
-        entityTypeName: 'plantDisease',
-        entityId: diseaseId,
-        value: 'Probna bolest',
-    });
-    await upsertAttributeValue({
-        attributeDefinitionId: symptomsDefinitionId,
-        entityTypeName: 'plantDisease',
-        entityId: diseaseId,
-        value: 'Pjege na listu.',
-    });
-    await upsertAttributeValue({
-        attributeDefinitionId: affectedPlantsDefinitionId,
-        entityTypeName: 'plantDisease',
-        entityId: diseaseId,
-        value: String(plantId),
-    });
-    await upsertAttributeValue({
-        attributeDefinitionId: preventionDefinitionId,
-        entityTypeName: 'plantDisease',
-        entityId: diseaseId,
-        value: String(operationId),
-    });
-
-    const symptomFields = await getCommunityEditableFieldsForEntity({
-        entityTypeName: 'plantDisease',
-        entityId: diseaseId,
-        sectionKey: 'symptoms',
-    });
-    assert.equal(symptomFields[0]?.currentValue, 'Pjege na listu.');
-
-    const relationshipFields = await getCommunityEditableFieldsForEntity({
-        entityTypeName: 'plantDisease',
-        entityId: diseaseId,
-        sectionKey: 'relationships',
-    });
-    assert.equal(relationshipFields[0]?.currentValue, `["${plantId}"]`);
-    assert.ok(
-        relationshipFields[0]?.options?.some(
-            (option) => option.value === String(plantId),
-        ),
-    );
-
-    const operationFields = await getCommunityEditableFieldsForEntity({
-        entityTypeName: 'plantDisease',
-        entityId: diseaseId,
-        sectionKey: 'operations',
-    });
-    assert.equal(operationFields[0]?.currentValue, `["${operationId}"]`);
-    assert.ok(
-        operationFields[0]?.options?.some(
-            (option) =>
-                option.value === String(operationId) &&
-                option.label === 'Preventivni pregled',
-        ),
-    );
-});
-
 test('community entity suggestions store a reviewable new plant sort proposal', async () => {
     const data = await fixture();
     const plantId = await createPublishedPlant();
@@ -1221,8 +1123,8 @@ test('community edit requests submit plant relationship references', async () =>
     const entity = await getEntityRaw(plantId);
     assert.ok(entity);
     assert.deepEqual(
-        attributeValues(entity, data.plantCompanionsDefinitionId),
-        [String(basilId), String(calendulaId)],
+        attributeValues(entity, data.plantCompanionsDefinitionId).sort(),
+        [String(basilId), String(calendulaId)].sort(),
     );
     assert.deepEqual(
         attributeValues(entity, data.plantAntagonistsDefinitionId),

--- a/packages/storage/tests/entitiesRepo.node.spec.ts
+++ b/packages/storage/tests/entitiesRepo.node.spec.ts
@@ -7,6 +7,7 @@ import {
     deleteAttributeValue,
     deleteEntity,
     generatedImageUrlDefaultValue,
+    getCommunityEditableFieldsForEntity,
     getEntitiesFormatted,
     getEntitiesRaw,
     getEntityFormatted,
@@ -834,6 +835,35 @@ test('plant health read model derives diseases and pests from affected plant ref
             value: String(treatmentOperationId),
         }),
     ]);
+
+    const symptomFields = await getCommunityEditableFieldsForEntity({
+        entityTypeName: 'plantDisease',
+        entityId: disease.id,
+        sectionKey: 'symptoms',
+    });
+    assert.equal(symptomFields[0]?.currentValue, `Disease ${suffix} symptoms`);
+
+    const relationshipFields = await getCommunityEditableFieldsForEntity({
+        entityTypeName: 'plantDisease',
+        entityId: disease.id,
+        sectionKey: 'relationships',
+    });
+    assert.ok(
+        relationshipFields[0]?.options?.some(
+            (option) => option.value === String(tomatoId),
+        ),
+    );
+
+    const operationFields = await getCommunityEditableFieldsForEntity({
+        entityTypeName: 'plantDisease',
+        entityId: disease.id,
+        sectionKey: 'operations',
+    });
+    assert.ok(
+        operationFields[0]?.options?.some(
+            (option) => option.value === String(preventionOperationId),
+        ),
+    );
 
     const formattedPlants =
         await getEntitiesFormatted<FormattedPlantWithHealth>('plant');

--- a/packages/ui/src/PublicChrome/PublicFooter.tsx
+++ b/packages/ui/src/PublicChrome/PublicFooter.tsx
@@ -142,6 +142,20 @@ function sectionsData(linkMode: PublicChromeLinkMode): SectionData[] {
                             ),
                         },
                         {
+                            label: 'Bolesti',
+                            href: publicChromeHref(
+                                PublicPagePaths.PlantDiseases,
+                                linkMode,
+                            ),
+                        },
+                        {
+                            label: 'Štetnici',
+                            href: publicChromeHref(
+                                PublicPagePaths.PlantPests,
+                                linkMode,
+                            ),
+                        },
+                        {
                             label: 'Biljni susjedi',
                             href: publicChromeHref(
                                 PublicPagePaths.CompanionPlanting,

--- a/packages/ui/src/PublicChrome/links.ts
+++ b/packages/ui/src/PublicChrome/links.ts
@@ -6,6 +6,8 @@ export const PublicPagePaths = {
     Delivery: '/dostava',
     DeliverySlots: '/dostava/termini',
     Plants: '/biljke',
+    PlantDiseases: '/bolesti',
+    PlantPests: '/stetnici',
     Blocks: '/blokovi',
     Sunflowers: '/suncokreti',
     RaisedBeds: '/podignuta-gredica',


### PR DESCRIPTION
## What changed

- add Bolesti and Štetnici to the public footer
- standardize disease and pest detail icons and show an empty state when no recommended operations exist
- add section-level community editing for disease and pest content, affected plants, and recommended operations
- add moderated suggestions for new diseases and pests, including affected-plant selection
- expose the new suggestion types in the admin moderation queue

## Why

Disease and pest pages did not offer the same community contribution workflow as plants and operations. Their detail icon also used a non-standard background and alignment, and empty recommendation sections rendered without guidance.

## Impact

Authenticated users can now submit reviewable edits and new disease or pest proposals without exposing raw directory IDs. New records remain unpublished until an administrator processes the request.

## Validation

- `pnpm lint --filter www --filter app --filter api --filter @gredice/storage --filter @gredice/ui`
- `pnpm --filter @gredice/storage test:node -- communityEditRequestsRepo.node.spec.ts` — 20 passed
- `pnpm --filter www exec playwright test --project=chromium --workers=1 tests/community-entity-suggestion-button.spec.tsx` — 5 passed
- `pnpm build --filter www`
- local production browser verification of `/bolesti`, `/stetnici`, and `/stetnici/bijela-musica`