### PR TITLE
feat(game): surface detailed inspection notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
               - packages/client/**
               - packages/js/**
               - packages/label-printer/**
+              - packages/notifications/**
               - packages/storage/**
               - packages/ui/**
               - .github/workflows/**

--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -8,6 +8,7 @@ import {
     gardenPreviewSourceRevisionHeader,
     gardenPreviewWidth,
 } from '@gredice/js/gardenPreviews';
+import { detailedRaisedBedInspectionNotificationType } from '@gredice/js/notifications';
 import { userAllowedPlantStatusTransitions } from '@gredice/js/plants';
 import {
     isRaisedBedAbandoned,
@@ -54,6 +55,7 @@ import {
     getGardenStack,
     getGardenStackForUpdate,
     getGardenVisitState,
+    getOperationsByIds,
     getOperationsPage,
     getPreviousPlantStatusChangedAtForUpdate,
     getPublicGarden,
@@ -67,11 +69,13 @@ import {
     getRaisedBedSensors,
     getRaisedBedsForGardens,
     getSandboxGardenDeletionCandidate,
+    getUnreadNotificationsByType,
     getUserLikedGardenIds,
     isPlantStatusEffectiveDateAllowed,
     knownEvents,
     knownEventTypes,
     markGardenVisitSummarySeen,
+    maxNotificationReadBatchSize,
     PublicGardenLikeTargetNotFoundError,
     queueGardenPreviewBlobDeletion,
     recordGardenPreviewBlobDeletionFailures,
@@ -79,6 +83,7 @@ import {
     replaceGardenPreview,
     rescheduleGardenDiaryOperation,
     rescheduleGardenDiaryRaisedBedField,
+    setAllNotificationsRead,
     setGardenLike,
     sowSandboxField,
     spendSunflowers,
@@ -104,6 +109,10 @@ import {
     serializeAppliedRaisedBedOperation,
 } from '../../../lib/garden/appliedRaisedBedOperations';
 import { resolveGardenBlockPlacement } from '../../../lib/garden/blockPlacementService';
+import {
+    buildDetailedRaisedBedInspectionReports,
+    detailedInspectionOperationId,
+} from '../../../lib/garden/detailedRaisedBedInspectionReports';
 import { deleteGardenBlock } from '../../../lib/garden/gardenBlocksService';
 import { serializeGardenOperationEvidence } from '../../../lib/garden/gardenOperationsSerialization';
 import {
@@ -164,6 +173,15 @@ const DEFAULT_TIMEZONE = 'Europe/Paris';
 const gardenLikeBodySchema = z
     .object({
         liked: z.boolean(),
+    })
+    .strict();
+
+const detailedInspectionReportsSeenBodySchema = z
+    .object({
+        notificationIds: z
+            .array(z.string().min(1))
+            .min(1)
+            .max(maxNotificationReadBatchSize),
     })
     .strict();
 
@@ -519,6 +537,38 @@ function serializeGardenOperation(
             'Vrt',
         statusHistory,
     };
+}
+
+async function loadDetailedRaisedBedInspectionReports({
+    accountId,
+    garden,
+    userId,
+}: {
+    accountId: string;
+    garden: NonNullable<Awaited<ReturnType<typeof getGarden>>>;
+    userId: string;
+}) {
+    const notifications = await getUnreadNotificationsByType({
+        accountId,
+        gardenId: garden.id,
+        type: detailedRaisedBedInspectionNotificationType,
+        userId,
+    });
+    const operationIds = notifications.flatMap((notification) => {
+        const operationId = detailedInspectionOperationId(
+            notification.metadata,
+        );
+        return operationId === null ? [] : [operationId];
+    });
+    const operations = await getOperationsByIds(operationIds);
+
+    return buildDetailedRaisedBedInspectionReports({
+        accountId,
+        gardenId: garden.id,
+        notifications,
+        operations,
+        raisedBeds: garden.raisedBeds,
+    });
 }
 
 function serializeGardenVisitState(
@@ -1166,6 +1216,95 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 nextCursor: operationsPage.nextCursor,
                 total: operationsPage.total,
             });
+        },
+    )
+    .get(
+        '/:gardenId/detailed-inspection-reports',
+        describeRoute({
+            description:
+                'Get unread detailed raised bed inspection reports for the current account and garden.',
+            security: authSecurity,
+        }),
+        zValidator(
+            'param',
+            z.object({
+                gardenId: z.string(),
+            }),
+        ),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { gardenId } = context.req.valid('param');
+            const gardenIdNumber = Number.parseInt(gardenId, 10);
+            if (Number.isNaN(gardenIdNumber)) {
+                return context.json({ error: 'Invalid garden ID' }, 400);
+            }
+
+            const { accountId, userId } = context.get('authContext');
+            const garden = await getGarden(gardenIdNumber);
+            if (!garden || garden.accountId !== accountId) {
+                return context.json({ error: 'Garden not found' }, 404);
+            }
+
+            const reports = await loadDetailedRaisedBedInspectionReports({
+                accountId,
+                garden,
+                userId,
+            });
+            return context.json({ reports }, 200);
+        },
+    )
+    .post(
+        '/:gardenId/detailed-inspection-reports/seen',
+        describeRoute({
+            description:
+                'Dismiss detailed raised bed inspection reports after the current user views the farmer notes.',
+            security: authSecurity,
+        }),
+        zValidator(
+            'param',
+            z.object({
+                gardenId: z.string(),
+            }),
+        ),
+        zValidator('json', detailedInspectionReportsSeenBodySchema),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { gardenId } = context.req.valid('param');
+            const { notificationIds } = context.req.valid('json');
+            const gardenIdNumber = Number.parseInt(gardenId, 10);
+            if (Number.isNaN(gardenIdNumber)) {
+                return context.json({ error: 'Invalid garden ID' }, 400);
+            }
+
+            const { accountId, userId } = context.get('authContext');
+            const garden = await getGarden(gardenIdNumber);
+            if (!garden || garden.accountId !== accountId) {
+                return context.json({ error: 'Garden not found' }, 404);
+            }
+
+            const reports = await loadDetailedRaisedBedInspectionReports({
+                accountId,
+                garden,
+                userId,
+            });
+            const unreadReportIds = new Set(
+                reports.map((report) => report.notificationId),
+            );
+            const dismissedNotificationIds = [
+                ...new Set(notificationIds),
+            ].filter((notificationId) => unreadReportIds.has(notificationId));
+
+            if (dismissedNotificationIds.length > 0) {
+                await setAllNotificationsRead(
+                    accountId,
+                    userId,
+                    dismissedNotificationIds,
+                    true,
+                    'game_detailed_inspection_farmer',
+                );
+            }
+
+            return context.json({ dismissedNotificationIds }, 200);
         },
     )
     .post(

--- a/apps/api/lib/garden/detailedRaisedBedInspectionReports.node.spec.ts
+++ b/apps/api/lib/garden/detailedRaisedBedInspectionReports.node.spec.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { RAISED_BED_DETAILED_INSPECTION_OPERATION_ID } from '@gredice/storage';
+import {
+    buildDetailedRaisedBedInspectionReports,
+    detailedInspectionOperationId,
+} from './detailedRaisedBedInspectionReports';
+
+test('reads only positive safe operation IDs from notification metadata', () => {
+    assert.equal(detailedInspectionOperationId({ operationId: 12 }), 12);
+    assert.equal(detailedInspectionOperationId({ operationId: '12' }), null);
+    assert.equal(detailedInspectionOperationId({ operationId: -1 }), null);
+});
+
+test('hydrates unread inspection notifications from current operation notes', () => {
+    const completedAt = new Date('2026-08-10T08:30:00.000Z');
+    const reports = buildDetailedRaisedBedInspectionReports({
+        accountId: 'account-1',
+        gardenId: 8,
+        notifications: [
+            {
+                id: 'notification-1',
+                metadata: { operationId: 42 },
+                timestamp: new Date('2026-08-10T08:31:00.000Z'),
+            },
+        ],
+        operations: [
+            {
+                accountId: 'account-1',
+                completedAt,
+                completionNotes: '  Tlo je rahlo i dovoljno vlažno.  ',
+                entityId: RAISED_BED_DETAILED_INSPECTION_OPERATION_ID,
+                gardenId: 8,
+                id: 42,
+                raisedBedId: 17,
+                status: 'pendingVerification',
+            },
+        ],
+        raisedBeds: [{ id: 17, name: 'Gredica Sjever' }],
+    });
+
+    assert.deepEqual(reports, [
+        {
+            inspectedAt: completedAt.toISOString(),
+            notes: 'Tlo je rahlo i dovoljno vlažno.',
+            notificationId: 'notification-1',
+            operationId: 42,
+            raisedBedId: 17,
+            raisedBedName: 'Gredica Sjever',
+        },
+    ]);
+});
+
+test('rejects reports outside the authenticated account and garden', () => {
+    const reports = buildDetailedRaisedBedInspectionReports({
+        accountId: 'account-1',
+        gardenId: 8,
+        notifications: [
+            {
+                id: 'notification-1',
+                metadata: { operationId: 42 },
+                timestamp: new Date('2026-08-10T08:31:00.000Z'),
+            },
+        ],
+        operations: [
+            {
+                accountId: 'account-2',
+                entityId: RAISED_BED_DETAILED_INSPECTION_OPERATION_ID,
+                gardenId: 9,
+                id: 42,
+                raisedBedId: 17,
+                status: 'completed',
+            },
+        ],
+        raisedBeds: [{ id: 17, name: 'Tuđa gredica' }],
+    });
+
+    assert.deepEqual(reports, []);
+});

--- a/apps/api/lib/garden/detailedRaisedBedInspectionReports.ts
+++ b/apps/api/lib/garden/detailedRaisedBedInspectionReports.ts
@@ -1,0 +1,93 @@
+import { RAISED_BED_DETAILED_INSPECTION_OPERATION_ID } from '@gredice/storage';
+
+type DetailedInspectionNotification = {
+    id: string;
+    metadata: Record<string, unknown>;
+    timestamp: Date;
+};
+
+type DetailedInspectionOperation = {
+    accountId?: string | null;
+    completedAt?: Date | null;
+    completionNotes?: string | null;
+    entityId: number;
+    gardenId?: number | null;
+    id: number;
+    raisedBedId?: number | null;
+    status: string;
+};
+
+type DetailedInspectionRaisedBed = {
+    id: number;
+    name: string;
+};
+
+export function detailedInspectionOperationId(
+    metadata: Record<string, unknown>,
+) {
+    const operationId = metadata.operationId;
+    return typeof operationId === 'number' &&
+        Number.isSafeInteger(operationId) &&
+        operationId > 0
+        ? operationId
+        : null;
+}
+
+export function buildDetailedRaisedBedInspectionReports({
+    accountId,
+    gardenId,
+    notifications,
+    operations,
+    raisedBeds,
+}: {
+    accountId: string;
+    gardenId: number;
+    notifications: DetailedInspectionNotification[];
+    operations: DetailedInspectionOperation[];
+    raisedBeds: DetailedInspectionRaisedBed[];
+}) {
+    const operationById = new Map(
+        operations.map((operation) => [operation.id, operation]),
+    );
+    const raisedBedById = new Map(
+        raisedBeds.map((raisedBed) => [raisedBed.id, raisedBed]),
+    );
+
+    return notifications.flatMap((notification) => {
+        const operationId = detailedInspectionOperationId(
+            notification.metadata,
+        );
+        const operation =
+            operationId === null ? undefined : operationById.get(operationId);
+        if (
+            !operation ||
+            operation.accountId !== accountId ||
+            operation.gardenId !== gardenId ||
+            operation.entityId !==
+                RAISED_BED_DETAILED_INSPECTION_OPERATION_ID ||
+            (operation.status !== 'pendingVerification' &&
+                operation.status !== 'completed') ||
+            !operation.raisedBedId
+        ) {
+            return [];
+        }
+
+        const raisedBed = raisedBedById.get(operation.raisedBedId);
+        if (!raisedBed) {
+            return [];
+        }
+
+        return [
+            {
+                inspectedAt: (
+                    operation.completedAt ?? notification.timestamp
+                ).toISOString(),
+                notes: operation.completionNotes?.trim() || null,
+                notificationId: notification.id,
+                operationId: operation.id,
+                raisedBedId: raisedBed.id,
+                raisedBedName: raisedBed.name,
+            },
+        ];
+    });
+}

--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -10,6 +10,7 @@ import {
     validateHostedImageUrl,
 } from '@gredice/js/urls';
 import {
+    notifyDetailedRaisedBedInspectionCompleted,
     notifyOperationAssignedUsers,
     notifyOperationUpdate,
 } from '@gredice/notifications';
@@ -29,6 +30,7 @@ import {
     getRaisedBed,
     type InsertOperation,
     knownEvents,
+    RAISED_BED_DETAILED_INSPECTION_OPERATION_ID,
     submitOperationTaskCompletion,
     switchOperationEntity,
     unacceptOperation,
@@ -933,8 +935,6 @@ async function notifyVerifiedOperationCompletion(
     operation: Awaited<ReturnType<typeof getOperationById>>,
     { notifySlack }: { notifySlack: boolean },
 ) {
-    const { header, content, linkUrl } =
-        await buildOperationCompletionNotification(operation);
     if (!operation.completedBy) {
         throw new Error('Completed operation is missing a completion actor.');
     }
@@ -942,22 +942,30 @@ async function notifyVerifiedOperationCompletion(
         throw new Error('Completed operation is missing a verification event.');
     }
 
+    const detailedInspectionHandled =
+        operation.entityId === RAISED_BED_DETAILED_INSPECTION_OPERATION_ID
+            ? await notifyDetailedRaisedBedInspectionCompleted(operation.id)
+            : false;
+    const completionNotification = detailedInspectionHandled
+        ? null
+        : await buildOperationCompletionNotification(operation);
+
     await Promise.all([
         notifySlack
             ? notifyOperationUpdate(operation.id, 'completed', {
                   completedBy: operation.completedBy,
               })
             : undefined,
-        operation.accountId
+        operation.accountId && completionNotification
             ? createNotification(
                   {
                       accountId: operation.accountId,
                       gardenId: operation.gardenId,
                       raisedBedId: operation.raisedBedId,
-                      header,
-                      content,
+                      header: completionNotification.header,
+                      content: completionNotification.content,
                       imageUrl: operation.imageUrls?.[0],
-                      linkUrl,
+                      linkUrl: completionNotification.linkUrl,
                       timestamp: operation.verifiedAt,
                   },
                   {
@@ -1027,6 +1035,10 @@ async function completeOperationForActor(
         await notifyVerifiedOperationCompletion(verifiedOperation, {
             notifySlack: result.created,
         });
+    } else if (
+        expectedEntityId === RAISED_BED_DETAILED_INSPECTION_OPERATION_ID
+    ) {
+        await notifyDetailedRaisedBedInspectionCompleted(operationId);
     }
 
     await revalidateOperationPaths(operation);

--- a/apps/farm/app/schedule/actions.spec.ts
+++ b/apps/farm/app/schedule/actions.spec.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+
+const actionsSource = readFileSync(
+    new URL('./actions.ts', import.meta.url),
+    'utf8',
+);
+
+test('retries the idempotent detailed-inspection notification before returning a keyed replay', () => {
+    const replayStart = actionsSource.indexOf('if (replay) {');
+    const replayEnd = actionsSource.indexOf(
+        '        } catch (error) {',
+        replayStart,
+    );
+    const replayBlock = actionsSource.slice(replayStart, replayEnd);
+
+    expect(replayStart).toBeGreaterThan(-1);
+    expect(replayEnd).toBeGreaterThan(replayStart);
+    expect(replayBlock).toContain(
+        'RAISED_BED_DETAILED_INSPECTION_OPERATION_ID',
+    );
+
+    const notificationCall = replayBlock.indexOf(
+        'await notifyDetailedRaisedBedInspectionCompleted(',
+    );
+    const replayReturn = replayBlock.indexOf('return actionResult(');
+
+    expect(notificationCall).toBeGreaterThan(-1);
+    expect(replayReturn).toBeGreaterThan(notificationCall);
+});

--- a/apps/farm/app/schedule/actions.ts
+++ b/apps/farm/app/schedule/actions.ts
@@ -519,6 +519,14 @@ export async function completeFarmOperation(
                 submissionId: validSubmissionId,
             });
             if (replay) {
+                if (
+                    validExpectedEntityId ===
+                    RAISED_BED_DETAILED_INSPECTION_OPERATION_ID
+                ) {
+                    await notifyDetailedRaisedBedInspectionCompleted(
+                        validOperationId,
+                    );
+                }
                 return actionResult(
                     completionState(replay.status),
                     replay.occurredAt,

--- a/apps/farm/app/schedule/actions.ts
+++ b/apps/farm/app/schedule/actions.ts
@@ -1,10 +1,12 @@
 'use server';
 
+import { notifyDetailedRaisedBedInspectionCompleted } from '@gredice/notifications';
 import {
     type EntityStandardized,
     getEntitiesFormatted,
     getFarmUserPrintableHarvestTraceLinkIds,
     markHarvestTraceLinksPrinted,
+    RAISED_BED_DETAILED_INSPECTION_OPERATION_ID,
     resolveOperationTaskCompletionSubmission,
     ScheduleTaskSubmissionError,
     submitOperationTaskBlock,
@@ -636,6 +638,10 @@ export async function completeFarmOperation(
             return failure;
         }
         throw error;
+    }
+
+    if (validExpectedEntityId === RAISED_BED_DETAILED_INSPECTION_OPERATION_ID) {
+        await notifyDetailedRaisedBedInspectionCompleted(validOperationId);
     }
 
     return actionResult(completionState(result.status), result.occurredAt);

--- a/apps/farm/package.json
+++ b/apps/farm/package.json
@@ -41,6 +41,7 @@
         "@gredice/client": "workspace:*",
         "@gredice/js": "workspace:*",
         "@gredice/label-printer": "workspace:*",
+        "@gredice/notifications": "workspace:*",
         "@gredice/storage": "workspace:*",
         "@gredice/ui": "workspace:*",
         "@mdxeditor/editor": "4.0.4",

--- a/apps/garden/tests/ActorSpeechBubbleFixture.tsx
+++ b/apps/garden/tests/ActorSpeechBubbleFixture.tsx
@@ -8,9 +8,14 @@ import {
 
 const fixtureMessages = ['Lijep dan u vrtu!', 'Vrt izgleda prekrasno!'];
 
-export function ActorSpeechBubbleFixture() {
+export function ActorSpeechBubbleFixture({
+    interactive = false,
+}: {
+    interactive?: boolean;
+}) {
     const [ready, setReady] = useState(false);
     const [actorX, setActorX] = useState(0);
+    const [bubbleClicks, setBubbleClicks] = useState(0);
     const actorRef = useRef<ActorSpeechAnchor>(null);
     const { message, showMessage } = useActorHoverSpeech(
         fixtureMessages,
@@ -30,6 +35,7 @@ export function ActorSpeechBubbleFixture() {
     return (
         <div
             data-actor-x={actorX}
+            data-bubble-clicks={bubbleClicks}
             data-message={message ?? ''}
             data-render-ready={ready ? 'true' : 'false'}
             data-testid="actor-speech-bubble-fixture"
@@ -63,9 +69,15 @@ export function ActorSpeechBubbleFixture() {
                 </group>
                 {message ? (
                     <ActorSpeechBubble
+                        actionLabel={interactive ? 'Otvori poruku' : undefined}
                         actorRef={actorRef}
                         message={message}
                         offsetY={1.2}
+                        onClick={
+                            interactive
+                                ? () => setBubbleClicks((count) => count + 1)
+                                : undefined
+                        }
                     />
                 ) : null}
             </Canvas>

--- a/apps/garden/tests/DetailedRaisedBedInspectionModalStory.tsx
+++ b/apps/garden/tests/DetailedRaisedBedInspectionModalStory.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { DetailedRaisedBedInspectionModal } from '../../../packages/game/src/hud/DetailedRaisedBedInspectionModal';
+
+const reports = [
+    {
+        inspectedAt: '2026-08-10T08:30:00.000Z',
+        notes: 'Tlo je rahlo i dovoljno vlažno.',
+        notificationId: 'notification-1',
+        operationId: 42,
+        raisedBedId: 17,
+        raisedBedName: 'Gredica Sjever',
+    },
+    {
+        inspectedAt: '2026-08-10T08:35:00.000Z',
+        notes: null,
+        notificationId: 'notification-2',
+        operationId: 43,
+        raisedBedId: 18,
+        raisedBedName: 'Gredica Jug',
+    },
+];
+
+export function DetailedRaisedBedInspectionModalStory({
+    withDismissError = false,
+}: {
+    withDismissError?: boolean;
+}) {
+    const [open, setOpen] = useState(true);
+    const [retryCount, setRetryCount] = useState(0);
+
+    return (
+        <div data-retry-count={retryCount} data-testid="inspection-modal-story">
+            <DetailedRaisedBedInspectionModal
+                dismissError={
+                    withDismissError ? new Error('Dismissal unavailable') : null
+                }
+                dismissPending={false}
+                onClose={() => setOpen(false)}
+                onRetryDismiss={() => setRetryCount((count) => count + 1)}
+                open={open}
+                reports={reports}
+            />
+        </div>
+    );
+}

--- a/apps/garden/tests/actor-speech-bubble.spec.tsx
+++ b/apps/garden/tests/actor-speech-bubble.spec.tsx
@@ -50,3 +50,25 @@ test('keeps one speech bubble attached to the actor and refreshes its lifetime',
     await expect(bubble).toBeVisible();
     await expect(bubble).toHaveCount(0, { timeout: 2_000 });
 });
+
+test('allows an actor speech bubble to open its action', async ({ mount }) => {
+    const fixture = await mount(<ActorSpeechBubbleFixture interactive />);
+    const canvas = fixture.locator('canvas');
+    await expect(fixture).toHaveAttribute('data-render-ready', 'true');
+
+    const canvasBox = await canvas.boundingBox();
+    expect(canvasBox).not.toBeNull();
+    if (!canvasBox) {
+        return;
+    }
+
+    await canvas.hover({
+        position: {
+            x: canvasBox.width / 2,
+            y: canvasBox.height / 2,
+        },
+    });
+    const bubble = fixture.getByRole('button', { name: 'Otvori poruku' });
+    await bubble.click();
+    await expect(fixture).toHaveAttribute('data-bubble-clicks', '1');
+});

--- a/apps/garden/tests/detailed-raised-bed-inspection-modal.spec.tsx
+++ b/apps/garden/tests/detailed-raised-bed-inspection-modal.spec.tsx
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { DetailedRaisedBedInspectionModalStory } from './DetailedRaisedBedInspectionModalStory';
+
+test('shows the farmer notes for every inspected raised bed', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DetailedRaisedBedInspectionModalStory />);
+
+    await expect(
+        page.getByRole('heading', { name: 'Farmerov detaljan pregled' }).last(),
+    ).toBeVisible();
+    await expect(page.getByText('Broj pregledanih gredica: 2')).toBeVisible();
+    await expect(page.getByText('Gredica Sjever')).toBeVisible();
+    await expect(
+        page.getByText('Tlo je rahlo i dovoljno vlažno.'),
+    ).toBeVisible();
+    await expect(page.getByText('Gredica Jug')).toBeVisible();
+    await expect(
+        page.getByText('Pregled je završen bez dodatne bilješke.'),
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: 'Zatvori' }).first().click();
+    await expect(
+        page.getByRole('heading', { name: 'Farmerov detaljan pregled' }),
+    ).toHaveCount(0);
+});
+
+test('offers a retry when cross-device dismissal fails', async ({
+    mount,
+    page,
+}) => {
+    const story = await mount(
+        <DetailedRaisedBedInspectionModalStory withDismissError />,
+    );
+
+    await expect(
+        page.getByText(
+            'Bilješke su prikazane, ali pregled nije označen kao pročitan na drugim uređajima.',
+        ),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Pokušaj ponovno' }).click();
+    await expect(story).toHaveAttribute('data-retry-count', '1');
+});

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -14,6 +14,8 @@ import { BlockInteractionLayer } from './controls/BlockInteractionLayer';
 import { BlockInteractionRegistryProvider } from './controls/BlockInteractionRegistry';
 import { GameCameraRig } from './controls/GameCameraRig';
 import { HudPlacementDragPreview } from './controls/HudPlacementDragPreview';
+import { DetailedInspectionFarmer } from './entities/avatar/DetailedInspectionFarmer';
+import { findDetailedInspectionFarmerTransform } from './entities/avatar/detailedInspectionFarmerPosition';
 import { GardenAvatar } from './entities/avatar/GardenAvatar';
 import { Bees } from './entities/bees/Bees';
 import { Birds } from './entities/birds/Birds';
@@ -42,15 +44,22 @@ import {
     defaultGameCameraZoom,
     farGameCameraZoom,
 } from './gameCamera';
+import { detailedInspectionFarmerMessage } from './hooks/detailedRaisedBedInspectionReports';
 import { useBlockData } from './hooks/useBlockData';
 import { useClearSandboxEnvironmentOverrides } from './hooks/useClearSandboxEnvironmentOverrides';
 import { type CurrentGarden, useCurrentGarden } from './hooks/useCurrentGarden';
 import { useDeferredSceneDetails } from './hooks/useDeferredSceneDetails';
+import {
+    type DetailedRaisedBedInspectionReport,
+    useDetailedRaisedBedInspectionReports,
+    useMarkDetailedRaisedBedInspectionReportsSeen,
+} from './hooks/useDetailedRaisedBedInspectionReports';
 import { useFocusPlacedBlock } from './hooks/useFocusPlacedBlock';
 import { useSceneCurrentGarden } from './hooks/useSceneCurrentGarden';
 import { useSyncGardenBackgroundPalette } from './hooks/useSyncGardenBackgroundPalette';
 import { useWeatherNow } from './hooks/useWeatherNow';
 import { DebugHud } from './hud/DebugHud';
+import { DetailedRaisedBedInspectionModal } from './hud/DetailedRaisedBedInspectionModal';
 import { GardenLoadingIndicator } from './indicators/GardenLoadingIndicator';
 import { PlacementGrid } from './indicators/PlacementGrid';
 import { isOperationVisualRewardDebugProfile } from './operationVisualRewardDebugProfile';
@@ -344,6 +353,14 @@ export function GameScene({
         (zoom !== 'far' || isOperationRewardDebug);
     const [sunflowerDropFlyOrigin, setSunflowerDropFlyOrigin] =
         useState<SunflowerDropFlyOrigin | null>(null);
+    const detailedInspectionReportsQuery =
+        useDetailedRaisedBedInspectionReports();
+    const markDetailedInspectionReportsSeen =
+        useMarkDetailedRaisedBedInspectionReportsSeen();
+    const [openedDetailedInspection, setOpenedDetailedInspection] = useState<{
+        gardenId: number;
+        reports: DetailedRaisedBedInspectionReport[];
+    } | null>(null);
     const autoQualityProfileMetrics = useAutoQualityProfileMetrics(
         quality === undefined && gameQualitySetting === 'auto',
     );
@@ -377,9 +394,39 @@ export function GameScene({
         useState<AdaptiveHighQualityLevelProfile>(adaptiveHighQualityLevels.L0);
 
     // Start non-critical metadata early, but don't block the first scene frame.
-    useBlockData();
+    const { data: blockData } = useBlockData();
     const { data: gardenData, isLoading: gardenLoading } = useCurrentGarden();
     const garden = useSceneCurrentGarden(gardenData);
+    const detailedInspectionReports =
+        detailedInspectionReportsQuery.data?.reports;
+    const detailedInspectionMessage = useMemo(
+        () =>
+            detailedInspectionFarmerMessage(
+                detailedInspectionReports?.map(
+                    (report) => report.notificationId,
+                ) ?? [],
+            ),
+        [detailedInspectionReports],
+    );
+    const detailedInspectionFirstReport = detailedInspectionReports?.[0];
+    const detailedInspectionTargetRaisedBedId =
+        detailedInspectionFirstReport?.raisedBedId;
+    const detailedInspectionTargetBlockId = garden?.raisedBeds.find(
+        (raisedBed) => raisedBed.id === detailedInspectionTargetRaisedBedId,
+    )?.blockId;
+    const detailedInspectionFarmerTransform = useMemo(
+        () =>
+            findDetailedInspectionFarmerTransform({
+                blockData,
+                stacks: garden?.stacks,
+                targetBlockId: detailedInspectionTargetBlockId,
+            }),
+        [blockData, detailedInspectionTargetBlockId, garden?.stacks],
+    );
+    const openedDetailedInspectionForCurrentGarden =
+        openedDetailedInspection?.gardenId === garden?.id
+            ? openedDetailedInspection
+            : null;
     const gardenInitialViewKey = garden?.id ?? 'default';
     const gardenInitialHomeCameraRef = useRef<{
         key: string | number;
@@ -434,6 +481,33 @@ export function GameScene({
     }
 
     const showDebugHud = debugHud ?? Boolean(flags?.enableDebugHudFlag);
+
+    function markDetailedInspectionSeen(
+        inspection: NonNullable<
+            typeof openedDetailedInspectionForCurrentGarden
+        >,
+    ) {
+        markDetailedInspectionReportsSeen.mutate({
+            gardenId: inspection.gardenId,
+            notificationIds: inspection.reports.map(
+                (report) => report.notificationId,
+            ),
+        });
+    }
+
+    function openDetailedInspectionReports() {
+        if (!garden || !detailedInspectionReports?.length) {
+            return;
+        }
+
+        const inspection = {
+            gardenId: garden.id,
+            reports: detailedInspectionReports,
+        };
+        markDetailedInspectionReportsSeen.reset();
+        setOpenedDetailedInspection(inspection);
+        markDetailedInspectionSeen(inspection);
+    }
 
     return (
         <div
@@ -580,6 +654,30 @@ export function GameScene({
                                             />
                                         </Suspense>
                                     )}
+                                {!hideHud &&
+                                    renderDetails &&
+                                    zoom !== 'far' &&
+                                    !openedDetailedInspectionForCurrentGarden &&
+                                    detailedInspectionFirstReport &&
+                                    detailedInspectionMessage &&
+                                    detailedInspectionFarmerTransform && (
+                                        <Suspense fallback={null}>
+                                            <DetailedInspectionFarmer
+                                                id={
+                                                    detailedInspectionFirstReport.notificationId
+                                                }
+                                                message={
+                                                    detailedInspectionMessage
+                                                }
+                                                onOpen={
+                                                    openDetailedInspectionReports
+                                                }
+                                                transform={
+                                                    detailedInspectionFarmerTransform
+                                                }
+                                            />
+                                        </Suspense>
+                                    )}
                                 {renderDetails && zoom !== 'far' && (
                                     <Suspense fallback={null}>
                                         <Bees
@@ -608,6 +706,25 @@ export function GameScene({
                     </ParticleSystemProvider>
                 </Scene>
             </GameSceneDetailContext.Provider>
+            {!hideHud && openedDetailedInspectionForCurrentGarden ? (
+                <DetailedRaisedBedInspectionModal
+                    dismissError={
+                        markDetailedInspectionReportsSeen.error instanceof Error
+                            ? markDetailedInspectionReportsSeen.error
+                            : null
+                    }
+                    dismissPending={markDetailedInspectionReportsSeen.isPending}
+                    onClose={() => setOpenedDetailedInspection(null)}
+                    onRetryDismiss={() => {
+                        markDetailedInspectionReportsSeen.reset();
+                        markDetailedInspectionSeen(
+                            openedDetailedInspectionForCurrentGarden,
+                        );
+                    }}
+                    open
+                    reports={openedDetailedInspectionForCurrentGarden.reports}
+                />
+            ) : null}
             <GardenPreviewCaptureController
                 enabled={!isLocalSandbox && !isMock}
                 garden={garden}

--- a/packages/game/src/entities/animals/ActorSpeechBubble.tsx
+++ b/packages/game/src/entities/animals/ActorSpeechBubble.tsx
@@ -1,5 +1,6 @@
 import { Html } from '@react-three/drei';
 import {
+    type MouseEventHandler,
     type RefObject,
     useCallback,
     useEffect,
@@ -65,13 +66,17 @@ export function useActorHoverSpeech(
 }
 
 export function ActorSpeechBubble({
+    actionLabel,
     actorRef,
     message,
     offsetY,
+    onClick,
 }: {
+    actionLabel?: string;
     actorRef: RefObject<Object3D | null>;
     message: string;
     offsetY: number;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
 }) {
     const actorWorldPositionRef = useRef(new Vector3());
     const calculateActorPosition = useCallback(
@@ -103,18 +108,32 @@ export function ActorSpeechBubble({
         <Html
             calculatePosition={calculateActorPosition}
             center
-            style={{ pointerEvents: 'none' }}
+            style={{ pointerEvents: onClick ? 'auto' : 'none' }}
             zIndexRange={[50, 31]}
         >
-            <div
-                aria-live="polite"
-                className="relative max-w-[min(15rem,75vw)] whitespace-nowrap rounded-xl border border-emerald-200 bg-white/95 px-3 py-1.5 text-center text-sm font-semibold leading-snug text-emerald-900 shadow-lg backdrop-blur-sm dark:border-emerald-800/80 dark:bg-neutral-950/95 dark:text-emerald-100"
-                data-actor-speech-bubble
-                role="status"
-            >
-                {message}
-                <span className="absolute top-full left-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rotate-45 border-r border-b border-emerald-200 bg-white/95 dark:border-emerald-800/80 dark:bg-neutral-950/95" />
-            </div>
+            {onClick ? (
+                <button
+                    type="button"
+                    aria-label={actionLabel}
+                    aria-live="polite"
+                    className="relative max-w-[min(15rem,75vw)] whitespace-normal rounded-xl border border-emerald-200 bg-white/95 px-3 py-1.5 text-center text-sm font-semibold leading-snug text-emerald-900 shadow-lg backdrop-blur-sm transition-transform hover:scale-105 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 dark:border-emerald-800/80 dark:bg-neutral-950/95 dark:text-emerald-100"
+                    data-actor-speech-bubble
+                    onClick={onClick}
+                >
+                    {message}
+                    <span className="absolute top-full left-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rotate-45 border-r border-b border-emerald-200 bg-white/95 dark:border-emerald-800/80 dark:bg-neutral-950/95" />
+                </button>
+            ) : (
+                <div
+                    aria-live="polite"
+                    className="relative max-w-[min(15rem,75vw)] whitespace-nowrap rounded-xl border border-emerald-200 bg-white/95 px-3 py-1.5 text-center text-sm font-semibold leading-snug text-emerald-900 shadow-lg backdrop-blur-sm dark:border-emerald-800/80 dark:bg-neutral-950/95 dark:text-emerald-100"
+                    data-actor-speech-bubble
+                    role="status"
+                >
+                    {message}
+                    <span className="absolute top-full left-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rotate-45 border-r border-b border-emerald-200 bg-white/95 dark:border-emerald-800/80 dark:bg-neutral-950/95" />
+                </div>
+            )}
         </Html>
     );
 }

--- a/packages/game/src/entities/avatar/DetailedInspectionFarmer.tsx
+++ b/packages/game/src/entities/avatar/DetailedInspectionFarmer.tsx
@@ -1,0 +1,156 @@
+import { type ThreeEvent, useFrame, useThree } from '@react-three/fiber';
+import {
+    type MouseEvent as ReactMouseEvent,
+    useEffect,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+} from 'react';
+import type { Group } from 'three';
+import {
+    sceneFrameRates,
+    useSceneTimeInvalidation,
+} from '../../scene/SceneTime';
+import { useGameState } from '../../useGameState';
+import { useGameGLTF } from '../../utils/useGameGLTF';
+import { useActorGroundingShadow } from '../animals/ActorGroundingShadows';
+import { ActorSpeechBubble } from '../animals/ActorSpeechBubble';
+import type { DetailedInspectionFarmerTransform } from './detailedInspectionFarmerPosition';
+import {
+    animateGardenAvatarRig,
+    avatarModelScale,
+    prepareGardenAvatarModel,
+} from './GardenAvatar';
+
+const inspectionFarmerSpeechOffsetY = 1.85;
+
+export function DetailedInspectionFarmer({
+    id,
+    message,
+    onOpen,
+    transform,
+}: {
+    id: string;
+    message: string;
+    onOpen: () => void;
+    transform: DetailedInspectionFarmerTransform;
+}) {
+    const gltf = useGameGLTF('FarmerAvatar');
+    const localAvatarView = useGameState((state) => state.gardenAvatarView);
+    const actorRef = useRef<Group>(null);
+    const { gl } = useThree();
+    const model = useMemo(() => {
+        const scene = gltf.scene.clone(true);
+        return { ...prepareGardenAvatarModel(scene), scene };
+    }, [gltf.scene]);
+    const castsRealShadow = localAvatarView !== 'overview';
+    const updateActorGroundingShadow = useActorGroundingShadow({
+        id: `detailed-inspection-farmer-${id}`,
+        primaryCasterCount: castsRealShadow ? model.primaryCasterCount : 0,
+        species: 'avatar',
+    });
+
+    useSceneTimeInvalidation(true, sceneFrameRates.interactive);
+
+    useLayoutEffect(() => {
+        for (const mesh of model.meshes) {
+            mesh.castShadow = castsRealShadow;
+        }
+        gl.shadowMap.needsUpdate = true;
+    }, [castsRealShadow, gl, model.meshes]);
+
+    useEffect(
+        () => () => {
+            model.shadowOnlyMaterial.dispose();
+            gl.domElement.style.cursor = 'auto';
+        },
+        [gl.domElement, model.shadowOnlyMaterial],
+    );
+
+    useFrame(({ clock, gl: frameGl }, delta) => {
+        const actor = actorRef.current;
+        if (!actor) {
+            return;
+        }
+
+        animateGardenAvatarRig({
+            crouchAmount: 0,
+            delta: Math.min(delta, 0.05),
+            distanceWalked: 0,
+            grounded: true,
+            headPitch: Math.sin(clock.elapsedTime * 0.7) * 0.035,
+            rig: model.rig,
+            walkAmount: 0,
+        });
+        if (castsRealShadow) {
+            frameGl.shadowMap.needsUpdate = true;
+        }
+        updateActorGroundingShadow?.({
+            actorY: actor.position.y,
+            receiverY: transform.position[1],
+            visible: !castsRealShadow,
+            x: actor.position.x,
+            yaw: actor.rotation.y,
+            z: actor.position.z,
+        });
+    });
+
+    function handleOpen(event: ThreeEvent<MouseEvent>) {
+        event.stopPropagation();
+        onOpen();
+    }
+
+    function handleBubbleOpen(event: ReactMouseEvent<HTMLButtonElement>) {
+        event.stopPropagation();
+        onOpen();
+    }
+
+    function handlePointerOver(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+        gl.domElement.style.cursor = 'pointer';
+    }
+
+    function handlePointerOut(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+        gl.domElement.style.cursor = 'auto';
+    }
+
+    return (
+        <>
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: Three.js actor opens the inspection notes modal. */}
+            <group
+                ref={actorRef}
+                name="DetailedInspectionFarmer"
+                position={transform.position}
+                rotation={[0, transform.rotationY, 0]}
+                onClick={handleOpen}
+                onPointerOut={handlePointerOut}
+                onPointerOver={handlePointerOver}
+            >
+                <mesh
+                    name="Interaction:DetailedInspectionFarmer"
+                    position={[0, 0.6, 0]}
+                    scale={[0.76, 1.32, 0.76]}
+                >
+                    <boxGeometry />
+                    <meshBasicMaterial
+                        colorWrite={false}
+                        depthWrite={false}
+                        opacity={0}
+                        transparent
+                    />
+                </mesh>
+                <group scale={avatarModelScale}>
+                    <primitive object={model.scene} />
+                </group>
+            </group>
+            <ActorSpeechBubble
+                actionLabel="Otvori bilješke detaljnog pregleda gredica"
+                actorRef={actorRef}
+                message={message}
+                offsetY={inspectionFarmerSpeechOffsetY}
+                onClick={handleBubbleOpen}
+            />
+        </>
+    );
+}

