### PR TITLE
feat(game): add actor hover dialogue

### DIFF
--- a/apps/garden/playwright.config.ts
+++ b/apps/garden/playwright.config.ts
@@ -19,7 +19,7 @@ const reporter: PlaywrightTestConfig['reporter'] = [
     ['html', { open: 'never' }],
 ];
 const webglTestPattern =
-    /(garden-preview-capture|hover-outline|instanced-mesh-material-swap)\.spec\.tsx/;
+    /(actor-speech-bubble|garden-preview-capture|hover-outline|instanced-mesh-material-swap)\.spec\.tsx/;
 
 // Plugin to intercept next/font/google before Vite's resolver
 function nextFontMockPlugin() {

--- a/apps/garden/tests/ActorSpeechBubbleFixture.tsx
+++ b/apps/garden/tests/ActorSpeechBubbleFixture.tsx
@@ -1,6 +1,7 @@
 import { Canvas } from '@react-three/fiber';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import {
+    type ActorSpeechAnchor,
     ActorSpeechBubble,
     useActorHoverSpeech,
 } from '../../../packages/game/src/entities/animals/ActorSpeechBubble';
@@ -9,16 +10,39 @@ const fixtureMessages = ['Lijep dan u vrtu!', 'Vrt izgleda prekrasno!'];
 
 export function ActorSpeechBubbleFixture() {
     const [ready, setReady] = useState(false);
-    const { hideMessage, message, showMessage } =
-        useActorHoverSpeech(fixtureMessages);
+    const [actorX, setActorX] = useState(0);
+    const actorRef = useRef<ActorSpeechAnchor>(null);
+    const { message, showMessage } = useActorHoverSpeech(
+        fixtureMessages,
+        3_000,
+    );
+
+    function moveActor() {
+        const nextActorX = actorX === 0 ? 0.75 : 0;
+        if (actorRef.current) {
+            actorRef.current.position.x = nextActorX;
+            setActorX(actorRef.current.position.x);
+            return;
+        }
+        setActorX(Number.NaN);
+    }
 
     return (
         <div
+            data-actor-x={actorX}
             data-message={message ?? ''}
             data-render-ready={ready ? 'true' : 'false'}
             data-testid="actor-speech-bubble-fixture"
-            style={{ height: 240, width: 360 }}
+            style={{ height: 240, position: 'relative', width: 360 }}
         >
+            <button
+                type="button"
+                data-testid="move-actor"
+                onClick={moveActor}
+                style={{ position: 'absolute', right: 0, top: 0, zIndex: 1 }}
+            >
+                Pomakni glumca
+            </button>
             <Canvas
                 orthographic
                 camera={{ position: [0, 0, 10], zoom: 80 }}
@@ -26,26 +50,24 @@ export function ActorSpeechBubbleFixture() {
                 onCreated={() => setReady(true)}
             >
                 <group
+                    ref={actorRef}
                     onPointerOver={(event) => {
                         event.stopPropagation();
                         showMessage();
-                    }}
-                    onPointerOut={(event) => {
-                        event.stopPropagation();
-                        hideMessage();
                     }}
                 >
                     <mesh>
                         <planeGeometry args={[2.5, 2.5]} />
                         <meshBasicMaterial color="#3f6585" />
                     </mesh>
-                    {message ? (
-                        <ActorSpeechBubble
-                            message={message}
-                            position={[0, 1.2, 0]}
-                        />
-                    ) : null}
                 </group>
+                {message ? (
+                    <ActorSpeechBubble
+                        actorRef={actorRef}
+                        message={message}
+                        offsetY={1.2}
+                    />
+                ) : null}
             </Canvas>
         </div>
     );

--- a/apps/garden/tests/ActorSpeechBubbleFixture.tsx
+++ b/apps/garden/tests/ActorSpeechBubbleFixture.tsx
@@ -1,0 +1,52 @@
+import { Canvas } from '@react-three/fiber';
+import { useState } from 'react';
+import {
+    ActorSpeechBubble,
+    useActorHoverSpeech,
+} from '../../../packages/game/src/entities/animals/ActorSpeechBubble';
+
+const fixtureMessages = ['Lijep dan u vrtu!', 'Vrt izgleda prekrasno!'];
+
+export function ActorSpeechBubbleFixture() {
+    const [ready, setReady] = useState(false);
+    const { hideMessage, message, showMessage } =
+        useActorHoverSpeech(fixtureMessages);
+
+    return (
+        <div
+            data-message={message ?? ''}
+            data-render-ready={ready ? 'true' : 'false'}
+            data-testid="actor-speech-bubble-fixture"
+            style={{ height: 240, width: 360 }}
+        >
+            <Canvas
+                orthographic
+                camera={{ position: [0, 0, 10], zoom: 80 }}
+                frameloop="always"
+                onCreated={() => setReady(true)}
+            >
+                <group
+                    onPointerOver={(event) => {
+                        event.stopPropagation();
+                        showMessage();
+                    }}
+                    onPointerOut={(event) => {
+                        event.stopPropagation();
+                        hideMessage();
+                    }}
+                >
+                    <mesh>
+                        <planeGeometry args={[2.5, 2.5]} />
+                        <meshBasicMaterial color="#3f6585" />
+                    </mesh>
+                    {message ? (
+                        <ActorSpeechBubble
+                            message={message}
+                            position={[0, 1.2, 0]}
+                        />
+                    ) : null}
+                </group>
+            </Canvas>
+        </div>
+    );
+}

--- a/apps/garden/tests/actor-speech-bubble.spec.tsx
+++ b/apps/garden/tests/actor-speech-bubble.spec.tsx
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { ActorSpeechBubbleFixture } from './ActorSpeechBubbleFixture';
+
+test('shows a fresh speech bubble above a hovered actor without stealing pointer events', async ({
+    mount,
+}) => {
+    const fixture = await mount(<ActorSpeechBubbleFixture />);
+    const canvas = fixture.locator('canvas');
+    const bubble = fixture.locator('[data-actor-speech-bubble]');
+    await expect(fixture).toHaveAttribute('data-render-ready', 'true');
+
+    const canvasBox = await canvas.boundingBox();
+    expect(canvasBox).not.toBeNull();
+    if (!canvasBox) {
+        return;
+    }
+
+    const actorPosition = {
+        x: canvasBox.width / 2,
+        y: canvasBox.height / 2,
+    };
+    await canvas.hover({ position: actorPosition });
+    await expect(fixture).not.toHaveAttribute('data-message', '');
+    await expect(bubble).toBeVisible();
+    const firstMessage = await bubble.textContent();
+
+    await canvas.hover({ position: { x: 10, y: 10 } });
+    await expect(bubble).toHaveCount(0);
+
+    await canvas.hover({ position: actorPosition });
+    await expect(bubble).toBeVisible();
+    await expect(bubble).not.toHaveText(firstMessage ?? '');
+});

--- a/apps/garden/tests/actor-speech-bubble.spec.tsx
+++ b/apps/garden/tests/actor-speech-bubble.spec.tsx
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import { ActorSpeechBubbleFixture } from './ActorSpeechBubbleFixture';
 
-test('shows a fresh speech bubble above a hovered actor without stealing pointer events', async ({
+test('keeps one speech bubble attached to the actor and refreshes its lifetime', async ({
     mount,
+    page,
 }) => {
     const fixture = await mount(<ActorSpeechBubbleFixture />);
     const canvas = fixture.locator('canvas');
@@ -23,11 +24,29 @@ test('shows a fresh speech bubble above a hovered actor without stealing pointer
     await expect(fixture).not.toHaveAttribute('data-message', '');
     await expect(bubble).toBeVisible();
     const firstMessage = await bubble.textContent();
+    const firstBubbleBox = await bubble.boundingBox();
+    expect(firstBubbleBox).not.toBeNull();
 
     await canvas.hover({ position: { x: 10, y: 10 } });
-    await expect(bubble).toHaveCount(0);
+    await expect(bubble).toBeVisible();
+    await expect(bubble).toHaveText(firstMessage ?? '');
 
+    await fixture.getByTestId('move-actor').click();
+    await expect(fixture).toHaveAttribute('data-actor-x', '0.75');
+    if (firstBubbleBox) {
+        await expect
+            .poll(async () => (await bubble.boundingBox())?.x)
+            .toBeGreaterThan(firstBubbleBox.x + 40);
+    }
+    await fixture.getByTestId('move-actor').click();
+    await expect(fixture).toHaveAttribute('data-actor-x', '0');
+
+    await page.waitForTimeout(1_800);
     await canvas.hover({ position: actorPosition });
     await expect(bubble).toBeVisible();
-    await expect(bubble).not.toHaveText(firstMessage ?? '');
+    await expect(bubble).toHaveText(firstMessage ?? '');
+
+    await page.waitForTimeout(1_800);
+    await expect(bubble).toBeVisible();
+    await expect(bubble).toHaveCount(0, { timeout: 2_000 });
 });

--- a/packages/game/src/entities/animals/ActorSpeechBubble.tsx
+++ b/packages/game/src/entities/animals/ActorSpeechBubble.tsx
@@ -1,36 +1,108 @@
 import { Html } from '@react-three/drei';
-import { useCallback, useRef, useState } from 'react';
-import { pickActorSpeechMessage } from './actorSpeechMessages';
+import {
+    type RefObject,
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+} from 'react';
+import { type Camera, type Group, type Object3D, Vector3 } from 'three';
+import {
+    actorSpeechDurationMs,
+    pickActorSpeechMessage,
+} from './actorSpeechMessages';
 
-export function useActorHoverSpeech(messages: readonly string[]) {
+export type ActorSpeechAnchor = Group;
+
+export function useActorHoverSpeech(
+    messages: readonly string[],
+    durationMs = actorSpeechDurationMs,
+) {
     const [message, setMessage] = useState<string | null>(null);
+    const messageRef = useRef<string | null>(null);
     const previousMessageRef = useRef<string | null>(null);
+    const dismissTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+        null,
+    );
+
+    const clearDismissTimeout = useCallback(() => {
+        if (dismissTimeoutRef.current === null) {
+            return;
+        }
+
+        clearTimeout(dismissTimeoutRef.current);
+        dismissTimeoutRef.current = null;
+    }, []);
+
+    const dismissMessage = useCallback(() => {
+        clearDismissTimeout();
+        messageRef.current = null;
+        setMessage(null);
+    }, [clearDismissTimeout]);
 
     const showMessage = useCallback(() => {
-        const nextMessage = pickActorSpeechMessage({
-            messages,
-            previousMessage: previousMessageRef.current,
-        });
-        previousMessageRef.current = nextMessage;
-        setMessage(nextMessage);
-    }, [messages]);
+        if (messageRef.current === null) {
+            const nextMessage = pickActorSpeechMessage({
+                messages,
+                previousMessage: previousMessageRef.current,
+            });
+            previousMessageRef.current = nextMessage;
+            messageRef.current = nextMessage;
+            setMessage(nextMessage);
+        }
 
-    const hideMessage = useCallback(() => setMessage(null), []);
+        clearDismissTimeout();
+        dismissTimeoutRef.current = setTimeout(() => {
+            dismissTimeoutRef.current = null;
+            messageRef.current = null;
+            setMessage(null);
+        }, durationMs);
+    }, [clearDismissTimeout, durationMs, messages]);
 
-    return { hideMessage, message, showMessage };
+    useEffect(() => clearDismissTimeout, [clearDismissTimeout]);
+
+    return { dismissMessage, message, showMessage };
 }
 
 export function ActorSpeechBubble({
+    actorRef,
     message,
-    position,
+    offsetY,
 }: {
+    actorRef: RefObject<Object3D | null>;
     message: string;
-    position: [number, number, number];
+    offsetY: number;
 }) {
+    const actorWorldPositionRef = useRef(new Vector3());
+    const calculateActorPosition = useCallback(
+        (
+            _element: Object3D,
+            camera: Camera,
+            size: { width: number; height: number },
+        ) => {
+            const actor = actorRef.current;
+            if (!actor) {
+                return [size.width / 2, size.height / 2];
+            }
+
+            actor.getWorldPosition(actorWorldPositionRef.current);
+            actorWorldPositionRef.current.y += offsetY;
+            actorWorldPositionRef.current.project(camera);
+            const screenPosition = [
+                actorWorldPositionRef.current.x * (size.width / 2) +
+                    size.width / 2,
+                -actorWorldPositionRef.current.y * (size.height / 2) +
+                    size.height / 2,
+            ];
+            return screenPosition;
+        },
+        [actorRef, offsetY],
+    );
+
     return (
         <Html
+            calculatePosition={calculateActorPosition}
             center
-            position={position}
             style={{ pointerEvents: 'none' }}
             zIndexRange={[50, 31]}
         >

--- a/packages/game/src/entities/animals/ActorSpeechBubble.tsx
+++ b/packages/game/src/entities/animals/ActorSpeechBubble.tsx
@@ -1,0 +1,48 @@
+import { Html } from '@react-three/drei';
+import { useCallback, useRef, useState } from 'react';
+import { pickActorSpeechMessage } from './actorSpeechMessages';
+
+export function useActorHoverSpeech(messages: readonly string[]) {
+    const [message, setMessage] = useState<string | null>(null);
+    const previousMessageRef = useRef<string | null>(null);
+
+    const showMessage = useCallback(() => {
+        const nextMessage = pickActorSpeechMessage({
+            messages,
+            previousMessage: previousMessageRef.current,
+        });
+        previousMessageRef.current = nextMessage;
+        setMessage(nextMessage);
+    }, [messages]);
+
+    const hideMessage = useCallback(() => setMessage(null), []);
+
+    return { hideMessage, message, showMessage };
+}
+
+export function ActorSpeechBubble({
+    message,
+    position,
+}: {
+    message: string;
+    position: [number, number, number];
+}) {
+    return (
+        <Html
+            center
+            position={position}
+            style={{ pointerEvents: 'none' }}
+            zIndexRange={[50, 31]}
+        >
+            <div
+                aria-live="polite"
+                className="relative max-w-[min(15rem,75vw)] whitespace-nowrap rounded-xl border border-emerald-200 bg-white/95 px-3 py-1.5 text-center text-sm font-semibold leading-snug text-emerald-900 shadow-lg backdrop-blur-sm dark:border-emerald-800/80 dark:bg-neutral-950/95 dark:text-emerald-100"
+                data-actor-speech-bubble
+                role="status"
+            >
+                {message}
+                <span className="absolute top-full left-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rotate-45 border-r border-b border-emerald-200 bg-white/95 dark:border-emerald-800/80 dark:bg-neutral-950/95" />
+            </div>
+        </Html>
+    );
+}

--- a/packages/game/src/entities/animals/actorSpeechMessages.ts
+++ b/packages/game/src/entities/animals/actorSpeechMessages.ts
@@ -1,3 +1,5 @@
+export const actorSpeechDurationMs = 5_000;
+
 export const catSpeechMessages = ['Mijau!', 'Prrr...', 'Mjau-mjau!'] as const;
 
 export const dogSpeechMessages = ['Vau!', 'Av-av!', 'Hov-hov!'] as const;

--- a/packages/game/src/entities/animals/actorSpeechMessages.ts
+++ b/packages/game/src/entities/animals/actorSpeechMessages.ts
@@ -1,0 +1,44 @@
+export const catSpeechMessages = ['Mijau!', 'Prrr...', 'Mjau-mjau!'] as const;
+
+export const dogSpeechMessages = ['Vau!', 'Av-av!', 'Hov-hov!'] as const;
+
+export const birdSpeechMessages = [
+    'Cvrk-cvrk!',
+    'Ćiju-ći!',
+    'Piju-piju!',
+] as const;
+
+export const beeSpeechMessages = ['Bzzz!', 'Zum-zum!', 'Bzz-bzz!'] as const;
+
+export const playerSpeechMessages = [
+    'Baš je lijep dan u vrtu!',
+    'Vrt danas izgleda prekrasno.',
+    'Divan dan za šetnju vrtom.',
+    'Danas sve u vrtu lijepo raste!',
+    'Kakav ugodan dan u vrtu!',
+] as const;
+
+export function pickActorSpeechMessage({
+    messages,
+    previousMessage,
+    random = Math.random,
+}: {
+    messages: readonly string[];
+    previousMessage?: string | null;
+    random?: () => number;
+}) {
+    if (messages.length === 0) {
+        return null;
+    }
+
+    const availableMessages =
+        messages.length > 1 && previousMessage
+            ? messages.filter((message) => message !== previousMessage)
+            : messages;
+    const randomIndex = Math.min(
+        Math.floor(Math.max(0, random()) * availableMessages.length),
+        availableMessages.length - 1,
+    );
+
+    return availableMessages[randomIndex] ?? null;
+}

--- a/packages/game/src/entities/animals/actorSpeechMessages.unit.ts
+++ b/packages/game/src/entities/animals/actorSpeechMessages.unit.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    actorSpeechDurationMs,
     beeSpeechMessages,
     birdSpeechMessages,
     catSpeechMessages,
@@ -8,6 +9,10 @@ import {
     pickActorSpeechMessage,
     playerSpeechMessages,
 } from './actorSpeechMessages';
+
+test('keeps actor speech visible for five seconds by default', () => {
+    assert.equal(actorSpeechDurationMs, 5_000);
+});
 
 test('provides speech for every interactive animal and the player', () => {
     assert.ok(catSpeechMessages.length > 1);

--- a/packages/game/src/entities/animals/actorSpeechMessages.unit.ts
+++ b/packages/game/src/entities/animals/actorSpeechMessages.unit.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    beeSpeechMessages,
+    birdSpeechMessages,
+    catSpeechMessages,
+    dogSpeechMessages,
+    pickActorSpeechMessage,
+    playerSpeechMessages,
+} from './actorSpeechMessages';
+
+test('provides speech for every interactive animal and the player', () => {
+    assert.ok(catSpeechMessages.length > 1);
+    assert.ok(dogSpeechMessages.length > 1);
+    assert.ok(birdSpeechMessages.length > 1);
+    assert.ok(beeSpeechMessages.length > 1);
+    assert.ok(playerSpeechMessages.length > 1);
+    assert.ok(
+        playerSpeechMessages.every((message) => /vrt|vrtu/i.test(message)),
+    );
+});
+
+test('picks a message using the supplied random source', () => {
+    assert.equal(
+        pickActorSpeechMessage({
+            messages: ['prva', 'druga', 'treća'],
+            random: () => 0.5,
+        }),
+        'druga',
+    );
+});
+
+test('does not immediately repeat a message when alternatives exist', () => {
+    assert.equal(
+        pickActorSpeechMessage({
+            messages: ['prva', 'druga', 'treća'],
+            previousMessage: 'prva',
+            random: () => 0,
+        }),
+        'druga',
+    );
+});
+
+test('returns null for an empty message collection', () => {
+    assert.equal(pickActorSpeechMessage({ messages: [] }), null);
+});

--- a/packages/game/src/entities/avatar/GardenAvatar.tsx
+++ b/packages/game/src/entities/avatar/GardenAvatar.tsx
@@ -59,7 +59,7 @@ import type { GardenAvatarPresenceState } from './gardenVisitorPresence';
 
 export const avatarModelScale = 0.697;
 const avatarEyeHeight = 1.2;
-const avatarSpeechBubblePosition: [number, number, number] = [0, 1.85, 0];
+const avatarSpeechBubbleOffsetY = 1.85;
 const avatarCrouchEyeHeight = 0.9;
 const avatarWalkSpeed = 2.15;
 const avatarRunSpeed = 4.68;
@@ -628,7 +628,7 @@ export function GardenAvatar({
     });
     const initializedRef = useRef(false);
     const {
-        hideMessage: hideSpeechMessage,
+        dismissMessage: dismissSpeechMessage,
         message: speechMessage,
         showMessage: showSpeechMessage,
     } = useActorHoverSpeech(playerSpeechMessages);
@@ -942,7 +942,7 @@ export function GardenAvatar({
         yawRef.current = actor.rotation.y;
         pitchRef.current = -0.08;
         roamRef.current.route = [];
-        hideSpeechMessage();
+        dismissSpeechMessage();
         setView('third-person');
     }
 
@@ -965,7 +965,6 @@ export function GardenAvatar({
 
     function hideAvatarPointer() {
         gl.domElement.style.cursor = 'auto';
-        hideSpeechMessage();
     }
 
     useFrame(({ clock }, frameDelta) => {
@@ -1314,12 +1313,6 @@ export function GardenAvatar({
                 <group scale={avatarModelScale}>
                     <primitive object={model.scene} />
                 </group>
-                {view === 'overview' && speechMessage ? (
-                    <ActorSpeechBubble
-                        message={speechMessage}
-                        position={avatarSpeechBubblePosition}
-                    />
-                ) : null}
                 {view === 'overview' ? (
                     <Html center position={[0, 1.43, 0]} zIndexRange={[30, 20]}>
                         <button
@@ -1335,6 +1328,13 @@ export function GardenAvatar({
                     </Html>
                 ) : null}
             </group>
+            {view === 'overview' && speechMessage ? (
+                <ActorSpeechBubble
+                    actorRef={actorRef}
+                    message={speechMessage}
+                    offsetY={avatarSpeechBubbleOffsetY}
+                />
+            ) : null}
             {collisionDebugVisible ? (
                 <GardenAvatarCollisionDebug
                     actorRef={actorRef}

--- a/packages/game/src/entities/avatar/GardenAvatar.tsx
+++ b/packages/game/src/entities/avatar/GardenAvatar.tsx
@@ -27,6 +27,11 @@ import type { Stack } from '../../types/Stack';
 import { type GardenAvatarView, useGameState } from '../../useGameState';
 import { useGameGLTF } from '../../utils/useGameGLTF';
 import { useActorGroundingShadow } from '../animals/ActorGroundingShadows';
+import {
+    ActorSpeechBubble,
+    useActorHoverSpeech,
+} from '../animals/ActorSpeechBubble';
+import { playerSpeechMessages } from '../animals/actorSpeechMessages';
 import { GardenAvatarCollisionDebug } from './GardenAvatarCollisionDebug';
 import { getGardenAvatarPerspectiveEntryPosition } from './gardenAvatarCamera';
 import {
@@ -54,6 +59,7 @@ import type { GardenAvatarPresenceState } from './gardenVisitorPresence';
 
 export const avatarModelScale = 0.697;
 const avatarEyeHeight = 1.2;
+const avatarSpeechBubblePosition: [number, number, number] = [0, 1.85, 0];
 const avatarCrouchEyeHeight = 0.9;
 const avatarWalkSpeed = 2.15;
 const avatarRunSpeed = 4.68;
@@ -621,6 +627,11 @@ export function GardenAvatar({
         quaternion: camera.quaternion.clone(),
     });
     const initializedRef = useRef(false);
+    const {
+        hideMessage: hideSpeechMessage,
+        message: speechMessage,
+        showMessage: showSpeechMessage,
+    } = useActorHoverSpeech(playerSpeechMessages);
     const finishTemporaryZoom = useCallback(() => {
         if (mouseZoomingRef.current || touchZoomInputRef.current) {
             return;
@@ -931,6 +942,7 @@ export function GardenAvatar({
         yawRef.current = actor.rotation.y;
         pitchRef.current = -0.08;
         roamRef.current.route = [];
+        hideSpeechMessage();
         setView('third-person');
     }
 
@@ -947,11 +959,13 @@ export function GardenAvatar({
         event.stopPropagation();
         if (view === 'overview') {
             gl.domElement.style.cursor = 'pointer';
+            showSpeechMessage();
         }
     }
 
     function hideAvatarPointer() {
         gl.domElement.style.cursor = 'auto';
+        hideSpeechMessage();
     }
 
     useFrame(({ clock }, frameDelta) => {
@@ -1300,6 +1314,12 @@ export function GardenAvatar({
                 <group scale={avatarModelScale}>
                     <primitive object={model.scene} />
                 </group>
+                {view === 'overview' && speechMessage ? (
+                    <ActorSpeechBubble
+                        message={speechMessage}
+                        position={avatarSpeechBubblePosition}
+                    />
+                ) : null}
                 {view === 'overview' ? (
                     <Html center position={[0, 1.43, 0]} zIndexRange={[30, 20]}>
                         <button

--- a/packages/game/src/entities/bees/Bees.tsx
+++ b/packages/game/src/entities/bees/Bees.tsx
@@ -28,8 +28,13 @@ import {
 } from '../../utils/raisedBedOrientation';
 import { useGameGLTF } from '../../utils/useGameGLTF';
 import { useActorGroundingShadow } from '../animals/ActorGroundingShadows';
+import {
+    ActorSpeechBubble,
+    useActorHoverSpeech,
+} from '../animals/ActorSpeechBubble';
 import { AnimalTargetDebugMarker } from '../animals/AnimalDebugIndicators';
 import { configureActorMeshShadows } from '../animals/actorMeshShadows';
+import { beeSpeechMessages } from '../animals/actorSpeechMessages';
 import { getCactusVariantConfig } from '../Cactus';
 import { getBlockSurfaceDecorations } from '../groundDecorations/getBlockSurfaceDecorations';
 import { resolveGroundDecorationSurface } from '../groundDecorations/groundDecorationConfig';
@@ -147,6 +152,7 @@ const clearBeeWeather = {
 } satisfies BeeWeather;
 
 const beeScale = 0.095;
+const beeSpeechBubblePosition: [number, number, number] = [0, 2.6, 0];
 const beeFlightSpeedBlocksPerSecond = 1.1;
 const beeFlightTurnDamping = 7.5;
 const beeFlightLookAheadProgress = 0.06;
@@ -1158,6 +1164,11 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
     const lastAnimalDebugUpdateRef = useRef(0);
     const lastDebugCommandSequenceRef = useRef(0);
     const lastDisturbanceSequenceRef = useRef(0);
+    const {
+        hideMessage: hideSpeechMessage,
+        message: speechMessage,
+        showMessage: showSpeechMessage,
+    } = useActorHoverSpeech(beeSpeechMessages);
     const animalTargetsDebugVisible = useGameState(
         (state) => state.animalTargetsDebugVisible,
     );
@@ -1231,6 +1242,16 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
 
     function handlePointerDown(event: ThreeEvent<PointerEvent>) {
         event.stopPropagation();
+    }
+
+    function handlePointerOver(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+        showSpeechMessage();
+    }
+
+    function handlePointerOut(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+        hideSpeechMessage();
     }
 
     function handleClick(event: ThreeEvent<MouseEvent>) {
@@ -1459,8 +1480,16 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
                 scale={beeScale}
                 onPointerDown={handlePointerDown}
                 onClick={handleClick}
+                onPointerOver={handlePointerOver}
+                onPointerOut={handlePointerOut}
             >
                 <primitive object={beeModel.scene} />
+                {speechMessage ? (
+                    <ActorSpeechBubble
+                        message={speechMessage}
+                        position={beeSpeechBubblePosition}
+                    />
+                ) : null}
             </group>
             <AnimalTargetDebugMarker ref={targetDebugRef} color="#facc15" />
         </>

--- a/packages/game/src/entities/bees/Bees.tsx
+++ b/packages/game/src/entities/bees/Bees.tsx
@@ -152,7 +152,7 @@ const clearBeeWeather = {
 } satisfies BeeWeather;
 
 const beeScale = 0.095;
-const beeSpeechBubblePosition: [number, number, number] = [0, 2.6, 0];
+const beeSpeechBubbleOffsetY = 0.25;
 const beeFlightSpeedBlocksPerSecond = 1.1;
 const beeFlightTurnDamping = 7.5;
 const beeFlightLookAheadProgress = 0.06;
@@ -1164,11 +1164,8 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
     const lastAnimalDebugUpdateRef = useRef(0);
     const lastDebugCommandSequenceRef = useRef(0);
     const lastDisturbanceSequenceRef = useRef(0);
-    const {
-        hideMessage: hideSpeechMessage,
-        message: speechMessage,
-        showMessage: showSpeechMessage,
-    } = useActorHoverSpeech(beeSpeechMessages);
+    const { message: speechMessage, showMessage: showSpeechMessage } =
+        useActorHoverSpeech(beeSpeechMessages);
     const animalTargetsDebugVisible = useGameState(
         (state) => state.animalTargetsDebugVisible,
     );
@@ -1247,11 +1244,6 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
     function handlePointerOver(event: ThreeEvent<PointerEvent>) {
         event.stopPropagation();
         showSpeechMessage();
-    }
-
-    function handlePointerOut(event: ThreeEvent<PointerEvent>) {
-        event.stopPropagation();
-        hideSpeechMessage();
     }
 
     function handleClick(event: ThreeEvent<MouseEvent>) {
@@ -1481,16 +1473,16 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
                 onPointerDown={handlePointerDown}
                 onClick={handleClick}
                 onPointerOver={handlePointerOver}
-                onPointerOut={handlePointerOut}
             >
                 <primitive object={beeModel.scene} />
-                {speechMessage ? (
-                    <ActorSpeechBubble
-                        message={speechMessage}
-                        position={beeSpeechBubblePosition}
-                    />
-                ) : null}
             </group>
+            {speechMessage ? (
+                <ActorSpeechBubble
+                    actorRef={groupRef}
+                    message={speechMessage}
+                    offsetY={beeSpeechBubbleOffsetY}
+                />
+            ) : null}
             <AnimalTargetDebugMarker ref={targetDebugRef} color="#facc15" />
         </>
     );

--- a/packages/game/src/entities/birds/Birds.tsx
+++ b/packages/game/src/entities/birds/Birds.tsx
@@ -157,7 +157,7 @@ const birdDebugBehaviors = [
 ] satisfies BirdBehavior[];
 
 const birdScale = 0.28;
-const birdSpeechBubblePosition: [number, number, number] = [0, 2, 0];
+const birdSpeechBubbleOffsetY = 0.56;
 const birdGroundLift = 0.02;
 const birdHousePerchYOffset = 1.3;
 const birdHouseEntranceYawOffset = Math.PI;
@@ -1541,11 +1541,8 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
     const lastDebugCommandSequenceRef = useRef(0);
     const lastDisturbanceSequenceRef = useRef(0);
     const [isFlapping, setIsFlapping] = useState(false);
-    const {
-        hideMessage: hideSpeechMessage,
-        message: speechMessage,
-        showMessage: showSpeechMessage,
-    } = useActorHoverSpeech(birdSpeechMessages);
+    const { message: speechMessage, showMessage: showSpeechMessage } =
+        useActorHoverSpeech(birdSpeechMessages);
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const animalTargetsDebugVisible = useGameState(
         (state) => state.animalTargetsDebugVisible,
@@ -1651,11 +1648,6 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
     function handlePointerOver(event: ThreeEvent<PointerEvent>) {
         event.stopPropagation();
         showSpeechMessage();
-    }
-
-    function handlePointerOut(event: ThreeEvent<PointerEvent>) {
-        event.stopPropagation();
-        hideSpeechMessage();
     }
 
     function handleClick(event: ThreeEvent<MouseEvent>) {
@@ -2091,16 +2083,16 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
                 onPointerDown={handlePointerDown}
                 onClick={handleClick}
                 onPointerOver={handlePointerOver}
-                onPointerOut={handlePointerOut}
             >
                 <primitive object={birdModel.scene} />
-                {speechMessage ? (
-                    <ActorSpeechBubble
-                        message={speechMessage}
-                        position={birdSpeechBubblePosition}
-                    />
-                ) : null}
             </group>
+            {speechMessage ? (
+                <ActorSpeechBubble
+                    actorRef={groupRef}
+                    message={speechMessage}
+                    offsetY={birdSpeechBubbleOffsetY}
+                />
+            ) : null}
             <AnimalTargetDebugMarker ref={targetDebugRef} color="#fb7185" />
         </>
     );

--- a/packages/game/src/entities/birds/Birds.tsx
+++ b/packages/game/src/entities/birds/Birds.tsx
@@ -15,8 +15,13 @@ import {
 import { getStackHeight } from '../../utils/getStackHeight';
 import { useGameGLTF } from '../../utils/useGameGLTF';
 import { useActorGroundingShadow } from '../animals/ActorGroundingShadows';
+import {
+    ActorSpeechBubble,
+    useActorHoverSpeech,
+} from '../animals/ActorSpeechBubble';
 import { AnimalTargetDebugMarker } from '../animals/AnimalDebugIndicators';
 import { configureActorMeshShadows } from '../animals/actorMeshShadows';
+import { birdSpeechMessages } from '../animals/actorSpeechMessages';
 import { waterBlockName } from '../waterBlockFoam';
 import {
     type BirdBehavior,
@@ -152,6 +157,7 @@ const birdDebugBehaviors = [
 ] satisfies BirdBehavior[];
 
 const birdScale = 0.28;
+const birdSpeechBubblePosition: [number, number, number] = [0, 2, 0];
 const birdGroundLift = 0.02;
 const birdHousePerchYOffset = 1.3;
 const birdHouseEntranceYawOffset = Math.PI;
@@ -1535,6 +1541,11 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
     const lastDebugCommandSequenceRef = useRef(0);
     const lastDisturbanceSequenceRef = useRef(0);
     const [isFlapping, setIsFlapping] = useState(false);
+    const {
+        hideMessage: hideSpeechMessage,
+        message: speechMessage,
+        showMessage: showSpeechMessage,
+    } = useActorHoverSpeech(birdSpeechMessages);
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const animalTargetsDebugVisible = useGameState(
         (state) => state.animalTargetsDebugVisible,
@@ -1635,6 +1646,16 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
 
     function handlePointerDown(event: ThreeEvent<PointerEvent>) {
         event.stopPropagation();
+    }
+
+    function handlePointerOver(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+        showSpeechMessage();
+    }
+
+    function handlePointerOut(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+        hideSpeechMessage();
     }
 
     function handleClick(event: ThreeEvent<MouseEvent>) {
@@ -2069,8 +2090,16 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
                 scale={birdScale}
                 onPointerDown={handlePointerDown}
                 onClick={handleClick}
+                onPointerOver={handlePointerOver}
+                onPointerOut={handlePointerOut}
             >
                 <primitive object={birdModel.scene} />
+                {speechMessage ? (
+                    <ActorSpeechBubble
+                        message={speechMessage}
+                        position={birdSpeechBubblePosition}
+                    />
+                ) : null}
             </group>
             <AnimalTargetDebugMarker ref={targetDebugRef} color="#fb7185" />
         </>

--- a/packages/game/src/entities/cats/Cats.tsx
+++ b/packages/game/src/entities/cats/Cats.tsx
@@ -19,11 +19,16 @@ import { getStackHeight } from '../../utils/getStackHeight';
 import { useGameGLTF } from '../../utils/useGameGLTF';
 import { useActorGroundingShadow } from '../animals/ActorGroundingShadows';
 import {
+    ActorSpeechBubble,
+    useActorHoverSpeech,
+} from '../animals/ActorSpeechBubble';
+import {
     type AnimalDebugPathPoint,
     AnimalPathDebugIndicator,
     AnimalTargetDebugMarker,
 } from '../animals/AnimalDebugIndicators';
 import { configureActorMeshShadows } from '../animals/actorMeshShadows';
+import { catSpeechMessages } from '../animals/actorSpeechMessages';
 import {
     type AnimalMovementSurface,
     canAnimalSettleAt,
@@ -125,6 +130,7 @@ const clearCatWeather = {
 } satisfies CatWeather;
 
 const catScale = 0.42;
+const catSpeechBubblePosition: [number, number, number] = [0, 2.2, 0];
 const catGroundLift = 0.02;
 const catPillowSurfaceYOffset = 0.24;
 const catSwimDepth = 0.12;
@@ -1273,6 +1279,11 @@ function Cat({
     const [pathDebugPoints, setPathDebugPoints] = useState<
         AnimalDebugPathPoint[]
     >([]);
+    const {
+        hideMessage: hideSpeechMessage,
+        message: speechMessage,
+        showMessage: showSpeechMessage,
+    } = useActorHoverSpeech(catSpeechMessages);
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const animalPathfindingDebugVisible = useGameState(
         (state) => state.animalPathfindingDebugVisible,
@@ -1392,6 +1403,16 @@ function Cat({
 
     function handlePointerDown(event: ThreeEvent<PointerEvent>) {
         event.stopPropagation();
+    }
+
+    function handlePointerOver(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+        showSpeechMessage();
+    }
+
+    function handlePointerOut(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+        hideSpeechMessage();
     }
 
     function handleClick(event: ThreeEvent<MouseEvent>) {
@@ -1706,8 +1727,16 @@ function Cat({
                 scale={catScale}
                 onPointerDown={handlePointerDown}
                 onClick={handleClick}
+                onPointerOver={handlePointerOver}
+                onPointerOut={handlePointerOut}
             >
                 <primitive object={catModel.scene} />
+                {speechMessage ? (
+                    <ActorSpeechBubble
+                        message={speechMessage}
+                        position={catSpeechBubblePosition}
+                    />
+                ) : null}
             </group>
             <AnimalTargetDebugMarker ref={targetDebugRef} color="#38bdf8" />
             <AnimalPathDebugIndicator

--- a/packages/game/src/entities/cats/Cats.tsx
+++ b/packages/game/src/entities/cats/Cats.tsx
@@ -130,7 +130,7 @@ const clearCatWeather = {
 } satisfies CatWeather;
 
 const catScale = 0.42;
-const catSpeechBubblePosition: [number, number, number] = [0, 2.2, 0];
+const catSpeechBubbleOffsetY = 0.92;
 const catGroundLift = 0.02;
 const catPillowSurfaceYOffset = 0.24;
 const catSwimDepth = 0.12;
@@ -1279,11 +1279,8 @@ function Cat({
     const [pathDebugPoints, setPathDebugPoints] = useState<
         AnimalDebugPathPoint[]
     >([]);
-    const {
-        hideMessage: hideSpeechMessage,
-        message: speechMessage,
-        showMessage: showSpeechMessage,
-    } = useActorHoverSpeech(catSpeechMessages);
+    const { message: speechMessage, showMessage: showSpeechMessage } =
+        useActorHoverSpeech(catSpeechMessages);
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const animalPathfindingDebugVisible = useGameState(
         (state) => state.animalPathfindingDebugVisible,
@@ -1408,11 +1405,6 @@ function Cat({
     function handlePointerOver(event: ThreeEvent<PointerEvent>) {
         event.stopPropagation();
         showSpeechMessage();
-    }
-
-    function handlePointerOut(event: ThreeEvent<PointerEvent>) {
-        event.stopPropagation();
-        hideSpeechMessage();
     }
 
     function handleClick(event: ThreeEvent<MouseEvent>) {
@@ -1728,16 +1720,16 @@ function Cat({
                 onPointerDown={handlePointerDown}
                 onClick={handleClick}
                 onPointerOver={handlePointerOver}
-                onPointerOut={handlePointerOut}
             >
                 <primitive object={catModel.scene} />
-                {speechMessage ? (
-                    <ActorSpeechBubble
-                        message={speechMessage}
-                        position={catSpeechBubblePosition}
-                    />
-                ) : null}
             </group>
+            {speechMessage ? (
+                <ActorSpeechBubble
+                    actorRef={groupRef}
+                    message={speechMessage}
+                    offsetY={catSpeechBubbleOffsetY}
+                />
+            ) : null}
             <AnimalTargetDebugMarker ref={targetDebugRef} color="#38bdf8" />
             <AnimalPathDebugIndicator
                 color="#38bdf8"

--- a/packages/game/src/entities/dogs/Dogs.tsx
+++ b/packages/game/src/entities/dogs/Dogs.tsx
@@ -151,7 +151,7 @@ const clearDogWeather = {
 } satisfies DogWeather;
 
 const dogScale = 0.46;
-const dogSpeechBubblePosition: [number, number, number] = [0, 2.45, 0];
+const dogSpeechBubbleOffsetY = 1.13;
 const dogGroundLift = 0.02;
 const dogHouseDoorOffset = 0.46;
 const dogHouseNightRestInset = 0.42;
@@ -1451,11 +1451,8 @@ function Dog({
     const [pathDebugPoints, setPathDebugPoints] = useState<
         AnimalDebugPathPoint[]
     >([]);
-    const {
-        hideMessage: hideSpeechMessage,
-        message: speechMessage,
-        showMessage: showSpeechMessage,
-    } = useActorHoverSpeech(dogSpeechMessages);
+    const { message: speechMessage, showMessage: showSpeechMessage } =
+        useActorHoverSpeech(dogSpeechMessages);
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const animalPathfindingDebugVisible = useGameState(
         (state) => state.animalPathfindingDebugVisible,
@@ -1581,11 +1578,6 @@ function Dog({
     function handlePointerOver(event: ThreeEvent<PointerEvent>) {
         event.stopPropagation();
         showSpeechMessage();
-    }
-
-    function handlePointerOut(event: ThreeEvent<PointerEvent>) {
-        event.stopPropagation();
-        hideSpeechMessage();
     }
 
     function handleClick(event: ThreeEvent<MouseEvent>) {
@@ -1922,18 +1914,18 @@ function Dog({
                 onPointerDown={handlePointerDown}
                 onClick={handleClick}
                 onPointerOver={handlePointerOver}
-                onPointerOut={handlePointerOut}
             >
                 <group rotation={[0, dogVisualYawOffset, 0]}>
                     <primitive object={dogModel.scene} />
                 </group>
-                {speechMessage ? (
-                    <ActorSpeechBubble
-                        message={speechMessage}
-                        position={dogSpeechBubblePosition}
-                    />
-                ) : null}
             </group>
+            {speechMessage ? (
+                <ActorSpeechBubble
+                    actorRef={groupRef}
+                    message={speechMessage}
+                    offsetY={dogSpeechBubbleOffsetY}
+                />
+            ) : null}
             <AnimalTargetDebugMarker ref={targetDebugRef} color="#f59e0b" />
             <AnimalPathDebugIndicator
                 color="#f59e0b"

--- a/packages/game/src/entities/dogs/Dogs.tsx
+++ b/packages/game/src/entities/dogs/Dogs.tsx
@@ -19,11 +19,16 @@ import { getStackHeight } from '../../utils/getStackHeight';
 import { useGameGLTF } from '../../utils/useGameGLTF';
 import { useActorGroundingShadow } from '../animals/ActorGroundingShadows';
 import {
+    ActorSpeechBubble,
+    useActorHoverSpeech,
+} from '../animals/ActorSpeechBubble';
+import {
     type AnimalDebugPathPoint,
     AnimalPathDebugIndicator,
     AnimalTargetDebugMarker,
 } from '../animals/AnimalDebugIndicators';
 import { configureActorMeshShadows } from '../animals/actorMeshShadows';
+import { dogSpeechMessages } from '../animals/actorSpeechMessages';
 import {
     type AnimalMovementSurface,
     canAnimalSettleAt,
@@ -146,6 +151,7 @@ const clearDogWeather = {
 } satisfies DogWeather;
 
 const dogScale = 0.46;
+const dogSpeechBubblePosition: [number, number, number] = [0, 2.45, 0];
 const dogGroundLift = 0.02;
 const dogHouseDoorOffset = 0.46;
 const dogHouseNightRestInset = 0.42;
@@ -1445,6 +1451,11 @@ function Dog({
     const [pathDebugPoints, setPathDebugPoints] = useState<
         AnimalDebugPathPoint[]
     >([]);
+    const {
+        hideMessage: hideSpeechMessage,
+        message: speechMessage,
+        showMessage: showSpeechMessage,
+    } = useActorHoverSpeech(dogSpeechMessages);
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const animalPathfindingDebugVisible = useGameState(
         (state) => state.animalPathfindingDebugVisible,
@@ -1565,6 +1576,16 @@ function Dog({
 
     function handlePointerDown(event: ThreeEvent<PointerEvent>) {
         event.stopPropagation();
+    }
+
+    function handlePointerOver(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+        showSpeechMessage();
+    }
+
+    function handlePointerOut(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+        hideSpeechMessage();
     }
 
     function handleClick(event: ThreeEvent<MouseEvent>) {
@@ -1900,10 +1921,18 @@ function Dog({
                 scale={dogScale}
                 onPointerDown={handlePointerDown}
                 onClick={handleClick}
+                onPointerOver={handlePointerOver}
+                onPointerOut={handlePointerOut}
             >
                 <group rotation={[0, dogVisualYawOffset, 0]}>
                     <primitive object={dogModel.scene} />
                 </group>
+                {speechMessage ? (
+                    <ActorSpeechBubble
+                        message={speechMessage}
+                        position={dogSpeechBubblePosition}
+                    />
+                ) : null}
             </group>
             <AnimalTargetDebugMarker ref={targetDebugRef} color="#f59e0b" />
             <AnimalPathDebugIndicator


### PR DESCRIPTION
## What changed

- Show a world-anchored chat bubble when the garden player, cat, dog, bird, or bee is hovered.
- Keep each message visible for five seconds after hover; later hover passes renew that lifetime without rerolling the text.
- Anchor the bubble to the actor world position so it follows moving animals for its full lifetime.
- Pick Croatian garden remarks for the player and species-specific animal sounds without immediate repetition between speech events.
- Keep the bubble pointer-transparent so existing actor click interactions continue to work.
- Add unit coverage for message selection and a WebGL component test for persistence, movement, timer renewal, and dismissal.

## Why

Actors respond with lightweight personality without flickering through new copy on every hover pass, and their speech remains visually attached while they move.

## Validation

- pnpm --filter @gredice/game test (859 passed)
- pnpm --filter @gredice/game typecheck
- pnpm --filter garden typecheck
- pnpm --filter garden test:prepare
- pnpm --filter garden exec playwright test tests/actor-speech-bubble.spec.tsx --project=chromium-webgl
- Focused Biome checks and git diff --check