### PR TITLE
feat(garden): polish detailed inspection reviews

### DIFF
--- a/apps/api/lib/garden/detailedRaisedBedInspectionReports.node.spec.ts
+++ b/apps/api/lib/garden/detailedRaisedBedInspectionReports.node.spec.ts
@@ -27,6 +27,11 @@ test('hydrates unread inspection notifications from current operation notes', ()
         operations: [
             {
                 accountId: 'account-1',
+                assignedUser: {
+                    avatarUrl: 'https://cdn.example.com/farmer.jpg',
+                    displayName: '  Ana Farmer  ',
+                    userName: 'ana',
+                },
                 completedAt,
                 completionNotes: '  Tlo je rahlo i dovoljno vlažno.  ',
                 entityId: RAISED_BED_DETAILED_INSPECTION_OPERATION_ID,
@@ -36,17 +41,35 @@ test('hydrates unread inspection notifications from current operation notes', ()
                 status: 'pendingVerification',
             },
         ],
-        raisedBeds: [{ id: 17, name: 'Gredica Sjever' }],
+        raisedBeds: [
+            {
+                id: 17,
+                latestPhotoOperation: {
+                    imageUrls: [
+                        'https://cdn.example.com/latest.jpg',
+                        'https://cdn.example.com/second.jpg',
+                    ],
+                },
+                name: 'Gredica Sjever',
+                physicalId: 'S-17',
+            },
+        ],
     });
 
     assert.deepEqual(reports, [
         {
+            assignedFarmer: {
+                avatarUrl: 'https://cdn.example.com/farmer.jpg',
+                displayName: 'Ana Farmer',
+            },
             inspectedAt: completedAt.toISOString(),
             notes: 'Tlo je rahlo i dovoljno vlažno.',
             notificationId: 'notification-1',
             operationId: 42,
             raisedBedId: 17,
+            raisedBedImageUrl: 'https://cdn.example.com/latest.jpg',
             raisedBedName: 'Gredica Sjever',
+            raisedBedPhysicalId: 'S-17',
         },
     ]);
 });
@@ -76,4 +99,38 @@ test('rejects reports outside the authenticated account and garden', () => {
     });
 
     assert.deepEqual(reports, []);
+});
+
+test('falls back to the assigned username and omits unavailable raised bed media', () => {
+    const reports = buildDetailedRaisedBedInspectionReports({
+        accountId: 'account-1',
+        gardenId: 8,
+        notifications: [
+            {
+                id: 'notification-1',
+                metadata: { operationId: 42 },
+                timestamp: new Date('2026-08-10T08:31:00.000Z'),
+            },
+        ],
+        operations: [
+            {
+                accountId: 'account-1',
+                assignedUser: {
+                    avatarUrl: null,
+                    displayName: null,
+                    userName: 'ivan',
+                },
+                entityId: RAISED_BED_DETAILED_INSPECTION_OPERATION_ID,
+                gardenId: 8,
+                id: 42,
+                raisedBedId: 17,
+                status: 'completed',
+            },
+        ],
+        raisedBeds: [{ id: 17, name: 'Gredica Jug' }],
+    });
+
+    assert.equal(reports[0]?.assignedFarmer?.displayName, 'ivan');
+    assert.equal(reports[0]?.raisedBedImageUrl, null);
+    assert.equal(reports[0]?.raisedBedPhysicalId, null);
 });

