### PR TITLE
feat(game): add seasonal Perseids meteor shower

### DIFF
--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -27,6 +27,8 @@ import {
 } from './gameQuality';
 import { enableGeneratedPlantShadowLayer } from './generatedPlantShadowLayer';
 import { getMoonlitNightScales } from './moonlight';
+import { Perseids } from './PerseidMeteorShower';
+import { getPerseidsMeteorRatePerHour, shouldRenderPerseids } from './perseids';
 import { Drops } from './Rain/Drops';
 import { resolveRainParticleState } from './Rain/rainParticles';
 import { useSceneTimeInvalidation } from './SceneTime';
@@ -858,6 +860,12 @@ export function Environment({
         ? 0
         : Math.max(0, 1 - cloudCover / 0.6) ** 1.5 * nightVisibility;
     const showStars = starVisibility > 0;
+    const perseidsVisibility = closeupCameraSettled ? 0 : starVisibility;
+    const perseidsMeteorRate = getPerseidsMeteorRatePerHour(currentTime);
+    const showPerseids = shouldRenderPerseids({
+        date: currentTime,
+        skyVisibility: perseidsVisibility,
+    });
     // Dense clouds or fog dim the sun/moon discs toward a small residual
     // glow. The curve drops fast so 70%+ overcast reads as "no sun" rather
     // than a dimmer but still-solid disc, but never fully hits zero — matching
@@ -1100,6 +1108,12 @@ export function Environment({
             )}
             {showStars && (
                 <Stars visibility={closeupCameraSettled ? 0 : starVisibility} />
+            )}
+            {showPerseids && (
+                <Perseids
+                    meteorsPerHour={perseidsMeteorRate}
+                    visibility={perseidsVisibility}
+                />
             )}
             {!noBackground && (
                 <SunMoon

--- a/packages/game/src/scene/PerseidMeteorShower.tsx
+++ b/packages/game/src/scene/PerseidMeteorShower.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+import { useFrame, useThree } from '@react-three/fiber';
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import {
+    AdditiveBlending,
+    BufferAttribute,
+    BufferGeometry,
+    type Camera,
+    Color,
+    DoubleSide,
+    type InterleavedBufferAttribute,
+    MathUtils,
+    type Mesh,
+    OrthographicCamera,
+    Raycaster,
+    ShaderMaterial,
+    Vector2,
+    Vector3,
+} from 'three';
+import { useGameState } from '../useGameState';
+import {
+    createPerseidsMeteor,
+    type PerseidsMeteorDefinition,
+    samplePerseidsIntervalSeconds,
+} from './perseids';
+import { useSceneTimeInvalidation } from './SceneTime';
+
+const METEOR_SKY_DISTANCE = 42;
+const METEOR_REFERENCE_VERTICAL_FOV_DEGREES = 55;
+const MAX_FRAME_DELTA_SECONDS = 0.1;
+const METEOR_REFERENCE_HALF_HEIGHT =
+    METEOR_SKY_DISTANCE *
+    Math.tan(MathUtils.degToRad(METEOR_REFERENCE_VERTICAL_FOV_DEGREES) / 2);
+
+const meteorVertexShader = /* glsl */ `
+    varying vec2 vUv;
+
+    void main() {
+        vUv = uv;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+`;
+
+const meteorFragmentShader = /* glsl */ `
+    uniform vec3 uColor;
+    uniform float uBrightness;
+    uniform float uProgress;
+    uniform float uVisibility;
+
+    varying vec2 vUv;
+
+    void main() {
+        float across = abs(vUv.y - 0.5) * 2.0;
+        float widthTaper = mix(0.12, 1.0, smoothstep(0.0, 0.55, vUv.x));
+        float core = 1.0 - smoothstep(
+            0.05 * widthTaper,
+            0.24 * widthTaper,
+            across
+        );
+        float glow = 1.0 - smoothstep(
+            0.14 * widthTaper,
+            widthTaper,
+            across
+        );
+        float tailFade = smoothstep(0.0, 0.24, vUv.x);
+        float endCap = 1.0 - smoothstep(0.97, 1.0, vUv.x);
+        float life = smoothstep(0.0, 0.08, uProgress) *
+            (1.0 - smoothstep(0.72, 1.0, uProgress));
+        float alpha = (core * 0.92 + glow * 0.3) *
+            tailFade *
+            mix(0.82, 1.0, endCap) *
+            life *
+            uBrightness *
+            uVisibility;
+
+        if (alpha <= 0.01) {
+            discard;
+        }
+
+        vec3 color = mix(uColor, vec3(1.0), core * 0.55);
+        gl_FragColor = vec4(color, min(1.0, alpha));
+        #include <colorspace_fragment>
+    }
+`;
+
+type ActiveMeteor = {
+    definition: PerseidsMeteorDefinition;
+    elapsedSeconds: number;
+};
+
+function createMeteorGeometry() {
+    const geometry = new BufferGeometry();
+    geometry.setAttribute(
+        'position',
+        new BufferAttribute(new Float32Array(4 * 3), 3),
+    );
+    geometry.setAttribute(
+        'uv',
+        new BufferAttribute(new Float32Array([0, 0, 0, 1, 1, 0, 1, 1]), 2),
+    );
+    geometry.setIndex([0, 1, 2, 2, 1, 3]);
+    return geometry;
+}
+
+function easeOutCubic(value: number) {
+    return 1 - (1 - value) ** 3;
+}
+
+function getMeteorWorldWidth(width: number, camera: Camera) {
+    if (!(camera instanceof OrthographicCamera)) {
+        return width;
+    }
+
+    const halfHeight = (camera.top - camera.bottom) / (2 * camera.zoom);
+    return width * (halfHeight / METEOR_REFERENCE_HALF_HEIGHT);
+}
+
+function setMeteorVertex(
+    positions: BufferAttribute | InterleavedBufferAttribute,
+    index: number,
+    point: Vector3,
+    perpendicular: Vector3,
+    width: number,
+) {
+    positions.setXYZ(
+        index,
+        point.x + perpendicular.x * width,
+        point.y + perpendicular.y * width,
+        point.z + perpendicular.z * width,
+    );
+}
+
+export function Perseids({
+    meteorsPerHour,
+    visibility,
+}: {
+    meteorsPerHour: number;
+    visibility: number;
+}) {
+    const camera = useThree((state) => state.camera);
+    const gardenAvatarView = useGameState((state) => state.gardenAvatarView);
+    const meshRef = useRef<Mesh>(null);
+    const rateRef = useRef(meteorsPerHour);
+    const activeMeteorRef = useRef<ActiveMeteor | null>(null);
+    const nextMeteorInRef = useRef(Number.POSITIVE_INFINITY);
+    const raycasterRef = useRef(new Raycaster());
+    const ndcRef = useRef(new Vector2());
+    const startOffsetRef = useRef(new Vector3());
+    const endOffsetRef = useRef(new Vector3());
+    const headOffsetRef = useRef(new Vector3());
+    const tailOffsetRef = useRef(new Vector3());
+    const headRef = useRef(new Vector3());
+    const tailRef = useRef(new Vector3());
+    const pathDirectionRef = useRef(new Vector3());
+    const skyDirectionRef = useRef(new Vector3());
+    const perpendicularRef = useRef(new Vector3());
+    const geometry = useMemo(createMeteorGeometry, []);
+    const material = useMemo(
+        () =>
+            new ShaderMaterial({
+                blending: AdditiveBlending,
+                depthTest: true,
+                depthWrite: false,
+                fragmentShader: meteorFragmentShader,
+                side: DoubleSide,
+                toneMapped: false,
+                transparent: true,
+                uniforms: {
+                    uBrightness: { value: 1 },
+                    uColor: { value: new Color('#dcecff') },
+                    uProgress: { value: 0 },
+                    uVisibility: { value: 0 },
+                },
+                vertexShader: meteorVertexShader,
+            }),
+        [],
+    );
+
+    useSceneTimeInvalidation(true);
+
+    useEffect(
+        () => () => {
+            geometry.dispose();
+            material.dispose();
+        },
+        [geometry, material],
+    );
+
+    useLayoutEffect(() => {
+        material.uniforms.uVisibility.value = Math.min(
+            1,
+            Math.max(0, visibility),
+        );
+    }, [material, visibility]);
+
+    useLayoutEffect(() => {
+        material.depthTest = gardenAvatarView !== 'overview';
+    }, [gardenAvatarView, material]);
+
+    useEffect(() => {
+        const previousRate = rateRef.current;
+        rateRef.current = meteorsPerHour;
+        if (
+            Number.isFinite(nextMeteorInRef.current) &&
+            nextMeteorInRef.current > 0 &&
+            previousRate > 0 &&
+            meteorsPerHour > 0
+        ) {
+            nextMeteorInRef.current *= previousRate / meteorsPerHour;
+        }
+    }, [meteorsPerHour]);
+
+    useLayoutEffect(() => {
+        if (meshRef.current) {
+            meshRef.current.visible = false;
+        }
+        nextMeteorInRef.current = samplePerseidsIntervalSeconds({
+            meteorsPerHour: rateRef.current,
+        });
+    }, []);
+
+    useFrame((_, frameDelta) => {
+        const mesh = meshRef.current;
+        if (!mesh) {
+            return;
+        }
+
+        const schedulerDelta = Math.max(0, frameDelta);
+        const animationDelta = Math.min(
+            MAX_FRAME_DELTA_SECONDS,
+            schedulerDelta,
+        );
+        nextMeteorInRef.current -= schedulerDelta;
+        const activeMeteor = activeMeteorRef.current;
+        if (!activeMeteor) {
+            if (nextMeteorInRef.current > 0) {
+                return;
+            }
+
+            const definition = createPerseidsMeteor();
+            const raycaster = raycasterRef.current;
+            const ndc = ndcRef.current;
+            const projectToSky = (
+                point: [x: number, y: number],
+                target: Vector3,
+            ) => {
+                ndc.set(point[0] * 2 - 1, point[1] * 2 - 1);
+                raycaster.setFromCamera(ndc, camera);
+                target
+                    .copy(raycaster.ray.origin)
+                    .addScaledVector(
+                        raycaster.ray.direction,
+                        METEOR_SKY_DISTANCE,
+                    )
+                    .sub(camera.position);
+            };
+            projectToSky(definition.start, startOffsetRef.current);
+            projectToSky(definition.end, endOffsetRef.current);
+            pathDirectionRef.current
+                .subVectors(endOffsetRef.current, startOffsetRef.current)
+                .normalize();
+
+            activeMeteorRef.current = {
+                definition,
+                elapsedSeconds: 0,
+            };
+            nextMeteorInRef.current += samplePerseidsIntervalSeconds({
+                meteorsPerHour: rateRef.current,
+            });
+            material.uniforms.uBrightness.value = definition.brightness;
+            material.uniforms.uColor.value.set(
+                definition.fireball ? '#fff0c7' : '#dcecff',
+            );
+            material.uniforms.uProgress.value = 0;
+            mesh.visible = true;
+            return;
+        }
+
+        activeMeteor.elapsedSeconds += animationDelta;
+        const progress = Math.min(
+            1,
+            activeMeteor.elapsedSeconds /
+                activeMeteor.definition.durationSeconds,
+        );
+        const headProgress = easeOutCubic(progress);
+        const tailProgress = Math.max(
+            0,
+            headProgress - activeMeteor.definition.trailFraction,
+        );
+        const headOffset = headOffsetRef.current.lerpVectors(
+            startOffsetRef.current,
+            endOffsetRef.current,
+            headProgress,
+        );
+        const tailOffset = tailOffsetRef.current.lerpVectors(
+            startOffsetRef.current,
+            endOffsetRef.current,
+            tailProgress,
+        );
+        const head = headRef.current.copy(camera.position).add(headOffset);
+        const tail = tailRef.current.copy(camera.position).add(tailOffset);
+        const skyDirection = skyDirectionRef.current
+            .addVectors(headOffset, tailOffset)
+            .normalize();
+        const perpendicular = perpendicularRef.current.crossVectors(
+            pathDirectionRef.current,
+            skyDirection,
+        );
+        if (perpendicular.lengthSq() < Number.EPSILON) {
+            perpendicular.set(0, 1, 0).applyQuaternion(camera.quaternion);
+        } else {
+            perpendicular.normalize();
+        }
+
+        const positions = geometry.getAttribute('position');
+        const width = getMeteorWorldWidth(
+            activeMeteor.definition.width,
+            camera,
+        );
+        setMeteorVertex(positions, 0, tail, perpendicular, -width * 0.45);
+        setMeteorVertex(positions, 1, tail, perpendicular, width * 0.45);
+        setMeteorVertex(positions, 2, head, perpendicular, -width);
+        setMeteorVertex(positions, 3, head, perpendicular, width);
+        positions.needsUpdate = true;
+        material.uniforms.uProgress.value = progress;
+
+        if (progress < 1) {
+            return;
+        }
+
+        mesh.visible = false;
+        activeMeteorRef.current = null;
+    });
+
+    return (
+        <mesh
+            ref={meshRef}
+            frustumCulled={false}
+            geometry={geometry}
+            material={material}
+            name="Environment:Perseids"
+            renderOrder={29}
+        />
+    );
+}

--- a/packages/game/src/scene/perseids.ts
+++ b/packages/game/src/scene/perseids.ts
@@ -1,0 +1,185 @@
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// The recurring window and peak ZHR follow the International Meteor
+// Organization calendar. The product multiplier intentionally makes the
+// in-game shower twice as dense as that real-world baseline.
+export const PERSEIDS_DENSITY_MULTIPLIER = 2;
+export const PERSEIDS_REAL_EDGE_RATE_PER_HOUR = 1;
+export const PERSEIDS_REAL_PEAK_ZHR = 100;
+
+const PERSEIDS_START_MONTH_INDEX = 6;
+const PERSEIDS_START_DAY = 17;
+const PERSEIDS_PEAK_MONTH_INDEX = 7;
+const PERSEIDS_PEAK_DAY = 13;
+const PERSEIDS_END_MONTH_INDEX = 7;
+const PERSEIDS_END_DAY = 24;
+
+export type PerseidsMeteorDefinition = {
+    brightness: number;
+    durationSeconds: number;
+    end: [x: number, y: number];
+    fireball: boolean;
+    start: [x: number, y: number];
+    trailFraction: number;
+    width: number;
+};
+
+function clamp01(value: number) {
+    return Math.min(1, Math.max(0, value));
+}
+
+function localDateTimestamp(date: Date) {
+    return Date.UTC(
+        date.getFullYear(),
+        date.getMonth(),
+        date.getDate(),
+        date.getHours(),
+        date.getMinutes(),
+        date.getSeconds(),
+        date.getMilliseconds(),
+    );
+}
+
+function dateTimestamp(
+    year: number,
+    monthIndex: number,
+    day: number,
+    hour = 0,
+) {
+    return Date.UTC(year, monthIndex, day, hour);
+}
+
+export function getPerseidsRealRatePerHour(date: Date) {
+    if (!Number.isFinite(date.getTime())) {
+        return 0;
+    }
+
+    const year = date.getFullYear();
+    const timestamp = localDateTimestamp(date);
+    const start = dateTimestamp(
+        year,
+        PERSEIDS_START_MONTH_INDEX,
+        PERSEIDS_START_DAY,
+    );
+    const peak = dateTimestamp(
+        year,
+        PERSEIDS_PEAK_MONTH_INDEX,
+        PERSEIDS_PEAK_DAY,
+    );
+    const endExclusive = dateTimestamp(
+        year,
+        PERSEIDS_END_MONTH_INDEX,
+        PERSEIDS_END_DAY + 1,
+    );
+
+    if (timestamp < start || timestamp >= endExclusive) {
+        return 0;
+    }
+
+    const normalizedActivity =
+        timestamp <= peak
+            ? ((timestamp - start) / (peak - start)) ** 4
+            : ((endExclusive - timestamp) / (endExclusive - peak)) ** 3;
+
+    return (
+        PERSEIDS_REAL_EDGE_RATE_PER_HOUR +
+        (PERSEIDS_REAL_PEAK_ZHR - PERSEIDS_REAL_EDGE_RATE_PER_HOUR) *
+            clamp01(normalizedActivity)
+    );
+}
+
+export function getPerseidsMeteorRatePerHour(date: Date) {
+    return getPerseidsRealRatePerHour(date) * PERSEIDS_DENSITY_MULTIPLIER;
+}
+
+export function shouldRenderPerseids({
+    date,
+    skyVisibility,
+}: {
+    date: Date;
+    skyVisibility: number;
+}) {
+    return (
+        Number.isFinite(skyVisibility) &&
+        skyVisibility > 0 &&
+        getPerseidsMeteorRatePerHour(date) > 0
+    );
+}
+
+export function samplePerseidsIntervalSeconds({
+    meteorsPerHour,
+    random = Math.random,
+}: {
+    meteorsPerHour: number;
+    random?: () => number;
+}) {
+    if (!Number.isFinite(meteorsPerHour) || meteorsPerHour <= 0) {
+        return Number.POSITIVE_INFINITY;
+    }
+
+    const sample = Math.min(
+        1 - Number.EPSILON,
+        Math.max(Number.EPSILON, random()),
+    );
+    return (-Math.log(1 - sample) * 60 * 60) / meteorsPerHour;
+}
+
+function randomBetween(min: number, max: number, random: () => number) {
+    return min + (max - min) * clamp01(random());
+}
+
+export function createPerseidsMeteor(
+    random: () => number = Math.random,
+): PerseidsMeteorDefinition {
+    // The shared upper-left radiant makes the streaks read as one shower while
+    // the varied endpoints spread them across the player's visible sky.
+    const radiantX = randomBetween(0.12, 0.28, random);
+    const radiantY = randomBetween(0.78, 0.92, random);
+    const endX = randomBetween(0.52, 1.08, random);
+    const endY = randomBetween(-0.08, 0.64, random);
+    const directionX = endX - radiantX;
+    const directionY = endY - radiantY;
+    const directionLength = Math.max(
+        Number.EPSILON,
+        Math.hypot(directionX, directionY),
+    );
+    const startDistance = randomBetween(0.03, 0.16, random);
+    const start: [number, number] = [
+        radiantX + (directionX / directionLength) * startDistance,
+        radiantY + (directionY / directionLength) * startDistance,
+    ];
+    const fireball = random() < 0.06;
+
+    return {
+        brightness: fireball
+            ? randomBetween(1.25, 1.55, random)
+            : randomBetween(0.78, 1.08, random),
+        durationSeconds: fireball
+            ? randomBetween(0.85, 1.15, random)
+            : randomBetween(0.46, 0.72, random),
+        end: [endX, endY],
+        fireball,
+        start,
+        trailFraction: fireball
+            ? randomBetween(0.34, 0.46, random)
+            : randomBetween(0.2, 0.34, random),
+        width: fireball
+            ? randomBetween(0.13, 0.18, random)
+            : randomBetween(0.065, 0.105, random),
+    };
+}
+
+export function getPerseidsActiveWindowDurationDays() {
+    const referenceYear = 2026;
+    const start = dateTimestamp(
+        referenceYear,
+        PERSEIDS_START_MONTH_INDEX,
+        PERSEIDS_START_DAY,
+    );
+    const endExclusive = dateTimestamp(
+        referenceYear,
+        PERSEIDS_END_MONTH_INDEX,
+        PERSEIDS_END_DAY + 1,
+    );
+    return (endExclusive - start) / MILLISECONDS_PER_DAY;
+}

--- a/packages/game/src/scene/perseids.unit.ts
+++ b/packages/game/src/scene/perseids.unit.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    createPerseidsMeteor,
+    getPerseidsActiveWindowDurationDays,
+    getPerseidsMeteorRatePerHour,
+    getPerseidsRealRatePerHour,
+    PERSEIDS_DENSITY_MULTIPLIER,
+    PERSEIDS_REAL_EDGE_RATE_PER_HOUR,
+    PERSEIDS_REAL_PEAK_ZHR,
+    samplePerseidsIntervalSeconds,
+    shouldRenderPerseids,
+} from './perseids';
+
+test('uses the recurring July 17 through August 24 activity window', () => {
+    assert.equal(
+        getPerseidsMeteorRatePerHour(new Date(2026, 6, 16, 23, 59)),
+        0,
+    );
+    assert.equal(
+        getPerseidsMeteorRatePerHour(new Date(2026, 6, 17, 0, 0)),
+        PERSEIDS_REAL_EDGE_RATE_PER_HOUR * PERSEIDS_DENSITY_MULTIPLIER,
+    );
+    assert.ok(getPerseidsMeteorRatePerHour(new Date(2026, 7, 24, 23, 59)) > 0);
+    assert.equal(getPerseidsMeteorRatePerHour(new Date(2026, 7, 25, 0, 0)), 0);
+    assert.ok(getPerseidsMeteorRatePerHour(new Date(2031, 7, 12, 22, 0)) > 0);
+    assert.equal(getPerseidsActiveWindowDurationDays(), 39);
+});
+
+test('doubles the real-world activity profile and peaks on August 13', () => {
+    const peak = new Date(2026, 7, 13, 0, 0);
+    assert.equal(PERSEIDS_DENSITY_MULTIPLIER, 2);
+    assert.equal(getPerseidsRealRatePerHour(peak), PERSEIDS_REAL_PEAK_ZHR);
+    assert.equal(
+        getPerseidsMeteorRatePerHour(peak),
+        PERSEIDS_REAL_PEAK_ZHR * PERSEIDS_DENSITY_MULTIPLIER,
+    );
+
+    for (const date of [
+        new Date(2026, 6, 19, 23, 0),
+        new Date(2026, 7, 1, 23, 0),
+        new Date(2026, 7, 12, 23, 0),
+        new Date(2026, 7, 18, 23, 0),
+    ]) {
+        assert.equal(
+            getPerseidsMeteorRatePerHour(date),
+            getPerseidsRealRatePerHour(date) * 2,
+        );
+    }
+});
+
+test('ramps toward the peak and tapers after it', () => {
+    const opening = getPerseidsMeteorRatePerHour(new Date(2026, 6, 17, 0, 0));
+    const earlyAugust = getPerseidsMeteorRatePerHour(
+        new Date(2026, 7, 2, 0, 0),
+    );
+    const peak = getPerseidsMeteorRatePerHour(new Date(2026, 7, 13, 0, 0));
+    const lateAugust = getPerseidsMeteorRatePerHour(
+        new Date(2026, 7, 21, 0, 0),
+    );
+
+    assert.ok(opening < earlyAugust);
+    assert.ok(earlyAugust < peak);
+    assert.ok(lateAugust < peak);
+    assert.ok(lateAugust > 0);
+});
+
+test('requires both an active date and visible night sky', () => {
+    const activeDate = new Date(2026, 7, 12, 23, 0);
+    assert.equal(
+        shouldRenderPerseids({ date: activeDate, skyVisibility: 1 }),
+        true,
+    );
+    assert.equal(
+        shouldRenderPerseids({ date: activeDate, skyVisibility: 0 }),
+        false,
+    );
+    assert.equal(
+        shouldRenderPerseids({
+            date: new Date(2026, 5, 12, 23, 0),
+            skyVisibility: 1,
+        }),
+        false,
+    );
+});
+
+test('samples a natural exponential interval from the configured rate', () => {
+    const interval = samplePerseidsIntervalSeconds({
+        meteorsPerHour: 200,
+        random: () => 0.5,
+    });
+    assert.ok(Math.abs(interval - (Math.log(2) * 3600) / 200) < 1e-12);
+    assert.equal(
+        samplePerseidsIntervalSeconds({ meteorsPerHour: 0 }),
+        Number.POSITIVE_INFINITY,
+    );
+});
+
+test('creates deterministic, finite streaks moving away from the radiant', () => {
+    let seed = 0;
+    const random = () => {
+        seed = (seed * 1664525 + 1013904223) >>> 0;
+        return seed / 2 ** 32;
+    };
+    const first = createPerseidsMeteor(random);
+    seed = 0;
+    const second = createPerseidsMeteor(random);
+
+    assert.deepEqual(first, second);
+    assert.ok(first.start[0] >= 0 && first.start[0] <= 1);
+    assert.ok(first.start[1] >= 0 && first.start[1] <= 1);
+    assert.ok(first.end[0] >= 0.52 && first.end[0] <= 1.08);
+    assert.ok(first.end[1] >= -0.08 && first.end[1] <= 0.64);
+    assert.ok(first.durationSeconds > 0);
+    assert.ok(first.trailFraction > 0 && first.trailFraction < 1);
+    assert.ok(first.width > 0);
+});


### PR DESCRIPTION
## Summary
- add the annual Perseids activity window from July 17 through August 24
- render camera-aware meteor streaks in overview, TPV, and FPV at twice the real-world baseline
- gate the effect to visible night skies and add deterministic seasonal and cadence tests

## Why
Bring the real Perseids window into the Garden experience while keeping it subtle, seasonal, and grounded in the existing day/night and weather systems.

## Validation
- `pnpm --filter @gredice/game test` — 953 passed
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter garden build`
- live WebGL sandbox check in overview and TPV