### PR TITLE
fix(game): keep Suncokret actions visible

### DIFF
--- a/apps/garden/tests/suncokret-chat-hud.spec.tsx
+++ b/apps/garden/tests/suncokret-chat-hud.spec.tsx
@@ -100,10 +100,6 @@ async function mockSuncokretRoutes(
                                 role: 'assistant',
                                 parts: [
                                     {
-                                        type: 'text',
-                                        text: 'Provjeri odvodnju i zaštiti osjetljive biljke. Predlažem i ove korake:',
-                                    },
-                                    {
                                         type: 'tool-presentRecommendations',
                                         toolCallId: 'recommendations-1',
                                         state: 'output-available',
@@ -141,6 +137,15 @@ async function mockSuncokretRoutes(
                                                 },
                                             ],
                                         },
+                                    },
+                                    {
+                                        type: 'text',
+                                        text: [
+                                            'Provjeri odvodnju i zaštiti osjetljive biljke.',
+                                            'Prije kiše pregledaj rubove svake gredice, ukloni sve što usporava otjecanje vode i učvrsti više biljke koje bi vjetar mogao polegnuti.',
+                                            'Nakon kiše pričekaj da se površina tla malo prosuši pa provjeri zadržava li se voda uz stabljike. Nemoj dodatno zalijevati dok je zemlja još vlažna.',
+                                            'Predlažem i ove korake:',
+                                        ].join('\n\n'),
                                     },
                                 ],
                             },
@@ -323,6 +328,37 @@ test('saved AI recommendations open manual operation and sowing flows', async ({
     await expect(
         sowingDialog.getByRole('button', { name: 'Dodaj u košaru' }),
     ).toBeEnabled();
+});
+
+test('saved AI recommendations follow the answer and stay visible at the end', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await mockSuncokretRoutes(page);
+    await mount(<SuncokretChatHudStory />);
+    await page.getByRole('button', { name: 'Suncokret AI' }).click();
+    await page.getByRole('button', { name: 'Prijašnji razgovori' }).click();
+    await page.getByRole('button', { name: /Priprema vrta za kišu/ }).click();
+
+    const answer = page.getByText('Predlažem i ove korake:');
+    const recommendations = page.getByRole('group', {
+        name: 'Preporučene radnje i sijanja',
+    });
+    await expect(answer).toBeVisible();
+    await expect(recommendations).toBeVisible();
+    await expect
+        .poll(async () => {
+            const answerBox = await answer.boundingBox();
+            const recommendationsBox = await recommendations.boundingBox();
+            if (!answerBox || !recommendationsBox) {
+                return false;
+            }
+
+            return answerBox.y + answerBox.height <= recommendationsBox.y;
+        })
+        .toBe(true);
+    await expect(recommendations).toBeInViewport();
 });
 
 test('settings context replaces the raised-bed context in the header', async ({

--- a/packages/game/src/hud/SuncokretChatHud.tsx
+++ b/packages/game/src/hud/SuncokretChatHud.tsx
@@ -378,6 +378,14 @@ function isToolRunningState(state: string) {
     );
 }
 
+function isCompletedRecommendationPart(part: Record<string, unknown>) {
+    const state = toolState(part);
+    return (
+        toolName(part) === 'presentRecommendations' &&
+        (state === 'output-available' || state === 'result')
+    );
+}
+
 function debugJson(value: unknown) {
     try {
         return JSON.stringify(value, null, 2);
@@ -636,6 +644,23 @@ function ChatMessage({
 }) {
     const isUser = message.role === 'user';
     const partKeyCounts = new Map<string, number>();
+    const keyedParts = message.parts.map((part) => {
+        const baseKey = messagePartKey(part);
+        const duplicateCount = partKeyCounts.get(baseKey) ?? 0;
+        partKeyCounts.set(baseKey, duplicateCount + 1);
+
+        return {
+            key:
+                duplicateCount === 0 ? baseKey : `${baseKey}:${duplicateCount}`,
+            part,
+        };
+    });
+    const completedRecommendationParts = keyedParts.flatMap(({ key, part }) => {
+        const toolData = toolPart(part);
+        return toolData && isCompletedRecommendationPart(toolData)
+            ? [{ key, toolData }]
+            : [];
+    });
     const toolParts = message.parts
         .map(toolPart)
         .filter((part): part is Record<string, unknown> => Boolean(part));
@@ -686,14 +711,7 @@ function ChatMessage({
                 className={cx('flex flex-col gap-2', !isUser && 'w-full')}
                 variant={isUser ? 'sunflower' : 'ghost'}
             >
-                {message.parts.map((part) => {
-                    const baseKey = messagePartKey(part);
-                    const duplicateCount = partKeyCounts.get(baseKey) ?? 0;
-                    partKeyCounts.set(baseKey, duplicateCount + 1);
-                    const key =
-                        duplicateCount === 0
-                            ? baseKey
-                            : `${baseKey}:${duplicateCount}`;
+                {keyedParts.map(({ key, part }) => {
                     const text = textPart(part);
                     if (text) {
                         return (
@@ -705,29 +723,8 @@ function ChatMessage({
 
                     const toolData = toolPart(part);
                     if (toolData) {
-                        if (
-                            toolName(toolData) === 'presentRecommendations' &&
-                            (toolState(toolData) === 'output-available' ||
-                                toolState(toolData) === 'result')
-                        ) {
-                            return (
-                                <div className="space-y-2" key={key}>
-                                    <SuncokretRecommendationChips
-                                        output={
-                                            toolData.output ?? toolData.result
-                                        }
-                                    />
-                                    {debug && (
-                                        <ToolPart
-                                            addToolApprovalResponse={
-                                                addToolApprovalResponse
-                                            }
-                                            debug
-                                            part={toolData}
-                                        />
-                                    )}
-                                </div>
-                            );
+                        if (isCompletedRecommendationPart(toolData)) {
+                            return null;
                         }
 
                         if (!debug && !isToolApprovalRequested(toolData)) {
@@ -793,6 +790,22 @@ function ChatMessage({
                         </pre>
                     </details>
                 )}
+                {completedRecommendationParts.map(({ key, toolData }) => (
+                    <div className="space-y-2" key={key}>
+                        <SuncokretRecommendationChips
+                            output={toolData.output ?? toolData.result}
+                        />
+                        {debug && (
+                            <ToolPart
+                                addToolApprovalResponse={
+                                    addToolApprovalResponse
+                                }
+                                debug
+                                part={toolData}
+                            />
+                        )}
+                    </div>
+                ))}
             </ChatBubble>
         </ChatMessageLayout>
     );


### PR DESCRIPTION
## What changed

- render completed Suncokret recommendation actions after all assistant answer content
- keep approval requests in their original position
- add a mobile browser regression for a tool-first, long-answer conversation

## Why

The AI SDK preserves tool-part order. When `presentRecommendations` completed before the assistant's explanatory text, the clickable actions appeared near the start of a long answer and scrolled out of view. Recommendation actions now stay at the answer end where users can act on them after reading.

## Validation

- `pnpm --filter @gredice/game exec biome check src/hud/SuncokretChatHud.tsx`
- `pnpm --filter garden exec biome check tests/suncokret-chat-hud.spec.tsx`
- `pnpm typecheck --filter @gredice/game --filter garden --filter www`
- `pnpm test --filter @gredice/game` (866 passed)
- `pnpm --filter garden test:prepare`
- `pnpm --filter garden exec playwright test tests/suncokret-chat-hud.spec.tsx --project=chromium` (14 passed)
- `git diff --check`