### PR TITLE
feat(www): add live public garden visitor avatars

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -127,7 +127,9 @@ import {
     serializePublicRaisedBedField,
 } from '../../../lib/garden/publicGardenSerialization';
 import {
+    publicGardenVisitorClientAddress,
     publicGardenVisitorPresenceBodySchema,
+    publicGardenVisitorRateLimitAllows,
     removePublicGardenVisitorPresence,
     updatePublicGardenVisitorPresence,
 } from '../../../lib/garden/publicGardenVisitorPresence';
@@ -1956,21 +1958,54 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 return context.json({ error: 'Invalid garden ID' }, 400);
             }
 
-            const body = context.req.valid('json');
-            if (body.action === 'leave') {
-                await removePublicGardenVisitorPresence({
-                    gardenId: gardenIdNumber,
-                    visitorId: body.visitorId,
-                });
-                return context.json({ live: true, visitors: [] });
+            const withinRateLimit = await publicGardenVisitorRateLimitAllows(
+                publicGardenVisitorClientAddress(context.req.raw.headers),
+            );
+            if (!withinRateLimit) {
+                context.header('Retry-After', '1');
+                return context.json(
+                    { error: 'Too many visitor presence requests' },
+                    429,
+                );
             }
 
-            return context.json(
-                await updatePublicGardenVisitorPresence({
+            const body = context.req.valid('json');
+            if (body.action === 'leave') {
+                const result = await removePublicGardenVisitorPresence({
                     gardenId: gardenIdNumber,
-                    presence: body,
-                }),
-            );
+                    visitorCapability: body.visitorCapability,
+                    visitorId: body.visitorId,
+                });
+                if (result.status === 'unauthorized') {
+                    return context.json(
+                        { error: 'Invalid visitor capability' },
+                        403,
+                    );
+                }
+                return context.json({
+                    live: result.status === 'removed',
+                    visitors: [],
+                });
+            }
+
+            const result = await updatePublicGardenVisitorPresence({
+                gardenId: gardenIdNumber,
+                presence: body,
+            });
+            if (result.status === 'unauthorized') {
+                return context.json(
+                    { error: 'Invalid visitor capability' },
+                    403,
+                );
+            }
+            if (result.status === 'unavailable') {
+                return context.json({ live: false, visitors: [] });
+            }
+            return context.json({
+                live: result.live,
+                visitorCapability: result.visitorCapability,
+                visitors: result.visitors,
+            });
         },
     )
     .patch(

--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -126,6 +126,11 @@ import {
     countPublicGardenActivePlants,
     serializePublicRaisedBedField,
 } from '../../../lib/garden/publicGardenSerialization';
+import {
+    publicGardenVisitorPresenceBodySchema,
+    removePublicGardenVisitorPresence,
+    updatePublicGardenVisitorPresence,
+} from '../../../lib/garden/publicGardenVisitorPresence';
 import { purchaseGardenBlock } from '../../../lib/garden/purchaseGardenBlockService';
 import {
     AI_REQUEST_QUOTAS,
@@ -1928,6 +1933,44 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 likeCount: likeCounts.get(garden.id) ?? 0,
                 queuedTasks,
             });
+        },
+    )
+    .post(
+        '/:gardenId/public/visitors',
+        describeRoute({
+            description:
+                'Publish an anonymous visitor position and read other live visitors',
+            security: publicSecurity,
+        }),
+        zValidator(
+            'param',
+            z.object({
+                gardenId: z.string(),
+            }),
+        ),
+        zValidator('json', publicGardenVisitorPresenceBodySchema),
+        async (context) => {
+            const { gardenId } = context.req.valid('param');
+            const gardenIdNumber = parseInt(gardenId, 10);
+            if (!Number.isInteger(gardenIdNumber) || gardenIdNumber < 1) {
+                return context.json({ error: 'Invalid garden ID' }, 400);
+            }
+
+            const body = context.req.valid('json');
+            if (body.action === 'leave') {
+                await removePublicGardenVisitorPresence({
+                    gardenId: gardenIdNumber,
+                    visitorId: body.visitorId,
+                });
+                return context.json({ live: true, visitors: [] });
+            }
+
+            return context.json(
+                await updatePublicGardenVisitorPresence({
+                    gardenId: gardenIdNumber,
+                    presence: body,
+                }),
+            );
         },
     )
     .patch(

--- a/apps/api/lib/garden/publicGardenVisitorPresence.node.spec.ts
+++ b/apps/api/lib/garden/publicGardenVisitorPresence.node.spec.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { selectActivePublicGardenVisitors } from './publicGardenVisitorPresence';
+
+const now = Date.parse('2026-08-07T12:00:00.000Z');
+
+function presence(id: string, updatedAt = now) {
+    return {
+        crouchAmount: 0,
+        grounded: true,
+        headPitch: 0,
+        id,
+        movingSpeed: 1,
+        position: [1, 0, 2],
+        updatedAt,
+        view: 'overview',
+        yaw: 0,
+    };
+}
+
+test('selects current peers and removes the local and stale visitors', () => {
+    const localId = '00000000-0000-4000-8000-000000000001';
+    const peerId = '00000000-0000-4000-8000-000000000002';
+    const staleId = '00000000-0000-4000-8000-000000000003';
+    const result = selectActivePublicGardenVisitors({
+        entries: {
+            [localId]: presence(localId),
+            [peerId]: presence(peerId),
+            [staleId]: presence(staleId, now - 16_000),
+            malformed: { updatedAt: now },
+        },
+        now,
+        visitorId: localId,
+    });
+
+    assert.deepEqual(result.visitors, [presence(peerId)]);
+    assert.deepEqual(
+        result.staleVisitorIds.sort(),
+        [staleId, 'malformed'].sort(),
+    );
+});
+
+test('accepts Redis values returned as serialized JSON', () => {
+    const localId = '00000000-0000-4000-8000-000000000001';
+    const peerId = '00000000-0000-4000-8000-000000000002';
+    const result = selectActivePublicGardenVisitors({
+        entries: { [peerId]: JSON.stringify(presence(peerId)) },
+        now,
+        visitorId: localId,
+    });
+
+    assert.deepEqual(result.visitors, [presence(peerId)]);
+    assert.deepEqual(result.staleVisitorIds, []);
+});

--- a/apps/api/lib/garden/publicGardenVisitorPresence.node.spec.ts
+++ b/apps/api/lib/garden/publicGardenVisitorPresence.node.spec.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { selectActivePublicGardenVisitors } from './publicGardenVisitorPresence';
+import {
+    publicGardenVisitorClientAddress,
+    publicGardenVisitorPresenceBodySchema,
+    selectActivePublicGardenVisitors,
+} from './publicGardenVisitorPresence';
 
 const now = Date.parse('2026-08-07T12:00:00.000Z');
 
@@ -51,4 +55,31 @@ test('accepts Redis values returned as serialized JSON', () => {
 
     assert.deepEqual(result.visitors, [presence(peerId)]);
     assert.deepEqual(result.staleVisitorIds, []);
+});
+
+test('requires the private visitor capability before removing presence', () => {
+    const visitorId = '00000000-0000-4000-8000-000000000001';
+    assert.equal(
+        publicGardenVisitorPresenceBodySchema.safeParse({
+            action: 'leave',
+            visitorId,
+        }).success,
+        false,
+    );
+    assert.equal(
+        publicGardenVisitorPresenceBodySchema.safeParse({
+            action: 'leave',
+            visitorCapability: '00000000-0000-4000-8000-000000000002',
+            visitorId,
+        }).success,
+        true,
+    );
+});
+
+test('uses the platform client address instead of a prepended forwarded value', () => {
+    const headers = new Headers({
+        'x-forwarded-for': 'spoofed, trusted-proxy',
+        'x-vercel-forwarded-for': 'visitor-address, edge-proxy',
+    });
+    assert.equal(publicGardenVisitorClientAddress(headers), 'visitor-address');
 });

--- a/apps/api/lib/garden/publicGardenVisitorPresence.ts
+++ b/apps/api/lib/garden/publicGardenVisitorPresence.ts
@@ -1,9 +1,12 @@
+import { createHash, randomUUID } from 'node:crypto';
 import { redisCacheClient } from '@gredice/storage';
 import { z } from 'zod';
 
 const presenceLifetimeMs = 15_000;
 const presenceKeyLifetimeSeconds = 30;
+const maximumStoredVisitors = 32;
 const maximumVisibleVisitors = 16;
+const maximumRequestsPerAddressPerSecond = 48;
 let lastPresenceWarningAt = Number.NEGATIVE_INFINITY;
 
 const avatarPositionSchema = z.tuple([
@@ -11,6 +14,8 @@ const avatarPositionSchema = z.tuple([
     z.number().finite().min(-1_000).max(10_000),
     z.number().finite().min(-10_000).max(10_000),
 ]);
+const visitorIdSchema = z.string().uuid();
+const visitorCapabilitySchema = z.string().uuid();
 
 export const publicGardenVisitorPresenceBodySchema = z.discriminatedUnion(
     'action',
@@ -28,14 +33,16 @@ export const publicGardenVisitorPresenceBodySchema = z.discriminatedUnion(
                 movingSpeed: z.number().finite().min(0).max(10),
                 position: avatarPositionSchema,
                 view: z.enum(['overview', 'third-person', 'first-person']),
-                visitorId: z.string().uuid(),
+                visitorCapability: visitorCapabilitySchema.optional(),
+                visitorId: visitorIdSchema,
                 yaw: z.number().finite().min(-Math.PI).max(Math.PI),
             })
             .strict(),
         z
             .object({
                 action: z.literal('leave'),
-                visitorId: z.string().uuid(),
+                visitorCapability: visitorCapabilitySchema,
+                visitorId: visitorIdSchema,
             })
             .strict(),
     ],
@@ -46,7 +53,7 @@ const storedPublicGardenVisitorSchema = z
         crouchAmount: z.number(),
         grounded: z.boolean(),
         headPitch: z.number(),
-        id: z.string().uuid(),
+        id: visitorIdSchema,
         movingSpeed: z.number(),
         position: avatarPositionSchema,
         updatedAt: z.number().int(),
@@ -55,12 +62,27 @@ const storedPublicGardenVisitorSchema = z
     })
     .strict();
 
