### PR TITLE
fix(game): use icons for avatar touch controls

### DIFF
--- a/apps/storybook/stories/packages/game/hud/GardenAvatarHud.stories.tsx
+++ b/apps/storybook/stories/packages/game/hud/GardenAvatarHud.stories.tsx
@@ -1,0 +1,59 @@
+import { GardenAvatarHud } from '@packages/game/hud/GardenAvatarHud';
+import { createGameState, GameStateContext } from '@packages/game/useGameState';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useEffect, useRef } from 'react';
+
+function GardenAvatarHudStory() {
+    const gameStateRef = useRef<ReturnType<typeof createGameState> | null>(
+        null,
+    );
+
+    if (!gameStateRef.current) {
+        gameStateRef.current = createGameState({
+            appBaseUrl: '',
+            freezeTime: new Date('2026-08-11T18:00:00.000Z'),
+            isMock: true,
+            mockGardenProfile: 'default',
+            winterMode: 'summer',
+        });
+        gameStateRef.current.getState().setGardenAvatarView('third-person');
+    }
+
+    useEffect(() => {
+        const touchEventTimeout = window.setTimeout(() => {
+            window.dispatchEvent(
+                new PointerEvent('pointerdown', { pointerType: 'touch' }),
+            );
+        });
+
+        return () => window.clearTimeout(touchEventTimeout);
+    }, []);
+
+    return (
+        <GameStateContext.Provider value={gameStateRef.current}>
+            <div className="relative aspect-2/1 max-h-[450px] min-h-[320px] w-full overflow-hidden bg-emerald-950">
+                <div className="absolute inset-0 bg-[radial-gradient(circle_at_55%_45%,rgba(52,211,153,0.25),transparent_28%),linear-gradient(145deg,rgba(21,128,61,0.7),rgba(20,83,45,0.9))]" />
+                <GardenAvatarHud />
+            </div>
+        </GameStateContext.Provider>
+    );
+}
+
+const meta = {
+    title: 'packages/game/hud/GardenAvatarHud',
+    component: GardenAvatarHudStory,
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'Touch controls for walking through a garden, including the movement joystick and icon-only character actions.',
+            },
+        },
+    },
+} satisfies Meta<typeof GardenAvatarHudStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TouchControls: Story = {};

--- a/packages/game/src/hud/GardenAvatarHud.tsx
+++ b/packages/game/src/hud/GardenAvatarHud.tsx
@@ -1,7 +1,16 @@
 'use client';
 
 import { IconButton } from '@gredice/ui/IconButton';
-import { Camera, Close, LogOut, UserCircle } from '@gredice/ui/icons';
+import {
+    ArrowUp,
+    Camera,
+    ChevronsDown,
+    Close,
+    Footprints,
+    LogOut,
+    UserCircle,
+    ZoomIn,
+} from '@gredice/ui/icons';
 import { cx } from '@gredice/ui/utils';
 import { type PointerEvent, useEffect } from 'react';
 import { useGameState } from '../useGameState';
@@ -10,6 +19,8 @@ import { useGardenAvatarTouchControls } from './gardenAvatarTouchControls';
 
 const avatarHudButtonClassName =
     'pointer-events-auto border border-border/60 bg-background/85 shadow-lg backdrop-blur-md hover:bg-muted active:scale-95 touch-none';