--- a/packages/game/src/entities/avatar/detailedInspectionFarmerPosition.ts
+++ b/packages/game/src/entities/avatar/detailedInspectionFarmerPosition.ts
@@ -1,0 +1,74 @@
+import type { BlockData } from '@gredice/client';
+import type { Stack } from '../../types/Stack';
+import {
+    createGardenAvatarCollisionWorld,
+    findGardenAvatarSpawnPoint,
+    getGardenAvatarGroundY,
+} from './gardenAvatarMovement';
+
+export type DetailedInspectionFarmerTransform = {
+    position: [x: number, y: number, z: number];
+    rotationY: number;
+};
+
+export function findDetailedInspectionFarmerTransform({
+    blockData,
+    stacks,
+    targetBlockId,
+}: {
+    blockData: BlockData[] | null | undefined;
+    stacks: Stack[] | undefined;
+    targetBlockId: string | null | undefined;
+}): DetailedInspectionFarmerTransform | null {
+    const world = createGardenAvatarCollisionWorld({ blockData, stacks });
+    const targetStack = stacks?.find((stack) =>
+        stack.blocks.some((block) => block.id === targetBlockId),
+    );
+    const fallback = findGardenAvatarSpawnPoint(world);
+    if (!targetStack) {
+        return fallback
+            ? {
+                  position: [fallback.x, fallback.y, fallback.z],
+                  rotationY: 0,
+              }
+            : null;
+    }
+
+    const walkableCandidate = world.surfaces
+        .filter(
+            (surface) =>
+                surface.kind === 'ground' && surface.roamable !== false,
+        )
+        .map((surface) => ({
+            distance: Math.hypot(
+                surface.x - targetStack.position.x,
+                surface.z - targetStack.position.z,
+            ),
+            point: {
+                x: surface.x,
+                y: surface.y,
+                z: surface.z,
+            },
+        }))
+        .sort((left, right) => left.distance - right.distance)
+        .find(
+            ({ point }) =>
+                getGardenAvatarGroundY({
+                    currentGroundY: point.y,
+                    position: point,
+                    world,
+                }) !== null,
+        )?.point;
+    const spawn = walkableCandidate ?? fallback;
+    if (!spawn) {
+        return null;
+    }
+
+    return {
+        position: [spawn.x, spawn.y, spawn.z],
+        rotationY: Math.atan2(
+            targetStack.position.x - spawn.x,
+            targetStack.position.z - spawn.z,
+        ),
+    };
+}

