### PR TITLE
fix(ai): hide internal IDs in Suncokret answers

### DIFF
--- a/apps/api/lib/ai/suncokretContext.node.spec.ts
+++ b/apps/api/lib/ai/suncokretContext.node.spec.ts
@@ -57,6 +57,9 @@ test('buildSuncokretSystemPrompt requires structured actionable recommendations'
     assert.match(prompt, /ne dodaje ništa u košaricu/);
     assert.match(prompt, /ručno naručiti/);
     assert.match(prompt, /dodaš u košaricu/);
+    assert.match(prompt, /ID-evi radnji, biljaka i sorti interni su podaci/);
+    assert.match(prompt, /Nikada ih ne spominji korisniku/);
+    assert.match(prompt, /Brojevi polja u gredici korisnički su vidljivi/);
 });
 
 test('buildSuncokretSystemPrompt describes the active settings section', () => {
@@ -135,6 +138,8 @@ test('buildSuncokretFinalAnswerSystemPrompt forbids internal tool protocols', ()
     const prompt = buildSuncokretFinalAnswerSystemPrompt('Osnovne upute.');
 
     assert.match(prompt, /više ne koristi alate/);
+    assert.match(prompt, /Ne spominji interne brojčane ID-eve radnji/);
+    assert.match(prompt, /broj polja smiješ navesti/);
     assert.match(prompt, /Nikada ne ispisuj poziv alata, DSML, XML, JSON/);
     assert.match(prompt, /običnim hrvatskim jezikom/);
 });

--- a/apps/api/lib/ai/suncokretContext.ts
+++ b/apps/api/lib/ai/suncokretContext.ts
@@ -119,9 +119,10 @@ export function buildSuncokretSystemPrompt(input: {
         'Ne zovi isti alat s istim argumentima više puta u jednom odgovoru. Nakon dohvaćanja podataka nastavi korisniku završnim odgovorom; ne završavaj razgovor samo na rezultatu alata.',
         'Kada korisnik pita što treba napraviti ovaj tjedan, odgovori s naslovom "Plan za ovaj tjedan" i 3-6 prioriteta. Za svaki prioritet navedi zašto je važan, kada ga napraviti ako podaci imaju termin i koju Gredice radnju naručiti kada postoji odgovarajuća radnja.',
         'Korisnik nema nužno fizički pristup gredici. Kada preporuka traži rad na gredici, predloži naručivanje odgovarajuće radnje ili sijanja kroz dostupne alate.',
+        'Brojčani ID-evi radnji, biljaka i sorti interni su podaci namijenjeni isključivo argumentima alata. Nikada ih ne spominji korisniku i ne piši izraze poput "radnja 320", "ID radnje 320" ili "biljka #123". Umjesto toga koristi naziv radnje, biljke ili sorte. Brojevi polja u gredici korisnički su vidljivi i smiješ ih navoditi.',
         'Kada u završnom odgovoru preporučiš konkretnu dostupnu Gredice radnju ili sijanje za određenu gredicu ili polje, nakon provjere kataloga pozovi presentRecommendations kako bi korisnik dobio klikabilne prijedloge. Ako si radnju pronašao kroz searchDirectory, obavezno je provjeri kroz getOperationsDirectory kako bi znao odnosi li se na cijelu gredicu ili biljku. Za biljnu radnju pošalji zaseban prijedlog za svako ciljano polje i uvijek navedi positionIndex; nikada ne šalji biljnu radnju bez positionIndex. Prikaži samo stavke koje doista preporučuješ, najviše šest. Taj alat ne dodaje ništa u košaricu.',
         'Uz klikabilne prijedloge kratko reci da ih korisnik može otvoriti i ručno naručiti ili zatražiti da ih dodaš u košaricu.',
-        'Radnje za cijelu gredicu i primjenjive radnje za biljku na pojedinom polju mogu se naručiti alatom addOperationToCart nakon što iz kataloga dohvatiš ID radnje. Za radnju cijele gredice navedi gredicu, ali nikada indeks polja, čak ni kada je polje trenutačno u fokusu. Za biljnu radnju uvijek navedi gredicu i indeks polja.',
+        'Radnje za cijelu gredicu i primjenjive radnje za biljku na pojedinom polju mogu se naručiti alatom addOperationToCart nakon što iz kataloga dohvatiš interni ID radnje. Taj ID koristi samo u argumentima alata, nikada u odgovoru korisniku. Za radnju cijele gredice navedi gredicu, ali nikada indeks polja, čak ni kada je polje trenutačno u fokusu. Za biljnu radnju uvijek navedi gredicu i indeks polja.',
         'Ako neki alat ne podržava traženu promjenu, reci samo da je ne možeš izvršiti iz ovog razgovora. Nemoj iz toga zaključiti da Gredice općenito ne podržavaju ili ne nude tu radnju.',
         'Ne tvrdi da je radnja, sijanje, izmjena košarice ili checkout izvršen dok alat ne potvrdi rezultat.',
         'Za kupnju, checkout, promjene košarice, sijanje, zakazivanje, otkazivanje i druge promjene prvo sažmi što želiš napraviti i koristi alat koji traži odobrenje korisnika.',
@@ -146,6 +147,7 @@ export function buildSuncokretFinalAnswerSystemPrompt(baseSystem: string) {
         baseSystem,
         'Sada više ne koristi alate. Napiši završni odgovor korisniku iz već dohvaćenih podataka.',
         'Ako neki podatak nedostaje, reci to kratko i svejedno daj najbolji praktični odgovor iz dostupnog konteksta.',
+        'Ne spominji interne brojčane ID-eve radnji, biljaka ni sorti. Koristi njihove nazive; broj polja smiješ navesti kada pomaže korisniku prepoznati biljku.',
         'Nikada ne ispisuj poziv alata, DSML, XML, JSON ni drugi interni protokol. Ako si namjeravao pozvati alat, umjesto toga sažmi ono što već znaš običnim hrvatskim jezikom.',
     ].join('\n\n');
 }

--- a/packages/game/src/hud/suncokretChatContext.unit.ts
+++ b/packages/game/src/hud/suncokretChatContext.unit.ts
@@ -142,3 +142,25 @@ test('english model planning without a Croatian answer uses the retry fallback',
     assert.doesNotMatch(sanitized, /I should|tool output/);
     assert.match(sanitized, /Pokušaj ponovno/);
 });
+
+test('internal operation and plant ids are hidden while field numbers remain visible', () => {
+    const sanitized = sanitizeSuncokretAssistantText(
+        [
+            'Za to odaberi Zelenu rezidbu — radnja 320.',
+            'Primjenjuje se na biljku #741 na polju 5.',
+            'Drugi prijedlog ima ID radnje: 321 za polje 11.',
+        ].join('\n'),
+    );
+
+    assert.strictEqual(
+        sanitized,
+        [
+            'Za to odaberi Zelenu rezidbu.',
+            'Primjenjuje se na biljku na polju 5.',
+            'Drugi prijedlog ima radnju za polje 11.',
+        ].join('\n'),
+    );
+    assert.doesNotMatch(sanitized, /\b(?:320|321|741)\b/);
+    assert.match(sanitized, /polju 5/);
+    assert.match(sanitized, /polje 11/);
+});

--- a/packages/js/src/ai/index.ts
+++ b/packages/js/src/ai/index.ts
@@ -111,9 +111,39 @@ const SUNCOKRET_ENGLISH_META_PREAMBLE_PATTERN =
     /^\s*(?:Confirmed\b|I(?:'|’)ll\b|I\s+(?:can|cannot|can't|found|must|need|should|will)\b|Let me\b|The user\b|We need\b)/iu;
 const SUNCOKRET_CROATIAN_ANSWER_START_PATTERN =
     /\b(?:Da|Evo|Gotovo|Mogu|Možeš|Nažalost|Naravno|Ne|Nisam|Prema|Radnja|Razumijem|U Gredicama|Za ovu|Za tu|Zalijevanje)\b/iu;
+const SUNCOKRET_DASHED_INTERNAL_ENTITY_ID_PATTERN =
+    /[ \t]+[—–-][ \t]*(?:radnj(?:a|e|u|om)|operacij(?:a|e|u|om)|biljk(?:a|e|u|om)|sort(?:a|e|u|om))\s+(?:(?:s\s+)?ID(?:-om)?\s*[:#]?\s*|#\s*)?\d+\b/giu;
+const SUNCOKRET_INTERNAL_ENTITY_ID_PATTERN =
+    /\b(radnj(?:a|e|u|om)|operacij(?:a|e|u|om)|biljk(?:a|e|u|om)|sort(?:a|e|u|om))\s+(?:(?:s\s+)?ID(?:-om)?\s*[:#]?\s*|#\s*)?\d+\b/giu;
+const SUNCOKRET_INTERNAL_ID_ENTITY_PATTERN =
+    /\bID\s+(radnje|operacije|biljke|sorte)\s*[:#-]?\s*\d+\b/giu;
 
 export const SUNCOKRET_TOOL_PROTOCOL_FALLBACK =
     'Nisam uspio dovršiti odgovor. Pokušaj ponovno — ne moraš mijenjati pitanje.';
+
+function internalEntityNameWithoutId(value: string) {
+    switch (value.toLocaleLowerCase('hr')) {
+        case 'radnje':
+            return 'radnju';
+        case 'operacije':
+            return 'operaciju';
+        case 'biljke':
+            return 'biljku';
+        case 'sorte':
+            return 'sortu';
+        default:
+            return value;
+    }
+}
+
+function stripSuncokretInternalEntityIds(value: string) {
+    return value
+        .replace(SUNCOKRET_DASHED_INTERNAL_ENTITY_ID_PATTERN, '')
+        .replace(SUNCOKRET_INTERNAL_ENTITY_ID_PATTERN, '$1')
+        .replace(SUNCOKRET_INTERNAL_ID_ENTITY_PATTERN, (_match, entity) =>
+            internalEntityNameWithoutId(entity),
+        );
+}
 
 export function sanitizeSuncokretAssistantText(value: string) {
     const protocolStart = value.search(SUNCOKRET_TOOL_PROTOCOL_PATTERN);
@@ -127,16 +157,22 @@ export function sanitizeSuncokretAssistantText(value: string) {
                       : SUNCOKRET_TOOL_PROTOCOL_FALLBACK;
               })();
 
-    if (!SUNCOKRET_ENGLISH_META_PREAMBLE_PATTERN.test(protocolSafeText)) {
-        return protocolSafeText;
-    }
+    const answerText = SUNCOKRET_ENGLISH_META_PREAMBLE_PATTERN.test(
+        protocolSafeText,
+    )
+        ? (() => {
+              const answerStart =
+                  SUNCOKRET_CROATIAN_ANSWER_START_PATTERN.exec(
+                      protocolSafeText,
+                  );
 
-    const answerStart =
-        SUNCOKRET_CROATIAN_ANSWER_START_PATTERN.exec(protocolSafeText);
+              return answerStart?.index !== undefined
+                  ? protocolSafeText.slice(answerStart.index).trimStart()
+                  : SUNCOKRET_TOOL_PROTOCOL_FALLBACK;
+          })()
+        : protocolSafeText;
 
-    return answerStart?.index !== undefined
-        ? protocolSafeText.slice(answerStart.index).trimStart()
-        : SUNCOKRET_TOOL_PROTOCOL_FALLBACK;
+    return stripSuncokretInternalEntityIds(answerText);
 }
 
 function protectMarkdownLinkDestinations(value: string) {


### PR DESCRIPTION
## What changed

- mark operation, plant, and sort IDs as tool-only data in Suncokret prompts
- reinforce the rule in the final-answer prompt
- sanitize leaked ID references such as `radnja 320` while preserving user-visible field numbers
- add focused prompt and rendering regressions

## Why

Suncokret could echo internal catalogue IDs from tool results in otherwise user-friendly recommendations. Those implementation details are not useful to customers and make answers feel technical.

## Validation

- `pnpm --filter @gredice/game exec tsx --test src/hud/suncokretChatContext.unit.ts`
- `pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/ai/suncokretContext.node.spec.ts`
- scoped Biome checks for all changed files
- `pnpm --filter @gredice/game typecheck`
- `pnpm typecheck --filter garden --filter www`
- `git diff --check`
