### PR TITLE
feat(www): show plant sorts before plant details

### DIFF
--- a/apps/www/app/biljke/[alias]/PlantPageHeader.tsx
+++ b/apps/www/app/biljke/[alias]/PlantPageHeader.tsx
@@ -86,6 +86,12 @@ export function PlantPageHeader({
             href: `#${slug(section.header)}`,
             label: section.header,
         }));
+    if (!sort) {
+        contentLinks.unshift({
+            href: `#${slug('Sorte')}`,
+            label: 'Sorte',
+        });
+    }
     if ((plant.information.tip?.length ?? 0) > 0) {
         contentLinks.push({
             href: `#${slug('Savjeti')}`,
@@ -102,12 +108,6 @@ export function PlantPageHeader({
         contentLinks.push({
             href: `#${slug('Biljni susjedi')}`,
             label: 'Biljni susjedi',
-        });
-    }
-    if (!sort) {
-        contentLinks.push({
-            href: `#${slug('Sorte')}`,
-            label: 'Sorte',
         });
     }
 

--- a/apps/www/app/biljke/[alias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/page.tsx
@@ -151,6 +151,10 @@ export default async function PlantPage(props: PageProps<'/biljke/[alias]'>) {
                         publicPath: KnownPages.Plant(alias),
                     }}
                 />
+                <PlantSortsList
+                    basePlantName={plant.information.name}
+                    basePlantId={plant.id}
+                />
                 {informationSections
                     .filter((section) => section.avaialble)
                     .map((section) => (
@@ -181,10 +185,6 @@ export default async function PlantPage(props: PageProps<'/biljke/[alias]'>) {
                         publicPath: KnownPages.Plant(alias),
                     }}
                     relationships={plant.relationships}
-                />
-                <PlantSortsList
-                    basePlantName={plant.information.name}
-                    basePlantId={plant.id}
                 />
                 {recipes.length > 0 && (
                     <Stack spacing={4}>


### PR DESCRIPTION
## Sažetak

- prikazuje odjeljak Sorte odmah ispod zaglavlja biljke, prije generičkih informacija o uzgoju
- pomiče poveznicu Sorte na prvo mjesto u sadržaju kako bi navigacija pratila redoslijed stranice

## Zašto

Sorte su prije bile pri dnu stranice biljke, pa su korisnicima bile slabije vidljive.

## Provjera

- `pnpm --filter www exec biome check 'app/biljke/[alias]/page.tsx' 'app/biljke/[alias]/PlantPageHeader.tsx'`
- `pnpm typecheck --filter www`
- `pnpm build --filter www`

Build je uspješan; bez lokalnog `POSTGRES_URL` ispisuje postojeće upozorenje za opcionalnu povijest cijena, ali završava s izlaznim kodom 0.