### PR TITLE
feat(outlet): launch the 3D garden

### DIFF
--- a/apps/garden/app/.well-known/vercel/flags/route.ts
+++ b/apps/garden/app/.well-known/vercel/flags/route.ts
@@ -1,4 +1,7 @@
-import { createFlagsDiscoveryEndpoint, getProviderData } from 'flags/next';
+import { getProviderData } from '@flags-sdk/vercel';
+import { createFlagsDiscoveryEndpoint } from 'flags/next';
 import * as flags from '../../../../app/flags';
 
-export const GET = createFlagsDiscoveryEndpoint(() => getProviderData(flags));
+export const GET = createFlagsDiscoveryEndpoint(async () =>
+    getProviderData(flags),
+);

--- a/apps/garden/app/flags.ts
+++ b/apps/garden/app/flags.ts
@@ -1,3 +1,4 @@
+import { vercelAdapter } from '@flags-sdk/vercel';
 import { booleanFlagOptions } from '@gredice/js/featureFlags';
 import { flag } from 'flags/next';
 import { outletGardenEnabledByDefault } from './outletGardenFlagDefault';
@@ -48,8 +49,9 @@ export const enableGardenAvatarFlag = flag<boolean>({
 export const enableOutletGardenFlag = flag<boolean>({
     key: 'enableOutletGarden',
     description:
-        'Expose the read-only 3D Outlet garden validation route from the current Outlet flow.',
-    decide: () => outletGardenEnabledByDefault(process.env),
+        'Expose the 3D Outlet garden from the current Outlet flow; disabling restores the classic Outlet flow.',
+    adapter: vercelAdapter,
+    defaultValue: outletGardenEnabledByDefault(process.env),
     options: booleanFlagOptions,
 });
 

--- a/apps/garden/components/game/OutletGardenRenderer.tsx
+++ b/apps/garden/components/game/OutletGardenRenderer.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useGameAnalytics } from '@gredice/game/analytics';
+import type { OutletGardenFallbackReason } from '@gredice/game/outlet-garden-list';
+import dynamic from 'next/dynamic';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { GardenRouteLoading } from './GardenRouteLoading';
+import { OutletGardenSceneErrorBoundary } from './OutletGardenSceneErrorBoundary';
+
+const OutletGardenViewer = dynamic(
+    () =>
+        import('@gredice/game/outlet-garden').then(
+            (module) => module.OutletGardenViewer,
+        ),
+    { loading: () => <GardenRouteLoading />, ssr: false },
+);
+
+const OutletGardenBrowserViewer = dynamic(
+    () =>
+        import('@gredice/game/outlet-garden-list').then(
+            (module) => module.OutletGardenBrowserViewer,
+        ),
+    { loading: () => <GardenRouteLoading />, ssr: false },
+);
+
+type OutletGardenRendererMode = 'checking' | 'list' | 'three-dimensional';
+
+const outletGardenListPreferenceKey = 'gredice-outlet-garden-list-view';
+const outletGardenSceneReadyTimeoutMs = 20_000;
+
+function supportsWebGL() {
+    try {
+        const canvas = document.createElement('canvas');
+        return Boolean(
+            canvas.getContext('webgl2') ?? canvas.getContext('webgl'),
+        );
+    } catch {
+        return false;
+    }
+}
+
+function selectedOfferId() {
+    const value = new URLSearchParams(window.location.search).get('ponuda');
+    return value && /^[1-9]\d*$/u.test(value) ? Number(value) : null;
+}
+
+function rendererContext() {
+    return {
+        device_class: window.innerWidth < 768 ? 'mobile' : 'desktop',
+        input_mode: navigator.maxTouchPoints > 0 ? 'touch' : 'pointer',
+        selected_offer_id: selectedOfferId(),
+    };
+}
+
+function listPreferenceEnabled() {
+    try {
+        return sessionStorage.getItem(outletGardenListPreferenceKey) === '1';
+    } catch {
+        return false;
+    }
+}
+
+function setListPreference(enabled: boolean) {
+    try {
+        if (enabled) {
+            sessionStorage.setItem(outletGardenListPreferenceKey, '1');
+        } else {
+            sessionStorage.removeItem(outletGardenListPreferenceKey);
+        }
+    } catch {
+        // Session storage is optional; the current renderer still switches.
+    }
+}
+
+export function OutletGardenRenderer() {
+    const { track } = useGameAnalytics();
+    const [mode, setMode] = useState<OutletGardenRendererMode>('checking');
+    const [fallbackReason, setFallbackReason] =
+        useState<OutletGardenFallbackReason>('user');
+    const [focusThreeDimensionalOnMount, setFocusThreeDimensionalOnMount] =
+        useState(false);
+    const initializedRef = useRef(false);
+    const sceneReadyRef = useRef(false);
+    const failureHandledRef = useRef(false);
+    const sceneStartedAtRef = useRef(Date.now());
+
+    const showList = useCallback(
+        (reason: OutletGardenFallbackReason, remember: boolean) => {
+            if (failureHandledRef.current && reason !== 'user') {
+                return;
+            }
+
+            failureHandledRef.current = reason !== 'user';
+            sceneReadyRef.current = false;
+            setFallbackReason(reason);
+            setMode('list');
+            if (remember) {
+                setListPreference(true);
+            }
+
+            const properties = {
+                fallback_reason: reason,
+                scene_elapsed_ms: Math.max(
+                    0,
+                    Date.now() - sceneStartedAtRef.current,
+                ),
+                ...rendererContext(),
+            };
+            if (reason !== 'user') {
+                track('game_outlet_garden_scene_failed', {
+                    ...properties,
+                    failure_reason: reason,
+                    renderer: 'webgl',
+                });
+            }
+            track('game_outlet_garden_fallback_used', {
+                ...properties,
+                renderer: 'list',
+            });
+        },
+        [track],
+    );
+
+    const tryThreeDimensional = useCallback(() => {
+        if (!supportsWebGL()) {
+            showList('unsupported_webgl', false);
+            return;
+        }
+
+        failureHandledRef.current = false;
+        sceneReadyRef.current = false;
+        sceneStartedAtRef.current = Date.now();
+        setFocusThreeDimensionalOnMount(true);
+        setListPreference(false);
+        setMode('three-dimensional');
+    }, [showList]);
+
+    useEffect(() => {
+        if (initializedRef.current) {
+            return;
+        }
+        initializedRef.current = true;
+
+        if (listPreferenceEnabled()) {
+            showList('user', false);
+            return;
+        }
+
+        if (!supportsWebGL()) {
+            showList('unsupported_webgl', false);
+            return;
+        }
+
+        sceneStartedAtRef.current = Date.now();
+        setMode('three-dimensional');
+    }, [showList]);
+
+    useEffect(() => {
+        if (mode !== 'three-dimensional') {
+            return;
+        }
+
+        const timeout = window.setTimeout(() => {
+            if (!sceneReadyRef.current) {
+                showList('scene_ready_timeout', false);
+            }
+        }, outletGardenSceneReadyTimeoutMs);
+
+        return () => window.clearTimeout(timeout);
+    }, [mode, showList]);
+
+    if (mode === 'checking') {
+        return <GardenRouteLoading />;
+    }
+
+    if (mode === 'list') {
+        return (
+            <OutletGardenBrowserViewer
+                fallbackReason={fallbackReason}
+                onUse3D={
+                    fallbackReason === 'unsupported_webgl'
+                        ? undefined
+                        : tryThreeDimensional
+                }
+            />
+        );
+    }
+
+    return (
+        <OutletGardenSceneErrorBoundary
+            onError={() => showList('scene_load_error', false)}
+        >
+            <OutletGardenViewer
+                focusOnMount={focusThreeDimensionalOnMount}
+                onSceneFailure={(reason) => showList(reason, false)}
+                onSceneReady={() => {
+                    sceneReadyRef.current = true;
+                }}
+                onUseListFallback={() => showList('user', true)}
+                sceneStartedAt={sceneStartedAtRef.current}
+            />
+        </OutletGardenSceneErrorBoundary>
+    );
+}

--- a/apps/garden/components/game/OutletGardenSceneErrorBoundary.tsx
+++ b/apps/garden/components/game/OutletGardenSceneErrorBoundary.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+type OutletGardenSceneErrorBoundaryProps = {
+    children: ReactNode;
+    onError: (error: Error, info: ErrorInfo) => void;
+};
+
+type OutletGardenSceneErrorBoundaryState = {
+    failed: boolean;
+};
+
+export class OutletGardenSceneErrorBoundary extends Component<
+    OutletGardenSceneErrorBoundaryProps,
+    OutletGardenSceneErrorBoundaryState
+> {
+    state: OutletGardenSceneErrorBoundaryState = { failed: false };
+
+    static getDerivedStateFromError(): OutletGardenSceneErrorBoundaryState {
+        return { failed: true };
+    }
+
+    componentDidCatch(error: Error, info: ErrorInfo) {
+        this.props.onError(error, info);
+    }
+
+    render() {
+        return this.state.failed ? null : this.props.children;
+    }
+}

--- a/apps/garden/components/game/OutletGardenWithAnalytics.tsx
+++ b/apps/garden/components/game/OutletGardenWithAnalytics.tsx
@@ -1,27 +1,8 @@
 'use client';
 
 import { GameAnalyticsProvider } from '@gredice/game/analytics';
-import { Spinner } from '@gredice/ui/Spinner';
 import { usePostHog } from '@posthog/next';
-import dynamic from 'next/dynamic';
-
-const OutletGardenViewer = dynamic(
-    () =>
-        import('@gredice/game/outlet-garden').then(
-            (module) => module.OutletGardenViewer,
-        ),
-    {
-        loading: () => (
-            <div className="grid h-[100dvh] place-items-center bg-[#cfeaca]">
-                <Spinner
-                    className="size-8 text-green-900"
-                    loadingLabel="Teleportiranje u Outlet vrt"
-                />
-            </div>
-        ),
-        ssr: false,
-    },
-);
+import { OutletGardenRenderer } from './OutletGardenRenderer';
 
 export function OutletGardenWithAnalytics() {
     const posthog = usePostHog();
@@ -35,7 +16,7 @@ export function OutletGardenWithAnalytics() {
                 });
             }}
         >
-            <OutletGardenViewer />
+            <OutletGardenRenderer />
         </GameAnalyticsProvider>
     );
 }