+const avatarTouchActionButtonClassName =
+    'pointer-events-auto size-14 touch-none rounded-full border border-border/60 bg-background/85 shadow-lg backdrop-blur-md active:scale-95';
 
 export function GardenAvatarHud() {
     const showTouchControls = useGardenAvatarTouchControls();
@@ -111,9 +122,11 @@ export function GardenAvatarHud() {
                     </div>
 
                     <div className="absolute right-[calc(var(--game-safe-area-right,0px)+0.75rem)] bottom-[calc(var(--game-safe-area-bottom,0px)+0.75rem)] grid grid-cols-2 gap-2">
-                        <button
+                        <IconButton
                             type="button"
-                            className="pointer-events-auto flex min-h-12 min-w-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/85 px-3 text-xs font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95"
+                            aria-label="Čučni"
+                            variant="plain"
+                            className={avatarTouchActionButtonClassName}
                             onPointerDown={(event) =>
                                 startAction(event, setCrouchInput)
                             }
@@ -124,11 +137,16 @@ export function GardenAvatarHud() {
                                 stopAction(event, setCrouchInput)
                             }
                         >
-                            Čučni
-                        </button>
-                        <button
+                            <ChevronsDown
+                                aria-hidden="true"
+                                className="size-6"
+                            />
+                        </IconButton>
+                        <IconButton
                             type="button"
-                            className="pointer-events-auto flex min-h-12 min-w-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/85 px-3 text-xs font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95"
+                            aria-label="Zum"
+                            variant="plain"
+                            className={avatarTouchActionButtonClassName}
                             onPointerDown={(event) =>
                                 startAction(event, setZoomInput)
                             }
@@ -139,11 +157,13 @@ export function GardenAvatarHud() {
                                 stopAction(event, setZoomInput)
                             }
                         >
-                            Zum
-                        </button>
-                        <button
+                            <ZoomIn aria-hidden="true" className="size-6" />
+                        </IconButton>
+                        <IconButton
                             type="button"
-                            className="pointer-events-auto flex min-h-12 min-w-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/85 px-3 text-xs font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95"
+                            aria-label="Trči"
+                            variant="plain"
+                            className={avatarTouchActionButtonClassName}
                             onPointerDown={(event) =>
                                 startAction(event, setSprintInput)
                             }
@@ -154,18 +174,23 @@ export function GardenAvatarHud() {
                                 stopAction(event, setSprintInput)
                             }
                         >
-                            Trči
-                        </button>
-                        <button
+                            <Footprints aria-hidden="true" className="size-6" />
+                        </IconButton>
+                        <IconButton
                             type="button"
+                            aria-label="Skoči"
+                            variant="plain"
                             onPointerDown={(event) => {
                                 event.preventDefault();
                                 requestJump();
                             }}
-                            className="pointer-events-auto flex min-h-12 min-w-14 touch-none items-center justify-center rounded-full border border-border/60 bg-background/95 px-3 text-xs font-semibold shadow-lg backdrop-blur-md transition-transform active:scale-95"
+                            className={cx(
+                                avatarTouchActionButtonClassName,
+                                'bg-background/95',
+                            )}
                         >
-                            Skoči
-                        </button>
+                            <ArrowUp aria-hidden="true" className="size-6" />
+                        </IconButton>
                     </div>
                 </>
             ) : null}

--- a/packages/ui/src/icons/index.ts
+++ b/packages/ui/src/icons/index.ts
@@ -33,6 +33,7 @@ export {
     ChevronDown as Select,
     ChevronLeft as Left,
     ChevronRight as Navigate,
+    ChevronsDown,
     ChevronsRight as Right,
     ChevronUp as Up,
     Circle as Empty,
@@ -57,6 +58,7 @@ export {
     FileText,
     Filter,
     Flame,
+    Footprints,
     Frown as SmileSad,
     GamepadDirectional,
     Ghost,
@@ -174,6 +176,7 @@ export {
     X as Clear,
     X as Close,
     Zap as Lightning,
+    ZoomIn,
 } from 'lucide-react';
 
 export { CompanyFacebook } from './CompanyFacebook';


### PR DESCRIPTION
## What changed

- replaced the four bottom-right avatar action labels with crouch, zoom, run, and jump icons
- kept Croatian accessible names and 56 px circular touch targets
- added an isolated Storybook story for the touch-control layout

## Why

The text labels occupied more space than necessary in the immersive garden HUD. Familiar action icons make the controls quicker to scan while preserving assistive-technology labels and the existing press-and-hold behavior.

## Validation

- `pnpm --filter @gredice/game test` (947 passed)
- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/ui lint`
- `pnpm --filter @gredice/ui typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter storybook lint`
- `pnpm --filter storybook typecheck`
- `git diff --check`
- Storybook browser check at 900 x 450: icon-only controls, 56 x 56 px touch targets, accessible names, no runtime errors
