### PR TITLE
feat(www): add page-specific Open Graph previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,17 @@ jobs:
       testShardPrepareScript: "test:prepare:routes"
     secrets: inherit
 
+  ci_news:
+    name: "CI - news"
+    needs: changes
+    if: success() && needs.changes.outputs.app_news == 'true'
+    uses: ./.github/workflows/nextjs_ci_reusable.yml
+    with:
+      name: "news"
+      path: "apps/news"
+      vercelProjectIdSecretName: "VERCEL_PROJECT_ID_NEWS"
+    secrets: inherit
+
   ci_garden:
     name: "CI - garden"
     needs: changes

--- a/.github/workflows/nextjs_ci_reusable.yml
+++ b/.github/workflows/nextjs_ci_reusable.yml
@@ -180,6 +180,12 @@ jobs:
         env:
           TEST_ARGS: ${{ matrix.shard.args || (matrix.shard.total != 1 && format('--shard={0}/{1}', matrix.shard.index, matrix.shard.total)) || '' }}
         run: |
+          # Sensitive Vercel values are not available to `vercel env pull`.
+          # Keep WWW's signed OG build/runtime test aligned with an ephemeral key.
+          if [ "${{ inputs.name }}" = "www" ]; then
+            export CMS_PAGES_PREVIEW_SECRET="$(openssl rand -hex 32)"
+          fi
+
           if [ -z "$TEST_ARGS" ]; then
             pnpm test --filter=${{ inputs.name }}
           else

--- a/apps/news/app/opengraph-image.tsx
+++ b/apps/news/app/opengraph-image.tsx
@@ -1,0 +1,20 @@
+import {
+    CmsOgImage,
+    cmsOgImageContentType,
+    cmsOgImageSize,
+} from '@gredice/ui/cms';
+import { ImageResponse } from 'next/og';
+import { blogArchiveSeo } from '../lib/newsArchiveMetadata';
+
+export const alt = blogArchiveSeo.imageAlt;
+export const size = cmsOgImageSize;
+export const contentType = cmsOgImageContentType;
+
+export default function BlogArchiveOpenGraphImage() {
+    return new ImageResponse(
+        <CmsOgImage kind="blog" tags={['Blog']} title={blogArchiveSeo.title} />,
+        {
+            ...size,
+        },
+    );
+}

--- a/apps/news/app/page.tsx
+++ b/apps/news/app/page.tsx
@@ -1,14 +1,16 @@
 import { Container } from '@gredice/ui/Container';
-import type { Route } from 'next';
+import type { Metadata, Route } from 'next';
 import { redirect } from 'next/navigation';
 import { EmptyNewsState } from '../components/EmptyNewsState';
 import { FilterPills } from '../components/FilterPills';
 import { NewsArchiveNavigation } from '../components/NewsArchiveNavigation';
 import { NewsCard } from '../components/NewsCard';
 import { getBlogPosts, uniqueNewsValues } from '../lib/news';
+import { blogArchiveMetadata } from '../lib/newsArchiveMetadata';
 import { getNewsArticleViewTransitionName } from '../lib/viewTransitions';
 
 export const dynamic = 'force-dynamic';
+export const metadata: Metadata = blogArchiveMetadata;
 
 function normalizeFilterValue(value: string | undefined) {
     return value?.trim().toLocaleLowerCase('hr-HR');

--- a/apps/news/app/sto-je-novo/opengraph-image.tsx
+++ b/apps/news/app/sto-je-novo/opengraph-image.tsx
@@ -1,0 +1,24 @@
+import {
+    CmsOgImage,
+    cmsOgImageContentType,
+    cmsOgImageSize,
+} from '@gredice/ui/cms';
+import { ImageResponse } from 'next/og';
+import { changelogArchiveSeo } from '../../lib/newsArchiveMetadata';
+
+export const alt = changelogArchiveSeo.imageAlt;
+export const size = cmsOgImageSize;
+export const contentType = cmsOgImageContentType;
+
+export default function ChangelogArchiveOpenGraphImage() {
+    return new ImageResponse(
+        <CmsOgImage
+            kind="changelog"
+            tags={['Nadogradnje', 'Poboljšanja']}
+            title={changelogArchiveSeo.title}
+        />,
+        {
+            ...size,
+        },
+    );
+}

--- a/apps/news/app/sto-je-novo/page.tsx
+++ b/apps/news/app/sto-je-novo/page.tsx
@@ -1,6 +1,6 @@
 import { Container } from '@gredice/ui/Container';
 import { Timeline, TimelineEntry, TimelineGroup } from '@gredice/ui/Timeline';
-import type { Route } from 'next';
+import type { Metadata, Route } from 'next';
 import { EmptyNewsState } from '../../components/EmptyNewsState';
 import { NewsArchiveNavigation } from '../../components/NewsArchiveNavigation';
 import { NewsCard } from '../../components/NewsCard';
@@ -10,9 +10,11 @@ import {
     getPrimaryNewsTags,
     uniqueNewsValues,
 } from '../../lib/news';
+import { changelogArchiveMetadata } from '../../lib/newsArchiveMetadata';
 import { getNewsArticleViewTransitionName } from '../../lib/viewTransitions';
 
 export const dynamic = 'force-dynamic';
+export const metadata: Metadata = changelogArchiveMetadata;
 
 const monthFormatter = new Intl.DateTimeFormat('hr-HR', {
     month: 'long',

--- a/apps/news/lib/newsArchiveMetadata.node.spec.ts
+++ b/apps/news/lib/newsArchiveMetadata.node.spec.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { Metadata } from 'next';
+import {
+    blogArchiveMetadata,
+    blogArchiveSeo,
+    changelogArchiveMetadata,
+    changelogArchiveSeo,
+} from './newsArchiveMetadata.ts';
+
+type ExpectedArchiveMetadata = {
+    canonicalUrl: string;
+    description: string;
+    documentTitle: string;
+    imageAlt: string;
+    imageUrl: string;
+    title: string;
+};
+
+function assertArchiveMetadata(
+    metadata: Metadata,
+    expected: ExpectedArchiveMetadata,
+) {
+    assert.deepEqual(metadata.title, {
+        absolute: expected.documentTitle,
+    });
+    assert.deepEqual(metadata.alternates, {
+        canonical: expected.canonicalUrl,
+    });
+    assert.deepEqual(metadata.openGraph, {
+        title: expected.title,
+        description: expected.description,
+        images: [
+            {
+                alt: expected.imageAlt,
+                height: 630,
+                type: 'image/png',
+                url: expected.imageUrl,
+                width: 1200,
+            },
+        ],
+        locale: 'hr_HR',
+        siteName: 'Gredice',
+        type: 'website',
+        url: expected.canonicalUrl,
+    });
+    assert.deepEqual(metadata.twitter, {
+        card: 'summary_large_image',
+        title: expected.title,
+        description: expected.description,
+        images: [
+            {
+                alt: expected.imageAlt,
+                url: expected.imageUrl,
+            },
+        ],
+    });
+}
+
+describe('news archive metadata', () => {
+    it('publishes a complete blog archive social preview contract', () => {
+        assertArchiveMetadata(blogArchiveMetadata, blogArchiveSeo);
+    });
+
+    it('publishes a complete changelog archive social preview contract', () => {
+        assertArchiveMetadata(changelogArchiveMetadata, changelogArchiveSeo);
+    });
+
+    it('keeps the two archive previews distinct', () => {
+        assert.notEqual(
+            blogArchiveSeo.canonicalUrl,
+            changelogArchiveSeo.canonicalUrl,
+        );
+        assert.notEqual(blogArchiveSeo.title, changelogArchiveSeo.title);
+        assert.notEqual(blogArchiveSeo.imageUrl, changelogArchiveSeo.imageUrl);
+    });
+});

--- a/apps/news/lib/newsArchiveMetadata.ts
+++ b/apps/news/lib/newsArchiveMetadata.ts
@@ -1,0 +1,79 @@
+import type { Metadata } from 'next';
+
+type NewsArchiveSeo = {
+    canonicalUrl: string;
+    description: string;
+    documentTitle: string;
+    imageAlt: string;
+    imageUrl: string;
+    title: string;
+};
+
+const openGraphImageSize = {
+    height: 630,
+    width: 1200,
+};
+
+function createNewsArchiveMetadata(seo: NewsArchiveSeo): Metadata {
+    return {
+        title: {
+            absolute: seo.documentTitle,
+        },
+        description: seo.description,
+        alternates: {
+            canonical: seo.canonicalUrl,
+        },
+        openGraph: {
+            title: seo.title,
+            description: seo.description,
+            images: [
+                {
+                    ...openGraphImageSize,
+                    alt: seo.imageAlt,
+                    type: 'image/png',
+                    url: seo.imageUrl,
+                },
+            ],
+            locale: 'hr_HR',
+            siteName: 'Gredice',
+            type: 'website',
+            url: seo.canonicalUrl,
+        },
+        twitter: {
+            card: 'summary_large_image',
+            title: seo.title,
+            description: seo.description,
+            images: [
+                {
+                    alt: seo.imageAlt,
+                    url: seo.imageUrl,
+                },
+            ],
+        },
+    };
+}
+
+export const blogArchiveSeo = {
+    canonicalUrl: 'https://www.gredice.com/novosti',
+    description:
+        'Blog objave iz Gredica koje pomažu pratiti što se događa u vrtu i oko njega.',
+    documentTitle: 'Novosti | Gredice',
+    imageAlt: 'Novosti iz Gredica – blog objave iz vrta',
+    imageUrl: 'https://www.gredice.com/novosti/opengraph-image',
+    title: 'Novosti iz Gredica',
+} satisfies NewsArchiveSeo;
+
+export const changelogArchiveSeo = {
+    canonicalUrl: 'https://www.gredice.com/novosti/sto-je-novo',
+    description:
+        'Kronološki pregled nadogradnji, poboljšanja i novih značajki u Gredicama.',
+    documentTitle: 'Što je novo | Gredice',
+    imageAlt: 'Što je novo u Gredicama – promjene i nove mogućnosti',
+    imageUrl: 'https://www.gredice.com/novosti/sto-je-novo/opengraph-image',
+    title: 'Što je novo u Gredicama',
+} satisfies NewsArchiveSeo;
+
+export const blogArchiveMetadata = createNewsArchiveMetadata(blogArchiveSeo);
+
+export const changelogArchiveMetadata =
+    createNewsArchiveMetadata(changelogArchiveSeo);

--- a/apps/news/package.json
+++ b/apps/news/package.json
@@ -11,7 +11,9 @@
         "dev": "node ../../scripts/run-app-command.mjs dev",
         "build": "next build",
         "start": "node ../../scripts/run-app-command.mjs start",
-        "test": "pnpm run typecheck"
+        "test": "pnpm run typecheck && pnpm run test:unit && pnpm run test:production-metadata",
+        "test:unit": "node --test lib/newsArchiveMetadata.node.spec.ts",
+        "test:production-metadata": "pnpm run build && node --test tests/newsArchives.production.node.spec.mjs"
     },
     "dependencies": {
         "@posthog/next": "0.8.0",

--- a/apps/news/tests/newsArchives.production.node.spec.mjs
+++ b/apps/news/tests/newsArchives.production.node.spec.mjs
@@ -1,0 +1,294 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { createServer } from 'node:http';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const appDirectory = fileURLToPath(new URL('..', import.meta.url));
+const nextCli = join(
+    appDirectory,
+    'node_modules',
+    'next',
+    'dist',
+    'bin',
+    'next',
+);
+
+const archives = [
+    {
+        description:
+            'Blog objave iz Gredica koje pomažu pratiti što se događa u vrtu i oko njega.',
+        imageAlt: 'Novosti iz Gredica – blog objave iz vrta',
+        imagePath: '/novosti/opengraph-image',
+        path: '/novosti',
+        publicUrl: 'https://www.gredice.com/novosti',
+        title: 'Novosti iz Gredica',
+    },
+    {
+        description:
+            'Kronološki pregled nadogradnji, poboljšanja i novih značajki u Gredicama.',
+        imageAlt: 'Što je novo u Gredicama – promjene i nove mogućnosti',
+        imagePath: '/novosti/sto-je-novo/opengraph-image',
+        path: '/novosti/sto-je-novo',
+        publicUrl: 'https://www.gredice.com/novosti/sto-je-novo',
+        title: 'Što je novo u Gredicama',
+    },
+];
+
+function delay(milliseconds) {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function listen(server) {
+    await new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            server.off('error', reject);
+            resolve();
+        });
+    });
+
+    const address = server.address();
+    assert.ok(address && typeof address === 'object');
+    return address.port;
+}
+
+async function closeServer(server) {
+    if (!server.listening) {
+        return;
+    }
+
+    await new Promise((resolve, reject) => {
+        server.close((error) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve();
+        });
+    });
+}
+
+async function reservePort() {
+    const server = createServer();
+    const port = await listen(server);
+    await closeServer(server);
+    return port;
+}
+
+function startMockApi() {
+    const requests = [];
+    const server = createServer((request, response) => {
+        const url = new URL(request.url ?? '/', 'http://127.0.0.1');
+        requests.push(url.pathname);
+
+        if (
+            url.pathname === '/api/news/blog' ||
+            url.pathname === '/api/news/changelog'
+        ) {
+            response.writeHead(200, {
+                'content-type': 'application/json; charset=utf-8',
+            });
+            response.end(JSON.stringify({ items: [] }));
+            return;
+        }
+
+        response.writeHead(404, {
+            'content-type': 'application/json; charset=utf-8',
+        });
+        response.end(JSON.stringify({ error: 'not-found' }));
+    });
+
+    return { requests, server };
+}
+
+function startNextServer(port, apiOrigin) {
+    const child = spawn(process.execPath, [nextCli, 'start', '-p', `${port}`], {
+        cwd: appDirectory,
+        env: {
+            ...process.env,
+            GREDICE_API_HOST: apiOrigin,
+            NEXT_TELEMETRY_DISABLED: '1',
+            VERCEL_ENV: 'development',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+
+    for (const stream of [child.stdout, child.stderr]) {
+        stream.setEncoding('utf8');
+        stream.on('data', (chunk) => {
+            output = `${output}${chunk}`.slice(-12_000);
+        });
+    }
+
+    return { child, getOutput: () => output };
+}
+
+async function stopChild(child) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+        return;
+    }
+
+    await new Promise((resolve) => {
+        const forceStop = setTimeout(() => {
+            child.kill('SIGKILL');
+        }, 5_000);
+
+        child.once('exit', () => {
+            clearTimeout(forceStop);
+            resolve();
+        });
+        child.kill('SIGTERM');
+    });
+}
+
+async function waitForPage(url, nextServer) {
+    const deadline = Date.now() + 30_000;
+    let lastError;
+
+    while (Date.now() < deadline) {
+        if (nextServer.child.exitCode !== null) {
+            throw new Error(
+                `Next.js exited before becoming ready.\n${nextServer.getOutput()}`,
+            );
+        }
+
+        try {
+            const response = await fetch(url, {
+                headers: { 'user-agent': 'Twitterbot' },
+            });
+            if (response.ok) {
+                return await response.text();
+            }
+            lastError = new Error(
+                `Unexpected readiness status ${response.status}`,
+            );
+        } catch (error) {
+            lastError = error;
+        }
+
+        await delay(100);
+    }
+
+    throw new Error(
+        `Next.js did not become ready: ${String(lastError)}\n${nextServer.getOutput()}`,
+    );
+}
+
+function headMetadata(html) {
+    const metadata = new Map();
+    const tags = html.match(/<(?:link|meta)\s+[^>]*>/gu) ?? [];
+
+    for (const tag of tags) {
+        const attributes = new Map();
+        for (const match of tag.matchAll(/([\w:-]+)="([^"]*)"/gu)) {
+            attributes.set(match[1], match[2]);
+        }
+
+        const property = attributes.get('property') ?? attributes.get('name');
+        if (property?.startsWith('og:') || property?.startsWith('twitter:')) {
+            metadata.set(property, attributes.get('content'));
+        }
+        if (attributes.get('rel') === 'canonical') {
+            metadata.set('canonical', attributes.get('href'));
+        }
+    }
+
+    return metadata;
+}
+
+function assertArchiveMetadata(metadata, archive) {
+    const publicImageUrl = `https://www.gredice.com${archive.imagePath}`;
+
+    assert.equal(metadata.get('canonical'), archive.publicUrl);
+    assert.equal(metadata.get('og:title'), archive.title);
+    assert.equal(metadata.get('og:description'), archive.description);
+    assert.equal(metadata.get('og:url'), archive.publicUrl);
+    assert.equal(metadata.get('og:type'), 'website');
+    assert.equal(metadata.get('og:image'), publicImageUrl);
+    assert.equal(metadata.get('og:image:type'), 'image/png');
+    assert.equal(metadata.get('og:image:width'), '1200');
+    assert.equal(metadata.get('og:image:height'), '630');
+    assert.equal(metadata.get('og:image:alt'), archive.imageAlt);
+    assert.equal(metadata.get('twitter:card'), 'summary_large_image');
+    assert.equal(metadata.get('twitter:title'), archive.title);
+    assert.equal(metadata.get('twitter:description'), archive.description);
+    assert.equal(metadata.get('twitter:image'), publicImageUrl);
+    assert.equal(metadata.get('twitter:image:alt'), archive.imageAlt);
+}
+
+function pngDimensions(bytes) {
+    const pngSignature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+    assert.deepEqual(bytes.subarray(0, pngSignature.length), pngSignature);
+
+    return {
+        height: bytes.readUInt32BE(20),
+        width: bytes.readUInt32BE(16),
+    };
+}
+
+describe('production news archive metadata', () => {
+    it('renders distinct public metadata and 1200x630 PNG previews', {
+        timeout: 60_000,
+    }, async (testContext) => {
+        const mockApi = startMockApi();
+        const apiPort = await listen(mockApi.server);
+        testContext.after(() => closeServer(mockApi.server));
+
+        const nextPort = await reservePort();
+        const nextServer = startNextServer(
+            nextPort,
+            `http://127.0.0.1:${apiPort}`,
+        );
+        testContext.after(() => stopChild(nextServer.child));
+
+        const origin = `http://127.0.0.1:${nextPort}`;
+        const renderedMetadata = [];
+        const imageHashes = [];
+
+        for (const archive of archives) {
+            const html = await waitForPage(
+                `${origin}${archive.path}`,
+                nextServer,
+            );
+            const metadata = headMetadata(html);
+            assertArchiveMetadata(metadata, archive);
+            renderedMetadata.push(metadata);
+
+            const imageResponse = await fetch(`${origin}${archive.imagePath}`);
+            assert.equal(imageResponse.status, 200);
+            assert.equal(
+                imageResponse.headers.get('content-type'),
+                'image/png',
+            );
+
+            const imageBytes = Buffer.from(await imageResponse.arrayBuffer());
+            assert.deepEqual(pngDimensions(imageBytes), {
+                height: 630,
+                width: 1200,
+            });
+            imageHashes.push(
+                createHash('sha256').update(imageBytes).digest('hex'),
+            );
+        }
+
+        assert.notEqual(
+            renderedMetadata[0].get('og:url'),
+            renderedMetadata[1].get('og:url'),
+        );
+        assert.notEqual(
+            renderedMetadata[0].get('og:title'),
+            renderedMetadata[1].get('og:title'),
+        );
+        assert.notEqual(
+            renderedMetadata[0].get('og:image'),
+            renderedMetadata[1].get('og:image'),
+        );
+        assert.notEqual(imageHashes[0], imageHashes[1]);
+        assert.ok(mockApi.requests.includes('/api/news/blog'));
+        assert.ok(mockApi.requests.includes('/api/news/changelog'));
+    });
+});

