### PR TITLE
[Outlet][Phase 2A] Harden held reservation targets

### DIFF
--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -59,6 +59,7 @@ import {
     assertAdvancedSowingPlanAvailable,
     assertLegacySowingCartTargetsAvailable,
     assertNoBlockingLegacyPlantOperations,
+    DuplicateDirectSowingCartTargetError,
     LegacySowingSelectedPlantingConflictError,
 } from '../../../lib/checkout/advancedSowingAvailability';
 import {
@@ -302,6 +303,15 @@ const app = new Hono<{ Variables: CheckoutVariables }>()
                     return context.json(
                         {
                             code: 'LEGACY_SOWING_SELECTED_PLANTING_CONFLICT',
+                            error: error.message,
+                        },
+                        409,
+                    );
+                }
+                if (error instanceof DuplicateDirectSowingCartTargetError) {
+                    return context.json(
+                        {
+                            code: 'DUPLICATE_SOWING_CART_TARGET',
                             error: error.message,
                         },
                         409,

--- a/apps/api/app/api/[...route]/shoppingCartRoutes.ts
+++ b/apps/api/app/api/[...route]/shoppingCartRoutes.ts
@@ -18,6 +18,7 @@ import {
     getEntityFormatted,
     getEntityRaw,
     getGarden,
+    getGardenBlocks,
     getHarvestScheduleForCart,
     getOrCreateShoppingCart,
     getOutletOffer,
@@ -30,6 +31,7 @@ import {
     HarvestScheduleConflictError,
     normalizeShoppingCartInventoryUsage,
     normalizeShoppingCartScheduledDates,
+    OutletCartTargetUnavailableError,
     OutletOfferUnavailableError,
     OutletReservationUnavailableError,
     releaseOutletReservationForCartItem,
@@ -56,8 +58,16 @@ import {
 } from '../../../lib/checkout/advancedSowingPlan';
 import { isAdvancedSowingServerEnabled } from '../../../lib/checkout/advancedSowingServerFlag';
 import { getCartInfo } from '../../../lib/checkout/cartInfo';
+import {
+    assertOutletCartTargetAvailable,
+    OutletCartMutationConflictError,
+    outletCartMutationConflictCodes,
+    requireOutletCartTarget,
+    resolveOutletCartCurrency,
+} from '../../../lib/checkout/outletCartTarget';
 import { serializeShoppingCartItemForClient } from '../../../lib/checkout/shoppingCartClientSerialization';
 import { getDefaultCartItemCurrency } from '../../../lib/checkout/sunflowerCalculations';
+import { calculateRaisedBedsValidity } from '../../../lib/garden/raisedBedsService';
 import {
     type AuthVariables,
     authValidator,
@@ -206,7 +216,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
         '/',
         describeRoute({
             description:
-                'Add or update an item in the shopping cart. New items without an explicit currency use sunflowers when the current balance covers all sunflower commitments in the cart.',
+                'Add or update an item in the shopping cart. New items without an explicit currency use sunflowers when the current balance covers all sunflower commitments in the cart. Outlet additions require an owned, available garden field and return stable conflict codes when the offer or target is unavailable.',
         }),
         authValidator(['user', 'admin']),
         zValidator(
@@ -280,6 +290,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 typeof id === 'number'
                     ? cart.items.find((item) => item.id === id)
                     : undefined;
+            let outletMutationCurrency = currency;
             if (outletOfferId && entityTypeName !== 'plantSort') {
                 return context.json(
                     { error: 'Outlet offers can only be used for plant sorts' },
@@ -309,10 +320,22 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 );
             }
             if (outletOfferId && amount > 0) {
+                if (amount !== 1) {
+                    return context.json(
+                        {
+                            error: 'Outlet offer is not available',
+                            code: outletCartMutationConflictCodes.offerUnavailable,
+                        },
+                        409,
+                    );
+                }
                 const offer = await getOutletOffer(outletOfferId);
                 if (!offer) {
                     return context.json(
-                        { error: 'Outlet offer is not available' },
+                        {
+                            error: 'Outlet offer is not available',
+                            code: outletCartMutationConflictCodes.offerUnavailable,
+                        },
                         409,
                     );
                 }
@@ -322,16 +345,70 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     offer.status !== 'published' ||
                     offer.startAt.getTime() > now ||
                     offer.endAt.getTime() <= now ||
-                    offer.remainingQuantity < amount ||
                     offer.plantSortId.toString() !== entityId
                 ) {
                     return context.json(
-                        { error: 'Outlet offer is not available' },
+                        {
+                            error: 'Outlet offer is not available',
+                            code: outletCartMutationConflictCodes.offerUnavailable,
+                        },
                         409,
                     );
                 }
+
+                try {
+                    const target = requireOutletCartTarget({
+                        gardenId,
+                        positionIndex,
+                        raisedBedId,
+                    });
+                    const [garden, blocks] = await Promise.all([
+                        getGarden(target.gardenId),
+                        getGardenBlocks(target.gardenId),
+                    ]);
+                    const validityMap = garden
+                        ? calculateRaisedBedsValidity(
+                              garden.raisedBeds,
+                              garden.stacks,
+                              new Map(
+                                  blocks.map((block) => [block.id, block.name]),
+                              ),
+                          )
+                        : new Map<number, boolean>();
+                    assertOutletCartTargetAvailable({
+                        accountId,
+                        garden,
+                        isRaisedBedValid:
+                            validityMap.get(target.raisedBedId) ?? false,
+                        positionIndex: target.positionIndex,
+                        raisedBedId: target.raisedBedId,
+                    });
+                } catch (error) {
+                    if (error instanceof OutletCartMutationConflictError) {
+                        return context.json(
+                            { error: error.message, code: error.code },
+                            409,
+                        );
+                    }
+                    throw error;
+                }
+                const existingOutletTargetItem =
+                    existingItem ??
+                    cart.items.find(
+                        (item) =>
+                            item.status === 'new' &&
+                            item.amount > 0 &&
+                            item.entityTypeName === 'plantSort' &&
+                            item.gardenId === gardenId &&
+                            item.raisedBedId === raisedBedId &&
+                            item.positionIndex === positionIndex,
+                    );
+                outletMutationCurrency = resolveOutletCartCurrency(
+                    currency,
+                    existingOutletTargetItem?.currency,
+                );
             }
-            if (amount > 0 && raisedBedId) {
+            if (amount > 0 && raisedBedId && !outletOfferId) {
                 const raisedBed = await getRaisedBed(raisedBedId);
                 if (!raisedBed || raisedBed.accountId !== accountId) {
                     return context.json({ error: 'Raised bed not found' }, 404);
@@ -532,7 +609,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     throw error;
                 }
             }
-            let appliedCurrency = currency ?? undefined;
+            let appliedCurrency = outletMutationCurrency ?? undefined;
             try {
                 let cartItemId: number | null = null;
                 if (outletOfferId && amount > 0) {
@@ -547,7 +624,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                             raisedBedId,
                             positionIndex,
                             additionalData,
-                            currency,
+                            currency: outletMutationCurrency,
                             forceCreate,
                             outletOfferId,
                             accountId,
@@ -656,7 +733,19 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     error instanceof OutletReservationUnavailableError
                 ) {
                     return context.json(
-                        { error: 'Outlet offer is not available' },
+                        {
+                            error: 'Outlet offer is not available',
+                            code: outletCartMutationConflictCodes.offerUnavailable,
+                        },
+                        409,
+                    );
+                }
+                if (error instanceof OutletCartTargetUnavailableError) {
+                    return context.json(
+                        {
+                            error: 'Outlet target is not available',
+                            code: outletCartMutationConflictCodes.targetUnavailable,
+                        },
                         409,
                     );
                 }

--- a/apps/api/lib/checkout/advancedSowingAvailability.node.spec.ts
+++ b/apps/api/lib/checkout/advancedSowingAvailability.node.spec.ts
@@ -9,6 +9,8 @@ import {
     assertAdvancedSowingPlanAvailable,
     assertLegacySowingCartTargetsAvailable,
     assertLegacySowingTargetAvailable,
+    assertUniqueDirectSowingCartTargets,
+    DuplicateDirectSowingCartTargetError,
     getLegacySowingCartMutationTarget,
     getLegacySowingCartTargets,
     LegacySowingSelectedPlantingConflictError,
@@ -308,6 +310,17 @@ describe('legacy sowing selected-planting guard', () => {
             LegacySowingSelectedPlantingConflictError,
         );
         assert.deepEqual(loadedRaisedBedIds, [2]);
+    });
+
+    it('rejects duplicate direct planting anchors before payment', () => {
+        assert.throws(
+            () =>
+                assertUniqueDirectSowingCartTargets({
+                    authorizationsByCartItemId: new Map(),
+                    cartItems: [legacyCartItem, { ...legacyCartItem, id: 21 }],
+                }),
+            DuplicateDirectSowingCartTargetError,
+        );
     });
 
     it('preserves an exact authorized item update but guards conversions, moves, and outlet fallback', () => {

--- a/apps/api/lib/checkout/advancedSowingAvailability.ts
+++ b/apps/api/lib/checkout/advancedSowingAvailability.ts
@@ -53,6 +53,17 @@ export class LegacySowingSelectedPlantingConflictError extends Error {
     }
 }
 
+export class DuplicateDirectSowingCartTargetError extends Error {
+    override readonly name = 'DuplicateDirectSowingCartTargetError';
+
+    constructor(
+        readonly raisedBedId: number,
+        readonly positionIndex: number,
+    ) {
+        super('Multiple pending cart items use the same planting target.');
+    }
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
     return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
@@ -173,6 +184,33 @@ export function getLegacySowingCartTargets({
     });
 }
 
+export function assertUniqueDirectSowingCartTargets({
+    authorizationsByCartItemId,
+    cartItems,
+}: {
+    authorizationsByCartItemId: ReadonlyMap<
+        number,
+        AdvancedSowingCartAuthorizationV1
+    >;
+    cartItems: readonly PendingCartItem[];
+}) {
+    const targets = getLegacySowingCartTargets({
+        authorizationsByCartItemId,
+        cartItems,
+    });
+    const targetKeys = new Set<string>();
+    for (const target of targets) {
+        const key = `${target.raisedBedId.toString()}:${target.positionIndex.toString()}`;
+        if (targetKeys.has(key)) {
+            throw new DuplicateDirectSowingCartTargetError(
+                target.raisedBedId,
+                target.positionIndex,
+            );
+        }
+        targetKeys.add(key);
+    }
+}
+
 /**
  * Resolves the physical legacy target that the ordinary cart mutation will
  * leave behind. Exact idempotent updates to an explicitly identified selected
@@ -249,6 +287,10 @@ export async function assertLegacySowingCartTargetsAvailable({
     ) => Promise<readonly RaisedBedPlantingAvailabilitySource[]>;
 }) {
     const targets = getLegacySowingCartTargets({
+        authorizationsByCartItemId,
+        cartItems,
+    });
+    assertUniqueDirectSowingCartTargets({
         authorizationsByCartItemId,
         cartItems,
     });

--- a/apps/api/lib/checkout/outletCartTarget.node.spec.ts
+++ b/apps/api/lib/checkout/outletCartTarget.node.spec.ts
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    assertOutletCartTargetAvailable,
+    OutletCartMutationConflictError,
+    outletCartMutationConflictCodes,
+    requireOutletCartTarget,
+    resolveOutletCartCurrency,
+} from './outletCartTarget';
+
+function targetGarden(
+    overrides: Record<string, unknown> = {},
+    raisedBedOverrides: Record<string, unknown> = {},
+) {
+    return {
+        accountId: 'account-1',
+        id: 10,
+        isSandbox: false,
+        raisedBeds: [
+            {
+                accountId: 'account-1',
+                fields: [],
+                gardenId: 10,
+                id: 20,
+                plantings: [],
+                status: 'active',
+                ...raisedBedOverrides,
+            },
+        ],
+        ...overrides,
+    };
+}
+
+function assertConflict(
+    operation: () => unknown,
+    code: OutletCartMutationConflictError['code'],
+) {
+    assert.throws(operation, (error) => {
+        assert.ok(error instanceof OutletCartMutationConflictError);
+        assert.equal(error.code, code);
+        return true;
+    });
+}
+
+test('outlet cart conflict codes remain stable', () => {
+    assert.deepEqual(outletCartMutationConflictCodes, {
+        offerUnavailable: 'OUTLET_OFFER_UNAVAILABLE',
+        targetRequired: 'OUTLET_TARGET_REQUIRED',
+        targetUnavailable: 'OUTLET_TARGET_UNAVAILABLE',
+    });
+});
+
+test('requireOutletCartTarget returns a complete target and rejects omissions', () => {
+    assert.deepEqual(
+        requireOutletCartTarget({
+            gardenId: 10,
+            raisedBedId: 20,
+            positionIndex: 3,
+        }),
+        { gardenId: 10, raisedBedId: 20, positionIndex: 3 },
+    );
+    for (const target of [
+        { raisedBedId: 20, positionIndex: 3 },
+        { gardenId: 10, positionIndex: 3 },
+        { gardenId: 10, raisedBedId: 20 },
+    ]) {
+        assertConflict(
+            () => requireOutletCartTarget(target),
+            outletCartMutationConflictCodes.targetRequired,
+        );
+    }
+
+    for (const target of [
+        { gardenId: 1.5, raisedBedId: 20, positionIndex: 3 },
+        { gardenId: 0, raisedBedId: 20, positionIndex: 3 },
+        { gardenId: 10, raisedBedId: 20.5, positionIndex: 3 },
+        { gardenId: 10, raisedBedId: 0, positionIndex: 3 },
+        { gardenId: 10, raisedBedId: 20, positionIndex: -1 },
+        { gardenId: 10, raisedBedId: 20, positionIndex: 18 },
+    ]) {
+        assertConflict(
+            () => requireOutletCartTarget(target),
+            outletCartMutationConflictCodes.targetUnavailable,
+        );
+    }
+});
+
+test('assertOutletCartTargetAvailable accepts an owned empty valid target', () => {
+    assert.doesNotThrow(() =>
+        assertOutletCartTargetAvailable({
+            accountId: 'account-1',
+            garden: targetGarden(),
+            isRaisedBedValid: true,
+            positionIndex: 17,
+            raisedBedId: 20,
+        }),
+    );
+});
+
+test('assertOutletCartTargetAvailable rejects unavailable garden and bed states', () => {
+    const cases = [
+        { garden: null, valid: true },
+        { garden: targetGarden({ accountId: 'account-2' }), valid: true },
+        { garden: targetGarden({ isSandbox: true }), valid: true },
+        {
+            garden: targetGarden({}, { accountId: 'account-2' }),
+            valid: true,
+        },
+        { garden: targetGarden({}, { gardenId: 11 }), valid: true },
+        { garden: targetGarden({}, { status: 'abandoned' }), valid: true },
+        { garden: targetGarden(), valid: false },
+    ];
+
+    for (const { garden, valid } of cases) {
+        assertConflict(
+            () =>
+                assertOutletCartTargetAvailable({
+                    accountId: 'account-1',
+                    garden,
+                    isRaisedBedValid: valid,
+                    positionIndex: 0,
+                    raisedBedId: 20,
+                }),
+            outletCartMutationConflictCodes.targetUnavailable,
+        );
+    }
+});
+
+test('assertOutletCartTargetAvailable rejects positions outside the bed', () => {
+    for (const positionIndex of [-1, 18, 1.5, Number.NaN]) {
+        assertConflict(
+            () =>
+                assertOutletCartTargetAvailable({
+                    accountId: 'account-1',
+                    garden: targetGarden(),
+                    isRaisedBedValid: true,
+                    positionIndex,
+                    raisedBedId: 20,
+                }),
+            outletCartMutationConflictCodes.targetUnavailable,
+        );
+    }
+});
+
+test('assertOutletCartTargetAvailable rejects active physical occupancy', () => {
+    assertConflict(
+        () =>
+            assertOutletCartTargetAvailable({
+                accountId: 'account-1',
+                garden: targetGarden(
+                    {},
+                    {
+                        fields: [
+                            {
+                                active: true,
+                                plantSortId: 301,
+                                positionIndex: 4,
+                            },
+                        ],
+                    },
+                ),
+                isRaisedBedValid: true,
+                positionIndex: 4,
+                raisedBedId: 20,
+            }),
+        outletCartMutationConflictCodes.targetUnavailable,
+    );
+});
+
+test('assertOutletCartTargetAvailable rejects selected-layout occupancy', () => {
+    assertConflict(
+        () =>
+            assertOutletCartTargetAvailable({
+                accountId: 'account-1',
+                garden: targetGarden(
+                    {},
+                    {
+                        plantings: [
+                            {
+                                configurationSource: 'selected',
+                                isActive: true,
+                                layoutKey: 'selected-layout',
+                                memberships: [{ positionIndex: 5 }],
+                            },
+                        ],
+                    },
+                ),
+                isRaisedBedValid: true,
+                positionIndex: 5,
+                raisedBedId: 20,
+            }),
+        outletCartMutationConflictCodes.targetUnavailable,
+    );
+});
+
+test('assertOutletCartTargetAvailable fails closed for malformed selected occupancy', () => {
+    assertConflict(
+        () =>
+            assertOutletCartTargetAvailable({
+                accountId: 'account-1',
+                garden: targetGarden(
+                    {},
+                    {
+                        plantings: [
+                            {
+                                configurationSource: 'selected',
+                                isActive: true,
+                                layoutKey: 'selected-layout',
+                                memberships: [{}],
+                            },
+                        ],
+                    },
+                ),
+                isRaisedBedValid: true,
+                positionIndex: 5,
+                raisedBedId: 20,
+            }),
+        outletCartMutationConflictCodes.targetUnavailable,
+    );
+});
+
+test('resolveOutletCartCurrency preserves supported currencies and normalizes inventory', () => {
+    assert.equal(resolveOutletCartCurrency('sunflower', 'eur'), 'sunflower');
+    assert.equal(
+        resolveOutletCartCurrency(undefined, 'sunflower'),
+        'sunflower',
+    );
+    assert.equal(resolveOutletCartCurrency(undefined, 'inventory'), 'eur');
+    assert.equal(resolveOutletCartCurrency(null, undefined), 'eur');
+});

--- a/apps/api/lib/checkout/outletCartTarget.ts
+++ b/apps/api/lib/checkout/outletCartTarget.ts
@@ -1,0 +1,178 @@
+import { ADVANCED_SOWING_DEFAULT_BED_FIELD_COUNT } from '@gredice/js/plants';
+import { isRaisedBedAbandoned } from '@gredice/js/raisedBeds';
+import {
+    assertLegacySowingTargetAvailable,
+    LegacySowingSelectedPlantingConflictError,
+} from './advancedSowingAvailability';
+
+export const outletCartMutationConflictCodes = {
+    offerUnavailable: 'OUTLET_OFFER_UNAVAILABLE',
+    targetRequired: 'OUTLET_TARGET_REQUIRED',
+    targetUnavailable: 'OUTLET_TARGET_UNAVAILABLE',
+} as const;
+
+export type OutletCartMutationConflictCode =
+    (typeof outletCartMutationConflictCodes)[keyof typeof outletCartMutationConflictCodes];
+
+export class OutletCartMutationConflictError extends Error {
+    override readonly name = 'OutletCartMutationConflictError';
+
+    constructor(readonly code: OutletCartMutationConflictCode) {
+        super(
+            code === outletCartMutationConflictCodes.targetRequired
+                ? 'Outlet offer requires a garden, raised bed, and field target.'
+                : code === outletCartMutationConflictCodes.offerUnavailable
+                  ? 'Outlet offer is not available.'
+                  : 'Outlet target is not available.',
+        );
+    }
+}
+
+type OutletTargetField = {
+    active?: boolean | null;
+    plantSortId?: number | null;
+    positionIndex: number;
+};
+
+type OutletTargetPlanting = {
+    configurationSource: string;
+    isActive: boolean;
+    isDeleted?: boolean;
+    layoutKey: string | null;
+    memberships: readonly unknown[];
+};
+
+type OutletTargetRaisedBed = {
+    accountId: string | null;
+    fields: readonly OutletTargetField[];
+    gardenId: number | null;
+    id: number;
+    plantings: readonly OutletTargetPlanting[];
+    status: string;
+};
+
+type OutletTargetGarden = {
+    accountId: string | null;
+    id: number;
+    isSandbox: boolean;
+    raisedBeds: readonly OutletTargetRaisedBed[];
+};
+
+export type RequiredOutletCartTarget = {
+    gardenId: number;
+    positionIndex: number;
+    raisedBedId: number;
+};
+
+export function requireOutletCartTarget({
+    gardenId,
+    positionIndex,
+    raisedBedId,
+}: {
+    gardenId?: number;
+    positionIndex?: number;
+    raisedBedId?: number;
+}): RequiredOutletCartTarget {
+    if (
+        gardenId === undefined ||
+        raisedBedId === undefined ||
+        positionIndex === undefined
+    ) {
+        throw new OutletCartMutationConflictError(
+            outletCartMutationConflictCodes.targetRequired,
+        );
+    }
+    if (
+        !Number.isSafeInteger(gardenId) ||
+        gardenId <= 0 ||
+        !Number.isSafeInteger(raisedBedId) ||
+        raisedBedId <= 0 ||
+        !Number.isSafeInteger(positionIndex) ||
+        positionIndex < 0 ||
+        positionIndex >= ADVANCED_SOWING_DEFAULT_BED_FIELD_COUNT
+    ) {
+        throw new OutletCartMutationConflictError(
+            outletCartMutationConflictCodes.targetUnavailable,
+        );
+    }
+
+    return { gardenId, positionIndex, raisedBedId };
+}
+
+export function assertOutletCartTargetAvailable({
+    accountId,
+    garden,
+    isRaisedBedValid,
+    positionIndex,
+    raisedBedId,
+}: {
+    accountId: string;
+    garden: OutletTargetGarden | null;
+    isRaisedBedValid: boolean;
+    positionIndex: number;
+    raisedBedId: number;
+}) {
+    const raisedBed = garden?.raisedBeds.find(
+        (candidate) => candidate.id === raisedBedId,
+    );
+    if (
+        !garden ||
+        garden.accountId !== accountId ||
+        garden.isSandbox ||
+        !raisedBed ||
+        raisedBed.accountId !== accountId ||
+        raisedBed.gardenId !== garden.id ||
+        !isRaisedBedValid ||
+        isRaisedBedAbandoned(raisedBed.status) ||
+        !Number.isSafeInteger(positionIndex) ||
+        positionIndex < 0 ||
+        positionIndex >= ADVANCED_SOWING_DEFAULT_BED_FIELD_COUNT
+    ) {
+        throw new OutletCartMutationConflictError(
+            outletCartMutationConflictCodes.targetUnavailable,
+        );
+    }
+
+    const physicalFieldOccupied = raisedBed.fields.some(
+        (field) =>
+            field.positionIndex === positionIndex &&
+            field.active === true &&
+            typeof field.plantSortId === 'number',
+    );
+    if (physicalFieldOccupied) {
+        throw new OutletCartMutationConflictError(
+            outletCartMutationConflictCodes.targetUnavailable,
+        );
+    }
+
+    try {
+        assertLegacySowingTargetAvailable({
+            plantings: raisedBed.plantings,
+            positionIndex,
+            raisedBedId,
+        });
+    } catch (error) {
+        if (error instanceof LegacySowingSelectedPlantingConflictError) {
+            throw new OutletCartMutationConflictError(
+                outletCartMutationConflictCodes.targetUnavailable,
+            );
+        }
+        throw error;
+    }
+}
+
+export function isOutletCartCurrency(
+    currency: string | null | undefined,
+): currency is 'eur' | 'sunflower' {
+    return currency === 'eur' || currency === 'sunflower';
+}
+
+export function resolveOutletCartCurrency(
+    currency: string | null | undefined,
+    existingCurrency: string | null | undefined,
+) {
+    if (isOutletCartCurrency(currency)) {
+        return currency;
+    }
+    return isOutletCartCurrency(existingCurrency) ? existingCurrency : 'eur';
+}

--- a/apps/garden/tests/raised-bed-plant-picker.spec.tsx
+++ b/apps/garden/tests/raised-bed-plant-picker.spec.tsx
@@ -799,6 +799,59 @@ test('outlet sowing sends the selected outlet offer', async ({
     expect(post.additionalData).toBe(JSON.stringify({ outletOfferId: 302 }));
 });
 
+test('outlet sowing converts an existing inventory row to euros', async ({
+    mount,
+    page,
+}) => {
+    const posts = await mockShoppingCartPosts(page);
+    const inventoryCartItem = {
+        additionalData: JSON.stringify({
+            scheduledDate: '2026-05-14T00:00:00.000Z',
+        }),
+        amount: 1,
+        currency: 'inventory',
+        entityId: '101',
+        entityTypeName: 'plantSort',
+        gardenId: 1,
+        id: 41,
+        positionIndex: 0,
+        raisedBedId: 1,
+        shopData: {
+            discountPrice: null,
+            price: 1.5,
+        },
+        status: 'new',
+    } satisfies TestShoppingCartItem;
+
+    await mount(
+        <PlantPickerTestStory
+            cartItems={[inventoryCartItem]}
+            inShoppingCart
+            preselectedPlantId={1}
+            preselectedSortId={101}
+            selectedCartItemId={inventoryCartItem.id}
+        />,
+    );
+
+    await page.getByRole('button', { name: 'Sijanje' }).click();
+    const sowingMode = page.getByRole('radiogroup', {
+        name: 'Način sijanja',
+    });
+    await sowingMode.getByText('Preostalo 3').click();
+    await page.getByRole('button', { name: 'Dodaj u košaru' }).click();
+
+    await expect.poll(() => posts.length).toBe(1);
+    const post = posts[0];
+    expect(isRecord(post)).toBe(true);
+    if (!isRecord(post)) {
+        return;
+    }
+    expect(post.id).toBe(41);
+    expect(post.currency).toBe('eur');
+    expect(post.outletOfferId).toBe(302);
+    expect(post.additionalData).toBe(JSON.stringify({ outletOfferId: 302 }));
+});
+
 test('outlet selection param opens the selected outlet offer', async ({
     mount,
     page,

--- a/packages/game/src/hooks/shoppingCartItemMutation.ts
+++ b/packages/game/src/hooks/shoppingCartItemMutation.ts
@@ -1,0 +1,114 @@
+import type {
+    AdvancedSowingSelectionRequestV1,
+    AdvancedSowingSelectionSummaryV1,
+} from '@gredice/js/plants';
+
+const shoppingCartMutationFallbackMessage = 'Failed to set shopping cart item';
+
+export type SetShoppingCartItemInput = {
+    id?: number;
+    entityTypeName: string;
+    entityId: string;
+    amount: number;
+    gardenId?: number;
+    raisedBedId?: number;
+    positionIndex?: number;
+    additionalData?: string | null;
+    currency?: string | null;
+    outletOfferId?: number;
+    forceCreate?: boolean;
+    advancedSowingSelection?:
+        | AdvancedSowingSelectionRequestV1
+        | AdvancedSowingSelectionSummaryV1;
+};
+
+export type BuildOutletCartItemPayloadInput = {
+    cartItemId?: number;
+    currency?: 'eur' | 'sunflower';
+    gardenId: number;
+    outletOfferId: number;
+    plantSortId: number;
+    positionIndex: number;
+    raisedBedId: number;
+};
+
+export function buildOutletCartItemPayload({
+    cartItemId,
+    currency,
+    gardenId,
+    outletOfferId,
+    plantSortId,
+    positionIndex,
+    raisedBedId,
+}: BuildOutletCartItemPayloadInput): SetShoppingCartItemInput {
+    return {
+        ...(cartItemId === undefined ? {} : { id: cartItemId }),
+        entityTypeName: 'plantSort',
+        entityId: plantSortId.toString(),
+        amount: 1,
+        gardenId,
+        raisedBedId,
+        positionIndex,
+        additionalData: JSON.stringify({ outletOfferId }),
+        ...(currency === undefined ? {} : { currency }),
+        outletOfferId,
+    };
+}
+
+type ShoppingCartMutationErrorOptions = {
+    code: string | null;
+    message: string;
+    status: number;
+};
+
+export class ShoppingCartMutationError extends Error {
+    readonly code: string | null;
+    readonly status: number;
+
+    constructor({ code, message, status }: ShoppingCartMutationErrorOptions) {
+        super(message);
+        this.name = 'ShoppingCartMutationError';
+        this.code = code;
+        this.status = status;
+    }
+}
+
+function stringProperty(value: unknown, key: string) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return null;
+    }
+
+    const candidate: unknown = Reflect.get(value, key);
+    return typeof candidate === 'string' && candidate.trim()
+        ? candidate.trim()
+        : null;
+}
+
+async function responseJson(response: Response) {
+    try {
+        const text = (await response.text()).trim();
+        if (!text) {
+            return null;
+        }
+
+        const parsed: unknown = JSON.parse(text);
+        return parsed;
+    } catch {
+        return null;
+    }
+}
+
+export async function shoppingCartMutationErrorFromResponse(
+    response: Response,
+) {
+    const body = await responseJson(response);
+
+    return new ShoppingCartMutationError({
+        code: stringProperty(body, 'code'),
+        message:
+            stringProperty(body, 'error') ??
+            stringProperty(body, 'message') ??
+            shoppingCartMutationFallbackMessage,
+        status: response.status,
+    });
+}

--- a/packages/game/src/hooks/shoppingCartItemMutation.unit.ts
+++ b/packages/game/src/hooks/shoppingCartItemMutation.unit.ts
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    buildOutletCartItemPayload,
+    ShoppingCartMutationError,
+    shoppingCartMutationErrorFromResponse,
+} from './shoppingCartItemMutation';
+
+test('buildOutletCartItemPayload builds a new outlet field reservation', () => {
+    const payload = buildOutletCartItemPayload({
+        gardenId: 1,
+        outletOfferId: 302,
+        plantSortId: 101,
+        positionIndex: 0,
+        raisedBedId: 2,
+    });
+
+    assert.deepEqual(payload, {
+        entityTypeName: 'plantSort',
+        entityId: '101',
+        amount: 1,
+        gardenId: 1,
+        raisedBedId: 2,
+        positionIndex: 0,
+        additionalData: JSON.stringify({ outletOfferId: 302 }),
+        outletOfferId: 302,
+    });
+    assert.equal('advancedSowingSelection' in payload, false);
+    assert.equal('currency' in payload, false);
+    assert.equal('forceCreate' in payload, false);
+});
+
+test('buildOutletCartItemPayload preserves an existing item and explicit payment currency', () => {
+    assert.deepEqual(
+        buildOutletCartItemPayload({
+            cartItemId: 41,
+            currency: 'eur',
+            gardenId: 1,
+            outletOfferId: 302,
+            plantSortId: 101,
+            positionIndex: 8,
+            raisedBedId: 2,
+        }),
+        {
+            id: 41,
+            entityTypeName: 'plantSort',
+            entityId: '101',
+            amount: 1,
+            gardenId: 1,
+            raisedBedId: 2,
+            positionIndex: 8,
+            additionalData: JSON.stringify({ outletOfferId: 302 }),
+            currency: 'eur',
+            outletOfferId: 302,
+        },
+    );
+});
+
+test('shoppingCartMutationErrorFromResponse preserves the API error contract', async () => {
+    const error = await shoppingCartMutationErrorFromResponse(
+        new Response(
+            JSON.stringify({
+                code: 'OUTLET_TARGET_UNAVAILABLE',
+                error: 'Outlet target is not available',
+            }),
+            { status: 409 },
+        ),
+    );
+
+    assert.ok(error instanceof Error);
+    assert.ok(error instanceof ShoppingCartMutationError);
+    assert.equal(error.name, 'ShoppingCartMutationError');
+    assert.equal(error.status, 409);
+    assert.equal(error.code, 'OUTLET_TARGET_UNAVAILABLE');
+    assert.equal(error.message, 'Outlet target is not available');
+});
+
+test('shoppingCartMutationErrorFromResponse supports uncoded API errors', async () => {
+    const error = await shoppingCartMutationErrorFromResponse(
+        new Response(JSON.stringify({ message: 'Cart item not found' }), {
+            status: 404,
+        }),
+    );
+
+    assert.equal(error.status, 404);
+    assert.equal(error.code, null);
+    assert.equal(error.message, 'Cart item not found');
+});
+
+test('shoppingCartMutationErrorFromResponse hides malformed response bodies', async () => {
+    const error = await shoppingCartMutationErrorFromResponse(
+        new Response('<html>Proxy error</html>', { status: 502 }),
+    );
+
+    assert.equal(error.status, 502);
+    assert.equal(error.code, null);
+    assert.equal(error.message, 'Failed to set shopping cart item');
+});
+
+test('shoppingCartMutationErrorFromResponse falls back for empty response bodies', async () => {
+    const error = await shoppingCartMutationErrorFromResponse(
+        new Response('', { status: 500 }),
+    );
+
+    assert.equal(error.status, 500);
+    assert.equal(error.code, null);
+    assert.equal(error.message, 'Failed to set shopping cart item');
+});

--- a/packages/game/src/hooks/useSetShoppingCartItem.ts
+++ b/packages/game/src/hooks/useSetShoppingCartItem.ts
@@ -1,11 +1,11 @@
 import { clientAuthenticated } from '@gredice/client';
-import {
-    type AdvancedSowingSelectionRequestV1,
-    type AdvancedSowingSelectionSummaryV1,
-    advancedSowingSelectionRequestKind,
-} from '@gredice/js/plants';
+import { advancedSowingSelectionRequestKind } from '@gredice/js/plants';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { getEffectiveEurPrice } from '../utils/sunflowerPricing';
+import {
+    type SetShoppingCartItemInput,
+    shoppingCartMutationErrorFromResponse,
+} from './shoppingCartItemMutation';
 import {
     currentAccountKeys,
     type useCurrentAccount,
@@ -17,22 +17,10 @@ import {
 } from './useShoppingCart';
 import { tutorialChecklistKeys } from './useTutorialChecklist';
 
-type SetShoppingCartItemInput = {
-    id?: number;
-    entityTypeName: string;
-    entityId: string;
-    amount: number;
-    gardenId?: number;
-    raisedBedId?: number;
-    positionIndex?: number;
-    additionalData?: string | null;
-    currency?: string | null;
-    outletOfferId?: number;
-    forceCreate?: boolean;
-    advancedSowingSelection?:
-        | AdvancedSowingSelectionRequestV1
-        | AdvancedSowingSelectionSummaryV1;
-};
+export {
+    type SetShoppingCartItemInput,
+    ShoppingCartMutationError,
+} from './shoppingCartItemMutation';
 
 type CurrentAccountData = ReturnType<typeof useCurrentAccount>['data'];
 
@@ -188,8 +176,8 @@ export function useSetShoppingCartItem() {
                     cartId: cart.id,
                 },
             });
-            if (response.status !== 200) {
-                throw new Error('Failed to set shopping cart item');
+            if (!response.ok) {
+                throw await shoppingCartMutationErrorFromResponse(response);
             }
         },
         onMutate: async (item) => {

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -35,6 +35,7 @@ import {
 import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { SegmentedProgress } from '../../controls/components/SegmentedProgress';
 import { useGameFlags } from '../../GameFlagsContext';
+import { buildOutletCartItemPayload } from '../../hooks/shoppingCartItemMutation';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useGardens } from '../../hooks/useGardens';
 import { useInventory } from '../../hooks/useInventory';
@@ -492,37 +493,49 @@ export function PlantPicker({
         showShoppingCartTransientHub();
         setFlyToShoppingCart(true);
         try {
-            await setCartItem.mutateAsync({
-                entityTypeName: 'plantSort',
-                entityId: selectedSortId?.toString(),
-                id: existingItemCanBeUpdated ? existingItem.id : undefined,
-                amount: 1,
-                gardenId,
-                raisedBedId,
-                positionIndex,
-                additionalData: JSON.stringify({
-                    ...(useOutletOffer && selectedOutletOffer
-                        ? { outletOfferId: selectedOutletOffer.id }
-                        : {
+            await setCartItem.mutateAsync(
+                useOutletOffer && selectedOutletOffer
+                    ? buildOutletCartItemPayload({
+                          cartItemId: existingItemCanBeUpdated
+                              ? existingItem.id
+                              : undefined,
+                          currency:
+                              existingItemCanBeUpdated &&
+                              existingItem.currency === 'inventory'
+                                  ? 'eur'
+                                  : undefined,
+                          gardenId,
+                          outletOfferId: selectedOutletOffer.id,
+                          plantSortId: selectedSortId,
+                          positionIndex,
+                          raisedBedId,
+                      })
+                    : {
+                          entityTypeName: 'plantSort',
+                          entityId: selectedSortId.toString(),
+                          id: existingItemCanBeUpdated
+                              ? existingItem.id
+                              : undefined,
+                          amount: 1,
+                          gardenId,
+                          raisedBedId,
+                          positionIndex,
+                          additionalData: JSON.stringify({
                               scheduledDate:
                                   plantOptions?.scheduledDate?.toISOString(),
                               ...(sowInGreenhouse
                                   ? { sowingLocation: 'greenhouse' }
                                   : {}),
                           }),
-                }),
-                currency: useInventoryItem ? 'inventory' : undefined,
-                outletOfferId:
-                    useOutletOffer && selectedOutletOffer
-                        ? selectedOutletOffer.id
-                        : undefined,
-                ...(advancedSowingSelection
-                    ? {
-                          advancedSowingSelection,
-                          forceCreate: !existingItemCanBeUpdated,
-                      }
-                    : {}),
-            });
+                          currency: useInventoryItem ? 'inventory' : undefined,
+                          ...(advancedSowingSelection
+                              ? {
+                                    advancedSowingSelection,
+                                    forceCreate: !existingItemCanBeUpdated,
+                                }
+                              : {}),
+                      },
+            );
             await new Promise((resolve) => setTimeout(resolve, 800)); // Wait for animation to finish
         } finally {
             scheduleHideShoppingCartTransientHub();

--- a/packages/storage/src/repositories/shoppingCartRepo.ts
+++ b/packages/storage/src/repositories/shoppingCartRepo.ts
@@ -1,5 +1,5 @@
 import type { AdvancedSowingCartAuthorizationV1 } from '@gredice/js/plants';
-import { and, asc, desc, eq, gte, inArray, lte, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gt, gte, inArray, lte, sql } from 'drizzle-orm';
 import {
     events,
     notifications,
@@ -31,6 +31,7 @@ import {
 import { getCheckoutOperationMappings } from './operationsRepo';
 import {
     getOutletOfferReservationForCartItem,
+    OutletReservationUnavailableError,
     releaseOutletReservationForCartItem,
     releaseOutletReservationsForCart,
     reserveOutletOffer,
@@ -66,6 +67,18 @@ export class CheckoutCartItemFulfillmentStartedError extends Error {
 export class AdvancedSowingCartItemExplicitIdentityRequiredError extends Error {
     override readonly name =
         'AdvancedSowingCartItemExplicitIdentityRequiredError';
+}
+
+export class OutletCartTargetUnavailableError extends Error {
+    override readonly name = 'OutletCartTargetUnavailableError';
+
+    constructor() {
+        super('Another live cart item already uses the Outlet target.');
+    }
+}
+
+class OutletCartTargetChangedDuringMutationError extends Error {
+    override readonly name = 'OutletCartTargetChangedDuringMutationError';
 }
 
 class CheckoutCartChangedDuringDeleteError extends Error {
@@ -996,6 +1009,17 @@ export async function upsertOrRemoveCartItem(
         if (!activeCart) {
             throw new Error('Cannot add an item to an inactive shopping cart');
         }
+        if (
+            entityTypeName === 'plantSort' &&
+            typeof gardenId === 'number' &&
+            typeof raisedBedId === 'number' &&
+            typeof positionIndex === 'number'
+        ) {
+            await assertNoOutletReservationAtDirectTarget(
+                { cartId, gardenId, positionIndex, raisedBedId },
+                db,
+            );
+        }
 
         return (
             await db
@@ -1098,6 +1122,39 @@ export async function upsertOrRemoveCartItemWithAdvancedSowingAuthorization({
                     'Advanced Sowing cannot replace an outlet-reserved cart item.',
                 );
             }
+            if (
+                typeof gardenId !== 'number' ||
+                typeof raisedBedId !== 'number'
+            ) {
+                throw new AdvancedSowingCartAuthorizationPersistenceError(
+                    'Advanced Sowing target is incomplete.',
+                );
+            }
+            const bedItems = await getLivePlantCartItemsForBed(
+                { cartId, gardenId, raisedBedId },
+                tx,
+                true,
+            );
+            for (const targetItem of bedItems) {
+                if (
+                    targetItem.id === cartItemId ||
+                    targetItem.positionIndex === null ||
+                    !authorization.plan.occupiedPositionIndices.includes(
+                        targetItem.positionIndex,
+                    )
+                ) {
+                    continue;
+                }
+                const reservation = await getOutletOfferReservationForCartItem(
+                    targetItem.id,
+                    tx,
+                );
+                if (reservation?.status === 'held') {
+                    throw new AdvancedSowingCartAuthorizationPersistenceError(
+                        'Advanced Sowing target overlaps an Outlet reservation.',
+                    );
+                }
+            }
             await persistShoppingCartItemAdvancedSowingAuthorization(
                 cartItemId,
                 authorization,
@@ -1118,6 +1175,546 @@ export async function upsertOrRemoveCartItemWithAdvancedSowingAuthorization({
         }
         return cartItemId;
     });
+}
+
+type IdlessOutletCartItemMutation = {
+    accountId: string;
+    additionalData?: string | null;
+    amount: number;
+    cartId: number;
+    currency?: string | null;
+    entityId: string;
+    entityTypeName: string;
+    gardenId: number;
+    holdMinutes?: number;
+    now: Date;
+    outletOfferId: number;
+    positionIndex: number;
+    raisedBedId: number;
+};
+
+type ExplicitOutletCartItemMutation = IdlessOutletCartItemMutation & {
+    id: number;
+};
+
+function isSupportedOutletCartCurrency(
+    currency: string | null | undefined,
+): currency is 'eur' | 'sunflower' {
+    return currency === 'eur' || currency === 'sunflower';
+}
+
+async function getLivePlantCartItemsForBed(
+    {
+        cartId,
+        gardenId,
+        raisedBedId,
+    }: Pick<
+        IdlessOutletCartItemMutation,
+        'cartId' | 'gardenId' | 'raisedBedId'
+    >,
+    db: DatabaseClient,
+    lockRows = false,
+) {
+    const query = db
+        .select()
+        .from(shoppingCartItems)
+        .where(
+            and(
+                eq(shoppingCartItems.cartId, cartId),
+                eq(shoppingCartItems.entityTypeName, 'plantSort'),
+                eq(shoppingCartItems.gardenId, gardenId),
+                eq(shoppingCartItems.raisedBedId, raisedBedId),
+                eq(shoppingCartItems.isDeleted, false),
+                gt(shoppingCartItems.amount, 0),
+            ),
+        )
+        .orderBy(asc(shoppingCartItems.id));
+
+    return lockRows ? query.for('update') : query;
+}
+
+function getPlantCartItemsAtPosition<
+    T extends { id: number; positionIndex: number | null },
+>(items: readonly T[], positionIndex: number): T[] {
+    return items.filter((item) => item.positionIndex === positionIndex);
+}
+
+function sameCartItemIds(
+    expectedIds: readonly number[],
+    items: readonly { id: number }[],
+) {
+    return (
+        expectedIds.length === items.length &&
+        expectedIds.every((id, index) => id === items[index]?.id)
+    );
+}
+
+async function assertNoPendingAdvancedSowingFootprintAtTarget(
+    items: readonly { id: number; status: string }[],
+    positionIndex: number,
+    db: TransactionClient,
+    excludedCartItemId?: number,
+) {
+    const pendingItemIds = items
+        .filter(
+            (item) => item.status === 'new' && item.id !== excludedCartItemId,
+        )
+        .map((item) => item.id);
+    let authorizations: Awaited<
+        ReturnType<typeof getShoppingCartItemAdvancedSowingAuthorizations>
+    >;
+    try {
+        authorizations = await getShoppingCartItemAdvancedSowingAuthorizations(
+            pendingItemIds,
+            db,
+        );
+    } catch (error) {
+        if (error instanceof AdvancedSowingCartAuthorizationPersistenceError) {
+            throw new OutletCartTargetUnavailableError();
+        }
+        throw error;
+    }
+    if (
+        Array.from(authorizations.values()).some((authorization) =>
+            authorization.plan.occupiedPositionIndices.includes(positionIndex),
+        )
+    ) {
+        throw new OutletCartTargetUnavailableError();
+    }
+}
+
+async function lockCartForOutletMutation(
+    {
+        accountId,
+        cartId,
+    }: Pick<IdlessOutletCartItemMutation, 'accountId' | 'cartId'>,
+    db: TransactionClient,
+) {
+    const [cart] = await db
+        .select({
+            accountId: shoppingCarts.accountId,
+            id: shoppingCarts.id,
+            isDeleted: shoppingCarts.isDeleted,
+            status: shoppingCarts.status,
+        })
+        .from(shoppingCarts)
+        .where(eq(shoppingCarts.id, cartId))
+        .for('update')
+        .limit(1);
+    if (
+        !cart ||
+        cart.accountId !== accountId ||
+        cart.isDeleted ||
+        cart.status !== 'new'
+    ) {
+        throw new OutletReservationUnavailableError(
+            'Outlet reservation cart is no longer mutable.',
+        );
+    }
+    await assertNoActiveStripeCheckoutAttempt(cartId, db);
+}
+
+async function applyIdlessOutletCartItemMutation(
+    mutation: IdlessOutletCartItemMutation,
+    discoveredBedItemIds: readonly number[],
+    db: TransactionClient,
+) {
+    await lockCartForOutletMutation(mutation, db);
+    const bedItems = await getLivePlantCartItemsForBed(mutation, db, true);
+    if (!sameCartItemIds(discoveredBedItemIds, bedItems)) {
+        throw new OutletCartTargetChangedDuringMutationError();
+    }
+    await assertNoPendingAdvancedSowingFootprintAtTarget(
+        bedItems,
+        mutation.positionIndex,
+        db,
+    );
+    const targetItems = getPlantCartItemsAtPosition(
+        bedItems,
+        mutation.positionIndex,
+    );
+
+    const normalizedAdditionalData =
+        mutation.additionalData === undefined
+            ? undefined
+            : normalizeScheduledDateAdditionalData(mutation.additionalData);
+    const existingItem = targetItems[0];
+    if (existingItem) {
+        if (targetItems.length !== 1) {
+            throw new OutletCartTargetUnavailableError();
+        }
+        const reservation = await getOutletOfferReservationForCartItem(
+            existingItem.id,
+            db,
+        );
+        const isExactRetry =
+            existingItem.entityId === mutation.entityId &&
+            existingItem.entityTypeName === mutation.entityTypeName &&
+            existingItem.amount === mutation.amount &&
+            reservation?.accountId === mutation.accountId &&
+            reservation.cartId === mutation.cartId &&
+            reservation.cartItemId === existingItem.id &&
+            reservation.outletOfferId === mutation.outletOfferId &&
+            reservation.status === 'held';
+        if (!isExactRetry) {
+            throw new OutletCartTargetUnavailableError();
+        }
+
+        const fulfillmentStartedItemIds =
+            await getCheckoutFulfillmentStartedCartItemIds(
+                mutation.accountId,
+                [existingItem],
+                db,
+            );
+        if (fulfillmentStartedItemIds.has(existingItem.id)) {
+            throw new CheckoutCartItemFulfillmentStartedError(existingItem.id);
+        }
+
+        const finalCurrency = mutation.currency ?? existingItem.currency;
+        if (!isSupportedOutletCartCurrency(finalCurrency)) {
+            throw new OutletReservationUnavailableError(
+                'Outlet cart item has an unsupported currency.',
+            );
+        }
+        if (existingItem.currency !== finalCurrency) {
+            await db
+                .update(shoppingCartItems)
+                .set({ currency: finalCurrency })
+                .where(eq(shoppingCartItems.id, existingItem.id));
+        }
+        await clearShoppingCartItemAdvancedSowingAuthorization(
+            existingItem.id,
+            db,
+        );
+        await reserveOutletOffer({
+            offerId: mutation.outletOfferId,
+            accountId: mutation.accountId,
+            cartId: mutation.cartId,
+            cartItemId: existingItem.id,
+            quantity: mutation.amount,
+            now: mutation.now,
+            holdMinutes: mutation.holdMinutes,
+            db,
+        });
+        return existingItem.id;
+    }
+
+    const finalCurrency = mutation.currency ?? 'eur';
+    if (!isSupportedOutletCartCurrency(finalCurrency)) {
+        throw new OutletReservationUnavailableError(
+            'Outlet cart item has an unsupported currency.',
+        );
+    }
+    const [createdItem] = await db
+        .insert(shoppingCartItems)
+        .values({
+            cartId: mutation.cartId,
+            entityId: mutation.entityId,
+            entityTypeName: mutation.entityTypeName,
+            amount: mutation.amount,
+            gardenId: mutation.gardenId,
+            raisedBedId: mutation.raisedBedId,
+            positionIndex: mutation.positionIndex,
+            additionalData: normalizedAdditionalData,
+            currency: finalCurrency,
+        })
+        .returning({ id: shoppingCartItems.id });
+    if (!createdItem) {
+        throw new OutletReservationUnavailableError(
+            'Outlet cart item could not be created.',
+        );
+    }
+    await reserveOutletOffer({
+        offerId: mutation.outletOfferId,
+        accountId: mutation.accountId,
+        cartId: mutation.cartId,
+        cartItemId: createdItem.id,
+        quantity: mutation.amount,
+        now: mutation.now,
+        holdMinutes: mutation.holdMinutes,
+        db,
+    });
+    return createdItem.id;
+}
+
+async function assertNoOutletReservationAtDirectTarget(
+    {
+        cartId,
+        gardenId,
+        positionIndex,
+        raisedBedId,
+    }: {
+        cartId: number;
+        gardenId: number;
+        positionIndex: number;
+        raisedBedId: number;
+    },
+    db: TransactionClient,
+    excludedCartItemId?: number,
+) {
+    const bedItems = await getLivePlantCartItemsForBed(
+        { cartId, gardenId, raisedBedId },
+        db,
+        true,
+    );
+    const targetItems = getPlantCartItemsAtPosition(bedItems, positionIndex);
+    for (const targetItem of targetItems) {
+        if (targetItem.id === excludedCartItemId) {
+            continue;
+        }
+        const reservation = await getOutletOfferReservationForCartItem(
+            targetItem.id,
+            db,
+        );
+        if (reservation?.status === 'held') {
+            throw new OutletCartTargetUnavailableError();
+        }
+    }
+}
+
+async function applyExplicitOutletCartItemMutation(
+    mutation: ExplicitOutletCartItemMutation,
+    discoveredBedItemIds: readonly number[],
+    db: TransactionClient,
+) {
+    await lockCartForOutletMutation(mutation, db);
+    const bedItems = await getLivePlantCartItemsForBed(mutation, db, true);
+    if (!sameCartItemIds(discoveredBedItemIds, bedItems)) {
+        throw new OutletCartTargetChangedDuringMutationError();
+    }
+
+    const [existingItem] = await db
+        .select()
+        .from(shoppingCartItems)
+        .where(
+            and(
+                eq(shoppingCartItems.id, mutation.id),
+                eq(shoppingCartItems.isDeleted, false),
+            ),
+        )
+        .for('update')
+        .limit(1);
+    if (!existingItem || existingItem.cartId !== mutation.cartId) {
+        throw new OutletReservationUnavailableError(
+            'Outlet cart item is no longer available.',
+        );
+    }
+    if (existingItem.status === 'paid') {
+        throw new Error('Cannot update paid shopping cart item via API');
+    }
+
+    const fulfillmentStartedItemIds =
+        await getCheckoutFulfillmentStartedCartItemIds(
+            mutation.accountId,
+            [existingItem],
+            db,
+        );
+    if (fulfillmentStartedItemIds.has(existingItem.id)) {
+        throw new CheckoutCartItemFulfillmentStartedError(existingItem.id);
+    }
+    await assertNoPendingAdvancedSowingFootprintAtTarget(
+        bedItems,
+        mutation.positionIndex,
+        db,
+        existingItem.id,
+    );
+    const targetItems = getPlantCartItemsAtPosition(
+        bedItems,
+        mutation.positionIndex,
+    );
+
+    const reservation = await getOutletOfferReservationForCartItem(
+        existingItem.id,
+        db,
+    );
+    const hasMatchingHeldReservation =
+        reservation?.accountId === mutation.accountId &&
+        reservation.cartId === mutation.cartId &&
+        reservation.cartItemId === existingItem.id &&
+        reservation.outletOfferId === mutation.outletOfferId &&
+        reservation.quantity === mutation.amount &&
+        reservation.status === 'held';
+    const hasMatchingStaticTarget =
+        existingItem.entityId === mutation.entityId &&
+        existingItem.entityTypeName === mutation.entityTypeName &&
+        existingItem.gardenId === mutation.gardenId &&
+        existingItem.raisedBedId === mutation.raisedBedId;
+    const isPureHeldReservationPositionMove =
+        hasMatchingHeldReservation &&
+        hasMatchingStaticTarget &&
+        existingItem.amount === mutation.amount &&
+        existingItem.positionIndex !== mutation.positionIndex;
+
+    if (
+        !hasMatchingStaticTarget ||
+        (existingItem.positionIndex !== mutation.positionIndex &&
+            !isPureHeldReservationPositionMove)
+    ) {
+        throw new OutletCartTargetUnavailableError();
+    }
+    const otherTargetItems = targetItems.filter(
+        (item) => item.id !== existingItem.id,
+    );
+    if (otherTargetItems.length > 0) {
+        if (
+            !isPureHeldReservationPositionMove ||
+            otherTargetItems.length !== 1 ||
+            existingItem.positionIndex === null
+        ) {
+            throw new OutletCartTargetUnavailableError();
+        }
+        const swapItem = otherTargetItems[0];
+        if (swapItem?.status !== 'new') {
+            throw new OutletCartTargetUnavailableError();
+        }
+        let swapItemAuthorizations: Awaited<
+            ReturnType<typeof getShoppingCartItemAdvancedSowingAuthorizations>
+        >;
+        try {
+            swapItemAuthorizations =
+                await getShoppingCartItemAdvancedSowingAuthorizations(
+                    [swapItem.id],
+                    db,
+                );
+        } catch (error) {
+            if (
+                error instanceof AdvancedSowingCartAuthorizationPersistenceError
+            ) {
+                throw new OutletCartTargetUnavailableError();
+            }
+            throw error;
+        }
+        if (swapItemAuthorizations.has(swapItem.id)) {
+            throw new OutletCartTargetUnavailableError();
+        }
+        const swapItemFulfillmentStartedIds =
+            await getCheckoutFulfillmentStartedCartItemIds(
+                mutation.accountId,
+                [swapItem],
+                db,
+            );
+        if (swapItemFulfillmentStartedIds.has(swapItem.id)) {
+            throw new CheckoutCartItemFulfillmentStartedError(swapItem.id);
+        }
+        await assertNoPendingAdvancedSowingFootprintAtTarget(
+            bedItems,
+            existingItem.positionIndex,
+            db,
+            existingItem.id,
+        );
+        const oldPositionItems = getPlantCartItemsAtPosition(
+            bedItems,
+            existingItem.positionIndex,
+        ).filter((item) => item.id !== existingItem.id);
+        if (oldPositionItems.length > 0) {
+            throw new OutletCartTargetUnavailableError();
+        }
+        await db
+            .update(shoppingCartItems)
+            .set({ positionIndex: existingItem.positionIndex })
+            .where(eq(shoppingCartItems.id, swapItem.id));
+    }
+
+    const finalCurrency = mutation.currency ?? existingItem.currency;
+    if (!isSupportedOutletCartCurrency(finalCurrency)) {
+        throw new OutletReservationUnavailableError(
+            'Outlet cart item has an unsupported currency.',
+        );
+    }
+    const normalizedAdditionalData =
+        mutation.additionalData === undefined
+            ? undefined
+            : normalizeScheduledDateAdditionalData(mutation.additionalData);
+    await db
+        .update(shoppingCartItems)
+        .set({
+            additionalData: normalizedAdditionalData,
+            amount: mutation.amount,
+            currency: finalCurrency,
+            positionIndex: mutation.positionIndex,
+        })
+        .where(eq(shoppingCartItems.id, existingItem.id));
+    await clearShoppingCartItemAdvancedSowingAuthorization(existingItem.id, db);
+    await reserveOutletOffer({
+        offerId: mutation.outletOfferId,
+        accountId: mutation.accountId,
+        cartId: mutation.cartId,
+        cartItemId: existingItem.id,
+        quantity: mutation.amount,
+        now: mutation.now,
+        holdMinutes: mutation.holdMinutes,
+        db,
+    });
+    return existingItem.id;
+}
+
+async function upsertIdlessOutletCartItemWithReservation(
+    mutation: IdlessOutletCartItemMutation,
+) {
+    const retryLimit = 4;
+    for (let attempt = 0; attempt < retryLimit; attempt += 1) {
+        const discoveredItems = await getLivePlantCartItemsForBed(
+            mutation,
+            storage(),
+        );
+        const discoveredItemIds = discoveredItems.map((item) => item.id);
+        try {
+            return await withCheckoutCartItemLocks(discoveredItemIds, (db) =>
+                applyIdlessOutletCartItemMutation(
+                    mutation,
+                    discoveredItemIds,
+                    db,
+                ),
+            );
+        } catch (error) {
+            if (
+                error instanceof OutletCartTargetChangedDuringMutationError &&
+                attempt + 1 < retryLimit
+            ) {
+                continue;
+            }
+            if (error instanceof OutletCartTargetChangedDuringMutationError) {
+                throw new OutletCartTargetUnavailableError();
+            }
+            throw error;
+        }
+    }
+    throw new OutletCartTargetUnavailableError();
+}
+
+async function upsertExplicitOutletCartItemWithReservation(
+    mutation: ExplicitOutletCartItemMutation,
+) {
+    const retryLimit = 4;
+    for (let attempt = 0; attempt < retryLimit; attempt += 1) {
+        const discoveredBedItems = await getLivePlantCartItemsForBed(
+            mutation,
+            storage(),
+        );
+        const discoveredBedItemIds = discoveredBedItems.map((item) => item.id);
+        const lockItemIds = [...discoveredBedItemIds, mutation.id];
+        try {
+            return await withCheckoutCartItemLocks(lockItemIds, (db) =>
+                applyExplicitOutletCartItemMutation(
+                    mutation,
+                    discoveredBedItemIds,
+                    db,
+                ),
+            );
+        } catch (error) {
+            if (
+                error instanceof OutletCartTargetChangedDuringMutationError &&
+                attempt + 1 < retryLimit
+            ) {
+                continue;
+            }
+            if (error instanceof OutletCartTargetChangedDuringMutationError) {
+                throw new OutletCartTargetUnavailableError();
+            }
+            throw error;
+        }
+    }
+    throw new OutletCartTargetUnavailableError();
 }
 
 export async function upsertOrRemoveCartItemWithOutletReservation({
@@ -1155,6 +1752,52 @@ export async function upsertOrRemoveCartItemWithOutletReservation({
     now?: Date;
     holdMinutes?: number;
 }) {
+    if (amount > 0 && amount !== 1) {
+        throw new OutletReservationUnavailableError(
+            'Outlet cart items require exactly one plant.',
+        );
+    }
+    if (amount > 0) {
+        if (
+            typeof gardenId !== 'number' ||
+            !Number.isSafeInteger(gardenId) ||
+            gardenId <= 0 ||
+            typeof raisedBedId !== 'number' ||
+            !Number.isSafeInteger(raisedBedId) ||
+            raisedBedId <= 0 ||
+            typeof positionIndex !== 'number' ||
+            !Number.isSafeInteger(positionIndex) ||
+            positionIndex < 0
+        ) {
+            throw new OutletCartTargetUnavailableError();
+        }
+        const mutation = {
+            accountId,
+            additionalData,
+            amount,
+            cartId,
+            currency,
+            entityId,
+            entityTypeName,
+            gardenId,
+            holdMinutes,
+            now,
+            outletOfferId,
+            positionIndex,
+            raisedBedId,
+        };
+        if (id == null) {
+            return upsertIdlessOutletCartItemWithReservation(mutation);
+        }
+        if (forceCreate) {
+            throw new Error('Cannot create an item with an existing ID');
+        }
+        return upsertExplicitOutletCartItemWithReservation({
+            ...mutation,
+            id,
+        });
+    }
+
     return storage().transaction(async (tx) => {
         const cartItemId = await upsertOrRemoveCartItem(
             id,
@@ -1173,6 +1816,19 @@ export async function upsertOrRemoveCartItemWithOutletReservation({
         );
 
         if (amount > 0 && cartItemId) {
+            const persistedCartItem =
+                await tx.query.shoppingCartItems.findFirst({
+                    columns: { currency: true },
+                    where: eq(shoppingCartItems.id, cartItemId),
+                });
+            if (
+                !persistedCartItem ||
+                !isSupportedOutletCartCurrency(persistedCartItem.currency)
+            ) {
+                throw new OutletReservationUnavailableError(
+                    'Outlet cart item has an unsupported currency.',
+                );
+            }
             await clearShoppingCartItemAdvancedSowingAuthorization(
                 cartItemId,
                 tx,

--- a/packages/storage/tests/outletOffersRepo.node.spec.ts
+++ b/packages/storage/tests/outletOffersRepo.node.spec.ts
@@ -2,6 +2,10 @@ import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
+    advancedSowingCartAuthorizationKind,
+    buildAdvancedSowingCartConfigurationV1,
+} from '@gredice/js/plants';
+import {
     assignStripeCustomerId,
     bindStripeCheckoutAttempt,
     cleanupOutletLifecycle,
@@ -15,16 +19,21 @@ import {
     getOrCreateShoppingCart,
     getOutletOffer,
     getOutletOfferReservation,
+    getOutletOfferReservationForCartItem,
+    getOutletOfferReservationsForCartItems,
     getOutletOffers,
     getShoppingCart,
+    OutletCartTargetUnavailableError,
     OutletOfferIdentityImmutableError,
     OutletOfferUnavailableError,
+    OutletReservationUnavailableError,
     recordStripeCheckoutAttemptReconciliationMiss,
     releaseOutletReservationForCartItem,
     releaseStripeCheckoutAttempt,
     releaseStripeCheckoutAttemptAfterReconciliationMisses,
     reserveOutletOffer,
     StripeCheckoutAttemptConflictError,
+    StripeCheckoutAttemptInProgressError,
     type StripeCheckoutAttemptSnapshot,
     setCartItemPaid,
     storage,
@@ -32,12 +41,19 @@ import {
     updateOutletOffer,
     upsertEntityType,
     upsertOrRemoveCartItem,
+    upsertOrRemoveCartItemWithAdvancedSowingAuthorization,
     upsertOrRemoveCartItemWithOutletReservation,
     verifyStripeCheckoutAttemptLiveCart,
 } from '@gredice/storage';
 import { and, eq } from 'drizzle-orm';
 import { events, outletOfferReservations, outletOffers } from '../src/schema';
-import { createTestAccount } from './helpers/testHelpers';
+import {
+    createTestAccount,
+    createTestBlock,
+    createTestGarden,
+    createTestRaisedBed,
+    ensureFarmId,
+} from './helpers/testHelpers';
 import { createTestDb } from './testDb';
 
 async function createTestPlantSort() {
@@ -87,6 +103,14 @@ async function createCartItem(accountId: string, plantSortId: number) {
     };
 }
 
+async function createOutletCartTarget(accountId: string) {
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'Raised_Bed');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+    return { gardenId, positionIndex: 0, raisedBedId };
+}
+
 async function createPublishedOffer({
     plantSortId,
     quantity = 1,
@@ -116,6 +140,7 @@ function outletAttemptSnapshot({
     cartItemId,
     entityId,
     reservation,
+    target,
 }: {
     cartId: number;
     cartItemId: number;
@@ -123,6 +148,11 @@ function outletAttemptSnapshot({
     reservation: NonNullable<
         Awaited<ReturnType<typeof getOutletOfferReservation>>
     >;
+    target?: {
+        gardenId: number;
+        positionIndex: number;
+        raisedBedId: number;
+    };
 }): StripeCheckoutAttemptSnapshot {
     const attemptId = randomUUID();
     return {
@@ -140,7 +170,7 @@ function outletAttemptSnapshot({
                 currency: 'eur',
                 entityId,
                 entityTypeName: 'plantSort',
-                gardenId: null,
+                gardenId: target?.gardenId ?? null,
                 id: cartItemId,
                 outlet: {
                     comparePriceCents: reservation.heldComparePriceCents,
@@ -152,8 +182,8 @@ function outletAttemptSnapshot({
                 },
                 paymentAmount: reservation.heldOutletPriceCents,
                 paymentKind: 'stripe',
-                positionIndex: null,
-                raisedBedId: null,
+                positionIndex: target?.positionIndex ?? null,
+                raisedBedId: target?.raisedBedId ?? null,
                 status: 'new',
             },
         ],
@@ -730,6 +760,7 @@ test('outlet cart upsert rolls back when reservation fails', async () => {
     const otherAccountId = await createTestAccount();
     const otherCart = await getOrCreateShoppingCart(otherAccountId);
     assert.ok(otherCart, 'Cart should be created');
+    const target = await createOutletCartTarget(otherAccountId);
 
     await assert.rejects(
         () =>
@@ -740,6 +771,7 @@ test('outlet cart upsert rolls back when reservation fails', async () => {
                 amount: 1,
                 currency: 'eur',
                 forceCreate: true,
+                ...target,
                 outletOfferId: offerId,
                 accountId: otherAccountId,
                 now,
@@ -749,6 +781,719 @@ test('outlet cart upsert rolls back when reservation fails', async () => {
 
     const rolledBackCart = await getShoppingCart(otherCart.id);
     assert.deepEqual(rolledBackCart?.items ?? [], []);
+});
+
+test('concurrent exact outlet cart retries create one item and one hold', async () => {
+    createTestDb();
+    const now = new Date('2026-05-01T10:00:00.000Z');
+    const plantSortId = await createTestPlantSort();
+    const offerId = await createPublishedOffer({ plantSortId, now });
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart, 'Cart should be created');
+    const target = await createOutletCartTarget(accountId);
+    const input = {
+        accountId,
+        additionalData: JSON.stringify({ outletOfferId: offerId }),
+        amount: 1,
+        cartId: cart.id,
+        currency: 'eur',
+        entityId: plantSortId.toString(),
+        entityTypeName: 'plantSort',
+        ...target,
+        now,
+        outletOfferId: offerId,
+    };
+
+    const [firstItemId, secondItemId] = await Promise.all([
+        upsertOrRemoveCartItemWithOutletReservation(input),
+        upsertOrRemoveCartItemWithOutletReservation(input),
+    ]);
+
+    assert.ok(firstItemId);
+    assert.equal(secondItemId, firstItemId);
+    assert.equal(
+        await upsertOrRemoveCartItemWithOutletReservation(input),
+        firstItemId,
+    );
+    const persistedCart = await getShoppingCart(cart.id);
+    assert.deepEqual(
+        persistedCart?.items.map((item) => item.id),
+        [firstItemId],
+    );
+    const reservations = await getOutletOfferReservationsForCartItems([
+        firstItemId,
+    ]);
+    assert.equal(reservations.length, 1);
+    assert.equal(reservations[0]?.status, 'held');
+    const offer = await getOutletOffer(offerId, now);
+    assert.equal(offer?.reservedQuantity, 1);
+    assert.equal(offer?.remainingQuantity, 0);
+});
+
+test('id-less outlet cart retries retain the active checkout fence', async () => {
+    createTestDb();
+    const now = new Date('2026-05-01T10:00:00.000Z');
+    const plantSortId = await createTestPlantSort();
+    const offerId = await createPublishedOffer({ plantSortId, now });
+    const accountId = await createTestAccount();
+    await assignStripeCustomerId(accountId, 'cus_outlet');
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart, 'Cart should be created');
+    const target = await createOutletCartTarget(accountId);
+    const input = {
+        accountId,
+        amount: 1,
+        cartId: cart.id,
+        currency: 'eur',
+        entityId: plantSortId.toString(),
+        entityTypeName: 'plantSort',
+        ...target,
+        now,
+        outletOfferId: offerId,
+    };
+    const cartItemId = await upsertOrRemoveCartItemWithOutletReservation(input);
+    assert.ok(cartItemId);
+    const reservation = await getOutletOfferReservationForCartItem(cartItemId);
+    assert.ok(reservation);
+    await createStripeCheckoutAttempt(
+        outletAttemptSnapshot({
+            cartId: cart.id,
+            cartItemId,
+            entityId: plantSortId.toString(),
+            reservation,
+            target,
+        }),
+        { accountId, now },
+    );
+
+    await assert.rejects(
+        () => upsertOrRemoveCartItemWithOutletReservation(input),
+        StripeCheckoutAttemptInProgressError,
+    );
+    assert.deepEqual(
+        (await getShoppingCart(cart.id))?.items.map((item) => item.id),
+        [cartItemId],
+    );
+});
+
+test('id-less outlet cart addition rejects a different live plant target', async () => {
+    createTestDb();
+    const now = new Date('2026-05-01T10:00:00.000Z');
+    const plantSortId = await createTestPlantSort();
+    const offerId = await createPublishedOffer({ plantSortId, now });
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart, 'Cart should be created');
+    const target = await createOutletCartTarget(accountId);
+    const existingItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        plantSortId.toString(),
+        'plantSort',
+        1,
+        target.gardenId,
+        target.raisedBedId,
+        target.positionIndex,
+        null,
+        'eur',
+        true,
+    );
+    assert.ok(existingItemId);
+
+    await assert.rejects(
+        () =>
+            upsertOrRemoveCartItemWithOutletReservation({
+                accountId,
+                amount: 1,
+                cartId: cart.id,
+                currency: 'eur',
+                entityId: plantSortId.toString(),
+                entityTypeName: 'plantSort',
+                ...target,
+                now,
+                outletOfferId: offerId,
+            }),
+        OutletCartTargetUnavailableError,
+    );
+
+    const persistedCart = await getShoppingCart(cart.id);
+    assert.deepEqual(
+        persistedCart?.items.map((item) => item.id),
+        [existingItemId],
+    );
+    assert.equal((await getOutletOffer(offerId, now))?.remainingQuantity, 1);
+});
+
+test('outlet cart mutation rejects a non-unit amount without reserving stock', async () => {
+    createTestDb();
+    const now = new Date('2026-05-01T10:00:00.000Z');
+    const plantSortId = await createTestPlantSort();
+    const offerId = await createPublishedOffer({
+        plantSortId,
+        quantity: 2,
+        now,
+    });
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart, 'Cart should be created');
+    const target = await createOutletCartTarget(accountId);
+
+    await assert.rejects(
+        () =>
+            upsertOrRemoveCartItemWithOutletReservation({
+                accountId,
+                amount: 2,
+                cartId: cart.id,
+                currency: 'eur',
+                entityId: plantSortId.toString(),
+                entityTypeName: 'plantSort',
+                ...target,
+                now,
+                outletOfferId: offerId,
+            }),
+        OutletReservationUnavailableError,
+    );
+    assert.deepEqual((await getShoppingCart(cart.id))?.items, []);
+    assert.equal((await getOutletOffer(offerId, now))?.remainingQuantity, 2);
+});
+
+test('explicit outlet conversion rejects a different persisted garden and bed', async () => {
+    createTestDb();
+    const now = new Date('2026-05-01T10:00:00.000Z');
+    const plantSortId = await createTestPlantSort();
+    const offerId = await createPublishedOffer({ plantSortId, now });
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart, 'Cart should be created');
+    const persistedTarget = await createOutletCartTarget(accountId);
+    const suppliedTarget = await createOutletCartTarget(accountId);
+    const cartItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        plantSortId.toString(),
+        'plantSort',
+        1,
+        persistedTarget.gardenId,
+        persistedTarget.raisedBedId,
+        persistedTarget.positionIndex,
+        null,
+        'inventory',
+        true,
+    );
+    assert.ok(cartItemId);
+
+    await assert.rejects(
+        () =>
+            upsertOrRemoveCartItemWithOutletReservation({
+                accountId,
+                amount: 1,
+                cartId: cart.id,
+                currency: 'eur',
+                entityId: plantSortId.toString(),
+                entityTypeName: 'plantSort',
+                id: cartItemId,
+                ...suppliedTarget,
+                now,
+                outletOfferId: offerId,
+            }),
+        OutletCartTargetUnavailableError,
+    );
+    const persistedItem = (await getShoppingCart(cart.id))?.items.find(
+        (item) => item.id === cartItemId,
+    );
+    assert.equal(persistedItem?.gardenId, persistedTarget.gardenId);
+    assert.equal(persistedItem?.raisedBedId, persistedTarget.raisedBedId);
+    assert.equal(persistedItem?.currency, 'inventory');
+    assert.equal(
+        await getOutletOfferReservationForCartItem(cartItemId),
+        undefined,
+    );
+});
+
+test('explicit outlet conversion rejects another live row at its persisted target', async () => {
+    createTestDb();
+    const now = new Date('2026-05-01T10:00:00.000Z');
+    const plantSortId = await createTestPlantSort();
+    const offerId = await createPublishedOffer({ plantSortId, now });
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart, 'Cart should be created');
+    const target = await createOutletCartTarget(accountId);
+    const firstItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        plantSortId.toString(),
+        'plantSort',
+        1,
+        target.gardenId,
+        target.raisedBedId,
+        target.positionIndex,
+        'first',
+        'inventory',
+        true,
+    );
+    const secondItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        plantSortId.toString(),
+        'plantSort',
+        1,
+        target.gardenId,
+        target.raisedBedId,
+        target.positionIndex,
+        'second',
+        'eur',
+        true,
+    );
+    assert.ok(firstItemId);
+    assert.ok(secondItemId);
+
+    await assert.rejects(
+        () =>
+            upsertOrRemoveCartItemWithOutletReservation({
+                accountId,
+                amount: 1,
+                cartId: cart.id,
+                currency: 'eur',
+                entityId: plantSortId.toString(),
+                entityTypeName: 'plantSort',
+                id: firstItemId,
+                ...target,
+                now,
+                outletOfferId: offerId,
+            }),
+        OutletCartTargetUnavailableError,
+    );
+    assert.equal(
+        await getOutletOfferReservationForCartItem(firstItemId),
+        undefined,
+    );
+});
+
+test('held outlet item atomically swaps with one ordinary direct target row', async () => {
+    createTestDb();
+    const now = new Date('2026-05-01T10:00:00.000Z');
+    const plantSortId = await createTestPlantSort();
+    const offerId = await createPublishedOffer({ plantSortId, now });
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart, 'Cart should be created');
+    const target = await createOutletCartTarget(accountId);
+    const input = {
+        accountId,
+        amount: 1,
+        cartId: cart.id,
+        currency: 'eur',
+        entityId: plantSortId.toString(),
+        entityTypeName: 'plantSort',
+        ...target,
+        now,
+        outletOfferId: offerId,
+    };
+    const outletItemId =
+        await upsertOrRemoveCartItemWithOutletReservation(input);
+    assert.ok(outletItemId);
+    const occupiedItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        plantSortId.toString(),
+        'plantSort',
+        1,
+        target.gardenId,
+        target.raisedBedId,
+        1,
+        null,
+        'eur',
+        true,
+    );
+    assert.ok(occupiedItemId);
+
+    assert.equal(
+        await upsertOrRemoveCartItemWithOutletReservation({
+            ...input,
+            id: outletItemId,
+            positionIndex: 1,
+        }),
+        outletItemId,
+    );
+    const swappedCart = await getShoppingCart(cart.id);
+    assert.equal(
+        swappedCart?.items.find((item) => item.id === outletItemId)
+            ?.positionIndex,
+        1,
+    );
+    assert.equal(
+        swappedCart?.items.find((item) => item.id === occupiedItemId)
+            ?.positionIndex,
+        0,
+    );
+
+    await upsertOrRemoveCartItem(
+        occupiedItemId,
+        cart.id,
+        plantSortId.toString(),
+        'plantSort',
+        1,
+        target.gardenId,
+        target.raisedBedId,
+        0,
+        null,
+        'eur',
+    );
+    const idempotentSecondSwapRequest = await getShoppingCart(cart.id);
+    assert.equal(
+        idempotentSecondSwapRequest?.items.find(
+            (item) => item.id === occupiedItemId,
+        )?.positionIndex,
+        0,
+    );
+
+    assert.equal(
+        await upsertOrRemoveCartItemWithOutletReservation({
+            ...input,
+            id: outletItemId,
+            positionIndex: 2,
+        }),
+        outletItemId,
+    );
+    assert.equal(
+        (await getShoppingCart(cart.id))?.items.find(
+            (item) => item.id === outletItemId,
+        )?.positionIndex,
+        2,
+    );
+});
+
+test('two held outlet items atomically swap and keep their reservations', async () => {
+    createTestDb();
+    const now = new Date('2026-05-01T10:00:00.000Z');
+    const plantSortId = await createTestPlantSort();
+    const offerId = await createPublishedOffer({
+        plantSortId,
+        quantity: 2,
+        now,
+    });
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart, 'Cart should be created');
+    const target = await createOutletCartTarget(accountId);
+    const baseInput = {
+        accountId,
+        amount: 1,
+        cartId: cart.id,
+        currency: 'eur',
+        entityId: plantSortId.toString(),
+        entityTypeName: 'plantSort',
+        gardenId: target.gardenId,
+        now,
+        outletOfferId: offerId,
+        raisedBedId: target.raisedBedId,
+    };
+    const firstItemId = await upsertOrRemoveCartItemWithOutletReservation({
+        ...baseInput,
+        positionIndex: 0,
+    });
+    const secondItemId = await upsertOrRemoveCartItemWithOutletReservation({
+        ...baseInput,
+        positionIndex: 1,
+    });
+    assert.ok(firstItemId);
+    assert.ok(secondItemId);
+
+    await upsertOrRemoveCartItemWithOutletReservation({
+        ...baseInput,
+        id: firstItemId,
+        positionIndex: 1,
+    });
+    await upsertOrRemoveCartItemWithOutletReservation({
+        ...baseInput,
+        id: secondItemId,
+        positionIndex: 0,
+    });
+
+    const swappedCart = await getShoppingCart(cart.id);
+    assert.equal(
+        swappedCart?.items.find((item) => item.id === firstItemId)
+            ?.positionIndex,
+        1,
+    );
+    assert.equal(
+        swappedCart?.items.find((item) => item.id === secondItemId)
+            ?.positionIndex,
+        0,
+    );
+    assert.equal(
+        (await getOutletOfferReservationForCartItem(firstItemId))
+            ?.outletOfferId,
+        offerId,
+    );
+    assert.equal(
+        (await getOutletOfferReservationForCartItem(secondItemId))
+            ?.outletOfferId,
+        offerId,
+    );
+    assert.equal((await getOutletOffer(offerId, now))?.reservedQuantity, 2);
+});
+
+test('outlet target rejects another pending Advanced Sowing footprint', async () => {
+    createTestDb();
+    const now = new Date('2026-05-01T10:00:00.000Z');
+    const plantSortId = await createTestPlantSort();
+    const offerId = await createPublishedOffer({ plantSortId, now });
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart, 'Cart should be created');
+    const target = await createOutletCartTarget(accountId);
+    const plan = buildAdvancedSowingCartConfigurationV1({
+        anchorPositionIndex: 11,
+        bedFieldCount: 18,
+        maxDistanceCm: 60,
+        minDistanceCm: 15,
+        optimalDistanceCm: 30,
+        selectedDistanceCm: 60,
+    });
+    const overlappingPosition = plan.occupiedPositionIndices.find(
+        (positionIndex) => positionIndex !== plan.anchorPositionIndex,
+    );
+    assert.notEqual(overlappingPosition, undefined);
+    await upsertOrRemoveCartItemWithAdvancedSowingAuthorization({
+        amount: 1,
+        authorization: {
+            kind: advancedSowingCartAuthorizationKind,
+            plan,
+            version: 1,
+        },
+        cartId: cart.id,
+        currency: 'eur',
+        entityId: plantSortId.toString(),
+        entityTypeName: 'plantSort',
+        gardenId: target.gardenId,
+        positionIndex: plan.anchorPositionIndex,
+        raisedBedId: target.raisedBedId,
+    });
+
+    await assert.rejects(
+        () =>
+            upsertOrRemoveCartItemWithOutletReservation({
+                accountId,
+                amount: 1,
+                cartId: cart.id,
+                currency: 'eur',
+                entityId: plantSortId.toString(),
+                entityTypeName: 'plantSort',
+                gardenId: target.gardenId,
+                now,
+                outletOfferId: offerId,
+                positionIndex: overlappingPosition,
+                raisedBedId: target.raisedBedId,
+            }),
+        OutletCartTargetUnavailableError,
+    );
+    assert.equal((await getOutletOffer(offerId, now))?.remainingQuantity, 1);
+});
+
+test('concurrent Outlet and generic direct additions leave one target row', async () => {
+    createTestDb();
+    const now = new Date('2026-05-01T10:00:00.000Z');
+    const plantSortId = await createTestPlantSort();
+    const offerId = await createPublishedOffer({ plantSortId, now });
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart, 'Cart should be created');
+    const target = await createOutletCartTarget(accountId);
+
+    const results = await Promise.allSettled([
+        upsertOrRemoveCartItemWithOutletReservation({
+            accountId,
+            amount: 1,
+            cartId: cart.id,
+            currency: 'eur',
+            entityId: plantSortId.toString(),
+            entityTypeName: 'plantSort',
+            ...target,
+            now,
+            outletOfferId: offerId,
+        }),
+        upsertOrRemoveCartItem(
+            null,
+            cart.id,
+            plantSortId.toString(),
+            'plantSort',
+            1,
+            target.gardenId,
+            target.raisedBedId,
+            target.positionIndex,
+            'ordinary-direct',
+            'eur',
+            true,
+        ),
+    ]);
+
+    assert.equal(
+        results.filter((result) => result.status === 'fulfilled').length,
+        1,
+    );
+    assert.equal(
+        results.filter((result) => result.status === 'rejected').length,
+        1,
+    );
+    const persistedCart = await getShoppingCart(cart.id);
+    assert.equal(persistedCart?.items.length, 1);
+});
+
+test('concurrent Outlet and Advanced Sowing additions cannot overlap a footprint', async () => {
+    createTestDb();
+    const now = new Date('2026-05-01T10:00:00.000Z');
+    const plantSortId = await createTestPlantSort();
+    const offerId = await createPublishedOffer({ plantSortId, now });
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart, 'Cart should be created');
+    const target = await createOutletCartTarget(accountId);
+    const plan = buildAdvancedSowingCartConfigurationV1({
+        anchorPositionIndex: 11,
+        bedFieldCount: 18,
+        maxDistanceCm: 60,
+        minDistanceCm: 15,
+        optimalDistanceCm: 30,
+        selectedDistanceCm: 60,
+    });
+    const overlappingPosition = plan.occupiedPositionIndices.find(
+        (positionIndex) => positionIndex !== plan.anchorPositionIndex,
+    );
+    assert.notEqual(overlappingPosition, undefined);
+
+    const results = await Promise.allSettled([
+        upsertOrRemoveCartItemWithOutletReservation({
+            accountId,
+            amount: 1,
+            cartId: cart.id,
+            currency: 'eur',
+            entityId: plantSortId.toString(),
+            entityTypeName: 'plantSort',
+            gardenId: target.gardenId,
+            now,
+            outletOfferId: offerId,
+            positionIndex: overlappingPosition,
+            raisedBedId: target.raisedBedId,
+        }),
+        upsertOrRemoveCartItemWithAdvancedSowingAuthorization({
+            amount: 1,
+            authorization: {
+                kind: advancedSowingCartAuthorizationKind,
+                plan,
+                version: 1,
+            },
+            cartId: cart.id,
+            currency: 'eur',
+            entityId: plantSortId.toString(),
+            entityTypeName: 'plantSort',
+            forceCreate: true,
+            gardenId: target.gardenId,
+            positionIndex: plan.anchorPositionIndex,
+            raisedBedId: target.raisedBedId,
+        }),
+    ]);
+
+    assert.equal(
+        results.filter((result) => result.status === 'fulfilled').length,
+        1,
+    );
+    assert.equal(
+        results.filter((result) => result.status === 'rejected').length,
+        1,
+    );
+    assert.equal((await getShoppingCart(cart.id))?.items.length, 1);
+});
+
+test('outlet cart mutation normalizes a supplied currency and fails closed otherwise', async () => {
+    createTestDb();
+    const now = new Date('2026-05-01T10:00:00.000Z');
+    const plantSortId = await createTestPlantSort();
+    const offerId = await createPublishedOffer({
+        plantSortId,
+        quantity: 2,
+        now,
+    });
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart, 'Cart should be created');
+    const target = await createOutletCartTarget(accountId);
+    const inventoryItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        plantSortId.toString(),
+        'plantSort',
+        1,
+        target.gardenId,
+        target.raisedBedId,
+        target.positionIndex,
+        null,
+        'inventory',
+        true,
+    );
+    assert.ok(inventoryItemId);
+
+    await upsertOrRemoveCartItemWithOutletReservation({
+        accountId,
+        amount: 1,
+        cartId: cart.id,
+        currency: 'eur',
+        entityId: plantSortId.toString(),
+        entityTypeName: 'plantSort',
+        id: inventoryItemId,
+        ...target,
+        now,
+        outletOfferId: offerId,
+    });
+    assert.equal(
+        (await getShoppingCart(cart.id))?.items.find(
+            (item) => item.id === inventoryItemId,
+        )?.currency,
+        'eur',
+    );
+
+    const unsupportedTarget = { ...target, positionIndex: 1 };
+    const unsupportedItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        plantSortId.toString(),
+        'plantSort',
+        1,
+        unsupportedTarget.gardenId,
+        unsupportedTarget.raisedBedId,
+        unsupportedTarget.positionIndex,
+        null,
+        'inventory',
+        true,
+    );
+    assert.ok(unsupportedItemId);
+    await assert.rejects(
+        () =>
+            upsertOrRemoveCartItemWithOutletReservation({
+                accountId,
+                amount: 1,
+                cartId: cart.id,
+                entityId: plantSortId.toString(),
+                entityTypeName: 'plantSort',
+                id: unsupportedItemId,
+                ...unsupportedTarget,
+                now,
+                outletOfferId: offerId,
+            }),
+        OutletReservationUnavailableError,
+    );
+    assert.equal(
+        (await getShoppingCart(cart.id))?.items.find(
+            (item) => item.id === unsupportedItemId,
+        )?.currency,
+        'inventory',
+    );
+    assert.equal(
+        await getOutletOfferReservationForCartItem(unsupportedItemId),
+        undefined,
+    );
 });
 
 test('reserveOutletOffer refreshes an existing reservation without double-counting stock', async () => {


### PR DESCRIPTION
## What changed

- validates owned, available garden targets before an Outlet hold and returns stable conflict codes
- makes direct Outlet reservations atomic and idempotent, including stock locks, target collisions, currency normalization, and legacy drag swaps
- rejects duplicate direct sowing targets before checkout can charge them
- reuses one typed cart payload/error contract from the existing plant picker

## Why

The 3D Outlet commerce flow must use the same reservation path as the classic Outlet without allowing stale stock, occupied targets, duplicate retries, or malformed explicit-item moves to create an invalid paid cart.

## User impact

There is no new visible entry point in this PR. It provides the safe reservation boundary needed for the independently gated Phase 2 selection and checkout UI. The existing classic Outlet remains compatible.

## Validation

- API production build
- API node tests: 537/537
- focused target/availability tests: 22/22
- PostgreSQL storage reservation tests: 26/26
- game unit tests: 1056/1056
- raised-bed plant-picker component tests: 24/24
- game, Garden, and API typechecks
- targeted Biome checks and git diff check

No schema migration or environment change.

Advances #4466.