--- a/packages/game/src/entities/avatar/detailedInspectionFarmerPosition.unit.ts
+++ b/packages/game/src/entities/avatar/detailedInspectionFarmerPosition.unit.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { Vector3 } from 'three';
+import type { Stack } from '../../types/Stack';
+import { findDetailedInspectionFarmerTransform } from './detailedInspectionFarmerPosition';
+
+test('places the inspection farmer on walkable ground near the inspected bed', () => {
+    const stacks: Stack[] = [];
+    for (let x = -1; x <= 1; x += 1) {
+        for (let z = -1; z <= 1; z += 1) {
+            stacks.push({
+                blocks: [
+                    {
+                        id: `ground-${x.toString()}-${z.toString()}`,
+                        name: 'Block_Grass',
+                        rotation: 0,
+                    },
+                    ...(x === 0 && z === 0
+                        ? [
+                              {
+                                  id: 'raised-bed',
+                                  name: 'Raised_Bed',
+                                  rotation: 0,
+                              },
+                          ]
+                        : []),
+                ],
+                position: new Vector3(x, 0, z),
+            });
+        }
+    }
+
+    const transform = findDetailedInspectionFarmerTransform({
+        blockData: null,
+        stacks,
+        targetBlockId: 'raised-bed',
+    });
+
+    assert.ok(transform);
+    assert.notDeepEqual(transform.position, [0, 0, 0]);
+    assert.equal(Math.hypot(transform.position[0], transform.position[2]), 1);
+});
+
+test('falls back to the garden spawn when the inspected block is unavailable', () => {
+    const transform = findDetailedInspectionFarmerTransform({
+        blockData: null,
+        stacks: [
+            {
+                blocks: [{ id: 'ground', name: 'Block_Grass', rotation: 0 }],
+                position: new Vector3(2, 0, 3),
+            },
+        ],
+        targetBlockId: null,
+    });
+
+    assert.deepEqual(transform, {
+        position: [2, 0, 3],
+        rotationY: 0,
+    });
+});