--- a/apps/www/app/api/og/public/PublicOgCard.tsx
+++ b/apps/www/app/api/og/public/PublicOgCard.tsx
@@ -1,0 +1,285 @@
+import type { PublicOgCardData } from '../../../../lib/seo/publicMetadata';
+
+function titleFontSize(title: string) {
+    if (title.length > 72) {
+        return 46;
+    }
+    if (title.length > 48) {
+        return 54;
+    }
+
+    return 62;
+}
+
+function GardenIllustration() {
+    return (
+        <div
+            style={{
+                alignItems: 'center',
+                background: '#dcebd5',
+                border: '2px solid #b8d5b3',
+                borderRadius: 36,
+                display: 'flex',
+                height: 390,
+                justifyContent: 'center',
+                overflow: 'hidden',
+                position: 'relative',
+                width: 390,
+            }}
+        >
+            <div
+                style={{
+                    background: '#9ac36d',
+                    borderRadius: 60,
+                    height: 280,
+                    position: 'absolute',
+                    right: -90,
+                    top: -100,
+                    width: 280,
+                }}
+            />
+            <div
+                style={{
+                    background: '#4c852f',
+                    bottom: 36,
+                    height: 118,
+                    position: 'absolute',
+                    transform: 'skewY(-8deg)',
+                    width: 285,
+                }}
+            />
+            <div
+                style={{
+                    alignItems: 'center',
+                    background: '#a96845',
+                    border: '16px solid #d39769',
+                    bottom: 88,
+                    display: 'flex',
+                    height: 145,
+                    justifyContent: 'space-around',
+                    padding: '8px 22px',
+                    position: 'absolute',
+                    transform: 'skewY(-8deg)',
+                    width: 285,
+                }}
+            >
+                {[0, 1, 2].map((index) => (
+                    <div
+                        key={index}
+                        style={{
+                            alignItems: 'center',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            transform: 'skewY(8deg)',
+                        }}
+                    >
+                        <div
+                            style={{
+                                background: '#2e6f40',
+                                borderRadius: '90% 10% 90% 10%',
+                                height: 34,
+                                transform: 'rotate(-35deg)',
+                                width: 24,
+                            }}
+                        />
+                        <div
+                            style={{
+                                background: '#2e6f40',
+                                height: 38,
+                                width: 7,
+                            }}
+                        />
+                    </div>
+                ))}
+            </div>
+            <div
+                style={{
+                    background: '#f5b942',
+                    border: '12px solid #fff2b9',
+                    borderRadius: 999,
+                    height: 82,
+                    position: 'absolute',
+                    right: 34,
+                    top: 34,
+                    width: 82,
+                }}
+            />
+        </div>
+    );
+}
+
+export function PublicOgCard({
+    title,
+    description,
+    eyebrow,
+    imageUrl,
+}: PublicOgCardData) {
+    return (
+        <div
+            style={{
+                background: '#fefaf6',
+                color: '#1d3223',
+                display: 'flex',
+                fontFamily: 'Arial, sans-serif',
+                height: '100%',
+                overflow: 'hidden',
+                padding: '58px 62px',
+                position: 'relative',
+                width: '100%',
+            }}
+        >
+            <div
+                style={{
+                    background: '#e8f1e5',
+                    borderRadius: 999,
+                    height: 420,
+                    left: -210,
+                    position: 'absolute',
+                    top: -270,
+                    width: 620,
+                }}
+            />
+            <div
+                style={{
+                    alignItems: 'center',
+                    color: '#2e6f40',
+                    display: 'flex',
+                    fontSize: 29,
+                    fontWeight: 700,
+                    left: 62,
+                    letterSpacing: '-0.02em',
+                    position: 'absolute',
+                    top: 58,
+                }}
+            >
+                <span
+                    style={{
+                        alignItems: 'center',
+                        background: '#2e6f40',
+                        borderRadius: 10,
+                        color: '#fefaf6',
+                        display: 'flex',
+                        fontSize: 24,
+                        height: 42,
+                        justifyContent: 'center',
+                        marginRight: 14,
+                        width: 42,
+                    }}
+                >
+                    G
+                </span>
+                Gredice
+            </div>
+
+            <div
+                style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    left: 62,
+                    position: 'absolute',
+                    top: 210,
+                    width: 650,
+                }}
+            >
+                {eyebrow ? (
+                    <div
+                        style={{
+                            color: '#4c852f',
+                            display: 'flex',
+                            fontSize: 20,
+                            fontWeight: 700,
+                            letterSpacing: '0.08em',
+                            marginBottom: 16,
+                            textTransform: 'uppercase',
+                        }}
+                    >
+                        {eyebrow}
+                    </div>
+                ) : null}
+                <div
+                    style={{
+                        display: 'flex',
+                        fontSize: titleFontSize(title),
+                        fontWeight: 800,
+                        letterSpacing: '-0.045em',
+                        lineHeight: 1.03,
+                        marginBottom: 22,
+                    }}
+                >
+                    {title}
+                </div>
+                <div
+                    style={{
+                        color: '#46604d',
+                        display: 'flex',
+                        fontSize: 24,
+                        lineHeight: 1.35,
+                        maxWidth: 650,
+                    }}
+                >
+                    {description}
+                </div>
+            </div>
+
+            <div
+                style={{
+                    bottom: 58,
+                    color: '#66806d',
+                    display: 'flex',
+                    fontSize: 19,
+                    fontWeight: 600,
+                    left: 62,
+                    position: 'absolute',
+                }}
+            >
+                www.gredice.com
+            </div>
+
+            <div
+                style={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    height: 390,
+                    justifyContent: 'center',
+                    position: 'absolute',
+                    right: 62,
+                    top: 120,
+                    width: 390,
+                }}
+            >
+                {imageUrl ? (
+                    <div
+                        style={{
+                            alignItems: 'center',
+                            background: '#e8f1e5',
+                            border: '2px solid #c9ddc5',
+                            borderRadius: 36,
+                            display: 'flex',
+                            height: 390,
+                            justifyContent: 'center',
+                            overflow: 'hidden',
+                            padding: 18,
+                            width: 390,
+                        }}
+                    >
+                        {/* biome-ignore lint/performance/noImgElement: ImageResponse renders native image elements. */}
+                        <img
+                            alt=""
+                            height="354"
+                            src={imageUrl}
+                            style={{
+                                borderRadius: 24,
+                                height: '100%',
+                                objectFit: 'contain',
+                                width: '100%',
+                            }}
+                            width="354"
+                        />
+                    </div>
+                ) : (
+                    <GardenIllustration />
+                )}
+            </div>
+        </div>
+    );
+}

--- a/apps/www/app/api/og/public/route.ts
+++ b/apps/www/app/api/og/public/route.ts
@@ -1,0 +1,74 @@
+import { ImageResponse } from 'next/og';
+import { createElement } from 'react';
+import {
+    buildPublicOgCanonicalSearchParams,
+    isValidPublicOgSearchParams,
+    MAXIMUM_PUBLIC_OG_QUERY_LENGTH,
+    PUBLIC_OG_IMAGE_SIZE,
+    parsePublicOgCardSearchParams,
+} from '../../../../lib/seo/publicMetadata';
+import {
+    resolvePublicOgSigningConfig,
+    verifyPublicOgSignature,
+} from '../../../../lib/seo/publicOgSignature';
+import { resolvePublicOgImageDataUrl } from '../../../../lib/seo/resolvePublicOgImage';
+import { PublicOgCard } from './PublicOgCard';
+
+export const runtime = 'nodejs';
+
+export async function GET(request: Request) {
+    const requestUrl = new URL(request.url);
+    const isValidRequest =
+        requestUrl.search.length <= MAXIMUM_PUBLIC_OG_QUERY_LENGTH &&
+        isValidPublicOgSearchParams(requestUrl.searchParams);
+    const card = isValidRequest
+        ? parsePublicOgCardSearchParams(requestUrl.searchParams)
+        : null;
+
+    if (!card) {
+        return new Response('Invalid Open Graph card request.', {
+            headers: { 'Cache-Control': 'no-store' },
+            status: 400,
+        });
+    }
+
+    const signingConfig = resolvePublicOgSigningConfig();
+    const signatureVerification = verifyPublicOgSignature(
+        requestUrl.searchParams,
+        buildPublicOgCanonicalSearchParams(card),
+        signingConfig,
+    );
+    if (signatureVerification === 'configuration-error') {
+        return new Response('Open Graph signing is not configured.', {
+            headers: { 'Cache-Control': 'no-store' },
+            status: 503,
+        });
+    }
+    if (
+        signatureVerification !== 'valid' &&
+        signatureVerification !== 'unsigned-local'
+    ) {
+        return new Response('Invalid Open Graph card signature.', {
+            headers: { 'Cache-Control': 'no-store' },
+            status: 401,
+        });
+    }
+
+    const imageUrl = await resolvePublicOgImageDataUrl(card.imageUrl);
+    const coverResolutionFailed = Boolean(card.imageUrl && !imageUrl);
+
+    return new ImageResponse(
+        createElement(PublicOgCard, {
+            ...card,
+            imageUrl,
+        }),
+        {
+            ...PUBLIC_OG_IMAGE_SIZE,
+            headers: {
+                'Cache-Control': coverResolutionFailed
+                    ? 'no-store'
+                    : 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800',
+            },
+        },
+    );
+}

