### PR TITLE
fix(game): allow bridge placement on water

### DIFF
--- a/apps/api/lib/garden/blockPlacementService.node.spec.ts
+++ b/apps/api/lib/garden/blockPlacementService.node.spec.ts
@@ -14,6 +14,16 @@ const blockDataByName = new Map([
             },
         },
     ],
+    [
+        'SmallWoodenBridge',
+        {
+            attributes: {
+                stackable: false,
+                height: 0.38,
+                placeableOnWater: true,
+            },
+        },
+    ],
     ['Raised_Bed', { attributes: { stackable: true, height: 1 } }],
     ['Shade', { attributes: { stackable: false, height: 1 } }],
     [
@@ -217,6 +227,26 @@ describe('resolveGardenBlockPlacement', () => {
             blockName: 'Block_Water',
             stacks,
             blockNameById,
+            blockDataByName,
+        });
+
+        assert.deepStrictEqual(placement, {
+            valid: true,
+            placement: {
+                x: 0,
+                y: 0,
+                index: 1,
+                existingBlocks: ['water-origin'],
+            },
+        });
+    });
+
+    it('places the small wooden bridge on a requested water stack', () => {
+        const placement = resolveGardenBlockPlacement({
+            blockName: 'SmallWoodenBridge',
+            requestedPosition: { x: 0, y: 0 },
+            stacks: [{ positionX: 0, positionY: 0, blocks: ['water-origin'] }],
+            blockNameById: new Map([['water-origin', 'Block_Water']]),
             blockDataByName,
         });
 

--- a/apps/api/lib/garden/stacksPatchValidation.node.spec.ts
+++ b/apps/api/lib/garden/stacksPatchValidation.node.spec.ts
@@ -14,6 +14,16 @@ const blockDataByName = new Map([
             },
         },
     ],
+    [
+        'SmallWoodenBridge',
+        {
+            attributes: {
+                stackable: false,
+                height: 0.38,
+                placeableOnWater: true,
+            },
+        },
+    ],
     ['Tree', { attributes: { stackable: true, height: 1 } }],
 ]);
 
