### PR TITLE
[Outlet][Phase 2B] Reserve seedlings from the 3D garden

### DIFF
--- a/apps/garden/app/flags.ts
+++ b/apps/garden/app/flags.ts
@@ -55,6 +55,15 @@ export const enableOutletGardenFlag = flag<boolean>({
     options: booleanFlagOptions,
 });
 
+export const enableOutletGardenCommerceFlag = flag<boolean>({
+    key: 'enableOutletGardenCommerce',
+    description:
+        'Allow signed-in customers to choose a garden field and hold an Outlet seedling directly from the 3D or list experience.',
+    adapter: vercelAdapter,
+    defaultValue: false,
+    options: booleanFlagOptions,
+});
+
 export const enableAdvancedSowingFlag = flag<boolean>({
     key: 'enableAdvancedSowing',
     description:

--- a/apps/garden/app/outlet/page.tsx
+++ b/apps/garden/app/outlet/page.tsx
@@ -3,7 +3,10 @@ import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
 import { GardenRouteLoading } from '../../components/game/GardenRouteLoading';
 import { OutletGardenWithAnalytics } from '../../components/game/OutletGardenWithAnalytics';
-import { enableOutletGardenFlag } from '../flags';
+import {
+    enableOutletGardenCommerceFlag,
+    enableOutletGardenFlag,
+} from '../flags';
 
 export const metadata: Metadata = {
     title: 'Outlet vrt | Gredice',
@@ -25,8 +28,9 @@ async function OutletGardenGate({
 }: {
     searchParams: Promise<{ ponuda?: string | string[] }>;
 }) {
-    const [enabled, params] = await Promise.all([
+    const [enabled, commerceEnabled, params] = await Promise.all([
         enableOutletGardenFlag(),
+        enableOutletGardenCommerceFlag(),
         searchParams,
     ]);
     if (!enabled) {
@@ -40,7 +44,7 @@ async function OutletGardenGate({
         redirect(`/?outlet=${outletParam}`);
     }
 
-    return <OutletGardenWithAnalytics />;
+    return <OutletGardenWithAnalytics commerceEnabled={commerceEnabled} />;
 }
 
 export default function OutletGardenPage({

--- a/apps/garden/app/prijava/UrlAuthForward.tsx
+++ b/apps/garden/app/prijava/UrlAuthForward.tsx
@@ -1,29 +1,31 @@
 'use client';
 
+import { authCurrentUserQueryKeys } from '@gredice/ui/auth';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import {
+    resolveGardenOAuthCallbackQuery,
+    resolveGardenOAuthFragment,
+} from '../../lib/auth/gardenAuthContinuation';
 
 export function UrlAuthForward() {
     const router = useRouter();
     const searchParams = useSearchParams();
     const queryClient = useQueryClient();
+    const hasStartedRef = useRef(false);
+    const { failureReturnTo, hasServerError, returnTo } =
+        resolveGardenOAuthCallbackQuery(searchParams.toString());
 
     useEffect(() => {
-        const handleGoogleCallback = async () => {
-            const error = searchParams.get('error');
-            if (error) {
-                // TODO: Display notification
-                console.error('Authentication error:', error);
-                router.replace('/');
-                return;
-            }
+        if (hasStartedRef.current) {
+            return;
+        }
+        hasStartedRef.current = true;
 
-            // Read tokens from URL fragment (hash) to avoid server logs/referrer leakage
-            const hash = window.location.hash.substring(1);
-            const params = new URLSearchParams(hash);
-            const token = params.get('token');
-            const refreshToken = params.get('refreshToken');
+        const handleOAuthCallback = async () => {
+            const hash = window.location.hash;
+            const oauthFragment = resolveGardenOAuthFragment(hash);
 
             // Clear tokens from URL immediately to minimize exposure
             if (hash) {
@@ -34,41 +36,46 @@ export function UrlAuthForward() {
                 );
             }
 
-            if (token) {
-                // Exchange tokens for httpOnly cookies via local route handler
-                try {
-                    const response = await fetch('/api/oauth-callback', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ token, refreshToken }),
-                    });
-
-                    if (!response.ok) {
-                        // TODO: Display notification
-                        console.error(
-                            'Authentication callback failed with status:',
-                            response.status,
-                        );
-                        router.replace('/');
-                        return;
-                    }
-                } catch (err) {
-                    // TODO: Display notification
-                    console.error(
-                        'Network error during authentication callback:',
-                        err,
-                    );
-                    router.replace('/');
-                    return;
-                }
+            if (hasServerError || !oauthFragment) {
+                console.error('OAuth callback could not be completed', {
+                    reason: hasServerError
+                        ? 'provider_or_callback_error'
+                        : 'missing_or_invalid_fragment',
+                });
+                router.replace(failureReturnTo);
+                return;
             }
 
-            await queryClient.invalidateQueries();
-            router.replace('/');
+            try {
+                const response = await fetch('/api/oauth-callback', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(oauthFragment),
+                });
+
+                if (!response.ok) {
+                    console.error('OAuth cookie exchange was rejected', {
+                        status: response.status,
+                    });
+                    router.replace(failureReturnTo);
+                    return;
+                }
+            } catch {
+                console.error('OAuth cookie exchange request failed');
+                router.replace(failureReturnTo);
+                return;
+            }
+
+            await queryClient
+                .invalidateQueries({
+                    queryKey: authCurrentUserQueryKeys,
+                })
+                .catch(() => undefined);
+            router.replace(returnTo);
         };
 
-        handleGoogleCallback();
-    }, [router, searchParams, queryClient]);
+        void handleOAuthCallback();
+    }, [failureReturnTo, hasServerError, queryClient, returnTo, router]);
 
     return null;
 }

--- a/apps/garden/components/auth/LoginModal.tsx
+++ b/apps/garden/components/auth/LoginModal.tsx
@@ -3,6 +3,7 @@
 import { clientPublic, getBrowserGrediceAppOrigin } from '@gredice/client';
 import { Alert } from '@gredice/ui/Alert';
 import {
+    authCurrentUserQueryKeys,
     FacebookLoginButton,
     GoogleLoginButton,
     useLastLoginProvider,
@@ -16,10 +17,22 @@ import { usePostHog } from '@posthog/next';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useCallback, useState } from 'react';
+import {
+    type GardenOAuthProvider,
+    getGardenOAuthStartUrl,
+} from '../../lib/auth/gardenAuthContinuation';
 import { EmailPasswordForm } from './EmailPasswordForm';
 import LoginBanner from './LoginBanner';
 
 type AuthTab = 'login' | 'register';
+
+export type LoginModalProps = {
+    dismissible?: boolean;
+    onAuthenticated?: () => void;
+    onOpenChange?: (open: boolean) => void;
+    open?: boolean;
+    returnTo?: string;
+};
 
 const authContentTransitionClassName =
     'w-full animate-in fade-in-0 duration-200 ease-out motion-reduce:duration-[120ms]';
@@ -28,7 +41,13 @@ const authContentDirectionClassNames = {
     providers: 'motion-safe:slide-in-from-top-2',
 };
 
-export default function LoginModal() {
+export default function LoginModal({
+    dismissible = false,
+    onAuthenticated,
+    onOpenChange,
+    open = true,
+    returnTo = '/',
+}: LoginModalProps = {}) {
     const posthog = usePostHog();
     const router = useRouter();
     const queryClient = useQueryClient();
@@ -58,7 +77,14 @@ export default function LoginModal() {
 
         if (response.status === 200) {
             await response.json();
-            await queryClient.invalidateQueries();
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: authCurrentUserQueryKeys,
+                }),
+                queryClient.invalidateQueries({ queryKey: ['currentUser'] }),
+            ]);
+            handleOpenChange(false);
+            onAuthenticated?.();
             return;
         } else {
             const json = await response.json();
@@ -147,17 +173,28 @@ export default function LoginModal() {
         router.push('/prijava/registracija-uspijesna');
     };
 
-    const handleOAuthLogin = (provider: 'google' | 'facebook') => {
+    const handleOAuthLogin = (provider: GardenOAuthProvider) => {
         posthog?.capture('user_oauth_started', {
             provider,
             surface: 'garden',
         });
-        const authUrl = new URL(
-            `/api/auth/${provider}`,
-            getBrowserGrediceAppOrigin('api'),
-        );
-        window.location.href = authUrl.toString();
+        window.location.href = getGardenOAuthStartUrl({
+            apiOrigin: getBrowserGrediceAppOrigin('api'),
+            gardenOrigin: window.location.origin,
+            provider,
+            returnTo,
+        });
     };
+
+    function handleOpenChange(nextOpen: boolean) {
+        if (!nextOpen) {
+            setActiveTab('login');
+            setEmailExpanded(false);
+            setError(undefined);
+            setShouldAnimateAuthContent(false);
+        }
+        onOpenChange?.(nextOpen);
+    }
 
     const handleTabChange = (value: string) => {
         if (value === 'login' || value === 'register') {
@@ -178,12 +215,13 @@ export default function LoginModal() {
 
     return (
         <>
-            <LoginBanner />
+            {open ? <LoginBanner /> : null}
             <Modal
-                open
+                open={open}
                 title="Prijava"
                 className="bg-card z-[60] border-tertiary border-b-4 rounded-lg shadow-2xl"
-                dismissible={false}
+                dismissible={dismissible}
+                onOpenChange={handleOpenChange}
             >
                 <Tabs
                     value={activeTab}

--- a/apps/garden/components/game/OutletGardenRenderer.tsx
+++ b/apps/garden/components/game/OutletGardenRenderer.tsx
@@ -1,9 +1,15 @@
 'use client';
 
 import { useGameAnalytics } from '@gredice/game/analytics';
+import {
+    type OutletGardenCommerceController,
+    useOutletGardenCommerce,
+} from '@gredice/game/outlet-garden-commerce';
 import type { OutletGardenFallbackReason } from '@gredice/game/outlet-garden-list';
 import dynamic from 'next/dynamic';
+import { parseAsInteger, useQueryState } from 'nuqs';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import LoginModal from '../auth/LoginModal';
 import { GardenRouteLoading } from './GardenRouteLoading';
 import { OutletGardenSceneErrorBoundary } from './OutletGardenSceneErrorBoundary';
 
@@ -72,7 +78,11 @@ function setListPreference(enabled: boolean) {
     }
 }
 
-export function OutletGardenRenderer() {
+export function OutletGardenRenderer({
+    commerceEnabled,
+}: {
+    commerceEnabled: boolean;
+}) {
     const { track } = useGameAnalytics();
     const [mode, setMode] = useState<OutletGardenRendererMode>('checking');
     const [fallbackReason, setFallbackReason] =
@@ -83,6 +93,40 @@ export function OutletGardenRenderer() {
     const sceneReadyRef = useRef(false);
     const failureHandledRef = useRef(false);
     const sceneStartedAtRef = useRef(Date.now());
+    const [selectedOfferId] = useQueryState('ponuda', parseAsInteger);
+    const [reservationIntent, setReservationIntent] = useQueryState(
+        'rezervacija',
+        parseAsInteger,
+    );
+    const [loginOpen, setLoginOpen] = useState(false);
+    const renderer = mode === 'list' ? 'list' : 'webgl';
+    const updateReservationIntent = useCallback(
+        (requested: boolean) => {
+            void setReservationIntent(requested ? 1 : null);
+        },
+        [setReservationIntent],
+    );
+    const commerce: OutletGardenCommerceController = useOutletGardenCommerce({
+        enabled: commerceEnabled,
+        onReservationIntentChange: updateReservationIntent,
+        renderer,
+        requested: reservationIntent === 1,
+        selectedOfferId,
+    });
+
+    useEffect(() => {
+        if (selectedOfferId === null && reservationIntent !== null) {
+            void setReservationIntent(null);
+        }
+    }, [reservationIntent, selectedOfferId, setReservationIntent]);
+
+    const requestAuthentication = useCallback(() => {
+        if (selectedOfferId === null) {
+            return;
+        }
+        void setReservationIntent(1);
+        setLoginOpen(true);
+    }, [selectedOfferId, setReservationIntent]);
 
     const showList = useCallback(
         (reason: OutletGardenFallbackReason, remember: boolean) => {
@@ -169,14 +213,13 @@ export function OutletGardenRenderer() {
         return () => window.clearTimeout(timeout);
     }, [mode, showList]);
 
-    if (mode === 'checking') {
-        return <GardenRouteLoading />;
-    }
-
+    let content = <GardenRouteLoading />;
     if (mode === 'list') {
-        return (
+        content = (
             <OutletGardenBrowserViewer
+                commerce={commerce}
                 fallbackReason={fallbackReason}
+                onAuthenticationRequired={requestAuthentication}
                 onUse3D={
                     fallbackReason === 'unsupported_webgl'
                         ? undefined
@@ -184,21 +227,46 @@ export function OutletGardenRenderer() {
                 }
             />
         );
+    } else if (mode === 'three-dimensional') {
+        content = (
+            <OutletGardenSceneErrorBoundary
+                onError={() => showList('scene_load_error', false)}
+            >
+                <OutletGardenViewer
+                    commerce={commerce}
+                    focusOnMount={focusThreeDimensionalOnMount}
+                    onAuthenticationRequired={requestAuthentication}
+                    onSceneFailure={(reason) => showList(reason, false)}
+                    onSceneReady={() => {
+                        sceneReadyRef.current = true;
+                    }}
+                    onUseListFallback={() => showList('user', true)}
+                    sceneStartedAt={sceneStartedAtRef.current}
+                />
+            </OutletGardenSceneErrorBoundary>
+        );
     }
 
+    const returnTo =
+        selectedOfferId === null
+            ? '/outlet'
+            : `/outlet?ponuda=${selectedOfferId.toString()}&rezervacija=1`;
+
     return (
-        <OutletGardenSceneErrorBoundary
-            onError={() => showList('scene_load_error', false)}
-        >
-            <OutletGardenViewer
-                focusOnMount={focusThreeDimensionalOnMount}
-                onSceneFailure={(reason) => showList(reason, false)}
-                onSceneReady={() => {
-                    sceneReadyRef.current = true;
+        <>
+            {content}
+            <LoginModal
+                dismissible
+                onAuthenticated={() => {
+                    setLoginOpen(false);
+                    void commerce.refreshAuthentication();
                 }}
-                onUseListFallback={() => showList('user', true)}
-                sceneStartedAt={sceneStartedAtRef.current}
+                onOpenChange={(open) => {
+                    setLoginOpen(open);
+                }}
+                open={loginOpen}
+                returnTo={returnTo}
             />
-        </OutletGardenSceneErrorBoundary>
+        </>
     );
 }

--- a/apps/garden/components/game/OutletGardenWithAnalytics.tsx
+++ b/apps/garden/components/game/OutletGardenWithAnalytics.tsx
@@ -4,7 +4,11 @@ import { GameAnalyticsProvider } from '@gredice/game/analytics';
 import { usePostHog } from '@posthog/next';
 import { OutletGardenRenderer } from './OutletGardenRenderer';
 
-export function OutletGardenWithAnalytics() {
+export function OutletGardenWithAnalytics({
+    commerceEnabled,
+}: {
+    commerceEnabled: boolean;
+}) {
     const posthog = usePostHog();
 
     return (
@@ -16,7 +20,7 @@ export function OutletGardenWithAnalytics() {
                 });
             }}
         >
-            <OutletGardenRenderer />
+            <OutletGardenRenderer commerceEnabled={commerceEnabled} />
         </GameAnalyticsProvider>
     );
 }

--- a/apps/garden/lib/auth/gardenAuthContinuation.ts
+++ b/apps/garden/lib/auth/gardenAuthContinuation.ts
@@ -1,0 +1,208 @@
+const MAXIMUM_GARDEN_AUTH_RETURN_LENGTH = 2_048;
+const MAXIMUM_OAUTH_FRAGMENT_VALUE_LENGTH = 8_192;
+const GARDEN_AUTH_RETURN_BASE = 'https://garden.gredice.invalid';
+const supportedOutletReturnQueryKeys = new Set(['ponuda', 'rezervacija']);
+const supportedCallbackQueryKeys = new Set(['error', 'returnTo']);
+const supportedFragmentKeys = new Set(['refreshToken', 'token']);
+
+export type GardenOAuthProvider = 'facebook' | 'google';
+export type GardenAuthReturnPath = '/' | '/outlet' | `/outlet?${string}`;
+
+function containsControlCharacter(value: string) {
+    return Array.from(value).some((character) => {
+        const code = character.charCodeAt(0);
+        return code <= 31 || code === 127;
+    });
+}
+
+function hasOnlySupportedKeys(
+    searchParams: URLSearchParams,
+    supportedKeys: ReadonlySet<string>,
+) {
+    for (const key of searchParams.keys()) {
+        if (!supportedKeys.has(key)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function canonicalOutletReturnPath(
+    searchParams: URLSearchParams,
+): GardenAuthReturnPath {
+    if (
+        !hasOnlySupportedKeys(searchParams, supportedOutletReturnQueryKeys) ||
+        searchParams.getAll('ponuda').length > 1 ||
+        searchParams.getAll('rezervacija').length > 1
+    ) {
+        return '/';
+    }
+
+    const offerId = searchParams.get('ponuda');
+    const reservationIntent = searchParams.get('rezervacija');
+    if (
+        (offerId !== null &&
+            (!/^[1-9]\d*$/u.test(offerId) ||
+                !Number.isSafeInteger(Number(offerId)))) ||
+        (reservationIntent !== null &&
+            (reservationIntent !== '1' || offerId === null))
+    ) {
+        return '/';
+    }
+
+    const canonicalSearchParams = new URLSearchParams();
+    if (offerId !== null) {
+        canonicalSearchParams.set('ponuda', offerId);
+    }
+    if (reservationIntent !== null) {
+        canonicalSearchParams.set('rezervacija', reservationIntent);
+    }
+
+    const canonicalQuery = canonicalSearchParams.toString();
+    return canonicalQuery ? `/outlet?${canonicalQuery}` : '/outlet';
+}
+
+export function getSafeGardenAuthReturnPath(
+    candidate: string | null | undefined,
+): GardenAuthReturnPath {
+    if (
+        !candidate ||
+        candidate !== candidate.trim() ||
+        candidate.length > MAXIMUM_GARDEN_AUTH_RETURN_LENGTH ||
+        containsControlCharacter(candidate) ||
+        !candidate.startsWith('/') ||
+        candidate.startsWith('//') ||
+        candidate.includes('#')
+    ) {
+        return '/';
+    }
+
+    const queryIndex = candidate.indexOf('?');
+    const rawPathname =
+        queryIndex === -1 ? candidate : candidate.slice(0, queryIndex);
+    if (
+        rawPathname.includes('\\') ||
+        rawPathname.includes('%') ||
+        rawPathname
+            .split('/')
+            .some((segment) => segment === '.' || segment === '..')
+    ) {
+        return '/';
+    }
+
+    let parsedUrl: URL;
+    try {
+        parsedUrl = new URL(candidate, GARDEN_AUTH_RETURN_BASE);
+    } catch {
+        return '/';
+    }
+
+    if (
+        parsedUrl.origin !== GARDEN_AUTH_RETURN_BASE ||
+        parsedUrl.username ||
+        parsedUrl.password ||
+        parsedUrl.hash
+    ) {
+        return '/';
+    }
+
+    if (parsedUrl.pathname === '/') {
+        return '/';
+    }
+    if (parsedUrl.pathname !== '/outlet') {
+        return '/';
+    }
+
+    return canonicalOutletReturnPath(parsedUrl.searchParams);
+}
+
+export function getGardenAuthFailureReturnPath(
+    candidate: string | null | undefined,
+): GardenAuthReturnPath {
+    const safeReturnPath = getSafeGardenAuthReturnPath(candidate);
+    if (!safeReturnPath.startsWith('/outlet?')) {
+        return safeReturnPath;
+    }
+
+    const parsedUrl = new URL(safeReturnPath, GARDEN_AUTH_RETURN_BASE);
+    parsedUrl.searchParams.delete('rezervacija');
+    const query = parsedUrl.searchParams.toString();
+    return query ? `/outlet?${query}` : '/outlet';
+}
+
+export function getGardenOAuthStartUrl({
+    apiOrigin,
+    gardenOrigin,
+    provider,
+    returnTo,
+}: {
+    apiOrigin: string;
+    gardenOrigin: string;
+    provider: GardenOAuthProvider;
+    returnTo: string | null | undefined;
+}) {
+    const callbackUrl = new URL(
+        `/prijava/${provider}-prijava/povratak`,
+        gardenOrigin,
+    );
+    callbackUrl.searchParams.set(
+        'returnTo',
+        getSafeGardenAuthReturnPath(returnTo),
+    );
+
+    const authUrl = new URL(`/api/auth/${provider}`, apiOrigin);
+    authUrl.searchParams.set('redirect', callbackUrl.toString());
+    return authUrl.toString();
+}
+
+export function resolveGardenOAuthCallbackQuery(search: string) {
+    const searchParams = new URLSearchParams(search);
+    const returnToValues = searchParams.getAll('returnTo');
+    const errorValues = searchParams.getAll('error');
+    const isSupported =
+        hasOnlySupportedKeys(searchParams, supportedCallbackQueryKeys) &&
+        returnToValues.length <= 1 &&
+        errorValues.length <= 1;
+    const returnTo = getSafeGardenAuthReturnPath(
+        isSupported ? returnToValues[0] : null,
+    );
+
+    return {
+        failureReturnTo: getGardenAuthFailureReturnPath(returnTo),
+        hasServerError: !isSupported || errorValues.length === 1,
+        returnTo,
+    };
+}
+
+export function resolveGardenOAuthFragment(hash: string) {
+    const searchParams = new URLSearchParams(
+        hash.startsWith('#') ? hash.slice(1) : hash,
+    );
+    const tokenValues = searchParams.getAll('token');
+    const refreshTokenValues = searchParams.getAll('refreshToken');
+    if (
+        !hasOnlySupportedKeys(searchParams, supportedFragmentKeys) ||
+        tokenValues.length !== 1 ||
+        refreshTokenValues.length > 1
+    ) {
+        return null;
+    }
+
+    const [token] = tokenValues;
+    const [refreshToken] = refreshTokenValues;
+    if (
+        !token ||
+        token.length > MAXIMUM_OAUTH_FRAGMENT_VALUE_LENGTH ||
+        (refreshToken !== undefined &&
+            (!refreshToken ||
+                refreshToken.length > MAXIMUM_OAUTH_FRAGMENT_VALUE_LENGTH))
+    ) {
+        return null;
+    }
+
+    return {
+        refreshToken: refreshToken ?? null,
+        token,
+    };
+}

--- a/apps/garden/playwright.config.ts
+++ b/apps/garden/playwright.config.ts
@@ -11,6 +11,7 @@ import {
     getPlaywrightBaseUrl,
     shouldReusePlaywrightServer,
 } from '../../scripts/app-registry.ts';
+import { outletGardenTestFlagsSecret } from './playwright/outletGardenFlagTestSupport';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const app = getAppByName('garden');
@@ -91,6 +92,8 @@ export const config: PlaywrightTestConfig = {
     webServer: {
         command: 'node ../../scripts/run-app-command.mjs start',
         env: {
+            FLAGS_SECRET:
+                process.env.FLAGS_SECRET ?? outletGardenTestFlagsSecret,
             GREDICE_DETACH_CHILD_PROCESS: 'false',
             VERCEL_ENV: 'preview',
         },

--- a/apps/garden/playwright/outletGardenFlagTestSupport.ts
+++ b/apps/garden/playwright/outletGardenFlagTestSupport.ts
@@ -1,0 +1,2 @@
+export const outletGardenTestFlagsSecret =
+    'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY';

--- a/apps/garden/tests/LoginModalStory.tsx
+++ b/apps/garden/tests/LoginModalStory.tsx
@@ -15,8 +15,19 @@ function createLoginModalQueryClient() {
     });
 }
 
-export function LoginModalStory() {
+export function LoginModalStory({
+    controlled = false,
+    dismissible = false,
+    returnTo,
+}: {
+    controlled?: boolean;
+    dismissible?: boolean;
+    returnTo?: string;
+}) {
     const [lastRoute, setLastRoute] = useState('none');
+    const [open, setOpen] = useState(true);
+    const [openChangeCount, setOpenChangeCount] = useState(0);
+    const [authenticatedCount, setAuthenticatedCount] = useState(0);
     const queryClient = useMemo(createLoginModalQueryClient, []);
     const router = useMemo(
         () =>
@@ -35,9 +46,44 @@ export function LoginModalStory() {
     return (
         <AppRouterContext.Provider value={router}>
             <ReactQuery.QueryClientProvider client={queryClient}>
-                <LoginModal />
+                <LoginModal
+                    dismissible={dismissible}
+                    onAuthenticated={
+                        controlled
+                            ? () => setAuthenticatedCount((count) => count + 1)
+                            : undefined
+                    }
+                    onOpenChange={
+                        controlled
+                            ? (nextOpen) => {
+                                  setOpen(nextOpen);
+                                  setOpenChangeCount((count) => count + 1);
+                              }
+                            : undefined
+                    }
+                    open={controlled ? open : undefined}
+                    returnTo={returnTo}
+                />
                 <output className="sr-only" data-testid="last-router-push">
                     {lastRoute}
+                </output>
+                <output
+                    className="sr-only"
+                    data-testid="login-modal-open-state"
+                >
+                    {open ? 'open' : 'closed'}
+                </output>
+                <output
+                    className="sr-only"
+                    data-testid="login-modal-open-change-count"
+                >
+                    {openChangeCount}
+                </output>
+                <output
+                    className="sr-only"
+                    data-testid="login-modal-authenticated-count"
+                >
+                    {authenticatedCount}
                 </output>
             </ReactQuery.QueryClientProvider>
         </AppRouterContext.Provider>

--- a/apps/garden/tests/UrlAuthForwardStory.tsx
+++ b/apps/garden/tests/UrlAuthForwardStory.tsx
@@ -1,0 +1,56 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+    AppRouterContext,
+    type AppRouterInstance,
+} from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import { SearchParamsContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
+import { useMemo, useState } from 'react';
+import { UrlAuthForward } from '../app/prijava/UrlAuthForward';
+
+function createOAuthCallbackQueryClient() {
+    return new QueryClient({
+        defaultOptions: {
+            mutations: { retry: false },
+            queries: { retry: false },
+        },
+    });
+}
+
+export function UrlAuthForwardStory({ search = '' }: { search?: string }) {
+    const [lastRoute, setLastRoute] = useState('none');
+    const [replaceCount, setReplaceCount] = useState(0);
+    const queryClient = useMemo(createOAuthCallbackQueryClient, []);
+    const searchParams = useMemo(() => new URLSearchParams(search), [search]);
+    const router = useMemo(
+        () =>
+            ({
+                back: () => undefined,
+                bfcacheId: 'oauth-callback-test',
+                forward: () => undefined,
+                prefetch: () => undefined,
+                push: () => undefined,
+                refresh: () => undefined,
+                replace: (href) => {
+                    setLastRoute(href);
+                    setReplaceCount((count) => count + 1);
+                },
+            }) satisfies AppRouterInstance,
+        [],
+    );
+
+    return (
+        <AppRouterContext.Provider value={router}>
+            <SearchParamsContext.Provider value={searchParams}>
+                <QueryClientProvider client={queryClient}>
+                    <UrlAuthForward />
+                    <output data-testid="oauth-callback-route">
+                        {lastRoute}
+                    </output>
+                    <output data-testid="oauth-callback-replace-count">
+                        {replaceCount}
+                    </output>
+                </QueryClientProvider>
+            </SearchParamsContext.Provider>
+        </AppRouterContext.Provider>
+    );
+}

--- a/apps/garden/tests/login-modal.spec.tsx
+++ b/apps/garden/tests/login-modal.spec.tsx
@@ -154,6 +154,7 @@ test('animates login providers into the email form and focuses email', async ({
     const dialog = page.getByRole('dialog', { name: 'Prijava' });
     const content = page.getByTestId('auth-content-transition');
     await expect(dialog).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Zatvori' })).toHaveCount(0);
     await expect(content).toHaveAttribute('data-auth-content', 'providers');
     await expect(
         page.getByRole('button', { name: 'Google prijava' }),
@@ -310,3 +311,92 @@ test('uses opacity-only 120 ms transitions with reduced motion in both direction
         initialTranslateY: 0,
     });
 });
+
+test('supports a controlled dismissible mode without changing the legacy default', async ({
+    mount,
+    page,
+}) => {
+    await mount(<LoginModalStory controlled dismissible />);
+
+    await page.getByRole('button', { name: 'Zatvori' }).click();
+
+    await expect(page.getByRole('dialog', { name: 'Prijava' })).toBeHidden();
+    await expect(page.getByTestId('login-modal-open-state')).toHaveText(
+        'closed',
+    );
+    await expect(page.getByTestId('login-modal-open-change-count')).toHaveText(
+        '1',
+    );
+    await expect(page.locator('a[href="https://www.gredice.com"]')).toHaveCount(
+        0,
+    );
+});
+
+test('closes controlled mode and reports successful password authentication once', async ({
+    mount,
+    page,
+}) => {
+    await page.unrouteAll({ behavior: 'wait' });
+    const recorded = await mockAuthApi(page);
+    await mount(<LoginModalStory controlled dismissible />);
+
+    await page.getByRole('button', { name: 'Email prijava' }).click();
+    await page.getByLabel('Email').fill('vrtlar@example.com');
+    await page.getByLabel('Zaporka').fill('sigurna-zaporka');
+    await page.getByRole('button', { name: 'Prijava' }).click();
+
+    await expect(page.getByTestId('login-modal-open-state')).toHaveText(
+        'closed',
+    );
+    await expect(page.getByTestId('login-modal-open-change-count')).toHaveText(
+        '1',
+    );
+    await expect(
+        page.getByTestId('login-modal-authenticated-count'),
+    ).toHaveText('1');
+    expect(recorded.loginRequests).toEqual([
+        { email: 'vrtlar@example.com', password: 'sigurna-zaporka' },
+    ]);
+});
+
+for (const provider of ['google', 'facebook'] as const) {
+    test(`starts ${provider} OAuth with a provider-matched Outlet continuation`, async ({
+        mount,
+        page,
+    }) => {
+        let requestedUrl: string | undefined;
+        const gardenOrigin = new URL(page.url()).origin;
+        await page.route(`**/api/auth/${provider}**`, async (route) => {
+            requestedUrl = route.request().url();
+            await route.abort('aborted');
+        });
+        await mount(
+            <LoginModalStory
+                controlled
+                dismissible
+                returnTo="/outlet?rezervacija=1&ponuda=302"
+            />,
+        );
+
+        await page
+            .getByRole('button', {
+                name: new RegExp(`^${provider}`, 'iu'),
+            })
+            .click();
+        await expect.poll(() => requestedUrl).not.toBeUndefined();
+
+        const authUrl = new URL(requestedUrl ?? 'https://invalid.local');
+        const callbackUrl = new URL(
+            authUrl.searchParams.get('redirect') ?? 'https://invalid.local',
+        );
+        expect(authUrl.pathname).toBe(`/api/auth/${provider}`);
+        expect(callbackUrl.origin).toBe(gardenOrigin);
+        expect(callbackUrl.pathname).toBe(
+            `/prijava/${provider}-prijava/povratak`,
+        );
+        expect(callbackUrl.searchParams.getAll('returnTo')).toEqual([
+            '/outlet?ponuda=302&rezervacija=1',
+        ]);
+        expect(callbackUrl.hash).toBe('');
+    });
+}

--- a/apps/garden/tests/oauth-return-to.spec.tsx
+++ b/apps/garden/tests/oauth-return-to.spec.tsx
@@ -1,0 +1,220 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import {
+    getGardenAuthFailureReturnPath,
+    getGardenOAuthStartUrl,
+    getSafeGardenAuthReturnPath,
+    resolveGardenOAuthCallbackQuery,
+    resolveGardenOAuthFragment,
+} from '../lib/auth/gardenAuthContinuation';
+import { UrlAuthForwardStory } from './UrlAuthForwardStory';
+
+test('allows only canonical Garden and Outlet authentication returns', () => {
+    expect(getSafeGardenAuthReturnPath('/')).toBe('/');
+    expect(getSafeGardenAuthReturnPath('/outlet')).toBe('/outlet');
+    expect(getSafeGardenAuthReturnPath('/outlet?ponuda=302')).toBe(
+        '/outlet?ponuda=302',
+    );
+    expect(
+        getSafeGardenAuthReturnPath('/outlet?rezervacija=1&ponuda=302'),
+    ).toBe('/outlet?ponuda=302&rezervacija=1');
+});
+
+test('falls back for external, malformed, duplicate, and unsupported returns', () => {
+    for (const candidate of [
+        null,
+        '',
+        ' /outlet?ponuda=302',
+        '/outlet?ponuda=302 ',
+        'https://example.com/outlet?ponuda=302',
+        '//example.com/outlet?ponuda=302',
+        String.raw`\\example.com\outlet`,
+        String.raw`/outlet\details?ponuda=302`,
+        '/outlet/%2f/example.com?ponuda=302',
+        '/foo/../outlet?ponuda=302',
+        '/outlet?ponuda=302#reservation',
+        '/api/users/current',
+        '/prijava/google-prijava/povratak',
+        '/outlet?unknown=1&ponuda=302',
+        '/outlet?ponuda=302&ponuda=303',
+        '/outlet?ponuda=302&rezervacija=1&rezervacija=1',
+        '/outlet?ponuda=',
+        '/outlet?ponuda=0',
+        '/outlet?ponuda=-1',
+        '/outlet?ponuda=01',
+        '/outlet?ponuda=1.5',
+        '/outlet?ponuda=9007199254740992',
+        '/outlet?rezervacija=1',
+        '/outlet?ponuda=302&rezervacija=0',
+        `/outlet?ponuda=302&value=${'x'.repeat(2_048)}`,
+    ]) {
+        expect(getSafeGardenAuthReturnPath(candidate)).toBe('/');
+    }
+});
+
+test('keeps the selected offer but removes reservation intent after auth failure', () => {
+    expect(
+        getGardenAuthFailureReturnPath('/outlet?ponuda=302&rezervacija=1'),
+    ).toBe('/outlet?ponuda=302');
+    expect(getGardenAuthFailureReturnPath('/outlet?ponuda=302')).toBe(
+        '/outlet?ponuda=302',
+    );
+    expect(getGardenAuthFailureReturnPath('https://example.com/outlet')).toBe(
+        '/',
+    );
+});
+
+for (const provider of ['google', 'facebook'] as const) {
+    test(`builds a provider-matched ${provider} OAuth callback`, () => {
+        const authUrl = new URL(
+            getGardenOAuthStartUrl({
+                apiOrigin: 'https://api.gredice.com',
+                gardenOrigin: 'https://vrt.gredice.com',
+                provider,
+                returnTo: '/outlet?rezervacija=1&ponuda=302',
+            }),
+        );
+        const callbackUrl = new URL(authUrl.searchParams.get('redirect') ?? '');
+
+        expect(authUrl.origin).toBe('https://api.gredice.com');
+        expect(authUrl.pathname).toBe(`/api/auth/${provider}`);
+        expect(callbackUrl.origin).toBe('https://vrt.gredice.com');
+        expect(callbackUrl.pathname).toBe(
+            `/prijava/${provider}-prijava/povratak`,
+        );
+        expect(callbackUrl.searchParams.getAll('returnTo')).toEqual([
+            '/outlet?ponuda=302&rezervacija=1',
+        ]);
+        expect(callbackUrl.hash).toBe('');
+    });
+}
+
+test('resolves bounded callback queries and fails closed on outer query ambiguity', () => {
+    const canceled = resolveGardenOAuthCallbackQuery(
+        'returnTo=%2Foutlet%3Fponuda%3D302%26rezervacija%3D1&error=canceled',
+    );
+    expect(canceled).toEqual({
+        failureReturnTo: '/outlet?ponuda=302',
+        hasServerError: true,
+        returnTo: '/outlet?ponuda=302&rezervacija=1',
+    });
+
+    for (const search of [
+        'returnTo=%2Foutlet%3Fponuda%3D302&returnTo=%2F',
+        'returnTo=%2Foutlet%3Fponuda%3D302&unknown=1',
+        'returnTo=%2Foutlet%3Fponuda%3D302&error=canceled&error=callback_error',
+    ]) {
+        expect(resolveGardenOAuthCallbackQuery(search)).toEqual({
+            failureReturnTo: '/',
+            hasServerError: true,
+            returnTo: '/',
+        });
+    }
+});
+
+test('accepts one bounded OAuth token pair and rejects ambiguous fragments', () => {
+    expect(
+        resolveGardenOAuthFragment('#token=access&refreshToken=refresh'),
+    ).toEqual({
+        refreshToken: 'refresh',
+        token: 'access',
+    });
+    expect(resolveGardenOAuthFragment('token=access')).toEqual({
+        refreshToken: null,
+        token: 'access',
+    });
+
+    for (const hash of [
+        '',
+        '#refreshToken=refresh',
+        '#token=',
+        '#token=one&token=two',
+        '#token=access&refreshToken=one&refreshToken=two',
+        '#token=access&unknown=secret',
+    ]) {
+        expect(resolveGardenOAuthFragment(hash)).toBeNull();
+    }
+});
+
+test('exchanges OAuth tokens once and resumes the selected Outlet intent', async ({
+    mount,
+    page,
+}) => {
+    const requestBodies: unknown[] = [];
+    await page.route('**/api/oauth-callback', async (route) => {
+        requestBodies.push(route.request().postDataJSON());
+        await route.fulfill({
+            body: JSON.stringify({ success: true }),
+            contentType: 'application/json',
+            status: 200,
+        });
+    });
+    await page.evaluate(() => {
+        window.location.hash = 'token=access&refreshToken=refresh';
+    });
+
+    await mount(
+        <UrlAuthForwardStory search="returnTo=%2Foutlet%3Fponuda%3D302%26rezervacija%3D1" />,
+    );
+
+    await expect(page.getByTestId('oauth-callback-route')).toHaveText(
+        '/outlet?ponuda=302&rezervacija=1',
+    );
+    await expect(page.getByTestId('oauth-callback-replace-count')).toHaveText(
+        '1',
+    );
+    await expect.poll(() => requestBodies).toHaveLength(1);
+    expect(requestBodies).toEqual([
+        { refreshToken: 'refresh', token: 'access' },
+    ]);
+    expect(await page.evaluate(() => window.location.hash)).toBe('');
+});
+
+test('scrubs callback tokens and preserves offer selection on provider error', async ({
+    mount,
+    page,
+}) => {
+    let requestCount = 0;
+    await page.route('**/api/oauth-callback', async (route) => {
+        requestCount += 1;
+        await route.abort('failed');
+    });
+    await page.evaluate(() => {
+        window.location.hash = 'token=must-not-be-forwarded';
+    });
+
+    await mount(
+        <UrlAuthForwardStory search="returnTo=%2Foutlet%3Fponuda%3D302%26rezervacija%3D1&error=canceled" />,
+    );
+
+    await expect(page.getByTestId('oauth-callback-route')).toHaveText(
+        '/outlet?ponuda=302',
+    );
+    await expect(page.getByTestId('oauth-callback-replace-count')).toHaveText(
+        '1',
+    );
+    expect(requestCount).toBe(0);
+    expect(await page.evaluate(() => window.location.hash)).toBe('');
+});
+
+test('does not continue reservation intent when the token exchange is rejected', async ({
+    mount,
+    page,
+}) => {
+    await page.route('**/api/oauth-callback', async (route) => {
+        await route.fulfill({ status: 401 });
+    });
+    await page.evaluate(() => {
+        window.location.hash = 'token=invalid';
+    });
+
+    await mount(
+        <UrlAuthForwardStory search="returnTo=%2Foutlet%3Fponuda%3D302%26rezervacija%3D1" />,
+    );
+
+    await expect(page.getByTestId('oauth-callback-route')).toHaveText(
+        '/outlet?ponuda=302',
+    );
+    await expect(page.getByTestId('oauth-callback-replace-count')).toHaveText(
+        '1',
+    );
+});

--- a/apps/garden/tests/outlet-garden-flag.spec.ts
+++ b/apps/garden/tests/outlet-garden-flag.spec.ts
@@ -34,4 +34,13 @@ test('flag discovery resolves managed Vercel provider metadata', () => {
     expect(discoverySource).toContain(
         "import { createFlagsDiscoveryEndpoint } from 'flags/next';",
     );
+
+    const flagsSource = readFileSync(
+        new URL('../app/flags.ts', import.meta.url),
+        'utf8',
+    );
+    expect(flagsSource).toContain("key: 'enableOutletGardenCommerce'");
+    expect(flagsSource).toMatch(
+        /enableOutletGardenCommerceFlag[\s\S]*?adapter: vercelAdapter,[\s\S]*?defaultValue: false,/u,
+    );
 });

--- a/apps/garden/tests/outlet-garden-route.spec.ts
+++ b/apps/garden/tests/outlet-garden-route.spec.ts
@@ -1,5 +1,19 @@
 import { expect, type Page, test } from '@playwright/test';
+import { encryptOverrides } from 'flags';
 import { getLocalSandboxBlockData } from '../../../packages/game/src/localSandboxBlockData';
+import { outletGardenTestFlagsSecret } from '../playwright/outletGardenFlagTestSupport';
+
+const currentUser = {
+    avatarUrl: null,
+    birthday: null,
+    birthdayLastRewardAt: null,
+    birthdayLastUpdatedAt: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    displayName: 'Test User',
+    email: 'test@example.com',
+    id: 'test-user',
+    userName: 'test-user',
+};
 
 const outletOffers = [
     {
@@ -47,6 +61,88 @@ const outletOffers = [
         url: 'https://www.gredice.test/outlet?offer=302',
     },
 ];
+
+const outletTargetGarden = {
+    backgroundPalette: 'current',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    farmId: 1,
+    homeCamera: null,
+    id: 1,
+    isPublic: false,
+    isSandbox: false,
+    latitude: 45.739,
+    longitude: 16.572,
+    name: 'Testni vrt',
+    previewImage: null,
+    previewSourceRevision: null,
+    raisedBeds: [
+        {
+            abandonReason: null,
+            appliedOperations: [],
+            blockId: 'raised-bed-primary',
+            createdAt: '2026-07-01T00:00:00.000Z',
+            fields: [],
+            id: 10,
+            isValid: true,
+            name: 'Testna gredica',
+            orientation: 'vertical',
+            physicalId: null,
+            plantings: [],
+            status: 'active',
+            updatedAt: '2026-07-01T00:00:00.000Z',
+            weedState: null,
+        },
+    ],
+    stacks: {
+        '0': {
+            '0': [
+                {
+                    id: 'grass-0-0',
+                    name: 'Block_Grass',
+                    rotation: 0,
+                },
+                {
+                    id: 'raised-bed-primary',
+                    name: 'Raised_Bed',
+                    rotation: 0,
+                },
+            ],
+            '1': [
+                {
+                    id: 'grass-0-1',
+                    name: 'Block_Grass',
+                    rotation: 0,
+                },
+                {
+                    id: 'raised-bed-secondary',
+                    name: 'Raised_Bed',
+                    rotation: 0,
+                },
+            ],
+        },
+    },
+    updatedAt: '2026-07-01T00:00:00.000Z',
+};
+
+const outletTargetGardenListItem = {
+    backgroundPalette: outletTargetGarden.backgroundPalette,
+    createdAt: outletTargetGarden.createdAt,
+    homeCamera: outletTargetGarden.homeCamera,
+    id: outletTargetGarden.id,
+    isPublic: outletTargetGarden.isPublic,
+    isSandbox: outletTargetGarden.isSandbox,
+    name: outletTargetGarden.name,
+};
+
+const emptyShoppingCart = {
+    allowPurchase: true,
+    hasDeliverableItems: false,
+    id: 500,
+    items: [],
+    notes: [],
+    total: 0,
+    totalSunflowers: 0,
+};
 
 async function mockOutletGardenApi(page: Page) {
     const mutationRequests: string[] = [];
@@ -105,6 +201,211 @@ async function mockOutletGardenApi(page: Page) {
     };
 }
 
+async function mockOutletGardenCommerceApi(
+    page: Page,
+    {
+        gardensUnauthorized: initiallyGardensUnauthorized = false,
+    }: { gardensUnauthorized?: boolean } = {},
+) {
+    const finalUnitOffer = {
+        ...outletOffers[1],
+        remainingQuantity: 1,
+        reservedQuantity: 2,
+    };
+    const holdExpiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    const shoppingCartPosts: unknown[] = [];
+    let currentOffers = [finalUnitOffer];
+    let outletOfferRequestCount = 0;
+    let cartItems: Array<Record<string, unknown>> = [];
+    let gardensUnauthorized = initiallyGardensUnauthorized;
+
+    await page.route('**/api/gredice/**', async (route) => {
+        const request = route.request();
+        const { pathname } = new URL(request.url());
+
+        if (pathname.endsWith('/api/auth/login')) {
+            gardensUnauthorized = false;
+            await route.fulfill({
+                body: JSON.stringify({ success: true }),
+                contentType: 'application/json',
+                status: 200,
+            });
+            return;
+        }
+
+        if (pathname.endsWith('/api/auth/current-claims')) {
+            await route.fulfill({
+                body: JSON.stringify(currentUser),
+                contentType: 'application/json',
+                status: 200,
+            });
+            return;
+        }
+
+        if (pathname.endsWith('/api/users/current')) {
+            await route.fulfill({
+                body: JSON.stringify(currentUser),
+                contentType: 'application/json',
+                status: 200,
+            });
+            return;
+        }
+
+        if (pathname.endsWith('/api/outlet/offers')) {
+            outletOfferRequestCount += 1;
+            await route.fulfill({
+                body: JSON.stringify({ items: currentOffers }),
+                contentType: 'application/json',
+                status: 200,
+            });
+            return;
+        }
+
+        if (pathname.endsWith('/api/gardens/1')) {
+            await route.fulfill({
+                body: JSON.stringify(outletTargetGarden),
+                contentType: 'application/json',
+                status: 200,
+            });
+            return;
+        }
+
+        if (pathname.endsWith('/api/gardens')) {
+            if (initiallyGardensUnauthorized && !gardensUnauthorized) {
+                await new Promise((resolve) => setTimeout(resolve, 150));
+            }
+            await route.fulfill({
+                body: JSON.stringify(
+                    gardensUnauthorized
+                        ? { error: 'Unauthorized' }
+                        : [outletTargetGardenListItem],
+                ),
+                contentType: 'application/json',
+                status: gardensUnauthorized ? 401 : 200,
+            });
+            return;
+        }
+
+        if (pathname.endsWith('/api/shopping-cart')) {
+            if (request.method() === 'POST') {
+                shoppingCartPosts.push(request.postDataJSON());
+                cartItems = [
+                    {
+                        additionalData: JSON.stringify({
+                            outletOfferId: finalUnitOffer.id,
+                        }),
+                        amount: 1,
+                        currency: 'eur',
+                        entityData: {
+                            id: finalUnitOffer.plantSort.id,
+                            information: {
+                                name: finalUnitOffer.plantSort.name,
+                            },
+                        },
+                        entityId: finalUnitOffer.plantSort.id.toString(),
+                        entityTypeName: 'plantSort',
+                        gardenId: outletTargetGarden.id,
+                        id: 901,
+                        outlet: {
+                            comparePrice: finalUnitOffer.comparePrice,
+                            endAt: finalUnitOffer.endAt,
+                            expired: false,
+                            holdExpiresAt,
+                            initialPlantStatus:
+                                finalUnitOffer.initialPlantStatus,
+                            offerId: finalUnitOffer.id,
+                            outletPrice: finalUnitOffer.outletPrice,
+                            reservationId: 801,
+                            sowingDate: finalUnitOffer.sowingDate,
+                            status: 'held',
+                        },
+                        positionIndex: 0,
+                        raisedBedId: 10,
+                        shopData: {
+                            discountDescription: 'Outlet sadnica',
+                            discountPrice: finalUnitOffer.outletPrice,
+                            name: finalUnitOffer.plantSort.name,
+                            price: finalUnitOffer.comparePrice,
+                        },
+                        status: 'new',
+                    },
+                ];
+                currentOffers = [];
+                await route.fulfill({
+                    body: JSON.stringify({ success: true }),
+                    contentType: 'application/json',
+                    status: 200,
+                });
+                return;
+            }
+
+            await route.fulfill({
+                body: JSON.stringify({
+                    ...emptyShoppingCart,
+                    items: cartItems,
+                    total:
+                        cartItems.length > 0 ? finalUnitOffer.outletPrice : 0,
+                }),
+                contentType: 'application/json',
+                status: 200,
+            });
+            return;
+        }
+
+        if (pathname.endsWith('/api/directories/entities/block')) {
+            await route.fulfill({
+                body: JSON.stringify(getLocalSandboxBlockData()),
+                contentType: 'application/json',
+                status: 200,
+            });
+            return;
+        }
+
+        await route.fulfill({
+            body: JSON.stringify({ error: `Unexpected request: ${pathname}` }),
+            contentType: 'application/json',
+            status: 404,
+        });
+    });
+
+    return {
+        finalUnitOffer,
+        getOutletOfferRequestCount: () => outletOfferRequestCount,
+        holdExpiresAt,
+        shoppingCartPosts,
+    };
+}
+
+async function enableOutletGardenCommerce(page: Page, baseURL: string) {
+    const override = await encryptOverrides(
+        { enableOutletGardenCommerce: true },
+        process.env.FLAGS_SECRET ?? outletGardenTestFlagsSecret,
+        '1h',
+    );
+    await page.context().addCookies([
+        {
+            name: 'vercel-flag-overrides',
+            url: baseURL,
+            value: override,
+        },
+    ]);
+}
+
+async function disableOutletGardenCommerce(page: Page, baseURL: string) {
+    const override = await encryptOverrides(
+        { enableOutletGardenCommerce: false },
+        process.env.FLAGS_SECRET ?? outletGardenTestFlagsSecret,
+        '1h',
+    );
+    await page.context().addCookies([
+        {
+            name: 'vercel-flag-overrides',
+            url: baseURL,
+            value: override,
+        },
+    ]);
+}
+
 async function disableWebGL(page: Page) {
     await page.addInitScript(() => {
         const originalGetContext = HTMLCanvasElement.prototype.getContext;
@@ -130,10 +431,15 @@ async function disableWebGL(page: Page) {
 
 test('guest Outlet garden renders WebGL, selects an offer, and preserves its deep link', async ({
     page,
-}) => {
+}, testInfo) => {
     test.setTimeout(60_000);
     const runtimeErrors: string[] = [];
     page.on('pageerror', (error) => runtimeErrors.push(error.message));
+    const baseURL = testInfo.project.use.baseURL;
+    if (typeof baseURL !== 'string') {
+        throw new Error('Garden route test requires a Playwright base URL');
+    }
+    await disableOutletGardenCommerce(page, baseURL);
     const outletApi = await mockOutletGardenApi(page);
 
     await page.goto('/outlet');
@@ -184,6 +490,10 @@ test('guest Outlet garden renders WebGL, selects an offer, and preserves its dee
     await expect(
         page.locator('[data-outlet-garden-selected-offer="302"]'),
     ).toContainText('3 sadnica');
+    await expect(page.locator('[data-outlet-garden-commerce]')).toHaveCount(0);
+    await expect(
+        page.getByRole('button', { name: 'Rezerviraj u svom vrtu' }),
+    ).toHaveCount(0);
 
     const requestCountBeforeRefresh = outletApi.getOutletOfferRequestCount();
     outletApi.setOffers([
@@ -344,4 +654,125 @@ test('guest Outlet garden falls back to the semantic offer list without WebGL', 
 
     expect(modelRequests).toEqual([]);
     expect(outletApi.mutationRequests).toEqual([]);
+});
+
+test('signed-in list fallback holds the final unit and keeps its verified receipt', async ({
+    page,
+}, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL;
+    if (typeof baseURL !== 'string') {
+        throw new Error('Garden route test requires a Playwright base URL');
+    }
+
+    await disableWebGL(page);
+    await enableOutletGardenCommerce(page, baseURL);
+    const outletApi = await mockOutletGardenCommerceApi(page);
+
+    await page.goto('/outlet?ponuda=302');
+
+    await expect(
+        page.locator('[data-outlet-garden-renderer="list"]'),
+    ).toBeVisible();
+    await expect(
+        page.locator('[data-outlet-garden-selected-offer="302"]'),
+    ).toContainText('1 sadnica');
+
+    await page.getByRole('button', { name: 'Rezerviraj u svom vrtu' }).click();
+
+    const gardenSelect = page.getByRole('combobox', {
+        name: 'Vrt',
+        exact: true,
+    });
+    await expect(gardenSelect).toHaveValue('1');
+    const targetSelect = page.getByRole('combobox', {
+        name: 'Mjesto u gredici',
+        exact: true,
+    });
+    await expect(targetSelect.locator('option')).toHaveCount(18);
+    await targetSelect.selectOption('10:0');
+
+    await page.getByRole('button', { name: 'Rezerviraj sadnicu' }).click();
+
+    await expect.poll(() => outletApi.shoppingCartPosts.length).toBe(1);
+    expect(outletApi.shoppingCartPosts[0]).toEqual({
+        additionalData: JSON.stringify({ outletOfferId: 302 }),
+        amount: 1,
+        cartId: 500,
+        entityId: '102',
+        entityTypeName: 'plantSort',
+        gardenId: 1,
+        outletOfferId: 302,
+        positionIndex: 0,
+        raisedBedId: 10,
+    });
+
+    await expect
+        .poll(() => outletApi.getOutletOfferRequestCount())
+        .toBeGreaterThan(1);
+    await expect(page.locator('[data-outlet-garden-empty]')).toBeVisible();
+    await expect(page.locator('[data-outlet-garden-commerce]')).toHaveAttribute(
+        'data-outlet-garden-commerce-state',
+        'success',
+    );
+    await expect(
+        page.getByRole('heading', { name: 'Sadnica je rezervirana' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('link', { name: 'Nastavi u košaricu' }),
+    ).toHaveAttribute('href', '/?vrt=1&kosarica=true');
+
+    const storedReceipt = await page.evaluate(() =>
+        sessionStorage.getItem('gredice-outlet-garden-commerce-attribution-v1'),
+    );
+    expect(storedReceipt).not.toBeNull();
+    expect(JSON.parse(storedReceipt ?? 'null')).toEqual({
+        cartItemId: 901,
+        holdExpiresAt: outletApi.holdExpiresAt,
+        outletOfferId: outletApi.finalUnitOffer.id,
+    });
+
+    await page.reload();
+    await expect(page.locator('[data-outlet-garden-empty]')).toBeVisible();
+    await expect(
+        page.getByRole('heading', { name: 'Sadnica je rezervirana' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('link', { name: 'Nastavi u košaricu' }),
+    ).toHaveAttribute('href', '/?vrt=1&kosarica=true');
+});
+
+test('expired cached authentication returns to sign-in instead of reporting no fields', async ({
+    page,
+}, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL;
+    if (typeof baseURL !== 'string') {
+        throw new Error('Garden route test requires a Playwright base URL');
+    }
+
+    await disableWebGL(page);
+    await enableOutletGardenCommerce(page, baseURL);
+    await mockOutletGardenCommerceApi(page, { gardensUnauthorized: true });
+
+    await page.goto('/outlet?ponuda=302');
+    await page.getByRole('button', { name: 'Rezerviraj u svom vrtu' }).click();
+
+    await expect(
+        page.getByRole('heading', { name: 'Prijavi se za rezervaciju' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('heading', { name: 'Nema slobodnog mjesta' }),
+    ).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Prijavi se i nastavi' }).click();
+    await page.getByRole('button', { name: 'Email prijava' }).click();
+    await page.getByLabel('Email').fill('vrtlar@example.com');
+    await page.getByLabel('Zaporka').fill('sigurna-zaporka');
+    await page.getByRole('button', { name: 'Prijava', exact: true }).click();
+
+    await expect(
+        page.getByRole('heading', { name: 'Odaberi mjesto za sadnicu' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('heading', { name: 'Prijavi se za rezervaciju' }),
+    ).toHaveCount(0);
 });

--- a/apps/garden/tests/outlet-garden-route.spec.ts
+++ b/apps/garden/tests/outlet-garden-route.spec.ts
@@ -134,6 +134,18 @@ const outletTargetGardenListItem = {
     name: outletTargetGarden.name,
 };
 
+const secondOutletTargetGarden = {
+    ...outletTargetGarden,
+    id: 2,
+    name: 'Drugi testni vrt',
+};
+
+const secondOutletTargetGardenListItem = {
+    ...outletTargetGardenListItem,
+    id: secondOutletTargetGarden.id,
+    name: secondOutletTargetGarden.name,
+};
+
 const emptyShoppingCart = {
     allowPurchase: true,
     hasDeliverableItems: false,
@@ -204,8 +216,14 @@ async function mockOutletGardenApi(page: Page) {
 async function mockOutletGardenCommerceApi(
     page: Page,
     {
+        defaultGardenHasNoTargets = false,
         gardensUnauthorized: initiallyGardensUnauthorized = false,
-    }: { gardensUnauthorized?: boolean } = {},
+        targetUnavailableOnce = false,
+    }: {
+        defaultGardenHasNoTargets?: boolean;
+        gardensUnauthorized?: boolean;
+        targetUnavailableOnce?: boolean;
+    } = {},
 ) {
     const finalUnitOffer = {
         ...outletOffers[1],
@@ -218,6 +236,8 @@ async function mockOutletGardenCommerceApi(
     let outletOfferRequestCount = 0;
     let cartItems: Array<Record<string, unknown>> = [];
     let gardensUnauthorized = initiallyGardensUnauthorized;
+    let occupiedPositionIndex: number | null = null;
+    let targetGardenRequestCount = 0;
 
     await page.route('**/api/gredice/**', async (route) => {
         const request = route.request();
@@ -261,9 +281,33 @@ async function mockOutletGardenCommerceApi(
             return;
         }
 
-        if (pathname.endsWith('/api/gardens/1')) {
+        const targetGardenIdMatch = pathname.match(/\/api\/gardens\/(1|2)$/u);
+        if (targetGardenIdMatch) {
+            targetGardenRequestCount += 1;
+            const gardenId = Number(targetGardenIdMatch[1]);
+            const baseGarden =
+                gardenId === secondOutletTargetGarden.id
+                    ? secondOutletTargetGarden
+                    : outletTargetGarden;
+            const raisedBeds =
+                defaultGardenHasNoTargets && gardenId === outletTargetGarden.id
+                    ? []
+                    : baseGarden.raisedBeds.map((raisedBed) => ({
+                          ...raisedBed,
+                          fields:
+                              occupiedPositionIndex === null
+                                  ? raisedBed.fields
+                                  : [
+                                        {
+                                            active: true,
+                                            plantSortId: 999,
+                                            positionIndex:
+                                                occupiedPositionIndex,
+                                        },
+                                    ],
+                      }));
             await route.fulfill({
-                body: JSON.stringify(outletTargetGarden),
+                body: JSON.stringify({ ...baseGarden, raisedBeds }),
                 contentType: 'application/json',
                 status: 200,
             });
@@ -278,7 +322,12 @@ async function mockOutletGardenCommerceApi(
                 body: JSON.stringify(
                     gardensUnauthorized
                         ? { error: 'Unauthorized' }
-                        : [outletTargetGardenListItem],
+                        : [
+                              outletTargetGardenListItem,
+                              ...(defaultGardenHasNoTargets
+                                  ? [secondOutletTargetGardenListItem]
+                                  : []),
+                          ],
                 ),
                 contentType: 'application/json',
                 status: gardensUnauthorized ? 401 : 200,
@@ -288,7 +337,39 @@ async function mockOutletGardenCommerceApi(
 
         if (pathname.endsWith('/api/shopping-cart')) {
             if (request.method() === 'POST') {
-                shoppingCartPosts.push(request.postDataJSON());
+                const requestBody: unknown = request.postDataJSON();
+                shoppingCartPosts.push(requestBody);
+                const positionIndex = Number(
+                    requestBody && typeof requestBody === 'object'
+                        ? Reflect.get(requestBody, 'positionIndex')
+                        : Number.NaN,
+                );
+                const raisedBedId = Number(
+                    requestBody && typeof requestBody === 'object'
+                        ? Reflect.get(requestBody, 'raisedBedId')
+                        : Number.NaN,
+                );
+                const gardenId = Number(
+                    requestBody && typeof requestBody === 'object'
+                        ? Reflect.get(requestBody, 'gardenId')
+                        : Number.NaN,
+                );
+                if (
+                    targetUnavailableOnce &&
+                    shoppingCartPosts.length === 1 &&
+                    Number.isSafeInteger(positionIndex)
+                ) {
+                    occupiedPositionIndex = positionIndex;
+                    await route.fulfill({
+                        body: JSON.stringify({
+                            code: 'OUTLET_TARGET_UNAVAILABLE',
+                            error: 'Outlet target is unavailable',
+                        }),
+                        contentType: 'application/json',
+                        status: 409,
+                    });
+                    return;
+                }
                 cartItems = [
                     {
                         additionalData: JSON.stringify({
@@ -304,7 +385,7 @@ async function mockOutletGardenCommerceApi(
                         },
                         entityId: finalUnitOffer.plantSort.id.toString(),
                         entityTypeName: 'plantSort',
-                        gardenId: outletTargetGarden.id,
+                        gardenId,
                         id: 901,
                         outlet: {
                             comparePrice: finalUnitOffer.comparePrice,
@@ -319,8 +400,8 @@ async function mockOutletGardenCommerceApi(
                             sowingDate: finalUnitOffer.sowingDate,
                             status: 'held',
                         },
-                        positionIndex: 0,
-                        raisedBedId: 10,
+                        positionIndex,
+                        raisedBedId,
                         shopData: {
                             discountDescription: 'Outlet sadnica',
                             discountPrice: finalUnitOffer.outletPrice,
@@ -371,6 +452,7 @@ async function mockOutletGardenCommerceApi(
     return {
         finalUnitOffer,
         getOutletOfferRequestCount: () => outletOfferRequestCount,
+        getTargetGardenRequestCount: () => targetGardenRequestCount,
         holdExpiresAt,
         shoppingCartPosts,
     };
@@ -739,6 +821,99 @@ test('signed-in list fallback holds the final unit and keeps its verified receip
     await expect(
         page.getByRole('link', { name: 'Nastavi u košaricu' }),
     ).toHaveAttribute('href', '/?vrt=1&kosarica=true');
+});
+
+test('switches gardens when the default garden has no free targets', async ({
+    page,
+}, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL;
+    if (typeof baseURL !== 'string') {
+        throw new Error('Garden route test requires a Playwright base URL');
+    }
+
+    await disableWebGL(page);
+    await enableOutletGardenCommerce(page, baseURL);
+    await mockOutletGardenCommerceApi(page, {
+        defaultGardenHasNoTargets: true,
+    });
+
+    await page.goto('/outlet?ponuda=302');
+    await page.getByRole('button', { name: 'Rezerviraj u svom vrtu' }).click();
+
+    await expect(page.locator('[data-outlet-garden-commerce]')).toHaveAttribute(
+        'data-outlet-garden-commerce-state',
+        'no-targets',
+    );
+    const gardenSelect = page.getByRole('combobox', {
+        name: 'Vrt',
+        exact: true,
+    });
+    await expect(gardenSelect).toHaveValue('1');
+    await expect(gardenSelect.locator('option')).toHaveCount(2);
+
+    await gardenSelect.selectOption('2');
+
+    await expect(page.locator('[data-outlet-garden-commerce]')).toHaveAttribute(
+        'data-outlet-garden-commerce-state',
+        'ready',
+    );
+    await expect(gardenSelect).toHaveValue('2');
+    await expect(
+        page
+            .getByRole('combobox', {
+                name: 'Mjesto u gredici',
+                exact: true,
+            })
+            .locator('option'),
+    ).toHaveCount(18);
+});
+
+test('refreshes the selected garden and moves off a rejected target', async ({
+    page,
+}, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL;
+    if (typeof baseURL !== 'string') {
+        throw new Error('Garden route test requires a Playwright base URL');
+    }
+
+    await disableWebGL(page);
+    await enableOutletGardenCommerce(page, baseURL);
+    const outletApi = await mockOutletGardenCommerceApi(page, {
+        targetUnavailableOnce: true,
+    });
+
+    await page.goto('/outlet?ponuda=302');
+    await page.getByRole('button', { name: 'Rezerviraj u svom vrtu' }).click();
+    const targetSelect = page.getByRole('combobox', {
+        name: 'Mjesto u gredici',
+        exact: true,
+    });
+    await expect(targetSelect).toHaveValue('10:0');
+
+    await page.getByRole('button', { name: 'Rezerviraj sadnicu' }).click();
+
+    await expect.poll(() => outletApi.shoppingCartPosts.length).toBe(1);
+    await expect
+        .poll(() => outletApi.getTargetGardenRequestCount())
+        .toBeGreaterThan(1);
+    await expect(targetSelect).toHaveValue('10:1');
+    await expect(targetSelect.locator('option')).toHaveCount(17);
+    await expect(
+        page.getByText(
+            'Odabrano mjesto više nije slobodno. Odaberi drugo mjesto i pokušaj ponovno.',
+        ),
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: 'Pokušaj ponovno' }).click();
+
+    await expect.poll(() => outletApi.shoppingCartPosts.length).toBe(2);
+    expect(outletApi.shoppingCartPosts).toMatchObject([
+        { positionIndex: 0, raisedBedId: 10 },
+        { positionIndex: 1, raisedBedId: 10 },
+    ]);
+    await expect(
+        page.getByRole('heading', { name: 'Sadnica je rezervirana' }),
+    ).toBeVisible();
 });
 
 test('expired cached authentication returns to sign-in instead of reporting no fields', async ({

--- a/apps/garden/tests/outlet-garden.spec.tsx
+++ b/apps/garden/tests/outlet-garden.spec.tsx
@@ -59,7 +59,7 @@ test('selects a live offer and exposes truthful read-only details', async ({
     await expect(details).toContainText('Prvi cvjetovi');
     await expect(details).toContainText('21. kolovoza 2026.');
     await expect(details).toContainText(
-        'Pregled i odabir ovdje ne rezerviraju zalihu.',
+        'Pregled i odabir sadnice ne rezerviraju zalihu; rezervacija nastaje tek nakon potvrde polja.',
     );
     await expect(
         details.getByRole('link', { name: 'Nastavi u postojećem Outletu' }),

--- a/packages/game/package.json
+++ b/packages/game/package.json
@@ -13,6 +13,7 @@
         "./garden-2d": "./src/GardenOverview2DDynamic.tsx",
         "./outlet-garden": "./src/viewers/OutletGardenViewer.tsx",
         "./outlet-garden-browser": "./src/viewers/OutletGardenOfferBrowser.tsx",
+        "./outlet-garden-commerce": "./src/viewers/OutletGardenCommerce.tsx",
         "./outlet-garden-list": "./src/viewers/OutletGardenBrowserViewer.tsx",
         "./theme": "./src/hooks/useThemeManager.ts"
     },

--- a/packages/game/src/analytics/outletGardenCommerceAttribution.ts
+++ b/packages/game/src/analytics/outletGardenCommerceAttribution.ts
@@ -1,0 +1,143 @@
+const outletGardenCommerceAttributionKey =
+    'gredice-outlet-garden-commerce-attribution-v1';
+
+export type OutletGardenCommerceAttribution = {
+    cartItemId: number;
+    holdExpiresAt: string;
+    outletOfferId: number;
+};
+
+type OutletCartItemForAttribution = {
+    id: number;
+    outlet?: {
+        expired?: boolean;
+        holdExpiresAt?: string | null;
+        offerId?: number;
+        status?: string;
+    } | null;
+};
+
+function isPositiveSafeInteger(value: unknown): value is number {
+    return (
+        typeof value === 'number' && Number.isSafeInteger(value) && value > 0
+    );
+}
+
+function parseAttribution(value: string | null) {
+    if (!value) {
+        return null;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(value);
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            return null;
+        }
+        const cartItemId: unknown = Reflect.get(parsed, 'cartItemId');
+        const holdExpiresAt: unknown = Reflect.get(parsed, 'holdExpiresAt');
+        const outletOfferId: unknown = Reflect.get(parsed, 'outletOfferId');
+        if (
+            !isPositiveSafeInteger(cartItemId) ||
+            !isPositiveSafeInteger(outletOfferId) ||
+            typeof holdExpiresAt !== 'string' ||
+            !Number.isFinite(new Date(holdExpiresAt).getTime())
+        ) {
+            return null;
+        }
+
+        return { cartItemId, holdExpiresAt, outletOfferId };
+    } catch {
+        return null;
+    }
+}
+
+function storage() {
+    return typeof window === 'undefined' ? null : window.sessionStorage;
+}
+
+export function hasOutletGardenCommerceAttribution() {
+    try {
+        return Boolean(storage()?.getItem(outletGardenCommerceAttributionKey));
+    } catch {
+        return false;
+    }
+}
+
+export function storeOutletGardenCommerceAttribution(
+    attribution: OutletGardenCommerceAttribution,
+) {
+    try {
+        storage()?.setItem(
+            outletGardenCommerceAttributionKey,
+            JSON.stringify(attribution),
+        );
+    } catch {
+        // Attribution is optional and must never block a reservation.
+    }
+}
+
+export function clearOutletGardenCommerceAttribution() {
+    try {
+        storage()?.removeItem(outletGardenCommerceAttributionKey);
+    } catch {
+        // Session storage is optional.
+    }
+}
+
+export function resolveOutletGardenCommerceAttribution(
+    items: readonly OutletCartItemForAttribution[],
+    now = Date.now(),
+) {
+    let value: string | null = null;
+    try {
+        value = storage()?.getItem(outletGardenCommerceAttributionKey) ?? null;
+    } catch {
+        return null;
+    }
+
+    const attribution = resolveOutletGardenCommerceAttributionValue(
+        value,
+        items,
+        now,
+    );
+    if (!attribution) {
+        clearOutletGardenCommerceAttribution();
+    }
+    return attribution;
+}
+
+export function resolveOutletGardenCommerceAttributionValue(
+    value: string | null,
+    items: readonly OutletCartItemForAttribution[],
+    now = Date.now(),
+) {
+    const attribution = parseAttribution(value);
+
+    if (!attribution || new Date(attribution.holdExpiresAt).getTime() <= now) {
+        return null;
+    }
+
+    const item = items.find(
+        (candidate) => candidate.id === attribution?.cartItemId,
+    );
+    if (
+        !item?.outlet ||
+        item.outlet.expired ||
+        item.outlet.status !== 'held' ||
+        item.outlet.offerId !== attribution.outletOfferId ||
+        item.outlet.holdExpiresAt !== attribution.holdExpiresAt
+    ) {
+        return null;
+    }
+
+    return attribution;
+}
+
+export function consumeOutletGardenCommerceAttribution(
+    items: readonly OutletCartItemForAttribution[],
+    now = Date.now(),
+) {
+    const attribution = resolveOutletGardenCommerceAttribution(items, now);
+    clearOutletGardenCommerceAttribution();
+    return attribution;
+}

--- a/packages/game/src/analytics/outletGardenCommerceAttribution.unit.ts
+++ b/packages/game/src/analytics/outletGardenCommerceAttribution.unit.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { resolveOutletGardenCommerceAttributionValue } from './outletGardenCommerceAttribution';
+
+const now = Date.parse('2026-08-12T10:00:00.000Z');
+const holdExpiresAt = '2026-08-12T10:10:00.000Z';
+const value = JSON.stringify({
+    cartItemId: 11,
+    holdExpiresAt,
+    outletOfferId: 302,
+});
+const item = {
+    id: 11,
+    outlet: {
+        expired: false,
+        holdExpiresAt,
+        offerId: 302,
+        status: 'held',
+    },
+};
+
+test('resolves only a matching unexpired Outlet hold', () => {
+    assert.deepEqual(
+        resolveOutletGardenCommerceAttributionValue(value, [item], now),
+        { cartItemId: 11, holdExpiresAt, outletOfferId: 302 },
+    );
+    assert.equal(
+        resolveOutletGardenCommerceAttributionValue(value, [], now),
+        null,
+    );
+    assert.equal(
+        resolveOutletGardenCommerceAttributionValue(
+            value,
+            [{ ...item, outlet: { ...item.outlet, offerId: 303 } }],
+            now,
+        ),
+        null,
+    );
+});
+
+test('fails closed for expired or malformed attribution', () => {
+    assert.equal(
+        resolveOutletGardenCommerceAttributionValue(
+            value,
+            [item],
+            Date.parse(holdExpiresAt),
+        ),
+        null,
+    );
+    assert.equal(
+        resolveOutletGardenCommerceAttributionValue('{bad', [item], now),
+        null,
+    );
+});

--- a/packages/game/src/hooks/useOutletGardenTargetGarden.ts
+++ b/packages/game/src/hooks/useOutletGardenTargetGarden.ts
@@ -1,0 +1,80 @@
+import { clientAuthenticated, type GardenResponse } from '@gredice/client';
+import { useQuery } from '@tanstack/react-query';
+import { createGardenPosition, type GardenStack } from '../types/Stack';
+
+export const outletGardenTargetGardenQueryKey = (gardenId: number | null) => [
+    'gardens',
+    'outlet-target',
+    gardenId,
+];
+
+type OutletGardenTargetGardenResponse = Pick<
+    GardenResponse,
+    'id' | 'isSandbox' | 'raisedBeds' | 'stacks'
+>;
+
+export class OutletGardenAuthenticationRequiredError extends Error {
+    override readonly name = 'OutletGardenAuthenticationRequiredError';
+}
+
+export function normalizeOutletGardenTargetGarden(
+    garden: OutletGardenTargetGardenResponse,
+) {
+    const stacks: GardenStack[] = [];
+
+    for (const [x, yPositions] of Object.entries(garden.stacks ?? {})) {
+        for (const [y, blocks] of Object.entries(yPositions)) {
+            stacks.push({
+                position: createGardenPosition(Number(x), 0, Number(y)),
+                blocks: (blocks ?? []).map((block) => ({
+                    id: block.id,
+                    message: block.message,
+                    name: block.name,
+                    rotation: block.rotation ?? 0,
+                    variant: block.variant,
+                })),
+            });
+        }
+    }
+
+    return {
+        id: garden.id,
+        isSandbox: garden.isSandbox,
+        raisedBeds: garden.raisedBeds,
+        stacks,
+    };
+}
+
+export function useOutletGardenTargetGarden(gardenId: number | null) {
+    return useQuery({
+        enabled:
+            gardenId !== null && Number.isSafeInteger(gardenId) && gardenId > 0,
+        queryFn: async () => {
+            if (gardenId === null) {
+                return null;
+            }
+
+            const response = await clientAuthenticated().api.gardens[
+                ':gardenId'
+            ].$get({
+                param: { gardenId: gardenId.toString() },
+            });
+            if (response.status === 401) {
+                throw new OutletGardenAuthenticationRequiredError(
+                    'Outlet target garden authentication expired',
+                );
+            }
+            if (response.status === 404) {
+                return null;
+            }
+            if (response.status !== 200) {
+                throw new Error('Failed to fetch Outlet target garden');
+            }
+
+            return normalizeOutletGardenTargetGarden(await response.json());
+        },
+        queryKey: outletGardenTargetGardenQueryKey(gardenId),
+        retry: false,
+        staleTime: 60_000,
+    });
+}

--- a/packages/game/src/hooks/useOutletGardenTargetGarden.unit.ts
+++ b/packages/game/src/hooks/useOutletGardenTargetGarden.unit.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { normalizeOutletGardenTargetGarden } from './useOutletGardenTargetGarden';
+
+test('normalizes nested owner garden stacks for Outlet target discovery', () => {
+    const garden = normalizeOutletGardenTargetGarden({
+        id: 7,
+        isSandbox: false,
+        raisedBeds: [],
+        stacks: {
+            '2': {
+                '3': [
+                    {
+                        id: 'grass-1',
+                        message: null,
+                        name: 'Block_Grass',
+                        rotation: null,
+                        variant: null,
+                    },
+                ],
+            },
+        },
+    });
+
+    assert.equal(garden.id, 7);
+    assert.deepEqual(garden.stacks, [
+        {
+            blocks: [
+                {
+                    id: 'grass-1',
+                    message: null,
+                    name: 'Block_Grass',
+                    rotation: 0,
+                    variant: null,
+                },
+            ],
+            position: { x: 2, y: 0, z: 3 },
+        },
+    ]);
+});

--- a/packages/game/src/hooks/useSetShoppingCartItem.ts
+++ b/packages/game/src/hooks/useSetShoppingCartItem.ts
@@ -146,9 +146,9 @@ function applyOptimisticShoppingCartItem(
     );
 }
 
-export function useSetShoppingCartItem() {
+export function useSetShoppingCartItem(enabled = true) {
     const queryClient = useQueryClient();
-    const { data: cart } = useShoppingCart();
+    const { data: cart } = useShoppingCart(enabled);
     return useMutation({
         mutationFn: async (item: SetShoppingCartItemInput) => {
             if (!cart) {

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -16,6 +16,7 @@ import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import { useEffect, useLayoutEffect, useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
+import { consumeOutletGardenCommerceAttribution } from '../analytics/outletGardenCommerceAttribution';
 import { isCompleteDeliverySelection, useCheckout } from '../hooks/useCheckout';
 import { useCurrentAccount } from '../hooks/useCurrentAccount';
 import { useHarvestSchedule } from '../hooks/useHarvestSchedule';
@@ -147,6 +148,9 @@ export function ShoppingCart({
             }),
         };
 
+        const outletAttribution = consumeOutletGardenCommerceAttribution(
+            cart.items,
+        );
         track('game_cart_checkout_clicked', {
             has_delivery_selection:
                 isCompleteDeliverySelection(deliverySelection),
@@ -154,7 +158,14 @@ export function ShoppingCart({
             item_count: cart.items.length,
             total: cart.total,
             total_sunflowers: cart.totalSunflowers,
+            source: outletAttribution ? 'outlet_garden' : undefined,
         });
+        if (outletAttribution) {
+            track('game_outlet_garden_checkout_continued', {
+                cart_item_id: outletAttribution.cartItemId,
+                outlet_offer_id: outletAttribution.outletOfferId,
+            });
+        }
         checkout.mutate(checkoutData);
     }
 

--- a/packages/game/src/hud/raisedBed/plantPickerNavigation.ts
+++ b/packages/game/src/hud/raisedBed/plantPickerNavigation.ts
@@ -2,6 +2,10 @@ import { isRaisedBedAbandoned } from '../../raisedBedConstants';
 import type { GardenStack } from '../../types/Stack';
 import { getRaisedBedBlockIds } from '../../utils/raisedBedBlocks';
 import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
+import {
+    getLegacySowingTargetAvailability,
+    readAdvancedSowingCartItemSelectionSummary,
+} from './advancedSowingSubmission';
 
 type RaisedBedTargetField = {
     active?: boolean | null;
@@ -16,6 +20,7 @@ type RaisedBedTarget = {
     isValid: boolean;
     name?: string | null;
     orientation?: 'vertical' | 'horizontal';
+    plantings?: unknown;
     status: string;
 };
 
@@ -27,6 +32,7 @@ export type RaisedBedFieldTargetGarden = {
 };
 
 export type RaisedBedFieldTargetCartItem = {
+    advancedSowingSelection?: unknown;
     entityTypeName?: string | null;
     gardenId?: number | null;
     positionIndex?: number | null;
@@ -41,6 +47,7 @@ export type EmptyRaisedBedFieldTarget = {
 };
 
 type EmptyRaisedBedFieldTargetOptions = {
+    includeAllFields?: boolean;
     includeNotYetActiveRaisedBeds?: boolean;
 };
 
@@ -104,7 +111,15 @@ export function findEmptyRaisedBedFieldTargets(
         );
         for (const item of cartItems ?? []) {
             if (isRaisedBedCartPlantItem(item, garden.id, raisedBed.id)) {
-                occupiedPositionIndices.add(item.positionIndex);
+                const advancedSowingSelection =
+                    readAdvancedSowingCartItemSelectionSummary(item);
+                if (advancedSowingSelection) {
+                    for (const occupiedPositionIndex of advancedSowingSelection.occupiedPositionIndices) {
+                        occupiedPositionIndices.add(occupiedPositionIndex);
+                    }
+                } else {
+                    occupiedPositionIndices.add(item.positionIndex);
+                }
             }
         }
 
@@ -113,13 +128,21 @@ export function findEmptyRaisedBedFieldTargets(
             positionIndex < blockCount * 9;
             positionIndex += 1
         ) {
-            if (!occupiedPositionIndices.has(positionIndex)) {
+            if (
+                !occupiedPositionIndices.has(positionIndex) &&
+                getLegacySowingTargetAvailability({
+                    plantings: raisedBed.plantings,
+                    positionIndex,
+                }).available
+            ) {
                 targets.push({
                     positionIndex,
                     raisedBedId: raisedBed.id,
                     raisedBedName,
                 });
-                break;
+                if (!options.includeAllFields) {
+                    break;
+                }
             }
         }
     }

--- a/packages/game/src/hud/raisedBed/plantPickerNavigation.unit.ts
+++ b/packages/game/src/hud/raisedBed/plantPickerNavigation.unit.ts
@@ -87,3 +87,65 @@ test('findEmptyRaisedBedFieldTargets includes not-yet-active beds for outlet pla
         ],
     );
 });
+
+test('findEmptyRaisedBedFieldTargets can return every eligible field', () => {
+    assert.deepEqual(
+        findEmptyRaisedBedFieldTargets(garden, null, {
+            includeAllFields: true,
+        }).map((target) => target.positionIndex),
+        [1, 2, 3, 4, 5, 6, 7, 8],
+    );
+});
+
+test('findEmptyRaisedBedFieldTargets excludes a pending Advanced Sowing footprint', () => {
+    const cartItems = [
+        {
+            advancedSowingSelection: {
+                fieldSpanColumns: 2,
+                fieldSpanRows: 1,
+                kind: 'advanced-sowing-selection-summary',
+                layoutKey: 'v1:fields:1x2:plants:1x2',
+                occupiedPositionIndices: [1, 2],
+                plantCount: 2,
+                selectedDistanceCm: 20,
+                version: 1,
+            },
+            entityTypeName: 'plantSort',
+            gardenId: 1,
+            positionIndex: 1,
+            raisedBedId: 11,
+            status: 'new',
+        },
+    ] satisfies RaisedBedFieldTargetCartItem[];
+
+    assert.deepEqual(
+        findEmptyRaisedBedFieldTargets(garden, cartItems, {
+            includeAllFields: true,
+        }).map((target) => target.positionIndex),
+        [3, 4, 5, 6, 7, 8],
+    );
+});
+
+test('findEmptyRaisedBedFieldTargets excludes active selected planting memberships', () => {
+    const selectedPlantingGarden: RaisedBedFieldTargetGarden = {
+        ...garden,
+        raisedBeds: [
+            {
+                ...garden.raisedBeds[0],
+                plantings: [
+                    {
+                        configurationSource: 'selected',
+                        isActive: true,
+                        isDeleted: false,
+                        memberships: [{ positionIndex: 1 }],
+                    },
+                ],
+            },
+        ],
+    };
+
+    assert.equal(
+        findFirstEmptyRaisedBedField(selectedPlantingGarden)?.positionIndex,
+        2,
+    );
+});

--- a/packages/game/src/viewers/OutletGardenBrowserViewer.tsx
+++ b/packages/game/src/viewers/OutletGardenBrowserViewer.tsx
@@ -8,6 +8,7 @@ import { parseAsInteger, useQueryState } from 'nuqs';
 import { useCallback, useEffect, useRef } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useOutletOffers } from '../hooks/useOutletOffers';
+import type { OutletGardenCommerceController } from './OutletGardenCommerce';
 import { OutletGardenOfferBrowser } from './OutletGardenOfferBrowser';
 import type { OutletGardenFallbackReason } from './outletGardenRenderer';
 
@@ -27,12 +28,16 @@ function fallbackMessage(reason: OutletGardenFallbackReason) {
 }
 
 export type OutletGardenBrowserViewerProps = {
+    commerce?: OutletGardenCommerceController;
     fallbackReason?: OutletGardenFallbackReason;
+    onAuthenticationRequired?: () => void;
     onUse3D?: () => void;
 };
 
 export function OutletGardenBrowserViewer({
+    commerce,
     fallbackReason = 'user',
+    onAuthenticationRequired,
     onUse3D,
 }: OutletGardenBrowserViewerProps = {}) {
     const router = useRouter();
@@ -118,6 +123,7 @@ export function OutletGardenBrowserViewer({
 
             <OutletGardenOfferBrowser
                 className="border-t-0 lg:border-l"
+                commerce={commerce}
                 headerAction={
                     <div className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-lime-300 bg-lime-50 p-3 text-sm text-lime-950 dark:border-lime-900 dark:bg-lime-950/40 dark:text-lime-50">
                         <p
@@ -147,6 +153,7 @@ export function OutletGardenBrowserViewer({
                 isLoading={isLoading}
                 offers={offers}
                 onExit={requestExit}
+                onAuthenticationRequired={onAuthenticationRequired}
                 onRetry={retryOffers}
                 onSelectOffer={selectOffer}
                 renderer="list"

--- a/packages/game/src/viewers/OutletGardenCommerce.tsx
+++ b/packages/game/src/viewers/OutletGardenCommerce.tsx
@@ -1,0 +1,1076 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { Check, Reset, Sprout } from '@gredice/ui/icons';
+import { Spinner } from '@gredice/ui/Spinner';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
+import {
+    hasOutletGardenCommerceAttribution,
+    resolveOutletGardenCommerceAttribution,
+    storeOutletGardenCommerceAttribution,
+} from '../analytics/outletGardenCommerceAttribution';
+import { buildOutletCartItemPayload } from '../hooks/shoppingCartItemMutation';
+import {
+    queryKey as currentUserQueryKey,
+    useCurrentUser,
+} from '../hooks/useCurrentUser';
+import { useGardens, useGardensKeys } from '../hooks/useGardens';
+import {
+    OutletGardenAuthenticationRequiredError,
+    useOutletGardenTargetGarden,
+} from '../hooks/useOutletGardenTargetGarden';
+import {
+    type OutletOfferData,
+    useOutletOffers,
+    useOutletOffersQueryKey,
+} from '../hooks/useOutletOffers';
+import {
+    ShoppingCartMutationError,
+    useSetShoppingCartItem,
+} from '../hooks/useSetShoppingCartItem';
+import {
+    type ShoppingCartData,
+    useShoppingCart,
+    useShoppingCartQueryKey,
+} from '../hooks/useShoppingCart';
+import {
+    type EmptyRaisedBedFieldTarget,
+    findEmptyRaisedBedFieldTargets,
+} from '../hud/raisedBed/plantPickerNavigation';
+import type { OutletGardenRenderer } from './outletGardenRenderer';
+
+export type OutletGardenCommerceState =
+    | 'authentication-required'
+    | 'closed'
+    | 'error'
+    | 'expired'
+    | 'loading'
+    | 'no-targets'
+    | 'query-error'
+    | 'ready'
+    | 'reserving'
+    | 'success'
+    | 'unavailable';
+
+export type OutletGardenCommerceReceipt = {
+    cartItemId: number;
+    gardenId: number;
+    gardenName: string;
+    holdExpiresAt: string;
+    offer: OutletOfferData;
+    positionIndex: number;
+    raisedBedId: number;
+    raisedBedName: string;
+};
+
+type OutletGardenCommerceGarden = {
+    id: number;
+    name: string;
+};
+
+export type OutletGardenCommerceController = {
+    cartHref: `/?vrt=${number}&kosarica=true` | null;
+    close: () => void;
+    continueToCart: () => void;
+    enabled: boolean;
+    errorMessage: string | null;
+    gardens: readonly OutletGardenCommerceGarden[];
+    open: () => void;
+    opened: boolean;
+    receipt: OutletGardenCommerceReceipt | null;
+    refreshAuthentication: () => Promise<void>;
+    reserve: () => Promise<void>;
+    retryQueries: () => Promise<void>;
+    selectGarden: (gardenId: number) => void;
+    selectTarget: (targetKey: string) => void;
+    selectedGardenId: number | null;
+    selectedOffer: OutletOfferData | null;
+    selectedTargetKey: string | null;
+    state: OutletGardenCommerceState;
+    targets: readonly EmptyRaisedBedFieldTarget[];
+};
+
+type OutletGardenCommerceStateInput = {
+    authenticated: boolean;
+    authenticatedQueriesPending: boolean;
+    enabled: boolean;
+    hasEligibleTarget: boolean;
+    hasMutationError: boolean;
+    hasQueryError: boolean;
+    hasSelectedOffer: boolean;
+    mutationPending: boolean;
+    now: number;
+    opened: boolean;
+    queryRetrying: boolean;
+    receiptHoldExpiresAt: string | null;
+    userPending: boolean;
+};
+
+export function hasOutletGardenAuthenticationExpired({
+    authenticated,
+    gardensUnauthorized,
+    shoppingCartUnauthorized,
+    targetGardenUnauthorized,
+}: {
+    authenticated: boolean;
+    gardensUnauthorized: boolean;
+    shoppingCartUnauthorized: boolean;
+    targetGardenUnauthorized: boolean;
+}) {
+    return (
+        authenticated &&
+        (gardensUnauthorized ||
+            shoppingCartUnauthorized ||
+            targetGardenUnauthorized)
+    );
+}
+
+export function resolveOutletGardenCommerceState({
+    authenticated,
+    authenticatedQueriesPending,
+    enabled,
+    hasEligibleTarget,
+    hasMutationError,
+    hasQueryError,
+    hasSelectedOffer,
+    mutationPending,
+    now,
+    opened,
+    queryRetrying,
+    receiptHoldExpiresAt,
+    userPending,
+}: OutletGardenCommerceStateInput): OutletGardenCommerceState {
+    if (!enabled || !opened) {
+        return 'closed';
+    }
+    if (receiptHoldExpiresAt) {
+        return new Date(receiptHoldExpiresAt).getTime() > now
+            ? 'success'
+            : 'expired';
+    }
+    if (mutationPending) {
+        return 'reserving';
+    }
+    if (hasMutationError) {
+        return 'error';
+    }
+    if (queryRetrying || userPending) {
+        return 'loading';
+    }
+    if (hasQueryError) {
+        return 'query-error';
+    }
+    if (!authenticated) {
+        return 'authentication-required';
+    }
+    if (authenticatedQueriesPending) {
+        return 'loading';
+    }
+    if (!hasSelectedOffer) {
+        return 'unavailable';
+    }
+    if (!hasEligibleTarget) {
+        return 'no-targets';
+    }
+    return 'ready';
+}
+
+function targetKey(target: EmptyRaisedBedFieldTarget) {
+    return `${target.raisedBedId.toString()}:${target.positionIndex.toString()}`;
+}
+
+function isHeldOutletCartItem(
+    item: ShoppingCartData['items'][number],
+    offerId: number,
+    plantSortId: number,
+    gardenId: number,
+    target: EmptyRaisedBedFieldTarget,
+) {
+    return (
+        item.entityTypeName === 'plantSort' &&
+        item.entityId === plantSortId.toString() &&
+        item.amount === 1 &&
+        item.gardenId === gardenId &&
+        item.raisedBedId === target.raisedBedId &&
+        item.positionIndex === target.positionIndex &&
+        item.status === 'new' &&
+        item.outlet?.offerId === offerId &&
+        item.outlet.status === 'held' &&
+        !item.outlet.expired &&
+        typeof item.outlet.holdExpiresAt === 'string'
+    );
+}
+
+function serializedDate(value: unknown) {
+    if (typeof value !== 'string' && !(value instanceof Date)) {
+        return null;
+    }
+    const date = new Date(value);
+    return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+}
+
+type HeldOutletCartItemOfferSource = {
+    entityId: string;
+    entityTypeName: string;
+    outlet?: {
+        comparePrice: number | null;
+        endAt: unknown;
+        expired: boolean;
+        initialPlantStatus: string;
+        offerId: number;
+        outletPrice: number;
+        sowingDate: unknown;
+        status: string;
+    };
+    shopData: {
+        description?: string;
+        image?: string;
+        name?: string;
+    };
+};
+
+export function outletGardenOfferFromHeldCartItem(
+    item: HeldOutletCartItemOfferSource,
+) {
+    const outlet = item.outlet;
+    const plantSortId = Number(item.entityId);
+    const sowingDate = serializedDate(outlet?.sowingDate);
+    const endAt = serializedDate(outlet?.endAt);
+    if (
+        item.entityTypeName !== 'plantSort' ||
+        !Number.isSafeInteger(plantSortId) ||
+        plantSortId <= 0 ||
+        !outlet ||
+        outlet.status !== 'held' ||
+        outlet.expired ||
+        !sowingDate ||
+        !endAt
+    ) {
+        return null;
+    }
+
+    return {
+        comparePrice: outlet.comparePrice,
+        endAt,
+        id: outlet.offerId,
+        imageUrls: item.shopData.image ? [item.shopData.image] : [],
+        initialPlantStatus: outlet.initialPlantStatus,
+        outletPrice: outlet.outletPrice,
+        plantSort: {
+            description: item.shopData.description ?? null,
+            id: plantSortId,
+            imageUrl: item.shopData.image ?? null,
+            name: item.shopData.name ?? 'Outlet sadnica',
+            plant: null,
+        },
+        quantity: 1,
+        remainingQuantity: 0,
+        reservedQuantity: 1,
+        soldQuantity: 0,
+        sowingDate,
+        startAt: sowingDate,
+        url: '',
+    } satisfies OutletOfferData;
+}
+
+function commerceErrorMessage(error: unknown) {
+    if (error instanceof ShoppingCartMutationError) {
+        if (error.code === 'OUTLET_OFFER_UNAVAILABLE') {
+            return 'Ponuda je upravo rasprodana ili više nije aktivna. Osvježili smo dostupne ponude.';
+        }
+        if (error.code === 'OUTLET_TARGET_UNAVAILABLE') {
+            return 'Odabrano mjesto više nije slobodno. Odaberi drugo mjesto i pokušaj ponovno.';
+        }
+        if (error.code === 'OUTLET_TARGET_REQUIRED') {
+            return 'Odaberi vrt i slobodno mjesto u gredici.';
+        }
+    }
+
+    return 'Rezervacija trenutačno nije uspjela. Pokušaj ponovno.';
+}
+
+export function useOutletGardenCommerce({
+    enabled,
+    renderer,
+    requested = false,
+    selectedOfferId,
+    onReservationIntentChange,
+}: {
+    enabled: boolean;
+    onReservationIntentChange?: (requested: boolean) => void;
+    renderer: OutletGardenRenderer;
+    requested?: boolean;
+    selectedOfferId: number | null;
+}): OutletGardenCommerceController {
+    const { track } = useGameAnalytics();
+    const queryClient = useQueryClient();
+    const { data: offers = [], refetch: refetchOffers } = useOutletOffers();
+    const selectedLiveOffer =
+        offers.find((offer) => offer.id === selectedOfferId) ?? null;
+    const [opened, setOpened] = useState(requested && enabled);
+    const [selectedGardenId, setSelectedGardenId] = useState<number | null>(
+        null,
+    );
+    const [selectedTargetKey, setSelectedTargetKey] = useState<string | null>(
+        null,
+    );
+    const [receipt, setReceipt] = useState<OutletGardenCommerceReceipt | null>(
+        null,
+    );
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [queryRetrying, setQueryRetrying] = useState(false);
+    const [now, setNow] = useState(() => Date.now());
+    const previousOfferIdRef = useRef(selectedOfferId);
+    const shouldLoadAuthenticated = enabled && opened;
+    const currentUser = useCurrentUser(shouldLoadAuthenticated);
+    const authenticated = Boolean(currentUser.data);
+    const gardensQuery = useGardens(!shouldLoadAuthenticated || !authenticated);
+    const shoppingCart = useShoppingCart(
+        shouldLoadAuthenticated && authenticated,
+    );
+    const eligibleGardens = useMemo(
+        () =>
+            (gardensQuery.data ?? [])
+                .filter((garden) => !garden.isSandbox)
+                .map((garden) => ({ id: garden.id, name: garden.name })),
+        [gardensQuery.data],
+    );
+    const targetGarden = useOutletGardenTargetGarden(
+        shouldLoadAuthenticated && authenticated ? selectedGardenId : null,
+    );
+    const authenticationExpired = hasOutletGardenAuthenticationExpired({
+        authenticated,
+        gardensUnauthorized:
+            gardensQuery.isSuccess && gardensQuery.data === null,
+        shoppingCartUnauthorized:
+            shoppingCart.isSuccess && shoppingCart.data === null,
+        targetGardenUnauthorized:
+            targetGarden.error instanceof
+            OutletGardenAuthenticationRequiredError,
+    });
+    const targets = useMemo(
+        () =>
+            findEmptyRaisedBedFieldTargets(
+                targetGarden.data,
+                shoppingCart.data?.items,
+                {
+                    includeAllFields: true,
+                    includeNotYetActiveRaisedBeds: true,
+                },
+            ),
+        [shoppingCart.data?.items, targetGarden.data],
+    );
+    const selectedTarget =
+        targets.find((target) => targetKey(target) === selectedTargetKey) ??
+        targets[0] ??
+        null;
+    const mutation = useSetShoppingCartItem(
+        shouldLoadAuthenticated && authenticated && !authenticationExpired,
+    );
+
+    useEffect(() => {
+        if (!authenticationExpired) {
+            return;
+        }
+        queryClient.removeQueries({ queryKey: useGardensKeys });
+        queryClient.removeQueries({ queryKey: useShoppingCartQueryKey });
+        queryClient.setQueryData(currentUserQueryKey.currentUser, null);
+        onReservationIntentChange?.(true);
+    }, [authenticationExpired, onReservationIntentChange, queryClient]);
+
+    useEffect(() => {
+        if (requested && enabled && selectedOfferId !== null) {
+            setOpened(true);
+        }
+    }, [enabled, requested, selectedOfferId]);
+
+    useEffect(() => {
+        if (
+            enabled &&
+            selectedOfferId !== null &&
+            hasOutletGardenCommerceAttribution()
+        ) {
+            setOpened(true);
+        }
+    }, [enabled, selectedOfferId]);
+
+    useEffect(() => {
+        if (previousOfferIdRef.current === selectedOfferId) {
+            return;
+        }
+        previousOfferIdRef.current = selectedOfferId;
+        setOpened(requested && enabled && selectedOfferId !== null);
+        setReceipt(null);
+        setErrorMessage(null);
+        setSelectedTargetKey(null);
+    }, [enabled, requested, selectedOfferId]);
+
+    useEffect(() => {
+        if (
+            selectedGardenId === null ||
+            !eligibleGardens.some((garden) => garden.id === selectedGardenId)
+        ) {
+            setSelectedGardenId(eligibleGardens[0]?.id ?? null);
+            setSelectedTargetKey(null);
+        }
+    }, [eligibleGardens, selectedGardenId]);
+
+    useEffect(() => {
+        if (selectedTarget && selectedTargetKey !== targetKey(selectedTarget)) {
+            setSelectedTargetKey(targetKey(selectedTarget));
+        }
+    }, [selectedTarget, selectedTargetKey]);
+
+    useEffect(() => {
+        if (!receipt) {
+            return;
+        }
+        const expiresAt = new Date(receipt.holdExpiresAt).getTime();
+        const delay = Math.max(0, expiresAt - Date.now());
+        const timeout = window.setTimeout(
+            () => {
+                setNow(Date.now());
+                track('game_outlet_garden_hold_expired', {
+                    cart_item_id: receipt.cartItemId,
+                    garden_id: receipt.gardenId,
+                    outlet_offer_id: receipt.offer.id,
+                    renderer,
+                });
+            },
+            Math.min(delay + 50, 2_147_483_647),
+        );
+        return () => window.clearTimeout(timeout);
+    }, [receipt, renderer, track]);
+
+    useEffect(() => {
+        const cart = shoppingCart.data;
+        if (
+            receipt ||
+            selectedOfferId === null ||
+            !cart ||
+            eligibleGardens.length === 0
+        ) {
+            return;
+        }
+        const attribution = resolveOutletGardenCommerceAttribution(cart.items);
+        if (!attribution || attribution.outletOfferId !== selectedOfferId) {
+            return;
+        }
+        const item = cart.items.find(
+            (candidate) => candidate.id === attribution.cartItemId,
+        );
+        const offer = item ? outletGardenOfferFromHeldCartItem(item) : null;
+        if (
+            !item ||
+            !offer ||
+            typeof item.gardenId !== 'number' ||
+            typeof item.raisedBedId !== 'number' ||
+            typeof item.positionIndex !== 'number'
+        ) {
+            return;
+        }
+        const garden = eligibleGardens.find(
+            (candidate) => candidate.id === item.gardenId,
+        );
+        if (!garden) {
+            return;
+        }
+        const raisedBedName =
+            targetGarden.data?.raisedBeds
+                .find((raisedBed) => raisedBed.id === item.raisedBedId)
+                ?.name?.trim() ?? `Gredica ${item.raisedBedId.toString()}`;
+        setReceipt({
+            cartItemId: item.id,
+            gardenId: garden.id,
+            gardenName: garden.name,
+            holdExpiresAt: attribution.holdExpiresAt,
+            offer,
+            positionIndex: item.positionIndex,
+            raisedBedId: item.raisedBedId,
+            raisedBedName,
+        });
+        setSelectedGardenId(garden.id);
+        setOpened(true);
+        setNow(Date.now());
+    }, [
+        eligibleGardens,
+        receipt,
+        selectedOfferId,
+        shoppingCart.data,
+        targetGarden.data?.raisedBeds,
+    ]);
+
+    const open = useCallback(() => {
+        if (!enabled || selectedOfferId === null) {
+            return;
+        }
+        setOpened(true);
+        onReservationIntentChange?.(true);
+        setErrorMessage(null);
+        track('game_outlet_garden_reservation_opened', {
+            outlet_offer_id: selectedOfferId,
+            renderer,
+        });
+    }, [enabled, onReservationIntentChange, renderer, selectedOfferId, track]);
+
+    const close = useCallback(() => {
+        setOpened(false);
+        onReservationIntentChange?.(false);
+        setErrorMessage(null);
+    }, [onReservationIntentChange]);
+
+    const continueToCart = useCallback(() => {
+        if (!receipt) {
+            return;
+        }
+        track('game_outlet_garden_cart_continued', {
+            cart_item_id: receipt.cartItemId,
+            garden_id: receipt.gardenId,
+            outlet_offer_id: receipt.offer.id,
+            renderer,
+        });
+    }, [receipt, renderer, track]);
+
+    const refreshAuthentication = useCallback(async () => {
+        await Promise.all([
+            queryClient.invalidateQueries({ queryKey: ['currentUser'] }),
+            queryClient.invalidateQueries({ queryKey: useGardensKeys }),
+            queryClient.invalidateQueries({
+                queryKey: useShoppingCartQueryKey,
+            }),
+        ]);
+    }, [queryClient]);
+
+    const retryQueries = useCallback(async () => {
+        setQueryRetrying(true);
+        try {
+            if (currentUser.isError) {
+                await currentUser.refetch();
+                return;
+            }
+
+            const retries: Promise<unknown>[] = [];
+            if (gardensQuery.isError) {
+                retries.push(gardensQuery.refetch());
+            }
+            if (shoppingCart.isError) {
+                retries.push(shoppingCart.refetch());
+            }
+            if (targetGarden.isError) {
+                retries.push(targetGarden.refetch());
+            }
+            await Promise.all(retries);
+        } finally {
+            setQueryRetrying(false);
+        }
+    }, [currentUser, gardensQuery, shoppingCart, targetGarden]);
+
+    const selectGarden = useCallback(
+        (gardenId: number) => {
+            if (!eligibleGardens.some((garden) => garden.id === gardenId)) {
+                return;
+            }
+            setSelectedGardenId(gardenId);
+            setSelectedTargetKey(null);
+            setErrorMessage(null);
+            track('game_outlet_garden_field_selected', {
+                garden_id: gardenId,
+                outlet_offer_id: selectedOfferId ?? undefined,
+                renderer,
+            });
+        },
+        [eligibleGardens, renderer, selectedOfferId, track],
+    );
+
+    const selectTarget = useCallback(
+        (nextTargetKey: string) => {
+            const target = targets.find(
+                (candidate) => targetKey(candidate) === nextTargetKey,
+            );
+            if (!target) {
+                return;
+            }
+            setSelectedTargetKey(nextTargetKey);
+            setErrorMessage(null);
+            track('game_outlet_garden_field_selected', {
+                garden_id: selectedGardenId ?? undefined,
+                outlet_offer_id: selectedOfferId ?? undefined,
+                position_index: target.positionIndex,
+                raised_bed_id: target.raisedBedId,
+                renderer,
+            });
+        },
+        [renderer, selectedGardenId, selectedOfferId, targets, track],
+    );
+
+    const reserve = useCallback(async () => {
+        const offer = selectedLiveOffer;
+        const garden = eligibleGardens.find(
+            (candidate) => candidate.id === selectedGardenId,
+        );
+        if (!offer || !garden || !selectedTarget || mutation.isPending) {
+            return;
+        }
+
+        setErrorMessage(null);
+        track('game_outlet_garden_hold_attempted', {
+            garden_id: garden.id,
+            outlet_offer_id: offer.id,
+            plant_sort_id: offer.plantSort.id,
+            position_index: selectedTarget.positionIndex,
+            raised_bed_id: selectedTarget.raisedBedId,
+            renderer,
+        });
+
+        try {
+            await mutation.mutateAsync(
+                buildOutletCartItemPayload({
+                    gardenId: garden.id,
+                    outletOfferId: offer.id,
+                    plantSortId: offer.plantSort.id,
+                    positionIndex: selectedTarget.positionIndex,
+                    raisedBedId: selectedTarget.raisedBedId,
+                }),
+            );
+            await Promise.all([
+                queryClient.refetchQueries({
+                    queryKey: useShoppingCartQueryKey,
+                    type: 'active',
+                }),
+                refetchOffers(),
+            ]);
+            const refreshedCart =
+                queryClient.getQueryData<ShoppingCartData | null>(
+                    useShoppingCartQueryKey,
+                );
+            const heldItem = refreshedCart?.items.find((item) =>
+                isHeldOutletCartItem(
+                    item,
+                    offer.id,
+                    offer.plantSort.id,
+                    garden.id,
+                    selectedTarget,
+                ),
+            );
+            const holdExpiresAt = heldItem?.outlet?.holdExpiresAt;
+            const receiptOffer = heldItem
+                ? outletGardenOfferFromHeldCartItem(heldItem)
+                : null;
+            if (
+                !heldItem ||
+                !receiptOffer ||
+                typeof holdExpiresAt !== 'string' ||
+                new Date(holdExpiresAt).getTime() <= Date.now()
+            ) {
+                throw new Error('Verified Outlet hold was not returned');
+            }
+
+            const nextReceipt: OutletGardenCommerceReceipt = {
+                cartItemId: heldItem.id,
+                gardenId: garden.id,
+                gardenName: garden.name,
+                holdExpiresAt,
+                offer: receiptOffer,
+                positionIndex: selectedTarget.positionIndex,
+                raisedBedId: selectedTarget.raisedBedId,
+                raisedBedName: selectedTarget.raisedBedName,
+            };
+            setReceipt(nextReceipt);
+            setNow(Date.now());
+            storeOutletGardenCommerceAttribution({
+                cartItemId: heldItem.id,
+                holdExpiresAt,
+                outletOfferId: receiptOffer.id,
+            });
+            track('game_outlet_garden_hold_succeeded', {
+                cart_item_id: heldItem.id,
+                garden_id: garden.id,
+                outlet_offer_id: receiptOffer.id,
+                position_index: selectedTarget.positionIndex,
+                raised_bed_id: selectedTarget.raisedBedId,
+                renderer,
+            });
+        } catch (error) {
+            if (
+                error instanceof ShoppingCartMutationError &&
+                error.status === 401
+            ) {
+                queryClient.setQueryData(currentUserQueryKey.currentUser, null);
+                setErrorMessage(null);
+                onReservationIntentChange?.(true);
+                await queryClient.invalidateQueries({
+                    queryKey: currentUserQueryKey.currentUser,
+                });
+            } else {
+                const message = commerceErrorMessage(error);
+                setErrorMessage(message);
+            }
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: useShoppingCartQueryKey,
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: useOutletOffersQueryKey,
+                }),
+            ]);
+            track('game_outlet_garden_hold_failed', {
+                error_code:
+                    error instanceof ShoppingCartMutationError
+                        ? (error.code ?? 'unknown')
+                        : 'unknown',
+                garden_id: garden.id,
+                outlet_offer_id: offer.id,
+                position_index: selectedTarget.positionIndex,
+                raised_bed_id: selectedTarget.raisedBedId,
+                renderer,
+            });
+        }
+    }, [
+        eligibleGardens,
+        mutation,
+        onReservationIntentChange,
+        queryClient,
+        refetchOffers,
+        renderer,
+        selectedGardenId,
+        selectedLiveOffer,
+        selectedTarget,
+        track,
+    ]);
+
+    const state = resolveOutletGardenCommerceState({
+        authenticated: authenticated && !authenticationExpired,
+        authenticatedQueriesPending:
+            gardensQuery.isPending ||
+            shoppingCart.isPending ||
+            (selectedGardenId !== null && targetGarden.isPending),
+        enabled,
+        hasEligibleTarget: eligibleGardens.length > 0 && targets.length > 0,
+        hasMutationError: Boolean(errorMessage),
+        hasQueryError:
+            currentUser.isError ||
+            (authenticated &&
+                !authenticationExpired &&
+                (gardensQuery.isError ||
+                    shoppingCart.isError ||
+                    (selectedGardenId !== null && targetGarden.isError))),
+        hasSelectedOffer: Boolean(selectedLiveOffer),
+        mutationPending: mutation.isPending,
+        now,
+        opened,
+        queryRetrying,
+        receiptHoldExpiresAt: receipt?.holdExpiresAt ?? null,
+        userPending: currentUser.isPending,
+    });
+
+    return {
+        cartHref: receipt ? `/?vrt=${receipt.gardenId}&kosarica=true` : null,
+        close,
+        continueToCart,
+        enabled,
+        errorMessage,
+        gardens: eligibleGardens,
+        open,
+        opened,
+        receipt,
+        refreshAuthentication,
+        reserve,
+        retryQueries,
+        selectGarden,
+        selectTarget,
+        selectedGardenId,
+        selectedOffer: selectedLiveOffer ?? receipt?.offer ?? null,
+        selectedTargetKey: selectedTarget ? targetKey(selectedTarget) : null,
+        state,
+        targets,
+    };
+}
+
+const holdTimeFormatter = new Intl.DateTimeFormat('hr-HR', {
+    hour: '2-digit',
+    minute: '2-digit',
+});
+
+export function OutletGardenReservationPanel({
+    commerce,
+    onAuthenticationRequired,
+    onChooseAnother,
+    onContinueToCart,
+}: {
+    commerce: OutletGardenCommerceController;
+    onAuthenticationRequired: () => void;
+    onChooseAnother: () => void;
+    onContinueToCart?: () => void;
+}) {
+    const statusHeadingRef = useRef<HTMLHeadingElement>(null);
+
+    useEffect(() => {
+        if (commerce.state === 'success' || commerce.state === 'expired') {
+            statusHeadingRef.current?.focus({ preventScroll: true });
+        }
+    }, [commerce.state]);
+
+    if (!commerce.enabled) {
+        return null;
+    }
+
+    if (!commerce.opened) {
+        return (
+            <div className="mt-4" data-outlet-garden-commerce>
+                <Button fullWidth onClick={commerce.open} size="lg">
+                    Rezerviraj u svom vrtu
+                </Button>
+            </div>
+        );
+    }
+
+    return (
+        <section
+            aria-live="polite"
+            className="mt-4 rounded-xl border border-lime-200 bg-lime-50/70 p-3 dark:border-lime-900 dark:bg-lime-950/30"
+            data-outlet-garden-commerce
+            data-outlet-garden-commerce-state={commerce.state}
+        >
+            {commerce.state === 'loading' ? (
+                <div className="flex min-h-11 items-center gap-2 text-sm">
+                    <Spinner loadingLabel="Učitavanje vrtova" />
+                    Učitavamo tvoje vrtove i slobodna mjesta...
+                </div>
+            ) : null}
+
+            {commerce.state === 'authentication-required' ? (
+                <div>
+                    <h3 className="font-semibold">Prijavi se za rezervaciju</h3>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        Ponuda ostaje odabrana dok se prijavljuješ.
+                    </p>
+                    <Button
+                        className="mt-3"
+                        fullWidth
+                        onClick={onAuthenticationRequired}
+                        size="lg"
+                    >
+                        Prijavi se i nastavi
+                    </Button>
+                </div>
+            ) : null}
+
+            {commerce.state === 'query-error' ? (
+                <div>
+                    <h3 className="font-semibold">
+                        Nismo uspjeli učitati podatke
+                    </h3>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        Provjeri vezu i pokušaj ponovno. Odabrana ponuda ostaje
+                        sačuvana.
+                    </p>
+                    <Button
+                        className="mt-3"
+                        fullWidth
+                        onClick={() => void commerce.retryQueries()}
+                        size="lg"
+                        startDecorator={<Reset className="size-4" />}
+                        variant="outlined"
+                    >
+                        Pokušaj ponovno
+                    </Button>
+                </div>
+            ) : null}
+
+            {commerce.state === 'ready' ||
+            commerce.state === 'error' ||
+            commerce.state === 'reserving' ? (
+                <div>
+                    <h3 className="font-semibold">Odaberi mjesto za sadnicu</h3>
+                    <div className="mt-3 grid gap-3">
+                        <label className="grid gap-1 text-sm">
+                            <span className="font-medium">Vrt</span>
+                            <select
+                                className="min-h-11 rounded-lg border bg-background px-3"
+                                disabled={commerce.state === 'reserving'}
+                                onChange={(event) =>
+                                    commerce.selectGarden(
+                                        Number(event.currentTarget.value),
+                                    )
+                                }
+                                value={commerce.selectedGardenId ?? ''}
+                            >
+                                {commerce.gardens.map((garden) => (
+                                    <option key={garden.id} value={garden.id}>
+                                        {garden.name}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+                        <label className="grid gap-1 text-sm">
+                            <span className="font-medium">
+                                Mjesto u gredici
+                            </span>
+                            <select
+                                className="min-h-11 rounded-lg border bg-background px-3"
+                                disabled={commerce.state === 'reserving'}
+                                onChange={(event) =>
+                                    commerce.selectTarget(
+                                        event.currentTarget.value,
+                                    )
+                                }
+                                value={commerce.selectedTargetKey ?? ''}
+                            >
+                                {commerce.targets.map((target) => (
+                                    <option
+                                        key={targetKey(target)}
+                                        value={targetKey(target)}
+                                    >
+                                        {target.raisedBedName} · polje{' '}
+                                        {(target.positionIndex + 1).toString()}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+                    </div>
+                    {commerce.errorMessage ? (
+                        <p
+                            className="mt-3 text-sm text-red-700 dark:text-red-300"
+                            role="alert"
+                        >
+                            {commerce.errorMessage}
+                        </p>
+                    ) : null}
+                    <Button
+                        className="mt-3"
+                        disabled={commerce.state === 'reserving'}
+                        fullWidth
+                        onClick={() => void commerce.reserve()}
+                        size="lg"
+                        startDecorator={
+                            commerce.state === 'reserving' ? (
+                                <Spinner loadingLabel="Rezerviranje sadnice" />
+                            ) : undefined
+                        }
+                    >
+                        {commerce.state === 'reserving'
+                            ? 'Rezerviramo...'
+                            : commerce.state === 'error'
+                              ? 'Pokušaj ponovno'
+                              : 'Rezerviraj sadnicu'}
+                    </Button>
+                </div>
+            ) : null}
+
+            {commerce.state === 'no-targets' ? (
+                <div>
+                    <h3 className="font-semibold">Nema slobodnog mjesta</h3>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        Dodaj ili oslobodi mjesto u aktivnoj gredici pa pokušaj
+                        ponovno.
+                    </p>
+                    <Button
+                        className="mt-3"
+                        fullWidth
+                        href="/"
+                        size="lg"
+                        variant="outlined"
+                    >
+                        Povratak u moj vrt
+                    </Button>
+                </div>
+            ) : null}
+
+            {commerce.state === 'unavailable' ? (
+                <div>
+                    <h3 className="font-semibold">Ponuda više nije dostupna</h3>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        Odaberi drugu sadnicu iz aktualnih ponuda.
+                    </p>
+                    <Button
+                        className="mt-3"
+                        fullWidth
+                        onClick={onChooseAnother}
+                        size="lg"
+                        startDecorator={<Reset className="size-4" />}
+                        variant="outlined"
+                    >
+                        Odaberi drugu
+                    </Button>
+                </div>
+            ) : null}
+
+            {commerce.state === 'success' && commerce.receipt ? (
+                <div>
+                    <span className="grid size-10 place-items-center rounded-full bg-lime-200 text-lime-900 dark:bg-lime-900 dark:text-lime-100">
+                        <Check className="size-5" />
+                    </span>
+                    <h3
+                        className="mt-2 font-semibold"
+                        ref={statusHeadingRef}
+                        tabIndex={-1}
+                    >
+                        Sadnica je rezervirana
+                    </h3>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        {commerce.receipt.gardenName} ·{' '}
+                        {commerce.receipt.raisedBedName}, polje{' '}
+                        {(commerce.receipt.positionIndex + 1).toString()}.
+                        Rezervacija vrijedi do{' '}
+                        {holdTimeFormatter.format(
+                            new Date(commerce.receipt.holdExpiresAt),
+                        )}
+                        .
+                    </p>
+                    <div className="mt-3 grid gap-2">
+                        {commerce.cartHref ? (
+                            <Button
+                                fullWidth
+                                href={commerce.cartHref}
+                                onClick={() => {
+                                    commerce.continueToCart();
+                                    onContinueToCart?.();
+                                }}
+                                size="lg"
+                            >
+                                Nastavi u košaricu
+                            </Button>
+                        ) : null}
+                        <Button
+                            fullWidth
+                            onClick={onChooseAnother}
+                            size="lg"
+                            startDecorator={<Sprout className="size-4" />}
+                            variant="outlined"
+                        >
+                            Odaberi drugu sadnicu
+                        </Button>
+                    </div>
+                </div>
+            ) : null}
+
+            {commerce.state === 'expired' && commerce.receipt ? (
+                <div>
+                    <h3
+                        className="font-semibold"
+                        ref={statusHeadingRef}
+                        tabIndex={-1}
+                    >
+                        Rezervacija je istekla
+                    </h3>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        Sadnica više nije zadržana u košarici. Osvježi ponude i
+                        odaberi je ponovno ako je još dostupna.
+                    </p>
+                    <Button
+                        className="mt-3"
+                        fullWidth
+                        onClick={onChooseAnother}
+                        size="lg"
+                        startDecorator={<Reset className="size-4" />}
+                        variant="outlined"
+                    >
+                        Prikaži aktualne ponude
+                    </Button>
+                </div>
+            ) : null}
+        </section>
+    );
+}

--- a/packages/game/src/viewers/OutletGardenCommerce.tsx
+++ b/packages/game/src/viewers/OutletGardenCommerce.tsx
@@ -693,6 +693,9 @@ export function useOutletGardenCommerce({
                 renderer,
             });
         } catch (error) {
+            const targetUnavailable =
+                error instanceof ShoppingCartMutationError &&
+                error.code === 'OUTLET_TARGET_UNAVAILABLE';
             if (
                 error instanceof ShoppingCartMutationError &&
                 error.status === 401
@@ -714,6 +717,7 @@ export function useOutletGardenCommerce({
                 queryClient.invalidateQueries({
                     queryKey: useOutletOffersQueryKey,
                 }),
+                ...(targetUnavailable ? [targetGarden.refetch()] : []),
             ]);
             track('game_outlet_garden_hold_failed', {
                 error_code:
@@ -737,6 +741,7 @@ export function useOutletGardenCommerce({
         selectedGardenId,
         selectedLiveOffer,
         selectedTarget,
+        targetGarden,
         track,
     ]);
 
@@ -748,7 +753,7 @@ export function useOutletGardenCommerce({
             (selectedGardenId !== null && targetGarden.isPending),
         enabled,
         hasEligibleTarget: eligibleGardens.length > 0 && targets.length > 0,
-        hasMutationError: Boolean(errorMessage),
+        hasMutationError: Boolean(errorMessage) && targets.length > 0,
         hasQueryError:
             currentUser.isError ||
             (authenticated &&
@@ -963,9 +968,30 @@ export function OutletGardenReservationPanel({
                 <div>
                     <h3 className="font-semibold">Nema slobodnog mjesta</h3>
                     <p className="mt-1 text-sm text-muted-foreground">
-                        Dodaj ili oslobodi mjesto u aktivnoj gredici pa pokušaj
-                        ponovno.
+                        U odabranom vrtu nema slobodnog mjesta. Odaberi drugi
+                        vrt ili dodaj odnosno oslobodi mjesto u aktivnoj
+                        gredici.
                     </p>
+                    {commerce.gardens.length > 1 ? (
+                        <label className="mt-3 grid gap-1 text-sm">
+                            <span className="font-medium">Vrt</span>
+                            <select
+                                className="min-h-11 rounded-lg border bg-background px-3"
+                                onChange={(event) =>
+                                    commerce.selectGarden(
+                                        Number(event.currentTarget.value),
+                                    )
+                                }
+                                value={commerce.selectedGardenId ?? ''}
+                            >
+                                {commerce.gardens.map((garden) => (
+                                    <option key={garden.id} value={garden.id}>
+                                        {garden.name}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+                    ) : null}
                     <Button
                         className="mt-3"
                         fullWidth

--- a/packages/game/src/viewers/OutletGardenCommerce.unit.ts
+++ b/packages/game/src/viewers/OutletGardenCommerce.unit.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    hasOutletGardenAuthenticationExpired,
+    outletGardenOfferFromHeldCartItem,
+    resolveOutletGardenCommerceState,
+} from './OutletGardenCommerce';
+
+const readyStateInput = {
+    authenticated: true,
+    authenticatedQueriesPending: false,
+    enabled: true,
+    hasEligibleTarget: true,
+    hasMutationError: false,
+    hasQueryError: false,
+    hasSelectedOffer: true,
+    mutationPending: false,
+    now: Date.parse('2026-08-12T12:00:00.000Z'),
+    opened: true,
+    queryRetrying: false,
+    receiptHoldExpiresAt: null,
+    userPending: false,
+};
+
+test('prioritizes current-user query errors over authentication-required', () => {
+    assert.equal(
+        resolveOutletGardenCommerceState({
+            ...readyStateInput,
+            authenticated: false,
+            hasQueryError: true,
+        }),
+        'query-error',
+    );
+});
+
+test('prioritizes authenticated query errors over no-targets', () => {
+    assert.equal(
+        resolveOutletGardenCommerceState({
+            ...readyStateInput,
+            hasEligibleTarget: false,
+            hasQueryError: true,
+        }),
+        'query-error',
+    );
+});
+
+test('treats a dependent unauthorized response as expired cached authentication', () => {
+    assert.equal(
+        hasOutletGardenAuthenticationExpired({
+            authenticated: true,
+            gardensUnauthorized: true,
+            shoppingCartUnauthorized: false,
+            targetGardenUnauthorized: false,
+        }),
+        true,
+    );
+    assert.equal(
+        hasOutletGardenAuthenticationExpired({
+            authenticated: false,
+            gardensUnauthorized: true,
+            shoppingCartUnauthorized: true,
+            targetGardenUnauthorized: true,
+        }),
+        false,
+    );
+});
+
+test('preserves mutation errors and shows loading while retrying queries', () => {
+    assert.equal(
+        resolveOutletGardenCommerceState({
+            ...readyStateInput,
+            hasMutationError: true,
+            hasQueryError: true,
+        }),
+        'error',
+    );
+    assert.equal(
+        resolveOutletGardenCommerceState({
+            ...readyStateInput,
+            hasQueryError: true,
+            queryRetrying: true,
+        }),
+        'loading',
+    );
+});
+
+test('builds the receipt offer from the authoritative held cart snapshot', () => {
+    const offer = outletGardenOfferFromHeldCartItem({
+        entityId: '88',
+        entityTypeName: 'plantSort',
+        outlet: {
+            comparePrice: 4.2,
+            endAt: '2026-08-14T12:00:00.000Z',
+            expired: false,
+            initialPlantStatus: 'ready',
+            offerId: 302,
+            outletPrice: 1.75,
+            sowingDate: '2026-07-28T00:00:00.000Z',
+            status: 'held',
+        },
+        shopData: {
+            description: 'Snapshot description',
+            image: 'https://cdn.example.test/snapshot.webp',
+            name: 'Snapshot paprika',
+        },
+    });
+
+    assert.ok(offer);
+    assert.equal(offer.id, 302);
+    assert.equal(offer.outletPrice, 1.75);
+    assert.equal(offer.comparePrice, 4.2);
+    assert.equal(offer.initialPlantStatus, 'ready');
+    assert.equal(offer.endAt, '2026-08-14T12:00:00.000Z');
+    assert.equal(offer.plantSort.name, 'Snapshot paprika');
+    assert.deepEqual(offer.imageUrls, [
+        'https://cdn.example.test/snapshot.webp',
+    ]);
+});
+
+test('rejects a cart snapshot that is no longer held', () => {
+    const offer = outletGardenOfferFromHeldCartItem({
+        entityId: '88',
+        entityTypeName: 'plantSort',
+        outlet: {
+            comparePrice: null,
+            endAt: '2026-08-14T12:00:00.000Z',
+            expired: true,
+            initialPlantStatus: 'ready',
+            offerId: 302,
+            outletPrice: 1.75,
+            sowingDate: '2026-07-28T00:00:00.000Z',
+            status: 'held',
+        },
+        shopData: { name: 'Snapshot paprika' },
+    });
+
+    assert.equal(offer, null);
+});

--- a/packages/game/src/viewers/OutletGardenOfferBrowser.tsx
+++ b/packages/game/src/viewers/OutletGardenOfferBrowser.tsx
@@ -9,6 +9,10 @@ import type { Route } from 'next';
 import type { ReactNode } from 'react';
 import type { OutletOfferData } from '../hooks/useOutletOffers';
 import {
+    type OutletGardenCommerceController,
+    OutletGardenReservationPanel,
+} from './OutletGardenCommerce';
+import {
     outletGardenMaxDisplayedUnitsPerOffer,
     outletGardenMaxDisplayedUnitsTotal,
 } from './outletGardenLayout';
@@ -131,6 +135,7 @@ function plantGroupImageUrl(plantGroup: OutletGardenPlantGroup) {
 
 export type OutletGardenOfferBrowserProps = {
     className?: string;
+    commerce?: OutletGardenCommerceController;
     displayLimited?: boolean;
     headerAction?: ReactNode;
     isError: boolean;
@@ -138,6 +143,7 @@ export type OutletGardenOfferBrowserProps = {
     offers: readonly OutletOfferData[];
     onExit: (destination: 'existing_outlet' | 'garden', href: Route) => void;
     onHoverOffer?: (offerId: number | null) => void;
+    onAuthenticationRequired?: () => void;
     onRetry: () => void;
     onSelectOffer: (offerId: number | null) => void;
     renderer?: OutletGardenRenderer;
@@ -146,6 +152,7 @@ export type OutletGardenOfferBrowserProps = {
 
 export function OutletGardenOfferBrowser({
     className,
+    commerce,
     displayLimited = false,
     headerAction,
     isError,
@@ -153,6 +160,7 @@ export function OutletGardenOfferBrowser({
     offers,
     onExit,
     onHoverOffer,
+    onAuthenticationRequired,
     onRetry,
     onSelectOffer,
     renderer = 'webgl',
@@ -160,7 +168,10 @@ export function OutletGardenOfferBrowser({
 }: OutletGardenOfferBrowserProps) {
     const plantGroups = groupOutletGardenOffers(offers);
     const selectedOffer =
-        offers.find((offer) => offer.id === selectedOfferId) ?? null;
+        offers.find((offer) => offer.id === selectedOfferId) ??
+        (commerce?.receipt?.offer.id === selectedOfferId
+            ? commerce.receipt.offer
+            : null);
     const selectedOfferMissing =
         selectedOfferId !== null && !selectedOffer && !isLoading && !isError;
     const state = isLoading
@@ -611,11 +622,18 @@ export function OutletGardenOfferBrowser({
                                 </div>
                                 <div>
                                     <dt className="text-xs text-muted-foreground">
-                                        Preostalo
+                                        {commerce?.receipt?.offer.id ===
+                                            selectedOffer.id &&
+                                        commerce.state === 'success'
+                                            ? 'Rezervirano'
+                                            : 'Preostalo'}
                                     </dt>
                                     <dd className="font-medium">
-                                        {selectedOffer.remainingQuantity}{' '}
-                                        sadnica
+                                        {commerce?.receipt?.offer.id ===
+                                            selectedOffer.id &&
+                                        commerce.state === 'success'
+                                            ? '1 sadnica'
+                                            : `${selectedOffer.remainingQuantity.toString()} sadnica`}
                                     </dd>
                                 </div>
                                 <div>
@@ -643,32 +661,49 @@ export function OutletGardenOfferBrowser({
                             <p className="mt-3 text-xs leading-relaxed text-muted-foreground">
                                 Fotografija može prikazivati konkretnu ponudu
                                 ili pripadajuću sortu; 3D model je
-                                reprezentativan. Pregled i odabir ovdje ne
-                                rezerviraju zalihu.
+                                reprezentativan. Pregled i odabir sadnice ne
+                                rezerviraju zalihu; rezervacija nastaje tek
+                                nakon potvrde polja.
                             </p>
 
-                            <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-1">
-                                <Button
-                                    href={`/?outlet=${selectedOffer.id.toString()}`}
-                                    fullWidth
-                                    onClick={(event) => {
-                                        event.preventDefault();
-                                        onExit(
-                                            'existing_outlet',
-                                            `/?outlet=${selectedOffer.id.toString()}`,
-                                        );
+                            {commerce ? (
+                                <OutletGardenReservationPanel
+                                    commerce={commerce}
+                                    onAuthenticationRequired={() =>
+                                        onAuthenticationRequired?.()
+                                    }
+                                    onChooseAnother={() => {
+                                        commerce.close();
+                                        onSelectOffer(null);
                                     }}
-                                >
-                                    Nastavi u postojećem Outletu
-                                </Button>
-                                <Button
-                                    fullWidth
-                                    onClick={() => onSelectOffer(null)}
-                                    variant="outlined"
-                                >
-                                    Zatvori detalje
-                                </Button>
-                            </div>
+                                />
+                            ) : null}
+
+                            {commerce?.state !== 'success' &&
+                            commerce?.state !== 'expired' ? (
+                                <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-1">
+                                    <Button
+                                        href={`/?outlet=${selectedOffer.id.toString()}`}
+                                        fullWidth
+                                        onClick={(event) => {
+                                            event.preventDefault();
+                                            onExit(
+                                                'existing_outlet',
+                                                `/?outlet=${selectedOffer.id.toString()}`,
+                                            );
+                                        }}
+                                    >
+                                        Nastavi u postojećem Outletu
+                                    </Button>
+                                    <Button
+                                        fullWidth
+                                        onClick={() => onSelectOffer(null)}
+                                        variant="outlined"
+                                    >
+                                        Zatvori detalje
+                                    </Button>
+                                </div>
+                            ) : null}
                         </div>
                     </article>
                 ) : null}

--- a/packages/game/src/viewers/OutletGardenViewer.tsx
+++ b/packages/game/src/viewers/OutletGardenViewer.tsx
@@ -8,6 +8,7 @@ import { parseAsInteger, useQueryState } from 'nuqs';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useOutletOffers } from '../hooks/useOutletOffers';
+import type { OutletGardenCommerceController } from './OutletGardenCommerce';
 import { OutletGardenOfferBrowser } from './OutletGardenOfferBrowser';
 import { OutletGardenSeedlingMarkers } from './OutletGardenSeedlingMarkers';
 import {
@@ -36,7 +37,9 @@ const outletGardenCameraMinZoom = 10;
 const outletGardenCloseupZoom = 210;
 
 export type OutletGardenViewerProps = {
+    commerce?: OutletGardenCommerceController;
     focusOnMount?: boolean;
+    onAuthenticationRequired?: () => void;
     onSceneFailure?: (reason: OutletGardenSceneFailureReason) => void;
     onSceneReady?: () => void;
     onUseListFallback?: () => void;
@@ -61,7 +64,9 @@ function OutletGardenScenePlaceholder({ label }: { label: string }) {
 }
 
 export function OutletGardenViewer({
+    commerce,
     focusOnMount = false,
+    onAuthenticationRequired,
     onSceneFailure,
     onSceneReady,
     onUseListFallback,
@@ -523,11 +528,13 @@ export function OutletGardenViewer({
             </main>
 
             <OutletGardenOfferBrowser
+                commerce={commerce}
                 displayLimited={displayLimited}
                 isError={isError}
                 isLoading={isLoading}
                 offers={offers}
                 onExit={requestExit}
+                onAuthenticationRequired={onAuthenticationRequired}
                 onHoverOffer={setHoveredOfferId}
                 onRetry={() => {
                     void refetch();


### PR DESCRIPTION
## Summary

- add an independently managed, default-off `enableOutletGardenCommerce` gate
- let signed-in customers select an owned garden and an actually free raised-bed field from either the 3D or semantic-list Outlet experience
- reuse the Phase 2A held-reservation mutation and verify the exact server-returned hold before showing success
- preserve selection through password/OAuth authentication with a strict same-origin return-path allowlist
- retain an authoritative receipt when the final unit disappears, expire it safely, and attribute cart/checkout continuation
- provide explicit retry handling for account, garden, cart, and target-loading failures

## Why

Phase 2A (#4501) made Outlet holds atomic and conflict-safe. This PR adds the customer-facing reservation flow while keeping commerce independently disabled for production beta control.

## Validation

- `pnpm --filter @gredice/game test` — 1067/1067
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter garden build`
- Outlet real-route Playwright — 3/3
- auth, OAuth, Outlet, flag, and HUD Playwright — 33/33
- targeted Biome checks and `git diff --check`

## Rollout

`enableOutletGardenCommerce` remains off in Production and Preview and on in Development. Merging this PR does not expose direct reservation to users; beta activation remains a separate managed-flag decision after an authenticated deployed smoke.

Advances #4466