--- a/packages/game/src/hooks/detailedRaisedBedInspectionReports.ts
+++ b/packages/game/src/hooks/detailedRaisedBedInspectionReports.ts
@@ -1,0 +1,32 @@
+export const detailedInspectionFarmerMessages = [
+    'Zanimljivo... evo što mislim o tvojim gredicama.',
+    'Pregledao sam gredice. Imam nekoliko bilješki za tebe.',
+    'Završio sam pregled. Želiš čuti što sam primijetio?',
+    'Tvoje gredice imaju priču. Pogledaj moje bilješke.',
+] as const;
+
+function stableMessageIndex(keys: readonly string[], length: number) {
+    let hash = 2_166_136_261;
+    for (const character of [...keys].sort().join('|')) {
+        hash ^= character.codePointAt(0) ?? 0;
+        hash = Math.imul(hash, 16_777_619);
+    }
+    return (hash >>> 0) % length;
+}
+
+export function detailedInspectionFarmerMessage(
+    notificationIds: readonly string[],
+) {
+    if (notificationIds.length === 0) {
+        return null;
+    }
+
+    return (
+        detailedInspectionFarmerMessages[
+            stableMessageIndex(
+                notificationIds,
+                detailedInspectionFarmerMessages.length,
+            )
+        ] ?? null
+    );
+}

