### PR TITLE
fix(game): restore third-person view after zoom

### DIFF
--- a/packages/game/src/entities/avatar/GardenAvatar.tsx
+++ b/packages/game/src/entities/avatar/GardenAvatar.tsx
@@ -2,6 +2,7 @@ import { Html, PerspectiveCamera } from '@react-three/drei';
 import { type ThreeEvent, useFrame, useThree } from '@react-three/fiber';
 import {
     type RefObject,
+    useCallback,
     useEffect,
     useLayoutEffect,
     useMemo,
@@ -44,6 +45,10 @@ import {
     getGardenAvatarSurfaceY,
     resolveGardenAvatarHorizontalMovement,
 } from './gardenAvatarMovement';
+import {
+    getGardenAvatarZoomReleaseView,
+    getGardenAvatarZoomStart,
+} from './gardenAvatarZoomView';
 import type { GardenAvatarPresenceState } from './gardenVisitorPresence';
 
 export const avatarModelScale = 0.697;
@@ -598,6 +603,11 @@ export function GardenAvatar({
     const crouchingRef = useRef(false);
     const crouchAmountRef = useRef(0);
     const mouseZoomingRef = useRef(false);
+    const mouseZoomReturnsToThirdPersonRef = useRef(false);
+    const touchZoomReturnsToThirdPersonRef = useRef(false);
+    const previousTouchZoomInputRef = useRef(touchZoomInput);
+    const touchZoomInputRef = useRef(touchZoomInput);
+    touchZoomInputRef.current = touchZoomInput;
     const zoomingRef = useRef(false);
     const presenceCallbackRef = useRef(onPresenceChange);
     presenceCallbackRef.current = onPresenceChange;
@@ -607,6 +617,26 @@ export function GardenAvatar({
         quaternion: camera.quaternion.clone(),
     });
     const initializedRef = useRef(false);
+    const finishTemporaryZoom = useCallback(() => {
+        if (mouseZoomingRef.current || touchZoomInputRef.current) {
+            return;
+        }
+
+        const restoreThirdPerson =
+            mouseZoomReturnsToThirdPersonRef.current ||
+            touchZoomReturnsToThirdPersonRef.current;
+        mouseZoomReturnsToThirdPersonRef.current = false;
+        touchZoomReturnsToThirdPersonRef.current = false;
+        const currentView = avatarViewRef.current;
+        const nextView = getGardenAvatarZoomReleaseView({
+            restoreThirdPerson,
+            view: currentView,
+        });
+        if (nextView !== currentView) {
+            avatarViewRef.current = nextView;
+            setView(nextView);
+        }
+    }, [setView]);
     const model = useMemo(() => {
         const scene = gltf.scene.clone(true);
         return { ...prepareGardenAvatarModel(scene), scene };
@@ -717,6 +747,8 @@ export function GardenAvatar({
             jumpsUsedRef.current = 0;
             crouchingRef.current = false;
             mouseZoomingRef.current = false;
+            mouseZoomReturnsToThirdPersonRef.current = false;
+            touchZoomReturnsToThirdPersonRef.current = false;
             zoomingRef.current = false;
             if (document.pointerLockElement === gl.domElement) {
                 document.exitPointerLock();
@@ -765,6 +797,7 @@ export function GardenAvatar({
         const clearActiveInput = () => {
             clearKeyboardInput();
             mouseZoomingRef.current = false;
+            finishTemporaryZoom();
         };
         const handleVisibilityChange = () => {
             if (document.hidden) {
@@ -784,10 +817,18 @@ export function GardenAvatar({
             if (event.pointerType === 'mouse') {
                 if (event.button === 2) {
                     event.preventDefault();
-                    mouseZoomingRef.current = true;
-                    if (avatarViewRef.current === 'third-person') {
-                        setView('first-person');
+                    if (!mouseZoomingRef.current) {
+                        const zoomStart = getGardenAvatarZoomStart(
+                            avatarViewRef.current,
+                        );
+                        mouseZoomReturnsToThirdPersonRef.current =
+                            zoomStart.restoreThirdPerson;
+                        if (zoomStart.view !== avatarViewRef.current) {
+                            avatarViewRef.current = zoomStart.view;
+                            setView(zoomStart.view);
+                        }
                     }
+                    mouseZoomingRef.current = true;
                     return;
                 }
                 if (
@@ -817,6 +858,7 @@ export function GardenAvatar({
         const handlePointerEnd = (event: PointerEvent) => {
             if (event.pointerType === 'mouse' && event.button === 2) {
                 mouseZoomingRef.current = false;
+                finishTemporaryZoom();
             }
             if (event.pointerId === dragPointerId) {
                 dragPointerId = null;
@@ -852,13 +894,23 @@ export function GardenAvatar({
             window.removeEventListener('pointercancel', handlePointerEnd);
             gl.domElement.removeEventListener('contextmenu', handleContextMenu);
         };
-    }, [avatarActive, gl.domElement, setView]);
+    }, [avatarActive, finishTemporaryZoom, gl.domElement, setView]);
 
     useEffect(() => {
-        if (touchZoomInput && view === 'third-person') {
-            setView('first-person');
+        const wasZooming = previousTouchZoomInputRef.current;
+        previousTouchZoomInputRef.current = touchZoomInput;
+        if (touchZoomInput && !wasZooming) {
+            const zoomStart = getGardenAvatarZoomStart(view);
+            touchZoomReturnsToThirdPersonRef.current =
+                zoomStart.restoreThirdPerson;
+            if (zoomStart.view !== view) {
+                avatarViewRef.current = zoomStart.view;
+                setView(zoomStart.view);
+            }
+        } else if (!touchZoomInput && wasZooming) {
+            finishTemporaryZoom();
         }
-    }, [setView, touchZoomInput, view]);
+    }, [finishTemporaryZoom, setView, touchZoomInput, view]);
 
     function activateAvatarView() {
         const actor = actorRef.current;

--- a/packages/game/src/entities/avatar/gardenAvatarZoomView.ts
+++ b/packages/game/src/entities/avatar/gardenAvatarZoomView.ts
@@ -1,0 +1,20 @@
+import type { GardenAvatarView } from '../../useGameState';
+
+export function getGardenAvatarZoomStart(view: GardenAvatarView) {
+    return {
+        restoreThirdPerson: view === 'third-person',
+        view: view === 'third-person' ? ('first-person' as const) : view,
+    };
+}
+
+export function getGardenAvatarZoomReleaseView({
+    restoreThirdPerson,
+    view,
+}: {
+    restoreThirdPerson: boolean;
+    view: GardenAvatarView;
+}): GardenAvatarView {
+    return restoreThirdPerson && view === 'first-person'
+        ? 'third-person'
+        : view;
+}

--- a/packages/game/src/entities/avatar/gardenAvatarZoomView.ts
+++ b/packages/game/src/entities/avatar/gardenAvatarZoomView.ts
@@ -3,7 +3,7 @@ import type { GardenAvatarView } from '../../useGameState';
 export function getGardenAvatarZoomStart(view: GardenAvatarView) {
     return {
         restoreThirdPerson: view === 'third-person',
-        view: view === 'third-person' ? ('first-person' as const) : view,
+        view: view === 'third-person' ? 'first-person' : view,
     };
 }
 

--- a/packages/game/src/entities/avatar/gardenAvatarZoomView.unit.ts
+++ b/packages/game/src/entities/avatar/gardenAvatarZoomView.unit.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    getGardenAvatarZoomReleaseView,
+    getGardenAvatarZoomStart,
+} from './gardenAvatarZoomView';
+
+test('temporarily enters first person while zooming from third person', () => {
+    const started = getGardenAvatarZoomStart('third-person');
+
+    assert.deepEqual(started, {
+        restoreThirdPerson: true,
+        view: 'first-person',
+    });
+    assert.equal(
+        getGardenAvatarZoomReleaseView({
+            restoreThirdPerson: started.restoreThirdPerson,
+            view: started.view,
+        }),
+        'third-person',
+    );
+});
+
+test('keeps first person after zooming when zoom started there', () => {
+    const started = getGardenAvatarZoomStart('first-person');
+
+    assert.deepEqual(started, {
+        restoreThirdPerson: false,
+        view: 'first-person',
+    });
+    assert.equal(
+        getGardenAvatarZoomReleaseView({
+            restoreThirdPerson: started.restoreThirdPerson,
+            view: started.view,
+        }),
+        'first-person',
+    );
+});
+
+test('does not re-enter play mode when zoom ends after exiting to overview', () => {
+    assert.equal(
+        getGardenAvatarZoomReleaseView({
+            restoreThirdPerson: true,
+            view: 'overview',
+        }),
+        'overview',
+    );
+});


### PR DESCRIPTION
## Summary

- treat zoom from third person as a temporary first-person camera transition
- restore third person when right-click or the mobile zoom control is released
- preserve first person when zoom started in first person
- keep overview stable if the player exits while zooming

## Root cause

Right-click press changed the persistent avatar view to first person, while release only cleared the FOV zoom flag. The originating camera view was not recorded or restored.

## Validation

- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game test` (844 tests)
- focused zoom-view unit tests (3 passing)
- Playwright: actual right-button down/up restores TPV; FPV-origin zoom remains FPV; no page error or framework overlay