### PR TITLE
Adopt Agent Plugins 1.0 packaging

### DIFF
--- a/docs/plugin-marketplaces.md
+++ b/docs/plugin-marketplaces.md
@@ -3,18 +3,21 @@
 Status: repository package prepared; official OpenAI and Anthropic submissions
 remain blocked on production OAuth and reviewer-safe end-to-end verification.
 
-Last reviewed against vendor documentation: 2026-08-03.
+Last reviewed against vendor documentation: 2026-08-08.
 
-Gredice uses one release unit at [`plugins/gredice`](../plugins/gredice): aligned
-Codex and Claude manifests, one remote MCP configuration, three skills, brand
-assets, and submission eval fixtures. Keep both manifest versions identical and
-use strict semantic versions.
+Gredice uses one release unit at [`plugins/gredice`](../plugins/gredice): an
+[Agent Plugins 1.0.0](https://agent-plugins.org) portable manifest and MCP
+configuration, retained Codex and Claude compatibility manifests, three skills,
+brand assets, and submission eval fixtures. Keep all manifest versions and MCP
+endpoints aligned and use strict semantic versions.
 
 ## Prepared in this change
 
-- [x] Package `gredice@0.1.0` with `.codex-plugin/plugin.json` and
-  `.claude-plugin/plugin.json`.
-- [x] Shared Streamable HTTP server configuration for
+- [x] Portable `gredice@0.2.0` package with root `plugin.json`, root `mcp.json`,
+  fixed `skills/` discovery, and Agent Plugins 1.0.0 schema identifiers.
+- [x] Retained `.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`, and
+  `.mcp.json` compatibility metadata for existing client installation flows.
+- [x] Aligned Streamable HTTP server configuration for
   `https://api.gredice.com/api/mcp`.
 - [x] Skills for public plant research, read-only garden review, and confirmed
   cart changes.
@@ -147,8 +150,9 @@ customer credentials or reads private garden/cart data.
 
 1. Make MCP changes backward-compatible and deploy them through the protected
    release workflow.
-2. Bump both plugin manifests together and update skills, starter prompts,
-   evals, and release notes as one unit.
+2. Bump root `plugin.json` and both client compatibility manifests together;
+   keep root `mcp.json` and `.mcp.json` on the same endpoint, then update skills,
+   starter prompts, evals, and release notes as one unit.
 3. Re-run validators and fresh-profile authenticated smokes.
 4. OpenAI requires a new tool scan, reviewed snapshot, approval, and explicit
    publication. Claude requires a new explicit version and verified catalog

--- a/plugins/gredice/.codex-plugin/plugin.json
+++ b/plugins/gredice/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "gredice",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Explore Croatian plant knowledge and work with your Gredice garden and cart.",
 	"author": {
 		"name": "Gredice",

--- a/plugins/gredice/README.md
+++ b/plugins/gredice/README.md
@@ -1,9 +1,16 @@
 # Gredice plugin
 
-This shared package prepares Gredice for installation in Codex, ChatGPT, and
-Claude. It connects to the production Streamable HTTP MCP endpoint and bundles
-three focused workflows for plant research, read-only garden review, and
-confirmed cart planning.
+This shared package prepares Gredice for installation in Codex, ChatGPT,
+Claude, and other compatible agents. It conforms to
+[Agent Plugins 1.0.0](https://agent-plugins.org) with portable root
+`plugin.json` and `mcp.json` manifests, connects to the production Streamable
+HTTP MCP endpoint, and bundles three focused workflows for plant research,
+read-only garden review, and confirmed cart planning.
+
+The `.codex-plugin`, `.claude-plugin`, and `.mcp.json` files remain packaged as
+client compatibility metadata. Portable clients discover the same skills from
+`skills/` and the same server from root `mcp.json`; all manifests share one
+version and canonical endpoint.
 
 The package does not publish either marketplace listing. MCP discovery, public
 directory data, and the published product catalog are available without
@@ -23,6 +30,10 @@ python3 /path/to/skill-creator/scripts/quick_validate.py plugins/gredice/skills/
 claude plugin validate plugins/gredice --strict
 claude plugin validate .claude-plugin/marketplace.json --strict
 ```
+
+`pnpm plugins:check` validates the closed Agent Plugins 1.0.0 manifest shapes,
+schema identifiers, fixed component locations, Streamable HTTP transport, and
+alignment with the retained Codex and Claude compatibility manifests.
 
 ## Test from this repository
 

--- a/plugins/gredice/mcp.json
+++ b/plugins/gredice/mcp.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+	"mcpServers": {
+		"gredice": {
+			"type": "streamable-http",
+			"url": "https://api.gredice.com/api/mcp"
+		}
+	}
+}

--- a/plugins/gredice/plugin.json
+++ b/plugins/gredice/plugin.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
 	"name": "gredice",
 	"version": "0.2.0",
 	"description": "Explore Croatian plant knowledge and work with your Gredice garden and cart.",
@@ -10,6 +11,5 @@
 	"homepage": "https://www.gredice.com/mcp",
 	"repository": "https://github.com/gredice/gredice",
 	"license": "AGPL-3.0-only",
-	"keywords": ["gardening", "plants", "garden", "croatia", "mcp"],
-	"mcpServers": "./.mcp.json"
+	"keywords": ["gardening", "plants", "garden", "croatia", "mcp"]
 }

--- a/scripts/check-plugins.mjs
+++ b/scripts/check-plugins.mjs
@@ -3,6 +3,22 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const CANONICAL_MCP_URL = "https://api.gredice.com/api/mcp";
+const AGENT_PLUGIN_SCHEMA =
+	"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+const AGENT_MCP_SCHEMA =
+	"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json";
+const PORTABLE_MANIFEST_FIELDS = new Set([
+	"$schema",
+	"name",
+	"version",
+	"description",
+	"author",
+	"homepage",
+	"repository",
+	"license",
+	"keywords",
+	"extensions",
+]);
 const EXPECTED_SKILLS = ["explore-plants", "plan-garden-cart", "review-garden"];
 const SEMVER =
 	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
@@ -19,6 +35,20 @@ function readJson(root, relativePath) {
 
 function readText(root, relativePath) {
 	return readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function validateClosedObject(value, allowedFields, message) {
+	invariant(
+		value && typeof value === "object" && !Array.isArray(value),
+		`${message} must be an object`,
+	);
+	const unknownFields = Object.keys(value).filter(
+		(field) => !allowedFields.has(field),
+	);
+	invariant(
+		unknownFields.length === 0,
+		`${message} has unsupported fields: ${unknownFields.join(", ")}`,
+	);
 }
 
 function catalogToolNames(root) {
@@ -78,6 +108,8 @@ function validateSkill(root, skillName, knownTools) {
 export function validatePluginPackage(
 	root = path.resolve(fileURLToPath(new URL("..", import.meta.url))),
 ) {
+	const portableManifest = readJson(root, "plugins/gredice/plugin.json");
+	const portableMcp = readJson(root, "plugins/gredice/mcp.json");
 	const codexManifest = readJson(
 		root,
 		"plugins/gredice/.codex-plugin/plugin.json",
@@ -86,15 +118,59 @@ export function validatePluginPackage(
 		root,
 		"plugins/gredice/.claude-plugin/plugin.json",
 	);
-	const mcp = readJson(root, "plugins/gredice/.mcp.json");
+	const clientMcp = readJson(root, "plugins/gredice/.mcp.json");
 	const codexMarketplace = readJson(root, ".agents/plugins/marketplace.json");
 	const claudeMarketplace = readJson(root, ".claude-plugin/marketplace.json");
-	const evals = readJson(root, "plugins/gredice/evals/openai-submission.json");
+	const evals = readJson(
+		root,
+		"plugins/gredice/evals/openai-submission.json",
+	);
 	const knownTools = catalogToolNames(root);
 
+	validateClosedObject(
+		portableManifest,
+		PORTABLE_MANIFEST_FIELDS,
+		"Portable plugin manifest",
+	);
 	invariant(
-		codexManifest.name === "gredice",
-		"Codex plugin name must be gredice",
+		portableManifest.$schema === AGENT_PLUGIN_SCHEMA,
+		"Portable plugin manifest must target Agent Plugins 1.0.0",
+	);
+	validateClosedObject(
+		portableManifest.author,
+		new Set(["name", "email", "url"]),
+		"Portable plugin author",
+	);
+	invariant(
+		Object.values(portableManifest.author).every(
+			(value) => typeof value === "string",
+		),
+		"Portable plugin author fields must be strings",
+	);
+	invariant(
+		Array.isArray(portableManifest.keywords) &&
+			portableManifest.keywords.every(
+				(keyword) => typeof keyword === "string",
+			),
+		"Portable plugin keywords must be strings",
+	);
+	if (portableManifest.extensions !== undefined) {
+		validateClosedObject(
+			portableManifest.extensions,
+			new Set(Object.keys(portableManifest.extensions)),
+			"Portable plugin extensions",
+		);
+		invariant(
+			Object.values(portableManifest.extensions).every(
+				(value) =>
+					value && typeof value === "object" && !Array.isArray(value),
+			),
+			"Portable plugin extensions must be namespaced objects",
+		);
+	}
+	invariant(
+		portableManifest.name === "gredice" && codexManifest.name === "gredice",
+		"Portable and Codex plugin names must be gredice",
 	);
 	invariant(
 		claudeManifest.name === codexManifest.name,
@@ -105,9 +181,24 @@ export function validatePluginPackage(
 		"Plugin version must use strict semver",
 	);
 	invariant(
-		claudeManifest.version === codexManifest.version,
+		portableManifest.version === codexManifest.version &&
+			claudeManifest.version === codexManifest.version,
 		"Plugin versions must match",
 	);
+	for (const field of [
+		"description",
+		"author",
+		"homepage",
+		"repository",
+		"license",
+		"keywords",
+	]) {
+		invariant(
+			JSON.stringify(portableManifest[field]) ===
+				JSON.stringify(codexManifest[field]),
+			`Portable and Codex plugin ${field} must match`,
+		);
+	}
 	invariant(
 		codexManifest.mcpServers === "./.mcp.json",
 		"Codex must use shared MCP config",
@@ -117,14 +208,54 @@ export function validatePluginPackage(
 		"Claude must use shared MCP config",
 	);
 
-	const server = mcp.mcpServers?.gredice;
-	invariant(server?.type === "http", "Gredice MCP server must use remote HTTP");
+	validateClosedObject(
+		portableMcp,
+		new Set(["$schema", "mcpServers"]),
+		"Portable MCP configuration",
+	);
 	invariant(
-		server?.url === CANONICAL_MCP_URL,
-		"Gredice MCP URL must be canonical",
+		portableMcp.$schema === AGENT_MCP_SCHEMA,
+		"Portable MCP configuration must target Agent Plugins 1.0.0",
+	);
+	validateClosedObject(
+		portableMcp.mcpServers,
+		new Set(["gredice"]),
+		"Portable MCP servers",
+	);
+	const portableServer = portableMcp.mcpServers?.gredice;
+	validateClosedObject(
+		portableServer,
+		new Set(["type", "url", "headers"]),
+		"Portable Gredice MCP server",
+	);
+	invariant(
+		portableServer.type === "streamable-http",
+		"Portable Gredice MCP server must use Streamable HTTP",
+	);
+	invariant(
+		portableServer.url === CANONICAL_MCP_URL,
+		"Portable Gredice MCP URL must be canonical",
+	);
+	invariant(
+		portableServer.headers === undefined,
+		"Portable Gredice MCP config must not package credentials or headers",
 	);
 
-	for (const field of ["websiteURL", "privacyPolicyURL", "termsOfServiceURL"]) {
+	const clientServer = clientMcp.mcpServers?.gredice;
+	invariant(
+		clientServer?.type === "http",
+		"Client-compatible Gredice MCP server must use remote HTTP",
+	);
+	invariant(
+		clientServer?.url === portableServer.url,
+		"Portable and client-compatible MCP URLs must match",
+	);
+
+	for (const field of [
+		"websiteURL",
+		"privacyPolicyURL",
+		"termsOfServiceURL",
+	]) {
 		invariant(
 			codexManifest.interface?.[field]?.startsWith("https://"),
 			`Codex interface ${field} must be an HTTPS URL`,
@@ -213,8 +344,9 @@ export function validatePluginPackage(
 	}
 
 	return {
-		plugin: codexManifest.name,
-		version: codexManifest.version,
+		plugin: portableManifest.name,
+		version: portableManifest.version,
+		standard: "Agent Plugins 1.0.0",
 		skills: EXPECTED_SKILLS.length,
 		positiveCases: evals.positive.length,
 		negativeCases: evals.negative.length,
@@ -227,6 +359,6 @@ if (
 ) {
 	const result = validatePluginPackage();
 	console.log(
-		`Plugin validation passed: ${result.plugin}@${result.version}, ${result.skills} skills, ${result.positiveCases} positive and ${result.negativeCases} negative cases.`,
+		`Plugin validation passed: ${result.plugin}@${result.version}, ${result.standard}, ${result.skills} skills, ${result.positiveCases} positive and ${result.negativeCases} negative cases.`,
 	);
 }


### PR DESCRIPTION
## What changed

- add portable root `plugin.json` and `mcp.json` manifests conforming to Agent Plugins 1.0.0
- declare the Gredice endpoint as `streamable-http` and retain the existing Codex, Claude, and `.mcp.json` compatibility files
- bump the aligned package version to `gredice@0.2.0`
- extend `plugins:check` to enforce the portable schema identifiers, closed manifest shapes, version/metadata alignment, canonical endpoint, transport, and credential-free configuration
- document the portable package and compatibility layout in the package README and publication checklist

## Why

[Vercel's Agent Plugins announcement](https://vercel.com/blog/introducing-agent-plugins) introduces the vendor-neutral Agent Plugins 1.0.0 package contract supported by ChatGPT, Codex, and other clients. The existing Gredice package only exposed client-specific manifests and `.mcp.json`; portable clients require root `plugin.json`, root `mcp.json`, fixed `skills/` discovery, canonical schema identifiers, and the `streamable-http` transport value defined by the [Agent Plugins specification](https://github.com/agentplugins/agent-plugins-spec/tree/main/spec).

The client-specific files remain in place so current repository marketplace and Claude installation flows continue working.

## Validation

- `pnpm plugins:check`
- official Agent Plugins 1.0.0 JSON Schema validation for `plugins/gredice/plugin.json`
- official Agent Plugins 1.0.0 JSON Schema validation for `plugins/gredice/mcp.json`
- plugin-creator `validate_plugin.py plugins/gredice` in an isolated PyYAML environment
- skill-creator validation for all three packaged skills
- `claude plugin validate plugins/gredice --strict`
- `claude plugin validate .claude-plugin/marketplace.json --strict`
- `git diff --check`