--- a/packages/game/src/hooks/detailedRaisedBedInspectionReports.unit.ts
+++ b/packages/game/src/hooks/detailedRaisedBedInspectionReports.unit.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    detailedInspectionFarmerMessage,
+    detailedInspectionFarmerMessages,
+} from './detailedRaisedBedInspectionReports';
+
+test('provides several Croatian farmer prompts for inspection notes', () => {
+    assert.ok(detailedInspectionFarmerMessages.length > 2);
+    assert.ok(
+        detailedInspectionFarmerMessages.every((message) =>
+            /gredic|pregled|bilješk/i.test(message),
+        ),
+    );
+});
+
+test('keeps the prompt stable for the same notification set', () => {
+    assert.equal(
+        detailedInspectionFarmerMessage(['notification-b', 'notification-a']),
+        detailedInspectionFarmerMessage(['notification-a', 'notification-b']),
+    );
+});
+
+test('does not show a farmer prompt without inspection notifications', () => {
+    assert.equal(detailedInspectionFarmerMessage([]), null);
+});

--- a/packages/game/src/hooks/useDetailedRaisedBedInspectionReports.ts
+++ b/packages/game/src/hooks/useDetailedRaisedBedInspectionReports.ts
@@ -1,0 +1,133 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useGameState } from '../useGameState';
+import { useCurrentGarden } from './useCurrentGarden';
+
+export function detailedRaisedBedInspectionReportsQueryKey(
+    gardenId: number | null | undefined,
+) {
+    return [
+        'detailed-raised-bed-inspection-reports',
+        gardenId ?? null,
+    ] as const;
+}
+
+async function getDetailedRaisedBedInspectionReports(gardenId: number) {
+    const response = await clientAuthenticated().api.gardens[':gardenId'][
+        'detailed-inspection-reports'
+    ].$get({
+        param: { gardenId: gardenId.toString() },
+    });
+
+    if (!response.ok) {
+        throw new Error(
+            'Failed to load detailed raised bed inspection reports',
+        );
+    }
+
+    return response.json();
+}
+
+export type DetailedRaisedBedInspectionReport = Awaited<
+    ReturnType<typeof getDetailedRaisedBedInspectionReports>
+>['reports'][number];
+type DetailedRaisedBedInspectionReportsResponse = Awaited<
+    ReturnType<typeof getDetailedRaisedBedInspectionReports>
+>;
+
+export function useDetailedRaisedBedInspectionReports() {
+    const { data: currentGarden } = useCurrentGarden();
+    const isMock = useGameState((state) => state.isMock);
+    const localSandboxStorageKey = useGameState(
+        (state) => state.localSandboxStorageKey,
+    );
+    const enabled =
+        currentGarden?.id != null &&
+        !currentGarden.isSandbox &&
+        !isMock &&
+        localSandboxStorageKey === null;
+
+    return useQuery({
+        queryKey: detailedRaisedBedInspectionReportsQueryKey(currentGarden?.id),
+        queryFn: async () => {
+            if (currentGarden?.id == null) {
+                throw new Error(
+                    'Garden ID is required to load detailed inspection reports',
+                );
+            }
+            return getDetailedRaisedBedInspectionReports(currentGarden.id);
+        },
+        enabled,
+        refetchInterval: 60_000,
+        staleTime: 30_000,
+    });
+}
+
+export function useMarkDetailedRaisedBedInspectionReportsSeen() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({
+            gardenId,
+            notificationIds,
+        }: {
+            gardenId: number;
+            notificationIds: string[];
+        }) => {
+            const response = await clientAuthenticated().api.gardens[
+                ':gardenId'
+            ]['detailed-inspection-reports'].seen.$post({
+                param: { gardenId: gardenId.toString() },
+                json: { notificationIds },
+            });
+
+            if (!response.ok) {
+                throw new Error(
+                    'Failed to dismiss detailed raised bed inspection reports',
+                );
+            }
+
+            return response.json();
+        },
+        onMutate: async (variables) => {
+            const queryKey = detailedRaisedBedInspectionReportsQueryKey(
+                variables.gardenId,
+            );
+            await queryClient.cancelQueries({ queryKey });
+            const previous =
+                queryClient.getQueryData<DetailedRaisedBedInspectionReportsResponse>(
+                    queryKey,
+                );
+            const dismissedIds = new Set(variables.notificationIds);
+            queryClient.setQueryData<DetailedRaisedBedInspectionReportsResponse>(
+                queryKey,
+                (current) =>
+                    current
+                        ? {
+                              ...current,
+                              reports: current.reports.filter(
+                                  (report) =>
+                                      !dismissedIds.has(report.notificationId),
+                              ),
+                          }
+                        : current,
+            );
+            return { previous, queryKey };
+        },
+        onError: (_error, _variables, context) => {
+            if (context?.previous) {
+                queryClient.setQueryData(context.queryKey, context.previous);
+            }
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['notifications'] });
+        },
+        onSettled: (_data, _error, variables) => {
+            queryClient.invalidateQueries({
+                queryKey: detailedRaisedBedInspectionReportsQueryKey(
+                    variables.gardenId,
+                ),
+            });
+        },
+    });
+}