--- a/apps/www/app/api/og/public/route.ts
+++ b/apps/www/app/api/og/public/route.ts
@@ -34,7 +34,7 @@ export async function GET(request: Request) {
 
     const signingConfig = resolvePublicOgSigningConfig();
     const signatureVerification = verifyPublicOgSignature(
-        requestUrl.searchParams,
+        requestUrl.search.slice(1),
         buildPublicOgCanonicalSearchParams(card),
         signingConfig,
     );

--- a/apps/www/app/biljke/[alias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/page.tsx
@@ -12,6 +12,7 @@ import { StructuredDataScript } from '../../../components/shared/seo/StructuredD
 import { getOperationsData } from '../../../lib/plants/getOperationsData';
 import { getPlantsData } from '../../../lib/plants/getPlantsData';
 import { getRecipesData } from '../../../lib/recipes/getRecipesData';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
 import { KnownPages } from '../../../src/KnownPages';
 import { merchantReturnPolicy } from '../../../src/merchantReturnPolicy';
 import { matchesPageAlias, toPageAlias } from '../../../src/pageAliases';
@@ -38,15 +39,16 @@ export async function generateMetadata(
         matchesPageAlias(plant.information.name, alias),
     );
     if (!plant) {
-        return {
-            title: 'Biljka nije pronađena',
-            description: 'Biljka nije pronađena',
-        };
+        notFound();
     }
-    return {
+    return createPublicMetadata({
         title: plant.information.name,
         description: plant.information.description,
-    };
+        path: KnownPages.Plant(plant.slug || plant.information.name),
+        category: 'Biljka',
+        imageUrl: plant.image?.cover?.url,
+        imageAlt: `Fotografija biljke ${plant.information.name}`,
+    });
 }
 
 export async function generateStaticParams() {

--- a/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
@@ -11,6 +11,7 @@ import { getOperationsData } from '../../../../../lib/plants/getOperationsData';
 import { getPlantSortsData } from '../../../../../lib/plants/getPlantSortsData';
 import { getPlantsData } from '../../../../../lib/plants/getPlantsData';
 import { resolvePlantSowingPrice } from '../../../../../lib/plants/resolvePlantSowingPrice';
+import { createPublicMetadata } from '../../../../../lib/seo/publicMetadata';
 import { KnownPages } from '../../../../../src/KnownPages';
 import { merchantReturnPolicy } from '../../../../../src/merchantReturnPolicy';
 import { matchesPageAlias, toPageAlias } from '../../../../../src/pageAliases';
@@ -53,18 +54,22 @@ export async function generateMetadata(
             matchesPageAlias(sort.information.name, sortAlias),
     );
     if (!plant || !sort) {
-        return {
-            title: 'Sorta nije pronađena',
-            description: 'Sorta nije pronađena',
-        };
+        notFound();
     }
-    return {
+    return createPublicMetadata({
         title: sort.information.name,
         description:
             sort.information.shortDescription ??
             sort.information.description ??
             plant.information.description,
-    };
+        path: KnownPages.PlantSort(
+            plant.slug || plant.information.name,
+            sort.slug || sort.information.name,
+        ),
+        category: `Sorta biljke ${plant.information.name}`,
+        imageUrl: sort.image?.cover?.url,
+        imageAlt: `Fotografija sorte ${sort.information.name}`,
+    });
 }
 
 export async function generateStaticParams() {

--- a/apps/www/app/biljke/page.tsx
+++ b/apps/www/app/biljke/page.tsx
@@ -14,17 +14,20 @@ import { PageFilterInputNoSSR } from '../../components/shared/PageFilterInputNoS
 import { StructuredDataScript } from '../../components/shared/seo/StructuredDataScript';
 import { getPlantSortsData } from '../../lib/plants/getPlantSortsData';
 import { getPlantsData } from '../../lib/plants/getPlantsData';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 import { KnownPages } from '../../src/KnownPages';
 import { CalendarInfoChip } from './CalendarInfoChip';
 import { PlantsCalendar } from './PlantsCalendar';
 import { PlantsGallery } from './PlantsGallery';
 import { PlantsSeedTimeFilterToggle } from './PlantsSeedTimeFilterToggle';
 
-export const metadata: Metadata = {
+export const metadata: Metadata = createPublicMetadata({
     title: 'Biljke',
     description:
         'Za tebe smo pripremili opširnu listu biljaka koje možeš pronaći u našem asortimanu.',
-};
+    path: KnownPages.Plants,
+    category: 'Katalog biljaka',
+});
 
 export default async function PlantsPage({
     searchParams,

--- a/apps/www/app/blokovi/[alias]/page.tsx
+++ b/apps/www/app/blokovi/[alias]/page.tsx
@@ -15,6 +15,7 @@ import { AttributeCard } from '../../../components/attributes/DetailCard';
 import { CommunityEditButton } from '../../../components/community-edits/CommunityEditButton';
 import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal';
 import { getBlocksData } from '../../../lib/blocks/getBlocksData';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
 import { KnownPages } from '../../../src/KnownPages';
 import { matchesPageAlias, toPageAlias } from '../../../src/pageAliases';
 import { BlocksList } from './BlocksList';
@@ -31,15 +32,16 @@ export async function generateMetadata(
         matchesPageAlias(block.information.label, alias),
     );
     if (!block) {
-        return {
-            title: 'Blok nije pronađen',
-            description: 'Blok koji tražiš nije pronađen.',
-        };
+        notFound();
     }
-    return {
+    return createPublicMetadata({
         title: block.information.label,
         description: block.information.shortDescription,
-    };
+        path: KnownPages.Block(block.slug || block.information.label),
+        category: 'Vrtni blok',
+        imageUrl: block.image?.cover?.url,
+        imageAlt: `Prikaz bloka ${block.information.label}`,
+    });
 }
 
 export async function generateStaticParams() {

--- a/apps/www/app/blokovi/biljke/[alias]/page.tsx
+++ b/apps/www/app/blokovi/biljke/[alias]/page.tsx
@@ -8,6 +8,7 @@ import { notFound } from 'next/navigation';
 import { FeedbackModal } from '../../../../components/shared/feedback/FeedbackModal';
 import { getPlantSortsData } from '../../../../lib/plants/getPlantSortsData';
 import { getPlantsData } from '../../../../lib/plants/getPlantsData';
+import { createPublicMetadata } from '../../../../lib/seo/publicMetadata';
 import { KnownPages } from '../../../../src/KnownPages';
 import { matchesPageAlias, toPageAlias } from '../../../../src/pageAliases';
 import { resolveProceduralPlantType } from '../../plantNamesWithProceduralModels';
@@ -24,16 +25,17 @@ export async function generateMetadata(
     const plant = plants?.find((p) =>
         matchesPageAlias(p.information.name, alias),
     );
-    if (!plant) {
-        return {
-            title: 'Biljka nije pronađena',
-            description: 'Biljka nije pronađena.',
-        };
+    if (!plant || !resolveProceduralPlantType(plant.information.name)) {
+        notFound();
     }
-    return {
+    return createPublicMetadata({
         title: `${plant.information.name} - 3D prikaz`,
         description: `Pogledaj kako ${plant.information.name} raste u 3D prikazu.`,
-    };
+        path: KnownPages.BlockPlant(plant.slug || plant.information.name),
+        category: '3D prikaz biljke',
+        imageUrl: plant.image?.cover?.url,
+        imageAlt: `Fotografija biljke ${plant.information.name}`,
+    });
 }
 
 export async function generateStaticParams() {

--- a/apps/www/app/blokovi/biljke/page.tsx
+++ b/apps/www/app/blokovi/biljke/page.tsx
@@ -4,14 +4,18 @@ import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import { PageFilterInputNoSSR } from '../../../components/shared/PageFilterInputNoSSR';
 import { getPlantsData } from '../../../lib/plants/getPlantsData';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
+import { KnownPages } from '../../../src/KnownPages';
 import { PlantBlockGallery } from '../PlantBlockGallery';
 
 export const revalidate = 3600;
 
-export const metadata: Metadata = {
+export const metadata: Metadata = createPublicMetadata({
     title: 'Biljke - 3D prikaz',
     description: 'Pregledaj kako biljke rastu u 3D prikazu.',
-};
+    path: KnownPages.BlockPlants,
+    category: '3D prikaz biljaka',
+});
 
 export default async function BlockPlantsPage() {
     const plants = await getPlantsData();

--- a/apps/www/app/blokovi/page.tsx
+++ b/apps/www/app/blokovi/page.tsx
@@ -5,13 +5,17 @@ import { Suspense } from 'react';
 import { PageFilterInputNoSSR } from '../../components/shared/PageFilterInputNoSSR';
 import { getBlocksData } from '../../lib/blocks/getBlocksData';
 import { getPlantsData } from '../../lib/plants/getPlantsData';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
+import { KnownPages } from '../../src/KnownPages';
 import { BlockPlantGalleries } from './BlockPlantGalleries';
 
 export const revalidate = 3600; // 1 hour
-export const metadata: Metadata = {
+export const metadata: Metadata = createPublicMetadata({
     title: 'Blokovi',
     description: 'Pregledaj sve blokove koje možeš koristiti u svom vrtu.',
-};
+    path: KnownPages.Blocks,
+    category: '3D vrt',
+});
 
 export default async function BlocksPage() {
     const [blocks, plants] = await Promise.all([

--- a/apps/www/app/bolesti/[alias]/page.tsx
+++ b/apps/www/app/bolesti/[alias]/page.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../components/plant-health/plantHealthIssueContent';
 import { StructuredDataScript } from '../../../components/shared/seo/StructuredDataScript';
 import { getPlantDiseasesData } from '../../../lib/plants/getPlantHealthIssuesData';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
 import { KnownPages } from '../../../src/KnownPages';
 import { matchesPageAlias, toPageAlias } from '../../../src/pageAliases';
 
@@ -23,20 +24,18 @@ export async function generateMetadata(
     );
 
     if (!issue) {
-        return {
-            title: 'Bolest nije pronađena',
-            description: 'Bolest biljke nije pronađena.',
-        };
+        notFound();
     }
 
     const title = plantHealthIssueTitle(issue);
-    return {
+    return createPublicMetadata({
         title,
-        description: plantHealthIssueShortDescription(issue),
-        alternates: {
-            canonical: KnownPages.PlantDisease(issue.slug || title),
-        },
-    };
+        description:
+            plantHealthIssueShortDescription(issue) ||
+            `Saznaj više o bolesti biljaka ${title}.`,
+        path: KnownPages.PlantDisease(issue.slug || title),
+        category: 'Bolest biljaka',
+    });
 }
 
 export async function generateStaticParams() {

--- a/apps/www/app/bolesti/page.tsx
+++ b/apps/www/app/bolesti/page.tsx
@@ -15,19 +15,19 @@ import { PageFilterInput } from '../../components/shared/PageFilterInput';
 import { StructuredDataScript } from '../../components/shared/seo/StructuredDataScript';
 import { getPlantDiseasesData } from '../../lib/plants/getPlantHealthIssuesData';
 import { getPlantsData } from '../../lib/plants/getPlantsData';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 import { KnownPages } from '../../src/KnownPages';
 
 const pageDescription =
     'Pregled bolesti biljaka koje se mogu pojaviti u gredicama, s pogođenim biljkama i preporučenim radnjama.';
 
 export const revalidate = 3600;
-export const metadata: Metadata = {
+export const metadata: Metadata = createPublicMetadata({
     title: 'Bolesti biljaka',
     description: pageDescription,
-    alternates: {
-        canonical: KnownPages.PlantDiseases,
-    },
-};
+    path: KnownPages.PlantDiseases,
+    category: 'Zdravlje biljaka',
+});
 
 export default async function PlantDiseasesPage({
     searchParams,

--- a/apps/www/app/cesta-pitanja/page.tsx
+++ b/apps/www/app/cesta-pitanja/page.tsx
@@ -5,17 +5,20 @@ import { PageHeader } from '@gredice/ui/PageHeader';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
 import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { NoDataPlaceholder } from '../../components/shared/placeholders/NoDataPlaceholder';
 import { WhatsAppCard } from '../../components/social/WhatsAppCard';
 import { getFaqData } from '../../lib/plants/getFaqData';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
+import { KnownPages } from '../../src/KnownPages';
 
 export const revalidate = 3600; // 1 hour
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Česta pitanja',
     description: 'Odgovaramo na sva tvoja pitanja.',
-};
+    path: KnownPages.FAQ,
+    eyebrow: 'Pomoć i podrška',
+});
 
 export default async function FaqPage() {
     const faq = await getFaqData();

--- a/apps/www/app/cjenik/page.tsx
+++ b/apps/www/app/cjenik/page.tsx
@@ -17,7 +17,7 @@ import { PageHeader } from '@gredice/ui/PageHeader';
 import { PlantOrSortImage } from '@gredice/ui/plants';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata, Route } from 'next';
+import type { Route } from 'next';
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
@@ -26,6 +26,7 @@ import { getHqLocationsData } from '../../lib/getHqLocationsData';
 import { getOperationsData } from '../../lib/plants/getOperationsData';
 import { getPlantSortsData } from '../../lib/plants/getPlantSortsData';
 import { getPlantsData } from '../../lib/plants/getPlantsData';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 import { getPublicSunflowerPackages } from '../../lib/sunflowerPackages';
 import { KnownPages } from '../../src/KnownPages';
 import {
@@ -40,11 +41,13 @@ import {
 } from './pricingRows';
 import { ThirtyDayMinimumPrice } from './ThirtyDayMinimumPrice';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Cjenik',
     description:
         'Pregled cijena i dostupnosti paketa suncokreta, biljaka, sorti, radnji i dostave.',
-};
+    path: KnownPages.Pricing,
+    eyebrow: 'Ponuda Gredica',
+});
 
 const sunflowerFormatter = new Intl.NumberFormat('hr-HR', {
     maximumFractionDigits: 0,

--- a/apps/www/app/dostava/page.tsx
+++ b/apps/www/app/dostava/page.tsx
@@ -9,18 +9,20 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
 import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { WhatsAppCard } from '../../components/social/WhatsAppCard';
 import { formatPrice } from '../../lib/formatPrice';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 import { KnownPages } from '../../src/KnownPages';
 import { DeliveryAvailabilityChecker } from './DeliveryAvailabilityChecker';
 import { DeliveryZoneMap } from './DeliveryZoneMap';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Dostava',
     description: 'Sve informacije o dostavi povrća iz tvojih gredica.',
-};
+    path: KnownPages.Delivery,
+    eyebrow: 'Dostava uroda',
+});
 
 const deliveryLocations = [
     { name: 'Velika Gorica', distance: 20 },

--- a/apps/www/app/dostava/termini/page.tsx
+++ b/apps/www/app/dostava/termini/page.tsx
@@ -9,17 +9,20 @@ import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
-import type { Metadata } from 'next';
 import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal';
 import { WhatsAppCard } from '../../../components/social/WhatsAppCard';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
+import { KnownPages } from '../../../src/KnownPages';
 import { ClosingSoonIndicator } from './ClosingSoonIndicator';
 
 export const dynamic = 'force-dynamic';
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Termini dostave',
     description:
         'Vidi raspoložive i zatvorene termine za dostavu ili osobno preuzimanje u sljedećih mjesec dana.',
-};
+    path: KnownPages.DeliverySlots,
+    eyebrow: 'Raspored dostave',
+});
 
 // Types from API response - these match the type-safe client schema
 interface TimeSlot {

--- a/apps/www/app/kontakt/page.tsx
+++ b/apps/www/app/kontakt/page.tsx
@@ -1,16 +1,19 @@
 import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
-import type { Metadata } from 'next';
 import { FacebookCard } from '../../components/social/FacebookCard';
 import { InstagramCard } from '../../components/social/InstagramCard';
 import { WhatsAppCard } from '../../components/social/WhatsAppCard';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
+import { KnownPages } from '../../src/KnownPages';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Kontakt',
     description:
         'Slobodno nam se javi ako imaš pitanja, prijedloge ili komentare.',
-};
+    path: KnownPages.Contact,
+    eyebrow: 'Kontakt',
+});
 
 export default function ContactPage() {
     return (

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -11,6 +11,7 @@ import Head from 'next/head';
 import type { ReactNode } from 'react';
 import { PageViewTracker } from '../components/analytics/PageViewTracker';
 import { ClientAppProvider } from '../components/providers/ClientAppProvider';
+import { createPublicMetadata } from '../lib/seo/publicMetadata';
 import { LayoutContainer } from './LayoutContainer';
 
 const montserrat = Montserrat({
@@ -29,15 +30,27 @@ const gardenModelPreloadUrls = [
     'BlockTerrainReverseCorner',
 ].map((assetName) => `https://vrt.gredice.com/assets/models/${assetName}.glb`);
 
+const homepageDescription =
+    'Tvoj digitalni vrt s pravim povrćem i besplatnom dostavom. Postavi gredice, zasadi svoje omiljeno povrće, održavaj vrt i uberi plodove, a mi ćemo se pobrinuti o brzoj i besplatnoj dostavi na tvoj kućni prag.';
+
 export function generateMetadata(): Metadata {
+    const publicMetadata = createPublicMetadata({
+        title: 'Gredice - vrt po tvom',
+        description: homepageDescription,
+        path: '/',
+        eyebrow: 'Tvoj digitalni vrt',
+        imageUrl: 'https://www.gredice.com/seo-fallback.png',
+        imageAlt: 'Digitalni vrt Gredice s podignutom gredicom',
+    });
+
     return {
+        ...publicMetadata,
         metadataBase: new URL('https://www.gredice.com'),
         title: {
             template: '%s | Gredice',
             default: 'Gredice - vrt po tvom',
         },
-        description:
-            'Tvoj digitalni vrt s pravim povrćem i besplatnom dostavom. Postavi gredice, zasadi svoje omiljeno povrće, održavaj vrt i uberi plodove, a mi ćemo se pobrinuti o brzoj i besplatnoj dostavi na tvoj kućni prag.',
+        description: homepageDescription,
         keywords: [
             'gredice',
             'gredica',
@@ -65,12 +78,6 @@ export function generateMetadata(): Metadata {
             'virtualni vrt',
             'virtualno',
         ],
-        openGraph: {
-            type: 'website',
-            title: 'Gredice - vrt po tvom',
-            url: 'https://www.gredice.com',
-            siteName: 'Gredice - vrt po tvom',
-        },
     };
 }
 

--- a/apps/www/app/legalno/licenca/page.tsx
+++ b/apps/www/app/legalno/licenca/page.tsx
@@ -3,12 +3,15 @@ import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
+import { KnownPages } from '../../../src/KnownPages';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Licenca izvornog koda',
     description: 'Uvjeti korištenja izvornog koda aplikacije Gredice.',
-};
+    path: KnownPages.LegalLicense,
+    eyebrow: 'Pravni dokument',
+});
 
 export default function PolitikaPrivatnostiPage() {
     return (

--- a/apps/www/app/legalno/natjecaji/[occasionSlug]/page.tsx
+++ b/apps/www/app/legalno/natjecaji/[occasionSlug]/page.tsx
@@ -9,6 +9,7 @@ import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getOccasionsData } from '../../../../lib/occasions/getOccasionsData';
+import { createPublicMetadata } from '../../../../lib/seo/publicMetadata';
 
 type OccasionPageProps = {
     params: Promise<{ occasionSlug: string }>;
@@ -31,15 +32,15 @@ export async function generateMetadata({
     );
 
     if (!occasion) {
-        return {
-            title: 'Natječaj nije pronađen',
-        };
+        notFound();
     }
 
-    return {
+    return createPublicMetadata({
         title: `Pravila natječaja ${occasion.information.name}`,
         description: `Pročitaj službena pravila za sudjelovanje u natječaju ${occasion.information.name}.`,
-    };
+        path: `/legalno/natjecaji/${encodeURIComponent(occasionSlug)}`,
+        eyebrow: 'Pravila natječaja',
+    });
 }
 
 export default async function OccasionPage({ params }: OccasionPageProps) {

--- a/apps/www/app/legalno/natjecaji/page.tsx
+++ b/apps/www/app/legalno/natjecaji/page.tsx
@@ -7,14 +7,18 @@ import { PageHeader } from '@gredice/ui/PageHeader';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata, Route } from 'next';
+import type { Route } from 'next';
 import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { getOccasionsData } from '../../../lib/occasions/getOccasionsData';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
+import { KnownPages } from '../../../src/KnownPages';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Natječaji',
     description: 'Pregled svih natječaja i nagradnih igara.',
-};
+    path: KnownPages.LegalOccasions,
+    eyebrow: 'Natječaji i nagradne igre',
+});
 
 function formatDate(dateString: string) {
     return new Date(dateString).toLocaleDateString('hr-HR', {

--- a/apps/www/app/legalno/page.tsx
+++ b/apps/www/app/legalno/page.tsx
@@ -2,12 +2,14 @@ import { Container } from '@gredice/ui/Container';
 import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Legalno',
-    description: 'Pravni dokumenti i informacije',
-};
+    description: 'Pravni dokumenti i informacije.',
+    path: '/legalno',
+    eyebrow: 'Pravne informacije',
+});
 
 export default function LegalnoPage() {
     return (

--- a/apps/www/app/legalno/politika-kolacica/page.tsx
+++ b/apps/www/app/legalno/politika-kolacica/page.tsx
@@ -3,13 +3,16 @@ import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
+import { KnownPages } from '../../../src/KnownPages';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Politika kolačića',
     description:
         'Koje kolačiće koristimo na našoj web stranici, kako ih koristimo, te koja su tvoja prava vezana uz njih.',
-};
+    path: KnownPages.LegalCookies,
+    eyebrow: 'Pravni dokument',
+});
 
 export default function PolitikaKolacicaPage() {
     return (

--- a/apps/www/app/legalno/politika-privatnosti/page.tsx
+++ b/apps/www/app/legalno/politika-privatnosti/page.tsx
@@ -3,13 +3,16 @@ import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
+import { KnownPages } from '../../../src/KnownPages';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Politika privatnosti',
     description:
         'Kako prikupljamo, koristimo i štitimo tvoje osobne podatke prilikom korištenja naše web stranice.',
-};
+    path: KnownPages.LegalPrivacy,
+    eyebrow: 'Pravni dokument',
+});
 
 export default function PolitikaPrivatnostiPage() {
     return (

--- a/apps/www/app/legalno/trece-strane/page.tsx
+++ b/apps/www/app/legalno/trece-strane/page.tsx
@@ -3,12 +3,15 @@ import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
+import { KnownPages } from '../../../src/KnownPages';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Treće strane',
     description: 'Informacije o korištenim izvorima podataka trećih strana.',
-};
+    path: KnownPages.LegalThirdParty,
+    eyebrow: 'Pravni dokument',
+});
 
 const thirdPartyPlatforms = [
     {

--- a/apps/www/app/legalno/tvrtka/page.tsx
+++ b/apps/www/app/legalno/tvrtka/page.tsx
@@ -3,12 +3,15 @@ import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
+import { KnownPages } from '../../../src/KnownPages';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Tvrtka',
     description: 'Službeni podaci o društvu Gredice d.o.o.',
-};
+    path: KnownPages.LegalCompany,
+    eyebrow: 'Pravni dokument',
+});
 
 export default function UvjetiKoristenjaPage() {
     return (

--- a/apps/www/app/legalno/uvjeti-koristenja/page.tsx
+++ b/apps/www/app/legalno/uvjeti-koristenja/page.tsx
@@ -3,13 +3,16 @@ import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
+import { KnownPages } from '../../../src/KnownPages';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Uvjeti korištenja',
     description:
         'Uvjeti korištenja web stranice Gredice, uključujući pravila za suncokrete i Gredice saldo.',
-};
+    path: KnownPages.LegalTerms,
+    eyebrow: 'Pravni dokument',
+});
 
 export default function UvjetiKoristenjaPage() {
     return (

--- a/apps/www/app/mcp/page.tsx
+++ b/apps/www/app/mcp/page.tsx
@@ -5,7 +5,7 @@ import { NavigatingButton } from '@gredice/ui/NavigatingButton';
 import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 import { KnownPages } from '../../src/KnownPages';
 
 const mcpEndpoint = 'https://api.gredice.com/api/mcp';
@@ -20,18 +20,12 @@ const clientConfiguration = `{
 const metadataDescription =
     'Poveži AI asistenta s javnim znanjem Gredica i, uz autorizaciju, podacima svojeg vrta preko sigurnog MCP sučelja.';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Gredice za AI asistente',
     description: metadataDescription,
-    alternates: {
-        canonical: KnownPages.MCP,
-    },
-    openGraph: {
-        title: 'Gredice za AI asistente',
-        description: metadataDescription,
-        url: KnownPages.MCP,
-    },
-};
+    path: KnownPages.MCP,
+    eyebrow: 'Za AI asistente',
+});
 
 const accessLevels = [
     {

--- a/apps/www/app/o-nama/page.tsx
+++ b/apps/www/app/o-nama/page.tsx
@@ -3,15 +3,18 @@ import { PageHeader } from '@gredice/ui/PageHeader';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
 import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { WhatsAppCard } from '../../components/social/WhatsAppCard';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
+import { KnownPages } from '../../src/KnownPages';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'O nama',
     description:
         'Tvoj vrt, gdje god bio. Jer vrt ne mora biti ispred kuće da bi bio tvoj.',
-};
+    path: KnownPages.AboutUs,
+    eyebrow: 'O Gredicama',
+});
 
 function SectionHeader({
     children,

--- a/apps/www/app/opengraph-image.tsx
+++ b/apps/www/app/opengraph-image.tsx
@@ -1,7 +1,7 @@
-import { Logotype } from '@gredice/ui/PublicChrome';
 import { ImageResponse } from 'next/og';
+import { PublicOgCard } from './api/og/public/PublicOgCard';
 
-export const alt = 'Gredice';
+export const alt = 'Digitalni vrt Gredice s podignutom gredicom';
 export const size = {
     width: 1200,
     height: 630,
@@ -10,20 +10,12 @@ export const contentType = 'image/png';
 
 export default async function Image() {
     return new ImageResponse(
-        <div
-            style={{
-                fontSize: 128,
-                background: '#FEFAF6',
-                width: '100%',
-                height: '100%',
-                display: 'flex',
-                textAlign: 'center',
-                alignItems: 'center',
-                justifyContent: 'center',
-            }}
-        >
-            <Logotype width={800} />
-        </div>,
+        <PublicOgCard
+            title="Gredice - vrt po tvom"
+            description="Postavi gredice, zasadi omiljeno povrće i prati svoj pravi vrt iz digitalnog svijeta."
+            eyebrow="Tvoj digitalni vrt"
+            imageUrl="https://www.gredice.com/seo-fallback.png"
+        />,
         {
             ...size,
         },

--- a/apps/www/app/outlet/page.tsx
+++ b/apps/www/app/outlet/page.tsx
@@ -3,8 +3,8 @@ import { Discount, ShoppingCart, Sprout, Timer } from '@gredice/ui/icons';
 import { NavigatingButton } from '@gredice/ui/NavigatingButton';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
 import { StructuredDataScript } from '../../components/shared/seo/StructuredDataScript';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 import { KnownPages } from '../../src/KnownPages';
 import { OutletOfferCard } from './OutletOfferCard';
 import { getOutletOffers, outletOfferImage } from './outletData';
@@ -12,20 +12,13 @@ import { currencyFormatter } from './outletPresentation';
 
 export const dynamic = 'force-dynamic';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Outlet sadnica',
     description:
         'Vremenski ograničene outlet ponude presadnica koje su ostale u Gredice stakleniku.',
-    alternates: {
-        canonical: KnownPages.Outlet,
-    },
-    openGraph: {
-        title: 'Gredice Outlet sadnica',
-        description:
-            'Pogledaj dostupne presadnice iz staklenika po outlet cijeni.',
-        url: KnownPages.Outlet,
-    },
-};
+    path: KnownPages.Outlet,
+    eyebrow: 'Ponuda iz staklenika',
+});
 
 function outletStructuredData(
     offers: Awaited<ReturnType<typeof getOutletOffers>>,

--- a/apps/www/app/podignuta-gredica/page.tsx
+++ b/apps/www/app/podignuta-gredica/page.tsx
@@ -6,16 +6,18 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
 import Image from 'next/image';
 import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 import { KnownPages } from '../../src/KnownPages';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Podignuta gredica',
     description:
         'Kako funkcionira tvoja podignuta gredica u Gredicama: tlo, sadnja, održavanje, berba i dostava.',
-};
+    path: KnownPages.RaisedBeds,
+    eyebrow: 'Vrt po tvom',
+});
 
 export default function RaisedBedPage() {
     return (

--- a/apps/www/app/povrati-i-povrat-novca/page.tsx
+++ b/apps/www/app/povrati-i-povrat-novca/page.tsx
@@ -2,14 +2,16 @@ import { Container } from '@gredice/ui/Container';
 import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
-import type { Metadata } from 'next';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 import { KnownPages } from '../../src/KnownPages';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Povrat novca',
     description:
         'Informacije o povratu novca, suncokretima, rezervacijama i korekcijama Gredice salda.',
-};
+    path: KnownPages.Refunds,
+    eyebrow: 'Povrati',
+});
 
 export default function RefundsPage() {
     return (

--- a/apps/www/app/preporuke/page.tsx
+++ b/apps/www/app/preporuke/page.tsx
@@ -6,10 +6,10 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
 import Image from 'next/image';
 import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { formatPrice } from '../../lib/formatPrice';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 import { KnownPages } from '../../src/KnownPages';
 
 const referralReward = 10000;
@@ -24,9 +24,11 @@ const formattedCombinedReferralReward = new Intl.NumberFormat('hr-HR').format(
 );
 const referralMetadataDescription = `Program preporuka za Gredice: podijeli ili iskoristi kod i saznaj kako jedna preporuka donosi ukupno ${formattedCombinedReferralReward} 🌻 nagrade.`;
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Preporuke',
     description: referralMetadataDescription,
+    path: KnownPages.Referrals,
+    eyebrow: 'Program preporuka',
     keywords: [
         'Gredice',
         'program preporuka',
@@ -34,12 +36,7 @@ export const metadata: Metadata = {
         'nagrade',
         'vrt aplikacija',
     ],
-    openGraph: {
-        title: 'Preporuke',
-        description: referralMetadataDescription,
-        url: KnownPages.Referrals,
-    },
-};
+});
 
 const referralFlows = [
     {

--- a/apps/www/app/radnje/[alias]/page.tsx
+++ b/apps/www/app/radnje/[alias]/page.tsx
@@ -17,6 +17,7 @@ import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal
 import { StructuredDataScript } from '../../../components/shared/seo/StructuredDataScript';
 import { getOperationPriceAvailability } from '../../../lib/operationPricing';
 import { getOperationsData } from '../../../lib/plants/getOperationsData';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
 import { KnownPages } from '../../../src/KnownPages';
 import { merchantReturnPolicy } from '../../../src/merchantReturnPolicy';
 import { matchesPageAlias, toPageAlias } from '../../../src/pageAliases';
@@ -36,15 +37,18 @@ export async function generateMetadata(
         matchesPageAlias(op.information.label, alias),
     );
     if (!operation) {
-        return {
-            title: 'Radnja nije pronađena',
-            description: 'Radnja koju tražiš nije pronađena.',
-        };
+        notFound();
     }
-    return {
+    return createPublicMetadata({
         title: operation.information.label,
         description: operation.information.shortDescription,
-    };
+        path: KnownPages.Operation(
+            operation.slug || operation.information.label,
+        ),
+        category: 'Vrtlarska radnja',
+        imageUrl: operation.image?.cover?.url,
+        imageAlt: `Prikaz radnje ${operation.information.label}`,
+    });
 }
 
 export async function generateStaticParams() {

--- a/apps/www/app/radnje/page.tsx
+++ b/apps/www/app/radnje/page.tsx
@@ -11,6 +11,7 @@ import { PageFilterInput } from '../../components/shared/PageFilterInput';
 import { StructuredDataScript } from '../../components/shared/seo/StructuredDataScript';
 import { getOperationPriceAvailability } from '../../lib/operationPricing';
 import { getOperationsData } from '../../lib/plants/getOperationsData';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 import { KnownPages } from '../../src/KnownPages';
 import { merchantReturnPolicy } from '../../src/merchantReturnPolicy';
 import { OperationsList } from './OperationsList';
@@ -21,10 +22,12 @@ import {
 
 const pageDescription = `Sve što trebaš znati o radnjama koje možeš obavljati u svojim gredicama.`;
 export const revalidate = 3600; // 1 hour
-export const metadata: Metadata = {
+export const metadata: Metadata = createPublicMetadata({
     title: 'Radnje',
     description: pageDescription,
-};
+    path: KnownPages.Operations,
+    category: 'Vrtlarske radnje',
+});
 
 export default async function OperationsPage({
     searchParams,

--- a/apps/www/app/recepti/[slug]/page.tsx
+++ b/apps/www/app/recepti/[slug]/page.tsx
@@ -1,17 +1,31 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getRecipesData } from '../../../lib/recipes/getRecipesData';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
+import { KnownPages } from '../../../src/KnownPages';
 import { recipesFlag } from '../../flags';
 import { RecipeView } from './RecipeView';
 
 export async function generateMetadata(
     props: PageProps<'/recepti/[slug]'>,
 ): Promise<Metadata> {
+    const isRecipesEnabled = await recipesFlag();
+    if (!isRecipesEnabled) {
+        notFound();
+    }
+
     const { slug } = await props.params;
     const recipe = (await getRecipesData()).find((r) => r.slug === slug);
-    return recipe
-        ? { title: recipe.title, description: recipe.description }
-        : { title: 'Recept nije pronađen', description: '' };
+    if (!recipe) {
+        notFound();
+    }
+
+    return createPublicMetadata({
+        title: recipe.title,
+        description: recipe.description,
+        path: KnownPages.Recipe(recipe.slug),
+        category: 'Recept iz vrta',
+    });
 }
 
 export async function generateStaticParams() {

--- a/apps/www/app/recepti/page.tsx
+++ b/apps/www/app/recepti/page.tsx
@@ -4,12 +4,16 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { RecipeList } from '../../components/recipes/RecipeList';
 import { getRecipesData } from '../../lib/recipes/getRecipesData';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
+import { KnownPages } from '../../src/KnownPages';
 import { recipesFlag } from '../flags';
 
-export const metadata: Metadata = {
+export const metadata: Metadata = createPublicMetadata({
     title: 'Recepti',
     description: 'Ideje kako iskoristiti svoje povrće.',
-};
+    path: KnownPages.Recipes,
+    category: 'Iz vrta na stol',
+});
 
 export default async function RecipesPage() {
     const isRecipesEnabled = await recipesFlag();

--- a/apps/www/app/sjeme/brendovi/page.tsx
+++ b/apps/www/app/sjeme/brendovi/page.tsx
@@ -6,6 +6,7 @@ import type { Metadata } from 'next';
 import { StructuredDataScript } from '../../../components/shared/seo/StructuredDataScript';
 import { getSeedBrandsData } from '../../../lib/seeds/getSeedBrandsData';
 import { getSeedsData } from '../../../lib/seeds/getSeedsData';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
 import { KnownPages } from '../../../src/KnownPages';
 import { SeedBrandsGallery } from './SeedBrandsGallery';
 
@@ -15,29 +16,16 @@ const pageDescription =
 
 export const revalidate = 3600;
 
-export const metadata: Metadata = {
+export const metadata: Metadata = createPublicMetadata({
     title: pageTitle,
     description: pageDescription,
-    alternates: {
-        canonical: KnownPages.SeedBrands,
-    },
-    openGraph: {
-        type: 'website',
-        locale: 'hr_HR',
-        title: pageTitle,
-        description: pageDescription,
-        url: KnownPages.SeedBrands,
-    },
-    twitter: {
-        card: 'summary',
-        title: pageTitle,
-        description: pageDescription,
-    },
+    path: KnownPages.SeedBrands,
+    category: 'Katalog sjemena',
     robots: {
         index: true,
         follow: true,
     },
-};
+});
 
 export default async function SeedBrandsPage() {
     const [brands, seeds] = await Promise.all([

--- a/apps/www/app/sjeme/page.tsx
+++ b/apps/www/app/sjeme/page.tsx
@@ -6,6 +6,7 @@ import { Suspense } from 'react';
 import { PageFilterInput } from '../../components/shared/PageFilterInput';
 import { StructuredDataScript } from '../../components/shared/seo/StructuredDataScript';
 import { getSeedsData } from '../../lib/seeds/getSeedsData';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 import { KnownPages } from '../../src/KnownPages';
 import { SeedsGallery } from './SeedsGallery';
 import { seedPrimaryImageUrl } from './seedPresentation';
@@ -16,29 +17,16 @@ const pageDescription =
 
 export const revalidate = 3600;
 
-export const metadata: Metadata = {
+export const metadata: Metadata = createPublicMetadata({
     title: pageTitle,
     description: pageDescription,
-    alternates: {
-        canonical: KnownPages.Seeds,
-    },
-    openGraph: {
-        type: 'website',
-        locale: 'hr_HR',
-        title: pageTitle,
-        description: pageDescription,
-        url: KnownPages.Seeds,
-    },
-    twitter: {
-        card: 'summary',
-        title: pageTitle,
-        description: pageDescription,
-    },
+    path: KnownPages.Seeds,
+    category: 'Katalog sjemena',
     robots: {
         index: true,
         follow: true,
     },
-};
+});
 
 function stringParam(value: string | string[] | undefined) {
     return Array.isArray(value) ? (value[0] ?? '') : (value ?? '');

--- a/apps/www/app/sjetva/page.tsx
+++ b/apps/www/app/sjetva/page.tsx
@@ -4,20 +4,22 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
 import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { getOperationsData } from '../../lib/plants/getOperationsData';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 import { KnownPages } from '../../src/KnownPages';
 import {
     GrowthCalendarPreview,
     SowingCalendarPreview,
 } from './SowingCalendarPreview';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Sjetva biljaka',
     description:
         'Saznaj kako funkcionira sjetva biljaka u Gredicama, koliko košta i koje pogodnosti dobivaš tijekom ljeta.',
-};
+    path: KnownPages.Sowing,
+    eyebrow: 'Planiranje vrta',
+});
 
 const DEFAULT_FREE_WATERING_OPERATION_LABEL = 'Površinsko zalijevanje (20 L)';
 const FREE_WATERING_OPERATION_ID = 274;

--- a/apps/www/app/stetnici/[alias]/page.tsx
+++ b/apps/www/app/stetnici/[alias]/page.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../components/plant-health/plantHealthIssueContent';
 import { StructuredDataScript } from '../../../components/shared/seo/StructuredDataScript';
 import { getPlantPestsData } from '../../../lib/plants/getPlantHealthIssuesData';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
 import { KnownPages } from '../../../src/KnownPages';
 import { matchesPageAlias, toPageAlias } from '../../../src/pageAliases';
 
@@ -23,20 +24,18 @@ export async function generateMetadata(
     );
 
     if (!issue) {
-        return {
-            title: 'Štetnik nije pronađen',
-            description: 'Štetnik biljke nije pronađen.',
-        };
+        notFound();
     }
 
     const title = plantHealthIssueTitle(issue);
-    return {
+    return createPublicMetadata({
         title,
-        description: plantHealthIssueShortDescription(issue),
-        alternates: {
-            canonical: KnownPages.PlantPest(issue.slug || title),
-        },
-    };
+        description:
+            plantHealthIssueShortDescription(issue) ||
+            `Saznaj više o štetniku biljaka ${title}.`,
+        path: KnownPages.PlantPest(issue.slug || title),
+        category: 'Štetnik biljaka',
+    });
 }
 
 export async function generateStaticParams() {

--- a/apps/www/app/stetnici/page.tsx
+++ b/apps/www/app/stetnici/page.tsx
@@ -15,19 +15,19 @@ import { PageFilterInput } from '../../components/shared/PageFilterInput';
 import { StructuredDataScript } from '../../components/shared/seo/StructuredDataScript';
 import { getPlantPestsData } from '../../lib/plants/getPlantHealthIssuesData';
 import { getPlantsData } from '../../lib/plants/getPlantsData';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 import { KnownPages } from '../../src/KnownPages';
 
 const pageDescription =
     'Pregled štetnika koji mogu napasti biljke u gredicama, s pogođenim biljkama i preporučenim radnjama.';
 
 export const revalidate = 3600;
-export const metadata: Metadata = {
+export const metadata: Metadata = createPublicMetadata({
     title: 'Štetnici biljaka',
     description: pageDescription,
-    alternates: {
-        canonical: KnownPages.PlantPests,
-    },
-};
+    path: KnownPages.PlantPests,
+    category: 'Zdravlje biljaka',
+});
 
 export default async function PlantPestsPage({
     searchParams,

--- a/apps/www/app/suncokreti/page.tsx
+++ b/apps/www/app/suncokreti/page.tsx
@@ -6,20 +6,22 @@ import { Navigate } from '@gredice/ui/icons';
 import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 import {
     getPublicSunflowerPackages,
     type PublicSunflowerPackage,
 } from '../../lib/sunflowerPackages';
 import { KnownPages } from '../../src/KnownPages';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Suncokreti i Gredice saldo',
     description:
         'Suncokreti su prepaid Gredice bodovi za vrtne akcije. Pogledaj pakete, bonus suncokrete i pravila korištenja salda.',
-};
+    path: KnownPages.Sunflowers,
+    eyebrow: 'Gredice saldo',
+});
 
 const sunflowerFormatter = new Intl.NumberFormat('hr-HR', {
     maximumFractionDigits: 0,

--- a/apps/www/app/trag/[token]/page.tsx
+++ b/apps/www/app/trag/[token]/page.tsx
@@ -27,11 +27,11 @@ import { Stack } from '@gredice/ui/Stack';
 import { Timeline, TimelineEntry, TimelineGroup } from '@gredice/ui/Timeline';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
-import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 import Image from 'next/image';
 import Link from 'next/link';
 import type { ReactNode } from 'react';
+import { createPublicMetadata } from '../../../lib/seo/publicMetadata';
 import {
     PlantMonthCalendar,
     type PlantMonthCalendarRow,
@@ -40,14 +40,15 @@ import { HarvestTraceStatusEvent } from './HarvestTraceStatusEvent';
 
 export const dynamic = 'force-dynamic';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Trag berbe',
     description: 'Javni trag berbe Gredice.',
+    eyebrow: 'Od vrta do stola',
     robots: {
         index: false,
         follow: false,
     },
-};
+});
 
 const dayFormatter = new Intl.DateTimeFormat('hr-HR', {
     day: 'numeric',

--- a/apps/www/app/vodic-za-prvu-gredicu/page.tsx
+++ b/apps/www/app/vodic-za-prvu-gredicu/page.tsx
@@ -10,24 +10,17 @@ import { PageHeader } from '@gredice/ui/PageHeader';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
 import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 import { KnownPages } from '../../src/KnownPages';
 
-export const metadata: Metadata = {
+export const metadata = createPublicMetadata({
     title: 'Vodič za prvu gredicu',
     description:
         'Korak-po-korak vodič kroz prvi plan sadnje u Gredicama: od odabira obroka do popunjavanja praznih polja.',
-    alternates: {
-        canonical: firstRaisedBedTutorialPath,
-    },
-    openGraph: {
-        title: 'Vodič za prvu gredicu',
-        description:
-            'Nauči kako odabrati prijedlog sadnje, dodati plan u košaru i urediti preostala polja u svojoj prvoj gredici.',
-        url: firstRaisedBedTutorialPath,
-    },
-};
+    path: firstRaisedBedTutorialPath,
+    eyebrow: 'Vodič',
+});
 
 export default function FirstRaisedBedGuidePage() {
     return (

--- a/apps/www/app/vrtovi/page.tsx
+++ b/apps/www/app/vrtovi/page.tsx
@@ -4,6 +4,7 @@ import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
+import { createPublicMetadata } from '../../lib/seo/publicMetadata';
 import { KnownPages } from '../../src/KnownPages';
 import { PublicGardenLikeButton } from './PublicGardenLikeButton';
 import { PublicGardenPreviewBackfill } from './PublicGardenPreviewBackfill';
@@ -18,18 +19,12 @@ const pageDescription =
 
 export const dynamic = 'force-dynamic';
 
-export const metadata: Metadata = {
+export const metadata: Metadata = createPublicMetadata({
     title: 'Vrtovi',
     description: pageDescription,
-    alternates: {
-        canonical: KnownPages.PublicGardens,
-    },
-    openGraph: {
-        title: 'Vrtovi',
-        description: pageDescription,
-        url: KnownPages.PublicGardens,
-    },
-};
+    path: KnownPages.PublicGardens,
+    category: 'Javni vrtovi',
+});
 
 export default async function PublicGardensPage() {
     const gardens = await getPublicGardensForWww();

--- a/apps/www/lib/seo/publicMetadata.node.spec.ts
+++ b/apps/www/lib/seo/publicMetadata.node.spec.ts
@@ -1,0 +1,249 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    buildPublicOgImagePath,
+    createPublicMetadata,
+    isValidPublicOgSearchParams,
+    PUBLIC_OG_IMAGE_SIZE,
+    parsePublicOgCardSearchParams,
+    sanitizePublicOgImageUrl,
+} from './publicMetadata.ts';
+
+const localUnsignedSigningConfig = {
+    allowUnsigned: true,
+    configurationValid: true,
+} as const;
+const configuredSigningConfig = {
+    secret: 'test-preview-secret',
+    allowUnsigned: false,
+    configurationValid: true,
+} as const;
+
+test('creates complete page-specific Open Graph and Twitter metadata', () => {
+    const metadata = createPublicMetadata(
+        {
+            title: 'Biljke',
+            description:
+                'Istraži biljke koje možeš posaditi u svojim gredicama.',
+            path: '/biljke',
+            eyebrow: 'Katalog biljaka',
+            imageAlt: '  Naslovna slika\n biljnog kataloga  ',
+            keywords: ['biljke', 'vrt'],
+        },
+        localUnsignedSigningConfig,
+    );
+
+    assert.deepEqual(metadata.alternates, { canonical: '/biljke' });
+    assert.deepEqual(metadata.openGraph, {
+        type: 'website',
+        locale: 'hr_HR',
+        siteName: 'Gredice',
+        title: 'Biljke',
+        description: 'Istraži biljke koje možeš posaditi u svojim gredicama.',
+        url: '/biljke',
+        images: [
+            {
+                url: '/api/og/public?title=Biljke&description=Istra%C5%BEi+biljke+koje+mo%C5%BEe%C5%A1+posaditi+u+svojim+gredicama.&eyebrow=Katalog+biljaka',
+                width: PUBLIC_OG_IMAGE_SIZE.width,
+                height: PUBLIC_OG_IMAGE_SIZE.height,
+                alt: 'Naslovna slika biljnog kataloga',
+                type: 'image/png',
+            },
+        ],
+    });
+    assert.deepEqual(metadata.twitter, {
+        card: 'summary_large_image',
+        title: 'Biljke',
+        description: 'Istraži biljke koje možeš posaditi u svojim gredicama.',
+        images: [
+            {
+                url: '/api/og/public?title=Biljke&description=Istra%C5%BEi+biljke+koje+mo%C5%BEe%C5%A1+posaditi+u+svojim+gredicama.&eyebrow=Katalog+biljaka',
+                alt: 'Naslovna slika biljnog kataloga',
+            },
+        ],
+    });
+    assert.deepEqual(metadata.keywords, ['biljke', 'vrt']);
+});
+
+test('keeps noindex share metadata generic when no canonical path is provided', () => {
+    const robots = { index: false, follow: false };
+    const metadata = createPublicMetadata(
+        {
+            title: 'Trag berbe',
+            description: 'Javni trag berbe Gredice.',
+            eyebrow: 'Od vrta do stola',
+            robots,
+        },
+        localUnsignedSigningConfig,
+    );
+
+    assert.equal(metadata.alternates, undefined);
+    assert.equal(metadata.openGraph && 'url' in metadata.openGraph, false);
+    assert.deepEqual(metadata.robots, robots);
+    const images = metadata.openGraph?.images;
+    assert.ok(Array.isArray(images));
+    assert.doesNotMatch(JSON.stringify(images[0]), /token|trag\//);
+});
+
+test('only accepts public Gredice, CDN, and Vercel Blob image origins', () => {
+    const accepted = [
+        'https://cdn.gredice.com/plants/rajcica.webp',
+        'https://www.gredice.com/assets/blocks/GardenBox.webp',
+        'https://www.gredice.com/seo-fallback.png',
+        'https://vrt.gredice.com/assets/previews/garden.webp',
+        'https://myegtvromcktt2y7.public.blob.vercel-storage.com/plants/cover.jpg',
+        'https://7ql7fvz1vzzo6adz.public.blob.vercel-storage.com/operations/cover.jpg',
+    ];
+
+    for (const imageUrl of accepted) {
+        assert.equal(sanitizePublicOgImageUrl(imageUrl), imageUrl);
+    }
+
+    const rejected = [
+        'http://cdn.gredice.com/plant.webp',
+        'https://cdn.gredice.com.evil.example/plant.webp',
+        'https://www.gredice.com/api/og/public',
+        'https://vrt.gredice.com/private/plant.webp',
+        'https://user:password@cdn.gredice.com/plant.webp',
+        'https://cdn.gredice.com:444/plant.webp',
+        'https://attacker.public.blob.vercel-storage.com/plant.webp',
+        'https://example.com/plant.webp',
+        'not-a-url',
+    ];
+
+    for (const imageUrl of rejected) {
+        assert.equal(sanitizePublicOgImageUrl(imageUrl), undefined);
+    }
+});
+
+test('truncates and normalizes untrusted card query text', () => {
+    const params = new URLSearchParams({
+        title: `  Biljke\u0000${'a'.repeat(120)}  `,
+        description: `Opis\n${'b'.repeat(220)}`,
+        category: `  Katalog\tbiljaka  `,
+        image: 'https://example.com/private.jpg',
+    });
+    const parsed = parsePublicOgCardSearchParams(params);
+
+    assert.ok(parsed);
+    assert.equal(Array.from(parsed.title).length, 96);
+    assert.equal(Array.from(parsed.description).length, 190);
+    assert.equal(parsed.eyebrow, 'Katalog biljaka');
+    assert.equal(parsed.imageUrl, undefined);
+    assert.match(parsed.title, /^Biljke a+/);
+    assert.match(parsed.title, /…$/);
+});
+
+test('rejects missing card fields and invalid canonical paths', () => {
+    assert.equal(
+        parsePublicOgCardSearchParams(new URLSearchParams({ title: 'Biljke' })),
+        null,
+    );
+    assert.throws(
+        () =>
+            createPublicMetadata(
+                {
+                    title: 'Biljke',
+                    description: 'Opis.',
+                    path: 'https://example.com/biljke',
+                },
+                localUnsignedSigningConfig,
+            ),
+        /root-relative/,
+    );
+    assert.throws(
+        () =>
+            buildPublicOgImagePath(
+                {
+                    title: '   ',
+                    description: 'Opis.',
+                },
+                localUnsignedSigningConfig,
+            ),
+        /title must not be empty/,
+    );
+});
+
+test('rejects high-cardinality query variants outside the public card schema', () => {
+    assert.equal(
+        isValidPublicOgSearchParams(
+            new URLSearchParams({
+                title: 'Biljke',
+                description: 'Opis.',
+                image: 'https://example.com/untrusted.jpg',
+            }),
+        ),
+        false,
+    );
+    assert.equal(
+        isValidPublicOgSearchParams(
+            new URLSearchParams(
+                'title=Biljke&title=Drugi+naslov&description=Opis.',
+            ),
+        ),
+        false,
+    );
+    assert.equal(
+        isValidPublicOgSearchParams(
+            new URLSearchParams({
+                title: 'Biljke',
+                description: 'Opis.',
+                cacheBuster: 'arbitrary',
+            }),
+        ),
+        false,
+    );
+    assert.equal(
+        isValidPublicOgSearchParams(
+            new URLSearchParams({
+                title: '  Biljke  ',
+                description: 'Opis.',
+            }),
+        ),
+        false,
+    );
+    assert.equal(
+        isValidPublicOgSearchParams(
+            new URLSearchParams({
+                title: 'Biljke',
+                description: 'Opis.',
+                eyebrow: '   ',
+            }),
+        ),
+        false,
+    );
+});
+
+test('drops an oversized optional cover instead of creating an invalid card URL', () => {
+    const path = buildPublicOgImagePath(
+        {
+            title: 'Biljke',
+            description: 'Opis.',
+            imageUrl: `https://cdn.gredice.com/cover.webp?q=${'&'.repeat(1_800)}`,
+        },
+        localUnsignedSigningConfig,
+    );
+
+    assert.match(path, /^\/api\/og\/public\?title=Biljke&description=Opis\.$/);
+    assert.doesNotMatch(path, /image=/);
+});
+
+test('adds a canonical signature when a signing secret is configured', () => {
+    const path = buildPublicOgImagePath(
+        {
+            title: 'Biljke',
+            description: 'Opis.',
+            eyebrow: 'Katalog biljaka',
+        },
+        configuredSigningConfig,
+    );
+    const url = new URL(path, 'https://www.gredice.com');
+
+    assert.deepEqual(Array.from(url.searchParams.keys()), [
+        'title',
+        'description',
+        'eyebrow',
+        'sig',
+    ]);
+    assert.match(url.searchParams.get('sig') ?? '', /^[A-Za-z0-9_-]{43}$/);
+});