+const storedVisitorEntrySchema = z
+    .object({
+        capabilityHash: z.string().regex(/^[0-9a-f]{64}$/),
+        visitor: storedPublicGardenVisitorSchema,
+    })
+    .strict();
+
 export type PublicGardenVisitorPresence = z.infer<
     typeof storedPublicGardenVisitorSchema
 >;
 
-function presenceKey(gardenId: number) {
-    return `public-garden:${gardenId.toString()}:visitors:v1`;
+function presenceIndexKey(gardenId: number) {
+    return `public-garden:${gardenId.toString()}:visitors:v2`;
+}
+
+function presenceEntryKey(gardenId: number, visitorId: string) {
+    return `${presenceIndexKey(gardenId)}:${visitorId}`;
+}
+
+function capabilityHash(capability: string) {
+    return createHash('sha256').update(capability).digest('hex');
 }
 
 function parseStoredPresence(value: unknown) {
@@ -72,6 +94,75 @@ function parseStoredPresence(value: unknown) {
         return storedPublicGardenVisitorSchema.safeParse(JSON.parse(value));
     } catch {
         return storedPublicGardenVisitorSchema.safeParse(null);
+    }
+}
+
+function parseStoredEntry(value: unknown) {
+    if (typeof value !== 'string') {
+        return storedVisitorEntrySchema.safeParse(value);
+    }
+
+    try {
+        return storedVisitorEntrySchema.safeParse(JSON.parse(value));
+    } catch {
+        return storedVisitorEntrySchema.safeParse(null);
+    }
+}
+
+function warnPresenceFailure(
+    message: string,
+    details: Record<string, unknown>,
+) {
+    if (Date.now() - lastPresenceWarningAt < 60_000) {
+        return;
+    }
+    lastPresenceWarningAt = Date.now();
+    console.warn(message, details);
+}
+
+export function publicGardenVisitorClientAddress(headers: {
+    get(name: string): string | null | undefined;
+}) {
+    const headerValue = (name: string, position: 'first' | 'last') => {
+        const values = headers
+            .get(name)
+            ?.split(',')
+            .map((value) => value.trim())
+            .filter(Boolean);
+        return position === 'first' ? values?.[0] : values?.at(-1);
+    };
+
+    return (
+        headerValue('x-vercel-forwarded-for', 'first') ??
+        headerValue('x-forwarded-for', 'last') ??
+        'unknown'
+    );
+}
+
+export async function publicGardenVisitorRateLimitAllows(
+    clientAddress: string,
+) {
+    const client = redisCacheClient('gredice');
+    if (!client) {
+        return true;
+    }
+
+    const addressHash = createHash('sha256')
+        .update(clientAddress)
+        .digest('hex')
+        .slice(0, 24);
+    const bucket = Math.floor(Date.now() / 1_000).toString();
+    const key = `public-garden-visitors:rate:v1:${addressHash}:${bucket}`;
+
+    try {
+        const requestCount = await client.incr(key);
+        await client.expire(key, 2);
+        return requestCount <= maximumRequestsPerAddressPerSecond;
+    } catch (error) {
+        warnPresenceFailure('Unable to rate limit public garden visitors', {
+            error,
+        });
+        return false;
     }
 }
 
@@ -109,6 +200,50 @@ export function selectActivePublicGardenVisitors({
     };
 }
 
+async function readActiveVisitors({
+    gardenId,
+    now,
+    visitorId,
+}: {
+    gardenId: number;
+    now: number;
+    visitorId: string;
+}) {
+    const client = redisCacheClient('gredice');
+    if (!client) {
+        return [];
+    }
+
+    const indexKey = presenceIndexKey(gardenId);
+    const visitorIds = await client.zrange<string[]>(
+        indexKey,
+        0,
+        maximumVisibleVisitors,
+        { rev: true },
+    );
+    if (visitorIds.length === 0) {
+        return [];
+    }
+
+    const storedEntries = await client.mget<unknown[]>(
+        ...visitorIds.map((id) => presenceEntryKey(gardenId, id)),
+    );
+    const entries: Record<string, unknown> = {};
+    for (const [index, id] of visitorIds.entries()) {
+        const parsed = parseStoredEntry(storedEntries[index]);
+        entries[id] = parsed.success ? parsed.data.visitor : null;
+    }
+    const selected = selectActivePublicGardenVisitors({
+        entries,
+        now,
+        visitorId,
+    });
+    if (selected.staleVisitorIds.length > 0) {
+        await client.zrem(indexKey, ...selected.staleVisitorIds);
+    }
+    return selected.visitors;
+}
+
 export async function updatePublicGardenVisitorPresence({
     gardenId,
     presence,
@@ -121,61 +256,108 @@ export async function updatePublicGardenVisitorPresence({
 }) {
     const client = redisCacheClient('gredice');
     if (!client) {
-        return { live: false, visitors: [] };
+        return { status: 'unavailable' as const };
     }
 
     const now = Date.now();
-    const key = presenceKey(gardenId);
-    const { action: _, visitorId, ...avatar } = presence;
-    const storedPresence: PublicGardenVisitorPresence = {
-        ...avatar,
-        id: visitorId,
-        updatedAt: now,
-    };
-
+    const indexKey = presenceIndexKey(gardenId);
+    const entryKey = presenceEntryKey(gardenId, presence.visitorId);
     try {
-        await client.hset(key, { [visitorId]: storedPresence });
-        await client.expire(key, presenceKeyLifetimeSeconds);
-        const entries = await client.hgetall<Record<string, unknown>>(key);
-        const selected = selectActivePublicGardenVisitors({
-            entries,
-            now,
+        const existing = parseStoredEntry(await client.get(entryKey));
+        if (
+            existing.success &&
+            (!presence.visitorCapability ||
+                capabilityHash(presence.visitorCapability) !==
+                    existing.data.capabilityHash)
+        ) {
+            return { status: 'unauthorized' as const };
+        }
+
+        const visitorCapability = presence.visitorCapability ?? randomUUID();
+        const {
+            action: _,
+            visitorCapability: __,
             visitorId,
-        });
-        if (selected.staleVisitorIds.length > 0) {
-            await client.hdel(key, ...selected.staleVisitorIds);
-        }
-        return { live: true, visitors: selected.visitors };
-    } catch (error) {
-        if (Date.now() - lastPresenceWarningAt >= 60_000) {
-            lastPresenceWarningAt = Date.now();
-            console.warn('Unable to update public garden visitor presence', {
-                error,
+            ...avatar
+        } = presence;
+        const visitor: PublicGardenVisitorPresence = {
+            ...avatar,
+            id: visitorId,
+            updatedAt: now,
+        };
+
+        await client.set(
+            entryKey,
+            {
+                capabilityHash: capabilityHash(visitorCapability),
+                visitor,
+            },
+            { ex: presenceKeyLifetimeSeconds },
+        );
+        await client.zadd(indexKey, { member: visitorId, score: now });
+        await client.zremrangebyscore(
+            indexKey,
+            '-inf',
+            now - presenceLifetimeMs - 1,
+        );
+        await client.zremrangebyrank(indexKey, 0, -(maximumStoredVisitors + 1));
+        await client.expire(indexKey, presenceKeyLifetimeSeconds);
+
+        return {
+            live: true,
+            status: 'ok' as const,
+            visitorCapability,
+            visitors: await readActiveVisitors({
                 gardenId,
-            });
-        }
-        return { live: false, visitors: [] };
+                now,
+                visitorId,
+            }),
+        };
+    } catch (error) {
+        warnPresenceFailure('Unable to update public garden visitor presence', {
+            error,
+            gardenId,
+        });
+        return { status: 'unavailable' as const };
     }
 }
 
 export async function removePublicGardenVisitorPresence({
     gardenId,
+    visitorCapability,
     visitorId,
 }: {
     gardenId: number;
+    visitorCapability: string;
     visitorId: string;
 }) {
     const client = redisCacheClient('gredice');
     if (!client) {
-        return;
+        return { status: 'unavailable' as const };
     }
 
+    const entryKey = presenceEntryKey(gardenId, visitorId);
     try {
-        await client.hdel(presenceKey(gardenId), visitorId);
+        const existing = parseStoredEntry(await client.get(entryKey));
+        if (!existing.success) {
+            return { status: 'removed' as const };
+        }
+        if (
+            capabilityHash(visitorCapability) !== existing.data.capabilityHash
+        ) {
+            return { status: 'unauthorized' as const };
+        }
+
+        await Promise.all([
+            client.del(entryKey),
+            client.zrem(presenceIndexKey(gardenId), visitorId),
+        ]);
+        return { status: 'removed' as const };
     } catch (error) {
-        console.warn('Unable to remove public garden visitor presence', {
+        warnPresenceFailure('Unable to remove public garden visitor presence', {
             error,
             gardenId,
         });
+        return { status: 'unavailable' as const };
     }
 }

--- a/apps/api/lib/garden/publicGardenVisitorPresence.ts
+++ b/apps/api/lib/garden/publicGardenVisitorPresence.ts
@@ -1,0 +1,181 @@
+import { redisCacheClient } from '@gredice/storage';
+import { z } from 'zod';
+
+const presenceLifetimeMs = 15_000;
+const presenceKeyLifetimeSeconds = 30;
+const maximumVisibleVisitors = 16;
+let lastPresenceWarningAt = Number.NEGATIVE_INFINITY;
+
+const avatarPositionSchema = z.tuple([
+    z.number().finite().min(-10_000).max(10_000),
+    z.number().finite().min(-1_000).max(10_000),
+    z.number().finite().min(-10_000).max(10_000),
+]);
+
+export const publicGardenVisitorPresenceBodySchema = z.discriminatedUnion(
+    'action',
+    [
+        z
+            .object({
+                action: z.literal('presence'),
+                crouchAmount: z.number().finite().min(0).max(1),
+                grounded: z.boolean(),
+                headPitch: z
+                    .number()
+                    .finite()
+                    .min(-Math.PI / 2)
+                    .max(Math.PI / 2),
+                movingSpeed: z.number().finite().min(0).max(10),
+                position: avatarPositionSchema,
+                view: z.enum(['overview', 'third-person', 'first-person']),
+                visitorId: z.string().uuid(),
+                yaw: z.number().finite().min(-Math.PI).max(Math.PI),
+            })
+            .strict(),
+        z
+            .object({
+                action: z.literal('leave'),
+                visitorId: z.string().uuid(),
+            })
+            .strict(),
+    ],
+);
+
+const storedPublicGardenVisitorSchema = z
+    .object({
+        crouchAmount: z.number(),
+        grounded: z.boolean(),
+        headPitch: z.number(),
+        id: z.string().uuid(),
+        movingSpeed: z.number(),
+        position: avatarPositionSchema,
+        updatedAt: z.number().int(),
+        view: z.enum(['overview', 'third-person', 'first-person']),
+        yaw: z.number(),
+    })
+    .strict();
+
+export type PublicGardenVisitorPresence = z.infer<
+    typeof storedPublicGardenVisitorSchema
+>;
+
+function presenceKey(gardenId: number) {
+    return `public-garden:${gardenId.toString()}:visitors:v1`;
+}
+
+function parseStoredPresence(value: unknown) {
+    if (typeof value !== 'string') {
+        return storedPublicGardenVisitorSchema.safeParse(value);
+    }
+
+    try {
+        return storedPublicGardenVisitorSchema.safeParse(JSON.parse(value));
+    } catch {
+        return storedPublicGardenVisitorSchema.safeParse(null);
+    }
+}
+
+export function selectActivePublicGardenVisitors({
+    entries,
+    now,
+    visitorId,
+}: {
+    entries: Record<string, unknown> | null;
+    now: number;
+    visitorId: string;
+}) {
+    const staleVisitorIds: string[] = [];
+    const visitors: PublicGardenVisitorPresence[] = [];
+
+    for (const [entryId, value] of Object.entries(entries ?? {})) {
+        const parsed = parseStoredPresence(value);
+        if (
+            !parsed.success ||
+            parsed.data.id !== entryId ||
+            parsed.data.updatedAt < now - presenceLifetimeMs
+        ) {
+            staleVisitorIds.push(entryId);
+            continue;
+        }
+        if (entryId !== visitorId) {
+            visitors.push(parsed.data);
+        }
+    }
+
+    visitors.sort((left, right) => right.updatedAt - left.updatedAt);
+    return {
+        staleVisitorIds,
+        visitors: visitors.slice(0, maximumVisibleVisitors),
+    };
+}
+
+export async function updatePublicGardenVisitorPresence({
+    gardenId,
+    presence,
+}: {
+    gardenId: number;
+    presence: Extract<
+        z.infer<typeof publicGardenVisitorPresenceBodySchema>,
+        { action: 'presence' }
+    >;
+}) {
+    const client = redisCacheClient('gredice');
+    if (!client) {
+        return { live: false, visitors: [] };
+    }
+
+    const now = Date.now();
+    const key = presenceKey(gardenId);
+    const { action: _, visitorId, ...avatar } = presence;
+    const storedPresence: PublicGardenVisitorPresence = {
+        ...avatar,
+        id: visitorId,
+        updatedAt: now,
+    };
+
+    try {
+        await client.hset(key, { [visitorId]: storedPresence });
+        await client.expire(key, presenceKeyLifetimeSeconds);
+        const entries = await client.hgetall<Record<string, unknown>>(key);
+        const selected = selectActivePublicGardenVisitors({
+            entries,
+            now,
+            visitorId,
+        });
+        if (selected.staleVisitorIds.length > 0) {
+            await client.hdel(key, ...selected.staleVisitorIds);
+        }
+        return { live: true, visitors: selected.visitors };
+    } catch (error) {
+        if (Date.now() - lastPresenceWarningAt >= 60_000) {
+            lastPresenceWarningAt = Date.now();
+            console.warn('Unable to update public garden visitor presence', {
+                error,
+                gardenId,
+            });
+        }
+        return { live: false, visitors: [] };
+    }
+}
+
+export async function removePublicGardenVisitorPresence({
+    gardenId,
+    visitorId,
+}: {
+    gardenId: number;
+    visitorId: string;
+}) {
+    const client = redisCacheClient('gredice');
+    if (!client) {
+        return;
+    }
+
+    try {
+        await client.hdel(presenceKey(gardenId), visitorId);
+    } catch (error) {
+        console.warn('Unable to remove public garden visitor presence', {
+            error,
+            gardenId,
+        });
+    }
+}

--- a/apps/www/app/vrtovi/PublicGardenExplorer.tsx
+++ b/apps/www/app/vrtovi/PublicGardenExplorer.tsx
@@ -6,6 +6,7 @@ import { FullWidth, Minimize } from '@gredice/ui/icons';
 import { cx } from '@gredice/ui/utils';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { PublicGardenViewerDynamic } from './PublicGardenViewerDynamic';
+import { usePublicGardenVisitorPresence } from './usePublicGardenVisitorPresence';
 
 export function PublicGardenExplorer({
     className,
@@ -15,12 +16,13 @@ export function PublicGardenExplorer({
 }: {
     className?: string;
     framed?: boolean;
-    garden: PublicGardenViewerProps['garden'];
+    garden: NonNullable<PublicGardenViewerProps['garden']>;
     size?: 'card' | 'default';
 }) {
     const containerRef = useRef<HTMLDivElement>(null);
     const [isFullscreen, setIsFullscreen] = useState(false);
     const [supportsFullscreen, setSupportsFullscreen] = useState(false);
+    const visitorPresence = usePublicGardenVisitorPresence(garden.id);
 
     const openFullscreen = useCallback(() => {
         const element = containerRef.current;
@@ -91,9 +93,10 @@ export function PublicGardenExplorer({
                     className="size-full"
                     deferDetails={false}
                     garden={garden}
+                    visitorPresence={visitorPresence}
                 />
                 {supportsFullscreen ? (
-                    <div className="pointer-events-none absolute right-4 bottom-4 z-10 flex max-w-[calc(100%-2rem)] items-center gap-2 transition-[opacity,transform] duration-300 ease-out md:right-6 md:bottom-6">
+                    <div className="pointer-events-none absolute top-4 right-4 z-10 flex max-w-[calc(100%-2rem)] items-center gap-2 transition-[opacity,transform] duration-300 ease-out md:top-6 md:right-6">
                         <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-tertiary border-b-4 bg-background/90 p-1 shadow-lg backdrop-blur-xs">
                             {isFullscreen ? (
                                 <IconButton

--- a/apps/www/app/vrtovi/[gardenId]/page.tsx
+++ b/apps/www/app/vrtovi/[gardenId]/page.tsx
@@ -191,7 +191,8 @@ export default async function PublicGardenPage({
                 level="body3"
                 className="px-1 italic text-muted-foreground"
             >
-                Prikaz je samo za gledanje.
+                Tvoj vrtni lik slobodno šeće dok ne odabereš „Prošetaj vrtom”.
+                Tijekom posjeta možeš vidjeti i druge posjetitelje uživo.
             </Typography>
         </Stack>
     );

--- a/apps/www/app/vrtovi/usePublicGardenVisitorPresence.ts
+++ b/apps/www/app/vrtovi/usePublicGardenVisitorPresence.ts
@@ -1,0 +1,168 @@
+'use client';
+
+import type {
+    GardenAvatarPresenceState,
+    GardenVisitorPresence,
+    GardenVisitorPresenceController,
+} from '@gredice/game';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const visitorSessionStorageKey = 'gredice-public-garden-visitor-id';
+const presenceRefreshMs = 500;
+const visitorIdPattern =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isGardenVisitorPresence(
+    value: unknown,
+): value is GardenVisitorPresence {
+    if (!isRecord(value)) {
+        return false;
+    }
+    const position = value.position;
+    return (
+        typeof value.id === 'string' &&
+        Array.isArray(position) &&
+        position.length === 3 &&
+        position.every(isFiniteNumber) &&
+        isFiniteNumber(value.yaw) &&
+        isFiniteNumber(value.movingSpeed) &&
+        isFiniteNumber(value.crouchAmount) &&
+        isFiniteNumber(value.headPitch) &&
+        typeof value.grounded === 'boolean' &&
+        (value.view === 'overview' ||
+            value.view === 'third-person' ||
+            value.view === 'first-person') &&
+        isFiniteNumber(value.updatedAt)
+    );
+}
+
+function readVisitors(value: unknown) {
+    if (!isRecord(value) || !Array.isArray(value.visitors)) {
+        return [];
+    }
+    return value.visitors.filter(isGardenVisitorPresence);
+}
+
+function getVisitorId() {
+    const existing = window.sessionStorage.getItem(visitorSessionStorageKey);
+    if (existing && visitorIdPattern.test(existing)) {
+        return existing;
+    }
+    const visitorId = window.crypto.randomUUID();
+    window.sessionStorage.setItem(visitorSessionStorageKey, visitorId);
+    return visitorId;
+}
+
+export function usePublicGardenVisitorPresence(
+    gardenId: number,
+): GardenVisitorPresenceController {
+    const latestPresenceRef = useRef<GardenAvatarPresenceState | null>(null);
+    const [visitorId, setVisitorId] = useState<string | null>(null);
+    const [visitors, setVisitors] = useState<GardenVisitorPresence[]>([]);
+
+    const onLocalPresenceChange = useCallback(
+        (presence: GardenAvatarPresenceState) => {
+            latestPresenceRef.current = presence;
+        },
+        [],
+    );
+
+    useEffect(() => {
+        setVisitorId(getVisitorId());
+    }, []);
+
+    useEffect(() => {
+        if (!visitorId) {
+            return;
+        }
+
+        const endpoint = `/api/gredice/api/gardens/${gardenId.toString()}/public/visitors`;
+        const abortController = new AbortController();
+        let active = true;
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+
+        const schedule = (delay = presenceRefreshMs) => {
+            timeout = setTimeout(() => void synchronize(), delay);
+        };
+        const synchronize = async () => {
+            const presence = latestPresenceRef.current;
+            if (!presence || document.hidden) {
+                schedule(document.hidden ? 1_500 : 100);
+                return;
+            }
+
+            try {
+                const response = await fetch(endpoint, {
+                    body: JSON.stringify({
+                        action: 'presence',
+                        ...presence,
+                        visitorId,
+                    }),
+                    cache: 'no-store',
+                    headers: { 'content-type': 'application/json' },
+                    method: 'POST',
+                    signal: abortController.signal,
+                });
+                if (response.ok) {
+                    const body: unknown = await response.json();
+                    if (active) {
+                        setVisitors(readVisitors(body));
+                    }
+                }
+            } catch {
+                // The local avatar stays playable when live presence is unavailable.
+                if (active) {
+                    const staleBefore = Date.now() - 15_000;
+                    setVisitors((current) =>
+                        current.filter(
+                            (visitor) => visitor.updatedAt >= staleBefore,
+                        ),
+                    );
+                }
+            } finally {
+                if (active) {
+                    schedule();
+                }
+            }
+        };
+
+        const leaveBody = JSON.stringify({ action: 'leave', visitorId });
+        const leave = () => {
+            navigator.sendBeacon(
+                endpoint,
+                new Blob([leaveBody], { type: 'application/json' }),
+            );
+        };
+
+        setVisitors([]);
+        schedule(0);
+        window.addEventListener('pagehide', leave);
+        return () => {
+            active = false;
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+            abortController.abort();
+            window.removeEventListener('pagehide', leave);
+            leave();
+            setVisitors([]);
+        };
+    }, [gardenId, visitorId]);
+
+    return useMemo(
+        () => ({
+            localVisitorId: visitorId ?? 'visitor-initializing',
+            onLocalPresenceChange,
+            visitors,
+        }),
+        [onLocalPresenceChange, visitorId, visitors],
+    );
+}

--- a/apps/www/app/vrtovi/usePublicGardenVisitorPresence.ts
+++ b/apps/www/app/vrtovi/usePublicGardenVisitorPresence.ts
@@ -8,6 +8,8 @@ import type {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 const visitorSessionStorageKey = 'gredice-public-garden-visitor-id';
+const visitorCapabilitySessionStorageKey =
+    'gredice-public-garden-visitor-capability';
 const presenceRefreshMs = 500;
 const visitorIdPattern =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -51,20 +53,40 @@ function readVisitors(value: unknown) {
     return value.visitors.filter(isGardenVisitorPresence);
 }
 
-function getVisitorId() {
-    const existing = window.sessionStorage.getItem(visitorSessionStorageKey);
-    if (existing && visitorIdPattern.test(existing)) {
-        return existing;
+function readVisitorCapability(value: unknown) {
+    if (!isRecord(value)) {
+        return null;
     }
-    const visitorId = window.crypto.randomUUID();
+    return typeof value.visitorCapability === 'string' &&
+        visitorIdPattern.test(value.visitorCapability)
+        ? value.visitorCapability
+        : null;
+}
+
+function getVisitorIdentity() {
+    const existing = window.sessionStorage.getItem(visitorSessionStorageKey);
+    const visitorId =
+        existing && visitorIdPattern.test(existing)
+            ? existing
+            : window.crypto.randomUUID();
     window.sessionStorage.setItem(visitorSessionStorageKey, visitorId);
-    return visitorId;
+    const storedCapability = window.sessionStorage.getItem(
+        visitorCapabilitySessionStorageKey,
+    );
+    return {
+        visitorCapability:
+            storedCapability && visitorIdPattern.test(storedCapability)
+                ? storedCapability
+                : null,
+        visitorId,
+    };
 }
 
 export function usePublicGardenVisitorPresence(
     gardenId: number,
 ): GardenVisitorPresenceController {
     const latestPresenceRef = useRef<GardenAvatarPresenceState | null>(null);
+    const visitorCapabilityRef = useRef<string | null>(null);
     const [visitorId, setVisitorId] = useState<string | null>(null);
     const [visitors, setVisitors] = useState<GardenVisitorPresence[]>([]);
 
@@ -76,7 +98,9 @@ export function usePublicGardenVisitorPresence(
     );
 
     useEffect(() => {
-        setVisitorId(getVisitorId());
+        const identity = getVisitorIdentity();
+        visitorCapabilityRef.current = identity.visitorCapability;
+        setVisitorId(identity.visitorId);
     }, []);
 
     useEffect(() => {
@@ -88,6 +112,13 @@ export function usePublicGardenVisitorPresence(
         const abortController = new AbortController();
         let active = true;
         let timeout: ReturnType<typeof setTimeout> | undefined;
+
+        const expireStaleVisitors = () => {
+            const staleBefore = Date.now() - 15_000;
+            setVisitors((current) =>
+                current.filter((visitor) => visitor.updatedAt >= staleBefore),
+            );
+        };
 
         const schedule = (delay = presenceRefreshMs) => {
             timeout = setTimeout(() => void synchronize(), delay);
@@ -104,6 +135,8 @@ export function usePublicGardenVisitorPresence(
                     body: JSON.stringify({
                         action: 'presence',
                         ...presence,
+                        visitorCapability:
+                            visitorCapabilityRef.current ?? undefined,
                         visitorId,
                     }),
                     cache: 'no-store',
@@ -114,18 +147,23 @@ export function usePublicGardenVisitorPresence(
                 if (response.ok) {
                     const body: unknown = await response.json();
                     if (active) {
+                        const visitorCapability = readVisitorCapability(body);
+                        if (visitorCapability) {
+                            visitorCapabilityRef.current = visitorCapability;
+                            window.sessionStorage.setItem(
+                                visitorCapabilitySessionStorageKey,
+                                visitorCapability,
+                            );
+                        }
                         setVisitors(readVisitors(body));
                     }
+                } else if (active) {
+                    expireStaleVisitors();
                 }
             } catch {
                 // The local avatar stays playable when live presence is unavailable.
                 if (active) {
-                    const staleBefore = Date.now() - 15_000;
-                    setVisitors((current) =>
-                        current.filter(
-                            (visitor) => visitor.updatedAt >= staleBefore,
-                        ),
-                    );
+                    expireStaleVisitors();
                 }
             } finally {
                 if (active) {
@@ -134,11 +172,23 @@ export function usePublicGardenVisitorPresence(
             }
         };
 
-        const leaveBody = JSON.stringify({ action: 'leave', visitorId });
         const leave = () => {
+            const visitorCapability = visitorCapabilityRef.current;
+            if (!visitorCapability) {
+                return;
+            }
             navigator.sendBeacon(
                 endpoint,
-                new Blob([leaveBody], { type: 'application/json' }),
+                new Blob(
+                    [
+                        JSON.stringify({
+                            action: 'leave',
+                            visitorCapability,
+                            visitorId,
+                        }),
+                    ],
+                    { type: 'application/json' },
+                ),
             );
         };
 

--- a/packages/game/src/entities/avatar/GardenAvatar.tsx
+++ b/packages/game/src/entities/avatar/GardenAvatar.tsx
@@ -44,8 +44,9 @@ import {
     getGardenAvatarSurfaceY,
     resolveGardenAvatarHorizontalMovement,
 } from './gardenAvatarMovement';
+import type { GardenAvatarPresenceState } from './gardenVisitorPresence';
 
-const avatarModelScale = 0.697;
+export const avatarModelScale = 0.697;
 const avatarEyeHeight = 1.2;
 const avatarCrouchEyeHeight = 0.9;
 const avatarWalkSpeed = 2.15;
@@ -108,6 +109,15 @@ function createRandom(seed: number) {
     };
 }
 
+function hashAvatarSeed(value: string) {
+    let hash = 2_166_136_261;
+    for (const character of value) {
+        hash ^= character.codePointAt(0) ?? 0;
+        hash = Math.imul(hash, 16_777_619);
+    }
+    return hash >>> 0;
+}
+
 function isEditableTarget(target: EventTarget | null) {
     if (!(target instanceof HTMLElement)) {
         return false;
@@ -120,7 +130,7 @@ function isEditableTarget(target: EventTarget | null) {
     );
 }
 
-function dampAngle(
+export function dampGardenAvatarAngle(
     current: number,
     target: number,
     damping: number,
@@ -133,7 +143,7 @@ function dampAngle(
     return current + difference * (1 - Math.exp(-damping * delta));
 }
 
-function prepareAvatarModel(root: Object3D) {
+export function prepareGardenAvatarModel(root: Object3D) {
     const meshes: Mesh[] = [];
     const materials = new Map<Mesh, Mesh['material']>();
     root.traverse((object) => {
@@ -185,7 +195,7 @@ function prepareAvatarModel(root: Object3D) {
     };
 }
 
-function animateAvatarRig({
+export function animateGardenAvatarRig({
     crouchAmount,
     delta,
     distanceWalked,
@@ -542,12 +552,27 @@ function GardenAvatarCamera({
     );
 }
 
-export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
+export function GardenAvatar({
+    onPresenceChange,
+    roamSeed = 'garden-avatar',
+    stacks,
+}: {
+    onPresenceChange?: (presence: GardenAvatarPresenceState) => void;
+    roamSeed?: string;
+    stacks: Stack[] | undefined;
+}) {
     const gltf = useGameGLTF('FarmerAvatar');
     const { data: blockData } = useBlockData();
     const view = useGameState((state) => state.gardenAvatarView);
     const setView = useGameState((state) => state.setGardenAvatarView);
     const touchMoveInput = useGameState((state) => state.gardenAvatarMoveInput);
+    const touchSprintInput = useGameState(
+        (state) => state.gardenAvatarSprintInput,
+    );
+    const touchCrouchInput = useGameState(
+        (state) => state.gardenAvatarCrouchInput,
+    );
+    const touchZoomInput = useGameState((state) => state.gardenAvatarZoomInput);
     const jumpRequest = useGameState((state) => state.gardenAvatarJumpRequest);
     const { camera, gl } = useThree();
     const actorRef = useRef<Group>(null);
@@ -565,13 +590,18 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
     const avatarViewRef = useRef(view);
     avatarViewRef.current = view;
     const avatarActive = view !== 'overview';
-    const randomRef = useRef(createRandom(0x47524544));
+    const roamSeedRef = useRef(hashAvatarSeed(roamSeed));
+    const randomRef = useRef(createRandom(roamSeedRef.current));
     const roamRef = useRef<AvatarRoamState>({ route: [], waitUntil: 4 });
     const distanceWalkedRef = useRef(0);
     const gaitAmountRef = useRef(0);
     const crouchingRef = useRef(false);
     const crouchAmountRef = useRef(0);
+    const mouseZoomingRef = useRef(false);
     const zoomingRef = useRef(false);
+    const presenceCallbackRef = useRef(onPresenceChange);
+    presenceCallbackRef.current = onPresenceChange;
+    const lastPresenceReportAtRef = useRef(Number.NEGATIVE_INFINITY);
     const cameraEntryPoseRef = useRef<AvatarCameraEntryPose>({
         position: camera.position.clone(),
         quaternion: camera.quaternion.clone(),
@@ -579,7 +609,7 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
     const initializedRef = useRef(false);
     const model = useMemo(() => {
         const scene = gltf.scene.clone(true);
-        return { ...prepareAvatarModel(scene), scene };
+        return { ...prepareGardenAvatarModel(scene), scene };
     }, [gltf.scene]);
     const world = useMemo(
         () => createGardenAvatarCollisionWorld({ blockData, stacks }),
@@ -623,15 +653,40 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
     );
 
     useEffect(() => {
+        if (!avatarActive) {
+            return;
+        }
+        const previousTouchAction = gl.domElement.style.touchAction;
+        gl.domElement.style.touchAction = 'none';
+        return () => {
+            gl.domElement.style.touchAction = previousTouchAction;
+        };
+    }, [avatarActive, gl.domElement]);
+
+    useEffect(() => {
         const actor = actorRef.current;
         if (!actor) {
             return;
         }
-        const spawn = findGardenAvatarSpawnPoint(world);
-        if (!spawn) {
+        const defaultSpawn = findGardenAvatarSpawnPoint(world);
+        if (!defaultSpawn) {
             actor.visible = false;
             return;
         }
+        const nearbySpawnCandidates = roamCandidates
+            .map((candidate) => ({
+                candidate,
+                distance: Math.hypot(
+                    candidate.x - defaultSpawn.x,
+                    candidate.z - defaultSpawn.z,
+                ),
+            }))
+            .sort((left, right) => left.distance - right.distance)
+            .slice(0, 12);
+        const spawn =
+            nearbySpawnCandidates[
+                roamSeedRef.current % Math.max(nearbySpawnCandidates.length, 1)
+            ]?.candidate ?? defaultSpawn;
         actor.visible = true;
         const currentGroundY = getGardenAvatarGroundY({
             currentGroundY: groundYRef.current,
@@ -645,7 +700,7 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
         } else {
             groundYRef.current = currentGroundY;
         }
-    }, [world]);
+    }, [roamCandidates, world]);
 
     useEffect(() => {
         if (jumpRequest !== previousJumpRequestRef.current) {
@@ -661,6 +716,7 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
             verticalVelocityRef.current = 0;
             jumpsUsedRef.current = 0;
             crouchingRef.current = false;
+            mouseZoomingRef.current = false;
             zoomingRef.current = false;
             if (document.pointerLockElement === gl.domElement) {
                 document.exitPointerLock();
@@ -708,7 +764,7 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
         };
         const clearActiveInput = () => {
             clearKeyboardInput();
-            zoomingRef.current = false;
+            mouseZoomingRef.current = false;
         };
         const handleVisibilityChange = () => {
             if (document.hidden) {
@@ -728,7 +784,7 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
             if (event.pointerType === 'mouse') {
                 if (event.button === 2) {
                     event.preventDefault();
-                    zoomingRef.current = true;
+                    mouseZoomingRef.current = true;
                     if (avatarViewRef.current === 'third-person') {
                         setView('first-person');
                     }
@@ -760,7 +816,7 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
         };
         const handlePointerEnd = (event: PointerEvent) => {
             if (event.pointerType === 'mouse' && event.button === 2) {
-                zoomingRef.current = false;
+                mouseZoomingRef.current = false;
             }
             if (event.pointerId === dragPointerId) {
                 dragPointerId = null;
@@ -797,6 +853,12 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
             gl.domElement.removeEventListener('contextmenu', handleContextMenu);
         };
     }, [avatarActive, gl.domElement, setView]);
+
+    useEffect(() => {
+        if (touchZoomInput && view === 'third-person') {
+            setView('first-person');
+        }
+    }, [setView, touchZoomInput, view]);
 
     function activateAvatarView() {
         const actor = actorRef.current;
@@ -903,7 +965,7 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
                     actor.position.x = movement.position.x;
                     actor.position.z = movement.position.z;
                     groundYRef.current = movement.position.y;
-                    actor.rotation.y = dampAngle(
+                    actor.rotation.y = dampGardenAvatarAngle(
                         actor.rotation.y,
                         -Math.atan2(dx, -dz),
                         avatarTurnDamping,
@@ -927,7 +989,9 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
         } else {
             const keys = keyboardRef.current;
             const crouchRequested =
-                keys.has('ControlLeft') || keys.has('ControlRight');
+                touchCrouchInput ||
+                keys.has('ControlLeft') ||
+                keys.has('ControlRight');
             let crouching =
                 crouchRequested ||
                 (!groundedRef.current && crouchingRef.current);
@@ -964,7 +1028,9 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
             const inputLength = Math.hypot(inputForward, inputRight);
             const targetSpeed = crouching
                 ? avatarCrouchSpeed
-                : keys.has('ShiftLeft') || keys.has('ShiftRight')
+                : touchSprintInput ||
+                    keys.has('ShiftLeft') ||
+                    keys.has('ShiftRight')
                   ? avatarRunSpeed
                   : avatarWalkSpeed;
             const forwardX = -Math.sin(yawRef.current);
@@ -1035,7 +1101,7 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
             }
             movingSpeed = moved / Math.max(delta, 0.001);
             distanceWalkedRef.current += moved;
-            actor.rotation.y = dampAngle(
+            actor.rotation.y = dampGardenAvatarAngle(
                 actor.rotation.y,
                 yawRef.current,
                 avatarTurnDamping,
@@ -1107,7 +1173,8 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
             18,
             delta,
         );
-        animateAvatarRig({
+        zoomingRef.current = mouseZoomingRef.current || touchZoomInput;
+        animateGardenAvatarRig({
             crouchAmount: crouchAmountRef.current,
             delta,
             distanceWalked: distanceWalkedRef.current,
@@ -1127,6 +1194,28 @@ export function GardenAvatar({ stacks }: { stacks: Stack[] | undefined }) {
             yaw: actor.rotation.y,
             z: actor.position.z,
         });
+        if (
+            presenceCallbackRef.current &&
+            now - lastPresenceReportAtRef.current >= 0.1
+        ) {
+            lastPresenceReportAtRef.current = now;
+            presenceCallbackRef.current({
+                crouchAmount: crouchAmountRef.current,
+                grounded: groundedRef.current,
+                headPitch: view === 'overview' ? 0 : pitchRef.current,
+                movingSpeed,
+                position: [
+                    actor.position.x,
+                    actor.position.y,
+                    actor.position.z,
+                ],
+                view,
+                yaw: Math.atan2(
+                    Math.sin(actor.rotation.y),
+                    Math.cos(actor.rotation.y),
+                ),
+            });
+        }
     });
 
     return (

--- a/packages/game/src/entities/avatar/GardenVisitorAvatar.tsx
+++ b/packages/game/src/entities/avatar/GardenVisitorAvatar.tsx
@@ -1,0 +1,161 @@
+import { useFrame } from '@react-three/fiber';
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { type Group, MathUtils, Vector3 } from 'three';
+import {
+    sceneFrameRates,
+    useSceneTimeInvalidation,
+} from '../../scene/SceneTime';
+import { useGameState } from '../../useGameState';
+import { useGameGLTF } from '../../utils/useGameGLTF';
+import { useActorGroundingShadow } from '../animals/ActorGroundingShadows';
+import {
+    animateGardenAvatarRig,
+    avatarModelScale,
+    dampGardenAvatarAngle,
+    prepareGardenAvatarModel,
+} from './GardenAvatar';
+import type { GardenVisitorPresence } from './gardenVisitorPresence';
+
+const remotePositionDamping = 9;
+const remoteRotationDamping = 12;
+
+export function GardenVisitorAvatar({
+    presence,
+}: {
+    presence: GardenVisitorPresence;
+}) {
+    const gltf = useGameGLTF('FarmerAvatar');
+    const localView = useGameState((state) => state.gardenAvatarView);
+    const actorRef = useRef<Group>(null);
+    const targetPositionRef = useRef(new Vector3(...presence.position));
+    const targetYawRef = useRef(presence.yaw);
+    const targetMovingSpeedRef = useRef(presence.movingSpeed);
+    const targetCrouchAmountRef = useRef(presence.crouchAmount);
+    const targetHeadPitchRef = useRef(presence.headPitch);
+    const targetGroundedRef = useRef(presence.grounded);
+    const movingSpeedRef = useRef(presence.movingSpeed);
+    const crouchAmountRef = useRef(presence.crouchAmount);
+    const distanceWalkedRef = useRef(0);
+    const model = useMemo(() => {
+        const scene = gltf.scene.clone(true);
+        return { ...prepareGardenAvatarModel(scene), scene };
+    }, [gltf.scene]);
+    const castsRealShadow = localView !== 'overview';
+    const updateActorGroundingShadow = useActorGroundingShadow({
+        id: `garden-visitor-${presence.id}`,
+        primaryCasterCount: castsRealShadow ? model.primaryCasterCount : 0,
+        species: 'avatar',
+    });
+
+    targetPositionRef.current.set(...presence.position);
+    targetYawRef.current = presence.yaw;
+    targetMovingSpeedRef.current = presence.movingSpeed;
+    targetCrouchAmountRef.current = presence.crouchAmount;
+    targetHeadPitchRef.current = presence.headPitch;
+    targetGroundedRef.current = presence.grounded;
+
+    useSceneTimeInvalidation(true, sceneFrameRates.interactive);
+
+    useLayoutEffect(() => {
+        const actor = actorRef.current;
+        if (actor) {
+            actor.position.copy(targetPositionRef.current);
+            actor.rotation.y = targetYawRef.current;
+        }
+    }, []);
+
+    useLayoutEffect(() => {
+        for (const mesh of model.meshes) {
+            mesh.castShadow = castsRealShadow;
+        }
+    }, [castsRealShadow, model.meshes]);
+
+    useLayoutEffect(
+        () => () => {
+            model.shadowOnlyMaterial.dispose();
+        },
+        [model.shadowOnlyMaterial],
+    );
+
+    useFrame(({ gl }, frameDelta) => {
+        const actor = actorRef.current;
+        if (!actor) {
+            return;
+        }
+
+        const delta = Math.min(frameDelta, 0.05);
+        const previousX = actor.position.x;
+        const previousZ = actor.position.z;
+        actor.position.x = MathUtils.damp(
+            actor.position.x,
+            targetPositionRef.current.x,
+            remotePositionDamping,
+            delta,
+        );
+        actor.position.y = MathUtils.damp(
+            actor.position.y,
+            targetPositionRef.current.y,
+            remotePositionDamping,
+            delta,
+        );
+        actor.position.z = MathUtils.damp(
+            actor.position.z,
+            targetPositionRef.current.z,
+            remotePositionDamping,
+            delta,
+        );
+        actor.rotation.y = dampGardenAvatarAngle(
+            actor.rotation.y,
+            targetYawRef.current,
+            remoteRotationDamping,
+            delta,
+        );
+
+        const moved = Math.hypot(
+            actor.position.x - previousX,
+            actor.position.z - previousZ,
+        );
+        distanceWalkedRef.current += moved;
+        movingSpeedRef.current = MathUtils.damp(
+            movingSpeedRef.current,
+            targetMovingSpeedRef.current,
+            10,
+            delta,
+        );
+        crouchAmountRef.current = MathUtils.damp(
+            crouchAmountRef.current,
+            targetCrouchAmountRef.current,
+            12,
+            delta,
+        );
+        animateGardenAvatarRig({
+            crouchAmount: crouchAmountRef.current,
+            delta,
+            distanceWalked: distanceWalkedRef.current,
+            grounded: targetGroundedRef.current,
+            headPitch: targetHeadPitchRef.current,
+            rig: model.rig,
+            walkAmount: MathUtils.clamp(movingSpeedRef.current / 2.15, 0, 1),
+        });
+
+        if (castsRealShadow) {
+            gl.shadowMap.needsUpdate = true;
+        }
+        updateActorGroundingShadow?.({
+            actorY: actor.position.y,
+            receiverY: actor.position.y,
+            visible: !castsRealShadow,
+            x: actor.position.x,
+            yaw: actor.rotation.y,
+            z: actor.position.z,
+        });
+    });
+
+    return (
+        <group ref={actorRef}>
+            <group scale={avatarModelScale}>
+                <primitive object={model.scene} />
+            </group>
+        </group>
+    );
+}

--- a/packages/game/src/entities/avatar/gardenVisitorPresence.ts
+++ b/packages/game/src/entities/avatar/gardenVisitorPresence.ts
@@ -1,0 +1,22 @@
+import type { GardenAvatarView } from '../../useGameState';
+
+export type GardenAvatarPresenceState = {
+    crouchAmount: number;
+    grounded: boolean;
+    headPitch: number;
+    movingSpeed: number;
+    position: [number, number, number];
+    view: GardenAvatarView;
+    yaw: number;
+};
+
+export type GardenVisitorPresence = GardenAvatarPresenceState & {
+    id: string;
+    updatedAt: number;
+};
+
+export type GardenVisitorPresenceController = {
+    localVisitorId: string;
+    onLocalPresenceChange: (presence: GardenAvatarPresenceState) => void;
+    visitors: GardenVisitorPresence[];
+};

--- a/packages/game/src/hud/GardenAvatarHud.tsx
+++ b/packages/game/src/hud/GardenAvatarHud.tsx
@@ -1,19 +1,10 @@
 'use client';
 
 import { IconButton } from '@gredice/ui/IconButton';
-import {
-    ArrowDown,
-    ArrowLeft,
-    ArrowRight,
-    ArrowUp,
-    Camera,
-    Close,
-    LogOut,
-    UserCircle,
-} from '@gredice/ui/icons';
-import { cx } from '@gredice/ui/utils';
-import type { PointerEvent } from 'react';
+import { Camera, Close, LogOut, UserCircle } from '@gredice/ui/icons';
+import { type PointerEvent, useEffect } from 'react';
 import { useGameState } from '../useGameState';
+import { GardenAvatarJoystick } from './GardenAvatarJoystick';
 
 const avatarHudButtonClassName =
     'pointer-events-auto border border-border/60 bg-background/85 shadow-lg backdrop-blur-md hover:bg-muted active:scale-95 touch-none';
@@ -21,24 +12,42 @@ const avatarHudButtonClassName =
 export function GardenAvatarHud() {
     const view = useGameState((state) => state.gardenAvatarView);
     const setView = useGameState((state) => state.setGardenAvatarView);
-    const setMoveInput = useGameState(
-        (state) => state.setGardenAvatarMoveInput,
+    const setSprintInput = useGameState(
+        (state) => state.setGardenAvatarSprintInput,
+    );
+    const setCrouchInput = useGameState(
+        (state) => state.setGardenAvatarCrouchInput,
+    );
+    const setZoomInput = useGameState(
+        (state) => state.setGardenAvatarZoomInput,
     );
     const requestJump = useGameState((state) => state.requestGardenAvatarJump);
 
-    const startMove = (
+    useEffect(
+        () => () => {
+            setSprintInput(false);
+            setCrouchInput(false);
+            setZoomInput(false);
+        },
+        [setCrouchInput, setSprintInput, setZoomInput],
+    );
+
+    const startAction = (
         event: PointerEvent<HTMLButtonElement>,
-        input: { forward: number; right: number },
+        setActive: (active: boolean) => void,
     ) => {
         event.preventDefault();
         event.currentTarget.setPointerCapture(event.pointerId);
-        setMoveInput(input);
+        setActive(true);
     };
-    const stopMove = (event: PointerEvent<HTMLButtonElement>) => {
+    const stopAction = (
+        event: PointerEvent<HTMLButtonElement>,
+        setActive: (active: boolean) => void,
+    ) => {
         if (event.currentTarget.hasPointerCapture(event.pointerId)) {
             event.currentTarget.releasePointerCapture(event.pointerId);
         }
-        setMoveInput({ forward: 0, right: 0 });
+        setActive(false);
     };
 
     return (
@@ -48,7 +57,7 @@ export function GardenAvatarHud() {
                 Space za dvostruki skok · desni klik za POV zum · Esc za izlaz
             </div>
 
-            <div className="absolute bottom-[calc(var(--game-safe-area-bottom,0px)+0.5rem)] left-[calc(var(--game-safe-area-left,0px)+0.5rem)] flex items-center gap-1 rounded-xl border border-border/50 bg-background/70 p-1 shadow-lg backdrop-blur-md">
+            <div className="absolute top-[calc(var(--game-safe-area-top,0px)+0.5rem)] left-[calc(var(--game-safe-area-left,0px)+0.5rem)] flex items-center gap-1 rounded-xl border border-border/50 bg-background/70 p-1 shadow-lg backdrop-blur-md md:top-auto md:bottom-[calc(var(--game-safe-area-bottom,0px)+0.5rem)]">
                 <IconButton
                     title={
                         view === 'first-person'
@@ -82,80 +91,57 @@ export function GardenAvatarHud() {
                 </IconButton>
             </div>
 
-            <div className="absolute bottom-[calc(var(--game-safe-area-bottom,0px)+0.5rem)] left-1/2 grid -translate-x-1/2 grid-cols-3 grid-rows-2 gap-1 md:hidden">
-                <IconButton
-                    title="Hodaj naprijed"
-                    variant="plain"
-                    className={cx(
-                        avatarHudButtonClassName,
-                        'col-start-2 row-start-1 size-12',
-                    )}
-                    onPointerDown={(event) =>
-                        startMove(event, { forward: 1, right: 0 })
-                    }
-                    onPointerUp={stopMove}
-                    onPointerCancel={stopMove}
-                >
-                    <ArrowUp className="size-6" />
-                </IconButton>
-                <IconButton
-                    title="Hodaj lijevo"
-                    variant="plain"
-                    className={cx(
-                        avatarHudButtonClassName,
-                        'col-start-1 row-start-2 size-12',
-                    )}
-                    onPointerDown={(event) =>
-                        startMove(event, { forward: 0, right: -1 })
-                    }
-                    onPointerUp={stopMove}
-                    onPointerCancel={stopMove}
-                >
-                    <ArrowLeft className="size-6" />
-                </IconButton>
-                <IconButton
-                    title="Hodaj natrag"
-                    variant="plain"
-                    className={cx(
-                        avatarHudButtonClassName,
-                        'col-start-2 row-start-2 size-12',
-                    )}
-                    onPointerDown={(event) =>
-                        startMove(event, { forward: -1, right: 0 })
-                    }
-                    onPointerUp={stopMove}
-                    onPointerCancel={stopMove}
-                >
-                    <ArrowDown className="size-6" />
-                </IconButton>
-                <IconButton
-                    title="Hodaj desno"
-                    variant="plain"
-                    className={cx(
-                        avatarHudButtonClassName,
-                        'col-start-3 row-start-2 size-12',
-                    )}
-                    onPointerDown={(event) =>
-                        startMove(event, { forward: 0, right: 1 })
-                    }
-                    onPointerUp={stopMove}
-                    onPointerCancel={stopMove}
-                >
-                    <ArrowRight className="size-6" />
-                </IconButton>
+            <div className="absolute bottom-[calc(var(--game-safe-area-bottom,0px)+0.75rem)] left-[calc(var(--game-safe-area-left,0px)+0.75rem)] md:hidden">
+                <GardenAvatarJoystick />
             </div>
 
-            <button
-                type="button"
-                onPointerDown={(event) => {
-                    event.preventDefault();
-                    requestJump();
-                }}
-                className="pointer-events-auto absolute right-[calc(var(--game-safe-area-right,0px)+0.75rem)] bottom-[calc(var(--game-safe-area-bottom,0px)+0.75rem)] flex size-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/85 text-sm font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95 md:hidden"
-                aria-label="Skoči"
-            >
-                Skoči
-            </button>
+            <div className="absolute right-[calc(var(--game-safe-area-right,0px)+0.75rem)] bottom-[calc(var(--game-safe-area-bottom,0px)+0.75rem)] grid grid-cols-2 gap-2 md:hidden">
+                <button
+                    type="button"
+                    className="pointer-events-auto flex min-h-12 min-w-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/85 px-3 text-xs font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95"
+                    onPointerDown={(event) =>
+                        startAction(event, setCrouchInput)
+                    }
+                    onPointerUp={(event) => stopAction(event, setCrouchInput)}
+                    onPointerCancel={(event) =>
+                        stopAction(event, setCrouchInput)
+                    }
+                >
+                    Čučni
+                </button>
+                <button
+                    type="button"
+                    className="pointer-events-auto flex min-h-12 min-w-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/85 px-3 text-xs font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95"
+                    onPointerDown={(event) => startAction(event, setZoomInput)}
+                    onPointerUp={(event) => stopAction(event, setZoomInput)}
+                    onPointerCancel={(event) => stopAction(event, setZoomInput)}
+                >
+                    Zum
+                </button>
+                <button
+                    type="button"
+                    className="pointer-events-auto flex min-h-12 min-w-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/85 px-3 text-xs font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95"
+                    onPointerDown={(event) =>
+                        startAction(event, setSprintInput)
+                    }
+                    onPointerUp={(event) => stopAction(event, setSprintInput)}
+                    onPointerCancel={(event) =>
+                        stopAction(event, setSprintInput)
+                    }
+                >
+                    Trči
+                </button>
+                <button
+                    type="button"
+                    onPointerDown={(event) => {
+                        event.preventDefault();
+                        requestJump();
+                    }}
+                    className="pointer-events-auto flex min-h-12 min-w-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/95 px-3 text-xs font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95"
+                >
+                    Skoči
+                </button>
+            </div>
         </div>
     );
 }

--- a/packages/game/src/hud/GardenAvatarJoystick.tsx
+++ b/packages/game/src/hud/GardenAvatarJoystick.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { type PointerEvent, useEffect, useState } from 'react';
+import { useGameState } from '../useGameState';
+
+const joystickRadius = 42;
+
+export function GardenAvatarJoystick() {
+    const setMoveInput = useGameState(
+        (state) => state.setGardenAvatarMoveInput,
+    );
+    const [knob, setKnob] = useState({ x: 0, y: 0 });
+
+    useEffect(
+        () => () => {
+            setMoveInput({ forward: 0, right: 0 });
+        },
+        [setMoveInput],
+    );
+
+    const updatePosition = (event: PointerEvent<HTMLDivElement>) => {
+        const bounds = event.currentTarget.getBoundingClientRect();
+        const x = event.clientX - (bounds.left + bounds.width / 2);
+        const y = event.clientY - (bounds.top + bounds.height / 2);
+        const distance = Math.hypot(x, y);
+        const scale = distance > joystickRadius ? joystickRadius / distance : 1;
+        const constrainedX = x * scale;
+        const constrainedY = y * scale;
+        setKnob({ x: constrainedX, y: constrainedY });
+        setMoveInput({
+            forward: -constrainedY / joystickRadius,
+            right: constrainedX / joystickRadius,
+        });
+    };
+
+    const stopMoving = (event: PointerEvent<HTMLDivElement>) => {
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+            event.currentTarget.releasePointerCapture(event.pointerId);
+        }
+        setKnob({ x: 0, y: 0 });
+        setMoveInput({ forward: 0, right: 0 });
+    };
+
+    return (
+        <div
+            aria-label="Upravljač za hodanje"
+            className="pointer-events-auto relative size-28 touch-none rounded-full border border-border/60 bg-background/55 shadow-lg backdrop-blur-md"
+            onPointerDown={(event) => {
+                event.preventDefault();
+                event.currentTarget.setPointerCapture(event.pointerId);
+                updatePosition(event);
+            }}
+            onPointerMove={(event) => {
+                if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+                    updatePosition(event);
+                }
+            }}
+            onPointerUp={stopMoving}
+            onPointerCancel={stopMoving}
+            role="application"
+        >
+            <div className="absolute inset-4 rounded-full border border-border/40" />
+            <div
+                className="absolute top-1/2 left-1/2 size-12 -translate-x-1/2 -translate-y-1/2 rounded-full border border-border/70 bg-background/90 shadow-md"
+                style={{
+                    marginLeft: knob.x,
+                    marginTop: knob.y,
+                }}
+            />
+        </div>
+    );
+}

--- a/packages/game/src/index.ts
+++ b/packages/game/src/index.ts
@@ -2,6 +2,11 @@ export {
     GameAnalyticsProvider,
     useGameAnalytics,
 } from './analytics/GameAnalyticsContext';
+export type {
+    GardenAvatarPresenceState,
+    GardenVisitorPresence,
+    GardenVisitorPresenceController,
+} from './entities/avatar/gardenVisitorPresence';
 export type { GameFeatureFlags } from './GameFlagsContext';
 export type { GameSceneProps } from './GameScene';
 export { GameSceneDynamic as GameScene } from './GameSceneDynamic';

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -445,6 +445,9 @@ export type GameState = {
     view: 'normal' | 'closeup';
     gardenAvatarView: GardenAvatarView;
     gardenAvatarMoveInput: GardenAvatarMoveInput;
+    gardenAvatarSprintInput: boolean;
+    gardenAvatarCrouchInput: boolean;
+    gardenAvatarZoomInput: boolean;
     gardenAvatarJumpRequest: number;
     closeupBlock: Block | null;
     closeupCameraActive: boolean;
@@ -458,6 +461,9 @@ export type GameState = {
     ) => void;
     setGardenAvatarView: (view: GardenAvatarView) => void;
     setGardenAvatarMoveInput: (input: GardenAvatarMoveInput) => void;
+    setGardenAvatarSprintInput: (active: boolean) => void;
+    setGardenAvatarCrouchInput: (active: boolean) => void;
+    setGardenAvatarZoomInput: (active: boolean) => void;
     requestGardenAvatarJump: () => void;
 
     // Debug (overrides)
@@ -1053,6 +1059,9 @@ export function createGameState({
         view: 'normal',
         gardenAvatarView: 'overview',
         gardenAvatarMoveInput: { forward: 0, right: 0 },
+        gardenAvatarSprintInput: false,
+        gardenAvatarCrouchInput: false,
+        gardenAvatarZoomInput: false,
         gardenAvatarJumpRequest: 0,
         closeupBlock: null,
         closeupCameraActive: false,
@@ -1085,6 +1094,9 @@ export function createGameState({
                     ? {
                           gardenAvatarView,
                           gardenAvatarMoveInput: { forward: 0, right: 0 },
+                          gardenAvatarSprintInput: false,
+                          gardenAvatarCrouchInput: false,
+                          gardenAvatarZoomInput: false,
                       }
                     : {
                           gardenAvatarView,
@@ -1097,6 +1109,12 @@ export function createGameState({
         },
         setGardenAvatarMoveInput: (gardenAvatarMoveInput) =>
             set({ gardenAvatarMoveInput }),
+        setGardenAvatarSprintInput: (gardenAvatarSprintInput) =>
+            set({ gardenAvatarSprintInput }),
+        setGardenAvatarCrouchInput: (gardenAvatarCrouchInput) =>
+            set({ gardenAvatarCrouchInput }),
+        setGardenAvatarZoomInput: (gardenAvatarZoomInput) =>
+            set({ gardenAvatarZoomInput }),
         requestGardenAvatarJump: () =>
             set((state) => ({
                 gardenAvatarJumpRequest: state.gardenAvatarJumpRequest + 1,

--- a/packages/game/src/useGameState.unit.ts
+++ b/packages/game/src/useGameState.unit.ts
@@ -576,6 +576,9 @@ test('garden avatar view enters play mode and resets touch input on exit', () =>
     try {
         store.getState().setGardenAvatarView('third-person');
         store.getState().setGardenAvatarMoveInput({ forward: 1, right: -1 });
+        store.getState().setGardenAvatarSprintInput(true);
+        store.getState().setGardenAvatarCrouchInput(true);
+        store.getState().setGardenAvatarZoomInput(true);
         store.getState().requestGardenAvatarJump();
 
         assert.equal(store.getState().gardenAvatarView, 'third-person');
@@ -584,6 +587,9 @@ test('garden avatar view enters play mode and resets touch input on exit', () =>
             right: -1,
         });
         assert.equal(store.getState().gardenAvatarJumpRequest, 1);
+        assert.equal(store.getState().gardenAvatarSprintInput, true);
+        assert.equal(store.getState().gardenAvatarCrouchInput, true);
+        assert.equal(store.getState().gardenAvatarZoomInput, true);
 
         store.getState().setGardenAvatarView('overview');
         assert.equal(store.getState().gardenAvatarView, 'overview');
@@ -591,6 +597,9 @@ test('garden avatar view enters play mode and resets touch input on exit', () =>
             forward: 0,
             right: 0,
         });
+        assert.equal(store.getState().gardenAvatarSprintInput, false);
+        assert.equal(store.getState().gardenAvatarCrouchInput, false);
+        assert.equal(store.getState().gardenAvatarZoomInput, false);
     } finally {
         store.getState().audio.dispose();
     }

--- a/packages/game/src/viewers/PublicGardenViewer.tsx
+++ b/packages/game/src/viewers/PublicGardenViewer.tsx
@@ -25,6 +25,9 @@ import { Vector3 } from 'three';
 import { BlockInteractionLayer } from '../controls/BlockInteractionLayer';
 import { BlockInteractionRegistryProvider } from '../controls/BlockInteractionRegistry';
 import { GameCameraRig } from '../controls/GameCameraRig';
+import { GardenAvatar } from '../entities/avatar/GardenAvatar';
+import { GardenVisitorAvatar } from '../entities/avatar/GardenVisitorAvatar';
+import type { GardenVisitorPresenceController } from '../entities/avatar/gardenVisitorPresence';
 import { Bees } from '../entities/bees/Bees';
 import { Birds } from '../entities/birds/Birds';
 import { Cats } from '../entities/cats/Cats';
@@ -41,6 +44,7 @@ import { currentGardenKeys } from '../hooks/useCurrentGarden';
 import { useDeferredSceneDetails } from '../hooks/useDeferredSceneDetails';
 import { useGardensKeys } from '../hooks/useGardens';
 import { useAllSorts } from '../hooks/usePlantSorts';
+import { GardenAvatarHud } from '../hud/GardenAvatarHud';
 import { ParticleSystemProvider } from '../particles/ParticleSystem';
 import { Environment } from '../scene/Environment';
 import {
@@ -56,6 +60,7 @@ import {
     GameStateContext,
     type GameStateStore,
     useDisposeGameStateStore,
+    useGameState,
 } from '../useGameState';
 import { findRaisedBedByBlockId } from '../utils/raisedBedBlocks';
 import {
@@ -70,6 +75,7 @@ import {
 import { PublicGardenRaisedBedDetails } from './PublicGardenRaisedBedDetails';
 import { PublicGardenRaisedBedInteractions } from './PublicGardenRaisedBedInteractions';
 import { PublicGardenRaisedBedPicker } from './PublicGardenRaisedBedPicker';
+import type { PublicGardenRaisedBed } from './publicGardenRaisedBedDetailsModel';
 
 export type PublicGardenBlock = Block;
 
@@ -129,6 +135,7 @@ export type PublicGardenViewerProps = HTMLAttributes<HTMLDivElement> & {
     deferDetails?: boolean;
     className?: string;
     capture?: PublicGardenCapture;
+    visitorPresence?: GardenVisitorPresenceController;
 };
 
 const publicGardenCaptureQuality = {
@@ -379,6 +386,7 @@ function PublicGardenScene({
     normalizedStacks,
     onSelectRaisedBedBlock,
     renderDetails,
+    visitorPresence,
 }: {
     capture?: PublicGardenViewerProps['capture'];
     initialView: PublicGardenInitialView;
@@ -388,12 +396,16 @@ function PublicGardenScene({
     normalizedStacks: Stack[];
     onSelectRaisedBedBlock: (blockId: string) => void;
     renderDetails: boolean;
+    visitorPresence?: GardenVisitorPresenceController;
 }) {
     const blockDataQuery = useBlockData();
     const blockDataLoaded = Boolean(blockDataQuery.data);
     const plantSortsQuery = useAllSorts();
     const plantSortsLoaded = Boolean(plantSortsQuery.data);
     const fetchingQueryCount = useIsFetching();
+    const gardenAvatarView = useGameState((state) => state.gardenAvatarView);
+    const gardenAvatarActive =
+        Boolean(visitorPresence) && gardenAvatarView !== 'overview';
     const qualityProfile = useMemo(
         () =>
             capture?.output
@@ -496,7 +508,7 @@ function PublicGardenScene({
                                             />
                                         </Suspense>
                                     ) : null}
-                                    {!capture ? (
+                                    {!capture && !gardenAvatarActive ? (
                                         <>
                                             <PublicGardenRaisedBedInteractions
                                                 onSelect={
@@ -542,10 +554,36 @@ function PublicGardenScene({
                                             />
                                         </Suspense>
                                     )}
+                                    {visitorPresence ? (
+                                        <Suspense fallback={null}>
+                                            <GardenAvatar
+                                                key={
+                                                    visitorPresence.localVisitorId
+                                                }
+                                                onPresenceChange={
+                                                    visitorPresence.onLocalPresenceChange
+                                                }
+                                                roamSeed={
+                                                    visitorPresence.localVisitorId
+                                                }
+                                                stacks={normalizedStacks}
+                                            />
+                                            {visitorPresence.visitors.map(
+                                                (visitor) => (
+                                                    <GardenVisitorAvatar
+                                                        key={visitor.id}
+                                                        presence={visitor}
+                                                    />
+                                                ),
+                                            )}
+                                        </Suspense>
+                                    ) : null}
                                 </group>
                             </Suspense>
                             <GameCameraRig
-                                controlsEnabled={!capture}
+                                controlsEnabled={
+                                    !capture && !gardenAvatarActive
+                                }
                                 initialPosition={initialView.cameraPosition}
                                 initialSnapshot={
                                     garden?.homeCamera ?? undefined
@@ -579,6 +617,41 @@ function PublicGardenScene({
                 <div className="h-full w-full bg-[#d9f2dc]" />
             )}
         </div>
+    );
+}
+
+function PublicGardenInteractiveOverlays({
+    onCloseRaisedBed,
+    onSelectRaisedBed,
+    raisedBeds,
+    selectedRaisedBed,
+    visitorPresenceEnabled,
+}: {
+    onCloseRaisedBed: () => void;
+    onSelectRaisedBed: (raisedBedId: number) => void;
+    raisedBeds: PublicGardenRaisedBed[];
+    selectedRaisedBed: PublicGardenRaisedBed | undefined;
+    visitorPresenceEnabled: boolean;
+}) {
+    const gardenAvatarView = useGameState((state) => state.gardenAvatarView);
+    if (visitorPresenceEnabled && gardenAvatarView !== 'overview') {
+        return <GardenAvatarHud />;
+    }
+
+    return (
+        <>
+            <PublicGardenRaisedBedPicker
+                onSelect={onSelectRaisedBed}
+                raisedBeds={raisedBeds}
+            />
+            {selectedRaisedBed ? (
+                <PublicGardenRaisedBedDetails
+                    key={selectedRaisedBed.id}
+                    onClose={onCloseRaisedBed}
+                    raisedBed={selectedRaisedBed}
+                />
+            ) : null}
+        </>
     );
 }
 
@@ -629,6 +702,7 @@ export function PublicGardenViewer({
     garden,
     stacks,
     className,
+    visitorPresence,
 }: PublicGardenViewerProps) {
     const resolvedAppBaseUrl = appBaseUrl ?? 'https://vrt.gredice.com';
     const resolvedSpriteBaseUrl = spriteBaseUrl ?? resolvedAppBaseUrl;
@@ -780,11 +854,13 @@ export function PublicGardenViewer({
         if (gameGarden?.id === undefined) {
             setSelectedRaisedBedId(null);
             storeRef.current?.getState().setView({ view: 'normal' });
+            storeRef.current?.getState().setGardenAvatarView('overview');
             return;
         }
 
         setSelectedRaisedBedId(null);
         storeRef.current?.getState().setView({ view: 'normal' });
+        storeRef.current?.getState().setGardenAvatarView('overview');
     }, [gameGarden?.id]);
 
     return (
@@ -819,18 +895,17 @@ export function PublicGardenViewer({
                                         openRaisedBedByBlockId
                                     }
                                     renderDetails={renderDetails}
+                                    visitorPresence={visitorPresence}
                                 />
                                 {gameGarden && !capture ? (
-                                    <PublicGardenRaisedBedPicker
-                                        onSelect={openRaisedBed}
+                                    <PublicGardenInteractiveOverlays
+                                        onCloseRaisedBed={closeRaisedBed}
+                                        onSelectRaisedBed={openRaisedBed}
                                         raisedBeds={selectableRaisedBeds}
-                                    />
-                                ) : null}
-                                {selectedRaisedBed && !capture ? (
-                                    <PublicGardenRaisedBedDetails
-                                        key={selectedRaisedBed.id}
-                                        onClose={closeRaisedBed}
-                                        raisedBed={selectedRaisedBed}
+                                        selectedRaisedBed={selectedRaisedBed}
+                                        visitorPresenceEnabled={Boolean(
+                                            visitorPresence,
+                                        )}
                                     />
                                 ) : null}
                             </div>


### PR DESCRIPTION
## What changed

- mount one free, locally roaming gardener in the WWW `/vrtovi/[gardenId]` viewer, without a store item, entitlement, environment variable, profile embed, or capture-rendering impact
- let visitors select only their local avatar to enter the existing TPV/FPV movement and camera experience, while handing overview camera and raised-bed controls back on exit
- add a mobile analog stick plus touch jump, sprint, crouch, gradual zoom, camera toggle, and exit controls with safe-area layout and simultaneous-pointer support
- publish anonymous per-tab avatar poses through an ephemeral Redis hash, expire stale visitors, cap peer responses at 16, and render remote visitors with position/rotation/rig interpolation
- preserve local-only walking when Redis or the presence request is unavailable
- update the public-garden page copy for the interactive live experience

## Why

The product direction changed after the v0 gardener runtime landed: the avatar is no longer a 1,000-Sunflower store product. It is now a built-in public-garden experience for everyone viewing another garden, including signed-out and mobile visitors.

## Validation

- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game test` — 841 passing
- `pnpm --dir apps/api exec node --import tsx --test --conditions=react-server lib/garden/publicGardenVisitorPresence.node.spec.ts` — 2 passing
- `pnpm --filter api build`
- `pnpm --filter www typecheck`
- `pnpm --filter www build`
- focused Biome checks for all changed API, WWW, and game files
- Chromium desktop: avatar overview, TPV entry, camera handoff, touch-action ownership, and no Next error overlay
- Chromium mobile at 390 x 844: all controls visible, analog stick movement/recenter, TPV-to-FPV hold zoom, and no page errors
- two isolated Chromium sessions exchanged anonymous presence through the local API

## Operational notes

- no database migration
- no new environment variable; the existing Gredice Redis namespace is used when configured
- no store/catalogue entity, price, purchase, or ownership state

Closes #4440
Closes #4441
Closes #4442