--- a/packages/game/src/hud/DetailedRaisedBedInspectionModal.tsx
+++ b/packages/game/src/hud/DetailedRaisedBedInspectionModal.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Card } from '@gredice/ui/Card';
+import { Sprout } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import type { DetailedRaisedBedInspectionReport } from '../hooks/useDetailedRaisedBedInspectionReports';
+import { GameModal } from '../shared-ui/game-modal';
+
+export function DetailedRaisedBedInspectionModal({
+    dismissError,
+    dismissPending,
+    onClose,
+    onRetryDismiss,
+    open,
+    reports,
+}: {
+    dismissError: Error | null;
+    dismissPending: boolean;
+    onClose: () => void;
+    onRetryDismiss: () => void;
+    open: boolean;
+    reports: DetailedRaisedBedInspectionReport[];
+}) {
+    const raisedBedCount = new Set(reports.map((report) => report.raisedBedId))
+        .size;
+
+    return (
+        <GameModal
+            className="md:max-w-2xl"
+            headerDescription={`Broj pregledanih gredica: ${raisedBedCount.toString()}`}
+            headerIcon={<Sprout className="size-6" />}
+            hudLayer
+            onOpenChange={(nextOpen) => {
+                if (!nextOpen) {
+                    onClose();
+                }
+            }}
+            open={open}
+            showHeader
+            title="Farmerov detaljan pregled"
+        >
+            <Stack spacing={4} className="min-w-0">
+                <Typography level="body2" secondary>
+                    Ovo su bilješke iz posljednjih detaljnih pregleda tvojih
+                    gredica.
+                </Typography>
+                <Stack
+                    spacing={3}
+                    className="max-h-[55dvh] overflow-y-auto pr-1"
+                >
+                    {reports.map((report) => (
+                        <Card
+                            key={report.notificationId}
+                            className="min-w-0 p-4"
+                        >
+                            <Stack spacing={2}>
+                                <Row
+                                    className="min-w-0 justify-between gap-3"
+                                    alignItems="start"
+                                >
+                                    <Typography
+                                        className="min-w-0 break-words"
+                                        level="body1"
+                                        semiBold
+                                    >
+                                        {report.raisedBedName}
+                                    </Typography>
+                                    <time
+                                        className="shrink-0"
+                                        dateTime={report.inspectedAt}
+                                    >
+                                        <Typography level="body3" secondary>
+                                            {new Date(
+                                                report.inspectedAt,
+                                            ).toLocaleDateString('hr-HR')}
+                                        </Typography>
+                                    </time>
+                                </Row>
+                                <Typography
+                                    className="whitespace-pre-wrap break-words"
+                                    level="body2"
+                                >
+                                    {report.notes ??
+                                        'Pregled je završen bez dodatne bilješke.'}
+                                </Typography>
+                            </Stack>
+                        </Card>
+                    ))}
+                </Stack>
+                {dismissError ? (
+                    <Alert color="warning">
+                        <Stack spacing={2}>
+                            <Typography level="body2">
+                                Bilješke su prikazane, ali pregled nije označen
+                                kao pročitan na drugim uređajima.
+                            </Typography>
+                            <Button
+                                className="self-start"
+                                loading={dismissPending}
+                                onClick={onRetryDismiss}
+                                size="sm"
+                                variant="outlined"
+                            >
+                                Pokušaj ponovno
+                            </Button>
+                        </Stack>
+                    </Alert>
+                ) : null}
+                <Row className="justify-end">
+                    <Button onClick={onClose}>Zatvori</Button>
+                </Row>
+            </Stack>
+        </GameModal>
+    );
+}