--- a/apps/api/lib/garden/detailedRaisedBedInspectionReports.ts
+++ b/apps/api/lib/garden/detailedRaisedBedInspectionReports.ts
@@ -15,11 +15,20 @@ type DetailedInspectionOperation = {
     id: number;
     raisedBedId?: number | null;
     status: string;
+    assignedUser?: {
+        avatarUrl: string | null;
+        displayName: string | null;
+        userName: string;
+    } | null;
 };
 
 type DetailedInspectionRaisedBed = {
     id: number;
+    latestPhotoOperation?: {
+        imageUrls: string[];
+    } | null;
     name: string;
+    physicalId?: string | null;
 };
 
 export function detailedInspectionOperationId(
@@ -77,8 +86,18 @@ export function buildDetailedRaisedBedInspectionReports({
             return [];
         }
 
+        const assignedFarmer = operation.assignedUser
+            ? {
+                  avatarUrl: operation.assignedUser.avatarUrl,
+                  displayName:
+                      operation.assignedUser.displayName?.trim() ||
+                      operation.assignedUser.userName,
+              }
+            : null;
+
         return [
             {
+                assignedFarmer,
                 inspectedAt: (
                     operation.completedAt ?? notification.timestamp
                 ).toISOString(),
@@ -86,7 +105,10 @@ export function buildDetailedRaisedBedInspectionReports({
                 notificationId: notification.id,
                 operationId: operation.id,
                 raisedBedId: raisedBed.id,
+                raisedBedImageUrl:
+                    raisedBed.latestPhotoOperation?.imageUrls[0] ?? null,
                 raisedBedName: raisedBed.name,
+                raisedBedPhysicalId: raisedBed.physicalId ?? null,
             },
         ];
     });

--- a/apps/garden/tests/ActorSpeechBubbleFixture.tsx
+++ b/apps/garden/tests/ActorSpeechBubbleFixture.tsx
@@ -9,8 +9,10 @@ import {
 const fixtureMessages = ['Lijep dan u vrtu!', 'Vrt izgleda prekrasno!'];
 
 export function ActorSpeechBubbleFixture({
+    cameraZoom = 80,
     interactive = false,
 }: {
+    cameraZoom?: number;
     interactive?: boolean;
 }) {
     const [ready, setReady] = useState(false);
@@ -51,7 +53,7 @@ export function ActorSpeechBubbleFixture({
             </button>
             <Canvas
                 orthographic
-                camera={{ position: [0, 0, 10], zoom: 80 }}
+                camera={{ position: [0, 0, 10], zoom: cameraZoom }}
                 frameloop="always"
                 onCreated={() => setReady(true)}
             >

--- a/apps/garden/tests/DetailedRaisedBedInspectionModalStory.tsx
+++ b/apps/garden/tests/DetailedRaisedBedInspectionModalStory.tsx
@@ -3,20 +3,34 @@ import { DetailedRaisedBedInspectionModal } from '../../../packages/game/src/hud
 
 const reports = [
     {
+        assignedFarmer: {
+            avatarUrl:
+                'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="48" height="48"%3E%3Crect width="48" height="48" fill="%23166534"/%3E%3C/svg%3E',
+            displayName: 'Ana Farmer',
+        },
         inspectedAt: '2026-08-10T08:30:00.000Z',
         notes: 'Tlo je rahlo i dovoljno vlažno.',
         notificationId: 'notification-1',
         operationId: 42,
         raisedBedId: 17,
+        raisedBedImageUrl:
+            'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="48" height="48"%3E%3Crect width="48" height="48" fill="%2384cc16"/%3E%3C/svg%3E',
         raisedBedName: 'Gredica Sjever',
+        raisedBedPhysicalId: '17',
     },
     {
+        assignedFarmer: {
+            avatarUrl: null,
+            displayName: 'Ivan Marić',
+        },
         inspectedAt: '2026-08-10T08:35:00.000Z',
         notes: null,
         notificationId: 'notification-2',
         operationId: 43,
         raisedBedId: 18,
+        raisedBedImageUrl: null,
         raisedBedName: 'Gredica Jug',
+        raisedBedPhysicalId: '18',
     },
 ];
 

--- a/apps/garden/tests/actor-speech-bubble.spec.tsx
+++ b/apps/garden/tests/actor-speech-bubble.spec.tsx
@@ -72,3 +72,38 @@ test('allows an actor speech bubble to open its action', async ({ mount }) => {
     await bubble.click();
     await expect(fixture).toHaveAttribute('data-bubble-clicks', '1');
 });
+
+test('keeps the bubble body above its head anchor when zoomed out', async ({
+    mount,
+}) => {
+    const cameraZoom = 30;
+    const fixture = await mount(
+        <ActorSpeechBubbleFixture cameraZoom={cameraZoom} />,
+    );
+    const canvas = fixture.locator('canvas');
+    await expect(fixture).toHaveAttribute('data-render-ready', 'true');
+
+    const canvasBox = await canvas.boundingBox();
+    expect(canvasBox).not.toBeNull();
+    if (!canvasBox) {
+        return;
+    }
+
+    await canvas.hover({
+        position: {
+            x: canvasBox.width / 2,
+            y: canvasBox.height / 2,
+        },
+    });
+    const bubble = fixture.locator('[data-actor-speech-bubble]');
+    await expect(bubble).toBeVisible();
+
+    const bubbleBox = await bubble.boundingBox();
+    expect(bubbleBox).not.toBeNull();
+    if (!bubbleBox) {
+        return;
+    }
+
+    const headAnchorY = canvasBox.y + canvasBox.height / 2 - 1.2 * cameraZoom;
+    expect(bubbleBox.y + bubbleBox.height).toBeLessThan(headAnchorY - 3);
+});

--- a/apps/garden/tests/detailed-raised-bed-inspection-modal.spec.tsx
+++ b/apps/garden/tests/detailed-raised-bed-inspection-modal.spec.tsx
@@ -15,7 +15,9 @@ test('shows the farmer notes for every inspected raised bed', async ({
     await expect(
         page.getByAltText('Najnovija fotografija gredice Gredica Sjever'),
     ).toBeVisible();
-    await expect(page.getByLabel('Pregled obradio Ana Farmer')).toBeVisible();
+    await expect(
+        page.getByLabel('Dodijeljeni farmer Ana Farmer'),
+    ).toBeVisible();
     await expect(
         page.getByText('Tlo je rahlo i dovoljno vlažno.'),
     ).toBeVisible();
@@ -23,7 +25,9 @@ test('shows the farmer notes for every inspected raised bed', async ({
     await expect(
         page.locator('[data-raised-bed-review-fallback]'),
     ).toContainText('18');
-    await expect(page.getByLabel('Pregled obradio Ivan Marić')).toBeVisible();
+    await expect(
+        page.getByLabel('Dodijeljeni farmer Ivan Marić'),
+    ).toBeVisible();
     await expect(
         page.getByText('Pregled je završen bez dodatne bilješke.'),
     ).toBeVisible();

--- a/apps/garden/tests/detailed-raised-bed-inspection-modal.spec.tsx
+++ b/apps/garden/tests/detailed-raised-bed-inspection-modal.spec.tsx
@@ -8,21 +8,29 @@ test('shows the farmer notes for every inspected raised bed', async ({
     await mount(<DetailedRaisedBedInspectionModalStory />);
 
     await expect(
-        page.getByRole('heading', { name: 'Farmerov detaljan pregled' }).last(),
+        page.getByRole('heading', { name: 'OPGov Detaljan pregled' }).last(),
     ).toBeVisible();
-    await expect(page.getByText('Broj pregledanih gredica: 2')).toBeVisible();
+    await expect(page.getByText(/Broj pregledanih gredica/)).toHaveCount(0);
     await expect(page.getByText('Gredica Sjever')).toBeVisible();
+    await expect(
+        page.getByAltText('Najnovija fotografija gredice Gredica Sjever'),
+    ).toBeVisible();
+    await expect(page.getByLabel('Pregled obradio Ana Farmer')).toBeVisible();
     await expect(
         page.getByText('Tlo je rahlo i dovoljno vlažno.'),
     ).toBeVisible();
     await expect(page.getByText('Gredica Jug')).toBeVisible();
+    await expect(
+        page.locator('[data-raised-bed-review-fallback]'),
+    ).toContainText('18');
+    await expect(page.getByLabel('Pregled obradio Ivan Marić')).toBeVisible();
     await expect(
         page.getByText('Pregled je završen bez dodatne bilješke.'),
     ).toBeVisible();
 
     await page.getByRole('button', { name: 'Zatvori' }).first().click();
     await expect(
-        page.getByRole('heading', { name: 'Farmerov detaljan pregled' }),
+        page.getByRole('heading', { name: 'OPGov Detaljan pregled' }),
     ).toHaveCount(0);
 });
 

--- a/packages/game/src/entities/animals/ActorSpeechBubble.tsx
+++ b/packages/game/src/entities/animals/ActorSpeechBubble.tsx
@@ -107,7 +107,6 @@ export function ActorSpeechBubble({
     return (
         <Html
             calculatePosition={calculateActorPosition}
-            center
             style={{ pointerEvents: onClick ? 'auto' : 'none' }}
             zIndexRange={[50, 31]}
         >
@@ -116,7 +115,7 @@ export function ActorSpeechBubble({
                     type="button"
                     aria-label={actionLabel}
                     aria-live="polite"
-                    className="relative max-w-[min(15rem,75vw)] whitespace-normal rounded-xl border border-emerald-200 bg-white/95 px-3 py-1.5 text-center text-sm font-semibold leading-snug text-emerald-900 shadow-lg backdrop-blur-sm transition-transform hover:scale-105 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 dark:border-emerald-800/80 dark:bg-neutral-950/95 dark:text-emerald-100"
+                    className="relative max-w-[min(15rem,75vw)] -translate-x-1/2 -translate-y-[calc(100%+0.5rem)] whitespace-normal rounded-xl border border-emerald-200 bg-white/95 px-3 py-1.5 text-center text-sm font-semibold leading-snug text-emerald-900 shadow-lg backdrop-blur-sm transition-transform hover:scale-105 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 dark:border-emerald-800/80 dark:bg-neutral-950/95 dark:text-emerald-100"
                     data-actor-speech-bubble
                     onClick={onClick}
                 >
@@ -126,7 +125,7 @@ export function ActorSpeechBubble({
             ) : (
                 <div
                     aria-live="polite"
-                    className="relative max-w-[min(15rem,75vw)] whitespace-nowrap rounded-xl border border-emerald-200 bg-white/95 px-3 py-1.5 text-center text-sm font-semibold leading-snug text-emerald-900 shadow-lg backdrop-blur-sm dark:border-emerald-800/80 dark:bg-neutral-950/95 dark:text-emerald-100"
+                    className="relative max-w-[min(15rem,75vw)] -translate-x-1/2 -translate-y-[calc(100%+0.5rem)] whitespace-nowrap rounded-xl border border-emerald-200 bg-white/95 px-3 py-1.5 text-center text-sm font-semibold leading-snug text-emerald-900 shadow-lg backdrop-blur-sm dark:border-emerald-800/80 dark:bg-neutral-950/95 dark:text-emerald-100"
                     data-actor-speech-bubble
                     role="status"
                 >

--- a/packages/game/src/entities/avatar/detailedInspectionFarmerPosition.ts
+++ b/packages/game/src/entities/avatar/detailedInspectionFarmerPosition.ts
@@ -4,12 +4,17 @@ import {
     createGardenAvatarCollisionWorld,
     findGardenAvatarSpawnPoint,
     getGardenAvatarGroundY,
+    getGardenAvatarRoamBlockedCells,
 } from './gardenAvatarMovement';
 
 export type DetailedInspectionFarmerTransform = {
     position: [x: number, y: number, z: number];
     rotationY: number;
 };
+
+function gridCellKey(point: { x: number; z: number }) {
+    return `${Math.round(point.x).toString()}:${Math.round(point.z).toString()}`;
+}
 
 export function findDetailedInspectionFarmerTransform({
     blockData,
@@ -34,10 +39,16 @@ export function findDetailedInspectionFarmerTransform({
             : null;
     }
 
+    const blockedCellKeys = new Set(
+        getGardenAvatarRoamBlockedCells(world).map(gridCellKey),
+    );
+
     const walkableCandidate = world.surfaces
         .filter(
             (surface) =>
-                surface.kind === 'ground' && surface.roamable !== false,
+                surface.kind === 'ground' &&
+                surface.roamable !== false &&
+                !blockedCellKeys.has(gridCellKey(surface)),
         )
         .map((surface) => ({
             distance: Math.hypot(

--- a/packages/game/src/entities/avatar/detailedInspectionFarmerPosition.unit.ts
+++ b/packages/game/src/entities/avatar/detailedInspectionFarmerPosition.unit.ts
@@ -1,8 +1,57 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import type { BlockData } from '@gredice/client';
 import { Vector3 } from 'three';
 import type { Stack } from '../../types/Stack';
 import { findDetailedInspectionFarmerTransform } from './detailedInspectionFarmerPosition';
+
+const blockData: BlockData[] = [
+    {
+        attributes: {
+            height: 0.2,
+            nightOnlyPurchase: false,
+            stackable: true,
+            type: 'terrain',
+        },
+        createdAt: '2026-08-10T00:00:00.000Z',
+        entityType: { id: 8, label: 'Blok', name: 'block' },
+        functions: { raisedBed: false, recycler: false },
+        id: 1,
+        information: {
+            fullDescription: '',
+            label: 'Trava',
+            name: 'Block_Grass',
+            shortDescription: '',
+        },
+        prices: { sunflowers: 0 },
+        slug: 'block-grass',
+        updatedAt: '2026-08-10T00:00:00.000Z',
+    },
+    {
+        attributes: {
+            height: 0.25,
+            hitboxDepth: 0.8,
+            hitboxHeight: 0.25,
+            hitboxWidth: 0.8,
+            nightOnlyPurchase: false,
+            stackable: false,
+            type: 'raisedBed',
+        },
+        createdAt: '2026-08-10T00:00:00.000Z',
+        entityType: { id: 8, label: 'Blok', name: 'block' },
+        functions: { raisedBed: true, recycler: false },
+        id: 2,
+        information: {
+            fullDescription: '',
+            label: 'Podignuta gredica',
+            name: 'Raised_Bed',
+            shortDescription: '',
+        },
+        prices: { sunflowers: 0 },
+        slug: 'raised-bed',
+        updatedAt: '2026-08-10T00:00:00.000Z',
+    },
+];
 
 test('places the inspection farmer on walkable ground near the inspected bed', () => {
     const stacks: Stack[] = [];
@@ -31,7 +80,7 @@ test('places the inspection farmer on walkable ground near the inspected bed', (
     }
 
     const transform = findDetailedInspectionFarmerTransform({
-        blockData: null,
+        blockData,
         stacks,
         targetBlockId: 'raised-bed',
     });
@@ -39,11 +88,12 @@ test('places the inspection farmer on walkable ground near the inspected bed', (
     assert.ok(transform);
     assert.notDeepEqual(transform.position, [0, 0, 0]);
     assert.equal(Math.hypot(transform.position[0], transform.position[2]), 1);
+    assert.equal(transform.position[1], 0.2);
 });
 
 test('falls back to the garden spawn when the inspected block is unavailable', () => {
     const transform = findDetailedInspectionFarmerTransform({
-        blockData: null,
+        blockData,
         stacks: [
             {
                 blocks: [{ id: 'ground', name: 'Block_Grass', rotation: 0 }],
@@ -54,7 +104,7 @@ test('falls back to the garden spawn when the inspected block is unavailable', (
     });
 
     assert.deepEqual(transform, {
-        position: [2, 0, 3],
+        position: [2, 0.2, 3],
         rotationY: 0,
     });
 });

--- a/packages/game/src/hooks/detailedRaisedBedInspectionReports.ts
+++ b/packages/game/src/hooks/detailedRaisedBedInspectionReports.ts
@@ -1,8 +1,8 @@
 export const detailedInspectionFarmerMessages = [
-    'Zanimljivo... evo što mislim o tvojim gredicama.',
-    'Pregledao sam gredice. Imam nekoliko bilješki za tebe.',
-    'Završio sam pregled. Želiš čuti što sam primijetio?',
-    'Tvoje gredice imaju priču. Pogledaj moje bilješke.',
+    'Zanimljivo... evo što mislim o tvojim gredicama...',
+    'Pregledao sam gredice. Imam nekoliko bilješki za tebe...',
+    'Završio sam pregled. Želiš čuti što sam primijetio...',
+    'Tvoje gredice imaju priču. Pogledaj moje bilješke...',
 ] as const;
 
 function stableMessageIndex(keys: readonly string[], length: number) {

--- a/packages/game/src/hooks/detailedRaisedBedInspectionReports.unit.ts
+++ b/packages/game/src/hooks/detailedRaisedBedInspectionReports.unit.ts
@@ -12,6 +12,11 @@ test('provides several Croatian farmer prompts for inspection notes', () => {
             /gredic|pregled|bilješk/i.test(message),
         ),
     );
+    assert.ok(
+        detailedInspectionFarmerMessages.every((message) =>
+            message.endsWith('...'),
+        ),
+    );
 });
 
 test('keeps the prompt stable for the same notification set', () => {

--- a/packages/game/src/hud/DetailedRaisedBedInspectionModal.tsx
+++ b/packages/game/src/hud/DetailedRaisedBedInspectionModal.tsx
@@ -4,11 +4,47 @@ import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { Card } from '@gredice/ui/Card';
 import { Sprout } from '@gredice/ui/icons';
+import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
+import { UserAvatar } from '@gredice/ui/UserAvatar';
+import { useState } from 'react';
 import type { DetailedRaisedBedInspectionReport } from '../hooks/useDetailedRaisedBedInspectionReports';
 import { GameModal } from '../shared-ui/game-modal';
+
+function RaisedBedReviewThumbnail({
+    report,
+}: {
+    report: DetailedRaisedBedInspectionReport;
+}) {
+    const [imageFailed, setImageFailed] = useState(false);
+    const showImage = Boolean(report.raisedBedImageUrl) && !imageFailed;
+
+    return (
+        <span className="flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-xl border bg-muted text-muted-foreground">
+            {showImage ? (
+                // biome-ignore lint/performance/noImgElement: Raised bed operation photos use runtime blob URLs.
+                <img
+                    alt={`Najnovija fotografija gredice ${report.raisedBedName}`}
+                    className="size-full object-cover"
+                    data-raised-bed-review-photo
+                    loading="lazy"
+                    onError={() => setImageFailed(true)}
+                    src={report.raisedBedImageUrl ?? undefined}
+                />
+            ) : (
+                <span data-raised-bed-review-fallback>
+                    <RaisedBedIcon
+                        className="size-7"
+                        containerClassName="h-8 min-w-8"
+                        physicalId={report.raisedBedPhysicalId}
+                    />
+                </span>
+            )}
+        </span>
+    );
+}
 
 export function DetailedRaisedBedInspectionModal({
     dismissError,
@@ -25,13 +61,9 @@ export function DetailedRaisedBedInspectionModal({
     open: boolean;
     reports: DetailedRaisedBedInspectionReport[];
 }) {
-    const raisedBedCount = new Set(reports.map((report) => report.raisedBedId))
-        .size;
-
     return (
         <GameModal
             className="md:max-w-2xl"
-            headerDescription={`Broj pregledanih gredica: ${raisedBedCount.toString()}`}
             headerIcon={<Sprout className="size-6" />}
             hudLayer
             onOpenChange={(nextOpen) => {
@@ -41,7 +73,7 @@ export function DetailedRaisedBedInspectionModal({
             }}
             open={open}
             showHeader
-            title="Farmerov detaljan pregled"
+            title="OPGov Detaljan pregled"
         >
             <Stack spacing={4} className="min-w-0">
                 <Typography level="body2" secondary>
@@ -60,25 +92,55 @@ export function DetailedRaisedBedInspectionModal({
                             <Stack spacing={2}>
                                 <Row
                                     className="min-w-0 justify-between gap-3"
-                                    alignItems="start"
+                                    alignItems="center"
                                 >
-                                    <Typography
-                                        className="min-w-0 break-words"
-                                        level="body1"
-                                        semiBold
-                                    >
-                                        {report.raisedBedName}
-                                    </Typography>
-                                    <time
-                                        className="shrink-0"
-                                        dateTime={report.inspectedAt}
-                                    >
-                                        <Typography level="body3" secondary>
-                                            {new Date(
-                                                report.inspectedAt,
-                                            ).toLocaleDateString('hr-HR')}
-                                        </Typography>
-                                    </time>
+                                    <Row className="min-w-0 gap-3">
+                                        <RaisedBedReviewThumbnail
+                                            report={report}
+                                        />
+                                        <Stack className="min-w-0" spacing={0}>
+                                            <Typography
+                                                className="min-w-0 break-words"
+                                                level="body1"
+                                                semiBold
+                                            >
+                                                {report.raisedBedName}
+                                            </Typography>
+                                            <time dateTime={report.inspectedAt}>
+                                                <Typography
+                                                    level="body3"
+                                                    secondary
+                                                >
+                                                    {new Date(
+                                                        report.inspectedAt,
+                                                    ).toLocaleDateString(
+                                                        'hr-HR',
+                                                    )}
+                                                </Typography>
+                                            </time>
+                                        </Stack>
+                                    </Row>
+                                    {report.assignedFarmer ? (
+                                        <span
+                                            aria-label={`Pregled obradio ${report.assignedFarmer.displayName}`}
+                                            className="shrink-0"
+                                            data-raised-bed-review-farmer
+                                            role="img"
+                                            title={`Pregled obradio ${report.assignedFarmer.displayName}`}
+                                        >
+                                            <UserAvatar
+                                                avatarUrl={
+                                                    report.assignedFarmer
+                                                        .avatarUrl
+                                                }
+                                                displayName={
+                                                    report.assignedFarmer
+                                                        .displayName
+                                                }
+                                                size="md"
+                                            />
+                                        </span>
+                                    ) : null}
                                 </Row>
                                 <Typography
                                     className="whitespace-pre-wrap break-words"

--- a/packages/game/src/hud/DetailedRaisedBedInspectionModal.tsx
+++ b/packages/game/src/hud/DetailedRaisedBedInspectionModal.tsx
@@ -122,11 +122,11 @@ export function DetailedRaisedBedInspectionModal({
                                     </Row>
                                     {report.assignedFarmer ? (
                                         <span
-                                            aria-label={`Pregled obradio ${report.assignedFarmer.displayName}`}
+                                            aria-label={`Dodijeljeni farmer ${report.assignedFarmer.displayName}`}
                                             className="shrink-0"
                                             data-raised-bed-review-farmer
                                             role="img"
-                                            title={`Pregled obradio ${report.assignedFarmer.displayName}`}
+                                            title={`Dodijeljeni farmer ${report.assignedFarmer.displayName}`}
                                         >
                                             <UserAvatar
                                                 avatarUrl={


### PR DESCRIPTION
## Summary
- keep the detailed-inspection farmer on walkable cells beside raised beds and anchor speech bubbles above actor heads at every zoom
- add trailing ellipses and simplify the Croatian review modal title/header
- show each raised bed latest photo or physical-ID fallback plus the assigned farmer avatar

## Validation
- pnpm --filter @gredice/game test (867 passed)
- pnpm --filter @gredice/game typecheck
- pnpm --filter garden typecheck
- pnpm --filter www typecheck
- pnpm --filter api build
- pnpm --filter garden build
- API detailed inspection report node tests (4 passed)
- focused Playwright component tests: actor speech bubble chromium-webgl (3 passed), detailed review modal chromium (2 passed)