### PR TITLE
fix(game): anchor wheel zoom to cursor

### DIFF
--- a/apps/garden/playwright.config.ts
+++ b/apps/garden/playwright.config.ts
@@ -19,7 +19,7 @@ const reporter: PlaywrightTestConfig['reporter'] = [
     ['html', { open: 'never' }],
 ];
 const webglTestPattern =
-    /(actor-speech-bubble|garden-preview-capture|hover-outline|instanced-mesh-material-swap)\.spec\.tsx/;
+    /(actor-speech-bubble|cursor-anchored-zoom|garden-preview-capture|hover-outline|instanced-mesh-material-swap)\.spec\.tsx/;
 
 // Plugin to intercept next/font/google before Vite's resolver
 function nextFontMockPlugin() {

--- a/apps/garden/tests/cursor-anchored-zoom.spec.tsx
+++ b/apps/garden/tests/cursor-anchored-zoom.spec.tsx
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { CursorAnchoredZoomFixture } from '../../../packages/game/tests/CursorAnchoredZoomFixture';
+
+test('keeps the world position beneath the cursor fixed while wheel zooming', async ({
+    mount,
+    page,
+}) => {
+    const fixture = await mount(<CursorAnchoredZoomFixture />);
+    const probe = fixture.getByTestId('camera-projection');
+    await expect(probe).toHaveAttribute('data-ready', 'true');
+
+    const anchorBefore = {
+        x: Number(await probe.getAttribute('data-anchor-x')),
+        y: Number(await probe.getAttribute('data-anchor-y')),
+    };
+    const zoomBefore = Number(await probe.getAttribute('data-zoom'));
+
+    await page.mouse.move(anchorBefore.x, anchorBefore.y);
+    await page.mouse.wheel(0, -400);
+
+    await expect
+        .poll(async () => Number(await probe.getAttribute('data-zoom')))
+        .toBeGreaterThan(zoomBefore);
+
+    const anchorAfter = {
+        x: Number(await probe.getAttribute('data-anchor-x')),
+        y: Number(await probe.getAttribute('data-anchor-y')),
+    };
+    const targetAfter = await probe.getAttribute('data-target');
+
+    expect(Math.abs(anchorAfter.x - anchorBefore.x)).toBeLessThan(0.51);
+    expect(Math.abs(anchorAfter.y - anchorBefore.y)).toBeLessThan(0.51);
+    expect(targetAfter).not.toBe('[0,0,0]');
+});

--- a/packages/game/src/controls/GameCameraRig.tsx
+++ b/packages/game/src/controls/GameCameraRig.tsx
@@ -12,6 +12,10 @@ import {
     getRaisedBedBlockIds,
 } from '../utils/raisedBedBlocks';
 import {
+    applyCursorAnchoredZoom,
+    createCursorAnchoredZoomScratch,
+} from './cursorAnchoredZoom';
+import {
     getDragEdgeAutopanDelta,
     hasDragEdgeAutopanDelta,
 } from './dragEdgeAutopan';
@@ -238,6 +242,10 @@ export function GameCameraRig({
     });
     const scratchForwardRef = useRef(new Vector3());
     const scratchRightRef = useRef(new Vector3());
+    const cursorAnchoredZoomScratch = useMemo(
+        createCursorAnchoredZoomScratch,
+        [],
+    );
 
     const closeupTarget = useMemo(() => {
         if (!closeupBlock || !garden) {
@@ -780,7 +788,23 @@ export function GameCameraRig({
             }
 
             event.preventDefault();
-            setCameraZoom(camera.zoom * Math.exp(-event.deltaY * 0.001));
+            const nextZoom = MathUtils.clamp(
+                camera.zoom * Math.exp(-event.deltaY * 0.001),
+                minZoom,
+                maxZoom,
+            );
+            const changed = applyCursorAnchoredZoom({
+                camera,
+                cursor: event,
+                nextZoom,
+                scratch: cursorAnchoredZoomScratch,
+                target: targetRef.current,
+                viewport: element.getBoundingClientRect(),
+            });
+            if (changed) {
+                applyCamera();
+                saveNormalCamera();
+            }
         };
 
         element.addEventListener('pointerdown', handlePointerDown);
@@ -803,10 +827,13 @@ export function GameCameraRig({
             clearPointers();
         };
     }, [
+        applyCamera,
         camera,
         controlsDisabled,
+        cursorAnchoredZoomScratch,
         gl.domElement,
         panByScreenPixels,
+        saveNormalCamera,
         setCameraZoom,
         setIsDragging,
     ]);

--- a/packages/game/src/controls/cursorAnchoredZoom.ts
+++ b/packages/game/src/controls/cursorAnchoredZoom.ts
@@ -1,0 +1,113 @@
+import {
+    type OrthographicCamera,
+    Plane,
+    Raycaster,
+    Vector2,
+    Vector3,
+} from 'three';
+
+const up = new Vector3(0, 1, 0);
+
+type CursorPosition = {
+    clientX: number;
+    clientY: number;
+};
+
+type CursorZoomViewport = {
+    height: number;
+    left: number;
+    top: number;
+    width: number;
+};
+
+export type CursorAnchoredZoomScratch = {
+    anchorAfter: Vector3;
+    anchorBefore: Vector3;
+    ndc: Vector2;
+    plane: Plane;
+    raycaster: Raycaster;
+};
+
+export function createCursorAnchoredZoomScratch(): CursorAnchoredZoomScratch {
+    return {
+        anchorAfter: new Vector3(),
+        anchorBefore: new Vector3(),
+        ndc: new Vector2(),
+        plane: new Plane(),
+        raycaster: new Raycaster(),
+    };
+}
+
+function getCursorPointOnPlane({
+    camera,
+    cursor,
+    result,
+    scratch,
+    viewport,
+}: {
+    camera: OrthographicCamera;
+    cursor: CursorPosition;
+    result: Vector3;
+    scratch: CursorAnchoredZoomScratch;
+    viewport: CursorZoomViewport;
+}) {
+    scratch.ndc.set(
+        ((cursor.clientX - viewport.left) / viewport.width) * 2 - 1,
+        -((cursor.clientY - viewport.top) / viewport.height) * 2 + 1,
+    );
+    scratch.raycaster.setFromCamera(scratch.ndc, camera);
+    return scratch.raycaster.ray.intersectPlane(scratch.plane, result);
+}
+
+export function applyCursorAnchoredZoom({
+    camera,
+    cursor,
+    nextZoom,
+    scratch,
+    target,
+    viewport,
+}: {
+    camera: OrthographicCamera;
+    cursor: CursorPosition;
+    nextZoom: number;
+    scratch: CursorAnchoredZoomScratch;
+    target: Vector3;
+    viewport: CursorZoomViewport;
+}) {
+    if (camera.zoom === nextZoom) {
+        return false;
+    }
+
+    if (viewport.width <= 0 || viewport.height <= 0) {
+        camera.zoom = nextZoom;
+        camera.updateProjectionMatrix();
+        return true;
+    }
+
+    scratch.plane.setFromNormalAndCoplanarPoint(up, target);
+    const anchorBefore = getCursorPointOnPlane({
+        camera,
+        cursor,
+        result: scratch.anchorBefore,
+        scratch,
+        viewport,
+    });
+
+    camera.zoom = nextZoom;
+    camera.updateProjectionMatrix();
+
+    const anchorAfter = getCursorPointOnPlane({
+        camera,
+        cursor,
+        result: scratch.anchorAfter,
+        scratch,
+        viewport,
+    });
+    if (anchorBefore && anchorAfter) {
+        const offset = anchorBefore.sub(anchorAfter);
+        camera.position.add(offset);
+        target.add(offset);
+    }
+
+    return true;
+}

--- a/packages/game/src/controls/cursorAnchoredZoom.unit.ts
+++ b/packages/game/src/controls/cursorAnchoredZoom.unit.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { OrthographicCamera, Raycaster, Vector2, Vector3 } from 'three';
+import {
+    applyCursorAnchoredZoom,
+    createCursorAnchoredZoomScratch,
+} from './cursorAnchoredZoom';
+
+const viewport = {
+    height: 600,
+    left: 100,
+    top: 40,
+    width: 800,
+};
+
+function createCamera(target: Vector3) {
+    const camera = new OrthographicCamera(-4, 4, 3, -3, 0.1, 100);
+    camera.position.set(8, 10, 8);
+    camera.lookAt(target);
+    camera.updateProjectionMatrix();
+    camera.updateMatrixWorld();
+    return camera;
+}
+
+function getGroundPointAtCursor({
+    camera,
+    clientX,
+    clientY,
+    targetY,
+}: {
+    camera: OrthographicCamera;
+    clientX: number;
+    clientY: number;
+    targetY: number;
+}) {
+    const ndc = new Vector2(
+        ((clientX - viewport.left) / viewport.width) * 2 - 1,
+        -((clientY - viewport.top) / viewport.height) * 2 + 1,
+    );
+    const raycaster = new Raycaster();
+    raycaster.setFromCamera(ndc, camera);
+    const distance =
+        (targetY - raycaster.ray.origin.y) / raycaster.ray.direction.y;
+    return raycaster.ray.at(distance, new Vector3());
+}
+
+function projectToClient(camera: OrthographicCamera, point: Vector3) {
+    const projected = point.clone().project(camera);
+    return {
+        clientX: viewport.left + ((projected.x + 1) / 2) * viewport.width,
+        clientY: viewport.top + ((-projected.y + 1) / 2) * viewport.height,
+    };
+}
+
+describe('applyCursorAnchoredZoom', () => {
+    it('keeps the garden point beneath an off-center cursor stationary', () => {
+        const target = new Vector3(0, 0, 0);
+        const camera = createCamera(target);
+        const cursor = { clientX: 720, clientY: 220 };
+        const anchor = getGroundPointAtCursor({
+            camera,
+            ...cursor,
+            targetY: target.y,
+        });
+
+        const changed = applyCursorAnchoredZoom({
+            camera,
+            cursor,
+            nextZoom: 2.4,
+            scratch: createCursorAnchoredZoomScratch(),
+            target,
+            viewport,
+        });
+        camera.lookAt(target);
+        camera.updateMatrixWorld();
+
+        assert.equal(changed, true);
+        assert.equal(camera.zoom, 2.4);
+        assert.notDeepEqual(target.toArray(), [0, 0, 0]);
+        const projectedAnchor = projectToClient(camera, anchor);
+        assert.ok(
+            Math.abs(projectedAnchor.clientX - cursor.clientX) < 0.000_001,
+        );
+        assert.ok(
+            Math.abs(projectedAnchor.clientY - cursor.clientY) < 0.000_001,
+        );
+    });
+
+    it('zooms without panning when the cursor is at the viewport center', () => {
+        const target = new Vector3(0, 0, 0);
+        const camera = createCamera(target);
+        const initialCameraPosition = camera.position.clone();
+
+        applyCursorAnchoredZoom({
+            camera,
+            cursor: {
+                clientX: viewport.left + viewport.width / 2,
+                clientY: viewport.top + viewport.height / 2,
+            },
+            nextZoom: 1.8,
+            scratch: createCursorAnchoredZoomScratch(),
+            target,
+            viewport,
+        });
+
+        assert.ok(target.length() < 0.000_001);
+        assert.ok(
+            camera.position.distanceTo(initialCameraPosition) < 0.000_001,
+        );
+    });
+});

--- a/packages/game/tests/CursorAnchoredZoomFixture.tsx
+++ b/packages/game/tests/CursorAnchoredZoomFixture.tsx
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
+import { useEffect, useMemo, useState } from 'react';
+import { Vector3 } from 'three';
+import { GameCameraRig } from '../src/controls/GameCameraRig';
+import { Scene } from '../src/scene/Scene';
+import {
+    createGameState,
+    GameStateContext,
+    useGameState,
+} from '../src/useGameState';
+
+const anchor = new Vector3(1.5, 0, -1.25);
+const initialPosition = new Vector3(-10, 10, -10);
+const initialTarget = new Vector3(0, 0, 0);
+const initialZoom = 100;
+
+function CameraProjectionProbe() {
+    const gameCamera = useGameState((state) => state.gameCamera);
+    const [projection, setProjection] = useState<{
+        target: [number, number, number];
+        x: number;
+        y: number;
+        zoom: number;
+    } | null>(null);
+
+    useEffect(() => {
+        if (!gameCamera) {
+            return;
+        }
+
+        return gameCamera.subscribe((snapshot) => {
+            const screenPosition = gameCamera.projectToScreen(anchor);
+            if (!screenPosition) {
+                return;
+            }
+
+            setProjection({
+                target: snapshot.target,
+                x: screenPosition.x,
+                y: screenPosition.y,
+                zoom: snapshot.zoom,
+            });
+        });
+    }, [gameCamera]);
+
+    return (
+        <output
+            data-anchor-x={projection?.x}
+            data-anchor-y={projection?.y}
+            data-ready={projection ? 'true' : 'false'}
+            data-target={JSON.stringify(projection?.target ?? null)}
+            data-testid="camera-projection"
+            data-zoom={projection?.zoom}
+        />
+    );
+}
+
+export function CursorAnchoredZoomFixture() {
+    const queryClient = useMemo(
+        () =>
+            new QueryClient({
+                defaultOptions: { queries: { retry: false } },
+            }),
+        [],
+    );
+    const gameStore = useMemo(
+        () =>
+            createGameState({
+                appBaseUrl: 'http://localhost',
+                authenticatedGardenQueriesEnabled: false,
+                freezeTime: new Date('2026-08-11T12:00:00.000Z'),
+                isMock: true,
+            }),
+        [],
+    );
+
+    return (
+        <NuqsTestingAdapter>
+            <QueryClientProvider client={queryClient}>
+                <GameStateContext.Provider value={gameStore}>
+                    <div
+                        data-testid="cursor-anchored-zoom-fixture"
+                        style={{ height: 600, width: 800 }}
+                    >
+                        <Scene
+                            pixelRatio={1}
+                            position={initialPosition}
+                            suspendWhenOffscreen={false}
+                            zoom={initialZoom}
+                        >
+                            <mesh position={anchor}>
+                                <sphereGeometry args={[0.12, 12, 8]} />
+                                <meshBasicMaterial color="#facc15" />
+                            </mesh>
+                            <GameCameraRig
+                                controlsEnabled
+                                initialPosition={initialPosition}
+                                initialTarget={initialTarget}
+                                initialZoom={initialZoom}
+                            />
+                        </Scene>
+                        <CameraProjectionProbe />
+                    </div>
+                </GameStateContext.Provider>
+            </QueryClientProvider>
+        </NuqsTestingAdapter>
+    );
+}


### PR DESCRIPTION
## What changed

- zoom the orthographic game camera around the world position beneath the mouse cursor
- translate the camera and its target together after wheel zoom so the pointed garden position stays fixed on screen
- reuse raycasting scratch objects to avoid per-wheel allocations
- add unit coverage for off-center and centered zoom, plus a Playwright/WebGL wheel interaction regression

## Why

Wheel input previously changed only `camera.zoom`, so every zoom was centered on the canvas and the cursor drifted away from the garden position the user was inspecting.

## User impact

Scrolling over a garden position now keeps that position anchored beneath the cursor while the camera pans into the new zoomed view.

## Validation

- `pnpm lint --filter @gredice/game --filter garden`
- `pnpm --filter @gredice/game test` (869 passed)
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
- `pnpm --filter garden test:prepare`
- `pnpm --dir apps/garden exec playwright test tests/cursor-anchored-zoom.spec.tsx --project=chromium-webgl`