### PR TITLE
feat(garden): render available outlet stock in 3D

### DIFF
--- a/apps/garden/tests/OutletGardenOfferBrowserStory.tsx
+++ b/apps/garden/tests/OutletGardenOfferBrowserStory.tsx
@@ -104,9 +104,11 @@ export type OutletGardenOfferBrowserStoryState =
     | 'ready';
 
 export function OutletGardenOfferBrowserStory({
+    displayLimited = false,
     initialSelectedOfferId = null,
     state = 'ready',
 }: {
+    displayLimited?: boolean;
     initialSelectedOfferId?: number | null;
     state?: OutletGardenOfferBrowserStoryState;
 }) {
@@ -120,6 +122,7 @@ export function OutletGardenOfferBrowserStory({
         <div className="h-[100dvh] bg-muted">
             <OutletGardenOfferBrowser
                 className="h-full w-full max-w-md"
+                displayLimited={displayLimited}
                 isError={state === 'error'}
                 isLoading={state === 'loading'}
                 offers={state === 'ready' ? outletOffers : []}

--- a/apps/garden/tests/outlet-garden-route.spec.ts
+++ b/apps/garden/tests/outlet-garden-route.spec.ts
@@ -116,6 +116,10 @@ test('guest Outlet garden renders WebGL, selects an offer, and preserves its dee
     await page.goto('/outlet');
 
     await expect(page.locator('[data-outlet-garden]')).toBeVisible();
+    await expect(page.locator('[data-outlet-garden]')).toHaveAttribute(
+        'data-outlet-garden-display-count',
+        '5',
+    );
     await expect(page.locator('canvas')).toBeVisible();
     await expect(
         page.locator('[data-outlet-garden-offer-list]').getByRole('button'),
@@ -195,6 +199,10 @@ test('guest Outlet garden renders WebGL, selects an offer, and preserves its dee
     await expect(
         page.getByRole('button', { name: /Bosiljak Genovese/u }),
     ).toBeVisible();
+    await expect(page.locator('[data-outlet-garden]')).toHaveAttribute(
+        'data-outlet-garden-display-count',
+        '3',
+    );
     if (canvasElement) {
         expect(
             await canvas.evaluate(

--- a/apps/garden/tests/outlet-garden.spec.tsx
+++ b/apps/garden/tests/outlet-garden.spec.tsx
@@ -1,6 +1,20 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import { OutletGardenOfferBrowserStory } from './OutletGardenOfferBrowserStory';
 
+test('explains when extreme stock is summarized in 3D', async ({
+    mount,
+    page,
+}) => {
+    await mount(<OutletGardenOfferBrowserStory displayLimited />);
+
+    await expect(
+        page.getByText(/najviše 100 sadnica po ponudi i 500 ukupno/u),
+    ).toBeVisible();
+    await expect(
+        page.getByText(/kartice uvijek pokazuju punu dostupnu količinu/u),
+    ).toBeVisible();
+});
+
 test('selects a live offer and exposes truthful read-only details', async ({
     mount,
     page,

--- a/packages/game/src/viewers/OutletGardenOfferBrowser.tsx
+++ b/packages/game/src/viewers/OutletGardenOfferBrowser.tsx
@@ -7,6 +7,10 @@ import { Spinner } from '@gredice/ui/Spinner';
 import { cx } from '@gredice/ui/utils';
 import type { Route } from 'next';
 import type { OutletOfferData } from '../hooks/useOutletOffers';
+import {
+    outletGardenMaxDisplayedUnitsPerOffer,
+    outletGardenMaxDisplayedUnitsTotal,
+} from './outletGardenLayout';
 
 const currencyFormatter = new Intl.NumberFormat('hr-HR', {
     style: 'currency',
@@ -125,6 +129,7 @@ function plantGroupImageUrl(plantGroup: OutletGardenPlantGroup) {
 
 export type OutletGardenOfferBrowserProps = {
     className?: string;
+    displayLimited?: boolean;
     isError: boolean;
     isLoading: boolean;
     offers: readonly OutletOfferData[];
@@ -137,6 +142,7 @@ export type OutletGardenOfferBrowserProps = {
 
 export function OutletGardenOfferBrowser({
     className,
+    displayLimited = false,
     isError,
     isLoading,
     offers,
@@ -206,8 +212,9 @@ export function OutletGardenOfferBrowser({
                     </Button>
                 </div>
                 <p className="mt-2 text-sm text-muted-foreground">
-                    Razgledaj aktualne ponude. Broj 3D sadnica prati trenutno
-                    dostupnu količinu svake ponude.
+                    {displayLimited
+                        ? `Razgledaj aktualne ponude. Za velike zalihe prikazujemo najviše ${outletGardenMaxDisplayedUnitsPerOffer.toString()} sadnica po ponudi i ${outletGardenMaxDisplayedUnitsTotal.toString()} ukupno; kartice uvijek pokazuju punu dostupnu količinu.`
+                        : 'Razgledaj aktualne ponude. Broj 3D sadnica prati trenutno dostupnu količinu svake ponude.'}
                 </p>
             </header>
 

--- a/packages/game/src/viewers/OutletGardenOfferBrowser.tsx
+++ b/packages/game/src/viewers/OutletGardenOfferBrowser.tsx
@@ -206,8 +206,8 @@ export function OutletGardenOfferBrowser({
                     </Button>
                 </div>
                 <p className="mt-2 text-sm text-muted-foreground">
-                    Razgledaj aktualne ponude. Svaka 3D sadnica predstavlja
-                    jednu ponudu, a ne pojedinačni fizički primjerak.
+                    Razgledaj aktualne ponude. Broj 3D sadnica prati trenutno
+                    dostupnu količinu svake ponude.
                 </p>
             </header>
 
@@ -292,7 +292,7 @@ export function OutletGardenOfferBrowser({
                             className="mb-2 text-sm font-semibold"
                             id="outlet-garden-list-title"
                         >
-                            Dostupne sadnice ({offers.length})
+                            Dostupne ponude ({offers.length})
                         </h2>
                         <div
                             className="space-y-4"

--- a/packages/game/src/viewers/OutletGardenSeedlingMarkers.tsx
+++ b/packages/game/src/viewers/OutletGardenSeedlingMarkers.tsx
@@ -16,7 +16,6 @@ import {
     MAX_PLANT_GENERATION,
     type PlantDefinition,
 } from '../generators/plant/lib/plant-definitions';
-import { getApproximatePlantHeight } from '../generators/plant/lib/plantRenderData';
 import { useBlockData } from '../hooks/useBlockData';
 import type { OutletOfferData } from '../hooks/useOutletOffers';
 import { getStackHeight } from '../utils/getStackHeight';
@@ -123,10 +122,11 @@ function resolveOutletGardenPlantPreset(offer: OutletOfferData) {
 }
 
 type OutletGardenSeedlingMarker = {
+    blockId: string;
     fallbackColor: string;
     generation: number;
-    highlightHeight: number;
-    id: number;
+    highlightPosition: THREE.Vector3;
+    offerId: number;
     position: THREE.Vector3;
     preset: ResolvedInGamePlantPreset | null;
     rotation: number;
@@ -149,57 +149,21 @@ function OutletGardenSeedlingHighlight({
 }: {
     marker: OutletGardenSeedlingMarker;
 }) {
-    const height = marker.highlightHeight;
-    const radius = Math.min(0.42, Math.max(0.27, height * 0.32));
-
     return (
         <group
-            name={`OutletGardenSeedlingHighlight:${marker.id.toString()}`}
-            position={marker.position}
+            name={`OutletGardenSeedlingHighlight:${marker.blockId}`}
+            position={marker.highlightPosition}
         >
-            <mesh
-                position={[0, 0.018, 0]}
-                renderOrder={42}
-                rotation={[-Math.PI / 2, 0, 0]}
-            >
-                <ringGeometry args={[radius * 0.72, radius, 32]} />
+            <mesh position={[0, 0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+                <ringGeometry args={[0.32, 0.4, 32]} />
                 <meshBasicMaterial
-                    color="#facc15"
-                    depthTest={false}
+                    color="#eab308"
+                    depthTest
                     depthWrite={false}
-                    opacity={0.95}
-                    side={THREE.DoubleSide}
-                    toneMapped={false}
-                    transparent
-                />
-            </mesh>
-            <mesh position={[0, height / 2, 0]} renderOrder={41}>
-                <cylinderGeometry
-                    args={[radius * 0.55, radius, height, 20, 1, true]}
-                />
-                <meshBasicMaterial
-                    blending={THREE.AdditiveBlending}
-                    color="#fde047"
-                    depthTest={false}
-                    depthWrite={false}
-                    opacity={0.18}
-                    side={THREE.DoubleSide}
-                    toneMapped={false}
-                    transparent
-                />
-            </mesh>
-            <mesh
-                position={[0, height * 0.62, 0]}
-                renderOrder={43}
-                rotation={[-Math.PI / 2, 0, 0]}
-            >
-                <ringGeometry args={[radius * 0.68, radius * 0.86, 32]} />
-                <meshBasicMaterial
-                    blending={THREE.AdditiveBlending}
-                    color="#fef08a"
-                    depthTest={false}
-                    depthWrite={false}
-                    opacity={0.72}
+                    opacity={0.78}
+                    polygonOffset
+                    polygonOffsetFactor={-1}
+                    polygonOffsetUnits={-1}
                     side={THREE.DoubleSide}
                     toneMapped={false}
                     transparent
@@ -216,7 +180,7 @@ function OutletGardenFallbackSeedling({
 }) {
     return (
         <group
-            name={`OutletGardenFallbackSeedling:${marker.id.toString()}`}
+            name={`OutletGardenFallbackSeedling:${marker.blockId}`}
             position={marker.position}
             rotation={[0, marker.rotation, 0]}
             scale={0.78}
@@ -295,31 +259,20 @@ export function OutletGardenSeedlingMarkers({
                 const scale = preset
                     ? getInGamePlantInstanceScale(preset, 1) * 1.12
                     : 0.78;
-                const highlightHeight = preset
-                    ? Math.min(
-                          1.3,
-                          Math.max(
-                              0.28,
-                              getApproximatePlantHeight(preset.definition) *
-                                  scale *
-                                  Math.max(
-                                      0.28,
-                                      stage.generation / MAX_PLANT_GENERATION,
-                                  ),
-                          ),
-                      )
-                    : 0.48;
 
                 return [
                     {
+                        blockId: block.id,
                         fallbackColor:
                             fallbackLeafColors[
                                 Math.abs(plantVisualId) %
                                     fallbackLeafColors.length
                             ] ?? fallbackLeafColors[0],
                         generation: stage.generation,
-                        highlightHeight,
-                        id: offerId,
+                        highlightPosition: stack.position
+                            .clone()
+                            .setY(getStackHeight(blockData, stack, block)),
+                        offerId,
                         position: stack.position
                             .clone()
                             .setY(getStackHeight(blockData, stack) + 0.02),
@@ -373,9 +326,6 @@ export function OutletGardenSeedlingMarkers({
             fallbackMarkers: fallback,
         };
     }, [markers]);
-    const highlightedMarker =
-        markers.find((marker) => marker.id === highlightedOfferId) ?? null;
-
     return (
         <group
             name="OutletGardenSeedlingMarkers"
@@ -393,11 +343,19 @@ export function OutletGardenSeedlingMarkers({
                 />
             ))}
             {fallbackMarkers.map((marker) => (
-                <OutletGardenFallbackSeedling key={marker.id} marker={marker} />
+                <OutletGardenFallbackSeedling
+                    key={marker.blockId}
+                    marker={marker}
+                />
             ))}
-            {highlightedMarker ? (
-                <OutletGardenSeedlingHighlight marker={highlightedMarker} />
-            ) : null}
+            {markers
+                .filter((marker) => marker.offerId === highlightedOfferId)
+                .map((marker) => (
+                    <OutletGardenSeedlingHighlight
+                        key={marker.blockId}
+                        marker={marker}
+                    />
+                ))}
         </group>
     );
 }

--- a/packages/game/src/viewers/OutletGardenViewer.tsx
+++ b/packages/game/src/viewers/OutletGardenViewer.tsx
@@ -13,6 +13,7 @@ import { OutletGardenSeedlingMarkers } from './OutletGardenSeedlingMarkers';
 import {
     buildOutletGardenDetail,
     getOutletGardenDisplayUnits,
+    isOutletGardenDisplayLimited,
     type OutletGardenLayoutOffer,
     type OutletGardenSlotAssignments,
     outletOfferBlockId,
@@ -156,6 +157,10 @@ export function OutletGardenViewer() {
 
     const displayUnits = useMemo(
         () => getOutletGardenDisplayUnits(layoutOffers),
+        [layoutOffers],
+    );
+    const displayLimited = useMemo(
+        () => isOutletGardenDisplayLimited(layoutOffers),
         [layoutOffers],
     );
     const layoutReady = displayUnits.every((display) =>
@@ -332,6 +337,7 @@ export function OutletGardenViewer() {
             className={`relative grid h-[100dvh] grid-rows-[minmax(0,1fr)_minmax(18rem,46dvh)] overflow-hidden bg-[#cfeaca] lg:grid-cols-[minmax(0,1fr)_24rem] lg:grid-rows-1 ${exitTarget ? 'motion-safe:animate-out motion-safe:fade-out-0 motion-safe:zoom-out-95 motion-safe:duration-200' : 'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:zoom-in-95 motion-safe:duration-500'}`}
             data-outlet-garden
             data-outlet-garden-display-count={displayUnits.length}
+            data-outlet-garden-display-limited={displayLimited || undefined}
             data-outlet-garden-exiting={exitTarget ? true : undefined}
             data-outlet-garden-hovered-offer={hoveredOfferId ?? undefined}
         >
@@ -408,6 +414,7 @@ export function OutletGardenViewer() {
             </main>
 
             <OutletGardenOfferBrowser
+                displayLimited={displayLimited}
                 isError={isError}
                 isLoading={isLoading}
                 offers={offers}

--- a/packages/game/src/viewers/OutletGardenViewer.tsx
+++ b/packages/game/src/viewers/OutletGardenViewer.tsx
@@ -12,9 +12,11 @@ import { OutletGardenOfferBrowser } from './OutletGardenOfferBrowser';
 import { OutletGardenSeedlingMarkers } from './OutletGardenSeedlingMarkers';
 import {
     buildOutletGardenDetail,
+    getOutletGardenDisplayUnits,
     type OutletGardenLayoutOffer,
     type OutletGardenSlotAssignments,
     outletOfferBlockId,
+    outletOfferDisplayFromBlockId,
     outletOfferIdFromBlockId,
     reconcileOutletGardenSlots,
 } from './outletGardenLayout';
@@ -27,6 +29,7 @@ import {
 } from './PublicGardenViewer';
 
 const outletGardenPreviewTime = new Date('2026-06-21T10:00:00.000Z');
+const outletGardenCameraMinZoom = 10;
 
 function OutletGardenScenePlaceholder({ label }: { label: string }) {
     return (
@@ -58,6 +61,7 @@ export function OutletGardenViewer() {
         parseAsInteger,
     );
     const [hoveredOfferId, setHoveredOfferId] = useState<number | null>(null);
+    const [focusedBlockId, setFocusedBlockId] = useState<string | null>(null);
     const { track } = useGameAnalytics();
     const openedTrackedRef = useRef(false);
     const sceneReadyTrackedRef = useRef(false);
@@ -82,13 +86,22 @@ export function OutletGardenViewer() {
                             id: offer.id,
                             plantId: offer.plantSort.plant?.id ?? null,
                             plantSortId: offer.plantSort.id,
+                            remainingQuantity: Math.max(
+                                0,
+                                Math.trunc(offer.remainingQuantity),
+                            ),
                         },
                     ]),
                 ).values(),
             )
                 .sort((left, right) => left.id - right.id)
                 .map((offer) =>
-                    [offer.id, offer.plantId ?? 0, offer.plantSortId].join(':'),
+                    [
+                        offer.id,
+                        offer.plantId ?? 0,
+                        offer.plantSortId,
+                        offer.remainingQuantity,
+                    ].join(':'),
                 )
                 .join(','),
         [offers],
@@ -99,16 +112,21 @@ export function OutletGardenViewer() {
         }
 
         return layoutOffersKey.split(',').flatMap((encodedOffer) => {
-            const [offerIdValue, plantIdValue, plantSortIdValue] = encodedOffer
-                .split(':')
-                .map(Number);
+            const [
+                offerIdValue,
+                plantIdValue,
+                plantSortIdValue,
+                remainingQuantityValue,
+            ] = encodedOffer.split(':').map(Number);
             if (
                 !Number.isSafeInteger(offerIdValue) ||
                 !Number.isSafeInteger(plantIdValue) ||
                 !Number.isSafeInteger(plantSortIdValue) ||
+                !Number.isSafeInteger(remainingQuantityValue) ||
                 offerIdValue <= 0 ||
                 plantIdValue < 0 ||
-                plantSortIdValue <= 0
+                plantSortIdValue <= 0 ||
+                remainingQuantityValue < 0
             ) {
                 return [];
             }
@@ -118,6 +136,7 @@ export function OutletGardenViewer() {
                     id: offerIdValue,
                     plantId: plantIdValue === 0 ? null : plantIdValue,
                     plantSortId: plantSortIdValue,
+                    remainingQuantity: remainingQuantityValue,
                 } satisfies OutletGardenLayoutOffer,
             ];
         });
@@ -135,22 +154,31 @@ export function OutletGardenViewer() {
         }
     }, [reconciledSlotAssignments, slotAssignments]);
 
-    const layoutReady = layoutOffers.every((offer) =>
-        reconciledSlotAssignments.has(offer.id),
+    const displayUnits = useMemo(
+        () => getOutletGardenDisplayUnits(layoutOffers),
+        [layoutOffers],
+    );
+    const layoutReady = displayUnits.every((display) =>
+        reconciledSlotAssignments.has(display.blockId),
     );
     const outletGarden = useMemo(
         () => buildOutletGardenDetail(layoutOffers, reconciledSlotAssignments),
         [layoutOffers, reconciledSlotAssignments],
     );
     const interactiveBlockIds = useMemo(
-        () =>
-            new Set(layoutOffers.map((offer) => outletOfferBlockId(offer.id))),
-        [layoutOffers],
+        () => new Set(displayUnits.map((display) => display.blockId)),
+        [displayUnits],
     );
     const selectedOffer =
         offers.find((offer) => offer.id === selectedOfferId) ?? null;
+    const focusedDisplay = focusedBlockId
+        ? outletOfferDisplayFromBlockId(focusedBlockId)
+        : null;
     const selectedBlockId = selectedOffer
-        ? outletOfferBlockId(selectedOffer.id)
+        ? focusedDisplay?.offerId === selectedOffer.id &&
+          interactiveBlockIds.has(focusedBlockId ?? '')
+            ? focusedBlockId
+            : outletOfferBlockId(selectedOffer.id)
         : null;
 
     useEffect(() => {
@@ -202,7 +230,7 @@ export function OutletGardenViewer() {
 
         setSceneInitialView(
             getPublicGardenCaptureInitialView({
-                minimumZoom: 18,
+                minimumZoom: outletGardenCameraMinZoom,
                 stacks: normalizePublicGardenStacks(
                     publicGardenStacksFromResponse(outletGarden.stacks),
                 ),
@@ -272,12 +300,14 @@ export function OutletGardenViewer() {
     }, [exitTarget, router]);
 
     const selectOffer = useCallback(
-        (offerId: number | null) => {
+        (offerId: number | null, blockId?: string) => {
             void setSelectedOfferId(offerId);
             if (offerId === null) {
+                setFocusedBlockId(null);
                 return;
             }
 
+            setFocusedBlockId(blockId ?? outletOfferBlockId(offerId));
             const offer = offers.find((candidate) => candidate.id === offerId);
             track('game_outlet_garden_offer_viewed', {
                 outlet_offer_id: offerId,
@@ -291,7 +321,7 @@ export function OutletGardenViewer() {
         (blockId: string) => {
             const offerId = outletOfferIdFromBlockId(blockId);
             if (offerId !== null) {
-                selectOffer(offerId);
+                selectOffer(offerId, blockId);
             }
         },
         [selectOffer],
@@ -301,6 +331,7 @@ export function OutletGardenViewer() {
         <div
             className={`relative grid h-[100dvh] grid-rows-[minmax(0,1fr)_minmax(18rem,46dvh)] overflow-hidden bg-[#cfeaca] lg:grid-cols-[minmax(0,1fr)_24rem] lg:grid-rows-1 ${exitTarget ? 'motion-safe:animate-out motion-safe:fade-out-0 motion-safe:zoom-out-95 motion-safe:duration-200' : 'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:zoom-in-95 motion-safe:duration-500'}`}
             data-outlet-garden
+            data-outlet-garden-display-count={displayUnits.length}
             data-outlet-garden-exiting={exitTarget ? true : undefined}
             data-outlet-garden-hovered-offer={hoveredOfferId ?? undefined}
         >
@@ -311,7 +342,7 @@ export function OutletGardenViewer() {
                 {layoutReady && offers.length > 0 && sceneInitialView ? (
                     <PublicGardenViewer
                         appBaseUrl=""
-                        cameraMinZoom={18}
+                        cameraMinZoom={outletGardenCameraMinZoom}
                         className="size-full"
                         fixedTime={outletGardenPreviewTime}
                         garden={outletGarden}

--- a/packages/game/src/viewers/outletGardenLayout.ts
+++ b/packages/game/src/viewers/outletGardenLayout.ts
@@ -48,6 +48,15 @@ const outletGardenBackMargin = 3;
 const outletGardenVirtualId = -1;
 const outletGardenUpdatedAt = '1970-01-01T00:00:00.000Z';
 
+/**
+ * Outlet tables and pots are individual scene objects. Keep the beta viewer
+ * bounded when an admin enters a bulk quantity or an accidental large value;
+ * the offer browser still shows the complete server-reported stock.
+ */
+export const outletGardenMaxDisplayedUnitsPerOffer = 100;
+export const outletGardenMaxDisplayedUnitsTotal = 500;
+export const outletGardenMaxTrackedTombstones = 500;
+
 const outletGardenPotNames = [
     'PotLowBowl',
     'PotRoundedBowl',
@@ -134,24 +143,81 @@ export function getOutletGardenDisplayUnits(
         }
     }
 
-    return Array.from(offersById.values())
+    const sortedOffers = Array.from(offersById.values())
         .sort(compareOutletGardenOffers)
-        .flatMap((offer) => {
-            const remainingQuantity = Number.isSafeInteger(
-                offer.remainingQuantity,
-            )
-                ? Math.max(0, offer.remainingQuantity)
-                : 0;
+        .map((offer) => ({
+            offer,
+            visualQuantity: Number.isSafeInteger(offer.remainingQuantity)
+                ? Math.min(
+                      outletGardenMaxDisplayedUnitsPerOffer,
+                      Math.max(0, offer.remainingQuantity),
+                  )
+                : 0,
+        }));
+    const displayedQuantityByOffer = new Map<number, number>();
+    let remainingDisplayBudget = outletGardenMaxDisplayedUnitsTotal;
 
-            return Array.from(
-                { length: remainingQuantity },
-                (_, unitIndex) => ({
-                    ...offer,
-                    blockId: outletOfferBlockId(offer.id, unitIndex),
-                    unitIndex,
-                }),
-            );
-        });
+    while (remainingDisplayBudget > 0) {
+        let allocatedInRound = false;
+        for (const { offer, visualQuantity } of sortedOffers) {
+            const displayedQuantity =
+                displayedQuantityByOffer.get(offer.id) ?? 0;
+            if (displayedQuantity >= visualQuantity) {
+                continue;
+            }
+
+            displayedQuantityByOffer.set(offer.id, displayedQuantity + 1);
+            remainingDisplayBudget -= 1;
+            allocatedInRound = true;
+            if (remainingDisplayBudget === 0) {
+                break;
+            }
+        }
+
+        if (!allocatedInRound) {
+            break;
+        }
+    }
+
+    return sortedOffers.flatMap(({ offer }) =>
+        Array.from(
+            { length: displayedQuantityByOffer.get(offer.id) ?? 0 },
+            (_, unitIndex) => ({
+                ...offer,
+                blockId: outletOfferBlockId(offer.id, unitIndex),
+                unitIndex,
+            }),
+        ),
+    );
+}
+
+export function isOutletGardenDisplayLimited(
+    offers: readonly OutletGardenLayoutOffer[],
+) {
+    const offersById = new Map<number, OutletGardenLayoutOffer>();
+    for (const offer of offers) {
+        if (!offersById.has(offer.id)) {
+            offersById.set(offer.id, offer);
+        }
+    }
+
+    let requestedDisplayCount = 0;
+
+    for (const offer of offersById.values()) {
+        const remainingQuantity = Number.isSafeInteger(offer.remainingQuantity)
+            ? Math.max(0, offer.remainingQuantity)
+            : 0;
+        if (remainingQuantity > outletGardenMaxDisplayedUnitsPerOffer) {
+            return true;
+        }
+
+        requestedDisplayCount += remainingQuantity;
+        if (requestedDisplayCount > outletGardenMaxDisplayedUnitsTotal) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 function outletGardenPlantBay(slotIndex: number) {
@@ -159,23 +225,45 @@ function outletGardenPlantBay(slotIndex: number) {
 }
 
 /**
- * Keeps every allocated seedling slot, including stock tombstones. Initial
- * units receive plant-grouped bays with all tabletops filled before floor
- * positions. Later stock fills never-used room in an owned plant bay or a new
- * bay. Existing displays therefore never move during the mounted session.
+ * Initial units receive plant-grouped bays with all tabletops filled before
+ * floor positions. Recent stock tombstones retain their slots up to a bounded
+ * history budget; fully released, pruned bays can then be reused. Existing
+ * visible displays never move during the mounted session.
  */
 export function reconcileOutletGardenSlots(
     previousAssignments: OutletGardenSlotAssignments,
     offers: readonly OutletGardenLayoutOffer[],
 ) {
-    const unseenDisplays = getOutletGardenDisplayUnits(offers).filter(
-        (display) => !previousAssignments.has(display.blockId),
+    const displays = getOutletGardenDisplayUnits(offers);
+    const liveBlockIds = new Set(displays.map((display) => display.blockId));
+    const previousTombstoneIds = Array.from(previousAssignments.keys()).filter(
+        (blockId) => !liveBlockIds.has(blockId),
+    );
+    const excessTombstoneCount = Math.max(
+        0,
+        previousTombstoneIds.length - outletGardenMaxTrackedTombstones,
+    );
+    const retainedAssignments =
+        excessTombstoneCount === 0
+            ? previousAssignments
+            : (() => {
+                  const prunedAssignments = new Map(previousAssignments);
+                  for (const blockId of previousTombstoneIds.slice(
+                      0,
+                      excessTombstoneCount,
+                  )) {
+                      prunedAssignments.delete(blockId);
+                  }
+                  return prunedAssignments;
+              })();
+    const unseenDisplays = displays.filter(
+        (display) => !retainedAssignments.has(display.blockId),
     );
     if (unseenDisplays.length === 0) {
-        return previousAssignments;
+        return retainedAssignments;
     }
 
-    const assignments = new Map(previousAssignments);
+    const assignments = new Map(retainedAssignments);
     const usedSlots = new Set(
         Array.from(assignments.values(), (assignment) => assignment.slotIndex),
     );
@@ -188,13 +276,22 @@ export function reconcileOutletGardenSlots(
         existingPlantBays.set(plantKey, plantBays);
     }
 
-    let nextPlantBay =
-        Math.max(
-            -1,
-            ...Array.from(assignments.values(), (assignment) =>
-                outletGardenPlantBay(assignment.slotIndex),
-            ),
-        ) + 1;
+    const reservedPlantBays = new Set(
+        Array.from(assignments.values(), (assignment) =>
+            outletGardenPlantBay(assignment.slotIndex),
+        ),
+    );
+    let nextPlantBay = 0;
+    const reserveNextPlantBay = () => {
+        while (reservedPlantBays.has(nextPlantBay)) {
+            nextPlantBay += 1;
+        }
+
+        const reservedPlantBay = nextPlantBay;
+        reservedPlantBays.add(reservedPlantBay);
+        nextPlantBay += 1;
+        return reservedPlantBay;
+    };
     const unseenDisplaysByPlant = new Map<string, OutletGardenDisplayUnit[]>();
     for (const display of unseenDisplays) {
         const plantKey = outletGardenPlantKey(display);
@@ -221,8 +318,7 @@ export function reconcileOutletGardenSlots(
                 outletGardenOffersPerPlantBay,
         );
         for (let index = 0; index < newPlantBayCount; index += 1) {
-            plantBays.push(nextPlantBay);
-            nextPlantBay += 1;
+            plantBays.push(reserveNextPlantBay());
         }
 
         const availableSlots = plantBays
@@ -260,6 +356,17 @@ export function reconcileOutletGardenSlots(
             });
             usedSlots.add(slotIndex);
         }
+    }
+
+    const currentTombstoneIds = Array.from(assignments.keys()).filter(
+        (blockId) => !liveBlockIds.has(blockId),
+    );
+    const tombstonesToPrune = Math.max(
+        0,
+        currentTombstoneIds.length - outletGardenMaxTrackedTombstones,
+    );
+    for (const blockId of currentTombstoneIds.slice(0, tombstonesToPrune)) {
+        assignments.delete(blockId);
     }
 
     return assignments;

--- a/packages/game/src/viewers/outletGardenLayout.ts
+++ b/packages/game/src/viewers/outletGardenLayout.ts
@@ -7,17 +7,25 @@ export type OutletGardenLayoutOffer = {
     id: number;
     plantId: number | null;
     plantSortId: number;
+    remainingQuantity: number;
 };
 
 export type OutletGardenSlotAssignment = {
+    offerId: number;
     plantKey: string;
     slotIndex: number;
+    unitIndex: number;
 };
 
 export type OutletGardenSlotAssignments = ReadonlyMap<
-    number,
+    string,
     OutletGardenSlotAssignment
 >;
+
+export type OutletGardenDisplayUnit = OutletGardenLayoutOffer & {
+    blockId: string;
+    unitIndex: number;
+};
 
 export type OutletGardenOfferPlacement = {
     aisleRow: number;
@@ -63,22 +71,37 @@ export const outletGardenRegisteredBlockNames = [
     ...outletGardenPotNames,
 ] as const;
 
-export function outletOfferBlockId(offerId: number) {
-    return `${outletOfferBlockIdPrefix}${offerId.toString()}`;
+export function outletOfferBlockId(offerId: number, unitIndex = 0) {
+    const suffix = unitIndex === 0 ? '' : `:${unitIndex.toString()}`;
+    return `${outletOfferBlockIdPrefix}${offerId.toString()}${suffix}`;
 }
 
-export function outletOfferIdFromBlockId(blockId: string) {
+export function outletOfferDisplayFromBlockId(blockId: string) {
     if (!blockId.startsWith(outletOfferBlockIdPrefix)) {
         return null;
     }
 
-    const rawOfferId = blockId.slice(outletOfferBlockIdPrefix.length);
-    if (!/^[1-9]\d*$/u.test(rawOfferId)) {
+    const encodedDisplay = blockId.slice(outletOfferBlockIdPrefix.length);
+    const match = /^([1-9]\d*)(?::([1-9]\d*))?$/u.exec(encodedDisplay);
+    if (!match) {
         return null;
     }
 
-    const offerId = Number(rawOfferId);
-    return Number.isSafeInteger(offerId) ? offerId : null;
+    const offerId = Number(match[1]);
+    const unitIndex = match[2] ? Number(match[2]) : 0;
+    if (
+        !Number.isSafeInteger(offerId) ||
+        !Number.isSafeInteger(unitIndex) ||
+        unitIndex < 0
+    ) {
+        return null;
+    }
+
+    return { offerId, unitIndex };
+}
+
+export function outletOfferIdFromBlockId(blockId: string) {
+    return outletOfferDisplayFromBlockId(blockId)?.offerId ?? null;
 }
 
 function compareOutletGardenOffers(
@@ -101,18 +124,7 @@ function outletGardenPlantKey(offer: OutletGardenLayoutOffer) {
         : `plant:${offer.plantId.toString()}`;
 }
 
-function outletGardenPlantBay(slotIndex: number) {
-    return Math.floor(slotIndex / outletGardenOffersPerPlantBay);
-}
-
-/**
- * Keeps every allocated slot, including removed-offer tombstones. Initial
- * offers receive plant-grouped bays; later offers fill a never-used slot in an
- * existing plant bay when possible, otherwise they get a new bay. Existing
- * displays therefore never move during the mounted session.
- */
-export function reconcileOutletGardenSlots(
-    previousAssignments: OutletGardenSlotAssignments,
+export function getOutletGardenDisplayUnits(
     offers: readonly OutletGardenLayoutOffer[],
 ) {
     const offersById = new Map<number, OutletGardenLayoutOffer>();
@@ -122,10 +134,44 @@ export function reconcileOutletGardenSlots(
         }
     }
 
-    const unseenOffers = Array.from(offersById.values())
-        .filter((offer) => !previousAssignments.has(offer.id))
-        .sort(compareOutletGardenOffers);
-    if (unseenOffers.length === 0) {
+    return Array.from(offersById.values())
+        .sort(compareOutletGardenOffers)
+        .flatMap((offer) => {
+            const remainingQuantity = Number.isSafeInteger(
+                offer.remainingQuantity,
+            )
+                ? Math.max(0, offer.remainingQuantity)
+                : 0;
+
+            return Array.from(
+                { length: remainingQuantity },
+                (_, unitIndex) => ({
+                    ...offer,
+                    blockId: outletOfferBlockId(offer.id, unitIndex),
+                    unitIndex,
+                }),
+            );
+        });
+}
+
+function outletGardenPlantBay(slotIndex: number) {
+    return Math.floor(slotIndex / outletGardenOffersPerPlantBay);
+}
+
+/**
+ * Keeps every allocated seedling slot, including stock tombstones. Initial
+ * units receive plant-grouped bays with all tabletops filled before floor
+ * positions. Later stock fills never-used room in an owned plant bay or a new
+ * bay. Existing displays therefore never move during the mounted session.
+ */
+export function reconcileOutletGardenSlots(
+    previousAssignments: OutletGardenSlotAssignments,
+    offers: readonly OutletGardenLayoutOffer[],
+) {
+    const unseenDisplays = getOutletGardenDisplayUnits(offers).filter(
+        (display) => !previousAssignments.has(display.blockId),
+    );
+    if (unseenDisplays.length === 0) {
         return previousAssignments;
     }
 
@@ -149,17 +195,19 @@ export function reconcileOutletGardenSlots(
                 outletGardenPlantBay(assignment.slotIndex),
             ),
         ) + 1;
-    const unseenOffersByPlant = new Map<string, OutletGardenLayoutOffer[]>();
-    for (const offer of unseenOffers) {
-        const plantKey = outletGardenPlantKey(offer);
-        const plantOffers = unseenOffersByPlant.get(plantKey) ?? [];
-        plantOffers.push(offer);
-        unseenOffersByPlant.set(plantKey, plantOffers);
+    const unseenDisplaysByPlant = new Map<string, OutletGardenDisplayUnit[]>();
+    for (const display of unseenDisplays) {
+        const plantKey = outletGardenPlantKey(display);
+        const plantDisplays = unseenDisplaysByPlant.get(plantKey) ?? [];
+        plantDisplays.push(display);
+        unseenDisplaysByPlant.set(plantKey, plantDisplays);
     }
 
-    for (const [plantKey, plantOffers] of unseenOffersByPlant) {
-        const availableSlots = Array.from(existingPlantBays.get(plantKey) ?? [])
-            .sort((left, right) => left - right)
+    for (const [plantKey, plantDisplays] of unseenDisplaysByPlant) {
+        const plantBays = Array.from(
+            existingPlantBays.get(plantKey) ?? [],
+        ).sort((left, right) => left - right);
+        const availableExistingSlotCount = plantBays
             .flatMap((plantBay) =>
                 Array.from(
                     { length: outletGardenOffersPerPlantBay },
@@ -167,23 +215,49 @@ export function reconcileOutletGardenSlots(
                         plantBay * outletGardenOffersPerPlantBay + offset,
                 ),
             )
-            .filter((slotIndex) => !usedSlots.has(slotIndex));
+            .filter((slotIndex) => !usedSlots.has(slotIndex)).length;
+        const newPlantBayCount = Math.ceil(
+            Math.max(0, plantDisplays.length - availableExistingSlotCount) /
+                outletGardenOffersPerPlantBay,
+        );
+        for (let index = 0; index < newPlantBayCount; index += 1) {
+            plantBays.push(nextPlantBay);
+            nextPlantBay += 1;
+        }
 
-        for (const offer of plantOffers) {
-            let slotIndex = availableSlots.shift();
+        const availableSlots = plantBays
+            .flatMap((plantBay) =>
+                Array.from(
+                    { length: outletGardenOffersPerPlantBay },
+                    (_, offset) =>
+                        plantBay * outletGardenOffersPerPlantBay + offset,
+                ),
+            )
+            .filter((slotIndex) => !usedSlots.has(slotIndex))
+            .sort((left, right) => {
+                const leftOffset = left % outletGardenOffersPerPlantBay;
+                const rightOffset = right % outletGardenOffersPerPlantBay;
+                const leftSurface = leftOffset < 2 ? 0 : 1;
+                const rightSurface = rightOffset < 2 ? 0 : 1;
+                return (
+                    leftSurface - rightSurface ||
+                    outletGardenPlantBay(left) - outletGardenPlantBay(right) ||
+                    leftOffset - rightOffset
+                );
+            });
+
+        for (const display of plantDisplays) {
+            const slotIndex = availableSlots.shift();
             if (slotIndex === undefined) {
-                slotIndex = nextPlantBay * outletGardenOffersPerPlantBay;
-                nextPlantBay += 1;
-                for (
-                    let offset = 1;
-                    offset < outletGardenOffersPerPlantBay;
-                    offset += 1
-                ) {
-                    availableSlots.push(slotIndex + offset);
-                }
+                continue;
             }
 
-            assignments.set(offer.id, { plantKey, slotIndex });
+            assignments.set(display.blockId, {
+                offerId: display.id,
+                plantKey,
+                slotIndex,
+                unitIndex: display.unitIndex,
+            });
             usedSlots.add(slotIndex);
         }
     }
@@ -203,11 +277,8 @@ export function getOutletGardenOfferPlacement(
     const aisleRow = Math.floor(plantBay / outletGardenPlantBaysPerAisleRow);
     const side = plantBay % outletGardenPlantBaysPerAisleRow === 0 ? -1 : 1;
     const slotInPlantBay = slotIndex % outletGardenOffersPerPlantBay;
-    const y =
-        aisleRow * outletGardenAisleRowSpacing + Math.floor(slotInPlantBay / 2);
-    const startsOnTable = side < 0;
-    const surface =
-        (slotInPlantBay % 2 === 0) === startsOnTable ? 'table' : 'floor';
+    const y = aisleRow * outletGardenAisleRowSpacing + (slotInPlantBay % 2);
+    const surface = slotInPlantBay < 2 ? 'table' : 'floor';
     const distance =
         surface === 'table'
             ? outletGardenTableDistance
@@ -333,37 +404,37 @@ export function buildOutletGardenStacks(
         }
     }
 
-    const offersById = new Map(offers.map((offer) => [offer.id, offer]));
-    const placedOffers = Array.from(offersById.values())
-        .map((offer) => ({
-            assignment: assignments.get(offer.id),
-            offer,
+    const placedDisplays = getOutletGardenDisplayUnits(offers)
+        .map((display) => ({
+            assignment: assignments.get(display.blockId),
+            display,
         }))
         .filter(
             (
                 entry,
             ): entry is {
                 assignment: OutletGardenSlotAssignment;
-                offer: OutletGardenLayoutOffer;
+                display: OutletGardenDisplayUnit;
             } => entry.assignment !== undefined,
         )
         .sort(
             (left, right) =>
                 left.assignment.slotIndex - right.assignment.slotIndex ||
-                left.offer.id - right.offer.id,
+                left.display.id - right.display.id ||
+                left.display.unitIndex - right.display.unitIndex,
         );
 
-    for (const { assignment, offer } of placedOffers) {
+    for (const { assignment, display } of placedDisplays) {
         const position = getOutletGardenOfferPlacement(assignment.slotIndex);
         const rotation =
             position.surface === 'floor'
                 ? position.x < 0
                     ? 1
                     : 3
-                : ((offer.plantSortId % 4) + 4) % 4;
+                : ((display.plantSortId % 4) + 4) % 4;
         addBlock(stacksByPosition, position.x, position.y, {
-            id: outletOfferBlockId(offer.id),
-            name: outletGardenPotName(offer.plantSortId),
+            id: display.blockId,
+            name: outletGardenPotName(display.plantSortId),
             rotation,
         });
     }

--- a/packages/game/src/viewers/outletGardenLayout.unit.ts
+++ b/packages/game/src/viewers/outletGardenLayout.unit.ts
@@ -3,20 +3,22 @@ import { describe, it } from 'node:test';
 import {
     buildOutletGardenDetail,
     buildOutletGardenStacks,
+    getOutletGardenDisplayUnits,
     getOutletGardenOfferPlacement,
     type OutletGardenLayoutOffer,
     outletGardenRegisteredBlockNames,
     outletOfferBlockId,
+    outletOfferDisplayFromBlockId,
     outletOfferIdFromBlockId,
     reconcileOutletGardenSlots,
 } from './outletGardenLayout';
 
 const offers = [
-    { id: 301, plantId: 1, plantSortId: 102 },
-    { id: 302, plantId: 1, plantSortId: 101 },
-    { id: 303, plantId: 2, plantSortId: 201 },
-    { id: 304, plantId: 2, plantSortId: 202 },
-    { id: 305, plantId: null, plantSortId: 901 },
+    { id: 301, plantId: 1, plantSortId: 102, remainingQuantity: 1 },
+    { id: 302, plantId: 1, plantSortId: 101, remainingQuantity: 1 },
+    { id: 303, plantId: 2, plantSortId: 201, remainingQuantity: 1 },
+    { id: 304, plantId: 2, plantSortId: 202, remainingQuantity: 1 },
+    { id: 305, plantId: null, plantSortId: 901, remainingQuantity: 1 },
 ] satisfies OutletGardenLayoutOffer[];
 
 function offerMarkerPositions(
@@ -46,15 +48,16 @@ function stackForOffer(
 function assignedSlot(
     assignments: ReturnType<typeof reconcileOutletGardenSlots>,
     offerId: number,
+    unitIndex = 0,
 ) {
-    return assignments.get(offerId)?.slotIndex;
+    return assignments.get(outletOfferBlockId(offerId, unitIndex))?.slotIndex;
 }
 
 function assignmentSlots(
     assignments: ReturnType<typeof reconcileOutletGardenSlots>,
 ) {
-    return Array.from(assignments, ([offerId, assignment]) => [
-        offerId,
+    return Array.from(assignments, ([blockId, assignment]) => [
+        blockId,
         assignment.slotIndex,
     ]);
 }
@@ -62,8 +65,14 @@ function assignmentSlots(
 describe('outlet offer block IDs', () => {
     it('round-trips valid IDs and rejects malformed block IDs', () => {
         assert.equal(outletOfferIdFromBlockId(outletOfferBlockId(302)), 302);
+        assert.deepEqual(
+            outletOfferDisplayFromBlockId(outletOfferBlockId(302, 4)),
+            { offerId: 302, unitIndex: 4 },
+        );
         assert.equal(outletOfferIdFromBlockId('outlet-offer:0'), null);
         assert.equal(outletOfferIdFromBlockId('outlet-offer:0302'), null);
+        assert.equal(outletOfferIdFromBlockId('outlet-offer:302:0'), null);
+        assert.equal(outletOfferIdFromBlockId('outlet-offer:302:01'), null);
         assert.equal(outletOfferIdFromBlockId('outlet-offer:302-extra'), null);
         assert.equal(outletOfferIdFromBlockId('raised-bed:302'), null);
     });
@@ -80,11 +89,11 @@ describe('reconcileOutletGardenSlots', () => {
         ]);
 
         assert.deepEqual(assignmentSlots(assignments), [
-            [302, 0],
-            [301, 1],
-            [303, 4],
-            [304, 5],
-            [305, 8],
+            ['outlet-offer:302', 0],
+            ['outlet-offer:301', 1],
+            ['outlet-offer:303', 4],
+            ['outlet-offer:304', 5],
+            ['outlet-offer:305', 8],
         ]);
     });
 
@@ -95,8 +104,18 @@ describe('reconcileOutletGardenSlots', () => {
             offers[2],
             offers[3],
             offers[4],
-            { id: 306, plantId: 3, plantSortId: 301 },
-            { id: 307, plantId: 1, plantSortId: 103 },
+            {
+                id: 306,
+                plantId: 3,
+                plantSortId: 301,
+                remainingQuantity: 1,
+            },
+            {
+                id: 307,
+                plantId: 1,
+                plantSortId: 103,
+                remainingQuantity: 1,
+            },
         ]);
 
         assert.equal(assignedSlot(reconciled, 302), 0);
@@ -110,13 +129,18 @@ describe('reconcileOutletGardenSlots', () => {
 
     it('keeps a plant bay owned when its last live offer becomes a tombstone', () => {
         const plantAOffers = [
-            { id: 1, plantId: 1, plantSortId: 101 },
-            { id: 2, plantId: 1, plantSortId: 101 },
-            { id: 3, plantId: 1, plantSortId: 102 },
-            { id: 4, plantId: 1, plantSortId: 102 },
-            { id: 5, plantId: 1, plantSortId: 103 },
+            { id: 1, plantId: 1, plantSortId: 101, remainingQuantity: 1 },
+            { id: 2, plantId: 1, plantSortId: 101, remainingQuantity: 1 },
+            { id: 3, plantId: 1, plantSortId: 102, remainingQuantity: 1 },
+            { id: 4, plantId: 1, plantSortId: 102, remainingQuantity: 1 },
+            { id: 5, plantId: 1, plantSortId: 103, remainingQuantity: 1 },
         ];
-        const plantBOffer = { id: 6, plantId: 2, plantSortId: 201 };
+        const plantBOffer = {
+            id: 6,
+            plantId: 2,
+            plantSortId: 201,
+            remainingQuantity: 1,
+        };
         const initial = reconcileOutletGardenSlots(new Map(), [
             ...plantAOffers,
             plantBOffer,
@@ -124,12 +148,12 @@ describe('reconcileOutletGardenSlots', () => {
         const reconciled = reconcileOutletGardenSlots(initial, [
             ...plantAOffers.slice(0, 4),
             plantBOffer,
-            { id: 7, plantId: 1, plantSortId: 104 },
+            { id: 7, plantId: 1, plantSortId: 104, remainingQuantity: 1 },
         ]);
 
-        assert.equal(assignedSlot(initial, 5), 4);
+        assert.equal(assignedSlot(initial, 5), 2);
         assert.equal(assignedSlot(initial, 6), 8);
-        assert.equal(assignedSlot(reconciled, 7), 5);
+        assert.equal(assignedSlot(reconciled, 7), 3);
         assert.equal(assignedSlot(reconciled, 6), 8);
     });
 
@@ -154,10 +178,36 @@ describe('reconcileOutletGardenSlots', () => {
             initial,
         );
     });
+
+    it('fills tabletops across reserved bays first and restores quantity tombstones', () => {
+        const quantityOffer = {
+            id: 401,
+            plantId: 4,
+            plantSortId: 401,
+            remainingQuantity: 5,
+        };
+        const initial = reconcileOutletGardenSlots(new Map(), [quantityOffer]);
+
+        assert.deepEqual(
+            Array.from({ length: 5 }, (_, unitIndex) =>
+                assignedSlot(initial, quantityOffer.id, unitIndex),
+            ),
+            [0, 1, 4, 5, 2],
+        );
+
+        const reduced = reconcileOutletGardenSlots(initial, [
+            { ...quantityOffer, remainingQuantity: 3 },
+        ]);
+        const restored = reconcileOutletGardenSlots(reduced, [quantityOffer]);
+
+        assert.equal(reduced, initial);
+        assert.equal(restored, initial);
+        assert.equal(assignedSlot(restored, quantityOffer.id, 4), 2);
+    });
 });
 
 describe('getOutletGardenOfferPlacement', () => {
-    it('alternates table and floor displays inside plant bays on both sides', () => {
+    it('fills both tabletop positions before floor positions on either side', () => {
         assert.deepEqual(getOutletGardenOfferPlacement(0), {
             aisleRow: 0,
             plantBay: 0,
@@ -168,15 +218,15 @@ describe('getOutletGardenOfferPlacement', () => {
         assert.deepEqual(getOutletGardenOfferPlacement(1), {
             aisleRow: 0,
             plantBay: 0,
-            surface: 'floor',
-            x: -2,
-            y: 0,
+            surface: 'table',
+            x: -3,
+            y: 1,
         });
         assert.deepEqual(getOutletGardenOfferPlacement(4), {
             aisleRow: 0,
             plantBay: 1,
-            surface: 'floor',
-            x: 2,
+            surface: 'table',
+            x: 3,
             y: 0,
         });
         assert.deepEqual(getOutletGardenOfferPlacement(5), {
@@ -184,6 +234,13 @@ describe('getOutletGardenOfferPlacement', () => {
             plantBay: 1,
             surface: 'table',
             x: 3,
+            y: 1,
+        });
+        assert.deepEqual(getOutletGardenOfferPlacement(6), {
+            aisleRow: 0,
+            plantBay: 1,
+            surface: 'floor',
+            x: 2,
             y: 0,
         });
         assert.deepEqual(getOutletGardenOfferPlacement(8), {
@@ -197,7 +254,7 @@ describe('getOutletGardenOfferPlacement', () => {
 });
 
 describe('buildOutletGardenStacks', () => {
-    it('renders every offer once using only registered scene blocks', () => {
+    it('renders one display per remaining seedling using only registered scene blocks', () => {
         const assignments = reconcileOutletGardenSlots(new Map(), offers);
         const stacks = buildOutletGardenStacks(offers, assignments);
         const markerIds = stacks.flatMap((stack) =>
@@ -220,11 +277,59 @@ describe('buildOutletGardenStacks', () => {
         );
     });
 
+    it('uses unique interactive blocks for the full remaining quantity', () => {
+        const quantityOffers = [
+            { ...offers[0], remainingQuantity: 2 },
+            { ...offers[2], remainingQuantity: 3 },
+        ];
+        const assignments = reconcileOutletGardenSlots(
+            new Map(),
+            quantityOffers,
+        );
+        const stacks = buildOutletGardenStacks(quantityOffers, assignments);
+        const blockIds = stacks.flatMap((stack) =>
+            stack.blocks
+                .filter((block) => outletOfferIdFromBlockId(block.id) !== null)
+                .map((block) => block.id),
+        );
+
+        assert.equal(blockIds.length, 5);
+        assert.equal(new Set(blockIds).size, 5);
+        assert.deepEqual(
+            blockIds
+                .filter((blockId) => outletOfferIdFromBlockId(blockId) === 301)
+                .sort(),
+            [outletOfferBlockId(301), outletOfferBlockId(301, 1)].sort(),
+        );
+        assert.deepEqual(
+            blockIds
+                .filter((blockId) => outletOfferIdFromBlockId(blockId) === 303)
+                .sort(),
+            [
+                outletOfferBlockId(303),
+                outletOfferBlockId(303, 1),
+                outletOfferBlockId(303, 2),
+            ].sort(),
+        );
+    });
+
     it('places tabletop seedlings above the Outlet table and floor seedlings directly on grass', () => {
-        const assignments = reconcileOutletGardenSlots(new Map(), offers);
-        const stacks = buildOutletGardenStacks(offers, assignments);
+        const quantityOffer = {
+            id: 302,
+            plantId: 1,
+            plantSortId: 101,
+            remainingQuantity: 3,
+        };
+        const assignments = reconcileOutletGardenSlots(new Map(), [
+            quantityOffer,
+        ]);
+        const stacks = buildOutletGardenStacks([quantityOffer], assignments);
         const tableStack = stackForOffer(stacks, 302);
-        const floorStack = stackForOffer(stacks, 301);
+        const floorStack = stacks.find((stack) =>
+            stack.blocks.some(
+                (block) => block.id === outletOfferBlockId(302, 2),
+            ),
+        );
 
         assert.deepEqual(
             tableStack?.blocks.map((block) => block.name),
@@ -232,7 +337,7 @@ describe('buildOutletGardenStacks', () => {
         );
         assert.deepEqual(
             floorStack?.blocks.map((block) => block.name),
-            ['Block_Grass', 'PotBulbousNeck'],
+            ['Block_Grass', 'PotRoundedBowl'],
         );
         assert.equal(
             tableStack?.blocks.find(
@@ -240,13 +345,8 @@ describe('buildOutletGardenStacks', () => {
             )?.rotation,
             1,
         );
-        const emptyTableSegment = stacks.find(
-            (stack) => stack.x === -3 && stack.y === 1,
-        );
-        assert.deepEqual(
-            emptyTableSegment?.blocks.map((block) => block.name),
-            ['Block_Grass', 'OutletDisplayTable'],
-        );
+        assert.equal(tableStack?.x, -3);
+        assert.equal(floorStack?.x, -2);
     });
 
     it('builds a continuous one-tile mulch aisle with a matching front entrance', () => {
@@ -283,11 +383,33 @@ describe('buildOutletGardenStacks', () => {
     });
 
     it('turns floor displays toward the center aisle without changing tabletop variation', () => {
-        const assignments = reconcileOutletGardenSlots(new Map(), offers);
-        const stacks = buildOutletGardenStacks(offers, assignments);
-        const leftFloor = stackForOffer(stacks, 301);
-        const rightFloor = stackForOffer(stacks, 303);
-        const leftTable = stackForOffer(stacks, 302);
+        const floorOffers = [
+            {
+                id: 301,
+                plantId: 1,
+                plantSortId: 102,
+                remainingQuantity: 3,
+            },
+            {
+                id: 303,
+                plantId: 2,
+                plantSortId: 201,
+                remainingQuantity: 3,
+            },
+        ];
+        const assignments = reconcileOutletGardenSlots(new Map(), floorOffers);
+        const stacks = buildOutletGardenStacks(floorOffers, assignments);
+        const leftFloor = stacks.find((stack) =>
+            stack.blocks.some(
+                (block) => block.id === outletOfferBlockId(301, 2),
+            ),
+        );
+        const rightFloor = stacks.find((stack) =>
+            stack.blocks.some(
+                (block) => block.id === outletOfferBlockId(303, 2),
+            ),
+        );
+        const leftTable = stackForOffer(stacks, 301);
 
         assert.equal(leftFloor?.x, -2);
         assert.equal(
@@ -307,7 +429,7 @@ describe('buildOutletGardenStacks', () => {
             leftTable?.blocks.find((block) =>
                 block.id.startsWith('outlet-offer:'),
             )?.rotation,
-            1,
+            2,
         );
         assert.equal(
             stacks.some(
@@ -334,7 +456,12 @@ describe('buildOutletGardenStacks', () => {
             offers[2],
             offers[3],
             offers[4],
-            { id: 306, plantId: 3, plantSortId: 301 },
+            {
+                id: 306,
+                plantId: 3,
+                plantSortId: 301,
+                remainingQuantity: 1,
+            },
         ];
         const reconciledAssignments = reconcileOutletGardenSlots(
             initialAssignments,
@@ -377,7 +504,7 @@ describe('buildOutletGardenDetail', () => {
                 .flatMap((row) => Object.values(row))
                 .flat()
                 .filter((block) => block.id.startsWith('outlet-offer:')).length,
-            offers.length,
+            getOutletGardenDisplayUnits(offers).length,
         );
     });
 });

--- a/packages/game/src/viewers/outletGardenLayout.unit.ts
+++ b/packages/game/src/viewers/outletGardenLayout.unit.ts
@@ -5,7 +5,11 @@ import {
     buildOutletGardenStacks,
     getOutletGardenDisplayUnits,
     getOutletGardenOfferPlacement,
+    isOutletGardenDisplayLimited,
     type OutletGardenLayoutOffer,
+    outletGardenMaxDisplayedUnitsPerOffer,
+    outletGardenMaxDisplayedUnitsTotal,
+    outletGardenMaxTrackedTombstones,
     outletGardenRegisteredBlockNames,
     outletOfferBlockId,
     outletOfferDisplayFromBlockId,
@@ -75,6 +79,74 @@ describe('outlet offer block IDs', () => {
         assert.equal(outletOfferIdFromBlockId('outlet-offer:302:01'), null);
         assert.equal(outletOfferIdFromBlockId('outlet-offer:302-extra'), null);
         assert.equal(outletOfferIdFromBlockId('raised-bed:302'), null);
+    });
+});
+
+describe('getOutletGardenDisplayUnits', () => {
+    it('bounds a single pathological stock value before expanding scene objects', () => {
+        const bulkOffer = {
+            id: 900,
+            plantId: 9,
+            plantSortId: 901,
+            remainingQuantity: 1_000_000_000,
+        };
+        const displays = getOutletGardenDisplayUnits([bulkOffer]);
+
+        assert.equal(displays.length, outletGardenMaxDisplayedUnitsPerOffer);
+        assert.equal(displays[0]?.blockId, outletOfferBlockId(900));
+        assert.equal(
+            displays.at(-1)?.blockId,
+            outletOfferBlockId(900, outletGardenMaxDisplayedUnitsPerOffer - 1),
+        );
+        assert.equal(isOutletGardenDisplayLimited([bulkOffer]), true);
+    });
+
+    it('shares the total scene budget fairly while preserving offer grouping', () => {
+        const bulkOffers = Array.from({ length: 6 }, (_, index) => ({
+            id: 910 + index,
+            plantId: index + 1,
+            plantSortId: 910 + index,
+            remainingQuantity: outletGardenMaxDisplayedUnitsPerOffer,
+        }));
+        const displays = getOutletGardenDisplayUnits(bulkOffers);
+        const counts = bulkOffers.map(
+            (offer) =>
+                displays.filter((display) => display.id === offer.id).length,
+        );
+
+        assert.equal(displays.length, outletGardenMaxDisplayedUnitsTotal);
+        assert.deepEqual(
+            getOutletGardenDisplayUnits([...bulkOffers].reverse()),
+            displays,
+        );
+        assert.ok(Math.max(...counts) - Math.min(...counts) <= 1);
+        assert.deepEqual(
+            Array.from(new Set(displays.map((display) => display.id))),
+            bulkOffers.map((offer) => offer.id),
+        );
+        assert.equal(isOutletGardenDisplayLimited(bulkOffers), true);
+        assert.equal(
+            isOutletGardenDisplayLimited(bulkOffers.slice(0, 5)),
+            false,
+        );
+        assert.equal(
+            isOutletGardenDisplayLimited([
+                ...bulkOffers.slice(0, 5),
+                { ...bulkOffers[5], remainingQuantity: 1 },
+            ]),
+            true,
+        );
+        assert.equal(
+            isOutletGardenDisplayLimited([
+                {
+                    ...bulkOffers[0],
+                    remainingQuantity:
+                        outletGardenMaxDisplayedUnitsPerOffer + 1,
+                },
+            ]),
+            true,
+        );
+        assert.equal(isOutletGardenDisplayLimited(offers), false);
     });
 });
 
@@ -203,6 +275,114 @@ describe('reconcileOutletGardenSlots', () => {
         assert.equal(reduced, initial);
         assert.equal(restored, initial);
         assert.equal(assignedSlot(restored, quantityOffer.id, 4), 2);
+    });
+
+    it('bounds historical tombstones and reuses fully released plant bays', () => {
+        const offerBatch = (idOffset: number, plantOffset: number) =>
+            Array.from({ length: 6 }, (_, index) => ({
+                id: idOffset + index,
+                plantId: plantOffset + index,
+                plantSortId: idOffset + index,
+                remainingQuantity: outletGardenMaxDisplayedUnitsPerOffer,
+            }));
+        const firstBatch = offerBatch(1_000, 1_000);
+        const secondBatch = offerBatch(2_000, 2_000);
+        const thirdBatch = offerBatch(3_000, 3_000);
+        const firstAssignments = reconcileOutletGardenSlots(
+            new Map(),
+            firstBatch,
+        );
+        const secondAssignments = reconcileOutletGardenSlots(
+            firstAssignments,
+            secondBatch,
+        );
+        const onlySecondTombstones = reconcileOutletGardenSlots(
+            secondAssignments,
+            [],
+        );
+        const thirdAssignments = reconcileOutletGardenSlots(
+            onlySecondTombstones,
+            thirdBatch,
+        );
+
+        assert.equal(firstAssignments.size, outletGardenMaxDisplayedUnitsTotal);
+        assert.equal(
+            secondAssignments.size,
+            outletGardenMaxDisplayedUnitsTotal +
+                outletGardenMaxTrackedTombstones,
+        );
+        assert.equal(
+            onlySecondTombstones.size,
+            outletGardenMaxTrackedTombstones,
+        );
+        assert.equal(
+            thirdAssignments.size,
+            outletGardenMaxDisplayedUnitsTotal +
+                outletGardenMaxTrackedTombstones,
+        );
+        assert.ok(
+            Math.max(
+                ...Array.from(
+                    thirdAssignments.values(),
+                    (assignment) => assignment.slotIndex,
+                ),
+            ) <
+                (outletGardenMaxDisplayedUnitsTotal +
+                    outletGardenMaxTrackedTombstones) *
+                    2,
+        );
+        assert.ok(
+            (assignedSlot(secondAssignments, 2_000) ?? -1) >
+                Math.max(
+                    ...Array.from(
+                        firstAssignments.values(),
+                        (assignment) => assignment.slotIndex,
+                    ),
+                ),
+        );
+        assert.equal(assignedSlot(thirdAssignments, 3_000), 0);
+    });
+
+    it('keeps capped survivor slots stable through repeated stock churn', () => {
+        const stableOffer = {
+            id: 4_000,
+            plantId: 4_000,
+            plantSortId: 4_000,
+            remainingQuantity: outletGardenMaxDisplayedUnitsPerOffer,
+        };
+        const rotatingOffers = (cycle: number) =>
+            Array.from({ length: 5 }, (_, index) => ({
+                id: 5_000 + cycle * 10 + index,
+                plantId: 5_000 + cycle * 10 + index,
+                plantSortId: 5_000 + cycle * 10 + index,
+                remainingQuantity: outletGardenMaxDisplayedUnitsPerOffer,
+            }));
+        const initialOffers = [stableOffer, ...rotatingOffers(0)];
+        let assignments = reconcileOutletGardenSlots(new Map(), initialOffers);
+        const stableSlots = new Map(
+            getOutletGardenDisplayUnits(initialOffers)
+                .filter((display) => display.id === stableOffer.id)
+                .map((display) => [
+                    display.blockId,
+                    assignments.get(display.blockId)?.slotIndex,
+                ]),
+        );
+
+        for (let cycle = 1; cycle <= 10; cycle += 1) {
+            assignments = reconcileOutletGardenSlots(assignments, [
+                stableOffer,
+                ...rotatingOffers(cycle),
+            ]);
+
+            assert.ok(
+                assignments.size <=
+                    outletGardenMaxDisplayedUnitsTotal +
+                        outletGardenMaxTrackedTombstones,
+            );
+            for (const [blockId, slotIndex] of stableSlots) {
+                assert.equal(assignments.get(blockId)?.slotIndex, slotIndex);
+            }
+        }
     });
 });
 


### PR DESCRIPTION
## Summary

- render one interactive pot and generated seedling for every server-reported `remainingQuantity`, while preserving stable unit positions across stock refreshes
- fill all tabletop positions for a plant group before using floor positions, with floor pots still facing the center walkway
- replace the additive yellow hover column with a single depth-tested surface ring and highlight every displayed unit belonging to the hovered offer
- fit the expanded Outlet garden on mobile, update the quantity copy, and retain offer-level selection and deep links

This is a follow-up to #4467 and the Phase 1 merge in #4470. The production teleport flag remains unchanged and defaults off.

## Validation

- `pnpm --filter @gredice/game test` — 943 passed
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter garden exec playwright test tests/outlet-garden.spec.tsx --project=chromium` — 6 passed
- WebGL route smoke — 1 passed, including 5 to 3 live stock reconciliation without replacing the canvas
- desktop and 390px visual checks with the current public snapshot — 13 offers and 55 displayed seedlings, no runtime or framework overlay errors
- targeted Biome checks and `git diff --check`

## Rollout

The existing `enableOutletGarden` server flag still gates both the teleport entry and direct `/outlet` route. Production remains disabled by default; preview and explicit browser overrides can beta-test the complete flow.