--- a/packages/js/src/notifications/index.ts
+++ b/packages/js/src/notifications/index.ts
@@ -1,0 +1,2 @@
+export const detailedRaisedBedInspectionNotificationType =
+    'raised_bed_detailed_inspection_completed';

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -17,6 +17,7 @@
     },
     "dependencies": {
         "@gredice/directory-types": "workspace:*",
+        "@gredice/js": "workspace:*",
         "@gredice/slack": "workspace:*",
         "@gredice/storage": "workspace:*"
     },

--- a/packages/notifications/src/detailedRaisedBedInspection.node.spec.ts
+++ b/packages/notifications/src/detailedRaisedBedInspection.node.spec.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { detailedRaisedBedInspectionNotificationType } from '@gredice/js/notifications';
+import { buildDetailedRaisedBedInspectionNotification } from './detailedRaisedBedInspection';
+
+test('builds a garden-scoped detailed inspection notification with operation identity', () => {
+    const notification = buildDetailedRaisedBedInspectionNotification({
+        gardenId: 8,
+        operationId: 42,
+        raisedBedId: 17,
+        raisedBedName: 'Gredica Sjever',
+    });
+
+    assert.equal(notification.category, 'garden');
+    assert.equal(
+        notification.type,
+        detailedRaisedBedInspectionNotificationType,
+    );
+    assert.deepEqual(notification.metadata, { operationId: 42 });
+    assert.equal(notification.gardenId, 8);
+    assert.equal(notification.raisedBedId, 17);
+    assert.match(notification.content, /Gredica Sjever/);
+    assert.match(notification.linkUrl, /gredica=Gredica%20Sjever/);
+});

