### PR TITLE
feat(www): show seeds on plant sort pages

### DIFF
--- a/apps/www/app/api/revalidate/directories/revalidationPaths.ts
+++ b/apps/www/app/api/revalidate/directories/revalidationPaths.ts
@@ -1,0 +1,95 @@
+export type PublicDirectoryEntityType =
+    | 'block'
+    | 'brand'
+    | 'plant'
+    | 'plantDisease'
+    | 'plantPest'
+    | 'plantSort'
+    | 'operation'
+    | 'seed';
+
+export type RevalidationPath = {
+    path: string;
+    type?: 'page' | 'layout';
+};
+
+const revalidationPathsByEntityType: Record<
+    PublicDirectoryEntityType,
+    RevalidationPath[]
+> = {
+    block: [{ path: '/blokovi' }, { path: '/blokovi/[alias]', type: 'page' }],
+    brand: [
+        { path: '/sjeme' },
+        { path: '/sjeme/[slug]', type: 'page' },
+        { path: '/sjeme/brendovi' },
+        { path: '/sjeme/brend/[slug]', type: 'page' },
+    ],
+    plant: [
+        { path: '/' },
+        { path: '/biljke' },
+        { path: '/biljke/[alias]', type: 'page' },
+        { path: '/biljke/[alias]/sorte/[sortAlias]', type: 'page' },
+        { path: '/blokovi' },
+        { path: '/blokovi/biljke' },
+        { path: '/blokovi/biljke/[alias]', type: 'page' },
+        { path: '/radnje/[alias]', type: 'page' },
+        { path: '/cjenik' },
+        { path: '/sjeme' },
+        { path: '/sjeme/[slug]', type: 'page' },
+        { path: '/sjeme/brend/[slug]', type: 'page' },
+    ],
+    plantDisease: [
+        { path: '/bolesti' },
+        { path: '/bolesti/[alias]', type: 'page' },
+        { path: '/biljke/[alias]', type: 'page' },
+    ],
+    plantPest: [
+        { path: '/stetnici' },
+        { path: '/stetnici/[alias]', type: 'page' },
+        { path: '/biljke/[alias]', type: 'page' },
+    ],
+    plantSort: [
+        { path: '/' },
+        { path: '/biljke/[alias]', type: 'page' },
+        { path: '/biljke/[alias]/sorte/[sortAlias]', type: 'page' },
+        { path: '/blokovi/biljke/[alias]', type: 'page' },
+        { path: '/sjeme' },
+        { path: '/sjeme/[slug]', type: 'page' },
+        { path: '/sjeme/brend/[slug]', type: 'page' },
+    ],
+    operation: [
+        { path: '/radnje' },
+        { path: '/radnje/[alias]', type: 'page' },
+        { path: '/biljke/[alias]', type: 'page' },
+        { path: '/sjetva' },
+        { path: '/cjenik' },
+    ],
+    seed: [
+        { path: '/sjeme' },
+        { path: '/sjeme/[slug]', type: 'page' },
+        { path: '/sjeme/brendovi' },
+        { path: '/sjeme/brend/[slug]', type: 'page' },
+        { path: '/biljke/[alias]/sorte/[sortAlias]', type: 'page' },
+    ],
+};
+
+export function collectRevalidationPaths(
+    entityTypes: PublicDirectoryEntityType[],
+) {
+    const paths: RevalidationPath[] = [];
+    const pathKeys = new Set<string>();
+
+    for (const entityType of entityTypes) {
+        for (const revalidationPath of revalidationPathsByEntityType[
+            entityType
+        ]) {
+            const key = `${revalidationPath.type ?? 'path'}:${revalidationPath.path}`;
+            if (!pathKeys.has(key)) {
+                pathKeys.add(key);
+                paths.push(revalidationPath);
+            }
+        }
+    }
+
+    return paths;
+}

--- a/apps/www/app/api/revalidate/directories/route.ts
+++ b/apps/www/app/api/revalidate/directories/route.ts
@@ -1,78 +1,9 @@
 import { revalidatePath } from 'next/cache';
 import { type NextRequest, NextResponse } from 'next/server';