--- a/apps/garden/package.json
+++ b/apps/garden/package.json
@@ -32,6 +32,7 @@
         "test:local": "pnpm run test:prepare && pnpm run test:run"
     },
     "dependencies": {
+        "@flags-sdk/vercel": "1.4.6",
         "@opentelemetry/api-logs": "0.220.0",
         "@opentelemetry/exporter-logs-otlp-http": "0.220.0",
         "@opentelemetry/resources": "2.9.0",

--- a/apps/garden/tests/outlet-garden-flag.spec.ts
+++ b/apps/garden/tests/outlet-garden-flag.spec.ts
@@ -1,7 +1,8 @@
+import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
 import { outletGardenEnabledByDefault } from '../app/outletGardenFlagDefault';
 
-test('Outlet garden defaults off in production and on in preview', () => {
+test('Outlet garden provider fallback stays safe across environments', () => {
     expect(
         outletGardenEnabledByDefault({
             NODE_ENV: 'production',
@@ -14,4 +15,23 @@ test('Outlet garden defaults off in production and on in preview', () => {
             VERCEL_ENV: 'preview',
         }),
     ).toBe(true);
+    expect(
+        outletGardenEnabledByDefault({
+            NODE_ENV: 'development',
+        }),
+    ).toBe(true);
+});
+
+test('flag discovery resolves managed Vercel provider metadata', () => {
+    const discoverySource = readFileSync(
+        new URL('../app/.well-known/vercel/flags/route.ts', import.meta.url),
+        'utf8',
+    );
+
+    expect(discoverySource).toContain(
+        "import { getProviderData } from '@flags-sdk/vercel';",
+    );
+    expect(discoverySource).toContain(
+        "import { createFlagsDiscoveryEndpoint } from 'flags/next';",
+    );
 });

--- a/apps/garden/tests/outlet-garden-route.spec.ts
+++ b/apps/garden/tests/outlet-garden-route.spec.ts
@@ -105,6 +105,29 @@ async function mockOutletGardenApi(page: Page) {
     };
 }
 
+async function disableWebGL(page: Page) {
+    await page.addInitScript(() => {
+        const originalGetContext = HTMLCanvasElement.prototype.getContext;
+        Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+            configurable: true,
+            value(
+                this: HTMLCanvasElement,
+                contextId: string,
+                ...args: unknown[]
+            ) {
+                if (contextId === 'webgl' || contextId === 'webgl2') {
+                    return null;
+                }
+
+                return Reflect.apply(originalGetContext, this, [
+                    contextId,
+                    ...args,
+                ]);
+            },
+        });
+    });
+}
+
 test('guest Outlet garden renders WebGL, selects an offer, and preserves its deep link', async ({
     page,
 }) => {
@@ -220,13 +243,105 @@ test('guest Outlet garden renders WebGL, selects an offer, and preserves its dee
     await expect(
         page.locator('[data-outlet-garden-offer-id="302"]'),
     ).toHaveAttribute('aria-pressed', 'true');
+
+    await page
+        .getByRole('button', {
+            name: 'Prikaži Outlet ponude bez 3D prikaza',
+        })
+        .click();
     await expect(
-        page.getByRole('link', { name: 'Moj vrt', exact: true }),
+        page.locator('[data-outlet-garden-renderer="list"]'),
+    ).toBeVisible();
+    await expect(
+        page.getByText(/Pregledavaš sve aktualne ponude/u),
+    ).toBeFocused();
+    await expect(page.locator('canvas')).toHaveCount(0);
+    await expect(page).toHaveURL(/\/outlet\?ponuda=302$/u);
+
+    await page
+        .getByRole('button', {
+            name: 'Pokušaj ponovno otvoriti 3D Outlet vrt',
+        })
+        .click();
+    await expect(
+        page.locator('[data-outlet-garden-renderer="webgl"]'),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('main', {
+            name: 'Interaktivni 3D prikaz Outlet vrta',
+        }),
+    ).toBeFocused();
+    await expect(page.locator('canvas')).toBeVisible();
+
+    const contextLossRequested = await page
+        .locator('canvas')
+        .evaluate((currentCanvas) => {
+            if (!(currentCanvas instanceof HTMLCanvasElement)) {
+                return false;
+            }
+            const context =
+                currentCanvas.getContext('webgl2') ??
+                currentCanvas.getContext('webgl');
+            const extension = context?.getExtension('WEBGL_lose_context');
+            extension?.loseContext();
+            return Boolean(extension);
+        });
+    expect(contextLossRequested).toBe(true);
+    await expect(
+        page.locator('[data-outlet-garden-renderer="list"]'),
+    ).toBeVisible();
+    await expect(page.getByText(/3D prikaz je prekinut/u)).toBeFocused();
+    await expect(page.locator('canvas')).toHaveCount(0);
+    await expect(page).toHaveURL(/\/outlet\?ponuda=302$/u);
+    await expect(
+        page.getByRole('link', { name: 'Povratak u moj vrt' }),
     ).toHaveAttribute('href', '/');
 
-    await page.getByRole('link', { name: 'Moj vrt', exact: true }).click();
+    await page.getByRole('link', { name: 'Povratak u moj vrt' }).click();
     await page.waitForURL((url) => url.pathname === '/');
 
     expect(outletApi.mutationRequests).toEqual([]);
     expect(runtimeErrors).toEqual([]);
+});
+
+test('guest Outlet garden falls back to the semantic offer list without WebGL', async ({
+    page,
+}) => {
+    const modelRequests: string[] = [];
+    page.on('request', (request) => {
+        if (/\.glb(?:\?|$)/u.test(request.url())) {
+            modelRequests.push(request.url());
+        }
+    });
+    await disableWebGL(page);
+    const outletApi = await mockOutletGardenApi(page);
+
+    await page.goto('/outlet?ponuda=302');
+
+    await expect(
+        page.locator('[data-outlet-garden-renderer="list"]'),
+    ).toBeVisible();
+    await expect(page.locator('canvas')).toHaveCount(0);
+    await expect(
+        page.getByText('Ovaj uređaj ne podržava 3D prikaz.'),
+    ).toBeVisible();
+    await expect(
+        page.getByText('Ovaj uređaj ne podržava 3D prikaz.'),
+    ).toBeFocused();
+    await expect(
+        page.locator('[data-outlet-garden-selected-offer="302"]'),
+    ).toContainText('3 sadnica');
+    await expect(
+        page.getByRole('link', {
+            name: 'Nastavi u postojećem Outletu',
+        }),
+    ).toHaveAttribute('href', '/?outlet=302');
+    await expect(
+        page.getByRole('button', {
+            name: 'Pokušaj ponovno otvoriti 3D Outlet vrt',
+        }),
+    ).toHaveCount(0);
+
+    expect(modelRequests).toEqual([]);
+    expect(outletApi.mutationRequests).toEqual([]);
 });

--- a/apps/garden/turbo.json
+++ b/apps/garden/turbo.json
@@ -9,6 +9,7 @@
                 "CHECKLY_API_KEY",
                 "EDGE_CONFIG",
                 "ENABLE_EXPERIMENTAL_COREPACK",
+                "FLAGS",
                 "FLAGS_SECRET",
                 "GREDICE_API_HOST",
                 "GREDICE_GOOGLE_MAPS_API_KEY",

--- a/apps/www/app/outlet/OutletOfferCard.tsx
+++ b/apps/www/app/outlet/OutletOfferCard.tsx
@@ -158,7 +158,7 @@ export function OutletOfferCard({ offer }: { offer: OutletOffer }) {
                         size="sm"
                         className="w-fit shrink-0"
                     >
-                        Sadi u vrtu
+                        Razgledaj u 3D vrtu
                     </NavigatingButton>
                 </div>
             </div>

--- a/apps/www/app/outlet/outletData.ts
+++ b/apps/www/app/outlet/outletData.ts
@@ -51,5 +51,5 @@ export function outletOfferImage(offer: OutletOffer) {
 }
 
 export function outletGardenUrl(offerId: number) {
-    return `https://vrt.gredice.com/?outlet=${encodeURIComponent(offerId)}`;
+    return `https://vrt.gredice.com/outlet?ponuda=${encodeURIComponent(offerId)}`;
 }

--- a/apps/www/tests/staticGenerationData.node.spec.ts
+++ b/apps/www/tests/staticGenerationData.node.spec.ts
@@ -102,3 +102,20 @@ test('legacy changelog paths redirect below the canonical news base path', () =>
         null,
     );
 });
+
+test('public Outlet cards enter the selected offer in the 3D garden', () => {
+    const outletDataSource = readFileSync(
+        new URL('../app/outlet/outletData.ts', import.meta.url),
+        'utf8',
+    );
+    const outletCardSource = readFileSync(
+        new URL('../app/outlet/OutletOfferCard.tsx', import.meta.url),
+        'utf8',
+    );
+
+    assert.match(
+        outletDataSource,
+        /https:\/\/vrt\.gredice\.com\/outlet\?ponuda=/u,
+    );
+    assert.match(outletCardSource, /Razgledaj u 3D vrtu/u);
+});

--- a/docs/outlet-workflow.md
+++ b/docs/outlet-workflow.md
@@ -15,6 +15,11 @@ Outlet sells discounted leftover greenhouse seedlings as limited-time, limited-s
 ## Configuration
 
 - `CRON_SECRET` protects `GET /api/internal/cron/outlet-lifecycle`.
+- `enableOutletGarden` is a managed Vercel boolean flag. Its local fallback is
+  enabled in development and Preview, and disabled in Production if the flag
+  provider cannot be reached.
+- `FLAGS` connects the Garden app to Vercel Flags. `FLAGS_SECRET` protects the
+  flag discovery and browser-override flow.
 - Existing Stripe, auth, database, and PostHog configuration apply through checkout and webhook code.
 - Outlet offer images are stored as public URLs in the offer row; no new upload bucket is introduced.
 
@@ -27,7 +32,7 @@ Outlet sells discounted leftover greenhouse seedlings as limited-time, limited-s
 - Payment conversion: `apps/api/lib/stripe/processCheckoutSession.ts`.
 - Lifecycle cron: `apps/api/app/api/internal/cron/outlet-lifecycle/route.ts` and `apps/api/vercel.json`.
 - Public site: `apps/www/app/outlet` and `apps/www/app/outlet/OutletLandingSection.tsx`.
-- Garden game: `packages/game/src/hud/OutletHud.tsx`, `packages/game/src/hooks/useOutletOffers.ts`, and raised-bed plant picker/cart components.
+- Garden game: `apps/garden/app/outlet`, `packages/game/src/viewers/OutletGardenViewer.tsx`, `packages/game/src/hud/OutletHud.tsx`, `packages/game/src/hooks/useOutletOffers.ts`, and raised-bed plant picker/cart components.
 - Admin: `apps/app/app/admin/outlet`.
 
 ## State model
@@ -57,6 +62,22 @@ Price, sowing date, and initial plant status are copied from the offer into the 
 6. The webhook validates metadata against the cart item reservation, converts the reservation idempotently, and creates the raised-bed plant with `sowingLocation: greenhouse`.
 7. Garden raised-bed state uses the outlet sowing date as the effective event date, so the plant age matches the real greenhouse seedling.
 
+## 3D garden browsing
+
+- `/outlet?ponuda=<offer-id>` is a guest-readable, read-only 3D view of the
+  currently active offers. Selecting a seedling updates `ponuda` but does not
+  reserve stock or mutate a garden.
+- Devices without WebGL, renderer failures, context loss, and scene readiness
+  timeouts fall back to the same semantic offer browser without losing the
+  selected offer.
+- Customers can switch to the list explicitly. That preference lasts for the
+  browser session and can be reversed from the list.
+- The public Outlet cards link to the 3D route. The selected offer can still be
+  continued in the existing Garden Outlet flow, which remains responsible for
+  field selection, reservation, cart, and checkout.
+- Disabling `enableOutletGarden` removes the in-game teleport entry and sends a
+  direct 3D route visit back to the classic Outlet flow.
+
 ## Failure handling
 
 - Sold-out, unpublished, not-started, expired, and mismatched plant-sort offers return conflict errors during cart mutation.
@@ -70,7 +91,38 @@ Price, sowing date, and initial plant status are copied from the offer into the 
 
 - Outlet lifecycle cron returns released reservation and closed offer counts.
 - Payment conversion emits a PostHog `outlet_reservation_converted` event.
+- The 3D browser records scene readiness duration, renderer failures, list
+  fallback use, offer selection, and exits. Failure events use finite reason
+  values and device/input classes; they do not include garden contents or
+  customer-entered text.
 - Checkout and webhook failures use existing API logging paths and should avoid logging private payment payloads or secrets.
+
+## 3D launch and rollback
+
+Enable the compatible deployed build for everyone only after a clean Production
+smoke test:
+
+```bash
+vercel flags enable enableOutletGarden \
+  --environment production \
+  --message "Launch the 3D Outlet garden for all users" \
+  --cwd apps/garden \
+  --scope gredice
+```
+
+Rollback does not require a deployment:
+
+```bash
+vercel flags disable enableOutletGarden \
+  --environment production \
+  --message "Rollback to the classic Outlet flow" \
+  --cwd apps/garden \
+  --scope gredice
+```
+
+After either change, use a clean browser without a
+`vercel-flag-overrides` cookie. Verify the final browser URL, because the
+disabled Next.js route can stream its redirect in a successful HTTP response.
 
 ## Validation
 
@@ -98,6 +150,9 @@ Manual smoke checks before release:
 
 - Create a draft offer in `/admin/outlet`, publish it, pause it, republish it, then close it.
 - Confirm active offers show on `/outlet`, on the landing page, and in the garden Outlet panel.
+- Confirm the public Outlet card and in-game teleport open the 3D route, a
+  selected offer survives switching to the list, and disabling WebGL yields the
+  list without loading a canvas.
 - Add an outlet seedling to cart from a raised-bed field and verify stock remaining, cart price, hold expiry, and checkout eligibility.
 - Complete checkout in a test Stripe flow and confirm the reservation becomes converted and the raised-bed plant appears as greenhouse-grown.
 - Let or force a hold expire, run the outlet lifecycle cron with `CRON_SECRET`, and verify stock is returned.

--- a/packages/game/package.json
+++ b/packages/game/package.json
@@ -13,6 +13,7 @@
         "./garden-2d": "./src/GardenOverview2DDynamic.tsx",
         "./outlet-garden": "./src/viewers/OutletGardenViewer.tsx",
         "./outlet-garden-browser": "./src/viewers/OutletGardenOfferBrowser.tsx",
+        "./outlet-garden-list": "./src/viewers/OutletGardenBrowserViewer.tsx",
         "./theme": "./src/hooks/useThemeManager.ts"
     },
     "scripts": {

--- a/packages/game/src/scene/RendererContextLossReporter.tsx
+++ b/packages/game/src/scene/RendererContextLossReporter.tsx
@@ -1,0 +1,12 @@
+export function subscribeToRendererContextLoss({
+    eventTarget,
+    onContextLost,
+}: {
+    eventTarget: Pick<EventTarget, 'addEventListener' | 'removeEventListener'>;
+    onContextLost: () => void;
+}) {
+    const handleContextLost = () => onContextLost();
+    eventTarget.addEventListener('webglcontextlost', handleContextLost);
+    return () =>
+        eventTarget.removeEventListener('webglcontextlost', handleContextLost);
+}

--- a/packages/game/src/scene/RendererContextLossReporter.unit.ts
+++ b/packages/game/src/scene/RendererContextLossReporter.unit.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { subscribeToRendererContextLoss } from './RendererContextLossReporter';
+
+test('reports renderer context loss until the subscription is removed', () => {
+    const eventTarget = new EventTarget();
+    let lossCount = 0;
+    const unsubscribe = subscribeToRendererContextLoss({
+        eventTarget,
+        onContextLost: () => {
+            lossCount += 1;
+        },
+    });
+
+    eventTarget.dispatchEvent(new Event('webglcontextlost'));
+    assert.equal(lossCount, 1);
+
+    unsubscribe();
+    eventTarget.dispatchEvent(new Event('webglcontextlost'));
+    assert.equal(lossCount, 1);
+});

--- a/packages/game/src/scene/Scene.tsx
+++ b/packages/game/src/scene/Scene.tsx
@@ -35,6 +35,7 @@ import {
     type GameQualityProfile,
     resolveGameQualityProfile,
 } from './gameQuality';
+import { subscribeToRendererContextLoss } from './RendererContextLossReporter';
 import { SceneTimeProvider, sceneFrameRates } from './SceneTime';
 import { StaticOpaqueSceneCacheProvider } from './StaticOpaqueSceneCache';
 import { WeatherSurfaceUniformProvider } from './WeatherSurfaceUniformProvider';
@@ -50,6 +51,7 @@ export type SceneProps = HTMLAttributes<HTMLDivElement> &
         onAdaptiveHighProfileChange?: (
             profile: AdaptiveHighQualityLevelProfile,
         ) => void;
+        onContextLost?: () => void;
         pixelRatio?: number;
         position: FiberVector3;
         quality?: GameQualityProfile;
@@ -208,6 +210,7 @@ export function Scene({
     debugStats,
     fixedTimeSeconds,
     onAdaptiveHighProfileChange,
+    onContextLost,
     pixelRatio,
     position,
     quality,
@@ -217,6 +220,32 @@ export function Scene({
     zoom,
     ...rest
 }: SceneProps) {
+    const contextLossCallbackRef = useRef(onContextLost);
+    const contextLossCleanupRef = useRef<(() => void) | null>(null);
+    const handleCanvasRef = useCallback((canvas: HTMLCanvasElement | null) => {
+        contextLossCleanupRef.current?.();
+        contextLossCleanupRef.current = null;
+        if (!canvas || !contextLossCallbackRef.current) {
+            return;
+        }
+        contextLossCleanupRef.current = subscribeToRendererContextLoss({
+            eventTarget: canvas,
+            onContextLost: () => contextLossCallbackRef.current?.(),
+        });
+    }, []);
+
+    useEffect(
+        () => () => {
+            contextLossCleanupRef.current?.();
+            contextLossCleanupRef.current = null;
+        },
+        [],
+    );
+
+    useEffect(() => {
+        contextLossCallbackRef.current = onContextLost;
+    }, [onContextLost]);
+
     const qualityProfile = quality ?? resolveGameQualityProfile();
     const adaptiveHighActive =
         adaptiveHighEnabled && qualityProfile.tier === 'high';
@@ -272,6 +301,7 @@ export function Scene({
             }}
             {...rest}
             frameloop="demand"
+            ref={handleCanvasRef}
         >
             <SceneTimeProvider
                 baseFramesPerSecond={ambientFramesPerSecond}

--- a/packages/game/src/viewers/OutletGardenBrowserViewer.tsx
+++ b/packages/game/src/viewers/OutletGardenBrowserViewer.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { LayoutGrid, Sprout } from '@gredice/ui/icons';
+import type { Route } from 'next';
+import { useRouter } from 'next/navigation';
+import { parseAsInteger, useQueryState } from 'nuqs';
+import { useCallback, useEffect, useRef } from 'react';
+import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
+import { useOutletOffers } from '../hooks/useOutletOffers';
+import { OutletGardenOfferBrowser } from './OutletGardenOfferBrowser';
+import type { OutletGardenFallbackReason } from './outletGardenRenderer';
+
+function fallbackMessage(reason: OutletGardenFallbackReason) {
+    switch (reason) {
+        case 'unsupported_webgl':
+            return 'Ovaj uređaj ne podržava 3D prikaz. Sve ponude možeš pregledati i odabrati u popisu.';
+        case 'constrained_device':
+            return 'Za ugodniji rad prikazujemo laganiji popis sa svim aktualnim ponudama.';
+        case 'context_lost':
+        case 'scene_load_error':
+        case 'scene_ready_timeout':
+            return '3D prikaz je prekinut. Odabrana ponuda i sve aktualne ponude ostale su dostupne u popisu.';
+        case 'user':
+            return 'Pregledavaš sve aktualne ponude u popisu bez 3D prikaza.';
+    }
+}
+
+export type OutletGardenBrowserViewerProps = {
+    fallbackReason?: OutletGardenFallbackReason;
+    onUse3D?: () => void;
+};
+
+export function OutletGardenBrowserViewer({
+    fallbackReason = 'user',
+    onUse3D,
+}: OutletGardenBrowserViewerProps = {}) {
+    const router = useRouter();
+    const {
+        data: offers = [],
+        isError,
+        isLoading,
+        refetch,
+    } = useOutletOffers();
+    const [selectedOfferId, setSelectedOfferId] = useQueryState(
+        'ponuda',
+        parseAsInteger,
+    );
+    const { track } = useGameAnalytics();
+    const fallbackStatusRef = useRef<HTMLParagraphElement>(null);
+
+    useEffect(() => {
+        fallbackStatusRef.current?.focus({ preventScroll: true });
+    }, []);
+
+    const selectOffer = useCallback(
+        (offerId: number | null) => {
+            void setSelectedOfferId(offerId);
+            if (offerId === null) {
+                return;
+            }
+
+            const offer = offers.find((candidate) => candidate.id === offerId);
+            track('game_outlet_garden_offer_viewed', {
+                outlet_offer_id: offerId,
+                plant_sort_id: offer?.plantSort.id,
+                renderer: 'list',
+            });
+        },
+        [offers, setSelectedOfferId, track],
+    );
+
+    const requestExit = useCallback(
+        (destination: 'existing_outlet' | 'garden', href: Route) => {
+            track('game_outlet_garden_exited', {
+                destination,
+                renderer: 'list',
+            });
+            router.push(href);
+        },
+        [router, track],
+    );
+
+    const request3D = useCallback(() => {
+        track('game_outlet_garden_3d_retry_requested', {
+            fallback_reason: fallbackReason,
+            renderer: 'list',
+        });
+        onUse3D?.();
+    }, [fallbackReason, onUse3D, track]);
+
+    const retryOffers = useCallback(() => {
+        track('game_outlet_garden_offers_retry_requested', {
+            renderer: 'list',
+        });
+        void refetch();
+    }, [refetch, track]);
+
+    return (
+        <div
+            className="grid h-[100dvh] min-h-0 overflow-hidden bg-[#cfeaca] lg:grid-cols-[minmax(0,1fr)_24rem]"
+            data-outlet-garden
+            data-outlet-garden-renderer="list"
+        >
+            <div
+                aria-hidden="true"
+                className="relative hidden place-items-center overflow-hidden bg-[radial-gradient(circle_at_50%_35%,#effbe9_0%,#cfeaca_45%,#9fc99e_100%)] lg:grid"
+            >
+                <div className="grid max-w-sm place-items-center px-8 text-center text-green-950">
+                    <span className="grid size-20 place-items-center rounded-full bg-white/65 shadow-lg backdrop-blur-sm">
+                        <Sprout className="size-11" />
+                    </span>
+                    <p className="mt-4 text-base font-semibold">
+                        Ponude su dostupne u preglednom popisu
+                    </p>
+                </div>
+            </div>
+
+            <OutletGardenOfferBrowser
+                className="border-t-0 lg:border-l"
+                headerAction={
+                    <div className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-lime-300 bg-lime-50 p-3 text-sm text-lime-950 dark:border-lime-900 dark:bg-lime-950/40 dark:text-lime-50">
+                        <p
+                            className="min-w-48 flex-1"
+                            ref={fallbackStatusRef}
+                            role="status"
+                            tabIndex={-1}
+                        >
+                            {fallbackMessage(fallbackReason)}
+                        </p>
+                        {onUse3D ? (
+                            <Button
+                                aria-label="Pokušaj ponovno otvoriti 3D Outlet vrt"
+                                onClick={request3D}
+                                size="lg"
+                                startDecorator={
+                                    <LayoutGrid className="size-4" />
+                                }
+                                variant="outlined"
+                            >
+                                Pokušaj 3D prikaz
+                            </Button>
+                        ) : null}
+                    </div>
+                }
+                isError={isError}
+                isLoading={isLoading}
+                offers={offers}
+                onExit={requestExit}
+                onRetry={retryOffers}
+                onSelectOffer={selectOffer}
+                renderer="list"
+                selectedOfferId={selectedOfferId}
+            />
+        </div>
+    );
+}
+
+export type {
+    OutletGardenFallbackReason,
+    OutletGardenRenderer,
+    OutletGardenSceneFailureReason,
+} from './outletGardenRenderer';

--- a/packages/game/src/viewers/OutletGardenOfferBrowser.tsx
+++ b/packages/game/src/viewers/OutletGardenOfferBrowser.tsx
@@ -6,11 +6,13 @@ import { ArrowLeft, Reset, Sprout } from '@gredice/ui/icons';
 import { Spinner } from '@gredice/ui/Spinner';
 import { cx } from '@gredice/ui/utils';
 import type { Route } from 'next';
+import type { ReactNode } from 'react';
 import type { OutletOfferData } from '../hooks/useOutletOffers';
 import {
     outletGardenMaxDisplayedUnitsPerOffer,
     outletGardenMaxDisplayedUnitsTotal,
 } from './outletGardenLayout';
+import type { OutletGardenRenderer } from './outletGardenRenderer';
 
 const currencyFormatter = new Intl.NumberFormat('hr-HR', {
     style: 'currency',
@@ -130,6 +132,7 @@ function plantGroupImageUrl(plantGroup: OutletGardenPlantGroup) {
 export type OutletGardenOfferBrowserProps = {
     className?: string;
     displayLimited?: boolean;
+    headerAction?: ReactNode;
     isError: boolean;
     isLoading: boolean;
     offers: readonly OutletOfferData[];
@@ -137,12 +140,14 @@ export type OutletGardenOfferBrowserProps = {
     onHoverOffer?: (offerId: number | null) => void;
     onRetry: () => void;
     onSelectOffer: (offerId: number | null) => void;
+    renderer?: OutletGardenRenderer;
     selectedOfferId: number | null;
 };
 
 export function OutletGardenOfferBrowser({
     className,
     displayLimited = false,
+    headerAction,
     isError,
     isLoading,
     offers,
@@ -150,6 +155,7 @@ export function OutletGardenOfferBrowser({
     onHoverOffer,
     onRetry,
     onSelectOffer,
+    renderer = 'webgl',
     selectedOfferId,
 }: OutletGardenOfferBrowserProps) {
     const plantGroups = groupOutletGardenOffers(offers);
@@ -184,10 +190,14 @@ export function OutletGardenOfferBrowser({
                     <div className="min-w-0">
                         <div className="mb-1 flex items-center gap-2">
                             <span className="rounded-full bg-lime-100 px-2 py-0.5 text-[11px] font-semibold tracking-wide text-lime-900 uppercase dark:bg-lime-950 dark:text-lime-100">
-                                3D pregled
+                                {renderer === 'webgl'
+                                    ? '3D pregled'
+                                    : 'Popis ponuda'}
                             </span>
                             <span className="text-xs text-muted-foreground">
-                                Faza 1
+                                {renderer === 'webgl'
+                                    ? 'Interaktivni prikaz'
+                                    : 'Bez 3D prikaza'}
                             </span>
                         </div>
                         <h1
@@ -204,7 +214,7 @@ export function OutletGardenOfferBrowser({
                             event.preventDefault();
                             onExit('garden', '/');
                         }}
-                        size="sm"
+                        size="lg"
                         startDecorator={<ArrowLeft className="size-4" />}
                         variant="soft"
                     >
@@ -212,10 +222,15 @@ export function OutletGardenOfferBrowser({
                     </Button>
                 </div>
                 <p className="mt-2 text-sm text-muted-foreground">
-                    {displayLimited
-                        ? `Razgledaj aktualne ponude. Za velike zalihe prikazujemo najviše ${outletGardenMaxDisplayedUnitsPerOffer.toString()} sadnica po ponudi i ${outletGardenMaxDisplayedUnitsTotal.toString()} ukupno; kartice uvijek pokazuju punu dostupnu količinu.`
-                        : 'Razgledaj aktualne ponude. Broj 3D sadnica prati trenutno dostupnu količinu svake ponude.'}
+                    {renderer === 'list'
+                        ? 'Razgledaj aktualne ponude, njihove cijene i punu dostupnu količinu.'
+                        : displayLimited
+                          ? `Razgledaj aktualne ponude. Za velike zalihe prikazujemo najviše ${outletGardenMaxDisplayedUnitsPerOffer.toString()} sadnica po ponudi i ${outletGardenMaxDisplayedUnitsTotal.toString()} ukupno; kartice uvijek pokazuju punu dostupnu količinu.`
+                          : 'Razgledaj aktualne ponude. Broj 3D sadnica prati trenutno dostupnu količinu svake ponude.'}
                 </p>
+                {headerAction ? (
+                    <div className="mt-3">{headerAction}</div>
+                ) : null}
             </header>
 
             <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-4 sm:p-5">
@@ -225,7 +240,10 @@ export function OutletGardenOfferBrowser({
                             className="grid min-h-32 place-items-center gap-2 text-sm text-muted-foreground"
                             data-outlet-garden-loading
                         >
-                            <Spinner loadingLabel="Učitavanje outlet ponuda" />
+                            <Spinner
+                                className="motion-reduce:animate-none"
+                                loadingLabel="Učitavanje outlet ponuda"
+                            />
                             <span>Učitavamo današnje sadnice...</span>
                         </div>
                     ) : null}
@@ -244,7 +262,7 @@ export function OutletGardenOfferBrowser({
                             <Button
                                 className="mt-3"
                                 onClick={onRetry}
-                                size="sm"
+                                size="lg"
                                 startDecorator={<Reset className="size-4" />}
                                 variant="outlined"
                             >
@@ -284,7 +302,7 @@ export function OutletGardenOfferBrowser({
                             <Button
                                 className="mt-3"
                                 onClick={() => onSelectOffer(null)}
-                                size="sm"
+                                size="lg"
                                 variant="outlined"
                             >
                                 Prikaži dostupne ponude
@@ -419,7 +437,7 @@ export function OutletGardenOfferBrowser({
                                                                                 : '';
                                                                         return (
                                                                             <button
-                                                                                aria-label={`${plantGroup.name}, ${offer.plantSort.name}, sjetva ${shortDateFormatter.format(new Date(offer.sowingDate))}, ${status}, outlet cijena ${currencyFormatter.format(offer.outletPrice)}${comparePriceLabel}, preostalo ${offer.remainingQuantity}`}
+                                                                                aria-label={`${plantGroup.name}, ${offer.plantSort.name}, sjetva ${shortDateFormatter.format(new Date(offer.sowingDate))}, ${status}, outlet cijena ${currencyFormatter.format(offer.outletPrice)}${comparePriceLabel}, preostalo ${offer.remainingQuantity}, ponuda vrijedi do ${dateFormatter.format(new Date(offer.endAt))}`}
                                                                                 aria-pressed={
                                                                                     selected
                                                                                 }

--- a/packages/game/src/viewers/OutletGardenViewer.tsx
+++ b/packages/game/src/viewers/OutletGardenViewer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '@gredice/ui/Button';
-import { ArrowLeft, Sprout } from '@gredice/ui/icons';
+import { ArrowLeft, LayoutList, Sprout } from '@gredice/ui/icons';
 import type { Route } from 'next';
 import { useRouter } from 'next/navigation';
 import { parseAsInteger, useQueryState } from 'nuqs';
@@ -22,6 +22,7 @@ import {
     outletOfferIdFromBlockId,
     reconcileOutletGardenSlots,
 } from './outletGardenLayout';
+import type { OutletGardenSceneFailureReason } from './outletGardenRenderer';
 import {
     getPublicGardenCaptureInitialView,
     normalizePublicGardenStacks,
@@ -33,6 +34,14 @@ import {
 
 const outletGardenCameraMinZoom = 10;
 const outletGardenCloseupZoom = 210;
+
+export type OutletGardenViewerProps = {
+    focusOnMount?: boolean;
+    onSceneFailure?: (reason: OutletGardenSceneFailureReason) => void;
+    onSceneReady?: () => void;
+    onUseListFallback?: () => void;
+    sceneStartedAt?: number;
+};
 
 function OutletGardenScenePlaceholder({ label }: { label: string }) {
     return (
@@ -51,7 +60,13 @@ function OutletGardenScenePlaceholder({ label }: { label: string }) {
     );
 }
 
-export function OutletGardenViewer() {
+export function OutletGardenViewer({
+    focusOnMount = false,
+    onSceneFailure,
+    onSceneReady,
+    onUseListFallback,
+    sceneStartedAt,
+}: OutletGardenViewerProps = {}) {
     const router = useRouter();
     const {
         data: offers = [],
@@ -67,7 +82,9 @@ export function OutletGardenViewer() {
     const [focusedBlockId, setFocusedBlockId] = useState<string | null>(null);
     const { track } = useGameAnalytics();
     const openedTrackedRef = useRef(false);
+    const sceneFailureTrackedRef = useRef(false);
     const sceneReadyTrackedRef = useRef(false);
+    const sceneStartedAtRef = useRef(sceneStartedAt ?? Date.now());
     const sceneContainerRef = useRef<HTMLElement>(null);
     const [initialSceneViewport, setInitialSceneViewport] = useState<{
         height: number;
@@ -79,6 +96,16 @@ export function OutletGardenViewer() {
         destination: 'existing_outlet' | 'garden';
         href: Route;
     } | null>(null);
+    const sceneElapsedMs = useCallback(
+        () => Math.max(0, Date.now() - sceneStartedAtRef.current),
+        [],
+    );
+
+    useEffect(() => {
+        if (focusOnMount) {
+            sceneContainerRef.current?.focus({ preventScroll: true });
+        }
+    }, [focusOnMount]);
     const layoutOffersKey = useMemo(
         () =>
             Array.from(
@@ -283,6 +310,7 @@ export function OutletGardenViewer() {
         openedTrackedRef.current = true;
         track('game_outlet_garden_opened', {
             outlet_offer_count: offers.length,
+            renderer: 'webgl',
             selected_offer_id: selectedOfferId,
         });
     }, [isLoading, offers.length, selectedOfferId, track]);
@@ -294,9 +322,39 @@ export function OutletGardenViewer() {
 
         sceneReadyTrackedRef.current = true;
         track('game_outlet_garden_scene_ready', {
+            device_class: window.innerWidth < 768 ? 'mobile' : 'desktop',
+            input_mode: navigator.maxTouchPoints > 0 ? 'touch' : 'pointer',
             outlet_offer_count: offers.length,
+            renderer: 'webgl',
+            scene_ready_duration_ms: sceneElapsedMs(),
         });
-    }, [offers.length, track]);
+        onSceneReady?.();
+    }, [offers.length, onSceneReady, sceneElapsedMs, track]);
+
+    const reportSceneFailure = useCallback(
+        (reason: OutletGardenSceneFailureReason) => {
+            if (sceneFailureTrackedRef.current) {
+                return;
+            }
+
+            sceneFailureTrackedRef.current = true;
+            onSceneFailure?.(reason);
+        },
+        [onSceneFailure],
+    );
+
+    const reportSceneContextLost = useCallback(() => {
+        reportSceneFailure('context_lost');
+    }, [reportSceneFailure]);
+
+    const requestListFallback = useCallback(() => {
+        track('game_outlet_garden_fallback_requested', {
+            fallback_reason: 'user',
+            renderer: 'webgl',
+            scene_ready: sceneReadyTrackedRef.current,
+        });
+        onUseListFallback?.();
+    }, [onUseListFallback, track]);
 
     const requestExit = useCallback(
         (destination: 'existing_outlet' | 'garden', href: Route) => {
@@ -304,7 +362,11 @@ export function OutletGardenViewer() {
                 return;
             }
 
-            track('game_outlet_garden_exited', { destination });
+            track('game_outlet_garden_exited', {
+                destination,
+                renderer: 'webgl',
+                scene_ready: sceneReadyTrackedRef.current,
+            });
             setExitTarget({ destination, href });
         },
         [exitTarget, track],
@@ -342,6 +404,7 @@ export function OutletGardenViewer() {
             track('game_outlet_garden_offer_viewed', {
                 outlet_offer_id: offerId,
                 plant_sort_id: offer?.plantSort.id,
+                renderer: 'webgl',
             });
         },
         [offers, setSelectedOfferId, track],
@@ -365,10 +428,13 @@ export function OutletGardenViewer() {
             data-outlet-garden-display-limited={displayLimited || undefined}
             data-outlet-garden-exiting={exitTarget ? true : undefined}
             data-outlet-garden-hovered-offer={hoveredOfferId ?? undefined}
+            data-outlet-garden-renderer="webgl"
         >
             <main
+                aria-label="Interaktivni 3D prikaz Outlet vrta"
                 className="relative min-h-0 overflow-hidden"
                 ref={sceneContainerRef}
+                tabIndex={focusOnMount ? -1 : undefined}
             >
                 {layoutReady && offers.length > 0 && sceneInitialView ? (
                     <PublicGardenViewer
@@ -380,6 +446,7 @@ export function OutletGardenViewer() {
                         interactiveBlockIds={interactiveBlockIds}
                         noWeather
                         onSelectBlock={selectBlock}
+                        onSceneContextLost={reportSceneContextLost}
                         onSceneReady={trackSceneReady}
                         renderDetails={false}
                         sceneChildren={
@@ -413,18 +480,35 @@ export function OutletGardenViewer() {
                             event.preventDefault();
                             requestExit('garden', '/');
                         }}
-                        size="sm"
+                        size="lg"
                         startDecorator={<ArrowLeft className="size-4" />}
                         variant="outlined"
                     >
                         Moj vrt
                     </Button>
-                    <div className="hidden max-w-xs rounded-xl bg-black/55 px-3 py-2 text-right text-xs text-white shadow-lg backdrop-blur sm:block">
-                        <p className="font-semibold">Razgledaj Outlet vrt</p>
-                        <p className="mt-0.5 text-white/80">
-                            Povuci za zakretanje · kotačić ili dva prsta za
-                            približavanje
-                        </p>
+                    <div className="pointer-events-auto flex items-start gap-2">
+                        {onUseListFallback ? (
+                            <Button
+                                aria-label="Prikaži Outlet ponude bez 3D prikaza"
+                                onClick={requestListFallback}
+                                size="lg"
+                                startDecorator={
+                                    <LayoutList className="size-4" />
+                                }
+                                variant="outlined"
+                            >
+                                Popis ponuda
+                            </Button>
+                        ) : null}
+                        <div className="hidden max-w-xs rounded-xl bg-black/55 px-3 py-2 text-right text-xs text-white shadow-lg backdrop-blur sm:block">
+                            <p className="font-semibold">
+                                Razgledaj Outlet vrt
+                            </p>
+                            <p className="mt-0.5 text-white/80">
+                                Povuci za zakretanje · kotačić ili dva prsta za
+                                približavanje
+                            </p>
+                        </div>
                     </div>
                 </div>
 

--- a/packages/game/src/viewers/PublicGardenViewer.tsx
+++ b/packages/game/src/viewers/PublicGardenViewer.tsx
@@ -145,6 +145,7 @@ export type PublicGardenViewerProps = HTMLAttributes<HTMLDivElement> & {
     selectedBlockId?: string | null;
     selectedBlockFocus?: PublicGardenSelectedBlockFocus;
     onSelectBlock?: (blockId: string) => void;
+    onSceneContextLost?: () => void;
     onSceneReady?: () => void;
     noWeather?: boolean;
     renderDetails?: boolean;
@@ -419,6 +420,7 @@ function PublicGardenScene({
     normalizedStacks,
     onSelectBlock,
     onSelectRaisedBedBlock,
+    onSceneContextLost,
     onSceneReady,
     renderDetails,
     sceneChildren,
@@ -438,6 +440,7 @@ function PublicGardenScene({
     normalizedStacks: Stack[];
     onSelectBlock?: (blockId: string) => void;
     onSelectRaisedBedBlock: (blockId: string) => void;
+    onSceneContextLost?: () => void;
     onSceneReady?: () => void;
     renderDetails: boolean;
     sceneChildren?: ReactNode;
@@ -490,6 +493,7 @@ function PublicGardenScene({
                     pixelRatio={capture ? 1 : undefined}
                     position={initialView.cameraPosition}
                     quality={qualityProfile}
+                    onContextLost={onSceneContextLost}
                     rendererOptions={
                         capture
                             ? {
@@ -768,6 +772,7 @@ export function PublicGardenViewer({
     interactiveBlockIds,
     noWeather = false,
     onSelectBlock,
+    onSceneContextLost,
     onSceneReady,
     renderDetails: renderDetailsOverride,
     sceneChildren,
@@ -1033,6 +1038,7 @@ export function PublicGardenViewer({
                                     onSelectRaisedBedBlock={
                                         openRaisedBedByBlockId
                                     }
+                                    onSceneContextLost={onSceneContextLost}
                                     onSceneReady={onSceneReady}
                                     renderDetails={renderDetails}
                                     sceneChildren={sceneChildren}

--- a/packages/game/src/viewers/outletGardenBrowserBundleBoundary.unit.ts
+++ b/packages/game/src/viewers/outletGardenBrowserBundleBoundary.unit.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, extname, join, relative, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const sourceRoot = dirname(fileURLToPath(import.meta.url));
+const entryPath = join(sourceRoot, 'OutletGardenBrowserViewer.tsx');
+const sourceExtensions = ['.ts', '.tsx'];
+const prohibitedRuntimePackages = [
+    '@react-spring/three',
+    '@react-three/drei',
+    '@react-three/fiber',
+    'three',
+    'three-custom-shader-material',
+    'three-stdlib',
+];
+
+function resolveSourceImport(fromPath: string, specifier: string) {
+    if (!specifier.startsWith('.')) {
+        return null;
+    }
+
+    const unresolvedPath = resolve(dirname(fromPath), specifier);
+    const candidates = extname(unresolvedPath)
+        ? [unresolvedPath]
+        : [
+              ...sourceExtensions.map(
+                  (extension) => unresolvedPath + extension,
+              ),
+              ...sourceExtensions.map((extension) =>
+                  join(unresolvedPath, `index${extension}`),
+              ),
+          ];
+
+    return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+function getRuntimeImports(source: string) {
+    const imports: string[] = [];
+    const statementPattern =
+        /(?:import|export)\s+([\s\S]*?)\s+from\s+['"]([^'"]+)['"]\s*;/g;
+    const sideEffectPattern = /import\s+['"]([^'"]+)['"]\s*;/g;
+    const dynamicPattern = /import\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+    for (const match of source.matchAll(statementPattern)) {
+        const clause = match[1]?.trimStart();
+        const specifier = match[2];
+        if (clause?.startsWith('type ') || !specifier) {
+            continue;
+        }
+        imports.push(specifier);
+    }
+
+    for (const match of source.matchAll(sideEffectPattern)) {
+        if (match[1]) {
+            imports.push(match[1]);
+        }
+    }
+
+    for (const match of source.matchAll(dynamicPattern)) {
+        if (match[1]) {
+            imports.push(match[1]);
+        }
+    }
+
+    return imports;
+}
+
+function isProhibitedRuntimeImport(specifier: string) {
+    return prohibitedRuntimePackages.some(
+        (packageName) =>
+            specifier === packageName ||
+            specifier.startsWith(`${packageName}/`),
+    );
+}
+
+test('keeps the Outlet list fallback free of 3D runtime imports', () => {
+    const pending = [entryPath];
+    const visited = new Set<string>();
+
+    while (pending.length > 0) {
+        const sourcePath = pending.pop();
+        if (!sourcePath || visited.has(sourcePath)) {
+            continue;
+        }
+        visited.add(sourcePath);
+
+        const imports = getRuntimeImports(readFileSync(sourcePath, 'utf8'));
+        for (const specifier of imports) {
+            assert.equal(
+                isProhibitedRuntimeImport(specifier),
+                false,
+                `${relative(sourceRoot, sourcePath)} statically imports ${specifier}`,
+            );
+
+            const importedSource = resolveSourceImport(sourcePath, specifier);
+            if (importedSource) {
+                pending.push(importedSource);
+            }
+        }
+    }
+
+    assert.ok(
+        visited.has(join(sourceRoot, 'OutletGardenOfferBrowser.tsx')),
+        'expected to inspect the shared Outlet offer browser',
+    );
+    assert.ok(
+        visited.has(join(sourceRoot, '../hooks/useOutletOffers.ts')),
+        'expected to inspect the shared Outlet offer query',
+    );
+});
+
+test('exposes the list controller through its dedicated package entry', async () => {
+    const listEntry = await import('@gredice/game/outlet-garden-list');
+    assert.equal(typeof listEntry.OutletGardenBrowserViewer, 'function');
+});

--- a/packages/game/src/viewers/outletGardenRenderer.ts
+++ b/packages/game/src/viewers/outletGardenRenderer.ts
@@ -1,0 +1,11 @@
+export type OutletGardenRenderer = 'list' | 'webgl';
+
+export type OutletGardenSceneFailureReason = 'context_lost';
+
+export type OutletGardenFallbackReason =
+    | OutletGardenSceneFailureReason
+    | 'constrained_device'
+    | 'scene_load_error'
+    | 'scene_ready_timeout'
+    | 'unsupported_webgl'
+    | 'user';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
         version: 0.220.0(@opentelemetry/api@1.9.1)
       '@posthog/next':
         specifier: 0.8.0
-        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.8.0(@types/react@19.2.18)(@vercel/functions@3.9.2(@aws-sdk/credential-provider-web-identity@3.972.63)(ws@8.21.0))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@scalar/api-reference-react':
         specifier: 0.9.54
         version: 0.9.54(axios@1.16.1)(change-case@5.4.4)(jwt-decode@4.0.0)(qrcode@1.5.4)(react@19.2.8)(tailwindcss@4.3.2)(typescript@7.0.2)(zod@4.4.3)
@@ -119,7 +119,7 @@ importers:
         version: 0.5.3(hono@4.12.28)
       next:
         specifier: 16.3.0
-        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       pg:
         specifier: 8.22.0
         version: 8.22.0
@@ -143,7 +143,7 @@ importers:
         version: 1.4.2(typescript@7.0.2)
       web-push:
         specifier: 3.6.7
-        version: 3.6.7(supports-color@10.2.2)
+        version: 3.6.7
       xml2js:
         specifier: 0.6.2
         version: 0.6.2
@@ -222,7 +222,7 @@ importers:
         version: 0.4.14
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
       jsonwebtoken:
         specifier: 9.0.3
         version: 9.0.3
@@ -276,7 +276,7 @@ importers:
         version: 0.220.0(@opentelemetry/api@1.9.1)
       '@posthog/next':
         specifier: 0.8.0
-        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.8.0(@types/react@19.2.18)(@vercel/functions@3.9.2(@aws-sdk/credential-provider-web-identity@3.972.63)(ws@8.21.0))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@vercel/blob':
         specifier: 2.6.1
         version: 2.6.1
@@ -291,7 +291,7 @@ importers:
         version: 0.45.2(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(pg@8.22.0)
       next:
         specifier: 16.3.0
-        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -312,7 +312,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       react-email:
         specifier: 6.6.9
-        version: 6.6.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)
+        version: 6.6.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       recharts:
         specifier: 3.9.2
         version: 3.9.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-is@17.0.2)(react@19.2.8)(redux@5.0.1)
@@ -364,7 +364,7 @@ importers:
         version: 4.0.4(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(yjs@13.6.27)
       '@playwright/experimental-ct-react':
         specifier: 1.61.1
-        version: 1.61.1(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(supports-color@8.1.1)(tsx@4.23.0)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 1.61.1(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(tsx@4.23.0)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
       '@playwright/test':
         specifier: 1.61.1
         version: 1.61.1
@@ -391,7 +391,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
       '@zxing/library':
         specifier: 0.23.0
         version: 0.23.0
@@ -418,7 +418,7 @@ importers:
         version: 1.2.1
       next:
         specifier: 16.3.0
-        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -479,7 +479,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
       '@zxing/library':
         specifier: 0.23.0
         version: 0.23.0
@@ -527,7 +527,7 @@ importers:
         version: 0.220.0(@opentelemetry/api@1.9.1)
       '@posthog/next':
         specifier: 0.8.0
-        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.8.0(@types/react@19.2.18)(@vercel/functions@3.9.2(@aws-sdk/credential-provider-web-identity@3.972.63)(ws@8.21.0))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@posthog/react':
         specifier: 1.10.3
         version: 1.10.3(@types/react@19.2.18)(posthog-js@1.399.1)(react@19.2.8)
@@ -542,7 +542,7 @@ importers:
         version: 4.2.0(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next:
         specifier: 16.3.0
-        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       pg:
         specifier: 8.22.0
         version: 8.22.0
@@ -615,7 +615,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
       postcss:
         specifier: 8.5.23
         version: 8.5.23
@@ -628,6 +628,9 @@ importers:
 
   apps/garden:
     dependencies:
+      '@flags-sdk/vercel':
+        specifier: 1.4.6
+        version: 1.4.6(@aws-sdk/credential-provider-web-identity@3.972.63)(flags@4.2.0(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(ws@8.21.0)
       '@opentelemetry/api-logs':
         specifier: 0.220.0
         version: 0.220.0
@@ -642,7 +645,7 @@ importers:
         version: 0.220.0(@opentelemetry/api@1.9.1)
       '@posthog/next':
         specifier: 0.8.0
-        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.8.0(@types/react@19.2.18)(@vercel/functions@3.9.2(@aws-sdk/credential-provider-web-identity@3.972.63)(ws@8.21.0))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@vercel/toolbar':
         specifier: 0.2.6
         version: 0.2.6(@vercel/analytics@2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -651,7 +654,7 @@ importers:
         version: 4.2.0(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next:
         specifier: 16.3.0
-        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -685,7 +688,7 @@ importers:
         version: link:../../packages/ui
       '@playwright/experimental-ct-react':
         specifier: 1.61.1
-        version: 1.61.1(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(tsx@4.23.0)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 1.61.1(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(supports-color@10.2.2)(tsx@4.23.0)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
       '@playwright/test':
         specifier: 1.61.1
         version: 1.61.1
@@ -712,7 +715,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
       nuqs:
         specifier: 2.9.0
         version: 2.9.0(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)
@@ -733,16 +736,16 @@ importers:
     dependencies:
       '@posthog/next':
         specifier: 0.8.0
-        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.8.0(@types/react@19.2.18)(@vercel/functions@3.9.2(@aws-sdk/credential-provider-web-identity@3.972.63)(ws@8.21.0))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
       '@vercel/toolbar':
         specifier: 0.2.6
         version: 0.2.6(@vercel/analytics@2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
       next:
         specifier: 16.3.0
-        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -794,7 +797,7 @@ importers:
     dependencies:
       next:
         specifier: 16.3.0
-        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -852,10 +855,10 @@ importers:
         version: 5.101.2(react@19.2.8)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
       next:
         specifier: 16.3.0
-        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -931,7 +934,7 @@ importers:
         version: 0.220.0(@opentelemetry/api@1.9.1)
       '@posthog/next':
         specifier: 0.8.0
-        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.8.0(@types/react@19.2.18)(@vercel/functions@3.9.2(@aws-sdk/credential-provider-web-identity@3.972.63)(ws@8.21.0))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@vercel/toolbar':
         specifier: 0.2.6
         version: 0.2.6(@vercel/analytics@2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -943,7 +946,7 @@ importers:
         version: 4.2.0(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next:
         specifier: 16.3.0
-        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1019,7 +1022,7 @@ importers:
         version: 0.4.14
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+        version: 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
       dotenv:
         specifier: 17.4.2
         version: 17.4.2
@@ -1071,7 +1074,7 @@ importers:
         version: 24.12.4
       next:
         specifier: 16.3.0
-        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1328,7 +1331,7 @@ importers:
         version: 3.2.0
       next:
         specifier: 16.3.0
-        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1587,7 +1590,7 @@ importers:
         version: 19.2.8
       react-email:
         specifier: 6.6.9
-        version: 6.6.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)
+        version: 6.6.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@biomejs/biome':
         specifier: 2.5.3
@@ -1624,7 +1627,7 @@ importers:
         version: link:../js
       '@posthog/next':
         specifier: 0.8.0
-        version: 0.8.0(@types/react@19.2.18)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.8.0(@types/react@19.2.18)(@vercel/functions@3.9.2(@aws-sdk/credential-provider-web-identity@3.972.63)(ws@8.21.0))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-alert-dialog':
         specifier: 1.1.19
         version: 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1672,7 +1675,7 @@ importers:
         version: 12.42.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next:
         specifier: 16.3.0
-        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+        version: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -2956,6 +2959,11 @@ packages:
     resolution: {integrity: sha512-Drt5u2vzDnIONf4ZEkKtFlbvwj6rI3kxw1Ck9fpudmtgaZIHD4ucsWB2lCZBXRxJgXR+2IMSti+4rtM4C4rXgg==}
     cpu: [x64]
     os: [win32]
+
+  '@flags-sdk/vercel@1.4.6':
+    resolution: {integrity: sha512-S0hkhjdzFmOTvpfI5kQMF6fyTNkx3V0dov3DOi3C6M/EdXlieZhGeMv21npW7zzj5IyUYUmYHihextWLe7ib5Q==}
+    peerDependencies:
+      flags: '*'
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -6210,13 +6218,43 @@ packages:
   '@vercel/cli-config@0.2.0':
     resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
 
+  '@vercel/cli-config@0.2.3':
+    resolution: {integrity: sha512-Ggh0Wmi92TUkUexmSUPkkDtvJmbjUr7IvF5T3FkSsWrXXs3GFzOujfxFpECdJZpux1JG4SWDv9BT4w++TDgD6A==}
+
   '@vercel/cli-exec@1.0.0':
     resolution: {integrity: sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==}
+    engines: {node: '>= 18'}
+
+  '@vercel/cli-exec@1.0.1':
+    resolution: {integrity: sha512-g9XerViJ/paZujufXYcu5XYI2vU2rtB4sgdpjUHde5RnOkdmpu0ngH46LCFGHoPXO/C+qDPSczIHIRN+8Q2YKQ==}
     engines: {node: '>= 18'}
 
   '@vercel/firewall@1.2.1':
     resolution: {integrity: sha512-WlxjEPpf+GWYMontNNZqZjvLL40ziGwy9swwI9da/L1fB/syAO1S2fMtlBXkp4EGVF6nlXSKmwvkUd6YPWJbbg==}
     engines: {node: '>= 20'}
+
+  '@vercel/flags-core@1.7.1':
+    resolution: {integrity: sha512-Fzm/+ubwxjEjhdGC8RXp+maQzjRFCNCPbXuxHd75v1tKllya45+gYRhc71HHqIVuteVWkdaYAdRdi+ytwaShiQ==}
+    peerDependencies:
+      '@openfeature/server-sdk': 1.18.0
+      next: '*'
+    peerDependenciesMeta:
+      '@openfeature/server-sdk':
+        optional: true
+      next:
+        optional: true
+
+  '@vercel/functions@3.9.2':
+    resolution: {integrity: sha512-yz1WkUftukJXPWAze3eEKwO72beNOYjukB3369zwyTHAc6klTZTY5MOB6UZKZEvAlCSyGFWo/uf/r0lEr/s6kQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+      ws: '>=8'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+      ws:
+        optional: true
 
   '@vercel/microfrontends@2.3.2':
     resolution: {integrity: sha512-XwG9KrPmRXVIe2MzH+sPJscskk12m7qVPUVM7ehdod5c1HbTtwnuncK4B6KNitBpSL+2C5uRQP0/rUaBq/HLPQ==}
@@ -6253,8 +6291,16 @@ packages:
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
+  '@vercel/oidc@3.5.0':
+    resolution: {integrity: sha512-jo7GgeJx2YMkjg9A28pFM5p88n5SnSHvDeNlf9898bRWiG9jPxwedj/gn/2XTw4UOTyQ50uHlrTGSlf/XU5tgw==}
+    engines: {node: '>= 20'}
+
   '@vercel/oidc@3.8.0':
     resolution: {integrity: sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==}
+    engines: {node: '>= 20'}
+
+  '@vercel/oidc@3.8.3':
+    resolution: {integrity: sha512-FmKJ7Fic8CnHvEagfOK1VRczvg83WHQYAJinUMMuxFw5VHpGXeZ9abfP1+5a8SxhTazsTtPFCMBSrjf/heAWBQ==}
     engines: {node: '>= 20'}
 
   '@vercel/toolbar@0.2.6':
@@ -8276,6 +8322,9 @@ packages:
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
+  jose@5.2.1:
+    resolution: {integrity: sha512-qiaQhtQRw6YrOaOj0v59h3R6hUY9NvxBmmnMfKemkqYmBB0tEc97NbLP7ix44VP5p9/0YHG8Vyhzuo5YBNwviA==}
+
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
@@ -8291,6 +8340,10 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-xxhash@4.0.0:
+    resolution: {integrity: sha512-3Q2eIqG6s1KEBBmkj9tGM9lef8LJbuRyTVBdI3GpTnrvtytunjLPO0wqABp5qhtMzfA32jYn1FlnIV7GH1RAHQ==}
+    engines: {node: '>=18.0.0'}
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
@@ -11192,31 +11245,31 @@ snapshots:
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/core@7.29.7(supports-color@8.1.1)':
+  '@babel/core@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -11243,26 +11296,17 @@ snapshots:
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -11287,9 +11331,9 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
@@ -11297,9 +11341,9 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
@@ -11315,6 +11359,18 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
+  '@babel/traverse@7.27.0':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.27.0
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3(supports-color@8.1.1)
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/traverse@7.27.0(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -11327,7 +11383,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/traverse@7.29.7(supports-color@10.2.2)':
+  '@babel/traverse@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -11335,7 +11391,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11715,7 +11771,7 @@ snapshots:
 
   '@electron/get@3.1.0':
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       env-paths: 2.2.1
       fs-extra: 8.1.0
       got: 11.8.6
@@ -11742,7 +11798,7 @@ snapshots:
 
   '@electron/notarize@2.5.0':
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 9.1.0
       promise-retry: 2.0.1
     transitivePeerDependencies:
@@ -11751,7 +11807,7 @@ snapshots:
   '@electron/osx-sign@1.3.3':
     dependencies:
       compare-version: 0.1.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 10.1.0
       isbinaryfile: 4.0.10
       minimist: 1.2.8
@@ -11762,7 +11818,7 @@ snapshots:
   '@electron/rebuild@4.0.6':
     dependencies:
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       node-abi: 4.32.0
       node-api-version: 0.2.1
       node-gyp: 12.4.0
@@ -11774,7 +11830,7 @@ snapshots:
     dependencies:
       '@electron/asar': 3.4.1
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       dir-compare: 4.2.0
       fs-extra: 11.3.6
       minimatch: 9.0.9
@@ -11785,7 +11841,7 @@ snapshots:
   '@electron/windows-sign@1.2.2':
     dependencies:
       cross-dirname: 0.1.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 11.3.6
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
@@ -12174,6 +12230,16 @@ snapshots:
 
   '@ffmpeg-installer/win32-x64@4.1.0':
     optional: true
+
+  '@flags-sdk/vercel@1.4.6(@aws-sdk/credential-provider-web-identity@3.972.63)(flags@4.2.0(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(ws@8.21.0)':
+    dependencies:
+      '@vercel/flags-core': 1.7.1(@aws-sdk/credential-provider-web-identity@3.972.63)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(ws@8.21.0)
+      flags: 4.2.0(@opentelemetry/api@1.9.1)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-web-identity'
+      - '@openfeature/server-sdk'
+      - next
+      - ws
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -12747,7 +12813,7 @@ snapshots:
 
   '@malept/flatpak-bundler@0.4.0':
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 9.1.0
       lodash: 4.18.1
       tmp-promise: 3.0.3
@@ -13305,10 +13371,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@playwright/experimental-ct-react@1.61.1(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(supports-color@8.1.1)(tsx@4.23.0)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)':
+  '@playwright/experimental-ct-react@1.61.1(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(supports-color@10.2.2)(tsx@4.23.0)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
       '@playwright/experimental-ct-core': 1.61.1(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0)
-      '@vitejs/plugin-react': 4.7.0(supports-color@8.1.1)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitejs/plugin-react': 4.7.0(supports-color@10.2.2)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13351,16 +13417,18 @@ snapshots:
     dependencies:
       '@posthog/types': 1.393.0
 
-  '@posthog/next@0.8.0(@types/react@19.2.18)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@posthog/next@0.8.0(@types/react@19.2.18)(@vercel/functions@3.9.2(@aws-sdk/credential-provider-web-identity@3.972.63)(ws@8.21.0))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@posthog/core': 1.40.1
       '@posthog/react': 1.10.3(@types/react@19.2.18)(posthog-js@1.399.1)(react@19.2.8)
-      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       posthog-js: 1.399.1
       posthog-node: 5.40.0
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       server-only: 0.0.1
+    optionalDependencies:
+      '@vercel/functions': 3.9.2(@aws-sdk/credential-provider-web-identity@3.972.63)(ws@8.21.0)
     transitivePeerDependencies:
       - '@types/react'
       - preact-render-to-string
@@ -14879,11 +14947,11 @@ snapshots:
       '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
       '@storybook/react': 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(typescript@7.0.2)
       '@storybook/react-vite': 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(typescript@7.0.2)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
-      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8)
-      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.8)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.8)
       vite: 8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0)
       vite-plugin-storybook-nextjs: 3.3.0(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
     optionalDependencies:
@@ -15563,7 +15631,7 @@ snapshots:
   '@typespec/ts-http-runtime@0.3.2':
     dependencies:
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -15600,9 +15668,9 @@ snapshots:
     dependencies:
       valibot: 1.4.2(typescript@7.0.2)
 
-  '@vercel/analytics@2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))':
+  '@vercel/analytics@2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))':
     optionalDependencies:
-      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react: 19.2.8
       vue: 3.5.39(typescript@7.0.2)
 
@@ -15620,11 +15688,39 @@ snapshots:
       xdg-app-paths: 5.5.1
       zod: 4.1.11
 
+  '@vercel/cli-config@0.2.3':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
   '@vercel/cli-exec@1.0.0':
     dependencies:
       execa: 5.1.1
 
+  '@vercel/cli-exec@1.0.1':
+    dependencies:
+      execa: 5.1.1
+
   '@vercel/firewall@1.2.1': {}
+
+  '@vercel/flags-core@1.7.1(@aws-sdk/credential-provider-web-identity@3.972.63)(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(ws@8.21.0)':
+    dependencies:
+      '@vercel/functions': 3.9.2(@aws-sdk/credential-provider-web-identity@3.972.63)(ws@8.21.0)
+      '@vercel/oidc': 3.5.0
+      jose: 5.2.1
+      js-xxhash: 4.0.0
+    optionalDependencies:
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-web-identity'
+      - ws
+
+  '@vercel/functions@3.9.2(@aws-sdk/credential-provider-web-identity@3.972.63)(ws@8.21.0)':
+    dependencies:
+      '@vercel/oidc': 3.8.3
+    optionalDependencies:
+      '@aws-sdk/credential-provider-web-identity': 3.972.63
+      ws: 8.21.0
 
   '@vercel/microfrontends@2.3.2(@vercel/analytics@2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
@@ -15641,8 +15737,8 @@ snapshots:
       path-to-regexp: 6.3.0
       semver: 7.8.5
     optionalDependencies:
-      '@vercel/analytics': 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
-      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      '@vercel/analytics': 2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2))
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       vite: 8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0)
@@ -15653,10 +15749,18 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
+  '@vercel/oidc@3.5.0': {}
+
   '@vercel/oidc@3.8.0':
     dependencies:
       '@vercel/cli-config': 0.2.0
       '@vercel/cli-exec': 1.0.0
+      jose: 5.10.0
+
+  '@vercel/oidc@3.8.3':
+    dependencies:
+      '@vercel/cli-config': 0.2.3
+      '@vercel/cli-exec': 1.0.1
       jose: 5.10.0
 
   '@vercel/toolbar@0.2.6(@vercel/analytics@2.0.1(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react@19.2.8)(vue@3.5.39(typescript@7.0.2)))(next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))':
@@ -15669,7 +15773,7 @@ snapshots:
       get-port: 5.1.1
       strip-ansi: 6.0.1
     optionalDependencies:
-      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react: 19.2.8
       vite: 8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -15679,11 +15783,11 @@ snapshots:
       - debug
       - react-dom
 
-  '@vitejs/plugin-react@4.7.0(supports-color@8.1.1)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.7.0(supports-color@10.2.2)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -15886,9 +15990,15 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  agent-base@6.0.2(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15970,7 +16080,7 @@ snapshots:
       builder-util-runtime: 9.7.0
       chromium-pickle-js: 0.2.0
       ci-info: 4.3.1
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       dmg-builder: 26.15.3(electron-builder-squirrel-windows@26.15.3)
       dotenv: 16.6.1
       dotenv-expand: 11.0.7
@@ -16074,7 +16184,17 @@ snapshots:
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  axios@1.16.1(debug@4.4.3(supports-color@8.1.1))(supports-color@10.2.2):
+    dependencies:
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1(supports-color@10.2.2)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -16157,7 +16277,7 @@ snapshots:
 
   builder-util-runtime@9.7.0:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       sax: 1.6.0
     transitivePeerDependencies:
       - supports-color
@@ -16168,10 +16288,10 @@ snapshots:
       builder-util-runtime: 9.7.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       js-yaml: 4.3.0
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
@@ -16885,7 +17005,7 @@ snapshots:
   electron-winstaller@5.4.0:
     dependencies:
       '@electron/asar': 3.4.1
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 7.0.1
       lodash: 4.18.1
       temp: 0.9.4
@@ -16913,6 +17033,23 @@ snapshots:
       once: 1.4.0
 
   engine.io-parser@5.2.3: {}
+
+  engine.io@6.6.9:
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/node': 24.12.4
+      '@types/ws': 8.18.1
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.6
+      debug: 4.4.3(supports-color@8.1.1)
+      engine.io-parser: 5.2.3
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   engine.io@6.6.9(supports-color@10.2.2):
     dependencies:
@@ -17171,7 +17308,7 @@ snapshots:
       qs: 6.15.3
       range-parser: 1.2.1
       router: 2.2.0(supports-color@8.1.1)
-      send: 1.2.1(supports-color@10.2.2)
+      send: 1.2.1
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.0.1
@@ -17246,7 +17383,7 @@ snapshots:
       jose: 5.10.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
@@ -17677,7 +17814,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17696,10 +17833,24 @@ snapshots:
 
   http_ece@1.2.0: {}
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@10.2.2):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@10.2.2)
       debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
+    dependencies:
+      agent-base: 6.0.2(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17864,6 +18015,8 @@ snapshots:
 
   jose@5.10.0: {}
 
+  jose@5.2.1: {}
+
   jose@6.2.3: {}
 
   js-base64@3.8.1: {}
@@ -17873,6 +18026,8 @@ snapshots:
   js-md4@0.3.2: {}
 
   js-tokens@4.0.0: {}
+
+  js-xxhash@4.0.0: {}
 
   js-yaml@4.2.0:
     dependencies:
@@ -18626,7 +18781,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -18750,7 +18905,7 @@ snapshots:
       '@next/env': 13.5.11
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
 
   next-themes@0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -18766,7 +18921,7 @@ snapshots:
       postcss: 8.5.23
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.8)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.8)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.6
       '@next/swc-darwin-x64': 16.2.6
@@ -18784,7 +18939,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0):
+  next@16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -18793,7 +18948,7 @@ snapshots:
       postcss: 8.5.23
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.8)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.8)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.3.0
       '@next/swc-darwin-x64': 16.3.0
@@ -18859,7 +19014,7 @@ snapshots:
       '@standard-schema/spec': 1.0.0
       react: 19.2.8
     optionalDependencies:
-      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
 
   nypm@0.6.6:
     dependencies:
@@ -19305,7 +19460,7 @@ snapshots:
   react-docgen@8.0.3:
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
@@ -19326,6 +19481,37 @@ snapshots:
     dependencies:
       react: 19.2.8
       scheduler: 0.27.0
+
+  react-email@6.6.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@babel/traverse': 7.27.0
+      '@react-email/render': 2.0.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      chokidar: 4.0.3
+      commander: 13.1.0
+      conf: 15.1.0
+      css-tree: 3.2.1
+      debounce: 2.2.0
+      esbuild: 0.28.1
+      glob: 13.0.6
+      jiti: 2.4.2
+      log-symbols: 7.0.1
+      marked: 15.0.12
+      mime-types: 3.0.2
+      normalize-path: 3.0.0
+      nypm: 0.6.6
+      picospinner: 3.0.0
+      prismjs: 1.30.0
+      prompts: 2.4.2
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      socket.io: 4.8.3
+      tailwindcss: 4.3.2
+      tsconfig-paths: 4.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   react-email@6.6.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2):
     dependencies:
@@ -19439,7 +19625,7 @@ snapshots:
 
   read-binary-file-arch@1.0.6:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19765,9 +19951,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1(supports-color@10.2.2):
+  send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -19791,7 +19977,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1(supports-color@10.2.2)
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -19912,7 +20098,7 @@ snapshots:
 
   soap@1.9.3(supports-color@8.1.1):
     dependencies:
-      axios: 1.16.1(debug@4.4.3(supports-color@8.1.1))
+      axios: 1.16.1(debug@4.4.3(supports-color@8.1.1))(supports-color@10.2.2)
       axios-ntlm: 1.4.6(debug@4.4.3(supports-color@8.1.1))
       debug: 4.4.3(supports-color@8.1.1)
       follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
@@ -19923,6 +20109,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  socket.io-adapter@2.5.8:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   socket.io-adapter@2.5.8(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -19932,12 +20127,33 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  socket.io-parser@4.2.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   socket.io-parser@4.2.6(supports-color@10.2.2):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
+
+  socket.io@4.8.3:
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.6
+      debug: 4.4.3(supports-color@8.1.1)
+      engine.io: 6.6.9
+      socket.io-adapter: 2.5.8
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   socket.io@4.8.3(supports-color@10.2.2):
     dependencies:
@@ -20100,18 +20316,18 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.6
 
-  styled-jsx@5.1.6(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.8):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.8):
     dependencies:
       client-only: 0.0.1
       react: 19.2.8
     optionalDependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
 
   stylis@4.4.0: {}
 
   sumchecker@3.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -20550,7 +20766,7 @@ snapshots:
       image-size: 2.0.2
       magic-string: 0.30.21
       module-alias: 2.3.4
-      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
+      next: 16.3.0(patch_hash=55aa10de397e0471f31d9dc80e6bc429306bc37a80b4784e4b489290a54ed79f)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.12.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.0)
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8)
       ts-dedent: 2.3.0
       vite: 8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0)
@@ -20625,11 +20841,11 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
-  web-push@3.6.7(supports-color@10.2.2):
+  web-push@3.6.7:
     dependencies:
       asn1.js: 5.4.1
       http_ece: 1.2.0
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       jws: 4.0.1
       minimist: 1.2.8
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- connect `enableOutletGarden` to a managed Vercel flag with a production-safe fallback and instant rollback
- add a renderer-free semantic offer list for unsupported WebGL, context loss, scene errors, timeouts, and an explicit user choice
- preserve selected offers and keyboard focus across 3D/list transitions, keep every Outlet touch action at least 44px, and record readiness/failure/fallback telemetry
- point public Outlet cards at the selected 3D offer while retaining the classic reservation/cart handoff
- document the launch and rollback procedure

## Validation

- `pnpm --filter garden build`
- `pnpm --filter @gredice/game test` — 1017/1017
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter garden exec playwright test tests/outlet-garden-route.spec.ts --project=chromium-webgl --workers=1` — 2/2
- `pnpm --filter garden exec playwright test tests/outlet-garden-flag.spec.ts tests/outlet-hud.spec.tsx --project=chromium --workers=1` — 7/7
- `pnpm --filter www test:static-data` — 5/5
- targeted Biome checks
- `git diff --check`

The local WWW production build compiled and typechecked, then failed during static prerender when the external directory database query became unavailable. The changed WWW URL/copy is covered by typecheck and the static-data test.

## Rollout

- managed flag: `enableOutletGarden`
- Preview/Development: on
- Production: intentionally off until the merged Garden deployment is READY and passes a clean-browser smoke
- rollback: disable the Production flag; no deployment required
- no schema, migration, inventory, checkout, or generated-asset changes

Advances #4468
Advances #4469
Part of #4463
