### PR TITLE
fix(garden): clarify detailed inspection header

### DIFF
--- a/apps/garden/tests/detailed-raised-bed-inspection-modal.spec.tsx
+++ b/apps/garden/tests/detailed-raised-bed-inspection-modal.spec.tsx
@@ -8,7 +8,9 @@ test('shows the farmer notes for every inspected raised bed', async ({
     await mount(<DetailedRaisedBedInspectionModalStory />);
 
     await expect(
-        page.getByRole('heading', { name: 'OPGov Detaljan pregled' }).last(),
+        page
+            .getByRole('heading', { name: 'OPG - Detaljan pregled gredica' })
+            .last(),
     ).toBeVisible();
     await expect(page.getByText(/Broj pregledanih gredica/)).toHaveCount(0);
     await expect(page.getByText('Gredica Sjever')).toBeVisible();
@@ -34,7 +36,9 @@ test('shows the farmer notes for every inspected raised bed', async ({
 
     await page.getByRole('button', { name: 'Zatvori' }).first().click();
     await expect(
-        page.getByRole('heading', { name: 'OPGov Detaljan pregled' }),
+        page.getByRole('heading', {
+            name: 'OPG - Detaljan pregled gredica',
+        }),
     ).toHaveCount(0);
 });
 

--- a/packages/game/src/hud/DetailedRaisedBedInspectionModal.tsx
+++ b/packages/game/src/hud/DetailedRaisedBedInspectionModal.tsx
@@ -73,7 +73,7 @@ export function DetailedRaisedBedInspectionModal({
             }}
             open={open}
             showHeader
-            title="OPGov Detaljan pregled"
+            title="OPG - Detaljan pregled gredica"
         >
             <Stack spacing={4} className="min-w-0">
                 <Typography level="body2" secondary>


### PR DESCRIPTION
## Summary
- rename the detailed raised-bed inspection modal to `OPG - Detaljan pregled gredica`
- update the component regression assertion for the exact heading

## Validation
- `pnpm exec biome check src/hud/DetailedRaisedBedInspectionModal.tsx` (packages/game)
- `pnpm exec biome check tests/detailed-raised-bed-inspection-modal.spec.tsx` (apps/garden)
- `pnpm typecheck` (packages/game)
- `pnpm typecheck` (apps/garden)
- `pnpm exec playwright test tests/detailed-raised-bed-inspection-modal.spec.tsx --project=chromium` (apps/garden; 2 passed)