-
-type PublicDirectoryEntityType =
-    | 'block'
-    | 'brand'
-    | 'plant'
-    | 'plantDisease'
-    | 'plantPest'
-    | 'plantSort'
-    | 'operation'
-    | 'seed';
-type RevalidationPath = {
-    path: string;
-    type?: 'page' | 'layout';
-};
-
-const revalidationPathsByEntityType: Record<
-    PublicDirectoryEntityType,
-    RevalidationPath[]
-> = {
-    block: [{ path: '/blokovi' }, { path: '/blokovi/[alias]', type: 'page' }],
-    brand: [
-        { path: '/sjeme' },
-        { path: '/sjeme/[slug]', type: 'page' },
-        { path: '/sjeme/brendovi' },
-        { path: '/sjeme/brend/[slug]', type: 'page' },
-    ],
-    plant: [
-        { path: '/' },
-        { path: '/biljke' },
-        { path: '/biljke/[alias]', type: 'page' },
-        { path: '/biljke/[alias]/sorte/[sortAlias]', type: 'page' },
-        { path: '/blokovi' },
-        { path: '/blokovi/biljke' },
-        { path: '/blokovi/biljke/[alias]', type: 'page' },
-        { path: '/radnje/[alias]', type: 'page' },
-        { path: '/cjenik' },
-        { path: '/sjeme' },
-        { path: '/sjeme/[slug]', type: 'page' },
-        { path: '/sjeme/brend/[slug]', type: 'page' },
-    ],
-    plantDisease: [
-        { path: '/bolesti' },
-        { path: '/bolesti/[alias]', type: 'page' },
-        { path: '/biljke/[alias]', type: 'page' },
-    ],
-    plantPest: [
-        { path: '/stetnici' },
-        { path: '/stetnici/[alias]', type: 'page' },
-        { path: '/biljke/[alias]', type: 'page' },
-    ],
-    plantSort: [
-        { path: '/' },
-        { path: '/biljke/[alias]', type: 'page' },
-        { path: '/biljke/[alias]/sorte/[sortAlias]', type: 'page' },
-        { path: '/blokovi/biljke/[alias]', type: 'page' },
-        { path: '/sjeme' },
-        { path: '/sjeme/[slug]', type: 'page' },
-        { path: '/sjeme/brend/[slug]', type: 'page' },
-    ],
-    operation: [
-        { path: '/radnje' },
-        { path: '/radnje/[alias]', type: 'page' },
-        { path: '/biljke/[alias]', type: 'page' },
-        { path: '/sjetva' },
-        { path: '/cjenik' },
-    ],
-    seed: [
-        { path: '/sjeme' },
-        { path: '/sjeme/[slug]', type: 'page' },
-        { path: '/sjeme/brendovi' },
-        { path: '/sjeme/brend/[slug]', type: 'page' },
-    ],
-};
+import {
+    collectRevalidationPaths,
+    type PublicDirectoryEntityType,
+} from './revalidationPaths';
 
 function publicDirectoryEntityType(
     value: unknown,
@@ -132,25 +63,6 @@ function revalidationSecret(request: NextRequest) {
         request.headers.get('x-revalidate-secret') ??
         request.nextUrl.searchParams.get('secret')
     );
-}
-
-function collectRevalidationPaths(entityTypes: PublicDirectoryEntityType[]) {
-    const paths: RevalidationPath[] = [];
-    const pathKeys = new Set<string>();
-
-    for (const entityType of entityTypes) {
-        for (const revalidationPath of revalidationPathsByEntityType[
-            entityType
-        ]) {
-            const key = `${revalidationPath.type ?? 'path'}:${revalidationPath.path}`;
-            if (!pathKeys.has(key)) {
-                pathKeys.add(key);
-                paths.push(revalidationPath);
-            }
-        }
-    }
-
-    return paths;
 }
 
 async function handleRevalidationRequest(request: NextRequest) {

--- a/apps/www/app/biljke/[alias]/PlantSortSeedsList.tsx
+++ b/apps/www/app/biljke/[alias]/PlantSortSeedsList.tsx
@@ -1,0 +1,54 @@
+import type { SeedData } from '@gredice/client';
+import { slug } from '@gredice/js/slug';
+import { GalleryGrid } from '@gredice/ui/Gallery';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { Suspense } from 'react';
+import { getSeedsData } from '../../../lib/seeds/getSeedsData';
+import { SeedCard } from '../../sjeme/SeedCard';
+import { selectSeedsForPlantSort } from './plantSortSeeds';
+
+function PlantSortSeedCard({ seed }: { id: string; seed: SeedData }) {
+    return <SeedCard seed={seed} />;
+}
+
+async function PlantSortSeedsListContent({
+    plantSortId,
+}: {
+    plantSortId: number;
+}) {
+    const seeds = selectSeedsForPlantSort(await getSeedsData(), plantSortId);
+
+    if (seeds.length === 0) {
+        return null;
+    }
+
+    const items = seeds.map((seed) => ({
+        id: seed.id.toString(),
+        seed,
+    }));
+    const headingId = slug('Sjeme');
+
+    return (
+        <section aria-labelledby={headingId}>
+            <Stack spacing={4}>
+                <Typography level="h2" className="text-2xl" id={headingId}>
+                    Sjeme
+                </Typography>
+                <GalleryGrid items={items} itemComponent={PlantSortSeedCard} />
+            </Stack>
+        </section>
+    );
+}
+
+export function PlantSortSeedsList({ plantSortId }: { plantSortId: number }) {
+    return (
+        <Suspense
+            fallback={
+                <Typography level="body2">Učitavanje sjemena...</Typography>
+            }
+        >
+            <PlantSortSeedsListContent plantSortId={plantSortId} />
+        </Suspense>
+    );
+}

--- a/apps/www/app/biljke/[alias]/plantSortSeeds.ts
+++ b/apps/www/app/biljke/[alias]/plantSortSeeds.ts
@@ -1,0 +1,22 @@
+type SeedWithPlantSort = {
+    information: {
+        name: string;
+        plantSort: {
+            id: number;
+        };
+    };
+};
+
+export function selectSeedsForPlantSort<TSeed extends SeedWithPlantSort>(
+    seeds: TSeed[],
+    plantSortId: number,
+): TSeed[] {
+    return seeds
+        .filter((seed) => seed.information.plantSort.id === plantSortId)
+        .toSorted((left, right) =>
+            left.information.name.localeCompare(
+                right.information.name,
+                'hr-HR',
+            ),
+        );
+}

--- a/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
@@ -24,6 +24,7 @@ import {
     hasPlantRelationships,
     PlantRelationshipsSection,
 } from '../../PlantRelationshipsSection';
+import { PlantSortSeedsList } from '../../PlantSortSeedsList';
 import { PlantTips } from '../../PlantTips';
 import { SowingAttributeCards } from '../../SowingAttributeCards';
 import { WateringAttributeCards } from '../../WateringAttributeCards';
@@ -312,6 +313,7 @@ export default async function PlantSortPage(
                     }}
                     relationships={relationships}
                 />
