### PR TITLE
feat(garden): reshape the 3D Outlet garden

### DIFF
--- a/packages/game/src/controls/GameCameraRig.tsx
+++ b/packages/game/src/controls/GameCameraRig.tsx
@@ -71,6 +71,24 @@ type NormalCameraSnapshot = {
     zoom: number;
 };
 
+export type GameCameraCloseupFocus = {
+    mode: 'preserve-angle';
+    target?: Readonly<{
+        x: number;
+        y: number;
+        z: number;
+    }>;
+    zoom?: number;
+};
+
+type CameraCloseupTarget = {
+    key: string;
+    mode: 'preserve-angle' | 'top-down';
+    orientation?: 'vertical' | 'horizontal';
+    target: Vector3;
+    zoom: number;
+};
+
 function easeInOutCubic(value: number) {
     return value < 0.5
         ? 4 * value * value * value
@@ -133,6 +151,27 @@ function getCloseupCameraPosition({
     );
 }
 
+export function getPreservedAngleCameraPosition({
+    cameraPosition,
+    cameraTarget,
+    focusTarget,
+}: {
+    cameraPosition: Vector3;
+    cameraTarget: Vector3;
+    focusTarget: Vector3;
+}) {
+    return focusTarget
+        .clone()
+        .add(new Vector3().subVectors(cameraPosition, cameraTarget));
+}
+
+export function resolvePreservedAngleCloseupZoom(
+    currentZoom: number,
+    requestedZoom: number,
+) {
+    return Math.max(currentZoom, requestedZoom);
+}
+
 function getPointerDistance(left: Vector2, right: Vector2) {
     return Math.max(1, left.distanceTo(right));
 }
@@ -161,6 +200,7 @@ function toSnapshot({
 }
 
 export function GameCameraRig({
+    closeupFocus,
     controlsEnabled,
     initialPosition,
     initialSnapshot,
@@ -169,6 +209,7 @@ export function GameCameraRig({
     initialZoom,
     minZoom = defaultMinZoom,
 }: {
+    closeupFocus?: GameCameraCloseupFocus;
     controlsEnabled: boolean;
     initialPosition?: Vector3;
     initialSnapshot?: Pick<GameCameraSnapshot, 'position' | 'target' | 'zoom'>;
@@ -238,6 +279,7 @@ export function GameCameraRig({
         undefined,
     );
     const skipCloseupTransitionRef = useRef(false);
+    const closeupTransitionKeyRef = useRef<string | null>(null);
     const normalCameraRef = useRef<NormalCameraSnapshot>({
         position: resolvedInitialView.position.clone(),
         target: resolvedInitialView.target.clone(),
@@ -250,7 +292,7 @@ export function GameCameraRig({
         [],
     );
 
-    const closeupTarget = useMemo(() => {
+    const closeupTarget = useMemo<CameraCloseupTarget | null>(() => {
         if (!closeupBlock || !garden) {
             return null;
         }
@@ -265,21 +307,43 @@ export function GameCameraRig({
             return null;
         }
 
+        if (closeupFocus) {
+            const target = closeupFocus.target
+                ? new Vector3(
+                      closeupFocus.target.x,
+                      closeupFocus.target.y,
+                      closeupFocus.target.z,
+                  )
+                : closeupBlockPosition.clone();
+            const zoom = closeupFocus.zoom ?? closeupZoom;
+            return {
+                key: `${closeupBlock.id}:preserve-angle:${target.x}:${target.y}:${target.z}:${zoom}`,
+                mode: closeupFocus.mode,
+                orientation: undefined,
+                target,
+                zoom,
+            };
+        }
+
         const raisedBed = findRaisedBedByBlockId(garden, closeupBlock.id);
         if (!raisedBed) {
             return {
-                key: closeupBlock.id,
+                key: `${closeupBlock.id}:top-down:${closeupBlockPosition.x}:${closeupBlockPosition.y}:${closeupBlockPosition.z}:${closeupZoom}`,
+                mode: 'top-down',
                 orientation: undefined,
                 target: closeupBlockPosition.clone(),
+                zoom: closeupZoom,
             };
         }
 
         const raisedBedBlockIds = getRaisedBedBlockIds(garden, raisedBed.id);
         if (raisedBedBlockIds.length !== 2) {
             return {
-                key: closeupBlock.id,
+                key: `${closeupBlock.id}:top-down:${raisedBed.orientation ?? 'vertical'}:${closeupBlockPosition.x}:${closeupBlockPosition.y}:${closeupBlockPosition.z}:${closeupZoom}`,
+                mode: 'top-down',
                 orientation: raisedBed.orientation,
                 target: closeupBlockPosition.clone(),
+                zoom: closeupZoom,
             };
         }
 
@@ -289,25 +353,27 @@ export function GameCameraRig({
 
         if (connectedBlockPositions.length !== 2) {
             return {
-                key: closeupBlock.id,
+                key: `${closeupBlock.id}:top-down:${raisedBed.orientation ?? 'vertical'}:${closeupBlockPosition.x}:${closeupBlockPosition.y}:${closeupBlockPosition.z}:${closeupZoom}`,
+                mode: 'top-down',
                 orientation: raisedBed.orientation,
                 target: closeupBlockPosition.clone(),
+                zoom: closeupZoom,
             };
         }
 
+        const target = new Vector3(
+            (connectedBlockPositions[0].x + connectedBlockPositions[1].x) / 2,
+            (connectedBlockPositions[0].y + connectedBlockPositions[1].y) / 2,
+            (connectedBlockPositions[0].z + connectedBlockPositions[1].z) / 2,
+        );
         return {
-            key: `${raisedBedBlockIds.join('|')}:${raisedBed.orientation ?? 'vertical'}`,
+            key: `${raisedBedBlockIds.join('|')}:top-down:${raisedBed.orientation ?? 'vertical'}:${target.x}:${target.y}:${target.z}:${closeupZoom}`,
+            mode: 'top-down',
             orientation: raisedBed.orientation,
-            target: new Vector3(
-                (connectedBlockPositions[0].x + connectedBlockPositions[1].x) /
-                    2,
-                (connectedBlockPositions[0].y + connectedBlockPositions[1].y) /
-                    2,
-                (connectedBlockPositions[0].z + connectedBlockPositions[1].z) /
-                    2,
-            ),
+            target,
+            zoom: closeupZoom,
         };
-    }, [closeupBlock, garden]);
+    }, [closeupBlock, closeupFocus, garden]);
 
     const controlsDisabled =
         !controlsEnabled ||
@@ -597,6 +663,7 @@ export function GameCameraRig({
         if (shouldApplyInitialView) {
             const initialViewChanged = initializedRef.current;
             animationRef.current = null;
+            closeupTransitionKeyRef.current = null;
             setIsAnimating(false);
             camera.position.copy(resolvedInitialView.position);
             camera.zoom = MathUtils.clamp(
@@ -927,6 +994,13 @@ export function GameCameraRig({
         const previousView = previousViewRef.current;
 
         if (view === 'closeup' && closeupTarget) {
+            if (
+                previousView === 'closeup' &&
+                closeupTransitionKeyRef.current === closeupTarget.key
+            ) {
+                return;
+            }
+
             setCloseupCameraActive(true);
             setCloseupCameraSettled(false);
             if (previousView !== 'closeup') {
@@ -937,15 +1011,32 @@ export function GameCameraRig({
                 };
             }
 
+            const endPosition =
+                closeupTarget.mode === 'preserve-angle'
+                    ? getPreservedAngleCameraPosition({
+                          cameraPosition: camera.position,
+                          cameraTarget: targetRef.current,
+                          focusTarget: closeupTarget.target,
+                      })
+                    : getCloseupCameraPosition({
+                          cameraY: camera.position.y,
+                          orientation: closeupTarget.orientation,
+                          target: closeupTarget.target,
+                      });
+            const endZoom =
+                closeupTarget.mode === 'preserve-angle'
+                    ? resolvePreservedAngleCloseupZoom(
+                          camera.zoom,
+                          closeupTarget.zoom,
+                      )
+                    : closeupTarget.zoom;
+
+            closeupTransitionKeyRef.current = closeupTarget.key;
             startAnimation({
                 duration: animationDurationSeconds,
-                endPosition: getCloseupCameraPosition({
-                    cameraY: camera.position.y,
-                    orientation: closeupTarget.orientation,
-                    target: closeupTarget.target,
-                }),
+                endPosition,
                 endTarget: closeupTarget.target,
-                endZoom: closeupZoom,
+                endZoom,
                 onComplete: () => setCloseupCameraSettled(true),
             });
             previousViewRef.current = view;
@@ -953,6 +1044,7 @@ export function GameCameraRig({
         }
 
         if (view === 'normal' && previousView === 'closeup') {
+            closeupTransitionKeyRef.current = null;
             startAnimation({
                 duration: animationDurationSeconds,
                 endPosition: normalCameraRef.current.position,

--- a/packages/game/src/controls/GameCameraRig.unit.ts
+++ b/packages/game/src/controls/GameCameraRig.unit.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Vector3 } from 'three';
+import {
+    getPreservedAngleCameraPosition,
+    resolvePreservedAngleCloseupZoom,
+} from './GameCameraRig';
+
+describe('preserved-angle camera focus', () => {
+    it('pans to a new target without changing the camera viewing offset', () => {
+        const cameraPosition = new Vector3(-97, 100, -93);
+        const cameraTarget = new Vector3(3, 0, 7);
+        const focusTarget = new Vector3(14, 1.4, 22);
+
+        const focusedPosition = getPreservedAngleCameraPosition({
+            cameraPosition,
+            cameraTarget,
+            focusTarget,
+        });
+
+        assert.deepEqual(
+            focusedPosition.clone().sub(focusTarget).toArray(),
+            cameraPosition.clone().sub(cameraTarget).toArray(),
+        );
+        assert.deepEqual(cameraPosition.toArray(), [-97, 100, -93]);
+        assert.deepEqual(cameraTarget.toArray(), [3, 0, 7]);
+        assert.deepEqual(focusTarget.toArray(), [14, 1.4, 22]);
+    });
+
+    it('zooms in to the requested closeup without zooming out an existing view', () => {
+        assert.equal(resolvePreservedAngleCloseupZoom(90, 240), 240);
+        assert.equal(resolvePreservedAngleCloseupZoom(320, 240), 320);
+    });
+});

--- a/packages/game/src/viewers/OutletGardenViewer.tsx
+++ b/packages/game/src/viewers/OutletGardenViewer.tsx
@@ -13,6 +13,7 @@ import { OutletGardenSeedlingMarkers } from './OutletGardenSeedlingMarkers';
 import {
     buildOutletGardenDetail,
     getOutletGardenDisplayUnits,
+    getOutletGardenOfferPlacement,
     isOutletGardenDisplayLimited,
     type OutletGardenLayoutOffer,
     type OutletGardenSlotAssignments,
@@ -25,12 +26,13 @@ import {
     getPublicGardenCaptureInitialView,
     normalizePublicGardenStacks,
     type PublicGardenInitialView,
+    type PublicGardenSelectedBlockFocus,
     PublicGardenViewer,
     publicGardenStacksFromResponse,
 } from './PublicGardenViewer';
 
-const outletGardenPreviewTime = new Date('2026-06-21T10:00:00.000Z');
 const outletGardenCameraMinZoom = 10;
+const outletGardenCloseupZoom = 210;
 
 function OutletGardenScenePlaceholder({ label }: { label: string }) {
     return (
@@ -185,6 +187,29 @@ export function OutletGardenViewer() {
             ? focusedBlockId
             : outletOfferBlockId(selectedOffer.id)
         : null;
+    const selectedBlockFocus = useMemo<
+        PublicGardenSelectedBlockFocus | undefined
+    >(() => {
+        if (!selectedBlockId) {
+            return undefined;
+        }
+
+        const assignment = reconciledSlotAssignments.get(selectedBlockId);
+        if (!assignment) {
+            return undefined;
+        }
+
+        const placement = getOutletGardenOfferPlacement(assignment.slotIndex);
+        return {
+            mode: 'preserve-angle',
+            target: {
+                x: placement.x,
+                y: placement.surface === 'table' ? 1.5 : 0.9,
+                z: placement.y,
+            },
+            zoom: outletGardenCloseupZoom,
+        };
+    }, [reconciledSlotAssignments, selectedBlockId]);
 
     useEffect(() => {
         if (
@@ -350,7 +375,6 @@ export function OutletGardenViewer() {
                         appBaseUrl=""
                         cameraMinZoom={outletGardenCameraMinZoom}
                         className="size-full"
-                        fixedTime={outletGardenPreviewTime}
                         garden={outletGarden}
                         initialView={sceneInitialView}
                         interactiveBlockIds={interactiveBlockIds}
@@ -366,6 +390,7 @@ export function OutletGardenViewer() {
                             />
                         }
                         selectedBlockId={selectedBlockId}
+                        selectedBlockFocus={selectedBlockFocus}
                         spriteBaseUrl=""
                     />
                 ) : (

--- a/packages/game/src/viewers/PublicGardenViewer.tsx
+++ b/packages/game/src/viewers/PublicGardenViewer.tsx
@@ -24,7 +24,10 @@ import {
 import { Vector3 } from 'three';
 import { BlockInteractionLayer } from '../controls/BlockInteractionLayer';
 import { BlockInteractionRegistryProvider } from '../controls/BlockInteractionRegistry';
-import { GameCameraRig } from '../controls/GameCameraRig';
+import {
+    type GameCameraCloseupFocus,
+    GameCameraRig,
+} from '../controls/GameCameraRig';
 import { GardenAvatar } from '../entities/avatar/GardenAvatar';
 import { GardenVisitorAvatar } from '../entities/avatar/GardenVisitorAvatar';
 import type { GardenVisitorPresenceController } from '../entities/avatar/gardenVisitorPresence';
@@ -128,6 +131,8 @@ export type PublicGardenCapture = {
     transparent?: boolean;
 };
 
+export type PublicGardenSelectedBlockFocus = GameCameraCloseupFocus;
+
 export type PublicGardenViewerProps = HTMLAttributes<HTMLDivElement> & {
     garden?: PublicGardenDetail;
     stacks?: PublicGardenStack[];
@@ -138,6 +143,7 @@ export type PublicGardenViewerProps = HTMLAttributes<HTMLDivElement> & {
     initialView?: PublicGardenInitialView;
     interactiveBlockIds?: ReadonlySet<string>;
     selectedBlockId?: string | null;
+    selectedBlockFocus?: PublicGardenSelectedBlockFocus;
     onSelectBlock?: (blockId: string) => void;
     onSceneReady?: () => void;
     noWeather?: boolean;
@@ -415,6 +421,7 @@ function PublicGardenScene({
     onSceneReady,
     renderDetails,
     sceneChildren,
+    selectedBlockFocus,
     visitorPresence,
 }: {
     cameraMinZoom?: number;
@@ -433,6 +440,7 @@ function PublicGardenScene({
     onSceneReady?: () => void;
     renderDetails: boolean;
     sceneChildren?: ReactNode;
+    selectedBlockFocus?: PublicGardenSelectedBlockFocus;
     visitorPresence?: GardenVisitorPresenceController;
 }) {
     const blockDataQuery = useBlockData();
@@ -634,6 +642,7 @@ function PublicGardenScene({
                                 </group>
                             </Suspense>
                             <GameCameraRig
+                                closeupFocus={selectedBlockFocus}
                                 minZoom={cameraMinZoom}
                                 controlsEnabled={
                                     !capture && !gardenAvatarActive
@@ -762,6 +771,7 @@ export function PublicGardenViewer({
     renderDetails: renderDetailsOverride,
     sceneChildren,
     selectedBlockId,
+    selectedBlockFocus,
     stacks,
     className,
     visitorPresence,
@@ -1025,6 +1035,7 @@ export function PublicGardenViewer({
                                     onSceneReady={onSceneReady}
                                     renderDetails={renderDetails}
                                     sceneChildren={sceneChildren}
+                                    selectedBlockFocus={selectedBlockFocus}
                                     visitorPresence={visitorPresence}
                                 />
                                 {gameGarden && !capture ? (

--- a/packages/game/src/viewers/outletGardenLayout.ts
+++ b/packages/game/src/viewers/outletGardenLayout.ts
@@ -38,13 +38,16 @@ export type OutletGardenOfferPlacement = {
 const outletOfferBlockIdPrefix = 'outlet-offer:';
 const outletGardenOffersPerPlantBay = 4;
 const outletGardenPlantBaysPerAisleRow = 2;
+const outletGardenAisleRowsPerPathSegment = 2;
 const outletGardenAisleRowSpacing = 3;
+const outletGardenFirstAisleRowOffset = 1;
+const outletGardenPathSegmentLength = 10;
 const outletGardenTableDistance = 3;
 const outletGardenFloorDistance = 2;
-const outletGardenPathHalfWidth = 0;
-const outletGardenSideMargin = 2;
-const outletGardenFrontMargin = 3;
-const outletGardenBackMargin = 3;
+const outletGardenDecorationDistance = 5;
+const outletGardenMapMargin = 2;
+const outletGardenEntranceY =
+    -outletGardenDecorationDistance - outletGardenMapMargin;
 const outletGardenVirtualId = -1;
 const outletGardenUpdatedAt = '1970-01-01T00:00:00.000Z';
 
@@ -74,11 +77,32 @@ type OutletGardenPotName = (typeof outletGardenPotNames)[number];
 
 export const outletGardenRegisteredBlockNames = [
     'Block_Grass',
+    'Bush',
     'Fence',
     'MulchWood',
     'OutletDisplayTable',
+    'StoneSmall',
+    'Tree',
+    'WoodenBench',
     ...outletGardenPotNames,
 ] as const;
+
+type OutletGardenPoint = {
+    x: number;
+    y: number;
+};
+
+type OutletGardenPathSegment = {
+    direction: OutletGardenPoint;
+    index: number;
+    origin: OutletGardenPoint;
+};
+
+type OutletGardenDecorationName =
+    | 'Bush'
+    | 'StoneSmall'
+    | 'Tree'
+    | 'WoodenBench';
 
 export function outletOfferBlockId(offerId: number, unitIndex = 0) {
     const suffix = unitIndex === 0 ? '' : `:${unitIndex.toString()}`;
@@ -377,26 +401,133 @@ function outletGardenPotName(plantSortId: number): OutletGardenPotName {
     return outletGardenPotNames[potIndex] ?? outletGardenPotNames[0];
 }
 
+/**
+ * The route is a compact eastward serpentine. Each segment has exactly two
+ * display rows: two tables on each side per row, or eight table positions
+ * before the next 90-degree turn. The ten-tile segment leaves a small planted
+ * pause between the last table and the corner instead of crowding the turn.
+ */
+function outletGardenPathSegment(
+    segmentIndex: number,
+): OutletGardenPathSegment {
+    const cycle = Math.floor(segmentIndex / 4);
+    const segmentInCycle = segmentIndex % 4;
+    const cycleStartX = cycle * outletGardenPathSegmentLength * 2;
+
+    if (segmentInCycle === 0) {
+        return {
+            direction: { x: 0, y: 1 },
+            index: segmentIndex,
+            origin: { x: cycleStartX, y: 0 },
+        };
+    }
+    if (segmentInCycle === 1) {
+        return {
+            direction: { x: 1, y: 0 },
+            index: segmentIndex,
+            origin: { x: cycleStartX, y: outletGardenPathSegmentLength },
+        };
+    }
+    if (segmentInCycle === 2) {
+        return {
+            direction: { x: 0, y: -1 },
+            index: segmentIndex,
+            origin: {
+                x: cycleStartX + outletGardenPathSegmentLength,
+                y: outletGardenPathSegmentLength,
+            },
+        };
+    }
+
+    return {
+        direction: { x: 1, y: 0 },
+        index: segmentIndex,
+        origin: {
+            x: cycleStartX + outletGardenPathSegmentLength,
+            y: 0,
+        },
+    };
+}
+
+function outletGardenPointAlongSegment(
+    segment: OutletGardenPathSegment,
+    distance: number,
+) {
+    return {
+        x: segment.origin.x + segment.direction.x * distance,
+        y: segment.origin.y + segment.direction.y * distance,
+    };
+}
+
+function outletGardenAisleRowGeometry(aisleRow: number) {
+    const segmentIndex = Math.floor(
+        aisleRow / outletGardenAisleRowsPerPathSegment,
+    );
+    const aisleRowInSegment = aisleRow % outletGardenAisleRowsPerPathSegment;
+    const segment = outletGardenPathSegment(segmentIndex);
+    const distance =
+        outletGardenFirstAisleRowOffset +
+        aisleRowInSegment * outletGardenAisleRowSpacing;
+
+    return {
+        anchor: outletGardenPointAlongSegment(segment, distance),
+        segment,
+    };
+}
+
+function outletGardenSideNormal(
+    plantBay: number,
+    direction: OutletGardenPoint,
+) {
+    const isLeftSide = plantBay % outletGardenPlantBaysPerAisleRow === 0;
+    return isLeftSide
+        ? { x: -direction.y, y: direction.x }
+        : { x: direction.y, y: -direction.x };
+}
+
+function outletGardenRotationFacingPath(normal: OutletGardenPoint) {
+    const facing = { x: -normal.x, y: -normal.y };
+    if (facing.x === 1) {
+        return 1;
+    }
+    if (facing.y === -1) {
+        return 2;
+    }
+    if (facing.x === -1) {
+        return 3;
+    }
+    return 0;
+}
+
+function outletGardenFacingRotation(slotIndex: number) {
+    const plantBay = outletGardenPlantBay(slotIndex);
+    const aisleRow = Math.floor(plantBay / outletGardenPlantBaysPerAisleRow);
+    const { segment } = outletGardenAisleRowGeometry(aisleRow);
+    const normal = outletGardenSideNormal(plantBay, segment.direction);
+    return outletGardenRotationFacingPath(normal);
+}
+
 export function getOutletGardenOfferPlacement(
     slotIndex: number,
 ): OutletGardenOfferPlacement {
     const plantBay = outletGardenPlantBay(slotIndex);
     const aisleRow = Math.floor(plantBay / outletGardenPlantBaysPerAisleRow);
-    const side = plantBay % outletGardenPlantBaysPerAisleRow === 0 ? -1 : 1;
     const slotInPlantBay = slotIndex % outletGardenOffersPerPlantBay;
-    const y = aisleRow * outletGardenAisleRowSpacing + (slotInPlantBay % 2);
+    const { anchor, segment } = outletGardenAisleRowGeometry(aisleRow);
+    const normal = outletGardenSideNormal(plantBay, segment.direction);
     const surface = slotInPlantBay < 2 ? 'table' : 'floor';
     const distance =
         surface === 'table'
             ? outletGardenTableDistance
             : outletGardenFloorDistance;
+    const tangentOffset = slotInPlantBay % 2;
 
     return {
         aisleRow,
         plantBay,
         surface,
-        x: side * distance,
-        y,
+        x: anchor.x + normal.x * distance + segment.direction.x * tangentOffset,
+        y: anchor.y + normal.y * distance + segment.direction.y * tangentOffset,
     };
 }
 
@@ -424,7 +555,9 @@ function compareStacks(left: PublicGardenStack, right: PublicGardenStack) {
     return left.y - right.y || left.x - right.x;
 }
 
-function outletGardenBounds(assignments: OutletGardenSlotAssignments) {
+function outletGardenPathSegmentCount(
+    assignments: OutletGardenSlotAssignments,
+) {
     const highestPlantBay = Math.max(
         -1,
         ...Array.from(assignments.values(), (assignment) =>
@@ -435,26 +568,183 @@ function outletGardenBounds(assignments: OutletGardenSlotAssignments) {
         1,
         Math.ceil((highestPlantBay + 1) / outletGardenPlantBaysPerAisleRow),
     );
-    const lastDisplayY = (aisleRowCount - 1) * outletGardenAisleRowSpacing + 1;
-
-    const displayDistance = Math.max(
-        outletGardenFloorDistance,
-        outletGardenTableDistance,
+    // Even a small outlet should visibly read as a winding garden, not the old
+    // straight aisle, so always include the first corner and second segment.
+    return Math.max(
+        2,
+        Math.ceil(aisleRowCount / outletGardenAisleRowsPerPathSegment),
     );
+}
+
+function outletGardenPathPoints(segmentCount: number) {
+    const pathPoints = new Map<string, OutletGardenPoint>();
+
+    for (let y = outletGardenEntranceY; y <= 0; y += 1) {
+        pathPoints.set(stackKey(0, y), { x: 0, y });
+    }
+
+    for (let segmentIndex = 0; segmentIndex < segmentCount; segmentIndex += 1) {
+        const segment = outletGardenPathSegment(segmentIndex);
+        for (
+            let distance = 0;
+            distance <= outletGardenPathSegmentLength;
+            distance += 1
+        ) {
+            const point = outletGardenPointAlongSegment(segment, distance);
+            pathPoints.set(stackKey(point.x, point.y), point);
+        }
+    }
+
+    return Array.from(pathPoints.values());
+}
+
+function outletGardenBounds(segmentCount: number) {
+    const pathPoints = outletGardenPathPoints(segmentCount);
+    const maxPathX = Math.max(...pathPoints.map((point) => point.x));
 
     return {
-        maxX: displayDistance + outletGardenSideMargin,
-        maxY: lastDisplayY + outletGardenBackMargin,
-        minX: -displayDistance - outletGardenSideMargin,
-        minY: -outletGardenFrontMargin,
+        maxX: maxPathX + outletGardenDecorationDistance + outletGardenMapMargin,
+        maxY:
+            outletGardenPathSegmentLength +
+            outletGardenDecorationDistance +
+            outletGardenMapMargin,
+        minX: -outletGardenDecorationDistance - outletGardenMapMargin,
+        minY: outletGardenEntranceY,
     };
+}
+
+function outletGardenReservedDisplayPoints(segmentCount: number) {
+    const points: OutletGardenPoint[] = [];
+    const aisleRowCount = segmentCount * outletGardenAisleRowsPerPathSegment;
+
+    for (let aisleRow = 0; aisleRow < aisleRowCount; aisleRow += 1) {
+        for (let side = 0; side < outletGardenPlantBaysPerAisleRow; side += 1) {
+            const plantBay = aisleRow * outletGardenPlantBaysPerAisleRow + side;
+            for (let offset = 0; offset < 2; offset += 1) {
+                for (const surfaceOffset of [0, 2]) {
+                    const placement = getOutletGardenOfferPlacement(
+                        plantBay * outletGardenOffersPerPlantBay +
+                            surfaceOffset +
+                            offset,
+                    );
+                    points.push({ x: placement.x, y: placement.y });
+                }
+            }
+        }
+    }
+
+    return points;
+}
+
+function outletGardenDecorationCandidates(
+    segment: OutletGardenPathSegment,
+    ordinal: number,
+) {
+    const leftNormal = {
+        x: -segment.direction.y,
+        y: segment.direction.x,
+    };
+    const rightNormal = { x: -leftNormal.x, y: -leftNormal.y };
+    const preferredNormal =
+        (segment.index + (ordinal === 0 ? 0 : 1)) % 2 === 0
+            ? leftNormal
+            : rightNormal;
+    const otherNormal = {
+        x: -preferredNormal.x,
+        y: -preferredNormal.y,
+    };
+    const preferredDistance = [8, 6, 9][ordinal] ?? 7;
+    const distances = Array.from(new Set([preferredDistance, 8, 6, 9, 7, 3]));
+
+    return [preferredNormal, otherNormal].flatMap((normal) =>
+        distances.map((distance) => {
+            const pathPoint = outletGardenPointAlongSegment(segment, distance);
+            return {
+                normal,
+                point: {
+                    x: pathPoint.x + normal.x * outletGardenDecorationDistance,
+                    y: pathPoint.y + normal.y * outletGardenDecorationDistance,
+                },
+            };
+        }),
+    );
+}
+
+function outletGardenPointIsClear(
+    point: OutletGardenPoint,
+    blockedPoints: readonly OutletGardenPoint[],
+) {
+    return blockedPoints.every(
+        (blockedPoint) =>
+            Math.max(
+                Math.abs(point.x - blockedPoint.x),
+                Math.abs(point.y - blockedPoint.y),
+            ) > 1,
+    );
+}
+
+function outletGardenDecorations(segmentCount: number) {
+    const futureSafeSegmentCount = segmentCount + 1;
+    const blockedPoints = [
+        ...outletGardenPathPoints(futureSafeSegmentCount),
+        ...outletGardenReservedDisplayPoints(futureSafeSegmentCount),
+    ];
+    const decorations: Array<{
+        name: OutletGardenDecorationName;
+        point: OutletGardenPoint;
+        rotation: number;
+        segmentIndex: number;
+    }> = [];
+
+    for (let segmentIndex = 0; segmentIndex < segmentCount; segmentIndex += 1) {
+        const segment = outletGardenPathSegment(segmentIndex);
+        const decorationNames: OutletGardenDecorationName[] = [
+            segmentIndex % 2 === 0 ? 'Tree' : 'Bush',
+        ];
+        if (segmentIndex % 3 === 0) {
+            decorationNames.push('StoneSmall');
+        }
+        if (segmentIndex % 4 === 0) {
+            decorationNames.push('WoodenBench');
+        }
+
+        for (const [ordinal, name] of decorationNames.entries()) {
+            const candidate = outletGardenDecorationCandidates(
+                segment,
+                ordinal,
+            ).find(({ point }) =>
+                outletGardenPointIsClear(point, [
+                    ...blockedPoints,
+                    ...decorations.map((decoration) => decoration.point),
+                ]),
+            );
+            if (!candidate) {
+                continue;
+            }
+
+            decorations.push({
+                name,
+                point: candidate.point,
+                rotation: outletGardenRotationFacingPath(candidate.normal),
+                segmentIndex,
+            });
+        }
+    }
+
+    return decorations;
 }
 
 export function buildOutletGardenStacks(
     offers: readonly OutletGardenLayoutOffer[],
     assignments: OutletGardenSlotAssignments,
 ) {
-    const { maxX, maxY, minX, minY } = outletGardenBounds(assignments);
+    const segmentCount = outletGardenPathSegmentCount(assignments);
+    const { maxX, maxY, minX, minY } = outletGardenBounds(segmentCount);
+    const pathPositionKeys = new Set(
+        outletGardenPathPoints(segmentCount).map((point) =>
+            stackKey(point.x, point.y),
+        ),
+    );
     const stacksByPosition = new Map<string, PublicGardenStack>();
 
     for (let y = minY; y <= maxY; y += 1) {
@@ -465,7 +755,7 @@ export function buildOutletGardenStacks(
                 rotation: 0,
             });
 
-            if (y < maxY && Math.abs(x) <= outletGardenPathHalfWidth) {
+            if (pathPositionKeys.has(stackKey(x, y))) {
                 addBlock(stacksByPosition, x, y, {
                     id: `outlet-path:${x.toString()}:${y.toString()}`,
                     name: 'MulchWood',
@@ -475,8 +765,7 @@ export function buildOutletGardenStacks(
 
             const atBoundary =
                 x === minX || x === maxX || y === minY || y === maxY;
-            const atFrontOpening =
-                y === minY && Math.abs(x) <= outletGardenPathHalfWidth;
+            const atFrontOpening = y === minY && x === 0;
             if (atBoundary && !atFrontOpening) {
                 addBlock(stacksByPosition, x, y, {
                     id: `outlet-fence:${x.toString()}:${y.toString()}`,
@@ -495,18 +784,13 @@ export function buildOutletGardenStacks(
         ),
     ).sort((left, right) => left - right);
     for (const plantBay of assignedPlantBays) {
-        const aisleRow = Math.floor(
-            plantBay / outletGardenPlantBaysPerAisleRow,
-        );
-        const side = plantBay % outletGardenPlantBaysPerAisleRow === 0 ? -1 : 1;
-        const tableX = side * outletGardenTableDistance;
-        const tableStartY = aisleRow * outletGardenAisleRowSpacing;
-
         for (let offset = 0; offset < 2; offset += 1) {
-            addBlock(stacksByPosition, tableX, tableStartY + offset, {
+            const slotIndex = plantBay * outletGardenOffersPerPlantBay + offset;
+            const placement = getOutletGardenOfferPlacement(slotIndex);
+            addBlock(stacksByPosition, placement.x, placement.y, {
                 id: `outlet-table:${plantBay.toString()}:${offset.toString()}`,
                 name: 'OutletDisplayTable',
-                rotation: 1,
+                rotation: outletGardenFacingRotation(slotIndex),
             });
         }
     }
@@ -533,16 +817,18 @@ export function buildOutletGardenStacks(
 
     for (const { assignment, display } of placedDisplays) {
         const position = getOutletGardenOfferPlacement(assignment.slotIndex);
-        const rotation =
-            position.surface === 'floor'
-                ? position.x < 0
-                    ? 1
-                    : 3
-                : ((display.plantSortId % 4) + 4) % 4;
         addBlock(stacksByPosition, position.x, position.y, {
             id: display.blockId,
             name: outletGardenPotName(display.plantSortId),
-            rotation,
+            rotation: outletGardenFacingRotation(assignment.slotIndex),
+        });
+    }
+
+    for (const decoration of outletGardenDecorations(segmentCount)) {
+        addBlock(stacksByPosition, decoration.point.x, decoration.point.y, {
+            id: `outlet-decor:${decoration.name}:${decoration.segmentIndex.toString()}`,
+            name: decoration.name,
+            rotation: decoration.rotation,
         });
     }
 

--- a/packages/game/src/viewers/outletGardenLayout.unit.ts
+++ b/packages/game/src/viewers/outletGardenLayout.unit.ts
@@ -66,6 +66,28 @@ function assignmentSlots(
     ]);
 }
 
+function coordinateKey({ x, y }: { x: number; y: number }) {
+    return `${x.toString()}|${y.toString()}`;
+}
+
+function positionsForBlocks(
+    stacks: ReturnType<typeof buildOutletGardenStacks>,
+    predicate: (block: (typeof stacks)[number]['blocks'][number]) => boolean,
+) {
+    return stacks.flatMap((stack) =>
+        stack.blocks.some(predicate) ? [{ x: stack.x, y: stack.y }] : [],
+    );
+}
+
+function blockById(
+    stacks: ReturnType<typeof buildOutletGardenStacks>,
+    blockId: string,
+) {
+    return stacks
+        .flatMap((stack) => stack.blocks)
+        .find((block) => block.id === blockId);
+}
+
 describe('outlet offer block IDs', () => {
     it('round-trips valid IDs and rejects malformed block IDs', () => {
         assert.equal(outletOfferIdFromBlockId(outletOfferBlockId(302)), 302);
@@ -387,48 +409,62 @@ describe('reconcileOutletGardenSlots', () => {
 });
 
 describe('getOutletGardenOfferPlacement', () => {
-    it('fills both tabletop positions before floor positions on either side', () => {
+    it('fills both tabletop positions before floor positions around each winding segment', () => {
         assert.deepEqual(getOutletGardenOfferPlacement(0), {
             aisleRow: 0,
             plantBay: 0,
             surface: 'table',
             x: -3,
-            y: 0,
+            y: 1,
         });
         assert.deepEqual(getOutletGardenOfferPlacement(1), {
             aisleRow: 0,
             plantBay: 0,
             surface: 'table',
             x: -3,
-            y: 1,
+            y: 2,
         });
         assert.deepEqual(getOutletGardenOfferPlacement(4), {
             aisleRow: 0,
             plantBay: 1,
             surface: 'table',
             x: 3,
-            y: 0,
+            y: 1,
         });
         assert.deepEqual(getOutletGardenOfferPlacement(5), {
             aisleRow: 0,
             plantBay: 1,
             surface: 'table',
             x: 3,
-            y: 1,
+            y: 2,
         });
         assert.deepEqual(getOutletGardenOfferPlacement(6), {
             aisleRow: 0,
             plantBay: 1,
             surface: 'floor',
             x: 2,
-            y: 0,
+            y: 1,
         });
         assert.deepEqual(getOutletGardenOfferPlacement(8), {
             aisleRow: 1,
             plantBay: 2,
             surface: 'table',
             x: -3,
-            y: 3,
+            y: 4,
+        });
+        assert.deepEqual(getOutletGardenOfferPlacement(16), {
+            aisleRow: 2,
+            plantBay: 4,
+            surface: 'table',
+            x: 1,
+            y: 13,
+        });
+        assert.deepEqual(getOutletGardenOfferPlacement(32), {
+            aisleRow: 4,
+            plantBay: 8,
+            surface: 'table',
+            x: 13,
+            y: 9,
         });
     });
 });
@@ -453,6 +489,23 @@ describe('buildOutletGardenStacks', () => {
         assert.ok(
             stacks.every((stack) =>
                 stack.blocks.every((block) => registeredNames.has(block.name)),
+            ),
+        );
+        assert.ok(
+            ['Tree', 'Bush'].every((name) =>
+                stacks.some((stack) =>
+                    stack.blocks.some((block) => block.name === name),
+                ),
+            ),
+        );
+        assert.ok(
+            stacks.some(
+                (stack) =>
+                    stack.x === 1 &&
+                    stack.y === 10 &&
+                    stack.blocks.some((block) =>
+                        block.id.startsWith('outlet-path:'),
+                    ),
             ),
         );
     });
@@ -529,24 +582,95 @@ describe('buildOutletGardenStacks', () => {
         assert.equal(floorStack?.x, -2);
     });
 
-    it('builds a continuous one-tile mulch aisle with a matching front entrance', () => {
-        const assignments = reconcileOutletGardenSlots(new Map(), offers);
-        const stacks = buildOutletGardenStacks(offers, assignments);
+    it('turns after eight tables while keeping one connected one-tile mulch path', () => {
+        const windingOffer = {
+            id: 801,
+            plantId: 8,
+            plantSortId: 801,
+            remainingQuantity: 48,
+        };
+        const assignments = reconcileOutletGardenSlots(new Map(), [
+            windingOffer,
+        ]);
+        const stacks = buildOutletGardenStacks([windingOffer], assignments);
+        const pathPositions = positionsForBlocks(stacks, (block) =>
+            block.id.startsWith('outlet-path:'),
+        );
+        const pathKeys = new Set(pathPositions.map(coordinateKey));
+        const neighbors = ({ x, y }: { x: number; y: number }) =>
+            [
+                { x: x - 1, y },
+                { x: x + 1, y },
+                { x, y: y - 1 },
+                { x, y: y + 1 },
+            ].filter((point) => pathKeys.has(coordinateKey(point)));
+        const endpoints = pathPositions.filter(
+            (position) => neighbors(position).length === 1,
+        );
 
-        const pathStacks = stacks.filter((stack) =>
-            stack.blocks.some((block) => block.id.startsWith('outlet-path:')),
-        );
-        assert.deepEqual(
-            Array.from(new Set(pathStacks.map((stack) => stack.x))),
-            [0],
-        );
-        assert.deepEqual(
-            pathStacks.map((stack) => stack.y),
-            [-3, -2, -1, 0, 1, 2, 3, 4, 5, 6],
+        assert.equal(pathKeys.size, pathPositions.length);
+        assert.equal(endpoints.length, 2);
+        assert.ok(
+            pathPositions.every((position) => {
+                const degree = neighbors(position).length;
+                return degree === 1 || degree === 2;
+            }),
         );
 
+        const visited = new Set<string>();
+        const pending = [endpoints[0]];
+        while (pending.length > 0) {
+            const position = pending.pop();
+            if (!position) {
+                continue;
+            }
+            const key = coordinateKey(position);
+            if (visited.has(key)) {
+                continue;
+            }
+            visited.add(key);
+            pending.push(...neighbors(position));
+        }
+        assert.equal(visited.size, pathKeys.size);
+
+        for (const { x, y } of pathPositions) {
+            assert.equal(
+                [
+                    { x, y },
+                    { x: x + 1, y },
+                    { x, y: y + 1 },
+                    { x: x + 1, y: y + 1 },
+                ].every((point) => pathKeys.has(coordinateKey(point))),
+                false,
+            );
+        }
+
+        assert.deepEqual(neighbors({ x: 0, y: 10 }), [
+            { x: 1, y: 10 },
+            { x: 0, y: 9 },
+        ]);
+        assert.deepEqual(neighbors({ x: 10, y: 10 }), [
+            { x: 9, y: 10 },
+            { x: 10, y: 9 },
+        ]);
+
+        const tablesPerSegment = new Map<number, number>();
+        for (const table of stacks
+            .flatMap((stack) => stack.blocks)
+            .filter((block) => block.id.startsWith('outlet-table:'))) {
+            const plantBay = Number(table.id.split(':')[1]);
+            const aisleRow = Math.floor(plantBay / 2);
+            const segmentIndex = Math.floor(aisleRow / 2);
+            tablesPerSegment.set(
+                segmentIndex,
+                (tablesPerSegment.get(segmentIndex) ?? 0) + 1,
+            );
+        }
+        assert.deepEqual(Array.from(tablesPerSegment.values()), [8, 8, 8]);
+
+        const entranceY = Math.min(...pathPositions.map((point) => point.y));
         const entrance = stacks.find(
-            (stack) => stack.x === 0 && stack.y === -3,
+            (stack) => stack.x === 0 && stack.y === entranceY,
         );
         assert.equal(
             entrance?.blocks.some((block) => block.name === 'Fence'),
@@ -554,7 +678,7 @@ describe('buildOutletGardenStacks', () => {
         );
 
         const frontFence = stacks.find(
-            (stack) => stack.x === -1 && stack.y === -3,
+            (stack) => stack.x === -1 && stack.y === entranceY,
         );
         assert.equal(
             frontFence?.blocks.some((block) => block.name === 'Fence'),
@@ -562,65 +686,192 @@ describe('buildOutletGardenStacks', () => {
         );
     });
 
-    it('turns floor displays toward the center aisle without changing tabletop variation', () => {
-        const floorOffers = [
-            {
-                id: 301,
-                plantId: 1,
-                plantSortId: 102,
-                remainingQuantity: 3,
-            },
-            {
-                id: 303,
-                plantId: 2,
-                plantSortId: 201,
-                remainingQuantity: 3,
-            },
-        ];
-        const assignments = reconcileOutletGardenSlots(new Map(), floorOffers);
-        const stacks = buildOutletGardenStacks(floorOffers, assignments);
-        const leftFloor = stacks.find((stack) =>
-            stack.blocks.some(
-                (block) => block.id === outletOfferBlockId(301, 2),
-            ),
+    it('faces tables and every plant surface toward its local walkway segment', () => {
+        const facingOffer = {
+            id: 880,
+            plantId: 8,
+            plantSortId: 881,
+            remainingQuantity: 12,
+        };
+        const facingSlots = [0, 2, 4, 6, 16, 18, 20, 22, 32, 34, 36, 38];
+        const assignments = new Map(
+            facingSlots.map((slotIndex, unitIndex) => [
+                outletOfferBlockId(facingOffer.id, unitIndex),
+                {
+                    offerId: facingOffer.id,
+                    plantKey: 'plant:8',
+                    slotIndex,
+                    unitIndex,
+                },
+            ]),
         );
-        const rightFloor = stacks.find((stack) =>
-            stack.blocks.some(
-                (block) => block.id === outletOfferBlockId(303, 2),
-            ),
-        );
-        const leftTable = stackForOffer(stacks, 301);
+        const stacks = buildOutletGardenStacks([facingOffer], assignments);
+        const expectedOfferRotations = [1, 1, 3, 3, 2, 2, 0, 0, 3, 3, 1, 1];
 
-        assert.equal(leftFloor?.x, -2);
-        assert.equal(
-            leftFloor?.blocks.find((block) =>
-                block.id.startsWith('outlet-offer:'),
-            )?.rotation,
-            1,
-        );
-        assert.equal(rightFloor?.x, 2);
-        assert.equal(
-            rightFloor?.blocks.find((block) =>
-                block.id.startsWith('outlet-offer:'),
-            )?.rotation,
-            3,
-        );
-        assert.equal(
-            leftTable?.blocks.find((block) =>
-                block.id.startsWith('outlet-offer:'),
-            )?.rotation,
-            2,
-        );
-        assert.equal(
-            stacks.some(
-                (stack) =>
-                    stack.x === 0 &&
-                    stack.blocks.some((block) =>
-                        block.id.startsWith('outlet-offer:'),
-                    ),
+        assert.deepEqual(
+            Array.from(
+                { length: facingOffer.remainingQuantity },
+                (_, index) =>
+                    blockById(stacks, outletOfferBlockId(facingOffer.id, index))
+                        ?.rotation,
             ),
-            false,
+            expectedOfferRotations,
         );
+        assert.deepEqual(
+            [0, 1, 4, 5, 8, 9].map(
+                (plantBay) =>
+                    blockById(stacks, `outlet-table:${plantBay.toString()}:0`)
+                        ?.rotation,
+            ),
+            [1, 3, 2, 0, 3, 1],
+        );
+
+        const pathPositions = new Set(
+            positionsForBlocks(stacks, (block) =>
+                block.id.startsWith('outlet-path:'),
+            ).map(coordinateKey),
+        );
+        for (const slotIndex of facingSlots) {
+            const placement = getOutletGardenOfferPlacement(slotIndex);
+            const pathDistance = placement.surface === 'table' ? 3 : 2;
+            assert.ok(
+                [
+                    { x: placement.x - pathDistance, y: placement.y },
+                    { x: placement.x + pathDistance, y: placement.y },
+                    { x: placement.x, y: placement.y - pathDistance },
+                    { x: placement.x, y: placement.y + pathDistance },
+                ].some((point) => pathPositions.has(coordinateKey(point))),
+            );
+        }
+    });
+
+    it('adds restrained registered decor away from the path and every display position', () => {
+        const decoratedOffer = {
+            id: 890,
+            plantId: 8,
+            plantSortId: 891,
+            remainingQuantity: 64,
+        };
+        const assignments = reconcileOutletGardenSlots(new Map(), [
+            decoratedOffer,
+        ]);
+        const stacks = buildOutletGardenStacks([decoratedOffer], assignments);
+        const decorations = stacks.flatMap((stack) =>
+            stack.blocks.flatMap((block) =>
+                block.id.startsWith('outlet-decor:')
+                    ? [{ block, x: stack.x, y: stack.y }]
+                    : [],
+            ),
+        );
+        const decorationNames = Array.from(
+            new Set(decorations.map(({ block }) => block.name)),
+        ).sort();
+        const registeredNames = new Set<string>(
+            outletGardenRegisteredBlockNames,
+        );
+        const protectedPositions = [
+            ...positionsForBlocks(stacks, (block) =>
+                block.id.startsWith('outlet-path:'),
+            ),
+            ...positionsForBlocks(stacks, (block) =>
+                block.id.startsWith('outlet-table:'),
+            ),
+            ...positionsForBlocks(
+                stacks,
+                (block) => outletOfferIdFromBlockId(block.id) !== null,
+            ),
+        ];
+
+        assert.deepEqual(decorationNames, [
+            'Bush',
+            'StoneSmall',
+            'Tree',
+            'WoodenBench',
+        ]);
+        assert.equal(
+            new Set(decorations.map(({ block }) => block.id)).size,
+            decorations.length,
+        );
+        assert.ok(
+            decorations.every(
+                ({ block }) =>
+                    registeredNames.has(block.name) &&
+                    outletOfferIdFromBlockId(block.id) === null,
+            ),
+        );
+        assert.ok(
+            decorations.every(({ x, y }) =>
+                protectedPositions.every(
+                    (position) =>
+                        Math.max(
+                            Math.abs(x - position.x),
+                            Math.abs(y - position.y),
+                        ) > 1,
+                ),
+            ),
+        );
+    });
+
+    it('keeps existing decor and offer coordinates stable as the route grows and stock churns', () => {
+        const stockOffer = {
+            id: 895,
+            plantId: 8,
+            plantSortId: 896,
+            remainingQuantity: 16,
+        };
+        const initialAssignments = reconcileOutletGardenSlots(new Map(), [
+            stockOffer,
+        ]);
+        const initialStacks = buildOutletGardenStacks(
+            [stockOffer],
+            initialAssignments,
+        );
+        const expandedOffer = { ...stockOffer, remainingQuantity: 48 };
+        const expandedAssignments = reconcileOutletGardenSlots(
+            initialAssignments,
+            [expandedOffer],
+        );
+        const expandedStacks = buildOutletGardenStacks(
+            [expandedOffer],
+            expandedAssignments,
+        );
+        const reducedAssignments = reconcileOutletGardenSlots(
+            expandedAssignments,
+            [stockOffer],
+        );
+        const reducedStacks = buildOutletGardenStacks(
+            [stockOffer],
+            reducedAssignments,
+        );
+        const positionsById = (
+            stacks: ReturnType<typeof buildOutletGardenStacks>,
+        ) =>
+            new Map(
+                stacks.flatMap((stack) =>
+                    stack.blocks.flatMap((block) =>
+                        block.id.startsWith('outlet-decor:') ||
+                        outletOfferIdFromBlockId(block.id) !== null
+                            ? [[block.id, { x: stack.x, y: stack.y }] as const]
+                            : [],
+                    ),
+                ),
+            );
+        const initialPositions = positionsById(initialStacks);
+        const expandedPositions = positionsById(expandedStacks);
+        const reducedPositions = positionsById(reducedStacks);
+
+        for (const [blockId, position] of initialPositions) {
+            assert.deepEqual(expandedPositions.get(blockId), position);
+            assert.deepEqual(reducedPositions.get(blockId), position);
+        }
+        assert.ok(
+            expandedStacks.some((stack) =>
+                stack.blocks.some(
+                    (block) => block.id === 'outlet-decor:Tree:2',
+                ),
+            ),
+        );
+        assert.equal(reducedAssignments, expandedAssignments);
     });
 
     it('keeps surviving offer coordinates stable through removal and additions', () => {


### PR DESCRIPTION
## What changed

- reshape the Outlet into a deterministic winding garden with a one-block-wide connected mulch path that turns after eight table positions
- orient display tables and floor/table seedlings toward the local path
- add stable, registered tree, bush, stone, and bench decoration with clearance from offers and the walkway
- use the canonical live game day/night clock instead of a fixed preview timestamp
- add an Outlet-only preserve-angle closeup that pans and zooms without changing the existing isometric angle
- keep existing stock caps, table-first allocation, tombstone stability, read-only selection, and the default-off Outlet feature flag

## Why

The straight aisle validated the Phase 1 flow, but it did not yet feel like a designed Outlet garden. This makes the beta experience more spatial and legible while keeping the commerce flow and shared public-garden behavior unchanged.

## Validation

- `pnpm --filter @gredice/game test` — 951/951 passed
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter garden build`
- targeted Biome and `git diff --check`
- real `outlet-garden-route.spec.ts` WebGL smoke
- manual desktop and 390px visual checks, including live night lighting and selected-offer closeup

## Rollout

The production route and teleport entry remain gated by `enableOutletGarden`; merging this PR does not enable the experience for users.