--- a/apps/www/lib/seo/publicMetadata.ts
+++ b/apps/www/lib/seo/publicMetadata.ts
@@ -1,0 +1,368 @@
+import type { Metadata } from 'next';
+import {
+    addPublicOgSignature,
+    PUBLIC_OG_SIGNATURE_PARAMETER,
+    type PublicOgSigningConfig,
+    resolvePublicOgSigningConfig,
+} from './publicOgSignature.ts';
+
+export const PUBLIC_SITE_ORIGIN = 'https://www.gredice.com';
+export const MAXIMUM_PUBLIC_OG_QUERY_LENGTH = 4096;
+export const PUBLIC_OG_IMAGE_SIZE = {
+    width: 1200,
+    height: 630,
+} as const;
+
+const PUBLIC_OG_ENDPOINT = '/api/og/public';
+const textLimits = {
+    title: 96,
+    description: 190,
+    eyebrow: 48,
+    imageAlt: 120,
+} as const;
+const maximumImageUrlLength = 2048;
+// Keep aligned with the public image tenants in packages/js/src/urls/safeUrls.ts.
+const publicVercelBlobHosts = new Set([
+    'myegtvromcktt2y7.public.blob.vercel-storage.com',
+    '7ql7fvz1vzzo6adz.public.blob.vercel-storage.com',
+]);
+
+export type PublicOgCardData = {
+    title: string;
+    description: string;
+    eyebrow?: string;
+    imageUrl?: string;
+};
+
+export type PublicMetadataOptions = {
+    title: string;
+    description: string;
+    path?: string | null;
+    eyebrow?: string;
+    category?: string;
+    imageUrl?: string | null;
+    imageAlt?: string;
+    keywords?: Metadata['keywords'];
+    robots?: Metadata['robots'];
+};
+
+function truncateText(value: string, maximumLength: number) {
+    const characters = Array.from(value);
+
+    if (characters.length <= maximumLength) {
+        return value;
+    }
+
+    return `${characters
+        .slice(0, maximumLength - 1)
+        .join('')
+        .trimEnd()}…`;
+}
+
+function stripUnsafeOgCharacters(value: string) {
+    return Array.from(value, (character) => {
+        const codePoint = character.codePointAt(0) ?? 0;
+        const isControlCharacter =
+            codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+        const isBidirectionalOverride =
+            (codePoint >= 0x202a && codePoint <= 0x202e) ||
+            (codePoint >= 0x2066 && codePoint <= 0x2069);
+
+        return isControlCharacter || isBidirectionalOverride ? ' ' : character;
+    }).join('');
+}
+
+export function sanitizePublicOgText(
+    value: string | null | undefined,
+    maximumLength: number,
+) {
+    if (!value) {
+        return '';
+    }
+
+    const normalized = stripUnsafeOgCharacters(value)
+        .replace(/\s+/g, ' ')
+        .trim();
+
+    return truncateText(normalized, maximumLength);
+}
+
+export function sanitizePublicOgImageUrl(value: string | null | undefined) {
+    if (!value || value.length > maximumImageUrlLength) {
+        return undefined;
+    }
+
+    try {
+        const url = new URL(value);
+        if (url.href.length > maximumImageUrlLength) {
+            return undefined;
+        }
+        const hostname = url.hostname.toLowerCase();
+        const isGrediceCdn = hostname === 'cdn.gredice.com';
+        const isPublicWwwAsset =
+            hostname === 'www.gredice.com' &&
+            (url.pathname.startsWith('/assets/') ||
+                url.pathname === '/seo-fallback.png');
+        const isGardenAsset =
+            hostname === 'vrt.gredice.com' &&
+            url.pathname.startsWith('/assets/');
+        const isPublicVercelBlob = publicVercelBlobHosts.has(hostname);
+
+        if (
+            url.protocol !== 'https:' ||
+            url.port !== '' ||
+            url.username !== '' ||
+            url.password !== '' ||
+            !(
+                isGrediceCdn ||
+                isPublicWwwAsset ||
+                isGardenAsset ||
+                isPublicVercelBlob
+            )
+        ) {
+            return undefined;
+        }
+
+        return url.href;
+    } catch {
+        return undefined;
+    }
+}
+
+function normalizePublicPath(path: string | null | undefined) {
+    if (path === null || path === undefined) {
+        return undefined;
+    }
+
+    const normalized = path.trim();
+    if (!normalized.startsWith('/') || normalized.startsWith('//')) {
+        throw new Error('Public metadata paths must be root-relative.');
+    }
+
+    const url = new URL(normalized, PUBLIC_SITE_ORIGIN);
+    if (url.origin !== PUBLIC_SITE_ORIGIN || url.hash) {
+        throw new Error(
+            'Public metadata paths must use the public site origin.',
+        );
+    }
+
+    return `${url.pathname}${url.search}`;
+}
+
+function requiredCardText(value: string, field: 'title' | 'description') {
+    const sanitized = sanitizePublicOgText(value, textLimits[field]);
+    if (!sanitized) {
+        throw new Error(`Public metadata ${field} must not be empty.`);
+    }
+
+    return sanitized;
+}
+
+export function buildPublicOgCanonicalSearchParams({
+    title,
+    description,
+    eyebrow,
+    imageUrl,
+}: PublicOgCardData) {
+    const searchParams = new URLSearchParams({
+        title: requiredCardText(title, 'title'),
+        description: requiredCardText(description, 'description'),
+    });
+    const sanitizedEyebrow = sanitizePublicOgText(eyebrow, textLimits.eyebrow);
+    const sanitizedImageUrl = sanitizePublicOgImageUrl(imageUrl);
+
+    if (sanitizedEyebrow) {
+        searchParams.set('eyebrow', sanitizedEyebrow);
+    }
+    if (sanitizedImageUrl) {
+        searchParams.set('image', sanitizedImageUrl);
+    }
+
+    return searchParams;
+}
+
+export function buildPublicOgImagePath(
+    card: PublicOgCardData,
+    signingConfig: PublicOgSigningConfig = resolvePublicOgSigningConfig(),
+) {
+    const canonicalSearchParams = buildPublicOgCanonicalSearchParams(card);
+    let signedSearchParams = addPublicOgSignature(
+        canonicalSearchParams,
+        signingConfig,
+    );
+
+    if (
+        signedSearchParams.toString().length + 1 >
+            MAXIMUM_PUBLIC_OG_QUERY_LENGTH &&
+        canonicalSearchParams.has('image')
+    ) {
+        canonicalSearchParams.delete('image');
+        signedSearchParams = addPublicOgSignature(
+            canonicalSearchParams,
+            signingConfig,
+        );
+    }
+
+    if (
+        signedSearchParams.toString().length + 1 >
+        MAXIMUM_PUBLIC_OG_QUERY_LENGTH
+    ) {
+        throw new Error('Public Open Graph card query exceeds the size limit.');
+    }
+
+    return `${PUBLIC_OG_ENDPOINT}?${signedSearchParams.toString()}`;
+}
+
+export function parsePublicOgCardSearchParams(
+    searchParams: URLSearchParams,
+): PublicOgCardData | null {
+    const title = sanitizePublicOgText(
+        searchParams.get('title'),
+        textLimits.title,
+    );
+    const description = sanitizePublicOgText(
+        searchParams.get('description'),
+        textLimits.description,
+    );
+
+    if (!title || !description) {
+        return null;
+    }
+
+    const eyebrow = sanitizePublicOgText(
+        searchParams.get('eyebrow') ?? searchParams.get('category'),
+        textLimits.eyebrow,
+    );
+    const imageUrl = sanitizePublicOgImageUrl(searchParams.get('image'));
+
+    return {
+        title,
+        description,
+        ...(eyebrow ? { eyebrow } : {}),
+        ...(imageUrl ? { imageUrl } : {}),
+    };
+}
+
+export function isValidPublicOgSearchParams(searchParams: URLSearchParams) {
+    const allowedKeys = new Set([
+        'title',
+        'description',
+        'eyebrow',
+        'category',
+        'image',
+        PUBLIC_OG_SIGNATURE_PARAMETER,
+    ]);
+
+    for (const key of searchParams.keys()) {
+        if (!allowedKeys.has(key) || searchParams.getAll(key).length !== 1) {
+            return false;
+        }
+    }
+
+    if (searchParams.has('eyebrow') && searchParams.has('category')) {
+        return false;
+    }
+
+    const card = parsePublicOgCardSearchParams(searchParams);
+    if (
+        !card ||
+        searchParams.get('title') !== card.title ||
+        searchParams.get('description') !== card.description
+    ) {
+        return false;
+    }
+
+    const eyebrowKey = searchParams.has('eyebrow') ? 'eyebrow' : 'category';
+    if (
+        searchParams.has(eyebrowKey) &&
+        searchParams.get(eyebrowKey) !== card.eyebrow
+    ) {
+        return false;
+    }
+
+    const requestedImage = searchParams.get('image');
+    if (
+        searchParams.has('image') &&
+        requestedImage !== sanitizePublicOgImageUrl(requestedImage)
+    ) {
+        return false;
+    }
+
+    return true;
+}
+
+export function createPublicMetadata(
+    {
+        title,
+        description,
+        path,
+        eyebrow,
+        category,
+        imageUrl,
+        imageAlt,
+        keywords,
+        robots,
+    }: PublicMetadataOptions,
+    signingConfig: PublicOgSigningConfig = resolvePublicOgSigningConfig(),
+): Metadata {
+    const safeTitle = requiredCardText(title, 'title');
+    const safeDescription = requiredCardText(description, 'description');
+    const canonicalPath = normalizePublicPath(path);
+    const imagePath = buildPublicOgImagePath(
+        {
+            title: safeTitle,
+            description: safeDescription,
+            eyebrow: eyebrow ?? category,
+            imageUrl: imageUrl ?? undefined,
+        },
+        signingConfig,
+    );
+    const fallbackImageAlt = safeTitle
+        .toLocaleLowerCase('hr-HR')
+        .includes('gredice')
+        ? safeTitle
+        : `${safeTitle} – Gredice`;
+    const safeImageAlt =
+        sanitizePublicOgText(imageAlt, textLimits.imageAlt) || fallbackImageAlt;
+    const openGraphImage = {
+        url: imagePath,
+        width: PUBLIC_OG_IMAGE_SIZE.width,
+        height: PUBLIC_OG_IMAGE_SIZE.height,
+        alt: safeImageAlt,
+        type: 'image/png',
+    };
+
+    return {
+        title: safeTitle,
+        description: safeDescription,
+        ...(canonicalPath
+            ? {
+                  alternates: {
+                      canonical: canonicalPath,
+                  },
+              }
+            : {}),
+        ...(robots ? { robots } : {}),
+        ...(keywords !== undefined ? { keywords } : {}),
+        openGraph: {
+            type: 'website',
+            locale: 'hr_HR',
+            siteName: 'Gredice',
+            title: safeTitle,
+            description: safeDescription,
+            ...(canonicalPath ? { url: canonicalPath } : {}),
+            images: [openGraphImage],
+        },
+        twitter: {
+            card: 'summary_large_image',
+            title: safeTitle,
+            description: safeDescription,
+            images: [
+                {
+                    url: imagePath,
+                    alt: safeImageAlt,
+                },
+            ],
+        },
+    };
+}