+                <PlantSortSeedsList plantSortId={sortData.id} />
                 <Row spacing={4}>
                     <Typography level="body1">
                         Jesu li ti informacije o ovoj biljci korisne?

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -21,7 +21,7 @@
         "test:preview-backfill": "node --experimental-strip-types --test ./app/vrtovi/publicGardenPreviewBackfill.unit.ts",
         "test:wallpapers": "node --experimental-strip-types --test ./app/pozadine/wallpaperComposer.node.spec.ts ./app/pozadine/macOSDynamicWallpaper.node.spec.ts",
         "test:plant-operation-stages": "node --experimental-strip-types --test ./tests/plantOperationStageAvailability.node.spec.ts",
-        "test:seeds": "node --experimental-strip-types --test ./app/sjeme/seedPresentation.node.spec.ts ./tests/plantSortSeeds.node.spec.ts",
+        "test:seeds": "node --experimental-strip-types --test ./app/sjeme/seedPresentation.node.spec.ts ./tests/directoryRevalidationPaths.node.spec.ts ./tests/plantSortSeeds.node.spec.ts",
         "test:cms-pages": "node --experimental-strip-types --test ./tests/cmsPages.node.spec.ts ./lib/plants/qualityHarvestSafetyFaq.node.spec.ts",
         "test-ui": "pnpm run test:prepare && playwright test --project=chromium --ui",
         "generate-playwright": "node ./generate/populate-test-cases.js && playwright test --config playwright-generate.config.ts",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -21,7 +21,7 @@
         "test:preview-backfill": "node --experimental-strip-types --test ./app/vrtovi/publicGardenPreviewBackfill.unit.ts",
         "test:wallpapers": "node --experimental-strip-types --test ./app/pozadine/wallpaperComposer.node.spec.ts ./app/pozadine/macOSDynamicWallpaper.node.spec.ts",
         "test:plant-operation-stages": "node --experimental-strip-types --test ./tests/plantOperationStageAvailability.node.spec.ts",
