### PR TITLE
fix(garden): refresh queries after AI actions

### DIFF
--- a/apps/garden/tests/SuncokretChatHudStory.tsx
+++ b/apps/garden/tests/SuncokretChatHudStory.tsx
@@ -3,6 +3,7 @@ import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
 import { useMemo } from 'react';
 import { GameFlagsContext } from '../../../packages/game/src/GameFlagsContext';
 import { currentGardenKeys } from '../../../packages/game/src/hooks/useCurrentGarden';
+import { useShoppingCartQueryKey } from '../../../packages/game/src/hooks/useShoppingCart';
 import { SuncokretChatHud } from '../../../packages/game/src/hud/SuncokretChatHud';
 import {
     SuncokretChatProvider,
@@ -87,17 +88,34 @@ function createQueryClient() {
     return queryClient;
 }
 
+function ShoppingCartQueryProbe() {
+    const { data = 'učitavanje' } = ReactQuery.useQuery({
+        queryKey: useShoppingCartQueryKey,
+        queryFn: async () => {
+            const response = await fetch('/api/test/suncokret-shopping-cart');
+            if (!response.ok) {
+                throw new Error('Shopping-cart test query failed');
+            }
+            return response.text();
+        },
+    });
+
+    return <output aria-label="Verzija košarice">{data}</output>;
+}
+
 export function SuncokretChatHudStory({
     contextTarget,
     debug = false,
     fieldUiTarget,
     focusedRaisedBed = false,
+    observeShoppingCart = false,
     settingsSection,
 }: {
     contextTarget?: SuncokretChatTarget;
     debug?: boolean;
     fieldUiTarget?: SuncokretChatTarget;
     focusedRaisedBed?: boolean;
+    observeShoppingCart?: boolean;
     settingsSection?: string;
 }) {
     const queryClient = useMemo(createQueryClient, []);
@@ -131,6 +149,9 @@ export function SuncokretChatHudStory({
                         }}
                     >
                         <SuncokretChatProvider>
+                            {observeShoppingCart ? (
+                                <ShoppingCartQueryProbe />
+                            ) : null}
                             {fieldUiTarget ? (
                                 <GameModal open title="Kartica biljke">
                                     <SuncokretChatTrigger

--- a/apps/garden/tests/suncokret-chat-hud.spec.tsx
+++ b/apps/garden/tests/suncokret-chat-hud.spec.tsx
@@ -664,3 +664,56 @@ test('completed AI cart actions refresh the active shopping-cart query', async (
     expect(chatRequests).toBe(2);
     expect(cartReads).toBe(2);
 });
+
+test('completed AI cart actions refresh after a later stream error', async ({
+    mount,
+    page,
+}) => {
+    await mockSuncokretRoutes(page);
+    let cartReads = 0;
+    await page.route('**/api/test/suncokret-shopping-cart', async (route) => {
+        cartReads += 1;
+        await route.fulfill({ body: cartReads.toString() });
+    });
+    await page.route('**/api/ai/suncokret/chat', async (route) => {
+        await route.fulfill({
+            body: uiMessageStream([
+                { type: 'start', messageId: 'assistant-cart-error' },
+                { type: 'start-step' },
+                {
+                    type: 'tool-input-available',
+                    toolCallId: 'cart-call-error',
+                    toolName: 'addProductToCart',
+                    input: {
+                        productId: 'plant-sort-458',
+                        quantity: 1,
+                    },
+                },
+                {
+                    type: 'tool-output-available',
+                    toolCallId: 'cart-call-error',
+                    output: { cartItemId: 43 },
+                },
+                {
+                    type: 'error',
+                    errorText:
+                        'Model follow-up failed after the tool completed',
+                },
+            ]),
+            headers: {
+                'content-type': 'text/event-stream',
+                'x-vercel-ai-ui-message-stream': 'v1',
+            },
+        });
+    });
+
+    await mount(<SuncokretChatHudStory observeShoppingCart />);
+    await expect(page.getByLabel('Verzija košarice')).toHaveText('1');
+
+    await page.getByRole('button', { name: 'Suncokret AI' }).click();
+    await page.getByLabel('Pitaj Suncokret').fill('Dodaj bosiljak');
+    await page.getByRole('button', { name: 'Pošalji' }).click();
+
+    await expect(page.getByLabel('Verzija košarice')).toHaveText('2');
+    expect(cartReads).toBe(2);
+});

--- a/apps/garden/tests/suncokret-chat-hud.spec.tsx
+++ b/apps/garden/tests/suncokret-chat-hud.spec.tsx
@@ -585,3 +585,82 @@ test('approving a tool automatically continues the conversation', async ({
     await expect.poll(() => requestBodies.length).toBe(2);
     expect(JSON.stringify(requestBodies[1])).toContain('approval-responded');
 });
+
+test('completed AI cart actions refresh the active shopping-cart query', async ({
+    mount,
+    page,
+}) => {
+    await mockSuncokretRoutes(page);
+    let cartReads = 0;
+    let chatRequests = 0;
+    await page.route('**/api/test/suncokret-shopping-cart', async (route) => {
+        cartReads += 1;
+        await route.fulfill({ body: cartReads.toString() });
+    });
+    await page.route('**/api/ai/suncokret/chat', async (route) => {
+        chatRequests += 1;
+        const chunks =
+            chatRequests === 1
+                ? [
+                      { type: 'start', messageId: 'assistant-cart-approval' },
+                      { type: 'start-step' },
+                      {
+                          type: 'tool-input-available',
+                          toolCallId: 'cart-call-1',
+                          toolName: 'addProductToCart',
+                          input: {
+                              productId: 'plant-sort-458',
+                              quantity: 1,
+                          },
+                      },
+                      {
+                          type: 'tool-approval-request',
+                          approvalId: 'approval-cart-1',
+                          toolCallId: 'cart-call-1',
+                      },
+                      { type: 'finish-step' },
+                      { type: 'finish', finishReason: 'tool-calls' },
+                  ]
+                : [
+                      { type: 'start', messageId: 'assistant-cart-result' },
+                      { type: 'start-step' },
+                      {
+                          type: 'tool-output-available',
+                          toolCallId: 'cart-call-1',
+                          output: { cartItemId: 42 },
+                      },
+                      { type: 'text-start', id: 'text-cart-result' },
+                      {
+                          type: 'text-delta',
+                          id: 'text-cart-result',
+                          delta: 'Dodano u košaricu.',
+                      },
+                      { type: 'text-end', id: 'text-cart-result' },
+                      { type: 'finish-step' },
+                      { type: 'finish', finishReason: 'stop' },
+                  ];
+        await route.fulfill({
+            body: uiMessageStream(chunks),
+            headers: {
+                'content-type': 'text/event-stream',
+                'x-vercel-ai-ui-message-stream': 'v1',
+            },
+        });
+    });
+
+    await mount(<SuncokretChatHudStory observeShoppingCart />);
+    await expect(page.getByLabel('Verzija košarice')).toHaveText('1');
+
+    await page.getByRole('button', { name: 'Suncokret AI' }).click();
+    await page.getByLabel('Pitaj Suncokret').fill('Dodaj bosiljak');
+    await page.getByRole('button', { name: 'Pošalji' }).click();
+    await expect(page.getByRole('button', { name: 'Dopusti' })).toBeVisible();
+    await expect(page.getByLabel('Verzija košarice')).toHaveText('1');
+    expect(cartReads).toBe(1);
+
+    await page.getByRole('button', { name: 'Dopusti' }).click();
+
+    await expect(page.getByLabel('Verzija košarice')).toHaveText('2');
+    expect(chatRequests).toBe(2);
+    expect(cartReads).toBe(2);
+});

--- a/packages/game/src/hud/SuncokretChatHud.tsx
+++ b/packages/game/src/hud/SuncokretChatHud.tsx
@@ -29,6 +29,7 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
+import { useQueryClient } from '@tanstack/react-query';
 import {
     DefaultChatTransport,
     lastAssistantMessageIsCompleteWithApprovalResponses,
@@ -66,6 +67,7 @@ import {
     suncokretContextSuggestions,
     suncokretConversationLabel,
 } from './suncokretChatContext';
+import { invalidateSuncokretMutationQueries } from './suncokretChatQueryInvalidation';
 
 type SuncokretLimit = {
     retryAt: string;
@@ -797,6 +799,7 @@ function ChatMessage({
 }
 
 export function SuncokretChatHud() {
+    const queryClient = useQueryClient();
     const flags = useGameFlags();
     const debug = Boolean(flags.enableSuncokretDebugFlag);
     const chat = useSuncokretChat();
@@ -929,6 +932,17 @@ export function SuncokretChatHud() {
         id: chatSessionId,
         transport,
         experimental_throttle: 80,
+        onFinish: ({ isAbort, isDisconnect, isError, message }) => {
+            if (isAbort || isDisconnect || isError) {
+                return;
+            }
+
+            void invalidateSuncokretMutationQueries({
+                fallbackRaisedBedId: contextRaisedBedId,
+                message,
+                queryClient,
+            });
+        },
         sendAutomaticallyWhen:
             lastAssistantMessageIsCompleteWithApprovalResponses,
     });

--- a/packages/game/src/hud/SuncokretChatHud.tsx
+++ b/packages/game/src/hud/SuncokretChatHud.tsx
@@ -882,6 +882,7 @@ export function SuncokretChatHud() {
         raisedBedId: contextRaisedBedId,
         uiContext,
     });
+    const requestRaisedBedIdRef = useRef(contextRaisedBedId);
     requestContextRef.current = {
         conversationId: activeConversationId,
         debug,
@@ -900,6 +901,7 @@ export function SuncokretChatHud() {
                 credentials: 'include',
                 prepareSendMessagesRequest: ({ id, messages }) => {
                     const requestContext = requestContextRef.current;
+                    requestRaisedBedIdRef.current = requestContext.raisedBedId;
                     return {
                         body: {
                             id,
@@ -932,13 +934,9 @@ export function SuncokretChatHud() {
         id: chatSessionId,
         transport,
         experimental_throttle: 80,
-        onFinish: ({ isAbort, isDisconnect, isError, message }) => {
-            if (isAbort || isDisconnect || isError) {
-                return;
-            }
-
+        onFinish: ({ message }) => {
             void invalidateSuncokretMutationQueries({
-                fallbackRaisedBedId: contextRaisedBedId,
+                fallbackRaisedBedId: requestRaisedBedIdRef.current,
                 message,
                 queryClient,
             });

--- a/packages/game/src/hud/suncokretChatQueryInvalidation.ts
+++ b/packages/game/src/hud/suncokretChatQueryInvalidation.ts
@@ -1,0 +1,100 @@
+import type { QueryClient, QueryKey } from '@tanstack/react-query';
+import { queryKeys as raisedBedAiHistoryQueryKeys } from '../hooks/useRaisedBedAiHistory';
+import { queryKeys as raisedBedDiaryQueryKeys } from '../hooks/useRaisedBedDiaryEntries';
+import { useShoppingCartQueryKey } from '../hooks/useShoppingCart';
+import { tutorialChecklistKeys } from '../hooks/useTutorialChecklist';
+
+const shoppingCartMutationTools = new Set([
+    'addProductToCart',
+    'addOperationToCart',
+    'updateCartItem',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function completedToolName(part: unknown) {
+    if (!isRecord(part) || part.state !== 'output-available') {
+        return null;
+    }
+
+    const type = typeof part.type === 'string' ? part.type : '';
+    if (type === 'dynamic-tool') {
+        return typeof part.toolName === 'string' ? part.toolName : null;
+    }
+
+    return type.startsWith('tool-') ? type.replace(/^tool-/, '') : null;
+}
+
+function raisedBedIdFromToolPart(
+    part: Record<string, unknown>,
+    fallbackRaisedBedId: number | null,
+) {
+    const input = isRecord(part.input) ? part.input : null;
+    const raisedBedId = input?.raisedBedId;
+    return typeof raisedBedId === 'number' && Number.isInteger(raisedBedId)
+        ? raisedBedId
+        : fallbackRaisedBedId;
+}
+
+export function suncokretMutationQueryKeys({
+    fallbackRaisedBedId = null,
+    message,
+}: {
+    fallbackRaisedBedId?: number | null;
+    message: { parts: readonly unknown[] };
+}) {
+    let shoppingCartChanged = false;
+    const analyzedRaisedBedIds = new Set<number>();
+
+    for (const part of message.parts) {
+        const name = completedToolName(part);
+        if (!name || !isRecord(part)) {
+            continue;
+        }
+
+        if (shoppingCartMutationTools.has(name)) {
+            shoppingCartChanged = true;
+        }
+
+        if (name === 'analyzeRaisedBedImages') {
+            const raisedBedId = raisedBedIdFromToolPart(
+                part,
+                fallbackRaisedBedId,
+            );
+            if (raisedBedId !== null) {
+                analyzedRaisedBedIds.add(raisedBedId);
+            }
+        }
+    }
+
+    const queryKeys: QueryKey[] = [];
+    if (shoppingCartChanged) {
+        queryKeys.push(useShoppingCartQueryKey, tutorialChecklistKeys);
+    }
+    for (const raisedBedId of analyzedRaisedBedIds) {
+        queryKeys.push(
+            raisedBedDiaryQueryKeys.byId(raisedBedId),
+            raisedBedAiHistoryQueryKeys.byId(raisedBedId),
+        );
+    }
+
+    return queryKeys;
+}
+
+export async function invalidateSuncokretMutationQueries({
+    fallbackRaisedBedId,
+    message,
+    queryClient,
+}: {
+    fallbackRaisedBedId?: number | null;
+    message: { parts: readonly unknown[] };
+    queryClient: QueryClient;
+}) {
+    await Promise.all(
+        suncokretMutationQueryKeys({ fallbackRaisedBedId, message }).map(
+            (queryKey) => queryClient.invalidateQueries({ queryKey }),
+        ),
+    );
+}

--- a/packages/game/src/hud/suncokretChatQueryInvalidation.unit.ts
+++ b/packages/game/src/hud/suncokretChatQueryInvalidation.unit.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { suncokretMutationQueryKeys } from './suncokretChatQueryInvalidation';
+
+function messageWith(...parts: Record<string, unknown>[]) {
+    return { parts };
+}
+
+test('completed shopping-cart tools refresh the cart and tutorial queries once', () => {
+    assert.deepStrictEqual(
+        suncokretMutationQueryKeys({
+            message: messageWith(
+                {
+                    type: 'tool-addProductToCart',
+                    state: 'output-available',
+                },
+                {
+                    type: 'tool-updateCartItem',
+                    state: 'output-available',
+                },
+            ),
+        }),
+        [['shopping-cart'], ['accounts', 'current', 'tutorial-checklist']],
+    );
+});
+
+test('approval, denial, and error states do not refresh mutation queries', () => {
+    for (const state of [
+        'approval-requested',
+        'approval-responded',
+        'output-denied',
+        'output-error',
+    ]) {
+        assert.deepStrictEqual(
+            suncokretMutationQueryKeys({
+                message: messageWith({
+                    type: 'tool-addOperationToCart',
+                    state,
+                }),
+            }),
+            [],
+        );
+    }
+});
+
+test('raised-bed image analysis refreshes the related diary and AI history', () => {
+    assert.deepStrictEqual(
+        suncokretMutationQueryKeys({
+            fallbackRaisedBedId: 11,
+            message: messageWith({
+                type: 'tool-analyzeRaisedBedImages',
+                state: 'output-available',
+                input: {},
+            }),
+        }),
+        [
+            ['raisedBeds', 11, 'diary'],
+            ['raisedBeds', 11, 'ai-history'],
+        ],
+    );
+
+    assert.deepStrictEqual(
+        suncokretMutationQueryKeys({
+            fallbackRaisedBedId: 11,
+            message: messageWith({
+                type: 'tool-analyzeRaisedBedImages',
+                state: 'output-available',
+                input: { raisedBedId: 12 },
+            }),
+        }),
+        [
+            ['raisedBeds', 12, 'diary'],
+            ['raisedBeds', 12, 'ai-history'],
+        ],
+    );
+});
+
+test('read-only and presentation tools leave cached data alone', () => {
+    assert.deepStrictEqual(
+        suncokretMutationQueryKeys({
+            message: messageWith(
+                {
+                    type: 'tool-getCart',
+                    state: 'output-available',
+                },
+                {
+                    type: 'dynamic-tool',
+                    toolName: 'listGardenOperations',
+                    state: 'output-available',
+                },
+                {
+                    type: 'tool-presentRecommendations',
+                    state: 'output-available',
+                },
+            ),
+        }),
+        [],
+    );
+});


### PR DESCRIPTION
## What changed

- refresh React Query data after successful Suncokret mutation tool outputs
- invalidate the shopping cart and tutorial checklist after AI cart changes
- invalidate raised-bed diary and AI history after AI image analysis
- keep approvals, denials, failures, and read-only tools from causing unnecessary refetches
- cover the query-key mapping with unit tests and the approval-to-cart-refetch flow with a component browser test

## Why

Suncokret executes its tools on the server, bypassing the client mutation hooks that normally invalidate Garden queries. The server-side cart was updated, but the five-minute client cache remained current until a page refresh.

## User impact

The shopping cart now appears or updates immediately after the user approves and Suncokret completes a cart action. Other current AI-backed mutations refresh their related Garden data through the same explicit mapping.

## Validation

- `pnpm --filter @gredice/game test` (854 passed)
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter garden build`
- `pnpm --filter garden exec playwright test tests/suncokret-chat-hud.spec.tsx --project=chromium` (12 passed)
- focused Biome checks
- `git diff --check`
