### PR TITLE
feat(game): triple Perseids meteor frequency

### DIFF
--- a/packages/game/src/scene/perseids.ts
+++ b/packages/game/src/scene/perseids.ts
@@ -2,8 +2,9 @@ const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
 
 // The recurring window and peak ZHR follow the International Meteor
 // Organization calendar. The product multiplier intentionally makes the
-// in-game shower twice as dense as that real-world baseline.
-export const PERSEIDS_DENSITY_MULTIPLIER = 2;
+// in-game shower six times as dense as that real-world baseline: three times
+// the original in-game cadence.
+export const PERSEIDS_DENSITY_MULTIPLIER = 6;
 export const PERSEIDS_REAL_EDGE_RATE_PER_HOUR = 1;
 export const PERSEIDS_REAL_PEAK_ZHR = 100;
 

--- a/packages/game/src/scene/perseids.unit.ts
+++ b/packages/game/src/scene/perseids.unit.ts
@@ -27,9 +27,9 @@ test('uses the recurring July 17 through August 24 activity window', () => {
     assert.equal(getPerseidsActiveWindowDurationDays(), 39);
 });
 
-test('doubles the real-world activity profile and peaks on August 13', () => {
+test('triples the original in-game cadence and peaks on August 13', () => {
     const peak = new Date(2026, 7, 13, 0, 0);
-    assert.equal(PERSEIDS_DENSITY_MULTIPLIER, 2);
+    assert.equal(PERSEIDS_DENSITY_MULTIPLIER, 6);
     assert.equal(getPerseidsRealRatePerHour(peak), PERSEIDS_REAL_PEAK_ZHR);
     assert.equal(
         getPerseidsMeteorRatePerHour(peak),
@@ -44,7 +44,7 @@ test('doubles the real-world activity profile and peaks on August 13', () => {
     ]) {
         assert.equal(
             getPerseidsMeteorRatePerHour(date),
-            getPerseidsRealRatePerHour(date) * 2,
+            getPerseidsRealRatePerHour(date) * PERSEIDS_DENSITY_MULTIPLIER,
         );
     }
 });


### PR DESCRIPTION
## Summary
- increase the Perseids density multiplier from 2× to 6× the real-world baseline
- preserve the existing seasonal activity profile and night-sky gating
- update the regression test to assert the tripled in-game cadence across the season

## Why
Make the in-game shower three times more frequent than the previously shipped cadence, while retaining the same real-life dates and peak curve.

## Validation
- `pnpm --filter @gredice/game exec tsx --test src/scene/perseids.unit.ts` — 6 passed
- `pnpm --filter @gredice/game test` — 998 passed
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game exec biome check src/scene/perseids.ts src/scene/perseids.unit.ts`
- `git diff --check origin/main...HEAD`