-        "test:seeds": "node --experimental-strip-types --test ./app/sjeme/seedPresentation.node.spec.ts",
+        "test:seeds": "node --experimental-strip-types --test ./app/sjeme/seedPresentation.node.spec.ts ./tests/plantSortSeeds.node.spec.ts",
         "test:cms-pages": "node --experimental-strip-types --test ./tests/cmsPages.node.spec.ts ./lib/plants/qualityHarvestSafetyFaq.node.spec.ts",
         "test-ui": "pnpm run test:prepare && playwright test --project=chromium --ui",
         "generate-playwright": "node ./generate/populate-test-cases.js && playwright test --config playwright-generate.config.ts",

--- a/apps/www/tests/directoryRevalidationPaths.node.spec.ts
+++ b/apps/www/tests/directoryRevalidationPaths.node.spec.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { collectRevalidationPaths } from '../app/api/revalidate/directories/revalidationPaths.ts';
+
+test('seed changes revalidate plant-sort pages that render seed cards', () => {
+    assert.ok(
+        collectRevalidationPaths(['seed']).some(
+            ({ path, type }) =>
+                path === '/biljke/[alias]/sorte/[sortAlias]' && type === 'page',
+        ),
+    );
+});
+
+test('combined entity changes keep shared revalidation paths unique', () => {
+    const paths = collectRevalidationPaths(['plantSort', 'seed']);
+    const pathKeys = paths.map(({ path, type }) => `${type ?? 'path'}:${path}`);
+
+    assert.equal(new Set(pathKeys).size, pathKeys.length);
+});

--- a/apps/www/tests/plantSortSeeds.node.spec.ts
+++ b/apps/www/tests/plantSortSeeds.node.spec.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { selectSeedsForPlantSort } from '../app/biljke/[alias]/plantSortSeeds.ts';
+
+const seeds = [
+    {
+        id: 3,
+        information: {
+            name: 'Sjeme Žuta',
+            plantSort: { id: 12 },
+        },
+    },
+    {
+        id: 1,
+        information: {
+            name: 'Sjeme Abeceda',
+            plantSort: { id: 12 },
+        },
+    },
+    {
+        id: 2,
+        information: {
+            name: 'Sjeme druge sorte',
+            plantSort: { id: 99 },
+        },
+    },
+];
+
+test('selects and alphabetically orders seeds linked to the plant sort', () => {
+    assert.deepEqual(
+        selectSeedsForPlantSort(seeds, 12).map((seed) => seed.id),
+        [1, 3],
+    );
+});
+
+test('returns an empty list when the plant sort has no linked seeds', () => {
+    assert.deepEqual(selectSeedsForPlantSort(seeds, 404), []);
+});


### PR DESCRIPTION
## What changed

- add a related `Sjeme` section to public plant-sort detail pages immediately above feedback
- reuse the public seed catalogue cards and link each card to its seed detail page
- filter by the current plant-sort entity ID, order Croatian seed names alphabetically, and omit the section when no published seed is linked
- add focused relationship-selection tests to the existing seed test suite

## Why

Visitors viewing a plant variety can now discover the published seed packages connected to that exact variety without leaving the catalogue context.

## Validation

- `pnpm lint --filter www`
- `pnpm typecheck --filter www`
- `pnpm --filter www test:seeds`
- `pnpm build --filter www`
- responsive browser verification at 390 px and desktop using Artičoka Romanesco
- seed-card navigation to `/sjeme/miagra-articoka-romanesco-2g`
- Axe WCAG A/AA audit of the new section: 0 violations