### PR TITLE
fix(www): center social cards and support dark mode

### DIFF
--- a/apps/www/components/social/FacebookCard.tsx
+++ b/apps/www/components/social/FacebookCard.tsx
@@ -1,36 +1,15 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
-import { CompanyFacebook, Navigate } from '@gredice/ui/icons';
-import { cx } from '@gredice/ui/utils';
-import Link from 'next/link';
+import { CompanyFacebook } from '@gredice/ui/icons';
+import { SocialCard } from './SocialCard';
 
 export function FacebookCard() {
     return (
-        <Link href="https://gredice.link/fb">
-            <Card
-                className={cx(
-                    'h-full flex flex-row rounded-xl items-center justify-between max-w-md shadow hover:shadow-xl transition-all duration-300',
-                    'bg-gradient-to-br from-blue-50 to-cyan-50 border-blue-200 dark:from-blue-200 dark:to-cyan-200 dark:border-blue-700',
-                )}
-            >
-                <CardHeader className={cx('flex flex-row gap-4 items-center')}>
-                    <div
-                        className={cx(
-                            'size-16 shrink-0 rounded-full flex items-center justify-center shadow-lg',
-                            'bg-[#1877F2]',
-                        )}
-                    >
-                        <CompanyFacebook className="size-10 fill-white" />
-                    </div>
-                    <CardTitle className="text-lg leading-tight font-bold text-gray-800 max-w-xs mx-auto">
-                        Prati nas na Facebooku
-                    </CardTitle>
-                </CardHeader>
-                <CardContent className="pt-2">
-                    <Navigate
-                        className={cx('size-8 shrink-0', 'text-blue-600')}
-                    />
-                </CardContent>
-            </Card>
-        </Link>
+        <SocialCard
+            href="https://gredice.link/fb"
+            ctaText="Prati nas na Facebooku"
+            icon={<CompanyFacebook className="size-9 fill-white text-white" />}
+            bgColor="border-blue-200 bg-gradient-to-br from-blue-50 to-cyan-50 text-blue-950 dark:border-blue-800 dark:from-blue-950 dark:to-cyan-950 dark:text-blue-100"
+            bgIconColor="bg-[#1877F2]"
+            navigateIconColor="text-blue-600 dark:text-blue-300"
+        />
     );
 }

--- a/apps/www/components/social/InstagramCard.tsx
+++ b/apps/www/components/social/InstagramCard.tsx
@@ -1,37 +1,15 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
-import { Navigate } from '@gredice/ui/icons';
 import { CompanyInstagram } from '@gredice/ui/PublicChrome';
-import { cx } from '@gredice/ui/utils';
-import Link from 'next/link';
+import { SocialCard } from './SocialCard';
 
 export function InstagramCard() {
     return (
-        <Link href="https://gredice.link/ig">
-            <Card
-                className={cx(
-                    'h-full flex flex-row rounded-xl items-center justify-between max-w-md shadow hover:shadow-xl transition-all duration-300',
-                    'bg-gradient-to-br from-red-50 to-orange-50 border-red-200 dark:from-red-200 dark:to-orange-200 dark:border-red-700',
-                )}
-            >
-                <CardHeader className={cx('flex flex-row gap-4 items-center')}>
-                    <div
-                        className={cx(
-                            'size-16 shrink-0 rounded-full flex items-center justify-center shadow-lg',
-                            'bg-gradient-to-r from-[#833ab4] via-[#fd1d1d] to-[#fcb045]',
-                        )}
-                    >
-                        <CompanyInstagram className="size-10 text-white" />
-                    </div>
-                    <CardTitle className="text-lg leading-tight font-bold text-gray-800 max-w-xs mx-auto">
-                        Prati nas na Instagramu
-                    </CardTitle>
-                </CardHeader>
-                <CardContent className="pt-2">
-                    <Navigate
-                        className={cx('size-8 shrink-0', 'text-[#fcb045]')}
-                    />
-                </CardContent>
-            </Card>
-        </Link>
+        <SocialCard
+            href="https://gredice.link/ig"
+            ctaText="Prati nas na Instagramu"
+            icon={<CompanyInstagram className="size-9 text-white" />}
+            bgColor="border-rose-200 bg-gradient-to-br from-rose-50 to-orange-50 text-rose-950 dark:border-rose-800 dark:from-rose-950 dark:to-orange-950 dark:text-rose-100"
+            bgIconColor="bg-gradient-to-r from-[#833ab4] via-[#fd1d1d] to-[#fcb045]"
+            navigateIconColor="text-orange-500 dark:text-orange-300"
+        />
     );
 }