@@ -40,6 +50,19 @@ describe('validateStackPlacement', () => {
             blockNameById: new Map([
                 ['water-a', 'Block_Water'],
                 ['water-b', 'Block_Water'],
+            ]),
+            blockDataByName,
+        });
+
+        assert.deepEqual(validation, { valid: true });
+    });
+
+    it('allows the small wooden bridge directly above water', () => {
+        const validation = validateStackPlacement({
+            blockIds: ['water-a', 'bridge-a'],
+            blockNameById: new Map([
+                ['water-a', 'Block_Water'],
+                ['bridge-a', 'SmallWoodenBridge'],
             ]),
             blockDataByName,
         });

--- a/packages/client/src/directories-api.ts
+++ b/packages/client/src/directories-api.ts
@@ -3,7 +3,7 @@ import createClient from 'openapi-fetch';
 import { createDevSafeFetch, getAppUrl } from './shared';
 
 const blockDirectoryCacheVersion =
-    'wooden-bench-and-small-wooden-bridge-2026-08-10-2';
+    'small-wooden-bridge-water-placement-2026-08-10-3';
 const blockDirectoryPath = '/api/directories/entities/block';
 
 function withBlockDirectoryCacheVersion(baseFetch: typeof fetch): typeof fetch {

--- a/packages/game/src/controls/PickupPlacementResolver.unit.ts
+++ b/packages/game/src/controls/PickupPlacementResolver.unit.ts
@@ -138,6 +138,12 @@ const blockData = [
         name: 'Block_Water',
         placeableOnWater: true,
     }),
+    createBlockData({
+        id: 9,
+        name: 'SmallWoodenBridge',
+        placeableOnWater: true,
+        stackable: false,
+    }),
 ];
 
 describe('resolvePickupPlacementPreviewForRelative', () => {
@@ -419,6 +425,27 @@ describe('resolvePickupPlacementPreviewForRelative', () => {
         });
 
         assert.equal(preview?.nextIsBlocked, false);
+    });
+
+    it('allows the small wooden bridge to be dropped onto water', () => {
+        const bridge = createBlock('SmallWoodenBridge', 'bridge');
+        const water = createBlock('Block_Water', 'water');
+        const sourceStack = createStack(0, 0, [bridge]);
+        const waterStack = createStack(1, 0, [water]);
+
+        const preview = resolvePickupPlacementPreviewForRelative({
+            blockData,
+            gardenIsSandbox: false,
+            localSandboxStorageKey: null,
+            movingSegments: [
+                createMovingSegment({ block: bridge, sourceStack }),
+            ],
+            relative: new Vector3(1, 0, 0),
+            stacks: [sourceStack, waterStack],
+        });
+
+        assert.equal(preview?.nextIsBlocked, false);
+        assert.equal(preview?.targetOffsets[0]?.hoverHeight, 1);
     });
 
     it('matches the single-resolution path when reusing prepared placement state', () => {

--- a/packages/game/src/localSandboxBlockData.ts
+++ b/packages/game/src/localSandboxBlockData.ts
@@ -206,6 +206,7 @@ function createLocalSandboxBlockData(
         },
         attributes: {
             height: getLocalSandboxStackHeight(name),
+            ...(name === 'SmallWoodenBridge' ? { placeableOnWater: true } : {}),
             stackable: isGroundBlock,
             type: isRaisedBed ? 'raisedBed' : 'decoration',
             nightOnlyPurchase: false,

--- a/packages/game/src/localSandboxBlockData.unit.ts
+++ b/packages/game/src/localSandboxBlockData.unit.ts
@@ -92,6 +92,7 @@ test('local sandbox exposes the small wooden bridge with its model bounds', () =
     assert.equal(bridge.attributes.hitboxDepth, 1);
     assert.equal(bridge.attributes.hitboxHeight, 0.38);
     assert.equal(bridge.attributes.hitboxWidth, 0.84);
+    assert.equal(bridge.attributes.placeableOnWater, true);
 });
 
 test('local sandbox exposes flower decorations used by the item HUD', () => {

--- a/packages/storage/scripts/upsertSmallWoodenBridgeBlockEntity.ts
+++ b/packages/storage/scripts/upsertSmallWoodenBridgeBlockEntity.ts
@@ -24,6 +24,7 @@ const smallWoodenBridgeAttributes = {
     'attributes.hitboxDepth': '1',
     'attributes.hitboxHeight': '0.38',
     'attributes.hitboxWidth': '0.84',
+    'attributes.placeableOnWater': 'true',
     'attributes.spanDepth': '1',
     'attributes.spanWidth': '1',
     'attributes.stackable': 'false',

--- a/packages/storage/src/cache/directoriesCached.ts
+++ b/packages/storage/src/cache/directoriesCached.ts
@@ -8,7 +8,7 @@ import {
 export const cacheKeys = {
     entity: (entityId: number) => `entity:${entityId}`,
     entityTypeName: (entityTypeName: string) =>
-        `entities:formatted:${entityTypeName}:state:published:locale:default:v1`,
+        `entities:formatted:${entityTypeName}:state:published:locale:default:${entityTypeName === 'block' ? 'v2' : 'v1'}`,
     cmsPagesList: (
         state: 'draft' | 'in-review' | 'published' | 'all' = 'all',
     ) => `cms:pages:list:${state}:v1`,


### PR DESCRIPTION
## Summary

- mark `SmallWoodenBridge` as placeable on water in the directory upsert and local sandbox metadata
- cover client pickup, server placement, and stack patch validation for a bridge directly above water
- refresh block directory caches so the corrected published metadata reaches users with the rollout

## Validation

- `pnpm lint --filter api --filter @gredice/client --filter @gredice/game --filter @gredice/storage`
- `pnpm typecheck --filter api --filter @gredice/client --filter @gredice/game --filter @gredice/storage`
- `pnpm --filter @gredice/game exec tsx --test src/localSandboxBlockData.unit.ts src/controls/PickupPlacementResolver.unit.ts` (23 passed)
- `pnpm --dir apps/api exec tsx --test lib/garden/stacksPatchValidation.node.spec.ts lib/garden/blockPlacementService.node.spec.ts` (15 passed)
- `pnpm test --filter @gredice/game`
- `pnpm --dir apps/api test:node` (478 passed)
- `git diff --check`

## Data

- ran the bootstrapped bridge upsert
- read back block entity `736` with `attributes.placeableOnWater: true`
