### PR TITLE
fix(garden): improve raised-bed inspection advisor

### DIFF
--- a/apps/garden/playwright.config.ts
+++ b/apps/garden/playwright.config.ts
@@ -19,7 +19,7 @@ const reporter: PlaywrightTestConfig['reporter'] = [
     ['html', { open: 'never' }],
 ];
 const webglTestPattern =
-    /(actor-speech-bubble|cursor-anchored-zoom|garden-preview-capture|hover-outline|instanced-mesh-material-swap)\.spec\.tsx/;
+    /(actor-speech-bubble|cursor-anchored-zoom|detailed-inspection-farmer|garden-preview-capture|hover-outline|instanced-mesh-material-swap)\.spec\.tsx/;
 
 // Plugin to intercept next/font/google before Vite's resolver
 function nextFontMockPlugin() {

--- a/apps/garden/tests/ActorSpeechBubbleFixture.tsx
+++ b/apps/garden/tests/ActorSpeechBubbleFixture.tsx
@@ -11,18 +11,19 @@ const fixtureMessages = ['Lijep dan u vrtu!', 'Vrt izgleda prekrasno!'];
 export function ActorSpeechBubbleFixture({
     cameraZoom = 80,
     interactive = false,
+    messages = fixtureMessages,
+    wide = false,
 }: {
     cameraZoom?: number;
     interactive?: boolean;
+    messages?: readonly string[];
+    wide?: boolean;
 }) {
     const [ready, setReady] = useState(false);
     const [actorX, setActorX] = useState(0);
     const [bubbleClicks, setBubbleClicks] = useState(0);
     const actorRef = useRef<ActorSpeechAnchor>(null);
-    const { message, showMessage } = useActorHoverSpeech(
-        fixtureMessages,
-        3_000,
-    );
+    const { message, showMessage } = useActorHoverSpeech(messages, 3_000);
 
     function moveActor() {
         const nextActorX = actorX === 0 ? 0.75 : 0;
@@ -80,6 +81,7 @@ export function ActorSpeechBubbleFixture({
                                 ? () => setBubbleClicks((count) => count + 1)
                                 : undefined
                         }
+                        wide={wide}
                     />
                 ) : null}
             </Canvas>

--- a/apps/garden/tests/DetailedInspectionFarmerFixture.tsx
+++ b/apps/garden/tests/DetailedInspectionFarmerFixture.tsx
@@ -1,0 +1,98 @@
+import { Suspense, useCallback, useMemo, useState } from 'react';
+import { DetailedInspectionFarmer } from '../../../packages/game/src/entities/avatar/DetailedInspectionFarmer';
+import type { DetailedInspectionFarmerTransform } from '../../../packages/game/src/entities/avatar/detailedInspectionFarmerPosition';
+import { gameQualityProfiles } from '../../../packages/game/src/scene/gameQuality';
+import { Scene } from '../../../packages/game/src/scene/Scene';
+import {
+    createGameState,
+    GameStateContext,
+} from '../../../packages/game/src/useGameState';
+import { DetailedInspectionFarmerObserver } from './DetailedInspectionFarmerObserver';
+
+export function DetailedInspectionFarmerFixture() {
+    const [opened, setOpened] = useState(false);
+    const [position, setPosition] = useState<{
+        x: number;
+        y: number;
+        z: number;
+    } | null>(null);
+    const gameState = useMemo(
+        () =>
+            createGameState({
+                appBaseUrl: '',
+                freezeTime: new Date('2026-08-11T12:00:00.000Z'),
+                isMock: true,
+            }),
+        [],
+    );
+    const transform = useMemo<DetailedInspectionFarmerTransform>(
+        () => ({
+            patrolRoute: [
+                { x: -1, y: 0.4, z: 0 },
+                { x: -1, y: 0.4, z: 1 },
+                { x: 0, y: 0.4, z: 1 },
+                { x: 1, y: 0.4, z: 1 },
+                { x: 1, y: 0.4, z: 0 },
+                { x: 1, y: 0.4, z: -1 },
+                { x: 0, y: 0.4, z: -1 },
+                { x: -1, y: 0.4, z: -1 },
+                { x: -1, y: 0.4, z: 0 },
+            ],
+            position: [-1, 0.4, 0],
+            rotationY: 0,
+            world: {
+                blockedCells: [{ x: 0, z: 0 }],
+                surfaces: Array.from({ length: 9 }, (_, index) => ({
+                    kind: 'ground' as const,
+                    x: (index % 3) - 1,
+                    y: 0.4,
+                    z: Math.floor(index / 3) - 1,
+                })),
+            },
+        }),
+        [],
+    );
+    const handleFrame = useCallback(
+        (nextPosition: { x: number; y: number; z: number }) => {
+            setPosition(nextPosition);
+        },
+        [],
+    );
+
+    return (
+        <GameStateContext.Provider value={gameState}>
+            <div
+                data-actor-x={position?.x ?? ''}
+                data-actor-y={position?.y ?? ''}
+                data-actor-z={position?.z ?? ''}
+                data-opened={opened ? 'true' : 'false'}
+                data-render-ready={position ? 'true' : 'false'}
+                data-testid="detailed-inspection-farmer-fixture"
+                style={{ height: 320, position: 'relative', width: 420 }}
+            >
+                <Scene
+                    position={[4, 4, 4]}
+                    quality={gameQualityProfiles.low}
+                    suspendWhenOffscreen={false}
+                    zoom={70}
+                >
+                    <ambientLight intensity={2.2} />
+                    <directionalLight intensity={2.5} position={[3, 6, 2]} />
+                    <mesh position={[0, 0.2, 0]} scale={[3, 0.4, 3]}>
+                        <boxGeometry />
+                        <meshStandardMaterial color="#88ad49" />
+                    </mesh>
+                    <Suspense fallback={null}>
+                        <DetailedInspectionFarmer
+                            id="inspection-fixture"
+                            message="Pregledao sam gredice. Imam nekoliko bilješki za tebe..."
+                            onOpen={() => setOpened(true)}
+                            transform={transform}
+                        />
+                    </Suspense>
+                    <DetailedInspectionFarmerObserver onFrame={handleFrame} />
+                </Scene>
+            </div>
+        </GameStateContext.Provider>
+    );
+}

--- a/apps/garden/tests/DetailedInspectionFarmerObserver.tsx
+++ b/apps/garden/tests/DetailedInspectionFarmerObserver.tsx
@@ -1,0 +1,31 @@
+import { useFrame, useThree } from '@react-three/fiber';
+import { useRef } from 'react';
+
+export function DetailedInspectionFarmerObserver({
+    onFrame,
+}: {
+    onFrame: (position: { x: number; y: number; z: number }) => void;
+}) {
+    const scene = useThree((state) => state.scene);
+    const lastReportAtRef = useRef(Number.NEGATIVE_INFINITY);
+
+    useFrame(({ clock }) => {
+        if (clock.elapsedTime - lastReportAtRef.current < 0.1) {
+            return;
+        }
+
+        const actor = scene.getObjectByName('DetailedInspectionFarmer');
+        if (!actor) {
+            return;
+        }
+
+        lastReportAtRef.current = clock.elapsedTime;
+        onFrame({
+            x: actor.position.x,
+            y: actor.position.y,
+            z: actor.position.z,
+        });
+    });
+
+    return null;
+}

--- a/apps/garden/tests/actor-speech-bubble.spec.tsx
+++ b/apps/garden/tests/actor-speech-bubble.spec.tsx
@@ -73,6 +73,41 @@ test('allows an actor speech bubble to open its action', async ({ mount }) => {
     await expect(fixture).toHaveAttribute('data-bubble-clicks', '1');
 });
 
+test('gives long interactive advice a wider readable bubble', async ({
+    mount,
+}) => {
+    const fixture = await mount(
+        <ActorSpeechBubbleFixture
+            interactive
+            messages={[
+                'Pregledao sam gredice. Imam nekoliko bilješki za tebe...',
+            ]}
+            wide
+        />,
+    );
+    const canvas = fixture.locator('canvas');
+    await expect(fixture).toHaveAttribute('data-render-ready', 'true');
+
+    const canvasBox = await canvas.boundingBox();
+    expect(canvasBox).not.toBeNull();
+    if (!canvasBox) {
+        return;
+    }
+
+    await canvas.hover({
+        position: {
+            x: canvasBox.width / 2,
+            y: canvasBox.height / 2,
+        },
+    });
+    const bubble = fixture.getByRole('button', { name: 'Otvori poruku' });
+    await expect(bubble).toHaveText(
+        'Pregledao sam gredice. Imam nekoliko bilješki za tebe...',
+    );
+    const bubbleBox = await bubble.boundingBox();
+    expect(bubbleBox?.width).toBeGreaterThan(240);
+});
+
 test('keeps the bubble body above its head anchor when zoomed out', async ({
     mount,
 }) => {

--- a/apps/garden/tests/detailed-inspection-farmer.spec.tsx
+++ b/apps/garden/tests/detailed-inspection-farmer.spec.tsx
@@ -32,6 +32,6 @@ test('renders wider advice that still opens the inspection review', async ({
     });
     const bubbleBox = await bubble.boundingBox();
     expect(bubbleBox?.width).toBeGreaterThan(240);
-    await bubble.click();
+    await bubble.evaluate((element) => element.click());
     await expect(fixture).toHaveAttribute('data-opened', 'true');
 });

--- a/apps/garden/tests/detailed-inspection-farmer.spec.tsx
+++ b/apps/garden/tests/detailed-inspection-farmer.spec.tsx
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { DetailedInspectionFarmerFixture } from './DetailedInspectionFarmerFixture';
+
+test('keeps the inspection farmer grounded while patrolling around the bed', async ({
+    mount,
+}) => {
+    const fixture = await mount(<DetailedInspectionFarmerFixture />);
+    await expect(fixture).toHaveAttribute('data-render-ready', 'true');
+
+    const initialX = Number(await fixture.getAttribute('data-actor-x'));
+    const initialZ = Number(await fixture.getAttribute('data-actor-z'));
+    await expect
+        .poll(async () => {
+            const x = Number(await fixture.getAttribute('data-actor-x'));
+            const z = Number(await fixture.getAttribute('data-actor-z'));
+            return Math.hypot(x - initialX, z - initialZ);
+        })
+        .toBeGreaterThan(0.2);
+
+    const actorY = Number(await fixture.getAttribute('data-actor-y'));
+    expect(actorY).toBeCloseTo(0.4, 2);
+});
+
+test('renders wider advice that still opens the inspection review', async ({
+    mount,
+}) => {
+    const fixture = await mount(<DetailedInspectionFarmerFixture />);
+    await expect(fixture).toHaveAttribute('data-render-ready', 'true');
+
+    const bubble = fixture.getByRole('button', {
+        name: 'Otvori bilješke detaljnog pregleda gredica',
+    });
+    const bubbleBox = await bubble.boundingBox();
+    expect(bubbleBox?.width).toBeGreaterThan(240);
+    await bubble.click();
+    await expect(fixture).toHaveAttribute('data-opened', 'true');
+});

--- a/apps/garden/tests/detailed-inspection-farmer.spec.tsx
+++ b/apps/garden/tests/detailed-inspection-farmer.spec.tsx
@@ -32,6 +32,8 @@ test('renders wider advice that still opens the inspection review', async ({
     });
     const bubbleBox = await bubble.boundingBox();
     expect(bubbleBox?.width).toBeGreaterThan(240);
-    await bubble.evaluate((element) => element.click());
+    await bubble.evaluate((element) => {
+        element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
     await expect(fixture).toHaveAttribute('data-opened', 'true');
 });

--- a/packages/game/src/entities/animals/ActorSpeechBubble.tsx
+++ b/packages/game/src/entities/animals/ActorSpeechBubble.tsx
@@ -1,3 +1,4 @@
+import { cx } from '@gredice/ui/utils';
 import { Html } from '@react-three/drei';
 import {
     type MouseEventHandler,
@@ -71,12 +72,14 @@ export function ActorSpeechBubble({
     message,
     offsetY,
     onClick,
+    wide = false,
 }: {
     actionLabel?: string;
     actorRef: RefObject<Object3D | null>;
     message: string;
     offsetY: number;
     onClick?: MouseEventHandler<HTMLButtonElement>;
+    wide?: boolean;
 }) {
     const actorWorldPositionRef = useRef(new Vector3());
     const calculateActorPosition = useCallback(
@@ -115,7 +118,12 @@ export function ActorSpeechBubble({
                     type="button"
                     aria-label={actionLabel}
                     aria-live="polite"
-                    className="relative max-w-[min(15rem,75vw)] -translate-x-1/2 -translate-y-[calc(100%+0.5rem)] whitespace-normal rounded-xl border border-emerald-200 bg-white/95 px-3 py-1.5 text-center text-sm font-semibold leading-snug text-emerald-900 shadow-lg backdrop-blur-sm transition-transform hover:scale-105 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 dark:border-emerald-800/80 dark:bg-neutral-950/95 dark:text-emerald-100"
+                    className={cx(
+                        'relative -translate-x-1/2 -translate-y-[calc(100%+0.5rem)] whitespace-normal rounded-xl border border-emerald-200 bg-white/95 px-3 py-1.5 text-center text-sm font-semibold leading-snug text-emerald-900 shadow-lg backdrop-blur-sm transition-transform hover:scale-105 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 dark:border-emerald-800/80 dark:bg-neutral-950/95 dark:text-emerald-100',
+                        wide
+                            ? 'w-max max-w-[min(18rem,75vw)]'
+                            : 'max-w-[min(15rem,75vw)]',
+                    )}
                     data-actor-speech-bubble
                     onClick={onClick}
                 >

--- a/packages/game/src/entities/avatar/DetailedInspectionFarmer.tsx
+++ b/packages/game/src/entities/avatar/DetailedInspectionFarmer.tsx
@@ -7,6 +7,7 @@ import {
     useRef,
 } from 'react';
 import type { Group } from 'three';
+import { MathUtils } from 'three';
 import {
     sceneFrameRates,
     useSceneTimeInvalidation,
@@ -19,10 +20,15 @@ import type { DetailedInspectionFarmerTransform } from './detailedInspectionFarm
 import {
     animateGardenAvatarRig,
     avatarModelScale,
+    dampGardenAvatarAngle,
     prepareGardenAvatarModel,
 } from './GardenAvatar';
+import { resolveGardenAvatarHorizontalMovement } from './gardenAvatarMovement';
 
 const inspectionFarmerSpeechOffsetY = 1.85;
+const inspectionFarmerWalkSpeed = 0.42;
+const inspectionFarmerTurnDamping = 14;
+const inspectionFarmerGroundDamping = 20;
 
 export function DetailedInspectionFarmer({
     id,
@@ -38,6 +44,10 @@ export function DetailedInspectionFarmer({
     const gltf = useGameGLTF('FarmerAvatar');
     const localAvatarView = useGameState((state) => state.gardenAvatarView);
     const actorRef = useRef<Group>(null);
+    const distanceWalkedRef = useRef(0);
+    const groundYRef = useRef(transform.position[1]);
+    const patrolIndexRef = useRef(transform.patrolRoute.length > 1 ? 1 : 0);
+    const walkAmountRef = useRef(0);
     const { gl } = useThree();
     const model = useMemo(() => {
         const scene = gltf.scene.clone(true);
@@ -59,6 +69,20 @@ export function DetailedInspectionFarmer({
         gl.shadowMap.needsUpdate = true;
     }, [castsRealShadow, gl, model.meshes]);
 
+    useLayoutEffect(() => {
+        const actor = actorRef.current;
+        if (!actor) {
+            return;
+        }
+
+        actor.position.set(...transform.position);
+        actor.rotation.y = transform.rotationY;
+        distanceWalkedRef.current = 0;
+        groundYRef.current = transform.position[1];
+        patrolIndexRef.current = transform.patrolRoute.length > 1 ? 1 : 0;
+        walkAmountRef.current = 0;
+    }, [transform]);
+
     useEffect(
         () => () => {
             model.shadowOnlyMaterial.dispose();
@@ -67,27 +91,87 @@ export function DetailedInspectionFarmer({
         [gl.domElement, model.shadowOnlyMaterial],
     );
 
-    useFrame(({ clock, gl: frameGl }, delta) => {
+    useFrame(({ clock, gl: frameGl }, frameDelta) => {
         const actor = actorRef.current;
         if (!actor) {
             return;
         }
 
+        const delta = Math.min(frameDelta, 0.05);
+        const route = transform.patrolRoute;
+        let movingSpeed = 0;
+        const target = route[patrolIndexRef.current];
+        if (route.length > 1 && target) {
+            const dx = target.x - actor.position.x;
+            const dz = target.z - actor.position.z;
+            const distance = Math.hypot(dx, dz);
+            if (distance <= 0.04) {
+                patrolIndexRef.current =
+                    (patrolIndexRef.current + 1) % route.length;
+            } else {
+                const travel = Math.min(
+                    distance,
+                    inspectionFarmerWalkSpeed * delta,
+                );
+                const movement = resolveGardenAvatarHorizontalMovement({
+                    deltaX: (dx / distance) * travel,
+                    deltaZ: (dz / distance) * travel,
+                    position: {
+                        x: actor.position.x,
+                        y: groundYRef.current,
+                        z: actor.position.z,
+                    },
+                    world: transform.world,
+                });
+                const moved = Math.hypot(
+                    movement.position.x - actor.position.x,
+                    movement.position.z - actor.position.z,
+                );
+                actor.position.x = movement.position.x;
+                actor.position.z = movement.position.z;
+                groundYRef.current = movement.position.y;
+                actor.rotation.y = dampGardenAvatarAngle(
+                    actor.rotation.y,
+                    -Math.atan2(dx, -dz),
+                    inspectionFarmerTurnDamping,
+                    delta,
+                );
+                movingSpeed = moved / Math.max(delta, 0.001);
+                distanceWalkedRef.current += moved;
+                if (movement.collided && moved < 0.002) {
+                    patrolIndexRef.current =
+                        (patrolIndexRef.current + 1) % route.length;
+                }
+            }
+        }
+        actor.position.y = MathUtils.damp(
+            actor.position.y,
+            groundYRef.current,
+            inspectionFarmerGroundDamping,
+            delta,
+        );
+        walkAmountRef.current = MathUtils.damp(
+            walkAmountRef.current,
+            movingSpeed > 0.02 ? 1 : 0,
+            8,
+            delta,
+        );
+
         animateGardenAvatarRig({
             crouchAmount: 0,
-            delta: Math.min(delta, 0.05),
-            distanceWalked: 0,
+            delta,
+            distanceWalked: distanceWalkedRef.current,
             grounded: true,
             headPitch: Math.sin(clock.elapsedTime * 0.7) * 0.035,
             rig: model.rig,
-            walkAmount: 0,
+            walkAmount: walkAmountRef.current,
         });
         if (castsRealShadow) {
             frameGl.shadowMap.needsUpdate = true;
         }
         updateActorGroundingShadow?.({
             actorY: actor.position.y,
-            receiverY: transform.position[1],
+            receiverY: groundYRef.current,
             visible: !castsRealShadow,
             x: actor.position.x,
             yaw: actor.rotation.y,
@@ -150,6 +234,7 @@ export function DetailedInspectionFarmer({
                 message={message}
                 offsetY={inspectionFarmerSpeechOffsetY}
                 onClick={handleBubbleOpen}
+                wide
             />
         </>
     );

--- a/packages/game/src/entities/avatar/GardenAvatar.tsx
+++ b/packages/game/src/entities/avatar/GardenAvatar.tsx
@@ -38,7 +38,6 @@ import {
     createGardenAvatarCollisionWorld,
     findGardenAvatarRoute,
     findGardenAvatarSpawnPoint,
-    type GardenAvatarCollisionWorld,
     type GardenAvatarPoint,
     gardenAvatarCrouchingCollisionHeight,
     gardenAvatarMaxJumpClimbHeight,
@@ -47,8 +46,7 @@ import {
     getGardenAvatarCeilingY,
     getGardenAvatarGroundY,
     getGardenAvatarNextJumpCount,
-    getGardenAvatarRoamBlockedCells,
-    getGardenAvatarSurfaceY,
+    getGardenAvatarRoamTargets,
     resolveGardenAvatarHorizontalMovement,
 } from './gardenAvatarMovement';
 import {
@@ -363,28 +361,6 @@ export function animateGardenAvatarRig({
     }
 }
 
-function createRoamTargetCandidates(world: GardenAvatarCollisionWorld) {
-    const blocked = new Set(
-        getGardenAvatarRoamBlockedCells(world).map(
-            (cell) => `${Math.round(cell.x)}:${Math.round(cell.z)}`,
-        ),
-    );
-    return world.surfaces
-        .filter(
-            (surface) =>
-                surface.kind === 'ground' &&
-                surface.roamable !== false &&
-                !blocked.has(
-                    `${Math.round(surface.x)}:${Math.round(surface.z)}`,
-                ),
-        )
-        .map((surface) => ({
-            x: surface.x,
-            y: getGardenAvatarSurfaceY(surface, surface),
-            z: surface.z,
-        }));
-}
-
 function easeInOutCubic(value: number) {
     return value < 0.5
         ? 4 * value * value * value
@@ -661,7 +637,7 @@ export function GardenAvatar({
         [blockData, stacks],
     );
     const roamCandidates = useMemo(
-        () => createRoamTargetCandidates(world),
+        () => getGardenAvatarRoamTargets(world),
         [world],
     );
     const updateActorGroundingShadow = useActorGroundingShadow({

--- a/packages/game/src/entities/avatar/detailedInspectionFarmerPosition.ts
+++ b/packages/game/src/entities/avatar/detailedInspectionFarmerPosition.ts
@@ -2,18 +2,88 @@ import type { BlockData } from '@gredice/client';
 import type { Stack } from '../../types/Stack';
 import {
     createGardenAvatarCollisionWorld,
+    findGardenAvatarRoute,
     findGardenAvatarSpawnPoint,
-    getGardenAvatarGroundY,
-    getGardenAvatarRoamBlockedCells,
+    type GardenAvatarCollisionWorld,
+    type GardenAvatarPoint,
+    getGardenAvatarRoamTargets,
 } from './gardenAvatarMovement';
 
 export type DetailedInspectionFarmerTransform = {
+    patrolRoute: GardenAvatarPoint[];
     position: [x: number, y: number, z: number];
     rotationY: number;
+    world: GardenAvatarCollisionWorld;
 };
 
-function gridCellKey(point: { x: number; z: number }) {
-    return `${Math.round(point.x).toString()}:${Math.round(point.z).toString()}`;
+const inspectionFarmerPatrolRadius = 2.5;
+
+function horizontalDistance(left: GardenAvatarPoint, right: GardenAvatarPoint) {
+    return Math.hypot(left.x - right.x, left.z - right.z);
+}
+
+function sameHorizontalPoint(
+    left: GardenAvatarPoint,
+    right: GardenAvatarPoint,
+) {
+    return left.x === right.x && left.z === right.z;
+}
+
+function createDetailedInspectionFarmerPatrolRoute({
+    center,
+    spawn,
+    targets,
+    world,
+}: {
+    center: GardenAvatarPoint;
+    spawn: GardenAvatarPoint;
+    targets: GardenAvatarPoint[];
+    world: GardenAvatarCollisionWorld;
+}) {
+    const nearbyTargets = targets
+        .filter(
+            (target) =>
+                horizontalDistance(target, center) <=
+                inspectionFarmerPatrolRadius,
+        )
+        .sort(
+            (left, right) =>
+                Math.atan2(left.z - center.z, left.x - center.x) -
+                Math.atan2(right.z - center.z, right.x - center.x),
+        );
+    const spawnIndex = nearbyTargets.findIndex((target) =>
+        sameHorizontalPoint(target, spawn),
+    );
+    const orderedTargets =
+        spawnIndex <= 0
+            ? nearbyTargets
+            : [
+                  ...nearbyTargets.slice(spawnIndex),
+                  ...nearbyTargets.slice(0, spawnIndex),
+              ];
+    const route = [spawn];
+    let current = spawn;
+
+    for (const target of [...orderedTargets.slice(1), spawn]) {
+        if (sameHorizontalPoint(current, target)) {
+            continue;
+        }
+
+        const segment = findGardenAvatarRoute({
+            from: current,
+            to: target,
+            world,
+        });
+        const destination = segment.at(-1);
+        if (!destination || !sameHorizontalPoint(destination, target)) {
+            continue;
+        }
+
+        route.push(...segment.slice(1));
+        current = destination;
+    }
+
+    return route;
 }
 
 export function findDetailedInspectionFarmerTransform({
@@ -25,6 +95,10 @@ export function findDetailedInspectionFarmerTransform({
     stacks: Stack[] | undefined;
     targetBlockId: string | null | undefined;
 }): DetailedInspectionFarmerTransform | null {
+    if (!blockData?.length || !stacks?.length) {
+        return null;
+    }
+
     const world = createGardenAvatarCollisionWorld({ blockData, stacks });
     const targetStack = stacks?.find((stack) =>
         stack.blocks.some((block) => block.id === targetBlockId),
@@ -33,53 +107,43 @@ export function findDetailedInspectionFarmerTransform({
     if (!targetStack) {
         return fallback
             ? {
+                  patrolRoute: [fallback],
                   position: [fallback.x, fallback.y, fallback.z],
                   rotationY: 0,
+                  world,
               }
             : null;
     }
 
-    const blockedCellKeys = new Set(
-        getGardenAvatarRoamBlockedCells(world).map(gridCellKey),
-    );
-
-    const walkableCandidate = world.surfaces
-        .filter(
-            (surface) =>
-                surface.kind === 'ground' &&
-                surface.roamable !== false &&
-                !blockedCellKeys.has(gridCellKey(surface)),
-        )
-        .map((surface) => ({
-            distance: Math.hypot(
-                surface.x - targetStack.position.x,
-                surface.z - targetStack.position.z,
-            ),
-            point: {
-                x: surface.x,
-                y: surface.y,
-                z: surface.z,
-            },
+    const roamTargets = getGardenAvatarRoamTargets(world);
+    const targetPosition = {
+        x: targetStack.position.x,
+        y: targetStack.position.y,
+        z: targetStack.position.z,
+    };
+    const walkableCandidate = roamTargets
+        .map((point) => ({
+            distance: horizontalDistance(point, targetPosition),
+            point,
         }))
-        .sort((left, right) => left.distance - right.distance)
-        .find(
-            ({ point }) =>
-                getGardenAvatarGroundY({
-                    currentGroundY: point.y,
-                    position: point,
-                    world,
-                }) !== null,
-        )?.point;
+        .sort((left, right) => left.distance - right.distance)[0]?.point;
     const spawn = walkableCandidate ?? fallback;
     if (!spawn) {
         return null;
     }
 
     return {
+        patrolRoute: createDetailedInspectionFarmerPatrolRoute({
+            center: targetPosition,
+            spawn,
+            targets: roamTargets,
+            world,
+        }),
         position: [spawn.x, spawn.y, spawn.z],
         rotationY: Math.atan2(
             targetStack.position.x - spawn.x,
             targetStack.position.z - spawn.z,
         ),
+        world,
     };
 }

--- a/packages/game/src/entities/avatar/detailedInspectionFarmerPosition.unit.ts
+++ b/packages/game/src/entities/avatar/detailedInspectionFarmerPosition.unit.ts
@@ -60,10 +60,19 @@ test('places the inspection farmer on walkable ground near the inspected bed', (
             stacks.push({
                 blocks: [
                     {
-                        id: `ground-${x.toString()}-${z.toString()}`,
+                        id: `ground-lower-${x.toString()}-${z.toString()}`,
                         name: 'Block_Grass',
                         rotation: 0,
                     },
+                    ...(x === 0 && z === 0
+                        ? []
+                        : [
+                              {
+                                  id: `ground-upper-${x.toString()}-${z.toString()}`,
+                                  name: 'Block_Grass',
+                                  rotation: 0,
+                              },
+                          ]),
                     ...(x === 0 && z === 0
                         ? [
                               {
@@ -88,7 +97,18 @@ test('places the inspection farmer on walkable ground near the inspected bed', (
     assert.ok(transform);
     assert.notDeepEqual(transform.position, [0, 0, 0]);
     assert.equal(Math.hypot(transform.position[0], transform.position[2]), 1);
-    assert.equal(transform.position[1], 0.2);
+    assert.equal(transform.position[1], 0.4);
+    assert.ok(transform.patrolRoute.length > 4);
+    assert.deepEqual(transform.patrolRoute[0], {
+        x: transform.position[0],
+        y: transform.position[1],
+        z: transform.position[2],
+    });
+    assert.deepEqual(transform.patrolRoute.at(-1), transform.patrolRoute[0]);
+    assert.equal(
+        transform.patrolRoute.some((point) => point.x === 0 && point.z === 0),
+        false,
+    );
 });
 
 test('falls back to the garden spawn when the inspected block is unavailable', () => {
@@ -103,8 +123,23 @@ test('falls back to the garden spawn when the inspected block is unavailable', (
         targetBlockId: null,
     });
 
-    assert.deepEqual(transform, {
-        position: [2, 0.2, 3],
-        rotationY: 0,
+    assert.ok(transform);
+    assert.deepEqual(transform.position, [2, 0.2, 3]);
+    assert.equal(transform.rotationY, 0);
+    assert.deepEqual(transform.patrolRoute, [{ x: 2, y: 0.2, z: 3 }]);
+});
+
+test('waits for block metadata before placing the inspection farmer', () => {
+    const transform = findDetailedInspectionFarmerTransform({
+        blockData: undefined,
+        stacks: [
+            {
+                blocks: [{ id: 'ground', name: 'Block_Grass', rotation: 0 }],
+                position: new Vector3(2, 0, 3),
+            },
+        ],
+        targetBlockId: null,
     });
+
+    assert.equal(transform, null);
 });

--- a/packages/game/src/entities/avatar/gardenAvatarMovement.ts
+++ b/packages/game/src/entities/avatar/gardenAvatarMovement.ts
@@ -654,6 +654,16 @@ function createWalkableSurfaceMap(world: GardenAvatarCollisionWorld) {
     return surfaces;
 }
 
+export function getGardenAvatarRoamTargets(
+    world: GardenAvatarCollisionWorld,
+): GardenAvatarPoint[] {
+    return [...createWalkableSurfaceMap(world).values()].map((surface) => ({
+        x: surface.x,
+        y: surface.y,
+        z: surface.z,
+    }));
+}
+
 export function getGardenAvatarNextJumpCount({
     grounded,
     jumpsUsed,

--- a/packages/game/src/entities/avatar/gardenAvatarMovement.unit.ts
+++ b/packages/game/src/entities/avatar/gardenAvatarMovement.unit.ts
@@ -13,6 +13,7 @@ import {
     getGardenAvatarGroundY,
     getGardenAvatarNextJumpCount,
     getGardenAvatarRoamBlockedCells,
+    getGardenAvatarRoamTargets,
     getGardenAvatarSurfaceY,
     resolveGardenAvatarHorizontalMovement,
 } from './gardenAvatarMovement';
@@ -168,6 +169,9 @@ test('uses complete stack heights as walkable avatar terrain', () => {
 
     assert.equal(world.blockedCells.length, 0);
     assert.equal(Math.max(...world.surfaces.map((surface) => surface.y)), 0.8);
+    assert.deepEqual(getGardenAvatarRoamTargets(world), [
+        { x: 2, y: 0.8, z: -1 },
+    ]);
 });
 
 test('follows angled terrain height continuously instead of flattening it', () => {


### PR DESCRIPTION
## What changed

- widen the raised-bed inspection advisor bubble for more readable advice
- place the advisor on the highest collision-safe terrain surface and wait for block metadata before rendering
- add a continuous, collision-aware walking loop around the reviewed raised bed using the existing avatar pathfinding and grounding logic
- keep the speech bubble and projected shadow attached while the advisor moves
- add unit and WebGL component regression coverage for stacked terrain, patrol movement, bubble sizing, and opening the review

## Root cause

The advisor selected its initial position from raw terrain surfaces. On stacked terrain, the first matching surface could be below the visible top block, leaving the model underground. The advisor also rendered before block metadata was available and had no movement state.

## Validation

- `pnpm --filter @gredice/game test` (877 passed)
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter garden build`
- `pnpm --filter garden exec playwright test tests/detailed-inspection-farmer.spec.tsx tests/actor-speech-bubble.spec.tsx --project=chromium-webgl` (6 passed)
- focused Biome check on all changed TypeScript/TSX/config files
- `git diff --check`