### PR TITLE
fix(game): improve avatar view controls and framing

### DIFF
--- a/packages/game/src/entities/avatar/GardenAvatar.tsx
+++ b/packages/game/src/entities/avatar/GardenAvatar.tsx
@@ -33,7 +33,11 @@ import {
 } from '../animals/ActorSpeechBubble';
 import { playerSpeechMessages } from '../animals/actorSpeechMessages';
 import { GardenAvatarCollisionDebug } from './GardenAvatarCollisionDebug';
-import { getGardenAvatarPerspectiveEntryPosition } from './gardenAvatarCamera';
+import {
+    getGardenAvatarPerspectiveEntryPosition,
+    getGardenAvatarThirdPersonCameraDistance,
+    getGardenAvatarThirdPersonCameraTargetHeight,
+} from './gardenAvatarCamera';
 import {
     createGardenAvatarCollisionWorld,
     findGardenAvatarRoute,
@@ -465,14 +469,18 @@ function GardenAvatarCamera({
             );
             lookTargetRef.current.set(
                 actor.position.x,
-                actor.position.y + MathUtils.lerp(0.89, 0.64, crouchAmount),
+                actor.position.y +
+                    getGardenAvatarThirdPersonCameraTargetHeight(crouchAmount),
                 actor.position.z,
             );
             desiredPositionRef.current
                 .copy(lookTargetRef.current)
                 .addScaledVector(
                     orbitDirection,
-                    -MathUtils.lerp(2.45, 2.2, crouchAmount),
+                    -getGardenAvatarThirdPersonCameraDistance({
+                        aspect: camera.aspect,
+                        crouchAmount,
+                    }),
                 );
             desiredPositionRef.current.y = Math.max(
                 desiredPositionRef.current.y,

--- a/packages/game/src/entities/avatar/gardenAvatarCamera.ts
+++ b/packages/game/src/entities/avatar/gardenAvatarCamera.ts
@@ -6,6 +6,46 @@ import {
     type Vector3,
 } from 'three';
 
+const gardenAvatarThirdPersonStandingDistance = 3.05;
+const gardenAvatarThirdPersonCrouchingDistance = 2.8;
+const gardenAvatarThirdPersonPortraitDistanceBoost = 0.55;
+const gardenAvatarThirdPersonStandingTargetHeight = 1.08;
+const gardenAvatarThirdPersonCrouchingTargetHeight = 0.82;
+
+export function getGardenAvatarThirdPersonCameraDistance({
+    aspect,
+    crouchAmount,
+}: {
+    aspect: number;
+    crouchAmount: number;
+}) {
+    const safeAspect = Number.isFinite(aspect) && aspect > 0 ? aspect : 1;
+    const portraitAmount = MathUtils.clamp(
+        (1 - safeAspect) / (1 - 9 / 16),
+        0,
+        1,
+    );
+
+    return (
+        MathUtils.lerp(
+            gardenAvatarThirdPersonStandingDistance,
+            gardenAvatarThirdPersonCrouchingDistance,
+            MathUtils.clamp(crouchAmount, 0, 1),
+        ) +
+        gardenAvatarThirdPersonPortraitDistanceBoost * portraitAmount
+    );
+}
+
+export function getGardenAvatarThirdPersonCameraTargetHeight(
+    crouchAmount: number,
+) {
+    return MathUtils.lerp(
+        gardenAvatarThirdPersonStandingTargetHeight,
+        gardenAvatarThirdPersonCrouchingTargetHeight,
+        MathUtils.clamp(crouchAmount, 0, 1),
+    );
+}
+
 export function getGardenAvatarPerspectiveEntryPosition({
     actor,
     camera,

--- a/packages/game/src/entities/avatar/gardenAvatarCamera.unit.ts
+++ b/packages/game/src/entities/avatar/gardenAvatarCamera.unit.ts
@@ -6,7 +6,46 @@ import {
     PerspectiveCamera,
     Vector3,
 } from 'three';
-import { getGardenAvatarPerspectiveEntryPosition } from './gardenAvatarCamera';
+import {
+    getGardenAvatarPerspectiveEntryPosition,
+    getGardenAvatarThirdPersonCameraDistance,
+    getGardenAvatarThirdPersonCameraTargetHeight,
+} from './gardenAvatarCamera';
+
+test('keeps the third-person camera farther back on portrait screens', () => {
+    const landscapeDistance = getGardenAvatarThirdPersonCameraDistance({
+        aspect: 16 / 9,
+        crouchAmount: 0,
+    });
+    const portraitDistance = getGardenAvatarThirdPersonCameraDistance({
+        aspect: 9 / 16,
+        crouchAmount: 0,
+    });
+
+    assert.equal(landscapeDistance, 3.05);
+    assert.ok(Math.abs(portraitDistance - 3.6) < 0.000_001);
+    assert.ok(portraitDistance > landscapeDistance);
+});
+
+test('clamps third-person camera framing inputs', () => {
+    assert.ok(
+        Math.abs(
+            getGardenAvatarThirdPersonCameraDistance({
+                aspect: 9 / 16,
+                crouchAmount: 2,
+            }) - 3.35,
+        ) < 0.000_001,
+    );
+    assert.equal(
+        getGardenAvatarThirdPersonCameraDistance({
+            aspect: 0,
+            crouchAmount: -1,
+        }),
+        3.05,
+    );
+    assert.equal(getGardenAvatarThirdPersonCameraTargetHeight(-1), 1.08);
+    assert.equal(getGardenAvatarThirdPersonCameraTargetHeight(2), 0.82);
+});
 
 test('matches the overview framing when entering the perspective camera', () => {
     const aspect = 16 / 9;

--- a/packages/game/src/hud/GardenAvatarHud.tsx
+++ b/packages/game/src/hud/GardenAvatarHud.tsx
@@ -3,9 +3,9 @@
 import { IconButton } from '@gredice/ui/IconButton';
 import {
     ArrowUp,
-    Camera,
     ChevronsDown,
     Close,
+    Eye,
     Footprints,
     LogOut,
     UserCircle,
@@ -86,7 +86,7 @@ export function GardenAvatarHud() {
                     title={
                         view === 'first-person'
                             ? 'Prikaži pogled iz trećeg lica'
-                            : 'Prikaži POV pogled'
+                            : 'Prikaži pogled iz prvog lica'
                     }
                     variant="plain"
                     className={avatarHudButtonClassName}
@@ -101,7 +101,7 @@ export function GardenAvatarHud() {
                     {view === 'first-person' ? (
                         <UserCircle className="size-5" />
                     ) : (
-                        <Camera className="size-5" />
+                        <Eye className="size-5" />
                     )}
                 </IconButton>
                 <IconButton

--- a/packages/ui/src/icons/index.ts
+++ b/packages/ui/src/icons/index.ts
@@ -52,6 +52,7 @@ export {
     EqualNot,
     Euro,
     ExternalLink,
+    Eye,
     Fence,
     File,
     FileInput,


### PR DESCRIPTION
## Summary

- replace the camera glyph with an eye icon for switching into first-person view and clarify its Croatian accessible label
- move the third-person camera farther back and raise its target line
- add a portrait-aware distance boost so the avatar occupies less of narrow mobile screens
- cover responsive camera distance, crouching, and input clamping with unit tests

## Why

The third-person camera used one fixed distance and a low target height regardless of viewport aspect ratio. The avatar therefore dominated portrait screens, while the camera glyph suggested taking a photo rather than changing perspective.

## Impact

Third-person framing is wider in landscape and scales smoothly from 3.05 scene units to 3.6 at a 9:16 aspect ratio. First-person camera behavior is unchanged.

## Validation

- `pnpm --filter @gredice/game test` — 959 tests passed
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/ui typecheck`
- `pnpm --filter storybook typecheck`
- focused Biome checks and `git diff --check`
- browser-verified the local garden sandbox at 390×844 portrait and 844×390 landscape; avatar controls rendered and no framework error overlay appeared