### PR TITLE
fix(game): refine avatar world movement

### DIFF
--- a/apps/garden/app/debug/sandbox/page.tsx
+++ b/apps/garden/app/debug/sandbox/page.tsx
@@ -4,6 +4,7 @@ import { SandboxDebugActions } from './SandboxDebugActions';
 
 const debugSandboxFlags = {
     enableDebugHudFlag: true,
+    enableGardenAvatarFlag: true,
 } satisfies NonNullable<ComponentProps<typeof GameScene>['flags']>;
 
 export default function DebugSandboxPage() {

--- a/packages/game/src/entities/avatar/GardenAvatar.tsx
+++ b/packages/game/src/entities/avatar/GardenAvatar.tsx
@@ -10,6 +10,8 @@ import {
 import {
     type Group,
     MathUtils,
+    Mesh,
+    MeshBasicMaterial,
     type Object3D,
     Quaternion,
     PerspectiveCamera as ThreePerspectiveCamera,
@@ -24,7 +26,6 @@ import type { Stack } from '../../types/Stack';
 import { type GardenAvatarView, useGameState } from '../../useGameState';
 import { useGameGLTF } from '../../utils/useGameGLTF';
 import { useActorGroundingShadow } from '../animals/ActorGroundingShadows';
-import { configureActorMeshShadows } from '../animals/actorMeshShadows';
 import { getGardenAvatarPerspectiveEntryPosition } from './gardenAvatarCamera';
 import {
     createGardenAvatarCollisionWorld,
@@ -38,16 +39,18 @@ import {
     gardenAvatarStandingCollisionHeight,
     getGardenAvatarCeilingY,
     getGardenAvatarGroundY,
+    getGardenAvatarNextJumpCount,
     getGardenAvatarRoamBlockedCells,
+    getGardenAvatarSurfaceY,
     resolveGardenAvatarHorizontalMovement,
 } from './gardenAvatarMovement';
 
-const avatarModelScale = 0.82;
-const avatarEyeHeight = 1.42;
-const avatarCrouchEyeHeight = 0.86;
+const avatarModelScale = 0.697;
+const avatarEyeHeight = 1.2;
+const avatarCrouchEyeHeight = 0.9;
 const avatarWalkSpeed = 2.15;
-const avatarRunSpeed = 3.6;
-const avatarCrouchSpeed = 1.05;
+const avatarRunSpeed = 4.68;
+const avatarCrouchSpeed = 0.63;
 const avatarRoamSpeed = 0.55;
 const avatarAcceleration = 28;
 const avatarDeceleration = 22;
@@ -60,6 +63,11 @@ const avatarCameraTransitionSeconds = 0.58;
 const avatarThirdPersonCameraGroundClearance = 0.12;
 const avatarPitchLimit = Math.PI / 2;
 const avatarPerspectiveFov = 55;
+const avatarPerspectiveZoomFov = 34;
+const avatarZoomDamping = 9;
+const avatarHeadPitchLimit = 0.82;
+const avatarCrouchRigDrop = 0.34;
+const avatarCrouchLowerLegLength = 0.41;
 const pointerLookSensitivity = 0.0023;
 const touchLookSensitivity = 0.006;
 
@@ -74,6 +82,14 @@ type AvatarRig = {
     kneeRight: Object3D | undefined;
     legLeft: Object3D | undefined;
     legRight: Object3D | undefined;
+    restY: {
+        armLeft: number;
+        armRight: number;
+        body: number;
+        head: number;
+        legLeft: number;
+        legRight: number;
+    };
 };
 
 type AvatarRoamState = {
@@ -118,24 +134,53 @@ function dampAngle(
 }
 
 function prepareAvatarModel(root: Object3D) {
-    const { primaryCasterCount } = configureActorMeshShadows(root, (mesh) => {
-        mesh.receiveShadow = true;
-        mesh.frustumCulled = false;
+    const meshes: Mesh[] = [];
+    const materials = new Map<Mesh, Mesh['material']>();
+    root.traverse((object) => {
+        if (!(object instanceof Mesh)) {
+            return;
+        }
+        object.castShadow = false;
+        object.receiveShadow = true;
+        object.frustumCulled = false;
+        meshes.push(object);
+        materials.set(object, object.material);
     });
 
+    const armLeft = root.getObjectByName('FarmerAvatar_ArmPivot_L');
+    const armRight = root.getObjectByName('FarmerAvatar_ArmPivot_R');
+    const body = root.getObjectByName('FarmerAvatar_BodyPivot');
+    const head = root.getObjectByName('FarmerAvatar_HeadPivot');
+    const legLeft = root.getObjectByName('FarmerAvatar_LegPivot_L');
+    const legRight = root.getObjectByName('FarmerAvatar_LegPivot_R');
+
     return {
-        primaryCasterCount,
+        meshes,
+        materials,
+        primaryCasterCount: meshes.length,
+        shadowOnlyMaterial: new MeshBasicMaterial({
+            colorWrite: false,
+            depthWrite: false,
+        }),
         rig: {
-            armLeft: root.getObjectByName('FarmerAvatar_ArmPivot_L'),
-            armRight: root.getObjectByName('FarmerAvatar_ArmPivot_R'),
-            body: root.getObjectByName('FarmerAvatar_BodyPivot'),
+            armLeft,
+            armRight,
+            body,
             elbowLeft: root.getObjectByName('FarmerAvatar_ElbowPivot_L'),
             elbowRight: root.getObjectByName('FarmerAvatar_ElbowPivot_R'),
-            head: root.getObjectByName('FarmerAvatar_HeadPivot'),
+            head,
             kneeLeft: root.getObjectByName('FarmerAvatar_KneePivot_L'),
             kneeRight: root.getObjectByName('FarmerAvatar_KneePivot_R'),
-            legLeft: root.getObjectByName('FarmerAvatar_LegPivot_L'),
-            legRight: root.getObjectByName('FarmerAvatar_LegPivot_R'),
+            legLeft,
+            legRight,
+            restY: {
+                armLeft: armLeft?.position.y ?? 0,
+                armRight: armRight?.position.y ?? 0,
+                body: body?.position.y ?? 0,
+                head: head?.position.y ?? 0,
+                legLeft: legLeft?.position.y ?? 0,
+                legRight: legRight?.position.y ?? 0,
+            },
         } satisfies AvatarRig,
     };
 }
@@ -145,6 +190,7 @@ function animateAvatarRig({
     delta,
     distanceWalked,
     grounded,
+    headPitch,
     walkAmount,
     rig,
 }: {
@@ -152,6 +198,7 @@ function animateAvatarRig({
     delta: number;
     distanceWalked: number;
     grounded: boolean;
+    headPitch: number;
     walkAmount: number;
     rig: AvatarRig;
 }) {
@@ -160,14 +207,21 @@ function animateAvatarRig({
     const legSwing = grounded ? phaseSine * 0.44 * walkAmount : -0.2;
     const armSwing = grounded ? phaseSine * 0.34 * walkAmount : -0.48;
     const leftKneeBend = grounded
-        ? Math.max(0, -phaseSine) * 0.38 * walkAmount + crouchAmount * 0.68
+        ? Math.max(0, -phaseSine) * 0.38 * walkAmount + crouchAmount * 0.82
         : 0.42;
     const rightKneeBend = grounded
-        ? Math.max(0, phaseSine) * 0.38 * walkAmount + crouchAmount * 0.68
+        ? Math.max(0, phaseSine) * 0.38 * walkAmount + crouchAmount * 0.82
         : 0.42;
     const poseDamping = 1 - Math.exp(-12 * delta);
+    const crouchLegDrop =
+        avatarCrouchLowerLegLength * (1 - Math.cos(crouchAmount * 0.82));
 
     if (rig.legLeft) {
+        rig.legLeft.position.y = MathUtils.lerp(
+            rig.legLeft.position.y,
+            rig.restY.legLeft - crouchLegDrop,
+            poseDamping,
+        );
         rig.legLeft.rotation.x = MathUtils.lerp(
             rig.legLeft.rotation.x,
             legSwing,
@@ -175,6 +229,11 @@ function animateAvatarRig({
         );
     }
     if (rig.legRight) {
+        rig.legRight.position.y = MathUtils.lerp(
+            rig.legRight.position.y,
+            rig.restY.legRight - crouchLegDrop,
+            poseDamping,
+        );
         rig.legRight.rotation.x = MathUtils.lerp(
             rig.legRight.rotation.x,
             -legSwing,
@@ -182,6 +241,11 @@ function animateAvatarRig({
         );
     }
     if (rig.armLeft) {
+        rig.armLeft.position.y = MathUtils.lerp(
+            rig.armLeft.position.y,
+            rig.restY.armLeft - crouchAmount * avatarCrouchRigDrop,
+            poseDamping,
+        );
         rig.armLeft.rotation.x = MathUtils.lerp(
             rig.armLeft.rotation.x,
             -armSwing,
@@ -194,6 +258,11 @@ function animateAvatarRig({
         );
     }
     if (rig.armRight) {
+        rig.armRight.position.y = MathUtils.lerp(
+            rig.armRight.position.y,
+            rig.restY.armRight - crouchAmount * avatarCrouchRigDrop,
+            poseDamping,
+        );
         rig.armRight.rotation.x = MathUtils.lerp(
             rig.armRight.rotation.x,
             armSwing,
@@ -236,9 +305,11 @@ function animateAvatarRig({
     if (rig.body) {
         rig.body.position.y = MathUtils.lerp(
             rig.body.position.y,
-            grounded
-                ? Math.abs(phaseSine) * 0.015 * walkAmount - crouchAmount * 0.34
-                : 0.035,
+            rig.restY.body +
+                (grounded
+                    ? Math.abs(phaseSine) * 0.015 * walkAmount -
+                      crouchAmount * avatarCrouchRigDrop
+                    : 0.035),
             poseDamping,
         );
         rig.body.rotation.z = MathUtils.lerp(
@@ -248,6 +319,20 @@ function animateAvatarRig({
         );
     }
     if (rig.head) {
+        rig.head.position.y = MathUtils.lerp(
+            rig.head.position.y,
+            rig.restY.head - crouchAmount * avatarCrouchRigDrop,
+            poseDamping,
+        );
+        rig.head.rotation.x = MathUtils.lerp(
+            rig.head.rotation.x,
+            MathUtils.clamp(
+                headPitch,
+                -avatarHeadPitchLimit,
+                avatarHeadPitchLimit,
+            ),
+            poseDamping,
+        );
         rig.head.rotation.z = MathUtils.lerp(
             rig.head.rotation.z,
             grounded ? -Math.sin(walkPhase) * 0.012 * walkAmount : 0,
@@ -271,7 +356,11 @@ function createRoamTargetCandidates(world: GardenAvatarCollisionWorld) {
                     `${Math.round(surface.x)}:${Math.round(surface.z)}`,
                 ),
         )
-        .map((surface) => ({ x: surface.x, y: surface.y, z: surface.z }));
+        .map((surface) => ({
+            x: surface.x,
+            y: getGardenAvatarSurfaceY(surface, surface),
+            z: surface.z,
+        }));
 }
 
 function easeInOutCubic(value: number) {
@@ -293,6 +382,7 @@ function GardenAvatarCamera({
     pitchRef,
     view,
     yawRef,
+    zoomingRef,
 }: {
     actorRef: RefObject<Group | null>;
     crouchAmountRef: RefObject<number>;
@@ -301,6 +391,7 @@ function GardenAvatarCamera({
     pitchRef: RefObject<number>;
     view: Exclude<GardenAvatarView, 'overview'>;
     yawRef: RefObject<number>;
+    zoomingRef: RefObject<boolean>;
 }) {
     const cameraRef = useRef<ThreePerspectiveCamera>(null);
     const entryPositionRef = useRef(entryPose.position.clone());
@@ -376,7 +467,7 @@ function GardenAvatarCamera({
             );
             lookTargetRef.current.set(
                 actor.position.x,
-                actor.position.y + MathUtils.lerp(1.05, 0.7, crouchAmount),
+                actor.position.y + MathUtils.lerp(0.89, 0.64, crouchAmount),
                 actor.position.z,
             );
             desiredPositionRef.current
@@ -398,6 +489,20 @@ function GardenAvatarCamera({
         rotationHelper.position.copy(desiredPositionRef.current);
         rotationHelper.lookAt(lookTargetRef.current);
         desiredQuaternionRef.current.copy(rotationHelper.quaternion);
+
+        const targetFov = zoomingRef.current
+            ? avatarPerspectiveZoomFov
+            : avatarPerspectiveFov;
+        const nextFov = MathUtils.damp(
+            camera.fov,
+            targetFov,
+            avatarZoomDamping,
+            delta,
+        );
+        if (Math.abs(nextFov - camera.fov) > 0.000_1) {
+            camera.fov = nextFov;
+            camera.updateProjectionMatrix();
+        }
 
         transitionElapsedRef.current += delta;
         const transitionProgress = MathUtils.clamp(
@@ -446,7 +551,6 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
     const jumpRequest = useGameState((state) => state.gardenAvatarJumpRequest);
     const { camera, gl } = useThree();
     const actorRef = useRef<Group>(null);
-    const visualRef = useRef<Group>(null);
     const yawRef = useRef(0);
     const pitchRef = useRef(-0.08);
     const velocityRef = useRef(new Vector3());
@@ -455,14 +559,19 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
     const groundYRef = useRef(0);
     const keyboardRef = useRef(new Set<string>());
     const jumpQueuedRef = useRef(false);
+    const jumpsUsedRef = useRef(0);
     const previousJumpRequestRef = useRef(jumpRequest);
     const previousViewRef = useRef(view);
+    const avatarViewRef = useRef(view);
+    avatarViewRef.current = view;
+    const avatarActive = view !== 'overview';
     const randomRef = useRef(createRandom(0x47524544));
     const roamRef = useRef<AvatarRoamState>({ route: [], waitUntil: 4 });
     const distanceWalkedRef = useRef(0);
     const gaitAmountRef = useRef(0);
     const crouchingRef = useRef(false);
     const crouchAmountRef = useRef(0);
+    const zoomingRef = useRef(false);
     const cameraEntryPoseRef = useRef<AvatarCameraEntryPose>({
         position: camera.position.clone(),
         quaternion: camera.quaternion.clone(),
@@ -482,10 +591,29 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
     );
     const updateActorGroundingShadow = useActorGroundingShadow({
         id: 'garden-avatar',
-        primaryCasterCount: model.primaryCasterCount,
+        primaryCasterCount: view !== 'overview' ? model.primaryCasterCount : 0,
         species: 'avatar',
     });
     useSceneTimeInvalidation(true, sceneFrameRates.interactive);
+
+    useLayoutEffect(() => {
+        const castRealShadow = view !== 'overview';
+        for (const mesh of model.meshes) {
+            mesh.castShadow = castRealShadow;
+            mesh.material =
+                view === 'first-person'
+                    ? model.shadowOnlyMaterial
+                    : (model.materials.get(mesh) ?? mesh.material);
+        }
+        gl.shadowMap.needsUpdate = true;
+    }, [gl, model.materials, model.meshes, model.shadowOnlyMaterial, view]);
+
+    useEffect(
+        () => () => {
+            model.shadowOnlyMaterial.dispose();
+        },
+        [model.shadowOnlyMaterial],
+    );
 
     useEffect(
         () => () => {
@@ -527,11 +655,13 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
     }, [jumpRequest]);
 
     useEffect(() => {
-        if (view === 'overview') {
+        if (!avatarActive) {
             keyboardRef.current.clear();
             velocityRef.current.set(0, 0, 0);
             verticalVelocityRef.current = 0;
+            jumpsUsedRef.current = 0;
             crouchingRef.current = false;
+            zoomingRef.current = false;
             if (document.pointerLockElement === gl.domElement) {
                 document.exitPointerLock();
             }
@@ -576,9 +706,13 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
         const clearKeyboardInput = () => {
             keyboardRef.current.clear();
         };
+        const clearActiveInput = () => {
+            clearKeyboardInput();
+            zoomingRef.current = false;
+        };
         const handleVisibilityChange = () => {
             if (document.hidden) {
-                clearKeyboardInput();
+                clearActiveInput();
             }
         };
         const handleMouseMove = (event: MouseEvent) => {
@@ -592,6 +726,14 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
         };
         const handlePointerDown = (event: PointerEvent) => {
             if (event.pointerType === 'mouse') {
+                if (event.button === 2) {
+                    event.preventDefault();
+                    zoomingRef.current = true;
+                    if (avatarViewRef.current === 'third-person') {
+                        setView('first-person');
+                    }
+                    return;
+                }
                 if (
                     event.button === 0 &&
                     document.pointerLockElement !== gl.domElement
@@ -617,25 +759,32 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
             lastPointerY = event.clientY;
         };
         const handlePointerEnd = (event: PointerEvent) => {
+            if (event.pointerType === 'mouse' && event.button === 2) {
+                zoomingRef.current = false;
+            }
             if (event.pointerId === dragPointerId) {
                 dragPointerId = null;
             }
         };
+        const handleContextMenu = (event: MouseEvent) => {
+            event.preventDefault();
+        };
 
         window.addEventListener('keydown', handleKeyDown, { passive: false });
         window.addEventListener('keyup', handleKeyUp);
-        window.addEventListener('blur', clearKeyboardInput);
+        window.addEventListener('blur', clearActiveInput);
         document.addEventListener('visibilitychange', handleVisibilityChange);
         document.addEventListener('mousemove', handleMouseMove);
         gl.domElement.addEventListener('pointerdown', handlePointerDown);
         gl.domElement.addEventListener('pointermove', handlePointerMove);
-        gl.domElement.addEventListener('pointerup', handlePointerEnd);
-        gl.domElement.addEventListener('pointercancel', handlePointerEnd);
+        window.addEventListener('pointerup', handlePointerEnd);
+        window.addEventListener('pointercancel', handlePointerEnd);
+        gl.domElement.addEventListener('contextmenu', handleContextMenu);
         return () => {
             clearKeyboardInput();
             window.removeEventListener('keydown', handleKeyDown);
             window.removeEventListener('keyup', handleKeyUp);
-            window.removeEventListener('blur', clearKeyboardInput);
+            window.removeEventListener('blur', clearActiveInput);
             document.removeEventListener(
                 'visibilitychange',
                 handleVisibilityChange,
@@ -643,13 +792,11 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
             document.removeEventListener('mousemove', handleMouseMove);
             gl.domElement.removeEventListener('pointerdown', handlePointerDown);
             gl.domElement.removeEventListener('pointermove', handlePointerMove);
-            gl.domElement.removeEventListener('pointerup', handlePointerEnd);
-            gl.domElement.removeEventListener(
-                'pointercancel',
-                handlePointerEnd,
-            );
+            window.removeEventListener('pointerup', handlePointerEnd);
+            window.removeEventListener('pointercancel', handlePointerEnd);
+            gl.domElement.removeEventListener('contextmenu', handleContextMenu);
         };
-    }, [gl.domElement, setView, view]);
+    }, [avatarActive, gl.domElement, setView]);
 
     function activateAvatarView() {
         const actor = actorRef.current;
@@ -875,6 +1022,7 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
                 previousGroundY - groundYRef.current > gardenAvatarMaxStepHeight
             ) {
                 groundedRef.current = false;
+                jumpsUsedRef.current = Math.max(jumpsUsedRef.current, 1);
                 verticalVelocityRef.current = 0;
             }
             if (movement.collided) {
@@ -894,9 +1042,16 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
                 delta,
             );
 
-            if (jumpQueuedRef.current && groundedRef.current) {
-                verticalVelocityRef.current = avatarJumpVelocity;
-                groundedRef.current = false;
+            if (jumpQueuedRef.current) {
+                const nextJumpCount = getGardenAvatarNextJumpCount({
+                    grounded: groundedRef.current,
+                    jumpsUsed: jumpsUsedRef.current,
+                });
+                if (nextJumpCount !== null) {
+                    jumpsUsedRef.current = nextJumpCount;
+                    verticalVelocityRef.current = avatarJumpVelocity;
+                    groundedRef.current = false;
+                }
             }
             jumpQueuedRef.current = false;
             if (groundedRef.current) {
@@ -935,6 +1090,7 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
                     actor.position.y = groundYRef.current;
                     verticalVelocityRef.current = 0;
                     groundedRef.current = true;
+                    jumpsUsedRef.current = 0;
                 }
             }
         }
@@ -956,16 +1112,17 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
             delta,
             distanceWalked: distanceWalkedRef.current,
             grounded: groundedRef.current,
+            headPitch: view === 'overview' ? 0 : pitchRef.current,
             rig: model.rig,
             walkAmount: gaitAmountRef.current,
         });
-        if (visualRef.current) {
-            visualRef.current.visible = view !== 'first-person';
+        if (view !== 'overview') {
+            gl.shadowMap.needsUpdate = true;
         }
         updateActorGroundingShadow?.({
             actorY: actor.position.y,
             receiverY: groundYRef.current,
-            visible: actor.visible && view !== 'first-person',
+            visible: actor.visible && view === 'overview',
             x: actor.position.x,
             yaw: actor.rotation.y,
             z: actor.position.z,
@@ -984,8 +1141,8 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
             >
                 <mesh
                     name="Interaction:GardenAvatar"
-                    position={[0, 0.7, 0]}
-                    scale={[0.9, 1.55, 0.9]}
+                    position={[0, 0.6, 0]}
+                    scale={[0.76, 1.32, 0.76]}
                 >
                     <boxGeometry />
                     <meshBasicMaterial
@@ -995,11 +1152,11 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
                         opacity={0}
                     />
                 </mesh>
-                <group ref={visualRef} scale={avatarModelScale}>
+                <group scale={avatarModelScale}>
                     <primitive object={model.scene} />
                 </group>
                 {view === 'overview' ? (
-                    <Html center position={[0, 1.68, 0]} zIndexRange={[30, 20]}>
+                    <Html center position={[0, 1.43, 0]} zIndexRange={[30, 20]}>
                         <button
                             type="button"
                             className="whitespace-nowrap rounded-full border border-border/60 bg-background/85 px-2.5 py-1 text-xs font-medium shadow-md backdrop-blur-sm transition-transform hover:scale-105 hover:bg-muted"
@@ -1022,6 +1179,7 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
                     pitchRef={pitchRef}
                     view={view}
                     yawRef={yawRef}
+                    zoomingRef={zoomingRef}
                 />
             ) : null}
         </>

--- a/packages/game/src/entities/avatar/gardenAvatarMovement.ts
+++ b/packages/game/src/entities/avatar/gardenAvatarMovement.ts
@@ -73,8 +73,8 @@ export function getGardenAvatarSurfaceY(
     const sin = Math.sin(rotation);
     const dx = position.x - surface.x;
     const dz = position.z - surface.z;
-    const localX = dx * cos + dz * sin;
-    const localZ = -dx * sin + dz * cos;
+    const localX = dx * cos - dz * sin;
+    const localZ = dx * sin + dz * cos;
     const normalizedHeight = getSlopedGroundNormalizedHeight(
         surface.slopeBlockName,
         localX,

--- a/packages/game/src/entities/avatar/gardenAvatarMovement.ts
+++ b/packages/game/src/entities/avatar/gardenAvatarMovement.ts
@@ -11,6 +11,7 @@ import {
     isAnimalWaterBlockName,
 } from '../animals/animalMovementTerrain';
 import { findCatPath } from '../cats/catPathfinding';
+import { getSlopedGroundNormalizedHeight } from '../groundSurfaceHeight';
 
 export type GardenAvatarPoint = {
     x: number;
@@ -30,11 +31,12 @@ export type GardenAvatarMovementSurface = AnimalMovementSurface & {
     roamable?: boolean;
     roamBlockedCells?: AnimalMovementCell[];
     rotation?: number;
+    slopeBlockName?: string;
 };
 
-export const gardenAvatarRadius = 0.18;
-export const gardenAvatarStandingCollisionHeight = 1.32;
-export const gardenAvatarCrouchingCollisionHeight = 0.78;
+export const gardenAvatarRadius = 0.153;
+export const gardenAvatarStandingCollisionHeight = 1.12;
+export const gardenAvatarCrouchingCollisionHeight = 0.66;
 export const gardenAvatarMaxStepHeight = 0.42;
 export const gardenAvatarMaxJumpClimbHeight = 0.95;
 
@@ -58,13 +60,39 @@ function cellKey(cell: Pick<AnimalMovementCell, 'x' | 'z'>) {
     return `${Math.round(cell.x)}:${Math.round(cell.z)}`;
 }
 
-function getHighestSurfaceAt(
+export function getGardenAvatarSurfaceY(
+    position: Pick<GardenAvatarPoint, 'x' | 'z'>,
+    surface: GardenAvatarMovementSurface,
+) {
+    if (!surface.slopeBlockName || surface.bottomY === undefined) {
+        return surface.y;
+    }
+
+    const rotation = surface.rotation ?? 0;
+    const cos = Math.cos(rotation);
+    const sin = Math.sin(rotation);
+    const dx = position.x - surface.x;
+    const dz = position.z - surface.z;
+    const localX = dx * cos + dz * sin;
+    const localZ = -dx * sin + dz * cos;
+    const normalizedHeight = getSlopedGroundNormalizedHeight(
+        surface.slopeBlockName,
+        localX,
+        localZ,
+    );
+
+    return normalizedHeight === null
+        ? surface.y
+        : surface.bottomY + (surface.y - surface.bottomY) * normalizedHeight;
+}
+
+function getHighestSurfaceYAt(
     position: Pick<GardenAvatarPoint, 'x' | 'z'>,
     surfaces: GardenAvatarMovementSurface[],
     currentGroundY: number,
     collisionHeight: number,
 ) {
-    let selected: GardenAvatarMovementSurface | null = null;
+    let selectedY: number | null = null;
 
     for (const surface of surfaces) {
         const rotation = surface.rotation ?? 0;
@@ -83,16 +111,18 @@ function getHighestSurfaceAt(
             surface.bottomY === undefined ||
             surface.bottomY <= currentGroundY + collisionHeight;
 
+        const surfaceY = getGardenAvatarSurfaceY(position, surface);
+
         if (
             insideSurface &&
             clearsOverhead &&
-            (!selected || surface.y > selected.y)
+            surfaceY > (selectedY ?? Number.NEGATIVE_INFINITY)
         ) {
-            selected = surface;
+            selectedY = surfaceY;
         }
     }
 
-    return selected;
+    return selectedY;
 }
 
 function circleIntersectsCell(
@@ -181,7 +211,7 @@ export function getGardenAvatarGroundY({
 
     const sampleHeights: number[] = [];
     for (const sample of collisionSamples) {
-        const surface = getHighestSurfaceAt(
+        const surfaceY = getHighestSurfaceYAt(
             {
                 x: position.x + sample.x,
                 z: position.z + sample.z,
@@ -190,7 +220,7 @@ export function getGardenAvatarGroundY({
             currentGroundY,
             collisionHeight,
         );
-        sampleHeights.push(surface?.y ?? 0);
+        sampleHeights.push(surfaceY ?? 0);
     }
 
     const maxHeight = Math.max(...sampleHeights);
@@ -420,6 +450,7 @@ export function createGardenAvatarCollisionWorld({
                 roamable: isTerrain,
                 roamBlockedCells: placement.roamBlockedCells,
                 rotation: block.rotation * (Math.PI / 2),
+                slopeBlockName: isTerrain ? block.name : undefined,
                 x: placement.x,
                 y: stackHeight,
                 z: placement.z,
@@ -460,18 +491,36 @@ function createWalkableSurfaceMap(world: GardenAvatarCollisionWorld) {
 
     for (const surface of world.surfaces) {
         const key = cellKey(surface);
+        const surfaceY = getGardenAvatarSurfaceY(surface, surface);
         if (
             surface.kind === 'ground' &&
             surface.roamable !== false &&
             !blockedKeys.has(key) &&
             (!surfaces.has(key) ||
-                (surfaces.get(key)?.y ?? Number.NEGATIVE_INFINITY) < surface.y)
+                (surfaces.get(key)?.y ?? Number.NEGATIVE_INFINITY) < surfaceY)
         ) {
-            surfaces.set(key, surface);
+            surfaces.set(key, {
+                ...surface,
+                y: surfaceY,
+            });
         }
     }
 
     return surfaces;
+}
+
+export function getGardenAvatarNextJumpCount({
+    grounded,
+    jumpsUsed,
+}: {
+    grounded: boolean;
+    jumpsUsed: number;
+}) {
+    if (grounded) {
+        return 1;
+    }
+
+    return jumpsUsed < 2 ? 2 : null;
 }
 
 const neighborDirections = [

--- a/packages/game/src/entities/avatar/gardenAvatarMovement.unit.ts
+++ b/packages/game/src/entities/avatar/gardenAvatarMovement.unit.ts
@@ -11,7 +11,9 @@ import {
     gardenAvatarCrouchingCollisionHeight,
     getGardenAvatarCeilingY,
     getGardenAvatarGroundY,
+    getGardenAvatarNextJumpCount,
     getGardenAvatarRoamBlockedCells,
+    getGardenAvatarSurfaceY,
     resolveGardenAvatarHorizontalMovement,
 } from './gardenAvatarMovement';
 
@@ -166,6 +168,90 @@ test('uses complete stack heights as walkable avatar terrain', () => {
 
     assert.equal(world.blockedCells.length, 0);
     assert.equal(Math.max(...world.surfaces.map((surface) => surface.y)), 0.8);
+});
+
+test('follows angled terrain height continuously instead of flattening it', () => {
+    const world = createGardenAvatarCollisionWorld({
+        blockData: getLocalSandboxBlockData(),
+        stacks: [
+            {
+                blocks: [
+                    { id: 'slope', name: 'Block_Grass_Angle', rotation: 0 },
+                ],
+                position: new Vector3(0, 0, 0),
+            },
+        ],
+    });
+    const slope = world.surfaces[0];
+
+    assert.ok(slope);
+    assert.equal(getGardenAvatarSurfaceY({ x: -0.5, z: 0 }, slope), 0);
+    assert.equal(getGardenAvatarSurfaceY({ x: 0, z: 0 }, slope), 0.2);
+    assert.equal(getGardenAvatarSurfaceY({ x: 0.5, z: 0 }, slope), 0.4);
+});
+
+test('rotates slope height sampling with the terrain block', () => {
+    const world = createGardenAvatarCollisionWorld({
+        blockData: getLocalSandboxBlockData(),
+        stacks: [
+            {
+                blocks: [
+                    { id: 'slope', name: 'Block_Sand_Angle', rotation: 1 },
+                ],
+                position: new Vector3(0, 0, 0),
+            },
+        ],
+    });
+    const slope = world.surfaces[0];
+
+    assert.ok(slope);
+    assert.equal(getGardenAvatarSurfaceY({ x: 0, z: -0.5 }, slope), 0);
+    assert.equal(getGardenAvatarSurfaceY({ x: 0, z: 0.5 }, slope), 0.4);
+});
+
+test('matches corner and reverse-corner terrain silhouettes', () => {
+    const corner = {
+        bottomY: 0,
+        kind: 'ground',
+        slopeBlockName: 'Block_Grass_Corner',
+        x: 0,
+        y: 0.4,
+        z: 0,
+    } satisfies GardenAvatarCollisionWorld['surfaces'][number];
+    const reverseCorner = {
+        ...corner,
+        slopeBlockName: 'Block_Grass_Reverse_Corner',
+    };
+
+    assert.equal(getGardenAvatarSurfaceY({ x: 0.5, z: 0.5 }, corner), 0.4);
+    assert.equal(getGardenAvatarSurfaceY({ x: 0.5, z: -0.5 }, corner), 0);
+    assert.equal(
+        getGardenAvatarSurfaceY({ x: -0.5, z: -0.5 }, reverseCorner),
+        0,
+    );
+    assert.equal(
+        getGardenAvatarSurfaceY({ x: 0.5, z: -0.5 }, reverseCorner),
+        0.4,
+    );
+});
+
+test('allows one grounded jump and one airborne jump', () => {
+    assert.equal(
+        getGardenAvatarNextJumpCount({ grounded: true, jumpsUsed: 0 }),
+        1,
+    );
+    assert.equal(
+        getGardenAvatarNextJumpCount({ grounded: false, jumpsUsed: 1 }),
+        2,
+    );
+    assert.equal(
+        getGardenAvatarNextJumpCount({ grounded: false, jumpsUsed: 2 }),
+        null,
+    );
+    assert.equal(
+        getGardenAvatarNextJumpCount({ grounded: false, jumpsUsed: 0 }),
+        2,
+    );
 });
 
 test('walks on the support below water instead of the water surface', () => {
@@ -328,7 +414,8 @@ test('lets the shorter crouching collider pass under overhead geometry', () => {
                 collisionHeight: gardenAvatarCrouchingCollisionHeight,
                 position: { x: 0, y: 0, z: 0 },
                 world,
-            }) ?? 0) - 0.12,
+            }) ?? 0) -
+                (0.9 - gardenAvatarCrouchingCollisionHeight),
         ) < 0.000_001,
     );
 });

--- a/packages/game/src/entities/avatar/gardenAvatarMovement.unit.ts
+++ b/packages/game/src/entities/avatar/gardenAvatarMovement.unit.ts
@@ -190,7 +190,7 @@ test('follows angled terrain height continuously instead of flattening it', () =
     assert.equal(getGardenAvatarSurfaceY({ x: 0.5, z: 0 }, slope), 0.4);
 });
 
-test('rotates slope height sampling with the terrain block', () => {
+test('matches the rendered orientation of a quarter-turned slope', () => {
     const world = createGardenAvatarCollisionWorld({
         blockData: getLocalSandboxBlockData(),
         stacks: [
@@ -205,8 +205,8 @@ test('rotates slope height sampling with the terrain block', () => {
     const slope = world.surfaces[0];
 
     assert.ok(slope);
-    assert.equal(getGardenAvatarSurfaceY({ x: 0, z: -0.5 }, slope), 0);
-    assert.equal(getGardenAvatarSurfaceY({ x: 0, z: 0.5 }, slope), 0.4);
+    assert.equal(getGardenAvatarSurfaceY({ x: 0, z: -0.5 }, slope), 0.4);
+    assert.equal(getGardenAvatarSurfaceY({ x: 0, z: 0.5 }, slope), 0);
 });
 
 test('matches corner and reverse-corner terrain silhouettes', () => {

--- a/packages/game/src/entities/groundDecorations/GroundDecorationInstances.tsx
+++ b/packages/game/src/entities/groundDecorations/GroundDecorationInstances.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useThree } from '@react-three/fiber';
+import { useFrame, useThree } from '@react-three/fiber';
 import { useCallback, useLayoutEffect, useMemo, useRef } from 'react';
 import {
     Box3,
@@ -582,6 +582,7 @@ function GroundDecorationInstancedBatch({
         [batch.instances],
     );
     const gameCamera = useGameState((state) => state.gameCamera);
+    const gardenAvatarView = useGameState((state) => state.gardenAvatarView);
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const gameWeather = useGameState((state) => state.weather);
     const weather = weatherOverride ?? gameWeather;
@@ -735,6 +736,12 @@ function GroundDecorationInstancedBatch({
 
         return gameCamera.subscribe(() => updateMatrices(camera.quaternion));
     }, [camera, gameCamera, updateMatrices]);
+
+    useFrame(() => {
+        if (gardenAvatarView !== 'overview') {
+            updateMatrices(camera.quaternion);
+        }
+    }, -90);
 
     useLayoutEffect(
         () => () => {

--- a/packages/game/src/entities/groundDecorations/GroundDecorationInstances.tsx
+++ b/packages/game/src/entities/groundDecorations/GroundDecorationInstances.tsx
@@ -81,6 +81,12 @@ type GroundDecorationProfileBatchStats = {
     visibleCount: number;
 };
 
+type GroundDecorationCameraSnapshot = {
+    position: Vector3;
+    projectionMatrix: Matrix4;
+    quaternion: Quaternion;
+};
+
 type RecordGroundDecorationProfileBatch = (
     key: string,
     stats: GroundDecorationProfileBatchStats | null,
@@ -566,6 +572,11 @@ function GroundDecorationInstancedBatch({
     weather?: GroundDecorationWeather;
 }) {
     const meshRef = useRef<InstancedMesh | null>(null);
+    const avatarCameraSnapshotRef =
+        useRef<GroundDecorationCameraSnapshot | null>(null);
+    const visibleInstancesRef = useRef<GroundDecorationBatchInstance[]>([]);
+    const staticAttributeGeometryRef = useRef<PlaneGeometry | null>(null);
+    const profileInitializedRef = useRef(false);
     const camera = useThree((state) => state.camera);
     const matrix = useMemo(() => new Matrix4(), []);
     const frustumMatrix = useMemo(() => new Matrix4(), []);
@@ -663,6 +674,11 @@ function GroundDecorationInstancedBatch({
             const uvTransformAttribute = geometry.getAttribute(
                 'instanceUvTransform',
             ) as InstancedBufferAttribute;
+            const previousVisibleInstances = visibleInstancesRef.current;
+            const initializeStaticAttributes =
+                staticAttributeGeometryRef.current !== geometry;
+            let staticAttributesChanged = false;
+            let visibleInstancesChanged = initializeStaticAttributes;
             let visibleIndex = 0;
 
             for (const chunk of chunks) {
@@ -681,34 +697,56 @@ function GroundDecorationInstancedBatch({
                     );
                     matrix.compose(position, quaternion, scale);
                     mesh.setMatrixAt(visibleIndex, matrix);
-                    wobbleAttribute.setXYZW(visibleIndex, ...instance.wobble);
-                    alphaOpacityAttribute.setXY(
-                        visibleIndex,
-                        instance.alphaTest,
-                        instance.opacity,
-                    );
-                    uvTransformAttribute.setXYZW(
-                        visibleIndex,
-                        ...instance.uvTransform,
-                    );
+                    if (
+                        initializeStaticAttributes ||
+                        previousVisibleInstances[visibleIndex] !== instance
+                    ) {
+                        wobbleAttribute.setXYZW(
+                            visibleIndex,
+                            ...instance.wobble,
+                        );
+                        alphaOpacityAttribute.setXY(
+                            visibleIndex,
+                            instance.alphaTest,
+                            instance.opacity,
+                        );
+                        uvTransformAttribute.setXYZW(
+                            visibleIndex,
+                            ...instance.uvTransform,
+                        );
+                        staticAttributesChanged = true;
+                        visibleInstancesChanged = true;
+                    }
+                    previousVisibleInstances[visibleIndex] = instance;
                     visibleIndex += 1;
                 }
             }
 
+            if (previousVisibleInstances.length !== visibleIndex) {
+                previousVisibleInstances.length = visibleIndex;
+                visibleInstancesChanged = true;
+            }
+            staticAttributeGeometryRef.current = geometry;
+
             mesh.count = visibleIndex;
             mesh.visible = visibleIndex > 0;
             mesh.instanceMatrix.needsUpdate = true;
-            wobbleAttribute.needsUpdate = true;
-            alphaOpacityAttribute.needsUpdate = true;
-            uvTransformAttribute.needsUpdate = true;
+            if (staticAttributesChanged) {
+                wobbleAttribute.needsUpdate = true;
+                alphaOpacityAttribute.needsUpdate = true;
+                uvTransformAttribute.needsUpdate = true;
+            }
             mesh.computeBoundingBox();
             mesh.computeBoundingSphere();
-            recordProfileBatch(batch.key, {
-                atlasPageIndex: batch.atlasPageIndex,
-                chunkKeys: chunks.map((chunk) => chunk.key),
-                instanceCount: batch.instances.length,
-                visibleCount: visibleIndex,
-            });
+            if (!profileInitializedRef.current || visibleInstancesChanged) {
+                recordProfileBatch(batch.key, {
+                    atlasPageIndex: batch.atlasPageIndex,
+                    chunkKeys: chunks.map((chunk) => chunk.key),
+                    instanceCount: batch.instances.length,
+                    visibleCount: visibleIndex,
+                });
+                profileInitializedRef.current = true;
+            }
         },
         [
             batch.instances.length,
@@ -738,9 +776,32 @@ function GroundDecorationInstancedBatch({
     }, [camera, gameCamera, updateMatrices]);
 
     useFrame(() => {
-        if (gardenAvatarView !== 'overview') {
-            updateMatrices(camera.quaternion);
+        if (gardenAvatarView === 'overview') {
+            avatarCameraSnapshotRef.current = null;
+            return;
         }
+
+        const snapshot = avatarCameraSnapshotRef.current;
+        if (
+            snapshot?.position.equals(camera.position) &&
+            snapshot.quaternion.equals(camera.quaternion) &&
+            snapshot.projectionMatrix.equals(camera.projectionMatrix)
+        ) {
+            return;
+        }
+
+        if (snapshot) {
+            snapshot.position.copy(camera.position);
+            snapshot.quaternion.copy(camera.quaternion);
+            snapshot.projectionMatrix.copy(camera.projectionMatrix);
+        } else {
+            avatarCameraSnapshotRef.current = {
+                position: camera.position.clone(),
+                projectionMatrix: camera.projectionMatrix.clone(),
+                quaternion: camera.quaternion.clone(),
+            };
+        }
+        updateMatrices(camera.quaternion);
     }, -90);
 
     useLayoutEffect(

--- a/packages/game/src/entities/groundDecorations/getBlockSurfaceDecorations.ts
+++ b/packages/game/src/entities/groundDecorations/getBlockSurfaceDecorations.ts
@@ -1,5 +1,6 @@
 import { SeededRNG } from '../../generators/plant/lib/rng';
 import type { Block } from '../../types/Block';
+import { getSlopedGroundNormalizedHeight } from '../groundSurfaceHeight';
 import {
     type GroundDecorationSurface,
     getGroundDecorationSprites,
@@ -27,36 +28,19 @@ export type BlockSurfaceDecorationPlacement =
     | BlockSurfaceSpriteDecorationPlacement
     | BlockSurfaceFlowerDecorationPlacement;
 
-const angledBlockHighEdgeX = 0.5;
-
 function resolveDecorationBaseY(
     block: Block,
     options: (typeof groundDecorationOptions)[GroundDecorationSurface],
     x: number,
     z: number,
 ) {
-    if (block.name.endsWith('_Reverse_Corner')) {
-        return (
-            options.baseY +
-            (Math.max(x, z) - angledBlockHighEdgeX) * options.angleLiftPerUnit
-        );
-    }
-
-    if (block.name.endsWith('_Corner')) {
-        return (
-            options.baseY +
-            (Math.min(x, z) - angledBlockHighEdgeX) * options.angleLiftPerUnit
-        );
-    }
-
-    if (!block.name.endsWith('_Angle')) {
+    const normalizedHeight = getSlopedGroundNormalizedHeight(block.name, x, z);
+    if (normalizedHeight === null) {
         return options.baseY;
     }
 
-    // baseY is tuned for the raised local +X edge of angled block meshes.
-    return (
-        options.baseY + (x - angledBlockHighEdgeX) * options.angleLiftPerUnit
-    );
+    // baseY is tuned for the raised edge/corner of sloped block meshes.
+    return options.baseY + (normalizedHeight - 1) * options.angleLiftPerUnit;
 }
 
 function getDecorationCount(

--- a/packages/game/src/entities/groundSurfaceHeight.ts
+++ b/packages/game/src/entities/groundSurfaceHeight.ts
@@ -1,0 +1,29 @@
+const terrainHalfSize = 0.5;
+
+function clampUnit(value: number) {
+    return Math.max(0, Math.min(1, value));
+}
+
+/**
+ * Returns the normalized surface height for the garden's wedge-shaped terrain
+ * blocks. A value of 0 is the low edge and 1 is the raised edge/corner.
+ */
+export function getSlopedGroundNormalizedHeight(
+    blockName: string,
+    localX: number,
+    localZ: number,
+) {
+    if (blockName.endsWith('_Reverse_Corner')) {
+        return clampUnit(Math.max(localX, localZ) + terrainHalfSize);
+    }
+
+    if (blockName.endsWith('_Corner')) {
+        return clampUnit(Math.min(localX, localZ) + terrainHalfSize);
+    }
+
+    if (blockName.endsWith('_Angle')) {
+        return clampUnit(localX + terrainHalfSize);
+    }
+
+    return null;
+}

--- a/packages/game/src/generators/plant/parts/PlantBillboard.tsx
+++ b/packages/game/src/generators/plant/parts/PlantBillboard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useThree } from '@react-three/fiber';
+import { useFrame, useThree } from '@react-three/fiber';
 import {
     type PropsWithChildren,
     useCallback,
@@ -115,6 +115,7 @@ function CameraFacingBillboard({ children }: PropsWithChildren) {
     const groupRef = useRef<THREE.Group>(null);
     const camera = useThree((state) => state.camera);
     const gameCamera = useGameState((state) => state.gameCamera);
+    const gardenAvatarView = useGameState((state) => state.gardenAvatarView);
 
     const updateCameraFacing = useCallback(() => {
         groupRef.current?.quaternion.copy(camera.quaternion);
@@ -129,6 +130,12 @@ function CameraFacingBillboard({ children }: PropsWithChildren) {
 
         return gameCamera.subscribe(() => updateCameraFacing());
     }, [gameCamera, updateCameraFacing]);
+
+    useFrame(() => {
+        if (gardenAvatarView !== 'overview') {
+            updateCameraFacing();
+        }
+    }, -90);
 
     return <group ref={groupRef}>{children}</group>;
 }

--- a/packages/game/src/hud/GardenAvatarHud.tsx
+++ b/packages/game/src/hud/GardenAvatarHud.tsx
@@ -44,8 +44,8 @@ export function GardenAvatarHud() {
     return (
         <div className="pointer-events-none absolute inset-0 z-30 select-none">
             <div className="absolute top-[calc(var(--game-safe-area-top,0px)+0.5rem)] left-1/2 hidden -translate-x-1/2 rounded-full border border-border/50 bg-background/75 px-3 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur-sm md:block">
-                WASD za hodanje · Shift za trčanje · Ctrl za čučanj · Space za
-                skok · klik za pogled mišem · Esc za izlaz
+                WASD za hodanje · Shift za trčanje · Ctrl za čučanj · dvaput
+                Space za dvostruki skok · desni klik za POV zum · Esc za izlaz
             </div>
 
             <div className="absolute bottom-[calc(var(--game-safe-area-bottom,0px)+0.5rem)] left-[calc(var(--game-safe-area-left,0px)+0.5rem)] flex items-center gap-1 rounded-xl border border-border/50 bg-background/70 p-1 shadow-lg backdrop-blur-md">

--- a/packages/game/src/scene/SkyGradientBackground.tsx
+++ b/packages/game/src/scene/SkyGradientBackground.tsx
@@ -3,7 +3,14 @@
 import { useFrame, useThree } from '@react-three/fiber';
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import * as SunCalc from 'suncalc';
-import { Color, DoubleSide, type Mesh, ShaderMaterial, Vector2 } from 'three';
+import {
+    Color,
+    DoubleSide,
+    type Mesh,
+    ShaderMaterial,
+    Vector2,
+    Vector3,
+} from 'three';
 import { useGameState } from '../useGameState';
 import { useSceneTimeInvalidation } from './SceneTime';
 import {
@@ -36,20 +43,25 @@ const SKY_GRADIENT_TRANSITION_SECONDS = 0.6;
 const SKY_GRADIENT_TRANSITION_EPSILON = 0.001;
 const HORIZON_FADE_START = -0.05;
 const HORIZON_FADE_END = 0.18;
+const WORLD_SKY_RADIUS = 800;
 
 const skyGradientVertex = /* glsl */ `
     varying vec2 vUv;
+    varying vec3 vSkyDirection;
 
     void main() {
         vUv = uv;
+        vSkyDirection = position;
         gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
     }
 `;
 
 const skyGradientFragment = /* glsl */ `
     varying vec2 vUv;
+    varying vec3 vSkyDirection;
 
     uniform float uAspect;
+    uniform float uWorldSky;
     uniform vec3 uZenithColor;
     uniform vec3 uUpperColor;
     uniform vec3 uHorizonColor;
@@ -60,6 +72,8 @@ const skyGradientFragment = /* glsl */ `
     uniform float uMoonGlowIntensity;
     uniform vec2 uSunPosition;
     uniform vec2 uMoonPosition;
+    uniform vec3 uSunDirection;
+    uniform vec3 uMoonDirection;
 
     float glowAt(vec2 p, vec2 center, float radius) {
         vec2 delta = p - center;
@@ -68,15 +82,29 @@ const skyGradientFragment = /* glsl */ `
     }
 
     void main() {
-        float y = clamp(vUv.y, 0.0, 1.0);
+        vec3 skyDirection = normalize(vSkyDirection);
+        float worldSkyY = clamp(
+            0.42 + asin(clamp(skyDirection.y, -1.0, 1.0)) / 3.14159265 * 4.2,
+            0.0,
+            1.0
+        );
+        float y = mix(clamp(vUv.y, 0.0, 1.0), worldSkyY, uWorldSky);
         vec3 color = mix(uLowerColor, uHorizonColor, smoothstep(0.0, 0.42, y));
         color = mix(color, uUpperColor, smoothstep(0.38, 0.84, y));
         color = mix(color, uZenithColor, smoothstep(0.76, 1.0, y));
 
         vec2 p = vUv * 2.0 - 1.0;
-        float sunGlow = glowAt(p, uSunPosition, 0.95);
-        float sunCore = glowAt(p, uSunPosition, 0.36);
-        float moonGlow = glowAt(p, uMoonPosition, 0.58);
+        float screenSunGlow = glowAt(p, uSunPosition, 0.95);
+        float screenSunCore = glowAt(p, uSunPosition, 0.36);
+        float screenMoonGlow = glowAt(p, uMoonPosition, 0.58);
+        float sunDistance = 1.0 - dot(skyDirection, normalize(uSunDirection));
+        float moonDistance = 1.0 - dot(skyDirection, normalize(uMoonDirection));
+        float worldSunGlow = 1.0 - smoothstep(0.015, 0.24, sunDistance);
+        float worldSunCore = 1.0 - smoothstep(0.0015, 0.035, sunDistance);
+        float worldMoonGlow = 1.0 - smoothstep(0.008, 0.12, moonDistance);
+        float sunGlow = mix(screenSunGlow, worldSunGlow, uWorldSky);
+        float sunCore = mix(screenSunCore, worldSunCore, uWorldSky);
+        float moonGlow = mix(screenMoonGlow, worldMoonGlow, uWorldSky);
 
         color = mix(color, uSunGlowColor, clamp(sunGlow * uSunGlowIntensity, 0.0, 1.0));
         color = mix(color, vec3(1.0), clamp(sunCore * uSunGlowIntensity * 0.62, 0.0, 1.0));
@@ -123,6 +151,17 @@ function copyVectorUniform(
 ) {
     const uniform = material.uniforms[name];
     if (uniform?.value instanceof Vector2) {
+        uniform.value.copy(vector);
+    }
+}
+
+function copyVector3Uniform(
+    material: ShaderMaterial,
+    name: string,
+    vector: Vector3,
+) {
+    const uniform = material.uniforms[name];
+    if (uniform?.value instanceof Vector3) {
         uniform.value.copy(vector);
     }
 }
@@ -175,6 +214,7 @@ export function SkyGradientBackground({
         (state) => state.size,
     );
     const gameCamera = useGameState((state) => state.gameCamera);
+    const gardenAvatarView = useGameState((state) => state.gardenAvatarView);
     const meshRef = useRef<Mesh>(null);
     const basisRef = useRef(createSkyViewBasis());
     const cameraProjectionSnapshotRef = useRef(
@@ -204,6 +244,7 @@ export function SkyGradientBackground({
                 side: DoubleSide,
                 uniforms: {
                     uAspect: { value: 1 },
+                    uWorldSky: { value: 0 },
                     uZenithColor: { value: new Color('#e6f6ff') },
                     uUpperColor: { value: new Color('#f1f3ea') },
                     uHorizonColor: { value: new Color('#fff9ea') },
@@ -214,6 +255,8 @@ export function SkyGradientBackground({
                     uMoonGlowIntensity: { value: 0 },
                     uSunPosition: { value: new Vector2(0, 0) },
                     uMoonPosition: { value: new Vector2(0, 0) },
+                    uSunDirection: { value: new Vector3(0, 1, 0) },
+                    uMoonDirection: { value: new Vector3(0, 1, 0) },
                 },
             }),
         [],
@@ -325,6 +368,41 @@ export function SkyGradientBackground({
             }
 
             const basis = basisRef.current;
+            const worldSky = gardenAvatarView !== 'overview';
+            material.uniforms.uWorldSky.value = worldSky ? 1 : 0;
+            copyVector3Uniform(
+                material,
+                'uSunDirection',
+                celestialState.sunDirection,
+            );
+            copyVector3Uniform(
+                material,
+                'uMoonDirection',
+                celestialState.moonDirection,
+            );
+
+            if (worldSky) {
+                mesh.position.copy(camera.position);
+                mesh.quaternion.identity();
+                mesh.scale.setScalar(1);
+                sunOpacityRef.current = celestialState.sunOpacity;
+                moonOpacityRef.current = celestialState.moonOpacity;
+                const displayed = displayedGradientRef.current;
+                if (displayed) {
+                    applyVisibleGradientUniforms(
+                        material,
+                        displayed,
+                        celestialState.sunOpacity,
+                        celestialState.moonOpacity,
+                        hideCelestialGlow,
+                    );
+                }
+                if (requestRender) {
+                    invalidate();
+                }
+                return;
+            }
+
             mesh.position
                 .copy(camera.position)
                 .addScaledVector(basis.forward, SKY_FORWARD_DISTANCE);
@@ -376,6 +454,7 @@ export function SkyGradientBackground({
         [
             camera,
             celestialState,
+            gardenAvatarView,
             hideCelestialGlow,
             invalidate,
             material,
@@ -446,7 +525,11 @@ export function SkyGradientBackground({
             name="Environment:SkyGradientBackground"
             renderOrder={-1000}
         >
-            <planeGeometry args={[1, 1]} />
+            {gardenAvatarView === 'overview' ? (
+                <planeGeometry args={[1, 1]} />
+            ) : (
+                <sphereGeometry args={[WORLD_SKY_RADIUS, 48, 24]} />
+            )}
         </mesh>
     );
 }

--- a/packages/game/src/scene/Stars.tsx
+++ b/packages/game/src/scene/Stars.tsx
@@ -119,6 +119,9 @@ export function Stars({ visibility = 1 }: StarsProps) {
                 Math.sin(theta) * edgeRadius,
                 -forwardDot,
             );
+            const worldY = Math.random() * 2 - 1;
+            const worldRadius = Math.sqrt(Math.max(0, 1 - worldY * worldY));
+            const worldTheta = Math.random() * Math.PI * 2;
 
             const baseColor = {
                 r: tone,
@@ -154,6 +157,9 @@ export function Stars({ visibility = 1 }: StarsProps) {
                     STAR_TWINKLE.speedBase +
                     Math.random() * STAR_TWINKLE.speedRange,
                 twinkleStrength,
+                worldX: Math.cos(worldTheta) * worldRadius * radius,
+                worldY: worldY * radius,
+                worldZ: Math.sin(worldTheta) * worldRadius * radius,
             };
         }).sort((left, right) => right.brightness - left.brightness);
 
@@ -169,6 +175,9 @@ export function Stars({ visibility = 1 }: StarsProps) {
         const twinkleParams = new Float32Array(
             STAR_FIELD.count * STAR_RENDERING.positionStride,
         );
+        const worldPositions = new Float32Array(
+            STAR_FIELD.count * STAR_RENDERING.positionStride,
+        );
 
         for (let i = 0; i < STAR_FIELD.count; i += 1) {
             const star = stars[i];
@@ -177,6 +186,9 @@ export function Stars({ visibility = 1 }: StarsProps) {
             values[attributeOffset] = star.x;
             values[attributeOffset + 1] = star.y;
             values[attributeOffset + 2] = star.z;
+            worldPositions[attributeOffset] = star.worldX;
+            worldPositions[attributeOffset + 1] = star.worldY;
+            worldPositions[attributeOffset + 2] = star.worldZ;
             colors[attributeOffset] = star.baseColor.r;
             colors[attributeOffset + 1] = star.baseColor.g;
             colors[attributeOffset + 2] = star.baseColor.b;
@@ -193,6 +205,7 @@ export function Stars({ visibility = 1 }: StarsProps) {
             positions: values,
             twinkleColors,
             twinkleParams,
+            worldPositions,
         };
     }, []);
 
@@ -207,14 +220,16 @@ export function Stars({ visibility = 1 }: StarsProps) {
         );
     }, [clampedVisibility]);
 
-    const visiblePositions = useMemo(
-        () =>
-            starField.positions.subarray(
-                0,
-                visibleCount * STAR_RENDERING.positionStride,
-            ),
-        [starField, visibleCount],
-    );
+    const visiblePositions = useMemo(() => {
+        const positions =
+            gardenAvatarView === 'overview'
+                ? starField.positions
+                : starField.worldPositions;
+        return positions.subarray(
+            0,
+            visibleCount * STAR_RENDERING.positionStride,
+        );
+    }, [gardenAvatarView, starField, visibleCount]);
     const visibleColors = useMemo(
         () =>
             starField.colors.subarray(
@@ -258,13 +273,19 @@ export function Stars({ visibility = 1 }: StarsProps) {
             return;
         }
 
+        if (gardenAvatarView !== 'overview') {
+            pointsRef.current.scale.setScalar(1);
+            pointsRef.current.position.copy(camera.position);
+            pointsRef.current.quaternion.identity();
+            return;
+        }
+
         const orthographic = camera as OrthographicCamera;
         pointsRef.current.scale.setScalar(
             orthographic.isOrthographicCamera
                 ? defaultGameCameraZoom / orthographic.zoom
                 : 1,
         );
-
         camera.getWorldDirection(cameraForwardRef.current);
         pointsRef.current.position
             .copy(camera.position)
@@ -273,7 +294,7 @@ export function Stars({ visibility = 1 }: StarsProps) {
                 STAR_FIELD.radiusBase + STAR_FIELD.radiusRange,
             );
         pointsRef.current.quaternion.copy(camera.quaternion);
-    }, [camera]);
+    }, [camera, gardenAvatarView]);
 
     useLayoutEffect(() => {
         if (!gameCamera) {

--- a/packages/game/src/scene/SunMoon.tsx
+++ b/packages/game/src/scene/SunMoon.tsx
@@ -252,28 +252,33 @@ export function SunMoon({
             basis,
         );
         if (sunOpacity > 0.001 && sunProjectionScale !== null) {
-            const sx = sunDir.dot(basis.right) * sunProjectionScale;
-            const sy = sunDir.dot(basis.viewUp) * sunProjectionScale;
-
-            sunMesh.current.position
-                .copy(camera.position)
-                .addScaledVector(basis.forward, SKY_FORWARD_DISTANCE)
-                .addScaledVector(
-                    basis.right,
-                    sx *
-                        basis.skyRadius *
-                        SUN_SCREEN_OFFSET_MULTIPLIER *
-                        screenOffsetMultiplier *
-                        sunViewportTuning.horizontalOffsetMultiplier,
-                )
-                .addScaledVector(
-                    basis.viewUp,
-                    sy *
-                        basis.skyRadius *
-                        SUN_SCREEN_OFFSET_MULTIPLIER *
-                        screenOffsetMultiplier *
-                        sunViewportTuning.verticalOffsetMultiplier,
-                );
+            if (gardenAvatarView === 'overview') {
+                const sx = sunDir.dot(basis.right) * sunProjectionScale;
+                const sy = sunDir.dot(basis.viewUp) * sunProjectionScale;
+                sunMesh.current.position
+                    .copy(camera.position)
+                    .addScaledVector(basis.forward, SKY_FORWARD_DISTANCE)
+                    .addScaledVector(
+                        basis.right,
+                        sx *
+                            basis.skyRadius *
+                            SUN_SCREEN_OFFSET_MULTIPLIER *
+                            screenOffsetMultiplier *
+                            sunViewportTuning.horizontalOffsetMultiplier,
+                    )
+                    .addScaledVector(
+                        basis.viewUp,
+                        sy *
+                            basis.skyRadius *
+                            SUN_SCREEN_OFFSET_MULTIPLIER *
+                            screenOffsetMultiplier *
+                            sunViewportTuning.verticalOffsetMultiplier,
+                    );
+            } else {
+                sunMesh.current.position
+                    .copy(camera.position)
+                    .addScaledVector(sunDir, SKY_FORWARD_DISTANCE);
+            }
             sunMesh.current.lookAt(camera.position);
 
             const sunRgb = sunColorScale(timeOfDay).rgb();
@@ -307,20 +312,25 @@ export function SunMoon({
             basis,
         );
         if (moonOpacity > 0.001 && moonProjectionScale !== null) {
-            const mx = moonDir.dot(basis.right) * moonProjectionScale;
-            const my = moonDir.dot(basis.viewUp) * moonProjectionScale;
-
-            moonMesh.current.position
-                .copy(camera.position)
-                .addScaledVector(basis.forward, SKY_FORWARD_DISTANCE)
-                .addScaledVector(
-                    basis.right,
-                    mx * basis.skyRadius * screenOffsetMultiplier,
-                )
-                .addScaledVector(
-                    basis.viewUp,
-                    my * basis.skyRadius * screenOffsetMultiplier,
-                );
+            if (gardenAvatarView === 'overview') {
+                const mx = moonDir.dot(basis.right) * moonProjectionScale;
+                const my = moonDir.dot(basis.viewUp) * moonProjectionScale;
+                moonMesh.current.position
+                    .copy(camera.position)
+                    .addScaledVector(basis.forward, SKY_FORWARD_DISTANCE)
+                    .addScaledVector(
+                        basis.right,
+                        mx * basis.skyRadius * screenOffsetMultiplier,
+                    )
+                    .addScaledVector(
+                        basis.viewUp,
+                        my * basis.skyRadius * screenOffsetMultiplier,
+                    );
+            } else {
+                moonMesh.current.position
+                    .copy(camera.position)
+                    .addScaledVector(moonDir, SKY_FORWARD_DISTANCE);
+            }
             moonMesh.current.lookAt(camera.position);
 
             moonMaterial.uniforms.uPhase.value = moonVisualPhase.phase;
@@ -344,6 +354,7 @@ export function SunMoon({
         camera,
         currentTime,
         dayNightCycleDisabled,
+        gardenAvatarView,
         lat,
         lon,
         moonMaterial,


### PR DESCRIPTION
## What changed

- make angle, corner, and reverse-corner terrain continuously walkable at their rendered slope height
- add a grounded jump plus one airborne jump, faster sprinting, slower crouch movement, and a smaller matching model/collider
- rig crouching so the head and torso lower while the boots stay planted, and drive head pitch from the camera
- add gradual right-click POV zoom, including TPV-to-POV switching
- update grass and plant billboards from the active perspective camera
- replace the perspective grounding blob with a live sun-cast avatar shadow, including a shadow-only POV body
- render a world-fixed gradient sky, stars, sun, and moon whose celestial direction matches the directional shadow
- enable the already flag-gated feature on the developer sandbox only; the production flag still defaults off

## Why

The first avatar pass treated shaped terrain as flat, lost several overview-scene cues in perspective views, and had movement/camera proportions that made walking, crouching, and shadows feel disconnected from the garden world.

## Impact

The experimental gardener now has a more responsive and physically coherent v0 traversal loop without exposing the avatar in the item store. The separate 1,000-sunflower commerce follow-up remains open in #4433.

Refs #4432

## Validation

- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game test` (841 passed)
- `pnpm --filter garden lint`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- local `/debug/sandbox` browser pass for TPV, right-click POV transition, camera-facing ground decorations, fixed world gradient, scaled avatar, and directional TPV/POV shadow
