### PR TITLE
fix(game): prevent harvest basket flash

### DIFF
--- a/packages/game/src/entities/raisedBed/RaisedBedHarvestBasket.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedHarvestBasket.tsx
@@ -293,9 +293,13 @@ export function RaisedBedHarvestBaskets() {
                 : [];
         });
     }, [garden, operationItems, operations]);
+    const deliveryRequestsRequired =
+        harvestCandidates.length > 0 && !isMock && !isLocalSandbox;
     const deliveryRequests = useDeliveryRequests({
-        enabled: harvestCandidates.length > 0 && !isMock && !isLocalSandbox,
+        enabled: deliveryRequestsRequired,
     });
+    const hiddenHarvestOperationIdsResolved =
+        !deliveryRequestsRequired || deliveryRequests.data !== undefined;
     const hiddenHarvestOperationIds = useMemo(
         () =>
             new Set(
@@ -315,13 +319,19 @@ export function RaisedBedHarvestBaskets() {
                 const state = resolveRaisedBedHarvestBasketState({
                     fields: candidate.raisedBed.fields,
                     hiddenOperationIds: hiddenHarvestOperationIds,
+                    hiddenOperationIdsResolved:
+                        hiddenHarvestOperationIdsResolved,
                     raisedBedId: candidate.raisedBed.id,
                     visualRewards: candidate.visualRewards,
                 });
 
                 return state ? [{ ...candidate, state }] : [];
             }),
-        [harvestCandidates, hiddenHarvestOperationIds],
+        [
+            harvestCandidates,
+            hiddenHarvestOperationIds,
+            hiddenHarvestOperationIdsResolved,
+        ],
     );
     const harvestBasketPlacements = useMemo(
         () =>

--- a/packages/game/src/entities/raisedBed/raisedBedHarvestRewards.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedHarvestRewards.ts
@@ -24,6 +24,7 @@ type ResolveRaisedBedHarvestPositionsInput = {
 type ResolveRaisedBedHarvestBasketStateInput = {
     fields: RaisedBedHarvestFieldInput[];
     hiddenOperationIds?: ReadonlySet<number>;
+    hiddenOperationIdsResolved?: boolean;
     raisedBedId: number;
     visualRewards: OperationVisualReward[];
 };
@@ -120,9 +121,14 @@ export function resolveRaisedBedHarvestPositions({
 export function resolveRaisedBedHarvestBasketState({
     fields,
     hiddenOperationIds,
+    hiddenOperationIdsResolved = true,
     raisedBedId,
     visualRewards,
 }: ResolveRaisedBedHarvestBasketStateInput): RaisedBedHarvestBasketState | null {
+    if (!hiddenOperationIdsResolved) {
+        return null;
+    }
+
     const harvestRewards = visualRewards.filter(
         (reward) =>
             isHarvestRewardForRaisedBed(reward, raisedBedId) &&

--- a/packages/game/src/entities/raisedBed/raisedBedHarvestRewards.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedHarvestRewards.unit.ts
@@ -344,6 +344,32 @@ test('delivery-ready harvest operations hide the basket', () => {
     );
 });
 
+test('harvest basket waits for delivery visibility to resolve', () => {
+    const visualRewards = resolveOperationVisualRewards({
+        appliedOperations: [
+            applied(751, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                entityId: 1,
+                raisedBedId: 10,
+            }),
+        ],
+        operations,
+    });
+
+    assert.equal(
+        resolveRaisedBedHarvestBasketState({
+            fields: [
+                { active: true, id: 50, plantSortId: 337, positionIndex: 0 },
+            ],
+            hiddenOperationIds: new Set(),
+            hiddenOperationIdsResolved: false,
+            raisedBedId: 10,
+            visualRewards,
+        }),
+        null,
+    );
+});
+
 test('harvest basket uses the first free stackable neighbor block', () => {
     assert.deepStrictEqual(
         resolveRaisedBedHarvestBasketPlacement({


### PR DESCRIPTION
## Summary

- delay harvest basket rendering until delivery-request visibility has resolved
- keep mock and local sandbox reward visuals immediate
- cover the unresolved delivery-state regression

## Testing

- pnpm --filter @gredice/game exec biome check --write src/entities/raisedBed/RaisedBedHarvestBasket.tsx src/entities/raisedBed/raisedBedHarvestRewards.ts src/entities/raisedBed/raisedBedHarvestRewards.unit.ts
- pnpm --filter @gredice/game test
- pnpm typecheck --filter @gredice/game --filter garden --filter www
- git diff --check