--- a/packages/notifications/src/detailedRaisedBedInspection.ts
+++ b/packages/notifications/src/detailedRaisedBedInspection.ts
@@ -1,0 +1,79 @@
+import { detailedRaisedBedInspectionNotificationType } from '@gredice/js/notifications';
+import { getRaisedBedCloseupUrl } from '@gredice/js/urls';
+import {
+    createNotification,
+    getOperationById,
+    getRaisedBed,
+    RAISED_BED_DETAILED_INSPECTION_OPERATION_ID,
+} from '@gredice/storage';
+
+export function buildDetailedRaisedBedInspectionNotification({
+    gardenId,
+    operationId,
+    raisedBedId,
+    raisedBedName,
+}: {
+    gardenId: number;
+    operationId: number;
+    raisedBedId: number;
+    raisedBedName: string;
+}) {
+    return {
+        category: 'garden',
+        content: `Farmer je završio detaljan pregled gredice **${raisedBedName}**. U vrtu te čekaju njegove bilješke.`,
+        gardenId,
+        header: 'Novi detaljan pregled gredice',
+        linkUrl: getRaisedBedCloseupUrl(raisedBedName),
+        metadata: {
+            operationId,
+        },
+        raisedBedId,
+        type: detailedRaisedBedInspectionNotificationType,
+    } as const;
+}
+
+export async function notifyDetailedRaisedBedInspectionCompleted(
+    operationId: number,
+) {
+    const operation = await getOperationById(operationId);
+    if (operation.entityId !== RAISED_BED_DETAILED_INSPECTION_OPERATION_ID) {
+        return false;
+    }
+
+    if (
+        !operation.accountId ||
+        !operation.gardenId ||
+        !operation.raisedBedId ||
+        !operation.completionEventId ||
+        !operation.completedAt
+    ) {
+        throw new Error(
+            'Completed detailed raised bed inspection is missing its account, garden, raised bed, or completion event.',
+        );
+    }
+
+    const raisedBed = await getRaisedBed(operation.raisedBedId);
+    if (!raisedBed?.name) {
+        throw new Error(
+            'Completed detailed raised bed inspection is missing its raised bed.',
+        );
+    }
+
+    await createNotification(
+        {
+            accountId: operation.accountId,
+            timestamp: operation.completedAt,
+            ...buildDetailedRaisedBedInspectionNotification({
+                gardenId: operation.gardenId,
+                operationId: operation.id,
+                raisedBedId: operation.raisedBedId,
+                raisedBedName: raisedBed.name,
+            }),
+        },
+        {
+            idempotencyKey: `schedule-task:detailed-raised-bed-inspection:${operation.completionEventId.toString()}`,
+        },
+    );
+
+    return true;
+}

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -25,6 +25,7 @@ import {
 
 export * from './customerDeliveryNotifications';
 export * from './deliveryLifecycle';
+export * from './detailedRaisedBedInspection';
 
 type OperationEventType =
     | 'scheduled'

--- a/packages/storage/src/repositories/notificationsRepo.ts
+++ b/packages/storage/src/repositories/notificationsRepo.ts
@@ -4232,6 +4232,43 @@ export async function getNotificationsForCenter({
     });
 }
 
+export async function getUnreadNotificationsByType({
+    accountId,
+    gardenId,
+    limit = maxNotificationReadBatchSize,
+    type,
+    userId,
+}: {
+    accountId: string;
+    gardenId?: number;
+    limit?: number;
+    type: string;
+    userId: string;
+}) {
+    const boundedLimit = Math.min(
+        Math.max(Number.isSafeInteger(limit) ? limit : 1, 1),
+        maxNotificationReadBatchSize,
+    );
+
+    return await storage().query.notifications.findMany({
+        where: and(
+            eq(notifications.accountId, accountId),
+            or(eq(notifications.userId, userId), isNull(notifications.userId)),
+            gardenId === undefined
+                ? undefined
+                : eq(notifications.gardenId, gardenId),
+            eq(notifications.type, type),
+            isNull(notifications.readAt),
+        ),
+        orderBy: [
+            desc(notifications.timestamp),
+            desc(notifications.createdAt),
+            desc(notifications.id),
+        ],
+        limit: boundedLimit,
+    });
+}
+
 export function getNotifications(page: number, limit: number) {
     return storage().query.notifications.findMany({
         orderBy: desc(notifications.timestamp),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,6 +576,9 @@ importers:
       '@gredice/label-printer':
         specifier: workspace:*
         version: link:../../packages/label-printer
+      '@gredice/notifications':
+        specifier: workspace:*
+        version: link:../../packages/notifications
       '@gredice/storage':
         specifier: workspace:*
         version: link:../../packages/storage
@@ -1425,6 +1428,9 @@ importers:
       '@gredice/directory-types':
         specifier: workspace:*
         version: link:../directory-types
+      '@gredice/js':
+        specifier: workspace:*
+        version: link:../js
       '@gredice/slack':
         specifier: workspace:*
         version: link:../slack


### PR DESCRIPTION
## What changed

- create one idempotent, account-scoped notification when a detailed raised-bed inspection is completed from either App or Farm
- expose unread inspection reports through authenticated, garden-scoped endpoints that hydrate the current operation notes and mark only authorized report notifications as seen
- spawn a temporary Farmer avatar on walkable ground near an inspected bed, with a stable Croatian prompt and a clickable speech bubble
- show every pending raised-bed report in a Garden modal and optimistically despawn the Farmer after viewing, with a retry path if cross-device dismissal fails
- extend actor speech bubbles with an optional accessible button action while preserving passive animal-bubble behavior

## Why

Detailed weekly inspections already record valuable notes, but users have no prominent Garden moment that tells them those notes are ready. This makes the completed work discoverable in context and uses notification read state as the durable, cross-device dismissal record.

## Stack

This branch was built on the actor speech-bubble work from #4459. That PR merged while this change was being validated, so this PR now targets `main`; its diff contains only the inspection feature commit.

## Validation

- `pnpm --filter garden test:prepare`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --dir apps/api exec tsc --noEmit --pretty false`
- `pnpm --dir apps/farm exec tsc --noEmit --pretty false`
- `pnpm --filter @gredice/game test` — 864 passed
- `pnpm --filter @gredice/notifications test` — 21 passed
- focused API report tests — 3 passed
- focused Garden component tests — 4 passed
- focused Biome checks and `git diff --check`

The App workspace's standalone `tsc` remains blocked by existing unrelated admin/page type errors; none reference the operation action changed here.