### PR TITLE
feat(farm): simplify schedule and printer status UI

### DIFF
--- a/apps/farm/app/schedule/FarmScheduleLoadingState.spec.tsx
+++ b/apps/farm/app/schedule/FarmScheduleLoadingState.spec.tsx
@@ -10,9 +10,7 @@ for (const width of [320, 1280]) {
         await page.setViewportSize({ width, height: 800 });
         const component = await mount(<FarmScheduleLoadingState />);
 
-        await expect(
-            component.getByRole('heading', { level: 1, name: 'Raspored' }),
-        ).toBeVisible();
+        await expect(component.getByText('Raspored')).toHaveCount(0);
 
         expect(
             await page.evaluate(

--- a/apps/farm/app/schedule/FarmScheduleLoadingState.spec.tsx
+++ b/apps/farm/app/schedule/FarmScheduleLoadingState.spec.tsx
@@ -10,7 +10,9 @@ for (const width of [320, 1280]) {
         await page.setViewportSize({ width, height: 800 });
         const component = await mount(<FarmScheduleLoadingState />);
 
-        await expect(component.getByText('Raspored')).toHaveCount(0);
+        await expect(
+            component.getByRole('heading', { level: 1, name: 'Raspored' }),
+        ).toHaveClass(/sr-only/);
 
         expect(
             await page.evaluate(

--- a/apps/farm/app/schedule/FarmScheduleLoadingState.tsx
+++ b/apps/farm/app/schedule/FarmScheduleLoadingState.tsx
@@ -1,5 +1,6 @@
 import { Skeleton } from '@gredice/ui/Skeleton';
 import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
 import { FarmScheduleSectionSkeleton } from './FarmScheduleSectionSkeleton';
 import { ScheduleDaySummarySkeleton } from './ScheduleDaySummarySkeleton';
 
@@ -10,6 +11,9 @@ export function FarmScheduleLoadingState() {
             aria-busy="true"
         >
             <div className="space-y-2">
+                <Typography component="h1" className="sr-only">
+                    Raspored
+                </Typography>
                 <div className="grid min-w-0 items-start gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
                     <div className="min-w-0 justify-self-center sm:justify-self-start">
                         <div className="grid min-w-0 grid-cols-[2.5rem_minmax(0,1fr)_2.5rem] items-center gap-1 sm:gap-2">

--- a/apps/farm/app/schedule/FarmScheduleLoadingState.tsx
+++ b/apps/farm/app/schedule/FarmScheduleLoadingState.tsx
@@ -1,6 +1,5 @@
 import { Skeleton } from '@gredice/ui/Skeleton';
 import { Stack } from '@gredice/ui/Stack';
-import { Typography } from '@gredice/ui/Typography';
 import { FarmScheduleSectionSkeleton } from './FarmScheduleSectionSkeleton';
 import { ScheduleDaySummarySkeleton } from './ScheduleDaySummarySkeleton';
 
@@ -11,9 +10,6 @@ export function FarmScheduleLoadingState() {
             aria-busy="true"
         >
             <div className="space-y-2">
-                <Typography component="h1" level="h5" semiBold>
-                    Raspored
-                </Typography>
                 <div className="grid min-w-0 items-start gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
                     <div className="min-w-0 justify-self-center sm:justify-self-start">
                         <div className="grid min-w-0 grid-cols-[2.5rem_minmax(0,1fr)_2.5rem] items-center gap-1 sm:gap-2">

--- a/apps/farm/app/schedule/FarmScheduleNavigationFrame.tsx
+++ b/apps/farm/app/schedule/FarmScheduleNavigationFrame.tsx
@@ -129,9 +129,6 @@ export function FarmScheduleNavigationFrame({
         >
             <ScheduleTaskReturnFocus />
             <div className="space-y-2">
-                <Typography component="h1" level="h5" semiBold>
-                    Raspored
-                </Typography>
                 <div className="grid min-w-0 items-start gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
                     <div className="min-w-0 justify-self-center sm:justify-self-start">
                         <Row className="shrink-0 gap-1 sm:gap-2">
@@ -148,6 +145,7 @@ export function FarmScheduleNavigationFrame({
                             </Link>
                             <div className="min-w-16 text-center sm:min-w-20">
                                 <Typography
+                                    component="h1"
                                     level="body2"
                                     semiBold
                                     className="capitalize text-xs leading-tight sm:text-sm"

--- a/apps/farm/app/schedule/FieldOperationPrintModal.spec.tsx
+++ b/apps/farm/app/schedule/FieldOperationPrintModal.spec.tsx
@@ -9,6 +9,7 @@ const firstLabel: FieldOperationLabelData = {
     detailLabel: 'Berba',
     plantSortName: 'Salata',
     dateLabel: '02.08.2026.',
+    traceUrl: 'https://gredice.com/t/123',
 };
 
 const labels: FieldOperationLabelData[] = [
@@ -49,6 +50,7 @@ test('lets farmers exclude labels and restore the full print selection', async (
     });
 
     await expect(dialog.getByText('Odabrano: 3 od 3 etiketa')).toBeVisible();
+    await expect(dialog.getByText('QR trag uključen')).toHaveCount(0);
     const secondLabel = dialog.getByRole('checkbox', {
         name: 'Uključi etiketu #2',
     });

--- a/apps/farm/app/schedule/FieldOperationPrintModal.tsx
+++ b/apps/farm/app/schedule/FieldOperationPrintModal.tsx
@@ -5,16 +5,16 @@ import {
     type FieldOperationLabelData,
     GrediceLabelPrinter,
     getLabelPrinterAvailabilityMessage,
-    type LabelPrinterSnapshot,
 } from '@gredice/label-printer';
 import { Button, type ButtonProps } from '@gredice/ui/Button';
 import { Checkbox } from '@gredice/ui/Checkbox';
+import { LinkOff, Reset } from '@gredice/ui/icons';
 import { Modal } from '@gredice/ui/Modal';
-import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { type ReactNode, useEffect, useState } from 'react';
 import { FieldOperationLabelPreviewCanvas } from '../../components/labels/FieldOperationLabelPreviewCanvas';
+import { LabelPrinterStatusSummary } from './LabelPrinterStatusSummary';
 
 const sharedLabelPrinter = new GrediceLabelPrinter();
 
@@ -24,25 +24,6 @@ function getErrorMessage(error: unknown) {
     }
 
     return 'Pisač nije odgovorio. Pokušajte ponovno.';
-}
-
-function getStatusPillClassName(tone: 'neutral' | 'success' | 'warning') {
-    switch (tone) {
-        case 'success':
-            return 'rounded-full border border-green-200 bg-green-50 px-2 py-1 text-xs font-medium text-green-700';
-        case 'warning':
-            return 'rounded-full border border-amber-200 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700';
-        default:
-            return 'rounded-full border border-border bg-muted/40 px-2 py-1 text-xs font-medium text-foreground';
-    }
-}
-
-function getConsumableUsageLabel(snapshot: LabelPrinterSnapshot) {
-    if (!snapshot.consumableUsage) {
-        return null;
-    }
-
-    return `${snapshot.consumableUsage.remaining}/${snapshot.consumableUsage.total} etiketa`;
 }
 
 function getLabelPreviewItems(labels: FieldOperationLabelData[]) {
@@ -87,18 +68,6 @@ function getTraceLinkIds(labels: FieldOperationLabelData[]) {
                 ),
         ),
     );
-}
-
-function getTraceStatusLabel(label: FieldOperationLabelData) {
-    if (label.traceUrl) {
-        return 'QR trag uključen';
-    }
-
-    if (label.traceStatus === 'revoked') {
-        return 'QR trag opozvan';
-    }
-
-    return null;
 }
 
 interface FieldOperationPrintModalProps {
@@ -259,7 +228,7 @@ export function FieldOperationPrintModal({
                     await onPrintSuccess(traceLinkIds);
                 } catch {
                     setActionError(
-                        'Etikete su poslane na pisač, ali status QR traga nije spremljen.',
+                        'Etikete su poslane na pisač, ali evidencija ispisa nije spremljena.',
                     );
                 }
             }
@@ -276,7 +245,6 @@ export function FieldOperationPrintModal({
     const availabilityMessage = snapshot.availability.supported
         ? null
         : getLabelPrinterAvailabilityMessage(snapshot.availability);
-    const consumableUsageLabel = getConsumableUsageLabel(snapshot);
     const canPrint =
         snapshot.isConnected &&
         !snapshot.isConnecting &&
@@ -388,18 +356,6 @@ export function FieldOperationPrintModal({
                                                 labelData={item.label}
                                                 className="mx-auto block w-full max-w-sm rounded border bg-white shadow-xs"
                                             />
-                                            {getTraceStatusLabel(
-                                                item.label,
-                                            ) && (
-                                                <Typography
-                                                    level="body2"
-                                                    className="mt-1 text-center text-xs text-muted-foreground"
-                                                >
-                                                    {getTraceStatusLabel(
-                                                        item.label,
-                                                    )}
-                                                </Typography>
-                                            )}
                                         </div>
                                     </div>
                                 );
@@ -415,88 +371,7 @@ export function FieldOperationPrintModal({
                 ) : (
                     <Stack spacing={3}>
                         <Stack spacing={2}>
-                            <Typography semiBold>Stanje pisača</Typography>
-                            <Row spacing={2} className="flex-wrap gap-y-2">
-                                <span
-                                    className={getStatusPillClassName(
-                                        snapshot.isConnected
-                                            ? 'success'
-                                            : 'neutral',
-                                    )}
-                                >
-                                    {snapshot.isConnected
-                                        ? 'Povezan'
-                                        : 'Nije povezan'}
-                                </span>
-                                {snapshot.batteryPercent !== undefined && (
-                                    <span
-                                        className={getStatusPillClassName(
-                                            snapshot.batteryPercent > 25
-                                                ? 'success'
-                                                : 'warning',
-                                        )}
-                                    >
-                                        Baterija {snapshot.batteryPercent}%
-                                    </span>
-                                )}
-                                {snapshot.paperInserted !== undefined && (
-                                    <span
-                                        className={getStatusPillClassName(
-                                            snapshot.paperInserted
-                                                ? 'success'
-                                                : 'warning',
-                                        )}
-                                    >
-                                        {snapshot.paperInserted
-                                            ? 'Etikete su umetnute'
-                                            : 'Nema umetnutih etiketa'}
-                                    </span>
-                                )}
-                                {snapshot.lidClosed !== undefined && (
-                                    <span
-                                        className={getStatusPillClassName(
-                                            snapshot.lidClosed
-                                                ? 'success'
-                                                : 'warning',
-                                        )}
-                                    >
-                                        {snapshot.lidClosed
-                                            ? 'Poklopac zatvoren'
-                                            : 'Poklopac otvoren'}
-                                    </span>
-                                )}
-                                {consumableUsageLabel && (
-                                    <span
-                                        className={getStatusPillClassName(
-                                            'neutral',
-                                        )}
-                                    >
-                                        {consumableUsageLabel}
-                                    </span>
-                                )}
-                            </Row>
-
-                            {(snapshot.deviceName ||
-                                snapshot.modelName ||
-                                snapshot.serial) && (
-                                <Stack spacing={1}>
-                                    {snapshot.deviceName && (
-                                        <Typography level="body2">
-                                            Uređaj: {snapshot.deviceName}
-                                        </Typography>
-                                    )}
-                                    {snapshot.modelName && (
-                                        <Typography level="body2">
-                                            Model: {snapshot.modelName}
-                                        </Typography>
-                                    )}
-                                    {snapshot.serial && (
-                                        <Typography level="body2">
-                                            Serijski broj: {snapshot.serial}
-                                        </Typography>
-                                    )}
-                                </Stack>
-                            )}
+                            <LabelPrinterStatusSummary snapshot={snapshot} />
 
                             {!snapshot.consumableUsage &&
                                 snapshot.isConnected && (
@@ -543,8 +418,18 @@ export function FieldOperationPrintModal({
                                 {snapshot.isConnected ? (
                                     <>
                                         <Button
-                                            variant="outlined"
+                                            variant="plain"
+                                            size="sm"
                                             type="button"
+                                            aria-label="Osvježi stanje"
+                                            title="Osvježi stanje"
+                                            className="size-9 px-0"
+                                            startDecorator={
+                                                <Reset
+                                                    aria-hidden
+                                                    className="size-4"
+                                                />
+                                            }
                                             onClick={handleRefresh}
                                             loading={isRefreshing}
                                             disabled={
@@ -552,12 +437,20 @@ export function FieldOperationPrintModal({
                                                 snapshot.isPrinting ||
                                                 isDisconnecting
                                             }
-                                        >
-                                            Osvježi stanje
-                                        </Button>
+                                        />
                                         <Button
-                                            variant="outlined"
+                                            variant="plain"
+                                            size="sm"
                                             type="button"
+                                            aria-label="Prekini vezu"
+                                            title="Prekini vezu"
+                                            className="size-9 px-0"
+                                            startDecorator={
+                                                <LinkOff
+                                                    aria-hidden
+                                                    className="size-4"
+                                                />
+                                            }
                                             onClick={handleDisconnect}
                                             loading={isDisconnecting}
                                             disabled={
@@ -565,9 +458,7 @@ export function FieldOperationPrintModal({
                                                 snapshot.isPrinting ||
                                                 isRefreshing
                                             }
-                                        >
-                                            Prekini vezu
-                                        </Button>
+                                        />
                                     </>
                                 ) : (
                                     <Button

--- a/apps/farm/app/schedule/LabelPrinterStatusSummary.spec.tsx
+++ b/apps/farm/app/schedule/LabelPrinterStatusSummary.spec.tsx
@@ -1,0 +1,52 @@
+import type { LabelPrinterSnapshot } from '@gredice/label-printer';
+import { expect, test } from '@playwright/experimental-ct-react';
+import '../globals.css';
+import { LabelPrinterStatusSummary } from './LabelPrinterStatusSummary';
+
+const connectedSnapshot: LabelPrinterSnapshot = {
+    availability: { supported: true },
+    isConnecting: false,
+    isConnected: true,
+    isPrinting: false,
+    deviceName: 'B1-H708121015',
+    modelName: 'B1',
+    serial: 'H708121015',
+    batteryPercent: 100,
+    paperInserted: true,
+    lidClosed: true,
+    consumableUsage: {
+        remaining: 239,
+        total: 276,
+        used: 37,
+    },
+};
+
+test('shows compact printer status chips and remaining-label capacity', async ({
+    mount,
+}) => {
+    const component = await mount(
+        <LabelPrinterStatusSummary snapshot={connectedSnapshot} />,
+    );
+
+    for (const label of [
+        'Povezan',
+        'Baterija 100%',
+        'Etikete su umetnute',
+        'Poklopac zatvoren',
+    ]) {
+        const chip = component.getByText(label);
+        await expect(chip).toBeVisible();
+        await expect(chip.locator('svg')).toHaveCount(1);
+    }
+
+    const capacity = component.getByRole('progressbar', {
+        name: 'Preostale etikete u pisaču',
+    });
+    await expect(capacity).toHaveAttribute('aria-valuenow', '239');
+    await expect(capacity).toHaveAttribute('aria-valuemax', '276');
+    await expect(capacity.getByText('239')).toBeVisible();
+    await expect(capacity.getByText('/ 276')).toBeVisible();
+    await expect(
+        component.getByText(/Uređaj:|Model:|Serijski broj:/),
+    ).toHaveCount(0);
+});

--- a/apps/farm/app/schedule/LabelPrinterStatusSummary.tsx
+++ b/apps/farm/app/schedule/LabelPrinterStatusSummary.tsx
@@ -1,0 +1,146 @@
+import type { LabelPrinterSnapshot } from '@gredice/label-printer';
+import {
+    BatteryFull,
+    BatteryLow,
+    BatteryMedium,
+    Link,
+    LinkOff,
+    Lock,
+    Printer,
+    Warning,
+} from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { SegmentedCircularProgress } from '@gredice/ui/SegmentedCircularProgress';
+
+function getStatusPillClassName(tone: 'neutral' | 'success' | 'warning') {
+    switch (tone) {
+        case 'success':
+            return 'inline-flex items-center gap-1.5 rounded-full border border-green-200 bg-green-50 px-2 py-1 text-xs font-medium text-green-700';
+        case 'warning':
+            return 'inline-flex items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700';
+        default:
+            return 'inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/40 px-2 py-1 text-xs font-medium text-foreground';
+    }
+}
+
+function getConsumableUsagePercentage(snapshot: LabelPrinterSnapshot) {
+    if (!snapshot.consumableUsage) {
+        return null;
+    }
+
+    const { remaining, total } = snapshot.consumableUsage;
+    if (total <= 0) {
+        return 0;
+    }
+
+    return Math.round((Math.max(0, Math.min(remaining, total)) / total) * 100);
+}
+
+interface LabelPrinterStatusSummaryProps {
+    snapshot: LabelPrinterSnapshot;
+}
+
+export function LabelPrinterStatusSummary({
+    snapshot,
+}: LabelPrinterStatusSummaryProps) {
+    const consumableUsagePercentage = getConsumableUsagePercentage(snapshot);
+
+    return (
+        <Row spacing={2} className="flex-wrap items-center gap-y-2">
+            <span
+                className={getStatusPillClassName(
+                    snapshot.isConnected ? 'success' : 'neutral',
+                )}
+            >
+                {snapshot.isConnected ? (
+                    <Link aria-hidden className="size-3.5" />
+                ) : (
+                    <LinkOff aria-hidden className="size-3.5" />
+                )}
+                {snapshot.isConnected ? 'Povezan' : 'Nije povezan'}
+            </span>
+            {snapshot.batteryPercent !== undefined && (
+                <span
+                    className={getStatusPillClassName(
+                        snapshot.batteryPercent > 25 ? 'success' : 'warning',
+                    )}
+                >
+                    {snapshot.batteryPercent > 75 ? (
+                        <BatteryFull aria-hidden className="size-3.5" />
+                    ) : snapshot.batteryPercent > 25 ? (
+                        <BatteryMedium aria-hidden className="size-3.5" />
+                    ) : (
+                        <BatteryLow aria-hidden className="size-3.5" />
+                    )}
+                    Baterija {snapshot.batteryPercent}%
+                </span>
+            )}
+            {snapshot.paperInserted !== undefined && (
+                <span
+                    className={getStatusPillClassName(
+                        snapshot.paperInserted ? 'success' : 'warning',
+                    )}
+                >
+                    {snapshot.paperInserted ? (
+                        <Printer aria-hidden className="size-3.5" />
+                    ) : (
+                        <Warning aria-hidden className="size-3.5" />
+                    )}
+                    {snapshot.paperInserted
+                        ? 'Etikete su umetnute'
+                        : 'Nema umetnutih etiketa'}
+                </span>
+            )}
+            {snapshot.lidClosed !== undefined && (
+                <span
+                    className={getStatusPillClassName(
+                        snapshot.lidClosed ? 'success' : 'warning',
+                    )}
+                >
+                    {snapshot.lidClosed ? (
+                        <Lock aria-hidden className="size-3.5" />
+                    ) : (
+                        <Warning aria-hidden className="size-3.5" />
+                    )}
+                    {snapshot.lidClosed
+                        ? 'Poklopac zatvoren'
+                        : 'Poklopac otvoren'}
+                </span>
+            )}
+            {snapshot.consumableUsage && consumableUsagePercentage !== null && (
+                <div
+                    role="progressbar"
+                    aria-label="Preostale etikete u pisaču"
+                    aria-valuemin={0}
+                    aria-valuemax={snapshot.consumableUsage.total}
+                    aria-valuenow={snapshot.consumableUsage.remaining}
+                >
+                    <SegmentedCircularProgress
+                        size={64}
+                        strokeWidth={3}
+                        segments={[
+                            {
+                                percentage: 100,
+                                value: consumableUsagePercentage,
+                                color:
+                                    snapshot.consumableUsage.remaining > 0
+                                        ? 'stroke-green-500'
+                                        : 'stroke-amber-500',
+                                trackColor: 'stroke-muted',
+                            },
+                        ]}
+                    >
+                        <span className="flex flex-col items-center text-center leading-none">
+                            <span className="text-sm font-semibold text-foreground">
+                                {snapshot.consumableUsage.remaining}
+                            </span>
+                            <span className="mt-0.5 text-[10px] text-muted-foreground">
+                                / {snapshot.consumableUsage.total}
+                            </span>
+                        </span>
+                    </SegmentedCircularProgress>
+                </div>
+            )}
+        </Row>
+    );
+}

--- a/apps/farm/app/schedule/ScheduleLabelPrintSection.tsx
+++ b/apps/farm/app/schedule/ScheduleLabelPrintSection.tsx
@@ -32,7 +32,6 @@ function formatLabelCount(count: number) {
 function formatLabelSummary(
     sowingLabelCount: number,
     harvestLabelCount: number,
-    traceLabelCount: number,
 ) {
     const parts = [];
     if (sowingLabelCount > 0) {
@@ -41,10 +40,6 @@ function formatLabelSummary(
     if (harvestLabelCount > 0) {
         parts.push(`berba: ${formatLabelCount(harvestLabelCount)}`);
     }
-    if (traceLabelCount > 0) {
-        parts.push(`QR trag: ${formatLabelCount(traceLabelCount)}`);
-    }
-
     return parts.join(' · ');
 }
 
@@ -73,7 +68,6 @@ export async function ScheduleLabelPrintSection({
     const labelSummary = formatLabelSummary(
         printData.sowingLabelCount,
         printData.harvestLabelCount,
-        printData.traceLabelCount,
     );
 
     return (


### PR DESCRIPTION
## What changed

- remove the redundant visible `Raspored` heading while keeping the selected day as the page heading
- simplify the label print modal by removing printer identifiers, QR-trace indicators, and the printer-status heading
- add icon-backed printer status chips and a circular remaining-label capacity indicator
- convert refresh and disconnect actions to accessible plain icon buttons
- add focused component coverage for the connected printer summary and retained label selection behavior

## Farmer impact

The schedule has less repeated chrome, and the print dialog prioritizes the status information farmers need during daily label printing.

## Validation

- `pnpm --filter farm exec biome check app/schedule/FieldOperationPrintModal.tsx app/schedule/LabelPrinterStatusSummary.tsx app/schedule/LabelPrinterStatusSummary.spec.tsx app/schedule/ScheduleLabelPrintSection.tsx app/schedule/FarmScheduleNavigationFrame.tsx app/schedule/FarmScheduleLoadingState.tsx app/schedule/FieldOperationPrintModal.spec.tsx app/schedule/FarmScheduleLoadingState.spec.tsx`
- `pnpm --filter farm exec playwright test app/schedule/FieldOperationPrintModal.spec.tsx app/schedule/LabelPrinterStatusSummary.spec.tsx app/schedule/FarmScheduleLoadingState.spec.tsx` (6 passed)
- `pnpm build --filter farm`