--- a/apps/www/lib/seo/publicOgSignature.node.spec.ts
+++ b/apps/www/lib/seo/publicOgSignature.node.spec.ts
@@ -29,7 +29,7 @@ test('accepts a valid domain-separated public OG signature', () => {
     const signed = addPublicOgSignature(canonical, signingConfig);
 
     assert.equal(
-        verifyPublicOgSignature(signed, canonical, signingConfig),
+        verifyPublicOgSignature(signed.toString(), canonical, signingConfig),
         'valid',
     );
     assert.match(signed.get('sig') ?? '', /^[A-Za-z0-9_-]{43}$/);
@@ -43,8 +43,33 @@ test('rejects a tampered signed card query', () => {
     signed.set('title', 'Drugi naslov');
 
     assert.equal(
-        verifyPublicOgSignature(signed, tamperedCanonical, signingConfig),
+        verifyPublicOgSignature(
+            signed.toString(),
+            tamperedCanonical,
+            signingConfig,
+        ),
         'invalid-signature',
+    );
+});
+
+test('rejects equivalent noncanonical raw query encodings', () => {
+    const canonical = canonicalCardQuery();
+    const signed = addPublicOgSignature(canonical, signingConfig);
+    const noncanonicalRawQuery = signed
+        .toString()
+        .replace('title=Biljke', 'title=%42iljke');
+    const requestUrl = new URL(
+        `https://www.gredice.com/api/og/public?${noncanonicalRawQuery}`,
+    );
+
+    assert.equal(requestUrl.search.slice(1), noncanonicalRawQuery);
+    assert.equal(
+        verifyPublicOgSignature(
+            requestUrl.search.slice(1),
+            canonical,
+            signingConfig,
+        ),
+        'noncanonical-query',
     );
 });
 
@@ -52,7 +77,7 @@ test('rejects a missing signature when a secret is configured', () => {
     const canonical = canonicalCardQuery();
 
     assert.equal(
-        verifyPublicOgSignature(canonical, canonical, signingConfig),
+        verifyPublicOgSignature(canonical.toString(), canonical, signingConfig),
         'missing-signature',
     );
 });
@@ -61,7 +86,11 @@ test('allows unsigned cards only for explicit local/test configuration', () => {
     const canonical = canonicalCardQuery();
 
     assert.equal(
-        verifyPublicOgSignature(canonical, canonical, localUnsignedConfig),
+        verifyPublicOgSignature(
+            canonical.toString(),
+            canonical,
+            localUnsignedConfig,
+        ),
         'unsigned-local',
     );
     assert.deepEqual(resolvePublicOgSigningConfig({}), localUnsignedConfig);
@@ -72,6 +101,11 @@ test('allows unsigned cards only for explicit local/test configuration', () => {
 });
 
 test('fails closed when a deployment or CI environment lacks the secret', () => {
+    const invalidConfig = {
+        allowUnsigned: false,
+        configurationValid: false,
+    } as const;
+
     assert.deepEqual(resolvePublicOgSigningConfig({ VERCEL_ENV: 'preview' }), {
         allowUnsigned: false,
         configurationValid: false,
@@ -88,11 +122,15 @@ test('fails closed when a deployment or CI environment lacks the secret', () => 
         },
     );
     assert.throws(
-        () =>
-            addPublicOgSignature(canonicalCardQuery(), {
-                allowUnsigned: false,
-                configurationValid: false,
-            }),
+        () => addPublicOgSignature(canonicalCardQuery(), invalidConfig),
         /CMS_PAGES_PREVIEW_SECRET/,
+    );
+    assert.equal(
+        verifyPublicOgSignature(
+            canonicalCardQuery().toString(),
+            canonicalCardQuery(),
+            invalidConfig,
+        ),
+        'configuration-error',
     );
 });

--- a/apps/www/lib/seo/publicOgSignature.node.spec.ts
+++ b/apps/www/lib/seo/publicOgSignature.node.spec.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    addPublicOgSignature,
+    resolvePublicOgSigningConfig,
+    verifyPublicOgSignature,
+} from './publicOgSignature.ts';
+
+const signingConfig = {
+    secret: 'test-preview-secret',
+    allowUnsigned: false,
+    configurationValid: true,
+} as const;
+const localUnsignedConfig = {
+    allowUnsigned: true,
+    configurationValid: true,
+} as const;
+
+function canonicalCardQuery() {
+    return new URLSearchParams({
+        title: 'Biljke',
+        description: 'Istraži biljke u Gredicama.',
+        eyebrow: 'Katalog biljaka',
+    });
+}
+
+test('accepts a valid domain-separated public OG signature', () => {
+    const canonical = canonicalCardQuery();
+    const signed = addPublicOgSignature(canonical, signingConfig);
+
+    assert.equal(
+        verifyPublicOgSignature(signed, canonical, signingConfig),
+        'valid',
+    );
+    assert.match(signed.get('sig') ?? '', /^[A-Za-z0-9_-]{43}$/);
+});
+
+test('rejects a tampered signed card query', () => {
+    const canonical = canonicalCardQuery();
+    const signed = addPublicOgSignature(canonical, signingConfig);
+    const tamperedCanonical = canonicalCardQuery();
+    tamperedCanonical.set('title', 'Drugi naslov');
+    signed.set('title', 'Drugi naslov');
+
+    assert.equal(
+        verifyPublicOgSignature(signed, tamperedCanonical, signingConfig),
+        'invalid-signature',
+    );
+});
+
+test('rejects a missing signature when a secret is configured', () => {
+    const canonical = canonicalCardQuery();
+
+    assert.equal(
+        verifyPublicOgSignature(canonical, canonical, signingConfig),
+        'missing-signature',
+    );
+});
+
+test('allows unsigned cards only for explicit local/test configuration', () => {
+    const canonical = canonicalCardQuery();
+
+    assert.equal(
+        verifyPublicOgSignature(canonical, canonical, localUnsignedConfig),
+        'unsigned-local',
+    );
+    assert.deepEqual(resolvePublicOgSigningConfig({}), localUnsignedConfig);
+    assert.deepEqual(resolvePublicOgSigningConfig({ NODE_ENV: 'test' }), {
+        allowUnsigned: true,
+        configurationValid: true,
+    });
+});
+
+test('fails closed when a deployment or CI environment lacks the secret', () => {
+    assert.deepEqual(resolvePublicOgSigningConfig({ VERCEL_ENV: 'preview' }), {
+        allowUnsigned: false,
+        configurationValid: false,
+    });
+    assert.deepEqual(resolvePublicOgSigningConfig({ CI: 'true' }), {
+        allowUnsigned: false,
+        configurationValid: false,
+    });
+    assert.deepEqual(
+        resolvePublicOgSigningConfig({ CI: 'true', NODE_ENV: 'test' }),
+        {
+            allowUnsigned: false,
+            configurationValid: false,
+        },
+    );
+    assert.throws(
+        () =>
+            addPublicOgSignature(canonicalCardQuery(), {
+                allowUnsigned: false,
+                configurationValid: false,
+            }),
+        /CMS_PAGES_PREVIEW_SECRET/,
+    );
+});

--- a/apps/www/lib/seo/publicOgSignature.ts
+++ b/apps/www/lib/seo/publicOgSignature.ts
@@ -117,7 +117,7 @@ function signatureMatches(
 }
 
 export function verifyPublicOgSignature(
-    receivedSearchParams: URLSearchParams,
+    receivedRawQuery: string,
     canonicalSearchParams: URLSearchParams,
     config: PublicOgSigningConfig = resolvePublicOgSigningConfig(),
 ): PublicOgSignatureVerification {
@@ -125,15 +125,14 @@ export function verifyPublicOgSignature(
         return 'configuration-error';
     }
 
-    const receivedEntries = Array.from(receivedSearchParams.entries());
+    const receivedSearchParams = new URLSearchParams(receivedRawQuery);
     const signature = receivedSearchParams.get(PUBLIC_OG_SIGNATURE_PARAMETER);
-    const unsignedReceived = new URLSearchParams(
-        receivedEntries.filter(
-            ([key]) => key !== PUBLIC_OG_SIGNATURE_PARAMETER,
-        ),
-    );
+    const canonicalReceived = new URLSearchParams(canonicalSearchParams);
+    if (signature) {
+        canonicalReceived.set(PUBLIC_OG_SIGNATURE_PARAMETER, signature);
+    }
 
-    if (unsignedReceived.toString() !== canonicalSearchParams.toString()) {
+    if (receivedRawQuery !== canonicalReceived.toString()) {
         return 'noncanonical-query';
     }
 
@@ -145,10 +144,6 @@ export function verifyPublicOgSignature(
 
     if (!signature) {
         return 'missing-signature';
-    }
-
-    if (receivedEntries.at(-1)?.[0] !== PUBLIC_OG_SIGNATURE_PARAMETER) {
-        return 'noncanonical-query';
     }
 
     return signatureMatches(

--- a/apps/www/lib/seo/publicOgSignature.ts
+++ b/apps/www/lib/seo/publicOgSignature.ts
@@ -1,0 +1,161 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export const PUBLIC_OG_SIGNATURE_PARAMETER = 'sig';
+
+const publicOgSignatureDomain = 'gredice:public-og-card:v1';
+const signaturePattern = /^[A-Za-z0-9_-]{43}$/;
+
+export type PublicOgSigningConfig = {
+    secret?: string;
+    allowUnsigned: boolean;
+    configurationValid: boolean;
+};
+
+type PublicOgSigningEnvironment = {
+    CMS_PAGES_PREVIEW_SECRET?: string;
+    VERCEL_ENV?: string;
+    NODE_ENV?: string;
+    CI?: string;
+};
+
+export type PublicOgSignatureVerification =
+    | 'valid'
+    | 'unsigned-local'
+    | 'configuration-error'
+    | 'missing-signature'
+    | 'invalid-signature'
+    | 'noncanonical-query';
+
+function environmentFlag(value: string | undefined) {
+    return Boolean(value && value !== '0' && value !== 'false');
+}
+
+export function resolvePublicOgSigningConfig(
+    environment: PublicOgSigningEnvironment = process.env,
+): PublicOgSigningConfig {
+    const secret = environment.CMS_PAGES_PREVIEW_SECRET?.trim();
+    if (secret) {
+        return {
+            secret,
+            allowUnsigned: false,
+            configurationValid: true,
+        };
+    }
+
+    const vercelEnvironment = environment.VERCEL_ENV?.trim();
+    const isVercelDeployment =
+        vercelEnvironment === 'preview' || vercelEnvironment === 'production';
+    const isCi = environmentFlag(environment.CI);
+    const isLocalOrTest =
+        environment.NODE_ENV === 'test' ||
+        vercelEnvironment === 'development' ||
+        (!vercelEnvironment && !isCi);
+    const allowUnsigned = isLocalOrTest && !isCi && !isVercelDeployment;
+
+    return {
+        allowUnsigned,
+        configurationValid: allowUnsigned,
+    };
+}
+
+export function signPublicOgCanonicalQuery(
+    canonicalQuery: string,
+    secret: string,
+) {
+    return createHmac('sha256', secret)
+        .update(publicOgSignatureDomain)
+        .update('\0')
+        .update(canonicalQuery)
+        .digest('base64url');
+}
+
+export function addPublicOgSignature(
+    canonicalSearchParams: URLSearchParams,
+    config: PublicOgSigningConfig = resolvePublicOgSigningConfig(),
+) {
+    if (!config.configurationValid) {
+        throw new Error(
+            'CMS_PAGES_PREVIEW_SECRET is required to sign public Open Graph cards in this environment.',
+        );
+    }
+
+    const signed = new URLSearchParams(canonicalSearchParams);
+    if (config.secret) {
+        signed.set(
+            PUBLIC_OG_SIGNATURE_PARAMETER,
+            signPublicOgCanonicalQuery(
+                canonicalSearchParams.toString(),
+                config.secret,
+            ),
+        );
+    } else if (!config.allowUnsigned) {
+        throw new Error('Unsigned public Open Graph cards are not allowed.');
+    }
+
+    return signed;
+}
+
+function signatureMatches(
+    canonicalQuery: string,
+    signature: string,
+    secret: string,
+) {
+    if (!signaturePattern.test(signature)) {
+        return false;
+    }
+
+    const expected = createHmac('sha256', secret)
+        .update(publicOgSignatureDomain)
+        .update('\0')
+        .update(canonicalQuery)
+        .digest();
+    const actual = Buffer.from(signature, 'base64url');
+
+    return (
+        actual.length === expected.length && timingSafeEqual(actual, expected)
+    );
+}
+
+export function verifyPublicOgSignature(
+    receivedSearchParams: URLSearchParams,
+    canonicalSearchParams: URLSearchParams,
+    config: PublicOgSigningConfig = resolvePublicOgSigningConfig(),
+): PublicOgSignatureVerification {
+    if (!config.configurationValid) {
+        return 'configuration-error';
+    }
+
+    const receivedEntries = Array.from(receivedSearchParams.entries());
+    const signature = receivedSearchParams.get(PUBLIC_OG_SIGNATURE_PARAMETER);
+    const unsignedReceived = new URLSearchParams(
+        receivedEntries.filter(
+            ([key]) => key !== PUBLIC_OG_SIGNATURE_PARAMETER,
+        ),
+    );
+
+    if (unsignedReceived.toString() !== canonicalSearchParams.toString()) {
+        return 'noncanonical-query';
+    }
+
+    if (!config.secret) {
+        return !signature && config.allowUnsigned
+            ? 'unsigned-local'
+            : 'invalid-signature';
+    }
+
+    if (!signature) {
+        return 'missing-signature';
+    }
+
+    if (receivedEntries.at(-1)?.[0] !== PUBLIC_OG_SIGNATURE_PARAMETER) {
+        return 'noncanonical-query';
+    }
+
+    return signatureMatches(
+        canonicalSearchParams.toString(),
+        signature,
+        config.secret,
+    )
+        ? 'valid'
+        : 'invalid-signature';
+}

--- a/apps/www/lib/seo/resolvePublicOgImage.node.spec.ts
+++ b/apps/www/lib/seo/resolvePublicOgImage.node.spec.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import sharp from 'sharp';
+import { resolvePublicOgImageDataUrl } from './resolvePublicOgImage.ts';
+
+test('converts a trusted WebP cover to a bounded PNG data URL', async () => {
+    const source = await sharp({
+        create: {
+            width: 16,
+            height: 12,
+            channels: 4,
+            background: '#2e6f40',
+        },
+    })
+        .webp()
+        .toBuffer();
+    const fetcher = async () =>
+        new Response(source, {
+            headers: { 'Content-Type': 'image/webp' },
+        });
+
+    const dataUrl = await resolvePublicOgImageDataUrl(
+        'https://cdn.gredice.com/plants/cover.webp',
+        fetcher,
+    );
+
+    assert.match(dataUrl ?? '', /^data:image\/png;base64,/);
+    const converted = Buffer.from(dataUrl?.split(',', 2)[1] ?? '', 'base64');
+    const metadata = await sharp(converted).metadata();
+    assert.equal(metadata.format, 'png');
+    assert.equal(metadata.width, 16);
+    assert.equal(metadata.height, 12);
+});
+
+test('does not fetch image URLs outside trusted public origins', async () => {
+    let fetchCount = 0;
+    const fetcher = async () => {
+        fetchCount += 1;
+        return new Response();
+    };
+
+    assert.equal(
+        await resolvePublicOgImageDataUrl(
+            'https://example.com/private.jpg',
+            fetcher,
+        ),
+        undefined,
+    );
+    assert.equal(fetchCount, 0);
+});
+
+test('uses redirect error mode and rejects redirect responses', async () => {
+    let redirectMode: RequestRedirect | undefined;
+    const fetcher = async (_input: string, init: RequestInit) => {
+        redirectMode = init.redirect;
+        return new Response(null, {
+            status: 302,
+            headers: { Location: 'https://cdn.gredice.com/other.jpg' },
+        });
+    };
+
+    assert.equal(
+        await resolvePublicOgImageDataUrl(
+            'https://cdn.gredice.com/cover.jpg',
+            fetcher,
+        ),
+        undefined,
+    );
+    assert.equal(redirectMode, 'error');
+});
+
+test('rejects non-raster content types before conversion', async () => {
+    const fetcher = async () =>
+        new Response(null, {
+            headers: { 'Content-Type': 'image/svg+xml' },
+        });
+
+    assert.equal(
+        await resolvePublicOgImageDataUrl(
+            'https://cdn.gredice.com/cover.svg',
+            fetcher,
+        ),
+        undefined,
+    );
+});
+
+test('rejects oversized and incorrectly typed response bodies', async () => {
+    const oversizedFetcher = async () =>
+        new Response(new Uint8Array([0xff, 0xd8, 0xff]), {
+            headers: {
+                'Content-Length': String(6 * 1024 * 1024),
+                'Content-Type': 'image/jpeg',
+            },
+        });
+    const mismatchedFetcher = async () =>
+        new Response(new Uint8Array([0xff, 0xd8, 0xff]), {
+            headers: { 'Content-Type': 'image/png' },
+        });
+
+    assert.equal(
+        await resolvePublicOgImageDataUrl(
+            'https://cdn.gredice.com/oversized.jpg',
+            oversizedFetcher,
+        ),
+        undefined,
+    );
+    assert.equal(
+        await resolvePublicOgImageDataUrl(
+            'https://cdn.gredice.com/mismatched.png',
+            mismatchedFetcher,
+        ),
+        undefined,
+    );
+});
+
+test('stops streamed bodies that exceed the byte cap without Content-Length', async () => {
+    const chunkSize = 3 * 1024 * 1024;
+    const fetcher = async () =>
+        new Response(
+            new ReadableStream<Uint8Array>({
+                start(controller) {
+                    controller.enqueue(new Uint8Array(chunkSize));
+                    controller.enqueue(new Uint8Array(chunkSize));
+                    controller.close();
+                },
+            }),
+            {
+                headers: { 'Content-Type': 'image/png' },
+            },
+        );
+
+    assert.equal(
+        await resolvePublicOgImageDataUrl(
+            'https://cdn.gredice.com/streamed.png',
+            fetcher,
+        ),
+        undefined,
+    );
+});

--- a/apps/www/lib/seo/resolvePublicOgImage.ts
+++ b/apps/www/lib/seo/resolvePublicOgImage.ts
@@ -1,0 +1,215 @@
+import sharp from 'sharp';
+import { sanitizePublicOgImageUrl } from './publicMetadata.ts';
+
+type SupportedImageFormat = 'jpeg' | 'png' | 'webp';
+
+const allowedContentTypes = new Map<string, SupportedImageFormat>([
+    ['image/jpeg', 'jpeg'],
+    ['image/jpg', 'jpeg'],
+    ['image/png', 'png'],
+    ['image/webp', 'webp'],
+] as const);
+const maximumSourceBytes = 5 * 1024 * 1024;
+const maximumOutputBytes = 2 * 1024 * 1024;
+const maximumInputPixels = 20_000_000;
+const maximumOutputDimension = 800;
+const requestTimeoutMilliseconds = 4_000;
+
+type PublicOgImageFetcher = (
+    input: string,
+    init: RequestInit,
+) => Promise<Response>;
+
+function contentType(response: Response) {
+    return response.headers
+        .get('content-type')
+        ?.split(';', 1)[0]
+        ?.toLowerCase();
+}
+
+function declaredContentLength(response: Response) {
+    const value = response.headers.get('content-length');
+    if (!value) {
+        return undefined;
+    }
+
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+async function readBoundedResponseBody(response: Response) {
+    if (!response.body) {
+        return undefined;
+    }
+
+    const declaredLength = declaredContentLength(response);
+    if (declaredLength !== undefined && declaredLength > maximumSourceBytes) {
+        await response.body.cancel();
+        return undefined;
+    }
+
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    const reader = response.body.getReader();
+
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+                break;
+            }
+
+            totalBytes += value.byteLength;
+            if (totalBytes > maximumSourceBytes) {
+                await reader.cancel();
+                return undefined;
+            }
+            chunks.push(value);
+        }
+    } finally {
+        reader.releaseLock();
+    }
+
+    if (totalBytes === 0) {
+        return undefined;
+    }
+
+    const bytes = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+        bytes.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+
+    return bytes;
+}
+
+function sniffImageFormat(bytes: Uint8Array): SupportedImageFormat | undefined {
+    if (
+        bytes.length >= 8 &&
+        bytes[0] === 0x89 &&
+        bytes[1] === 0x50 &&
+        bytes[2] === 0x4e &&
+        bytes[3] === 0x47 &&
+        bytes[4] === 0x0d &&
+        bytes[5] === 0x0a &&
+        bytes[6] === 0x1a &&
+        bytes[7] === 0x0a
+    ) {
+        return 'png';
+    }
+
+    if (
+        bytes.length >= 3 &&
+        bytes[0] === 0xff &&
+        bytes[1] === 0xd8 &&
+        bytes[2] === 0xff
+    ) {
+        return 'jpeg';
+    }
+
+    if (
+        bytes.length >= 12 &&
+        bytes[0] === 0x52 &&
+        bytes[1] === 0x49 &&
+        bytes[2] === 0x46 &&
+        bytes[3] === 0x46 &&
+        bytes[8] === 0x57 &&
+        bytes[9] === 0x45 &&
+        bytes[10] === 0x42 &&
+        bytes[11] === 0x50
+    ) {
+        return 'webp';
+    }
+
+    return undefined;
+}
+
+async function convertToPngDataUrl(
+    bytes: Uint8Array,
+    expectedFormat: SupportedImageFormat,
+) {
+    if (sniffImageFormat(bytes) !== expectedFormat) {
+        return undefined;
+    }
+
+    const image = sharp(bytes, {
+        failOn: 'warning',
+        limitInputPixels: maximumInputPixels,
+        sequentialRead: true,
+    });
+    const metadata = await image.metadata();
+
+    if (
+        metadata.format !== expectedFormat ||
+        !metadata.width ||
+        !metadata.height
+    ) {
+        return undefined;
+    }
+
+    const converted = await image
+        .rotate()
+        .resize({
+            width: maximumOutputDimension,
+            height: maximumOutputDimension,
+            fit: 'inside',
+            withoutEnlargement: true,
+        })
+        .png({
+            compressionLevel: 9,
+            palette: true,
+            quality: 90,
+        })
+        .toBuffer();
+
+    if (converted.byteLength > maximumOutputBytes) {
+        return undefined;
+    }
+
+    return `data:image/png;base64,${converted.toString('base64')}`;
+}
+
+export async function resolvePublicOgImageDataUrl(
+    imageUrl: string | null | undefined,
+    fetcher: PublicOgImageFetcher = fetch,
+) {
+    const currentUrl = sanitizePublicOgImageUrl(imageUrl);
+    if (!currentUrl) {
+        return undefined;
+    }
+
+    const signal = AbortSignal.timeout(requestTimeoutMilliseconds);
+
+    try {
+        const response = await fetcher(currentUrl, {
+            headers: {
+                Accept: 'image/webp,image/png,image/jpeg',
+            },
+            redirect: 'error',
+            signal,
+        });
+
+        if (!response.ok) {
+            await response.body?.cancel();
+            return undefined;
+        }
+
+        const expectedFormat = allowedContentTypes.get(
+            contentType(response) ?? '',
+        );
+        if (!expectedFormat) {
+            await response.body?.cancel();
+            return undefined;
+        }
+
+        const bytes = await readBoundedResponseBody(response);
+        if (!bytes) {
+            return undefined;
+        }
+
+        return await convertToPngDataUrl(bytes, expectedFormat);
+    } catch {
+        return undefined;
+    }
+}

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -23,7 +23,7 @@
         "test:plant-operation-stages": "node --experimental-strip-types --test ./tests/plantOperationStageAvailability.node.spec.ts",
         "test:seeds": "node --experimental-strip-types --test ./app/sjeme/seedPresentation.node.spec.ts ./tests/directoryRevalidationPaths.node.spec.ts ./tests/plantSortSeeds.node.spec.ts",
         "test:static-data": "node --experimental-strip-types --test ./tests/staticGenerationData.node.spec.ts",
-        "test:seo": "node --experimental-strip-types --test ./components/shared/seo/structuredDataValidation.node.spec.ts",
+        "test:seo": "node --experimental-strip-types --test ./components/shared/seo/structuredDataValidation.node.spec.ts ./lib/seo/publicMetadata.node.spec.ts ./lib/seo/publicOgSignature.node.spec.ts ./lib/seo/resolvePublicOgImage.node.spec.ts",
         "test:cms-pages": "node --experimental-strip-types --test ./tests/cmsPages.node.spec.ts ./lib/plants/qualityHarvestSafetyFaq.node.spec.ts",
         "test-ui": "pnpm run test:prepare && playwright test --project=chromium --ui",
         "generate-playwright": "node ./generate/populate-test-cases.js && playwright test --config playwright-generate.config.ts",
@@ -54,6 +54,7 @@
         "nuqs": "2.9.0",
         "react": "19.2.8",
         "react-dom": "19.2.8",
+        "sharp": "0.35.3",
         "server-only": "0.0.1"
     },
     "devDependencies": {
@@ -82,7 +83,6 @@
         "postcss": "8.5.16",
         "react-confetti-boom": "2.0.1",
         "react-markdown": "10.1.0",
-        "sharp": "0.35.3",
         "tailwindcss": "4.3.2",
         "tailwindcss-animate": "1.0.7",
         "tsx": "4.23.0",

--- a/apps/www/tests/titlesPresent.spec.ts
+++ b/apps/www/tests/titlesPresent.spec.ts
@@ -1,14 +1,138 @@
 import { readFileSync } from 'node:fs';
+import sharp from 'sharp';
 import { validateSerializedStructuredData } from '../components/shared/seo/structuredDataValidation';
 import { expect, test } from './fixtures';
+
+const publicSiteOrigin = 'https://www.gredice.com';
+const homepageOpenGraphTitle = 'Gredice - vrt po tvom';
+const externalRewritePrefixes = ['/novosti'];
+const publicOgExactPaths = new Set([
+    '/',
+    '/biljke',
+    '/blokovi',
+    '/blokovi/biljke',
+    '/bolesti',
+    '/cesta-pitanja',
+    '/cjenik',
+    '/dostava',
+    '/dostava/termini',
+    '/kontakt',
+    '/mcp',
+    '/o-nama',
+    '/outlet',
+    '/podignuta-gredica',
+    '/povrati-i-povrat-novca',
+    '/preporuke',
+    '/radnje',
+    '/recepti',
+    '/sjeme',
+    '/sjeme/brendovi',
+    '/sjetva',
+    '/stetnici',
+    '/suncokreti',
+    '/vodic-za-prvu-gredicu',
+    '/vrtovi',
+]);
+
+function isExternalRewriteRoute(pathname: string) {
+    return externalRewritePrefixes.some(
+        (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+    );
+}
+
+function shouldUseEntityCover(pathname: string) {
+    if (pathname.startsWith('/biljke/')) {
+        return true;
+    }
+
+    if (pathname.startsWith('/radnje/')) {
+        return true;
+    }
+
+    return (
+        pathname.startsWith('/blokovi/') &&
+        pathname !== '/blokovi/biljke' &&
+        pathname !== '/blokovi/biljke/generator'
+    );
+}
+
+function dynamicCoverFamily(pathname: string) {
+    if (/^\/biljke\/[^/]+\/sorte\/[^/]+$/u.test(pathname)) {
+        return 'plant-sort';
+    }
+
+    if (/^\/biljke\/[^/]+$/u.test(pathname)) {
+        return 'plant';
+    }
+
+    if (/^\/radnje\/[^/]+$/u.test(pathname)) {
+        return 'operation';
+    }
+
+    if (/^\/blokovi\/biljke\/[^/]+$/u.test(pathname)) {
+        return pathname.endsWith('/generator') ? null : 'block-plant';
+    }
+
+    if (/^\/blokovi\/[^/]+$/u.test(pathname)) {
+        return pathname === '/blokovi/biljke' ? null : 'block';
+    }
+
+    return null;
+}
+
+function representativeDynamicCoverPaths(pages: string[]) {
+    const representativeByFamily = new Map<string, string>();
+
+    for (const page of pages) {
+        const pathname = new URL(page, publicSiteOrigin).pathname;
+        const family = dynamicCoverFamily(pathname);
+        if (family && !representativeByFamily.has(family)) {
+            representativeByFamily.set(family, pathname);
+        }
+    }
+
+    return new Set(representativeByFamily.values());
+}
+
+function requiresPublicOgCoverage(url: string) {
+    const { pathname } = new URL(url, publicSiteOrigin);
+
+    if (publicOgExactPaths.has(pathname) || pathname.startsWith('/legalno')) {
+        return true;
+    }
+
+    if (
+        pathname.startsWith('/biljke/') ||
+        pathname.startsWith('/bolesti/') ||
+        pathname.startsWith('/radnje/') ||
+        pathname.startsWith('/recepti/') ||
+        pathname.startsWith('/stetnici/')
+    ) {
+        return true;
+    }
+
+    if (pathname.startsWith('/blokovi/biljke/')) {
+        return pathname !== '/blokovi/biljke/generator';
+    }
+
+    return pathname.startsWith('/blokovi/') && pathname !== '/blokovi/biljke';
+}
 
 test.describe('public SEO metadata', () => {
     const pages = JSON.parse(
         readFileSync('./tests/sitemap-pages.json', 'utf8'),
     ) as string[];
+    const representativeCoverPaths = representativeDynamicCoverPaths(pages);
+
     for (const url of pages) {
         test(`page ${url} has valid SEO metadata`, async ({ page }) => {
             test.slow();
+            const sitemapPathname = new URL(url, publicSiteOrigin).pathname;
+
+            test.skip(
+                isExternalRewriteRoute(sitemapPathname),
+                'Route is rendered and tested by the separate News app.',
+            );
 
             await page.goto(`${url}`, {
                 waitUntil: 'domcontentloaded',
@@ -17,6 +141,137 @@ test.describe('public SEO metadata', () => {
             if (url !== '/') {
                 const title = await page.title();
                 expect(title).not.toBe('Gredice - vrt po tvom');
+            }
+
+            if (requiresPublicOgCoverage(url)) {
+                const expectedPathname = new URL(page.url()).pathname;
+                const expectedCanonicalUrl = new URL(
+                    expectedPathname,
+                    publicSiteOrigin,
+                ).href;
+                const canonical = page.locator('link[rel="canonical"]');
+                const openGraphTitle = page.locator(
+                    'meta[property="og:title"]',
+                );
+                const openGraphDescription = page.locator(
+                    'meta[property="og:description"]',
+                );
+                const openGraphUrl = page.locator('meta[property="og:url"]');
+                const openGraphImage = page
+                    .locator('meta[property="og:image"]')
+                    .first();
+                const twitterTitle = page.locator('meta[name="twitter:title"]');
+                const twitterDescription = page.locator(
+                    'meta[name="twitter:description"]',
+                );
+                const twitterImage = page
+                    .locator('meta[name="twitter:image"]')
+                    .first();
+
+                await expect(canonical).toHaveAttribute(
+                    'href',
+                    expectedCanonicalUrl,
+                );
+                await expect(openGraphTitle).toHaveAttribute('content', /.+/);
+                await expect(openGraphDescription).toHaveAttribute(
+                    'content',
+                    /.+/,
+                );
+                await expect(openGraphUrl).toHaveAttribute(
+                    'content',
+                    expectedCanonicalUrl,
+                );
+                await expect(openGraphImage).toHaveAttribute('content', /.+/);
+                await expect(
+                    page.locator('meta[property="og:image:width"]').first(),
+                ).toHaveAttribute('content', '1200');
+                await expect(
+                    page.locator('meta[property="og:image:height"]').first(),
+                ).toHaveAttribute('content', '630');
+                await expect(
+                    page.locator('meta[property="og:image:alt"]').first(),
+                ).toHaveAttribute('content', /.+/);
+                await expect(
+                    page.locator('meta[property="og:image:type"]').first(),
+                ).toHaveAttribute('content', 'image/png');
+                await expect(
+                    page.locator('meta[property="og:type"]'),
+                ).toHaveAttribute('content', 'website');
+                await expect(
+                    page.locator('meta[name="twitter:card"]'),
+                ).toHaveAttribute('content', 'summary_large_image');
+                await expect(twitterTitle).toHaveAttribute(
+                    'content',
+                    (await openGraphTitle.getAttribute('content')) ?? '',
+                );
+                await expect(twitterDescription).toHaveAttribute(
+                    'content',
+                    (await openGraphDescription.getAttribute('content')) ?? '',
+                );
+                await expect(twitterImage).toHaveAttribute('content', /.+/);
+                await expect(
+                    page.locator('meta[name="twitter:image:alt"]').first(),
+                ).toHaveAttribute('content', /.+/);
+
+                const openGraphTitleContent =
+                    await openGraphTitle.getAttribute('content');
+                const openGraphImageContent =
+                    await openGraphImage.getAttribute('content');
+                const twitterImageContent =
+                    await twitterImage.getAttribute('content');
+
+                if (expectedPathname !== '/') {
+                    expect(openGraphTitleContent).not.toBe(
+                        homepageOpenGraphTitle,
+                    );
+                    expect(twitterImageContent).toBe(openGraphImageContent);
+                }
+
+                if (shouldUseEntityCover(expectedPathname)) {
+                    expect(
+                        new URL(openGraphImageContent ?? '').searchParams.has(
+                            'image',
+                        ),
+                    ).toBe(true);
+                }
+
+                if (
+                    publicOgExactPaths.has(expectedPathname) ||
+                    expectedPathname.startsWith('/legalno') ||
+                    representativeCoverPaths.has(expectedPathname)
+                ) {
+                    const imageUrl = new URL(openGraphImageContent ?? '');
+                    const imageResponse = await page.request.get(
+                        `${imageUrl.pathname}${imageUrl.search}`,
+                    );
+                    const imageBody = await imageResponse.body();
+
+                    expect(imageResponse.ok()).toBe(true);
+                    expect(imageResponse.headers()['content-type']).toContain(
+                        'image/png',
+                    );
+                    expect(imageBody.subarray(1, 4).toString()).toBe('PNG');
+                    expect(imageBody.readUInt32BE(16)).toBe(1200);
+                    expect(imageBody.readUInt32BE(20)).toBe(630);
+
+                    if (representativeCoverPaths.has(expectedPathname)) {
+                        const coverStats = await sharp(imageBody)
+                            .extract({
+                                left: 808,
+                                top: 138,
+                                width: 318,
+                                height: 354,
+                            })
+                            .stats();
+                        const maximumColorDeviation = Math.max(
+                            ...coverStats.channels
+                                .slice(0, 3)
+                                .map((channel) => channel.stdev),
+                        );
+
+                        expect(maximumColorDeviation).toBeGreaterThan(3);
+                    }
+                }
             }
 
             const structuredDataScripts = await page

--- a/apps/www/tests/titlesPresent.spec.ts
+++ b/apps/www/tests/titlesPresent.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import sharp from 'sharp';
 import { validateSerializedStructuredData } from '../components/shared/seo/structuredDataValidation';
@@ -123,6 +124,41 @@ test.describe('public SEO metadata', () => {
         readFileSync('./tests/sitemap-pages.json', 'utf8'),
     ) as string[];
     const representativeCoverPaths = representativeDynamicCoverPaths(pages);
+
+    test('generated OG images survive a cache-miss image optimization', async ({
+        page,
+    }) => {
+        // The fragment creates a fresh optimizer key without changing the static asset request.
+        const optimizerCacheKey = encodeURIComponent(
+            `/web-app-manifest-192x192.png#${randomUUID()}`,
+        );
+        const optimizedImage = await page.request.get(
+            `/_next/image?url=${optimizerCacheKey}&w=3840&q=75`,
+        );
+
+        expect(optimizedImage.ok()).toBe(true);
+        expect(optimizedImage.headers()['x-nextjs-cache']).toBe('MISS');
+
+        await page.goto('/sjetva', { waitUntil: 'domcontentloaded' });
+
+        const openGraphImageContent = await page
+            .locator('meta[property="og:image"]')
+            .first()
+            .getAttribute('content');
+        const openGraphImageUrl = new URL(openGraphImageContent ?? '');
+        const openGraphImageResponse = await page.request.get(
+            `${openGraphImageUrl.pathname}${openGraphImageUrl.search}`,
+        );
+        const openGraphImageBody = await openGraphImageResponse.body();
+
+        expect(openGraphImageResponse.ok()).toBe(true);
+        expect(openGraphImageResponse.headers()['content-type']).toContain(
+            'image/png',
+        );
+        expect(openGraphImageBody.subarray(1, 4).toString()).toBe('PNG');
+        expect(openGraphImageBody.readUInt32BE(16)).toBe(1200);
+        expect(openGraphImageBody.readUInt32BE(20)).toBe(630);
+    });
 
     for (const url of pages) {
         test(`page ${url} has valid SEO metadata`, async ({ page }) => {

--- a/packages/ui/src/cms/CmsOgImage.tsx
+++ b/packages/ui/src/cms/CmsOgImage.tsx
@@ -113,7 +113,6 @@ export function CmsOgImage({
                     padding: '14px 18px',
                     position: 'relative',
                     width: hasImage ? 666 : '100%',
-                    zIndex: 1,
                 }}
             >
                 <div

--- a/patches/next@16.3.0.patch
+++ b/patches/next@16.3.0.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/esm/server/image-optimizer.js b/dist/esm/server/image-optimizer.js
+index 193b9c7..ce395b7 100644
+--- a/dist/esm/server/image-optimizer.js
++++ b/dist/esm/server/image-optimizer.js
+@@ -90,6 +90,7 @@ export function getSharp(concurrency, operationCache) {
+                 'VipsForeignLoadJpeg',
+                 'VipsForeignLoadNsgif',
+                 'VipsForeignLoadPng',
++                'VipsForeignLoadSvg',
+                 'VipsForeignLoadTiff',
+                 'VipsForeignLoadWebp'
+             ]
+diff --git a/dist/server/image-optimizer.js b/dist/server/image-optimizer.js
+index 74000ec..b5e4ee4 100644
+--- a/dist/server/image-optimizer.js
++++ b/dist/server/image-optimizer.js
+@@ -210,6 +210,7 @@ function getSharp(concurrency, operationCache) {
+                 'VipsForeignLoadJpeg',
+                 'VipsForeignLoadNsgif',
+                 'VipsForeignLoadPng',
++                'VipsForeignLoadSvg',
+                 'VipsForeignLoadTiff',
+                 'VipsForeignLoadWebp'
+             ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -961,6 +961,9 @@ importers:
       server-only:
         specifier: 0.0.1
         version: 0.0.1
+      sharp:
+        specifier: 0.35.3
+        version: 0.35.3(@types/node@24.12.4)
     devDependencies:
       '@axe-core/playwright':
         specifier: 4.12.1
@@ -1037,9 +1040,6 @@ importers:
       react-markdown:
         specifier: 10.1.0
         version: 10.1.0(@types/react@19.2.18)(react@19.2.8)
-      sharp:
-        specifier: 0.35.3
-        version: 0.35.3(@types/node@24.12.4)
       tailwindcss:
         specifier: 4.3.2
         version: 4.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ packageExtensionsChecksum: sha256-y2BYGjR2uQ+NBok9HqAy+T4U7Di94KBF/DmMKB9VtBc=
 
 patchedDependencies:
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0': 9c0494be68fc5d63ae2b8e9a96397680c82ea5ac7260f4b46b4f8814cb3c561f
+  next@16.3.0: 55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f
   openapi-typescript@7.13.0: fab737196e4bf943943c70c0e6955e385055ef06f3d8ad61ffb53c4b41c6d419
   react-docgen-typescript@2.4.0: c6a1bb9c2e242a146914bb8e4de55736df0f5fbcd6edcc210eb92b44a18db846
   tsconfck@3.1.6: 8e77e2162331e3bd628516d51ccbf2a0ce9c5a31d9bad8e22cc42458370bec37
@@ -79,7 +80,7 @@ importers:
         version: 0.220.0(@opentelemetry/api@1.9.1)
       '@posthog/next':
         specifier: 0.8.0
-        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@scalar/api-reference-react':
         specifier: 0.9.54
         version: 0.9.54(axios@1.16.1)(change-case@5.4.4)(jwt-decode@4.0.0)(qrcode@1.5.4)(react@19.2.8)(tailwindcss@4.3.2)(typescript@7.0.2)(zod@4.4.3)
@@ -118,7 +119,7 @@ importers:
         version: 0.5.3(hono@4.12.28)
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       pg:
         specifier: 8.22.0
         version: 8.22.0
@@ -221,7 +222,7 @@ importers:
         version: 0.4.14
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
       jsonwebtoken:
         specifier: 9.0.3
         version: 9.0.3
@@ -275,7 +276,7 @@ importers:
         version: 0.220.0(@opentelemetry/api@1.9.1)
       '@posthog/next':
         specifier: 0.8.0
-        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@vercel/blob':
         specifier: 2.6.1
         version: 2.6.1
@@ -290,7 +291,7 @@ importers:
         version: 0.45.2(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(pg@8.22.0)
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -390,7 +391,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
       '@zxing/library':
         specifier: 0.23.0
         version: 0.23.0
@@ -417,7 +418,7 @@ importers:
         version: 1.2.1
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -478,7 +479,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
       '@zxing/library':
         specifier: 0.23.0
         version: 0.23.0
@@ -526,7 +527,7 @@ importers:
         version: 0.220.0(@opentelemetry/api@1.9.1)
       '@posthog/next':
         specifier: 0.8.0
-        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@posthog/react':
         specifier: 1.10.3
         version: 1.10.3(@types/react@19.2.18)(posthog-js@1.399.1)(react@19.2.8)
@@ -535,13 +536,13 @@ importers:
         version: 2.6.1
       '@vercel/toolbar':
         specifier: 0.2.6
-        version: 0.2.6(@vercel/analytics@2.0.1(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 0.2.6(@vercel/analytics@2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
       flags:
         specifier: 4.2.0
-        version: 4.2.0(@opentelemetry/api@1.9.1)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 4.2.0(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       pg:
         specifier: 8.22.0
         version: 8.22.0
@@ -614,7 +615,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
       postcss:
         specifier: 8.5.23
         version: 8.5.23
@@ -641,16 +642,16 @@ importers:
         version: 0.220.0(@opentelemetry/api@1.9.1)
       '@posthog/next':
         specifier: 0.8.0
-        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@vercel/toolbar':
         specifier: 0.2.6
-        version: 0.2.6(@vercel/analytics@2.0.1(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 0.2.6(@vercel/analytics@2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
       flags:
         specifier: 4.2.0
-        version: 4.2.0(@opentelemetry/api@1.9.1)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 4.2.0(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -711,10 +712,10 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
       nuqs:
         specifier: 2.9.0
-        version: 2.9.0(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)
+        version: 2.9.0(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)
       postcss:
         specifier: 8.5.23
         version: 8.5.23
@@ -732,16 +733,16 @@ importers:
     dependencies:
       '@posthog/next':
         specifier: 0.8.0
-        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
       '@vercel/toolbar':
         specifier: 0.2.6
-        version: 0.2.6(@vercel/analytics@2.0.1(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 0.2.6(@vercel/analytics@2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -796,7 +797,7 @@ importers:
     dependencies:
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -854,10 +855,10 @@ importers:
         version: 5.101.2(react@19.2.8)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -882,7 +883,7 @@ importers:
         version: 0.6.0(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(typescript@7.0.2)
       '@storybook/nextjs-vite':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
       '@tailwindcss/postcss':
         specifier: 4.3.2
         version: 4.3.2
@@ -933,25 +934,25 @@ importers:
         version: 0.220.0(@opentelemetry/api@1.9.1)
       '@posthog/next':
         specifier: 0.8.0
-        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@vercel/toolbar':
         specifier: 0.2.6
-        version: 0.2.6(@vercel/analytics@2.0.1(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 0.2.6(@vercel/analytics@2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
       fflate:
         specifier: 0.8.3
         version: 0.8.3
       flags:
         specifier: 4.2.0
-        version: 4.2.0(@opentelemetry/api@1.9.1)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 4.2.0(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       nuqs:
         specifier: 2.9.0
-        version: 2.9.0(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)
+        version: 2.9.0(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -1021,7 +1022,7 @@ importers:
         version: 0.4.14
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
       dotenv:
         specifier: 17.4.2
         version: 17.4.2
@@ -1030,7 +1031,7 @@ importers:
         version: 12.42.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-sitemap:
         specifier: 4.2.3
-        version: 4.2.3(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))
+        version: 4.2.3(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))
       postcss:
         specifier: 8.5.23
         version: 8.5.23
@@ -1073,7 +1074,7 @@ importers:
         version: 24.12.4
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1251,7 +1252,7 @@ importers:
         version: 7.0.19(zod@4.4.3)
       nuqs:
         specifier: 2.9.0
-        version: 2.9.0(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)
+        version: 2.9.0(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)
     devDependencies:
       '@biomejs/biome':
         specifier: 2.5.3
@@ -1330,7 +1331,7 @@ importers:
         version: 3.2.0
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1623,7 +1624,7 @@ importers:
         version: link:../js
       '@posthog/next':
         specifier: 0.8.0
-        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-alert-dialog':
         specifier: 1.1.19
         version: 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1671,13 +1672,13 @@ importers:
         version: 12.42.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       nuqs:
         specifier: 2.9.0
-        version: 2.9.0(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)
+        version: 2.9.0(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -13350,11 +13351,11 @@ snapshots:
     dependencies:
       '@posthog/types': 1.393.0
 
-  '@posthog/next@0.8.0(@types/react@19.2.18)(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@posthog/next@0.8.0(@types/react@19.2.18)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@posthog/core': 1.40.1
       '@posthog/react': 1.10.3(@types/react@19.2.18)(posthog-js@1.399.1)(react@19.2.8)
-      next: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       posthog-js: 1.399.1
       posthog-node: 5.40.0
       react: 19.2.8
@@ -14873,18 +14874,18 @@ snapshots:
       - '@tmcp/auth'
       - typescript
 
-  '@storybook/nextjs-vite@10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@storybook/nextjs-vite@10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
       '@storybook/react': 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(typescript@7.0.2)
       '@storybook/react-vite': 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(typescript@7.0.2)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
-      next: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8)
       styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.8)
       vite: 8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0)
-      vite-plugin-storybook-nextjs: 3.3.0(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
+      vite-plugin-storybook-nextjs: 3.3.0(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
     optionalDependencies:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.4(@types/react@19.2.18)
@@ -15599,9 +15600,9 @@ snapshots:
     dependencies:
       valibot: 1.4.2(typescript@7.0.2)
 
-  '@vercel/analytics@2.0.1(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))':
+  '@vercel/analytics@2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))':
     optionalDependencies:
-      next: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react: 19.2.8
       vue: 3.5.39(typescript@7.0.2)
 
@@ -15625,7 +15626,7 @@ snapshots:
 
   '@vercel/firewall@1.2.1': {}
 
-  '@vercel/microfrontends@2.3.2(@vercel/analytics@2.0.1(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@vercel/microfrontends@2.3.2(@vercel/analytics@2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@next/env': 16.0.10
       '@types/md5': 2.3.6
@@ -15640,8 +15641,8 @@ snapshots:
       path-to-regexp: 6.3.0
       semver: 7.8.5
     optionalDependencies:
-      '@vercel/analytics': 2.0.1(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
-      next: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      '@vercel/analytics': 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       vite: 8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0)
@@ -15658,17 +15659,17 @@ snapshots:
       '@vercel/cli-exec': 1.0.0
       jose: 5.10.0
 
-  '@vercel/toolbar@0.2.6(@vercel/analytics@2.0.1(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@vercel/toolbar@0.2.6(@vercel/analytics@2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@tinyhttp/app': 1.3.0
-      '@vercel/microfrontends': 2.3.2(@vercel/analytics@2.0.1(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vercel/microfrontends': 2.3.2(@vercel/analytics@2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
       chokidar: 3.6.0
       execa: 5.1.1
       find-up: 5.0.0
       get-port: 5.1.1
       strip-ansi: 6.0.1
     optionalDependencies:
-      next: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react: 19.2.8
       vite: 8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -17239,13 +17240,13 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  flags@4.2.0(@opentelemetry/api@1.9.1)(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  flags@4.2.0(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@edge-runtime/cookies': 5.0.2
       jose: 5.10.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      next: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
@@ -18743,13 +18744,13 @@ snapshots:
 
   neverpanic@0.0.8: {}
 
-  next-sitemap@4.2.3(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)):
+  next-sitemap@4.2.3(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)):
     dependencies:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.5.11
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
 
   next-themes@0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -18783,7 +18784,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0):
+  next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -18853,12 +18854,12 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
-  nuqs@2.9.0(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8):
+  nuqs@2.9.0(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.8
     optionalDependencies:
-      next: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
 
   nypm@0.6.6:
     dependencies:
@@ -20543,13 +20544,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-plugin-storybook-nextjs@3.3.0(next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0)):
+  vite-plugin-storybook-nextjs@3.3.0(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@next/env': 16.0.0
       image-size: 2.0.2
       magic-string: 0.30.21
       module-alias: 2.3.4
-      next: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8)
       ts-dedent: 2.3.0
       vite: 8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,6 +40,8 @@ overrides:
   'tsconfck@3.1.6>typescript': '-'
 patchedDependencies:
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0': patches/@joshwooding__vite-plugin-react-docgen-typescript@0.7.0.patch
+  # Backport https://github.com/vercel/next.js/pull/96733 until it ships in stable Next.
+  'next@16.3.0': patches/next@16.3.0.patch
   openapi-typescript@7.13.0: patches/openapi-typescript@7.13.0.patch
   react-docgen-typescript@2.4.0: patches/react-docgen-typescript@2.4.0.patch
   tsconfck@3.1.6: patches/tsconfck@3.1.6.patch


### PR DESCRIPTION
## Summary

- add reusable, HMAC-signed 1200×630 public OG cards with bounded PNG/JPEG/WebP cover conversion and privacy-safe fallbacks
- add page-specific canonical, Open Graph, and Twitter metadata across every route in #4479, excluding the requested `/korisnici` and `/pozadine` routes
- give `/novosti` and `/novosti/sto-je-novo` distinct metadata and rendered cards, and restore the missing News CI job
- extend sitemap-driven coverage to canonical URLs, child-page identity, Twitter parity, image metadata, rendered static/legal cards, and representative real-cover cards
- keep `/trag/[token]` noindex with generic metadata that contains no token or trace data

Closes #4479

## Validation

- `pnpm --filter www lint`
- `pnpm --filter www typecheck`
- `pnpm --filter www test:seo` (25 passed)
- `CI=true pnpm --filter www test:seo` (25 passed)
- signed endpoint smoke: valid 200 PNG, tampered/unsigned 401
- real CDN WebP smoke: non-blank 1200×630 PNG with bounded conversion
- `pnpm --filter news lint`
- `pnpm test --filter=news` (production build, metadata units, rendered archives, distinct PNG endpoints)
- `pnpm --filter @gredice/ui lint`
- `pnpm --filter @gredice/ui typecheck`
- `pnpm --filter @gredice/ui test`
- `pnpm lint:ci-filters`
- `git diff --check`

`pnpm --filter www build` compiled and completed TypeScript locally, then stopped during page-data collection because this worktree has no `POSTGRES_URL`. The PR CI pulls the Vercel preview environment and is the authoritative full build/sitemap run.

## Operational notes

- no schema changes, migrations, generated assets, or new environment variables
- public-card signing reuses the existing `CMS_PAGES_PREVIEW_SECRET` with domain separation and fails closed in CI/Vercel when missing
- `sharp` moved from a development dependency to a runtime dependency for safe cover conversion
