### PR TITLE
fix(farm): upload completion images while online

### DIFF
--- a/apps/farm/app/flags.ts
+++ b/apps/farm/app/flags.ts
@@ -15,7 +15,7 @@ export const farmOperationCompletionSyncModeFlag =
     flag<FarmOperationCompletionSyncMode>({
         key: 'farmOperationCompletionSyncMode',
         description:
-            'Control local operation-completion queue creation and foreground draining.',
+            'Control offline operation-completion queue creation and foreground draining.',
         decide: () => 'enabled',
         options: [
             { label: 'Off', value: 'off' },

--- a/apps/farm/app/schedule/CompleteOperationModal.spec.tsx
+++ b/apps/farm/app/schedule/CompleteOperationModal.spec.tsx
@@ -2397,6 +2397,58 @@ test('queues a phone completion before network work and restores the waiting gat
     await expect(dialog.getByText('Možeš započeti novu skicu.')).toHaveCount(0);
 });
 
+test('uploads an online phone photo before confirming when offline sync is enabled', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.evaluate(() => {
+        window.__farmScheduleActionTestState = {
+            blockerCalls: 0,
+            hold: false,
+            operationCalls: 0,
+            plantingCalls: 0,
+        };
+    });
+    const getUploadCalls = await mockOperationPhotoUpload(page, 0);
+    await mount(
+        <OfflineQueueCompleteOperationModalStory
+            conditions={{ completionAttachImagesRequired: true }}
+            defaultOpen
+            expectedEntityId={701}
+            label="Fotografiraj završenu radnju uz vezu"
+            operationId={247}
+        />,
+    );
+    await settleResponsiveModal(page);
+
+    const dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    await dialog.locator('input[capture="environment"]').setInputFiles({
+        buffer: Buffer.from('online completion proof'),
+        mimeType: 'image/jpeg',
+        name: 'online-dokaz.jpg',
+    });
+    await dialog.getByRole('button', { name: 'Potvrdi' }).click();
+
+    await expect(
+        dialog.getByText(
+            'Radnja „Fotografiraj završenu radnju uz vezu” spremljena je i čeka potvrdu.',
+        ),
+    ).toBeVisible();
+    expect(getUploadCalls()).toBe(1);
+    await expect
+        .poll(() =>
+            page.evaluate(
+                () =>
+                    window.__farmScheduleActionTestState?.operationCalls ?? -1,
+            ),
+        )
+        .toBe(1);
+    await expect(dialog.getByText('čeka potvrdu farme')).toHaveCount(0);
+});
+
 test('replaces the local-only success copy with a live server receipt', async ({
     mount,
     page,
@@ -2429,9 +2481,10 @@ test('replaces the local-only success copy with a live server receipt', async ({
     await expect(dialog.locator('[data-operation-draft-status]')).toHaveText(
         'Spremljeno samo na ovom uređaju — radnja još nije dovršena.',
     );
+    await page.context().setOffline(true);
     await dialog.getByRole('button', { name: 'Potvrdi' }).click();
     await expect(dialog.getByRole('status')).toContainText(
-        'čeka potvrdu farme',
+        'sigurno je spremljena samo na ovom uređaju',
     );
 
     await component.update(
@@ -2456,6 +2509,7 @@ test('replaces the local-only success copy with a live server receipt', async ({
         dialog.locator('[data-operation-completion-server-receipt]'),
     ).toContainText('radnja sada čeka provjeru');
     await expect(dialog.getByText('čeka potvrdu farme')).toHaveCount(0);
+    await page.context().setOffline(false);
 });
 
 test('does not resurrect a cleared note while its first local save is in flight', async ({

--- a/apps/farm/app/schedule/CompleteOperationModal.spec.tsx
+++ b/apps/farm/app/schedule/CompleteOperationModal.spec.tsx
@@ -2446,7 +2446,115 @@ test('uploads an online phone photo before confirming when offline sync is enabl
             ),
         )
         .toBe(1);
+    const submitted = await page.evaluate(
+        () => window.__farmScheduleActionTestState?.lastOperationSubmission,
+    );
+    expect(submitted?.submissionId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu,
+    );
+    expect(submitted?.imageUrls).toHaveLength(1);
+    expect(submitted?.imageUrls?.[0]).toContain(
+        `/submissions/${submitted?.submissionId}/attachments/`,
+    );
     await expect(dialog.getByText('čeka potvrdu farme')).toHaveCount(0);
+});
+
+test('reuses the online submission identity when a lost response is queued offline', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.evaluate(() => {
+        window.__farmScheduleActionTestState = {
+            blockerCalls: 0,
+            hold: false,
+            operationCalls: 0,
+            operationFailuresRemaining: 1,
+            plantingCalls: 0,
+        };
+    });
+    const getUploadCalls = await mockOperationPhotoUpload(page, 0);
+    await mount(
+        <OfflineQueueCompleteOperationModalStory
+            conditions={{ completionAttachImagesRequired: true }}
+            defaultOpen
+            expectedEntityId={701}
+            label="Fotografiraj radnju uz izgubljen odgovor"
+            operationId={248}
+        />,
+    );
+    await settleResponsiveModal(page);
+
+    const dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    await dialog.locator('input[capture="environment"]').setInputFiles({
+        buffer: Buffer.from('lost response completion proof'),
+        mimeType: 'image/jpeg',
+        name: 'izgubljeni-odgovor.jpg',
+    });
+    await dialog.getByRole('button', { name: 'Potvrdi' }).click();
+    await expect(dialog.getByRole('alert')).toContainText(
+        'Radnja nije spremljena. Provjeri vezu i pokušaj ponovno.',
+    );
+
+    const firstSubmission = await page.evaluate(
+        () => window.__farmScheduleActionTestState?.lastOperationSubmission,
+    );
+    expect(firstSubmission?.submissionId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu,
+    );
+    expect(getUploadCalls()).toBe(1);
+
+    await page.context().setOffline(true);
+    await dialog.getByRole('button', { name: 'Pokušaj ponovno' }).click();
+    await expect(dialog.getByRole('status')).toContainText(
+        'sigurno je spremljena samo na ovom uređaju',
+    );
+
+    const queuedSubmissionId = await page.evaluate(
+        () =>
+            new Promise<string | null>((resolve, reject) => {
+                const request = indexedDB.open('gredice-farm-offline');
+                request.onerror = () => reject(request.error);
+                request.onsuccess = () => {
+                    const database = request.result;
+                    const transaction = database.transaction(
+                        'operation-completion-queue',
+                        'readonly',
+                    );
+                    const getAllRequest = transaction
+                        .objectStore('operation-completion-queue')
+                        .getAll();
+                    transaction.onerror = () => reject(transaction.error);
+                    transaction.oncomplete = () => {
+                        const item = getAllRequest.result.find(
+                            (candidate) =>
+                                typeof candidate === 'object' &&
+                                candidate !== null &&
+                                'operationId' in candidate &&
+                                candidate.operationId === 248,
+                        );
+                        resolve(
+                            item &&
+                                typeof item === 'object' &&
+                                'submissionId' in item &&
+                                typeof item.submissionId === 'string'
+                                ? item.submissionId
+                                : null,
+                        );
+                        database.close();
+                    };
+                };
+            }),
+    );
+    expect(queuedSubmissionId).toBe(firstSubmission?.submissionId);
+    expect(
+        await page.evaluate(
+            () => window.__farmScheduleActionTestState?.operationCalls ?? -1,
+        ),
+    ).toBe(1);
+    await page.context().setOffline(false);
 });
 
 test('replaces the local-only success copy with a live server receipt', async ({

--- a/apps/farm/app/schedule/CompleteOperationModal.tsx
+++ b/apps/farm/app/schedule/CompleteOperationModal.tsx
@@ -14,12 +14,14 @@ import type { HandoffOperationCompletionDraftToQueueResult } from '../../lib/off
 import {
     completeFarmOperation,
     completeFarmOperationWithImageUrls,
+    recoverFarmOperationCompletionImage,
     refreshFarmScheduleAfterSubmission,
     validateFarmOperationUploadTarget,
 } from './actions';
 import {
     getFarmOperationCompletionImageFileError,
     getFarmOperationCompletionImagePathPrefix,
+    getFarmOperationCompletionSubmissionImagePath,
     MAX_FARM_OPERATION_COMPLETION_IMAGE_COUNT,
 } from './operationCompletionProof';
 import { ScheduleTaskCompletionButton } from './ScheduleTaskCompletionButton';
@@ -517,11 +519,51 @@ export function CompleteOperationModal({
 
     const uploadImage = async (
         uploadItem: UploadItem,
+        submissionId?: string,
     ): Promise<UploadImageResult> => {
         const extension = uploadItem.file.name.includes('.')
             ? uploadItem.file.name.slice(uploadItem.file.name.lastIndexOf('.'))
             : '';
         let lastErrorMessage = 'Spremanje slike nije uspjelo.';
+
+        const markUploaded = (url: string, attempt: number) => {
+            updateUploadItem(uploadItem.id, (currentUploadItem) => ({
+                ...currentUploadItem,
+                progress: 100,
+                status: 'uploaded',
+                uploadedUrl: url,
+                errorMessage: undefined,
+                attempts: attempt,
+            }));
+            return { failure: null, url } satisfies UploadImageResult;
+        };
+
+        const recoverIdempotentUpload = async (
+            attempt = uploadItem.attempts,
+        ) => {
+            if (!submissionId) {
+                return null;
+            }
+            const recovered = await recoverFarmOperationCompletionImage(
+                operationId,
+                expectedEntityId,
+                expectedTaskVersionEventId,
+                expectedRequirementsFingerprint,
+                submissionId,
+                uploadItem.id,
+                uploadItem.file.name,
+            );
+            if (!recovered.success) {
+                markUploadTargetFailure(uploadItem.id, recovered);
+                return {
+                    failure: recovered,
+                    url: null,
+                } satisfies UploadImageResult;
+            }
+            return recovered.imageUrl
+                ? markUploaded(recovered.imageUrl, attempt)
+                : null;
+        };
 
         const initialTargetValidation = await validateFarmOperationUploadTarget(
             operationId,
@@ -534,8 +576,22 @@ export function CompleteOperationModal({
             return { failure: initialTargetValidation, url: null };
         }
 
+        const previouslyUploaded = await recoverIdempotentUpload();
+        if (previouslyUploaded) {
+            return previouslyUploaded;
+        }
+
         for (let attempt = 1; attempt <= MAX_UPLOAD_ATTEMPTS; attempt++) {
-            const pathname = `${getFarmOperationCompletionImagePathPrefix(operationId, expectedEntityId, expectedTaskVersionEventId)}${uploadItem.id}-${attempt}${extension}`;
+            const pathname = submissionId
+                ? getFarmOperationCompletionSubmissionImagePath(
+                      operationId,
+                      expectedEntityId,
+                      expectedTaskVersionEventId,
+                      submissionId,
+                      uploadItem.id,
+                      uploadItem.file.name,
+                  )
+                : `${getFarmOperationCompletionImagePathPrefix(operationId, expectedEntityId, expectedTaskVersionEventId)}${uploadItem.id}-${attempt}${extension}`;
 
             updateUploadItem(uploadItem.id, (currentUploadItem) => ({
                 ...currentUploadItem,
@@ -551,6 +607,13 @@ export function CompleteOperationModal({
                     contentType: uploadItem.file.type || undefined,
                     handleUploadUrl: '/api/operations/images/upload',
                     clientPayload: JSON.stringify({
+                        ...(submissionId
+                            ? {
+                                  attachmentId: uploadItem.id,
+                                  fileName: uploadItem.file.name,
+                                  submissionId,
+                              }
+                            : {}),
                         expectedEntityId,
                         expectedRequirementsFingerprint,
                         expectedTaskVersionEventId,
@@ -571,20 +634,15 @@ export function CompleteOperationModal({
                     },
                 });
 
-                updateUploadItem(uploadItem.id, (currentUploadItem) => ({
-                    ...currentUploadItem,
-                    progress: 100,
-                    status: 'uploaded',
-                    uploadedUrl: uploadedImage.url,
-                    errorMessage: undefined,
-                    attempts: attempt,
-                }));
-
-                return { failure: null, url: uploadedImage.url };
+                return markUploaded(uploadedImage.url, attempt);
             } catch {
                 console.error('Error uploading completion image.');
                 lastErrorMessage =
                     'Spremanje fotografije nije uspjelo. Pokušaj ponovno.';
+                const recoveredUpload = await recoverIdempotentUpload(attempt);
+                if (recoveredUpload) {
+                    return recoveredUpload;
+                }
                 const currentTargetValidation =
                     await validateFarmOperationUploadTarget(
                         operationId,
@@ -630,33 +688,48 @@ export function CompleteOperationModal({
             submissionInFlightRef.current = true;
             setIsSubmitting(true);
             const completionNotes = attachNotes ? trimmedNotes : undefined;
-            if (completionSync?.mode === 'enabled' && !navigator.onLine) {
-                const handoff = await localDraft.handoffToQueue({
-                    operationLabel: label,
-                });
-                if (handoff.status === 'error') {
+            let submissionId: string | undefined;
+            if (completionSync?.mode === 'enabled') {
+                if (!navigator.onLine) {
+                    const handoff = await localDraft.handoffToQueue({
+                        operationLabel: label,
+                    });
+                    if (handoff.status === 'error') {
+                        setErrorMessage(
+                            getQueueHandoffErrorMessage(handoff.reason),
+                        );
+                        setRequiresRefresh(
+                            handoff.reason === 'server_confirmed' ||
+                                handoff.reason === 'incompatible' ||
+                                handoff.reason === 'queue_conflict' ||
+                                handoff.reason === 'draft_changed',
+                        );
+                        requestAnimationFrame(() => errorRef.current?.focus());
+                        return;
+                    }
+                    if (handoff.status === 'existing') {
+                        return;
+                    }
+                    setSuccessMessage(
+                        `Radnja „${label}” sigurno je spremljena samo na ovom uređaju. Poslat će se kada ponovno otvoriš aplikaciju uz internetsku vezu.`,
+                    );
+                    setSuccessNeedsScheduleRefresh(false);
+                    return;
+                }
+
+                const preparation = await localDraft.prepareSubmission();
+                if (preparation.status === 'error') {
                     setErrorMessage(
-                        getQueueHandoffErrorMessage(handoff.reason),
+                        getLocalDraftSaveErrorMessage(preparation.reason),
                     );
                     setRequiresRefresh(
-                        handoff.reason === 'server_confirmed' ||
-                            handoff.reason === 'incompatible' ||
-                            handoff.reason === 'queue_conflict' ||
-                            handoff.reason === 'draft_changed',
+                        preparation.reason === 'draft_changed' ||
+                            preparation.reason === 'incompatible',
                     );
                     requestAnimationFrame(() => errorRef.current?.focus());
                     return;
                 }
-                if (handoff.status === 'existing') {
-                    return;
-                }
-                setSuccessMessage(
-                    navigator.onLine
-                        ? `Radnja „${label}” sigurno je spremljena na ovom uređaju i čeka potvrdu farme.`
-                        : `Radnja „${label}” sigurno je spremljena samo na ovom uređaju. Poslat će se kada ponovno otvoriš aplikaciju uz internetsku vezu.`,
-                );
-                setSuccessNeedsScheduleRefresh(false);
-                return;
+                submissionId = preparation.submissionId;
             }
             let result: Awaited<ReturnType<typeof completeFarmOperation>>;
             if (attachImages && uploadItems.length > 0) {
@@ -670,7 +743,10 @@ export function CompleteOperationModal({
                         continue;
                     }
 
-                    const uploadResult = await uploadImage(uploadItem);
+                    const uploadResult = await uploadImage(
+                        uploadItem,
+                        submissionId,
+                    );
                     if (uploadResult.failure) {
                         setErrorMessage(uploadResult.failure.message);
                         setRequiresRefresh(!uploadResult.failure.canRetry);
@@ -694,6 +770,7 @@ export function CompleteOperationModal({
                     expectedRequirementsFingerprint,
                     imageUrls,
                     completionNotes,
+                    submissionId,
                 );
             } else {
                 result = await completeFarmOperation(
@@ -703,6 +780,7 @@ export function CompleteOperationModal({
                     expectedRequirementsFingerprint,
                     undefined,
                     completionNotes,
+                    submissionId,
                 );
             }
             if (!result.success) {

--- a/apps/farm/app/schedule/CompleteOperationModal.tsx
+++ b/apps/farm/app/schedule/CompleteOperationModal.tsx
@@ -630,7 +630,7 @@ export function CompleteOperationModal({
             submissionInFlightRef.current = true;
             setIsSubmitting(true);
             const completionNotes = attachNotes ? trimmedNotes : undefined;
-            if (completionSync?.mode === 'enabled') {
+            if (completionSync?.mode === 'enabled' && !navigator.onLine) {
                 const handoff = await localDraft.handoffToQueue({
                     operationLabel: label,
                 });

--- a/apps/farm/app/schedule/useOperationCompletionDraft.ts
+++ b/apps/farm/app/schedule/useOperationCompletionDraft.ts
@@ -72,6 +72,16 @@ export type OperationCompletionDraftHandoffInput = {
     scheduleDateKey?: string;
 };
 
+export type PrepareOperationCompletionDraftSubmissionResult =
+    | { status: 'ready'; submissionId: string }
+    | {
+          reason: Extract<
+              SaveOperationCompletionDraftResult,
+              { status: 'error' }
+          >['reason'];
+          status: 'error';
+      };
+
 function photoSignature(photos: OperationCompletionDraftPhotoInput[]) {
     return photos
         .map(
@@ -486,6 +496,96 @@ export function useOperationCompletionDraft({
         [markSessionChanged, scope, scopeIdentity, showQueueGate],
     );
 
+    const prepareSubmission =
+        useCallback(async (): Promise<PrepareOperationCompletionDraftSubmissionResult> => {
+            const generation = generationRef.current;
+            const lease = leaseRef.current;
+            if (saveTimerRef.current) {
+                clearTimeout(saveTimerRef.current);
+                saveTimerRef.current = null;
+            }
+            if (!lease) {
+                markSessionChanged();
+                return { reason: 'session_changed', status: 'error' };
+            }
+
+            let preparation: PrepareOperationCompletionDraftSubmissionResult = {
+                reason: 'storage_unavailable',
+                status: 'error',
+            };
+            writeQueueRef.current = writeQueueRef.current
+                .catch(() => undefined)
+                .then(async () => {
+                    if (generationRef.current !== generation) {
+                        preparation = {
+                            reason: 'session_changed',
+                            status: 'error',
+                        };
+                        return;
+                    }
+                    const currentForm = {
+                        notes: latestFormRef.current.notes,
+                        photos: [...latestFormRef.current.photos],
+                    };
+                    const result = await saveOperationCompletionDraft(
+                        {
+                            ...scope,
+                            notes: currentForm.notes,
+                            photos: currentForm.photos,
+                        },
+                        {
+                            expectedRevisionId:
+                                persistedRevisionByScopeRef.current.get(
+                                    scopeIdentity,
+                                ) ?? null,
+                            lease,
+                            preserveEmpty: true,
+                        },
+                    );
+                    if (generationRef.current !== generation) {
+                        preparation = {
+                            reason: 'session_changed',
+                            status: 'error',
+                        };
+                        return;
+                    }
+                    if (result.status === 'error') {
+                        preparation = result;
+                        if (result.reason === 'session_changed') {
+                            markSessionChanged();
+                        } else {
+                            updateSaveState(
+                                { kind: 'error', reason: result.reason },
+                                generation,
+                            );
+                        }
+                        return;
+                    }
+                    if (!result.draftId || !result.revisionId) {
+                        preparation = {
+                            reason: 'storage_unavailable',
+                            status: 'error',
+                        };
+                        updateSaveState(
+                            { kind: 'error', reason: 'storage_unavailable' },
+                            generation,
+                        );
+                        return;
+                    }
+                    persistedRevisionByScopeRef.current.set(
+                        scopeIdentity,
+                        result.revisionId,
+                    );
+                    updateSaveState({ kind: 'saved' }, generation);
+                    preparation = {
+                        status: 'ready',
+                        submissionId: result.draftId,
+                    };
+                });
+            await writeQueueRef.current;
+            return preparation;
+        }, [markSessionChanged, scope, scopeIdentity, updateSaveState]);
+
     useEffect(() => {
         if (resetScopeIdentityRef.current === scopeIdentity) {
             return;
@@ -882,6 +982,7 @@ export function useOperationCompletionDraft({
         gate,
         handoffToQueue,
         notice,
+        prepareSubmission,
         resume,
         saveState,
     };

--- a/apps/farm/lib/offline/operationCompletionDraftStore.ts
+++ b/apps/farm/lib/offline/operationCompletionDraftStore.ts
@@ -159,6 +159,7 @@ type SaveOperationCompletionDraftInput = OperationCompletionDraftScope & {
 type SaveOperationCompletionDraftOptions = {
     expectedRevisionId?: string | null;
     lease?: OperationCompletionDraftLease;
+    preserveEmpty?: boolean;
 };
 
 type DiscardOperationCompletionDraftOptions = {
@@ -1139,7 +1140,11 @@ export async function loadOperationCompletionDraft(
 
 export async function saveOperationCompletionDraft(
     { notes, photos, ...scope }: SaveOperationCompletionDraftInput,
-    { expectedRevisionId, lease }: SaveOperationCompletionDraftOptions = {},
+    {
+        expectedRevisionId,
+        lease,
+        preserveEmpty = false,
+    }: SaveOperationCompletionDraftOptions = {},
 ): Promise<SaveOperationCompletionDraftResult> {
     const leaseResult = await resolveOperationCompletionDraftLease(
         scope.userId,
@@ -1210,7 +1215,7 @@ export async function saveOperationCompletionDraft(
                     }
                 }
 
-                if (!notes.trim() && photos.length === 0) {
+                if (!preserveEmpty && !notes.trim() && photos.length === 0) {
                     const storedValue: unknown =
                         await requestOperationCompletionStoreResult(
                             draftStore.get(key),

--- a/apps/farm/lib/offline/operationCompletionQueueStore.spec.tsx
+++ b/apps/farm/lib/offline/operationCompletionQueueStore.spec.tsx
@@ -231,6 +231,7 @@ test('atomically hands a draft to the queue, preserves File metadata, and fences
                 submissionId: queued.item.submissionId,
             },
             repeated,
+            sourceDraftId: save.draftId,
         };
     }, baseScope);
 
@@ -259,6 +260,7 @@ test('atomically hands a draft to the queue, preserves File metadata, and fences
         scheduleDateKey: '2026-07-15',
         state: 'queued',
     });
+    expect(result.queued.submissionId).toBe(result.sourceDraftId);
     expect(result.draftAfterHandoff).toEqual({
         reason: 'not_found',
         status: 'missing',

--- a/apps/farm/lib/offline/operationCompletionQueueStore.ts
+++ b/apps/farm/lib/offline/operationCompletionQueueStore.ts
@@ -800,7 +800,7 @@ export async function handoffOperationCompletionDraftToQueue(
                     serverConfirmedAt: null,
                     serverState: null,
                     state: 'queued',
-                    submissionId: newId(),
+                    submissionId: draft?.draftId ?? newId(),
                     updatedAt: now,
                     writerGeneration: lease.generation,
                 };

--- a/docs/farm-offline-operation-completion.md
+++ b/docs/farm-offline-operation-completion.md
@@ -3,9 +3,10 @@
 ## Summary
 
 Farm operators can finish a scheduled operation with notes and photographs even
-when connectivity is unavailable or unreliable. The Farm app first stores one
-immutable completion command on the current device and then sends that same
-command when the authenticated app is open with connectivity.
+when connectivity is unavailable. With connectivity, the Farm app uploads the
+photographs and confirms the operation directly. Without connectivity, it
+stores one immutable completion command on the current device and sends that
+same command when the authenticated app is open with connectivity.
 
 This workflow covers operation completion only. Planting completion, blocker
 reports, schedule caching, service-worker background synchronization, and farm
@@ -33,7 +34,7 @@ selection are outside its scope.
 | --- | --- | --- | --- |
 | `off` | Uses the legacy online path | Does not drain | Existing records remain visible for recovery |
 | `drain_only` | Uses the legacy online path | Drains in the foreground | Queue and resolution UI remain visible |
-| `enabled` | Persists before any network work | Drains in the foreground | Full queue and resolution UI |
+| `enabled` | Persists offline confirmations before network work; online confirmations upload directly | Drains in the foreground | Full queue and resolution UI |
 
 Production, development, and test default to `enabled` while Farm is in its
 active pilot. A Vercel flag override can select another mode for rollback or
@@ -78,22 +79,24 @@ different facts. A `server_confirmed` submission can still have the domain state
 ## Happy path
 
 1. The modal saves notes and selected photographs as a device-local draft.
-2. **Dovrši radnju** stops and flushes pending draft writes, then atomically
-   converts that draft into a queue record. Its persisted submission UUID and
-   attachment UUIDs never change during retry.
-3. A foreground coordinator claims the record with IndexedDB compare-and-swap.
+2. With connectivity, **Dovrši radnju** uploads photographs directly, confirms
+   the operation, and removes the local draft after the server responds.
+3. Without connectivity, **Dovrši radnju** stops and flushes pending draft
+   writes, then atomically converts that draft into a queue record. Its
+   persisted submission UUID and attachment UUIDs never change during retry.
+4. A foreground coordinator claims the record with IndexedDB compare-and-swap.
    Web Locks reduce duplicate work between tabs but are not the correctness
    boundary. While slow photographs are uploading, the active coordinator
    renews the exact claim; an expired or replaced claim cannot be renewed.
-4. Each photograph uses one deterministic path derived from operation, entity,
+5. Each queued photograph uses one deterministic path derived from operation, entity,
    task version, submission UUID, and attachment UUID. Before retrying an
    uncertain upload, an authenticated recovery action checks that exact object.
-5. The completion Server Action sends the persisted submission UUID. The
+6. The queued completion Server Action sends the persisted submission UUID. The
    storage repository runs under the operation lock:
    - the same UUID and canonical command returns the original receipt;
    - the same UUID with different content is a terminal conflict;
    - a different UUID against already-terminal work is a terminal conflict.
-6. The client stores a content-free `server_confirmed` tombstone, refreshes the
+7. The client stores a content-free `server_confirmed` tombstone, refreshes the
    schedule, and reports the server receipt separately from
    `pendingVerification` or verified completion.
 
@@ -111,8 +114,8 @@ session.
 
 ## Failure handling
 
-- Offline, network, Blob transport, and server-unavailable failures return the
-  record to a retryable state with persisted bounded backoff.
+- Queued Blob transport and server-unavailable failures return the record to a
+  retryable state with persisted bounded backoff.
 - A stale `syncing` claim becomes claimable again after its lease expires.
 - Assignment, authorization, task version, requirement, target status, or
   submission-content conflicts are resolution-required. The UI preserves the
@@ -168,7 +171,8 @@ and successful receipts without joining them to private farmer content.
 
 ## Rollout and rollback
 
-1. Keep production `enabled` while Farm is in its active pilot.
+1. Keep production `enabled` while Farm is in its active pilot so offline
+   confirmations are queued and online confirmations upload directly.
 2. Record physical iOS standalone and Android Chrome results, including weak
    connectivity, background/force-close/reopen, lost response, and logout
    cases. Reopen GitHub task #4194 if a formal go/no-go gate is reinstated.

--- a/docs/farm-offline-operation-completion.md
+++ b/docs/farm-offline-operation-completion.md
@@ -79,11 +79,15 @@ different facts. A `server_confirmed` submission can still have the domain state
 ## Happy path
 
 1. The modal saves notes and selected photographs as a device-local draft.
-2. With connectivity, **Dovrši radnju** uploads photographs directly, confirms
-   the operation, and removes the local draft after the server responds.
+2. With connectivity, **Dovrši radnju** first persists a stable submission UUID
+   in the local draft, uploads photographs directly to deterministic attachment
+   paths, confirms the operation with that UUID, and removes private draft
+   content after the server responds. A lost response can therefore be retried
+   or queued without creating a different completion identity.
 3. Without connectivity, **Dovrši radnju** stops and flushes pending draft
    writes, then atomically converts that draft into a queue record. Its
-   persisted submission UUID and attachment UUIDs never change during retry.
+   persisted submission UUID (reused from the draft) and attachment UUIDs never
+   change during retry.
 4. A foreground coordinator claims the record with IndexedDB compare-and-swap.
    Web Locks reduce duplicate work between tabs but are not the correctness
    boundary. While slow photographs are uploading, the active coordinator


### PR DESCRIPTION
## What changed

- send completion photos through the direct Vercel Blob upload path while the Farm app is online
- persist a stable submission UUID before online network work and use deterministic attachment paths
- recover uncertain uploads and reuse the same submission UUID if a lost response is later queued offline
- keep the durable IndexedDB handoff and foreground replay when the browser is offline
- add mobile regression coverage for online upload, offline queueing, and lost-response recovery
- update the offline completion workflow documentation

## Root cause

The `enabled` offline-sync mode unconditionally handed every completion to the local queue before any network work. After the pilot flag was enabled in production, online confirmations therefore reported that their images were saved locally instead of attempting the foreground upload.

## Farmer impact

Farmers with connectivity can upload evidence and confirm the task immediately. Farmers who are genuinely offline retain the local queue and later foreground replay behavior. Online and offline retries share one durable submission identity, so an uncertain server response cannot create a second completion or silently accept different evidence.

## Validation

- `corepack pnpm --filter farm exec playwright test app/schedule/CompleteOperationModal.spec.tsx app/schedule/useOperationCompletionDraft.spec.tsx lib/offline/operationCompletionDraftStore.spec.tsx lib/offline/operationCompletionQueueStore.spec.tsx lib/offline/operationCompletionQueueSync.spec.tsx` — 78 passed
- `corepack pnpm lint --filter farm`
- `corepack pnpm --filter farm exec tsc --noEmit`
- `corepack pnpm --filter farm test:prepare`
- `git diff --check`