### PR TITLE
fix(game): improve garden avatar controls and collisions

### DIFF
--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -125,7 +125,12 @@ export function GameHud({
         !isLocalSandbox && !suppressOpeningHud && openingFlowComplete;
 
     if (gardenAvatarView !== 'overview') {
-        return <GardenAvatarHud />;
+        return (
+            <>
+                <GardenAvatarHud />
+                {debugHud && viewMode === '3d' ? <DebugHudDynamic /> : null}
+            </>
+        );
     }
 
     return (

--- a/packages/game/src/entities/avatar/GardenAvatar.tsx
+++ b/packages/game/src/entities/avatar/GardenAvatar.tsx
@@ -27,6 +27,7 @@ import type { Stack } from '../../types/Stack';
 import { type GardenAvatarView, useGameState } from '../../useGameState';
 import { useGameGLTF } from '../../utils/useGameGLTF';
 import { useActorGroundingShadow } from '../animals/ActorGroundingShadows';
+import { GardenAvatarCollisionDebug } from './GardenAvatarCollisionDebug';
 import { getGardenAvatarPerspectiveEntryPosition } from './gardenAvatarCamera';
 import {
     createGardenAvatarCollisionWorld,
@@ -569,6 +570,9 @@ export function GardenAvatar({
     const gltf = useGameGLTF('FarmerAvatar');
     const { data: blockData } = useBlockData();
     const view = useGameState((state) => state.gardenAvatarView);
+    const collisionDebugVisible = useGameState(
+        (state) => state.gardenAvatarCollisionDebugVisible,
+    );
     const setView = useGameState((state) => state.setGardenAvatarView);
     const touchMoveInput = useGameState((state) => state.gardenAvatarMoveInput);
     const touchSprintInput = useGameState(
@@ -1311,6 +1315,13 @@ export function GardenAvatar({
                     </Html>
                 ) : null}
             </group>
+            {collisionDebugVisible ? (
+                <GardenAvatarCollisionDebug
+                    actorRef={actorRef}
+                    crouchingRef={crouchingRef}
+                    world={world}
+                />
+            ) : null}
             {view !== 'overview' ? (
                 <GardenAvatarCamera
                     actorRef={actorRef}

--- a/packages/game/src/entities/avatar/GardenAvatarCollisionDebug.tsx
+++ b/packages/game/src/entities/avatar/GardenAvatarCollisionDebug.tsx
@@ -1,0 +1,102 @@
+import { useFrame } from '@react-three/fiber';
+import { type RefObject, useMemo, useRef } from 'react';
+import type { Group } from 'three';
+import {
+    type GardenAvatarCollisionWorld,
+    gardenAvatarCrouchingCollisionHeight,
+    gardenAvatarRadius,
+    gardenAvatarStandingCollisionHeight,
+} from './gardenAvatarMovement';
+
+export function GardenAvatarCollisionDebug({
+    actorRef,
+    crouchingRef,
+    world,
+}: {
+    actorRef: RefObject<Group | null>;
+    crouchingRef: RefObject<boolean>;
+    world: GardenAvatarCollisionWorld;
+}) {
+    const playerColliderRef = useRef<Group>(null);
+    const boxes = useMemo(
+        () =>
+            world.surfaces.map((surface, index) => {
+                const bottomY = surface.bottomY ?? 0;
+                const height = Math.max(0.01, surface.y - bottomY);
+                return {
+                    color:
+                        surface.kind === 'water'
+                            ? '#38bdf8'
+                            : surface.roamable === false
+                              ? '#fb923c'
+                              : '#84cc16',
+                    depth: (surface.halfDepth ?? 0.5) * 2,
+                    height,
+                    key: `${surface.debugLabel ?? surface.kind}:${index}`,
+                    rotation: surface.rotation ?? 0,
+                    width: (surface.halfWidth ?? 0.5) * 2,
+                    x: surface.x,
+                    y: bottomY + height / 2,
+                    z: surface.z,
+                };
+            }),
+        [world],
+    );
+
+    useFrame(() => {
+        const actor = actorRef.current;
+        const playerCollider = playerColliderRef.current;
+        if (!actor || !playerCollider) {
+            return;
+        }
+
+        const height = crouchingRef.current
+            ? gardenAvatarCrouchingCollisionHeight
+            : gardenAvatarStandingCollisionHeight;
+        playerCollider.visible = actor.visible;
+        playerCollider.position.set(
+            actor.position.x,
+            actor.position.y + height / 2,
+            actor.position.z,
+        );
+        playerCollider.scale.set(1, height, 1);
+    });
+
+    return (
+        <>
+            {boxes.map((box) => (
+                <mesh
+                    key={box.key}
+                    position={[box.x, box.y, box.z]}
+                    rotation={[0, box.rotation, 0]}
+                    scale={[box.width, box.height, box.depth]}
+                    raycast={() => undefined}
+                    renderOrder={10_000}
+                >
+                    <boxGeometry />
+                    <meshBasicMaterial
+                        color={box.color}
+                        depthTest={false}
+                        transparent
+                        opacity={0.7}
+                        wireframe
+                    />
+                </mesh>
+            ))}
+            <group ref={playerColliderRef}>
+                <mesh raycast={() => undefined} renderOrder={10_001}>
+                    <cylinderGeometry
+                        args={[gardenAvatarRadius, gardenAvatarRadius, 1, 16]}
+                    />
+                    <meshBasicMaterial
+                        color="#e879f9"
+                        depthTest={false}
+                        transparent
+                        opacity={0.9}
+                        wireframe
+                    />
+                </mesh>
+            </group>
+        </>
+    );
+}

--- a/packages/game/src/entities/avatar/gardenAvatarMovement.ts
+++ b/packages/game/src/entities/avatar/gardenAvatarMovement.ts
@@ -25,6 +25,7 @@ export type GardenAvatarCollisionWorld = {
 };
 
 export type GardenAvatarMovementSurface = AnimalMovementSurface & {
+    debugLabel?: string;
     bottomY?: number;
     halfDepth?: number;
     halfWidth?: number;
@@ -228,7 +229,29 @@ export function getGardenAvatarGroundY({
         return null;
     }
 
-    return maxHeight;
+    const slopedCenterHeight = world.surfaces.reduce<number | null>(
+        (selectedY, surface) => {
+            if (
+                !surface.slopeBlockName ||
+                surface.roamable === false ||
+                !circleIntersectsSurface(position, surface) ||
+                (surface.bottomY !== undefined &&
+                    surface.bottomY > currentGroundY + collisionHeight)
+            ) {
+                return selectedY;
+            }
+
+            const surfaceY = getGardenAvatarSurfaceY(position, surface);
+            return selectedY === null
+                ? surfaceY
+                : Math.max(selectedY, surfaceY);
+        },
+        null,
+    );
+
+    return slopedCenterHeight === null
+        ? maxHeight
+        : Math.max(sampleHeights[0] ?? 0, slopedCenterHeight);
 }
 
 function tryMove(
@@ -317,7 +340,7 @@ export function resolveGardenAvatarHorizontalMovement({
 
 const narrowAvatarCollisionFootprints: Record<
     string,
-    { depth: number; width: number }
+    { depth: number; height?: number; width: number }
 > = {
     BirdHouse: { depth: 0.34, width: 0.34 },
     DeadTreeTall: { depth: 0.3, width: 0.42 },
@@ -328,6 +351,13 @@ const narrowAvatarCollisionFootprints: Record<
     Tree: { depth: 0.42, width: 0.42 },
 };
 
+const avatarCollisionSizeRelaxation = 0.12;
+const minimumAvatarCollisionSize = 0.12;
+const fencePostSize = 0.15;
+const fenceHeight = 0.55;
+const fenceRailHalfLength = 0.2125;
+const fenceRailCenterOffset = 0.2875;
+
 function positiveDimension(value: unknown, fallback: number) {
     return typeof value === 'number' && Number.isFinite(value) && value > 0
         ? value
@@ -335,22 +365,115 @@ function positiveDimension(value: unknown, fallback: number) {
 }
 
 function getAvatarCollisionFootprint(block: BlockData | undefined) {
-    const fallbackWidth = positiveDimension(block?.attributes.spanWidth, 0.68);
-    const fallbackDepth = positiveDimension(block?.attributes.spanDepth, 0.68);
+    const spanWidth = positiveDimension(block?.attributes.spanWidth, 0.8);
+    const spanDepth = positiveDimension(block?.attributes.spanDepth, 0.8);
+    const declaredWidth = positiveDimension(
+        block?.attributes.hitboxWidth,
+        spanWidth,
+    );
+    const declaredDepth = positiveDimension(
+        block?.attributes.hitboxDepth,
+        spanDepth,
+    );
     const narrow = block
         ? narrowAvatarCollisionFootprints[block.information.name]
         : undefined;
 
     return {
         depth: Math.min(
-            positiveDimension(block?.attributes.hitboxDepth, fallbackDepth),
+            Math.max(
+                minimumAvatarCollisionSize,
+                declaredDepth - avatarCollisionSizeRelaxation,
+            ),
             narrow?.depth ?? Number.POSITIVE_INFINITY,
         ),
+        height: Math.min(
+            positiveDimension(
+                block?.attributes.hitboxHeight,
+                positiveDimension(block?.attributes.height, 0.8),
+            ),
+            narrow?.height ?? Number.POSITIVE_INFINITY,
+        ),
         width: Math.min(
-            positiveDimension(block?.attributes.hitboxWidth, fallbackWidth),
+            Math.max(
+                minimumAvatarCollisionSize,
+                declaredWidth - avatarCollisionSizeRelaxation,
+            ),
             narrow?.width ?? Number.POSITIVE_INFINITY,
         ),
     };
+}
+
+function fenceLayerKey(
+    stack: { position: Pick<GardenAvatarPoint, 'x' | 'z'> },
+    blockIndex: number,
+) {
+    return `${stack.position.x}:${stack.position.z}:${blockIndex}`;
+}
+
+function createFenceCollisionSurfaces({
+    blockIndex,
+    bottomY,
+    fenceLayers,
+    stack,
+}: {
+    blockIndex: number;
+    bottomY: number;
+    fenceLayers: Set<string>;
+    stack: Stack;
+}) {
+    const roamBlockedCells = [{ x: stack.position.x, z: stack.position.z }];
+    const shared: Pick<
+        GardenAvatarMovementSurface,
+        'bottomY' | 'debugLabel' | 'kind' | 'roamable' | 'rotation' | 'y'
+    > = {
+        bottomY,
+        debugLabel: 'Fence',
+        kind: 'ground',
+        roamable: false,
+        rotation: 0,
+        y: bottomY + fenceHeight,
+    };
+    const surfaces: GardenAvatarMovementSurface[] = [
+        {
+            ...shared,
+            halfDepth: fencePostSize / 2,
+            halfWidth: fencePostSize / 2,
+            roamBlockedCells,
+            x: stack.position.x,
+            z: stack.position.z,
+        },
+    ];
+    const directions = [
+        { x: 1, z: 0 },
+        { x: -1, z: 0 },
+        { x: 0, z: 1 },
+        { x: 0, z: -1 },
+    ];
+
+    for (const direction of directions) {
+        const neighbor = {
+            position: {
+                x: stack.position.x + direction.x,
+                z: stack.position.z + direction.z,
+            },
+        };
+        if (!fenceLayers.has(fenceLayerKey(neighbor, blockIndex))) {
+            continue;
+        }
+
+        const alongX = direction.x !== 0;
+        surfaces.push({
+            ...shared,
+            halfDepth: alongX ? fencePostSize / 2 : fenceRailHalfLength,
+            halfWidth: alongX ? fenceRailHalfLength : fencePostSize / 2,
+            roamBlockedCells: [],
+            x: stack.position.x + direction.x * fenceRailCenterOffset,
+            z: stack.position.z + direction.z * fenceRailCenterOffset,
+        });
+    }
+
+    return surfaces;
 }
 
 function getAvatarCollisionPlacement({
@@ -392,6 +515,15 @@ export function createGardenAvatarCollisionWorld({
         blockData?.map((block) => [block.information.name, block]) ?? [],
     );
     const surfaces: GardenAvatarMovementSurface[] = [];
+    const fenceLayers = new Set(
+        (stacks ?? []).flatMap((stack) =>
+            stack.blocks.flatMap((block, blockIndex) =>
+                block.name === 'Fence'
+                    ? [fenceLayerKey(stack, blockIndex)]
+                    : [],
+            ),
+        ),
+    );
 
     for (const stack of stacks ?? []) {
         let stackHeight = 0;
@@ -426,10 +558,22 @@ export function createGardenAvatarCollisionWorld({
             }
 
             waterSupportY = null;
+            if (block.name === 'Fence') {
+                surfaces.push(
+                    ...createFenceCollisionSurfaces({
+                        blockIndex,
+                        bottomY,
+                        fenceLayers,
+                        stack,
+                    }),
+                );
+                continue;
+            }
+
             const isTerrain = isAnimalGroundBlockName(block.name);
             const blockDefinition = blockDataByName.get(block.name);
             const footprint = isTerrain
-                ? { depth: 1, width: 1 }
+                ? { depth: 1, height: stackHeight - bottomY, width: 1 }
                 : getAvatarCollisionFootprint(blockDefinition);
             const placement = isTerrain
                 ? {
@@ -444,6 +588,7 @@ export function createGardenAvatarCollisionWorld({
                   });
             surfaces.push({
                 bottomY,
+                debugLabel: block.name,
                 halfDepth: footprint.depth / 2,
                 halfWidth: footprint.width / 2,
                 kind: 'ground',
@@ -452,7 +597,7 @@ export function createGardenAvatarCollisionWorld({
                 rotation: block.rotation * (Math.PI / 2),
                 slopeBlockName: isTerrain ? block.name : undefined,
                 x: placement.x,
-                y: stackHeight,
+                y: bottomY + footprint.height,
                 z: placement.z,
             });
         }

--- a/packages/game/src/entities/avatar/gardenAvatarMovement.unit.ts
+++ b/packages/game/src/entities/avatar/gardenAvatarMovement.unit.ts
@@ -190,6 +190,42 @@ test('follows angled terrain height continuously instead of flattening it', () =
     assert.equal(getGardenAvatarSurfaceY({ x: 0.5, z: 0 }, slope), 0.4);
 });
 
+test('walks smoothly from the base plane across a slope onto raised terrain', () => {
+    const world = createGardenAvatarCollisionWorld({
+        blockData: getLocalSandboxBlockData(),
+        stacks: [
+            {
+                blocks: [
+                    { id: 'slope', name: 'Block_Grass_Angle', rotation: 0 },
+                ],
+                position: new Vector3(0, 0, 0),
+            },
+            {
+                blocks: [{ id: 'upper', name: 'Block_Grass', rotation: 0 }],
+                position: new Vector3(1, 0, 0),
+            },
+        ],
+    });
+    const halfway = resolveGardenAvatarHorizontalMovement({
+        deltaX: 0.5,
+        deltaZ: 0,
+        position: { x: -0.5, y: 0, z: 0 },
+        world,
+    });
+    const upper = resolveGardenAvatarHorizontalMovement({
+        deltaX: 1,
+        deltaZ: 0,
+        position: halfway.position,
+        world,
+    });
+
+    assert.equal(halfway.collided, false);
+    assert.ok(Math.abs(halfway.position.y - 0.2) < 0.000_001);
+    assert.equal(upper.collided, false);
+    assert.ok(Math.abs(upper.position.x - 1) < 0.000_001);
+    assert.equal(upper.position.y, 0.4);
+});
+
 test('matches the rendered orientation of a quarter-turned slope', () => {
     const world = createGardenAvatarCollisionWorld({
         blockData: getLocalSandboxBlockData(),
@@ -305,6 +341,63 @@ test('uses narrow trunk collision instead of a tree canopy-sized box', () => {
     );
 });
 
+test('uses model-sized fence posts and leaves disconnected gaps walkable', () => {
+    const world = createGardenAvatarCollisionWorld({
+        blockData: getLocalSandboxBlockData(),
+        stacks: [
+            {
+                blocks: [{ id: 'fence-a', name: 'Fence', rotation: 0 }],
+                position: new Vector3(0, 0, 0),
+            },
+            {
+                blocks: [{ id: 'fence-b', name: 'Fence', rotation: 0 }],
+                position: new Vector3(1, 0, 1),
+            },
+        ],
+    });
+    const result = resolveGardenAvatarHorizontalMovement({
+        deltaX: 0,
+        deltaZ: 2.5,
+        position: { x: 0.4, y: 0, z: -1 },
+        world,
+    });
+
+    assert.equal(world.surfaces.length, 2);
+    assert.ok(
+        world.surfaces.every(
+            (surface) =>
+                surface.halfWidth === 0.075 && surface.halfDepth === 0.075,
+        ),
+    );
+    assert.equal(result.collided, false);
+    assert.ok(Math.abs(result.position.z - 1.5) < 0.000_001);
+});
+
+test('adds narrow rails only between connected fence posts', () => {
+    const world = createGardenAvatarCollisionWorld({
+        blockData: getLocalSandboxBlockData(),
+        stacks: [
+            {
+                blocks: [{ id: 'fence-a', name: 'Fence', rotation: 0 }],
+                position: new Vector3(0, 0, 0),
+            },
+            {
+                blocks: [{ id: 'fence-b', name: 'Fence', rotation: 0 }],
+                position: new Vector3(1, 0, 0),
+            },
+        ],
+    });
+
+    assert.equal(world.surfaces.length, 4);
+    assert.equal(
+        world.surfaces.filter(
+            (surface) =>
+                surface.halfWidth === 0.2125 && surface.halfDepth === 0.075,
+        ).length,
+        2,
+    );
+});
+
 test('centers multi-cell collisions and blocks their complete roaming footprint', () => {
     const decorationWorld = createGardenAvatarCollisionWorld({
         blockData: getLocalSandboxBlockData(),
@@ -319,8 +412,8 @@ test('centers multi-cell collisions and blocks their complete roaming footprint'
 
     assert.equal(cart?.x, 2);
     assert.equal(cart?.z, 0.5);
-    assert.equal(cart?.halfWidth, 1.5);
-    assert.equal(cart?.halfDepth, 1);
+    assert.equal(cart?.halfWidth, 1.44);
+    assert.equal(cart?.halfDepth, 0.94);
     assert.deepEqual(getGardenAvatarRoamBlockedCells(decorationWorld), [
         { x: 1, z: 0 },
         { x: 1, z: 1 },

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -297,6 +297,12 @@ export function DebugHud() {
     const setEditHitboxDebugVisible = useGameState(
         (s) => s.setEditHitboxDebugVisible,
     );
+    const gardenAvatarCollisionDebugVisible = useGameState(
+        (s) => s.gardenAvatarCollisionDebugVisible,
+    );
+    const setGardenAvatarCollisionDebugVisible = useGameState(
+        (s) => s.setGardenAvatarCollisionDebugVisible,
+    );
     const entityRenderModeDebugVisible = useGameState(
         (s) => s.entityRenderModeDebugVisible,
     );
@@ -1097,7 +1103,7 @@ export function DebugHud() {
                             <Row spacing={1} className="flex-wrap">
                                 <Button
                                     size="xs"
-                                    className="flex-1"
+                                    className="min-w-32 flex-1"
                                     startDecorator={
                                         <Fence className="size-3.5" />
                                     }
@@ -1116,7 +1122,26 @@ export function DebugHud() {
                                 </Button>
                                 <Button
                                     size="xs"
-                                    className="flex-1"
+                                    className="min-w-32 flex-1"
+                                    startDecorator={
+                                        <Custom className="size-3.5" />
+                                    }
+                                    variant={
+                                        gardenAvatarCollisionDebugVisible
+                                            ? 'solid'
+                                            : 'outlined'
+                                    }
+                                    onClick={() =>
+                                        setGardenAvatarCollisionDebugVisible(
+                                            !gardenAvatarCollisionDebugVisible,
+                                        )
+                                    }
+                                >
+                                    Walk collisions
+                                </Button>
+                                <Button
+                                    size="xs"
+                                    className="min-w-32 flex-1"
                                     startDecorator={
                                         <Layers className="size-3.5" />
                                     }
@@ -1135,7 +1160,7 @@ export function DebugHud() {
                                 </Button>
                                 <Button
                                     size="xs"
-                                    className="flex-1"
+                                    className="min-w-32 flex-1"
                                     startDecorator={
                                         <Graph className="size-3.5" />
                                     }
@@ -1154,7 +1179,7 @@ export function DebugHud() {
                                 </Button>
                                 <Button
                                     size="xs"
-                                    className="flex-1"
+                                    className="min-w-32 flex-1"
                                     startDecorator={
                                         <MapPin className="size-3.5" />
                                     }

--- a/packages/game/src/hud/GardenAvatarHud.tsx
+++ b/packages/game/src/hud/GardenAvatarHud.tsx
@@ -2,14 +2,17 @@
 
 import { IconButton } from '@gredice/ui/IconButton';
 import { Camera, Close, LogOut, UserCircle } from '@gredice/ui/icons';
+import { cx } from '@gredice/ui/utils';
 import { type PointerEvent, useEffect } from 'react';
 import { useGameState } from '../useGameState';
 import { GardenAvatarJoystick } from './GardenAvatarJoystick';
+import { useGardenAvatarTouchControls } from './gardenAvatarTouchControls';
 
 const avatarHudButtonClassName =
     'pointer-events-auto border border-border/60 bg-background/85 shadow-lg backdrop-blur-md hover:bg-muted active:scale-95 touch-none';
 
 export function GardenAvatarHud() {
+    const showTouchControls = useGardenAvatarTouchControls();
     const view = useGameState((state) => state.gardenAvatarView);
     const setView = useGameState((state) => state.setGardenAvatarView);
     const setSprintInput = useGameState(
@@ -52,12 +55,22 @@ export function GardenAvatarHud() {
 
     return (
         <div className="pointer-events-none absolute inset-0 z-30 select-none">
-            <div className="absolute top-[calc(var(--game-safe-area-top,0px)+0.5rem)] left-1/2 hidden -translate-x-1/2 rounded-full border border-border/50 bg-background/75 px-3 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur-sm md:block">
-                WASD za hodanje · Shift za trčanje · Ctrl za čučanj · dvaput
-                Space za dvostruki skok · desni klik za POV zum · Esc za izlaz
-            </div>
+            {!showTouchControls ? (
+                <div className="absolute top-[calc(var(--game-safe-area-top,0px)+0.5rem)] left-1/2 hidden -translate-x-1/2 rounded-full border border-border/50 bg-background/75 px-3 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur-sm md:block">
+                    WASD za hodanje · Shift za trčanje · Ctrl za čučanj · dvaput
+                    Space za dvostruki skok · desni klik za POV zum · Esc za
+                    izlaz
+                </div>
+            ) : null}
 
-            <div className="absolute top-[calc(var(--game-safe-area-top,0px)+0.5rem)] left-[calc(var(--game-safe-area-left,0px)+0.5rem)] flex items-center gap-1 rounded-xl border border-border/50 bg-background/70 p-1 shadow-lg backdrop-blur-md md:top-auto md:bottom-[calc(var(--game-safe-area-bottom,0px)+0.5rem)]">
+            <div
+                className={cx(
+                    'absolute left-[calc(var(--game-safe-area-left,0px)+0.5rem)] flex items-center gap-1 rounded-xl border border-border/50 bg-background/70 p-1 shadow-lg backdrop-blur-md',
+                    showTouchControls
+                        ? 'top-[calc(var(--game-safe-area-top,0px)+0.5rem)]'
+                        : 'top-[calc(var(--game-safe-area-top,0px)+0.5rem)] md:top-auto md:bottom-[calc(var(--game-safe-area-bottom,0px)+0.5rem)]',
+                )}
+            >
                 <IconButton
                     title={
                         view === 'first-person'
@@ -91,57 +104,71 @@ export function GardenAvatarHud() {
                 </IconButton>
             </div>
 
-            <div className="absolute bottom-[calc(var(--game-safe-area-bottom,0px)+0.75rem)] left-[calc(var(--game-safe-area-left,0px)+0.75rem)] md:hidden">
-                <GardenAvatarJoystick />
-            </div>
+            {showTouchControls ? (
+                <>
+                    <div className="absolute bottom-[calc(var(--game-safe-area-bottom,0px)+0.75rem)] left-[calc(var(--game-safe-area-left,0px)+0.75rem)]">
+                        <GardenAvatarJoystick />
+                    </div>
 
-            <div className="absolute right-[calc(var(--game-safe-area-right,0px)+0.75rem)] bottom-[calc(var(--game-safe-area-bottom,0px)+0.75rem)] grid grid-cols-2 gap-2 md:hidden">
-                <button
-                    type="button"
-                    className="pointer-events-auto flex min-h-12 min-w-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/85 px-3 text-xs font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95"
-                    onPointerDown={(event) =>
-                        startAction(event, setCrouchInput)
-                    }
-                    onPointerUp={(event) => stopAction(event, setCrouchInput)}
-                    onPointerCancel={(event) =>
-                        stopAction(event, setCrouchInput)
-                    }
-                >
-                    Čučni
-                </button>
-                <button
-                    type="button"
-                    className="pointer-events-auto flex min-h-12 min-w-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/85 px-3 text-xs font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95"
-                    onPointerDown={(event) => startAction(event, setZoomInput)}
-                    onPointerUp={(event) => stopAction(event, setZoomInput)}
-                    onPointerCancel={(event) => stopAction(event, setZoomInput)}
-                >
-                    Zum
-                </button>
-                <button
-                    type="button"
-                    className="pointer-events-auto flex min-h-12 min-w-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/85 px-3 text-xs font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95"
-                    onPointerDown={(event) =>
-                        startAction(event, setSprintInput)
-                    }
-                    onPointerUp={(event) => stopAction(event, setSprintInput)}
-                    onPointerCancel={(event) =>
-                        stopAction(event, setSprintInput)
-                    }
-                >
-                    Trči
-                </button>
-                <button
-                    type="button"
-                    onPointerDown={(event) => {
-                        event.preventDefault();
-                        requestJump();
-                    }}
-                    className="pointer-events-auto flex min-h-12 min-w-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/95 px-3 text-xs font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95"
-                >
-                    Skoči
-                </button>
-            </div>
+                    <div className="absolute right-[calc(var(--game-safe-area-right,0px)+0.75rem)] bottom-[calc(var(--game-safe-area-bottom,0px)+0.75rem)] grid grid-cols-2 gap-2">
+                        <button
+                            type="button"
+                            className="pointer-events-auto flex min-h-12 min-w-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/85 px-3 text-xs font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95"
+                            onPointerDown={(event) =>
+                                startAction(event, setCrouchInput)
+                            }
+                            onPointerUp={(event) =>
+                                stopAction(event, setCrouchInput)
+                            }
+                            onPointerCancel={(event) =>
+                                stopAction(event, setCrouchInput)
+                            }
+                        >
+                            Čučni
+                        </button>
+                        <button
+                            type="button"
+                            className="pointer-events-auto flex min-h-12 min-w-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/85 px-3 text-xs font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95"
+                            onPointerDown={(event) =>
+                                startAction(event, setZoomInput)
+                            }
+                            onPointerUp={(event) =>
+                                stopAction(event, setZoomInput)
+                            }
+                            onPointerCancel={(event) =>
+                                stopAction(event, setZoomInput)
+                            }
+                        >
+                            Zum
+                        </button>
+                        <button
+                            type="button"
+                            className="pointer-events-auto flex min-h-12 min-w-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/85 px-3 text-xs font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95"
+                            onPointerDown={(event) =>
+                                startAction(event, setSprintInput)
+                            }
+                            onPointerUp={(event) =>
+                                stopAction(event, setSprintInput)
+                            }
+                            onPointerCancel={(event) =>
+                                stopAction(event, setSprintInput)
+                            }
+                        >
+                            Trči
+                        </button>
+                        <button
+                            type="button"
+                            onPointerDown={(event) => {
+                                event.preventDefault();
+                                requestJump();
+                            }}
+                            className="pointer-events-auto flex min-h-12 min-w-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/95 px-3 text-xs font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95"
+                        >
+                            Skoči
+                        </button>
+                    </div>
+                </>
+            ) : null}
         </div>
     );
 }

--- a/packages/game/src/hud/gardenAvatarTouchControls.ts
+++ b/packages/game/src/hud/gardenAvatarTouchControls.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function shouldShowGardenAvatarTouchControls({
+    coarsePointer,
+    hoverNone,
+    maxTouchPoints,
+}: {
+    coarsePointer: boolean;
+    hoverNone: boolean;
+    maxTouchPoints: number;
+}) {
+    return maxTouchPoints > 0 && (coarsePointer || hoverNone);
+}
+
+function readTouchControlCapability() {
+    return shouldShowGardenAvatarTouchControls({
+        coarsePointer: window.matchMedia('(pointer: coarse)').matches,
+        hoverNone: window.matchMedia('(hover: none)').matches,
+        maxTouchPoints: navigator.maxTouchPoints,
+    });
+}
+
+export function useGardenAvatarTouchControls() {
+    const [showTouchControls, setShowTouchControls] = useState(false);
+
+    useEffect(() => {
+        const coarsePointer = window.matchMedia('(pointer: coarse)');
+        const hoverNone = window.matchMedia('(hover: none)');
+        const refreshCapability = () => {
+            setShowTouchControls(readTouchControlCapability());
+        };
+        const rememberTouchInput = (event: PointerEvent) => {
+            if (event.pointerType === 'touch') {
+                setShowTouchControls(true);
+            }
+        };
+
+        refreshCapability();
+        coarsePointer.addEventListener('change', refreshCapability);
+        hoverNone.addEventListener('change', refreshCapability);
+        window.addEventListener('pointerdown', rememberTouchInput, {
+            passive: true,
+        });
+
+        return () => {
+            coarsePointer.removeEventListener('change', refreshCapability);
+            hoverNone.removeEventListener('change', refreshCapability);
+            window.removeEventListener('pointerdown', rememberTouchInput);
+        };
+    }, []);
+
+    return showTouchControls;
+}

--- a/packages/game/src/hud/gardenAvatarTouchControls.unit.ts
+++ b/packages/game/src/hud/gardenAvatarTouchControls.unit.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { shouldShowGardenAvatarTouchControls } from './gardenAvatarTouchControls';
+
+test('shows avatar touch controls for a coarse touch-first device at any viewport width', () => {
+    assert.equal(
+        shouldShowGardenAvatarTouchControls({
+            coarsePointer: true,
+            hoverNone: true,
+            maxTouchPoints: 5,
+        }),
+        true,
+    );
+});
+
+test('shows avatar touch controls when a touch device cannot hover', () => {
+    assert.equal(
+        shouldShowGardenAvatarTouchControls({
+            coarsePointer: false,
+            hoverNone: true,
+            maxTouchPoints: 1,
+        }),
+        true,
+    );
+});
+
+test('keeps keyboard and mouse controls on non-touch and hover-capable devices', () => {
+    assert.equal(
+        shouldShowGardenAvatarTouchControls({
+            coarsePointer: false,
+            hoverNone: false,
+            maxTouchPoints: 0,
+        }),
+        false,
+    );
+    assert.equal(
+        shouldShowGardenAvatarTouchControls({
+            coarsePointer: false,
+            hoverNone: false,
+            maxTouchPoints: 10,
+        }),
+        false,
+    );
+});

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -469,6 +469,8 @@ export type GameState = {
     // Debug (overrides)
     editHitboxDebugVisible: boolean;
     setEditHitboxDebugVisible: (visible: boolean) => void;
+    gardenAvatarCollisionDebugVisible: boolean;
+    setGardenAvatarCollisionDebugVisible: (visible: boolean) => void;
     entityRenderModeDebugVisible: boolean;
     setEntityRenderModeDebugVisible: (visible: boolean) => void;
     wireframeDebugVisible: boolean;
@@ -1137,6 +1139,10 @@ export function createGameState({
         editHitboxDebugVisible: false,
         setEditHitboxDebugVisible: (editHitboxDebugVisible) =>
             set({ editHitboxDebugVisible }),
+        gardenAvatarCollisionDebugVisible: false,
+        setGardenAvatarCollisionDebugVisible: (
+            gardenAvatarCollisionDebugVisible,
+        ) => set({ gardenAvatarCollisionDebugVisible }),
         entityRenderModeDebugVisible: false,
         setEntityRenderModeDebugVisible: (entityRenderModeDebugVisible) =>
             set({ entityRenderModeDebugVisible }),

--- a/packages/game/src/useGameState.unit.ts
+++ b/packages/game/src/useGameState.unit.ts
@@ -590,6 +590,10 @@ test('garden avatar view enters play mode and resets touch input on exit', () =>
         assert.equal(store.getState().gardenAvatarSprintInput, true);
         assert.equal(store.getState().gardenAvatarCrouchInput, true);
         assert.equal(store.getState().gardenAvatarZoomInput, true);
+        assert.equal(store.getState().gardenAvatarCollisionDebugVisible, false);
+
+        store.getState().setGardenAvatarCollisionDebugVisible(true);
+        assert.equal(store.getState().gardenAvatarCollisionDebugVisible, true);
 
         store.getState().setGardenAvatarView('overview');
         assert.equal(store.getState().gardenAvatarView, 'overview');


### PR DESCRIPTION
## Summary

- detect touch-first input capabilities so avatar controls remain visible on wide mobile landscape viewports
- make slope support follow the avatar center continuously from the base plane onto raised terrain
- introduce relaxed walk-mode collision footprints, with model-sized fence posts and rails only between connected fences
- keep the debug HUD mounted in POV/third-person mode and add a toggleable wireframe overlay for world and player colliders

## Root cause

The touch HUD depended on the `md` viewport breakpoint instead of input capabilities. Walk-mode collision surfaces reused broad declared footprints, and slope grounding selected the highest perimeter sample, which flattened or blocked traversal. Avatar mode also returned from `GameHud` before the debug panel could mount.

## Validation

- `pnpm --filter @gredice/game test` — 850 tests passed
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint`
- `git diff --check`
- browser: `/vrtovi/8` at 900×450 with touch emulation shows joystick and all four action controls
- browser: `/debug/sandbox` keeps the debug HUD in third-person mode and renders the Walk collisions overlay with no console errors