--- a/apps/www/components/social/SocialCard.tsx
+++ b/apps/www/components/social/SocialCard.tsx
@@ -29,7 +29,7 @@ export function SocialCard({
         >
             <Card
                 className={cx(
-                    'grid min-h-20 w-full grid-cols-[4rem_minmax(0,1fr)_4rem] items-center gap-3 rounded-xl p-3 shadow transition-shadow duration-300 group-hover:shadow-xl',
+                    'grid h-full min-h-20 w-full grid-cols-[4rem_minmax(0,1fr)_4rem] items-center gap-3 rounded-xl p-3 shadow transition-shadow duration-300 group-hover:shadow-xl',
                     bgColor,
                 )}
             >

--- a/apps/www/components/social/SocialCard.tsx
+++ b/apps/www/components/social/SocialCard.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
+import { Card } from '@gredice/ui/Card';
 import { Navigate } from '@gredice/ui/icons';
 import { cx } from '@gredice/ui/utils';
 import type { ReactNode } from 'react';
@@ -21,31 +21,37 @@ export function SocialCard({
     navigateIconColor,
 }: SocialCardProps) {
     return (
-        <a href={href} target="_blank" rel="noopener noreferrer">
+        <a
+            className="group block w-full max-w-md rounded-xl ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+        >
             <Card
                 className={cx(
-                    'h-full flex flex-row rounded-xl items-center justify-between max-w-md shadow hover:shadow-xl transition-all duration-300',
+                    'grid min-h-20 w-full grid-cols-[4rem_minmax(0,1fr)_4rem] items-center gap-3 rounded-xl p-3 shadow transition-shadow duration-300 group-hover:shadow-xl',
                     bgColor,
                 )}
             >
-                <CardHeader className={cx('flex flex-row gap-4 items-center')}>
-                    <div
-                        className={cx(
-                            'size-16 shrink-0 rounded-full flex items-center justify-center shadow-lg',
-                            bgIconColor,
-                        )}
-                    >
-                        {icon}
-                    </div>
-                    <CardTitle className="text-lg leading-tight font-bold text-gray-800 max-w-xs mx-auto">
-                        {ctaText}
-                    </CardTitle>
-                </CardHeader>
-                <CardContent className="pt-2">
-                    <Navigate
-                        className={cx('size-8 shrink-0', navigateIconColor)}
-                    />
-                </CardContent>
+                <div
+                    aria-hidden="true"
+                    className={cx(
+                        'grid size-14 place-items-center justify-self-center rounded-full shadow-lg',
+                        bgIconColor,
+                    )}
+                >
+                    {icon}
+                </div>
+                <span className="text-center text-base leading-snug font-bold text-current sm:text-lg">
+                    {ctaText}
+                </span>
+                <Navigate
+                    aria-hidden="true"
+                    className={cx(
+                        'size-7 justify-self-center transition-transform duration-300 group-hover:translate-x-0.5',
+                        navigateIconColor,
+                    )}
+                />
             </Card>
         </a>
     );

--- a/apps/www/components/social/WhatsAppCard.tsx
+++ b/apps/www/components/social/WhatsAppCard.tsx
@@ -6,10 +6,10 @@ export function WhatsAppCard() {
         <SocialCard
             href="https://gredice.link/wa"
             ctaText="Pridruži se našoj WhatsApp zajednici"
-            icon={<CompanyWhatsApp className="size-10 text-white" />}
-            bgColor="bg-gradient-to-br p-2 from-green-50 dark:from-green-200 to-emerald-50 dark:to-emerald-200 border-green-200 dark:border-green-700"
-            bgIconColor="bg-green-500"
-            navigateIconColor="text-green-600"
+            icon={<CompanyWhatsApp className="size-9 text-white" />}
+            bgColor="border-green-200 bg-gradient-to-br from-green-50 to-emerald-100 text-green-950 dark:border-green-800 dark:from-green-950 dark:to-emerald-950 dark:text-green-100"
+            bgIconColor="bg-green-500 dark:bg-green-600"
+            navigateIconColor="text-green-600 dark:text-green-300"
         />
     );
 }


### PR DESCRIPTION
## Što je promijenjeno

- ujednačen je raspored WhatsApp, Instagram i Facebook kartica kroz zajedničku `SocialCard` komponentu
- uvedene su simetrične bočne kolone i eksplicitno centriranje teksta, logotipa i strelice
- dodane su zasebne tamne gradijentne pozadine, obrubi te boje teksta i navigacijskih ikona za svaki brend
- dodan je vidljiv fokusni prsten za tipkovničku navigaciju

## Zašto

Prethodni raspored kombinirao je različite `CardHeader` i `CardContent` razmake, dok su prose stilovi dodavali marginu naslovu. Zbog toga sadržaj nije bio optički centriran. Tamni način rada pritom je koristio svijetle pastelne pozadine i fiksni tamni tekst.

## Utjecaj

Kartice društvenih mreža sada su poravnate i čitljive u svijetlom i tamnom načinu rada na mobilnim i desktop širinama, na kontakt stranici i svim drugim mjestima koja koriste zajedničku WhatsApp karticu.

## Provjere

- `pnpm lint --filter www`
- `pnpm typecheck --filter www`
- `pnpm build --filter www`
- Playwright: `/kontakt` u tamnom načinu na 1280x900 i svijetlom načinu na 390x844
- Playwright: izmjereno centriranje sva tri teksta, logotipa i strelice bez odstupanja
- Axe WCAG A/AA: nema ozbiljnih ni kritičnih prekršaja na `/kontakt`
