### PR TITLE
fix(game): allow twelve characters per sign row

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -19,7 +19,7 @@ import {
     isValidWoodenSignMessage,
     normalizeWoodenSignMessage,
     woodenSignBlockName,
-    woodenSignMessageMaxGraphemes,
+    woodenSignMessageMaxGraphemesPerLine,
 } from '@gredice/js/woodenSign';
 import { notifyOperationUpdate } from '@gredice/notifications';
 import { signalcoClient } from '@gredice/signalco';
@@ -194,7 +194,7 @@ const gardenLikeBodySchema = z
 const woodenSignMessageSchema = z
     .union([z.string(), z.null()])
     .refine(isValidWoodenSignMessage, {
-        message: `Sign message must contain at most ${woodenSignMessageMaxGraphemes.toString()} characters across one or two rows and no control characters`,
+        message: `Sign message must contain at most ${woodenSignMessageMaxGraphemesPerLine.toString()} characters per row across one or two rows and no control characters`,
     })
     .transform((message) =>
         message === null ? null : normalizeWoodenSignMessage(message),

--- a/apps/garden/tests/wooden-sign-modal.spec.tsx
+++ b/apps/garden/tests/wooden-sign-modal.spec.tsx
@@ -5,6 +5,7 @@ import { WoodenSignModalStory } from './WoodenSignModalStory';
 const woodenSignTestGardenId = 42;
 const woodenSignTestBlockId = 'wooden-sign-1';
 const woodenSignInitialMessage = 'DOBRO\nDOŠLI!!';
+const woodenSignMaximumMessage = 'ABCDEFGHIJKL\nMNOPQRSTUVWX';
 
 const updatePath = `/api/gredice/api/gardens/${woodenSignTestGardenId.toString()}/blocks/${woodenSignTestBlockId}`;
 
@@ -102,7 +103,7 @@ test('shows the existing two-row inscription and its grapheme counter', async ({
 
     await expect(dialog).toBeVisible();
     await expect(editor).toHaveValue(woodenSignInitialMessage);
-    await expect(dialog.getByText('12/12', { exact: true })).toBeVisible();
+    await expect(dialog.getByText('12/24', { exact: true })).toBeVisible();
 });
 
 test('keeps one Unicode grapheme intact while rejecting the thirteenth character', async ({
@@ -122,6 +123,23 @@ test('keeps one Unicode grapheme intact while rejecting the thirteenth character
     await expect(dialog.getByText('12/12', { exact: true })).toBeVisible();
 });
 
+test('allows twelve Unicode graphemes on each row and rejects the thirteenth per row', async ({
+    mount,
+    page,
+}) => {
+    await mount(<WoodenSignModalStory />);
+
+    const dialog = page.getByRole('dialog', {
+        name: 'Uredi drveni natpis',
+    });
+    const editor = dialog.getByLabel('Tekst na drvenom natpisu');
+
+    await editor.fill('12345678901👩‍🌾A\nABCDEFGHIJKLZ');
+
+    await expect(editor).toHaveValue('12345678901👩‍🌾\nABCDEFGHIJKL');
+    await expect(dialog.getByText('24/24', { exact: true })).toBeVisible();
+});
+
 test('optimistically updates the sign, sends the exact payload, and closes after success', async ({
     mount,
     page,
@@ -131,7 +149,7 @@ test('optimistically updates the sign, sends the exact payload, and closes after
         releaseResponse = resolve;
     });
     const updatePayloads = await mockWoodenSignRequests(page, {
-        responseMessage: 'MOJ\nVRT',
+        responseMessage: woodenSignMaximumMessage,
         responseReady,
     });
     await mount(<WoodenSignModalStory />);
@@ -139,12 +157,16 @@ test('optimistically updates the sign, sends the exact payload, and closes after
     const dialog = page.getByRole('dialog', {
         name: 'Uredi drveni natpis',
     });
-    await dialog.getByLabel('Tekst na drvenom natpisu').fill('MOJ\nVRT');
+    await dialog
+        .getByLabel('Tekst na drvenom natpisu')
+        .fill(woodenSignMaximumMessage);
     await dialog.getByRole('button', { name: 'Spremi natpis' }).click();
 
-    await expect.poll(() => updatePayloads).toEqual([{ message: 'MOJ\nVRT' }]);
+    await expect
+        .poll(() => updatePayloads)
+        .toEqual([{ message: woodenSignMaximumMessage }]);
     await expect(page.getByTestId('current-sign-message')).toHaveText(
-        'MOJ\nVRT',
+        woodenSignMaximumMessage,
     );
 
     releaseResponse();

--- a/packages/game/src/localSandboxGarden.unit.ts
+++ b/packages/game/src/localSandboxGarden.unit.ts
@@ -58,7 +58,7 @@ test('persists local sandbox stacks in local storage', () => {
                             id: createLocalSandboxBlockId('WoodenSign'),
                             name: 'WoodenSign',
                             rotation: 0,
-                            message: '  MOJ\nVRT  ',
+                            message: '  ABCDEFGHIJKL\nMNOPQRSTUVWX  ',
                         },
                     ],
                 },
@@ -75,7 +75,10 @@ test('persists local sandbox stacks in local storage', () => {
         assert.equal(loadedGarden.stacks[0]?.position.z, -1);
         assert.equal(loadedGarden.stacks[0]?.blocks[0]?.name, 'Tree');
         assert.equal(loadedGarden.stacks[0]?.blocks[0]?.rotation, 2);
-        assert.equal(loadedGarden.stacks[0]?.blocks[1]?.message, 'MOJ\nVRT');
+        assert.equal(
+            loadedGarden.stacks[0]?.blocks[1]?.message,
+            'ABCDEFGHIJKL\nMNOPQRSTUVWX',
+        );
     });
 });
 

--- a/packages/game/src/modals/WoodenSignModal.tsx
+++ b/packages/game/src/modals/WoodenSignModal.tsx
@@ -2,10 +2,10 @@
 
 import {
     countWoodenSignMessageGraphemes,
+    getWoodenSignMessageGraphemeLimit,
     normalizeWoodenSignMessage,
     sanitizeWoodenSignDraft,
     woodenSignBlockName,
-    woodenSignMessageMaxGraphemes,
 } from '@gredice/js/woodenSign';
 import { Button } from '@gredice/ui/Button';
 import { Stack } from '@gredice/ui/Stack';
@@ -31,6 +31,7 @@ function WoodenSignEditor({
     const updateMessage = useBlockMessage();
     const { track } = useGameAnalytics();
     const characterCount = countWoodenSignMessageGraphemes(draft);
+    const characterLimit = getWoodenSignMessageGraphemeLimit(draft);
 
     const handleSubmit = async (event: SubmitEvent<HTMLFormElement>) => {
         event.preventDefault();
@@ -70,8 +71,8 @@ function WoodenSignEditor({
                 />
                 <div className="flex items-start justify-between gap-4">
                     <Typography id="wooden-sign-help" level="body2" secondary>
-                        Upiši najviše 12 znakova u jedan ili dva reda. Natpis će
-                        vidjeti svi koji mogu vidjeti vrt.
+                        Upiši najviše 12 znakova po redu, u najviše dva reda.
+                        Natpis će vidjeti svi koji mogu vidjeti vrt.
                     </Typography>
                     <Typography
                         id="wooden-sign-counter"
@@ -79,7 +80,7 @@ function WoodenSignEditor({
                         className="shrink-0 tabular-nums"
                         aria-live="polite"
                     >
-                        {characterCount}/{woodenSignMessageMaxGraphemes}
+                        {characterCount}/{characterLimit}
                     </Typography>
                 </div>
                 {errorMessage ? (

--- a/packages/js/src/woodenSign/index.ts
+++ b/packages/js/src/woodenSign/index.ts
@@ -1,7 +1,9 @@
 export const woodenSignBlockName = 'WoodenSign';
-export const woodenSignMessageMaxGraphemes = 12;
+export const woodenSignMessageMaxGraphemesPerLine = 12;
 export const woodenSignMessageMaxLines = 2;
-export const woodenSignMessageMaxRawLength = 128;
+export const woodenSignMessageMaxGraphemes =
+    woodenSignMessageMaxGraphemesPerLine * woodenSignMessageMaxLines;
+export const woodenSignMessageMaxRawLength = 256;
 
 export type WoodenSignMessageValidationCode =
     | 'control_character'
@@ -13,7 +15,7 @@ const validationMessages = {
     control_character:
         'Wooden sign messages cannot contain control characters.',
     raw_too_long: 'Wooden sign message input is too long.',
-    too_many_graphemes: `Wooden sign messages can contain at most ${woodenSignMessageMaxGraphemes.toString()} characters.`,
+    too_many_graphemes: `Each wooden sign line can contain at most ${woodenSignMessageMaxGraphemesPerLine.toString()} characters.`,
     too_many_lines: `Wooden sign messages can contain at most ${woodenSignMessageMaxLines.toString()} lines.`,
 } satisfies Record<WoodenSignMessageValidationCode, string>;
 
@@ -80,6 +82,14 @@ export function countWoodenSignMessageGraphemes(value: string): number {
     return graphemes(normalizeUnicode(value).replaceAll('\n', '')).length;
 }
 
+export function getWoodenSignMessageGraphemeLimit(value: string): number {
+    const lineCount = Math.min(
+        normalizeLineEndings(value).split('\n').length,
+        woodenSignMessageMaxLines,
+    );
+    return lineCount * woodenSignMessageMaxGraphemesPerLine;
+}
+
 export function normalizeWoodenSignMessage(value: string): string | null {
     if (value.length > woodenSignMessageMaxRawLength) {
         throw new WoodenSignMessageValidationError('raw_too_long');
@@ -106,8 +116,15 @@ export function normalizeWoodenSignMessage(value: string): string | null {
         return null;
     }
 
-    const graphemeCount = countWoodenSignMessageGraphemes(message);
-    if (graphemeCount > woodenSignMessageMaxGraphemes) {
+    if (
+        message
+            .split('\n')
+            .some(
+                (row) =>
+                    graphemes(row).length >
+                    woodenSignMessageMaxGraphemesPerLine,
+            )
+    ) {
         throw new WoodenSignMessageValidationError('too_many_graphemes');
     }
 
@@ -121,20 +138,13 @@ export function sanitizeWoodenSignDraft(value: string): string {
     const rows = stripUnsupportedControlCharacters(normalized)
         .split('\n')
         .slice(0, woodenSignMessageMaxLines);
-    let remainingGraphemes = woodenSignMessageMaxGraphemes;
 
     return rows
-        .map((row) => {
-            const rowGraphemes = graphemes(row);
-            const sanitizedRow = rowGraphemes
-                .slice(0, remainingGraphemes)
-                .join('');
-            remainingGraphemes = Math.max(
-                0,
-                remainingGraphemes - rowGraphemes.length,
-            );
-            return sanitizedRow;
-        })
+        .map((row) =>
+            graphemes(row)
+                .slice(0, woodenSignMessageMaxGraphemesPerLine)
+                .join(''),
+        )
         .join('\n');
 }
 

--- a/packages/js/src/woodenSign/index.unit.ts
+++ b/packages/js/src/woodenSign/index.unit.ts
@@ -4,12 +4,14 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
     countWoodenSignMessageGraphemes,
+    getWoodenSignMessageGraphemeLimit,
     isValidWoodenSignMessage,
     normalizeWoodenSignMessage,
     sanitizeWoodenSignDraft,
     WoodenSignMessageValidationError,
     woodenSignBlockName,
     woodenSignMessageMaxGraphemes,
+    woodenSignMessageMaxGraphemesPerLine,
     woodenSignMessageMaxRawLength,
 } from './index';
 
@@ -22,6 +24,14 @@ describe('countWoodenSignMessageGraphemes', () => {
             ),
             2,
         );
+    });
+});
+
+describe('getWoodenSignMessageGraphemeLimit', () => {
+    it('doubles the character allowance when a second row is drawn', () => {
+        assert.equal(getWoodenSignMessageGraphemeLimit('MOJ VRT'), 12);
+        assert.equal(getWoodenSignMessageGraphemeLimit('MOJ\nVRT'), 24);
+        assert.equal(getWoodenSignMessageGraphemeLimit('MOJ\r\nVRT'), 24);
     });
 });
 
@@ -38,11 +48,12 @@ describe('normalizeWoodenSignMessage', () => {
         assert.equal(normalizeWoodenSignMessage(''), null);
     });
 
-    it('accepts twelve graphemes split across two rows', () => {
-        assert.equal(woodenSignMessageMaxGraphemes, 12);
+    it('accepts twelve graphemes on each of two rows', () => {
+        assert.equal(woodenSignMessageMaxGraphemesPerLine, 12);
+        assert.equal(woodenSignMessageMaxGraphemes, 24);
         assert.equal(
-            normalizeWoodenSignMessage('ABCDEF\nGHIJKL'),
-            'ABCDEF\nGHIJKL',
+            normalizeWoodenSignMessage('ABCDEFGHIJKL\nMNOPQRSTUVWX'),
+            'ABCDEFGHIJKL\nMNOPQRSTUVWX',
         );
 
         const decomposedCroatianLetters = 'C\u030C'.repeat(12);
@@ -52,14 +63,22 @@ describe('normalizeWoodenSignMessage', () => {
         );
 
         assert.equal(
-            normalizeWoodenSignMessage('👩‍🌾'.repeat(12)),
-            '👩‍🌾'.repeat(12),
+            normalizeWoodenSignMessage(
+                `${'👩‍🌾'.repeat(12)}\n${'👨‍🌾'.repeat(12)}`,
+            ),
+            `${'👩‍🌾'.repeat(12)}\n${'👨‍🌾'.repeat(12)}`,
         );
     });
 
-    it('rejects more than twelve graphemes in total', () => {
+    it('rejects more than twelve graphemes on either row', () => {
         assert.throws(
-            () => normalizeWoodenSignMessage('ABCDEFG\nGHIJKL'),
+            () => normalizeWoodenSignMessage('ABCDEFGHIJKLM\nOK'),
+            (error) =>
+                error instanceof WoodenSignMessageValidationError &&
+                error.code === 'too_many_graphemes',
+        );
+        assert.throws(
+            () => normalizeWoodenSignMessage('OK\nABCDEFGHIJKLM'),
             (error) =>
                 error instanceof WoodenSignMessageValidationError &&
                 error.code === 'too_many_graphemes',
@@ -106,10 +125,12 @@ describe('normalizeWoodenSignMessage', () => {
 });
 
 describe('sanitizeWoodenSignDraft', () => {
-    it('produces an NFC, control-free two-row draft capped at twelve graphemes', () => {
+    it('produces an NFC, control-free two-row draft capped at twelve graphemes per row', () => {
         assert.equal(
-            sanitizeWoodenSignDraft('ABCDEFG\r\nHIJKLMN\nignored\t'),
-            'ABCDEFG\nHIJKL',
+            sanitizeWoodenSignDraft(
+                'ABCDEFGHIJKLM\r\nNOPQRSTUVWXYZ\nignored\t',
+            ),
+            'ABCDEFGHIJKL\nNOPQRSTUVWXY',
         );
         assert.equal(sanitizeWoodenSignDraft('C\u030C'), 'Č');
     });
@@ -121,6 +142,10 @@ describe('isValidWoodenSignMessage', () => {
         assert.equal(isValidWoodenSignMessage(null), true);
         assert.equal(isValidWoodenSignMessage(''), true);
         assert.equal(isValidWoodenSignMessage('MOJ\nVRT'), true);
+        assert.equal(
+            isValidWoodenSignMessage('ABCDEFGHIJKL\nMNOPQRSTUVWX'),
+            true,
+        );
     });
 
     it('rejects invalid messages', () => {

--- a/packages/storage/scripts/upsertSignageBlockEntities.ts
+++ b/packages/storage/scripts/upsertSignageBlockEntities.ts
@@ -242,9 +242,9 @@ function createSignageBlockAttributes({
                 hitboxWidth: '0.88',
                 price: woodenSignPrice,
                 shortDescription:
-                    'Drvena vrtna ploča na koju možeš upisati vlastiti natpis do 12 znakova u jednom ili dva reda.',
+                    'Drvena vrtna ploča na koju možeš upisati vlastiti natpis do 12 znakova po redu, u jednom ili dva reda.',
                 fullDescription:
-                    'Postavi drvenu ploču uz gredicu, stazu ili ulaz, zatim je odaberi i upiši natpis do 12 znakova. Tekst može biti raspoređen u jednom ili dva reda i kasnije ga možeš ponovno urediti.',
+                    'Postavi drvenu ploču uz gredicu, stazu ili ulaz, zatim je odaberi i upiši natpis do 12 znakova po redu. Tekst može biti raspoređen u jednom ili dva reda i kasnije ga možeš ponovno urediti.',
             }),
         },
     ];


### PR DESCRIPTION
## Summary

- enforce a 12-grapheme limit independently on each wooden-sign row
- allow 24 graphemes when the message uses two rows and update the editor counter/help text
- align API validation, sandbox persistence coverage, component tests, and Croatian catalogue source copy

## Validation

- `pnpm --filter @gredice/js test` — 45 passed
- `pnpm --dir packages/game test` — 1,069 passed
- `pnpm --dir apps/garden exec playwright test tests/wooden-sign-modal.spec.tsx --config playwright.config.ts --workers=1` — 7 passed
- `pnpm --dir apps/api exec tsc --noEmit -p tsconfig.json`
- `pnpm --dir packages/game typecheck`
- `pnpm --filter garden typecheck`
- scoped Biome checks
- `git diff --check`