### PR TITLE
fix(game): render Perseids behind garden

### DIFF
--- a/packages/game/src/scene/PerseidMeteorShower.tsx
+++ b/packages/game/src/scene/PerseidMeteorShower.tsx
@@ -38,7 +38,11 @@ const meteorVertexShader = /* glsl */ `
 
     void main() {
         vUv = uv;
-        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        vec4 clipPosition = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        // Meteors are sky background: keep their screen projection while
+        // placing their depth behind every depth-writing garden surface.
+        clipPosition.z = clipPosition.w * ${PERSEIDS_RENDERING.backgroundNdcDepth.toFixed(1)};
+        gl_Position = clipPosition;
     }
 `;
 

--- a/packages/game/src/scene/PerseidMeteorShower.tsx
+++ b/packages/game/src/scene/PerseidMeteorShower.tsx
@@ -18,9 +18,9 @@ import {
     Vector2,
     Vector3,
 } from 'three';
-import { useGameState } from '../useGameState';
 import {
     createPerseidsMeteor,
+    PERSEIDS_RENDERING,
     type PerseidsMeteorDefinition,
     samplePerseidsIntervalSeconds,
 } from './perseids';
@@ -139,7 +139,6 @@ export function Perseids({
     visibility: number;
 }) {
     const camera = useThree((state) => state.camera);
-    const gardenAvatarView = useGameState((state) => state.gardenAvatarView);
     const meshRef = useRef<Mesh>(null);
     const rateRef = useRef(meteorsPerHour);
     const activeMeteorRef = useRef<ActiveMeteor | null>(null);
@@ -160,8 +159,8 @@ export function Perseids({
         () =>
             new ShaderMaterial({
                 blending: AdditiveBlending,
-                depthTest: true,
-                depthWrite: false,
+                depthTest: PERSEIDS_RENDERING.depthTest,
+                depthWrite: PERSEIDS_RENDERING.depthWrite,
                 fragmentShader: meteorFragmentShader,
                 side: DoubleSide,
                 toneMapped: false,
@@ -193,10 +192,6 @@ export function Perseids({
             Math.max(0, visibility),
         );
     }, [material, visibility]);
-
-    useLayoutEffect(() => {
-        material.depthTest = gardenAvatarView !== 'overview';
-    }, [gardenAvatarView, material]);
 
     useEffect(() => {
         const previousRate = rateRef.current;
@@ -340,7 +335,7 @@ export function Perseids({
             geometry={geometry}
             material={material}
             name="Environment:Perseids"
-            renderOrder={29}
+            renderOrder={PERSEIDS_RENDERING.renderOrder}
         />
     );
 }

--- a/packages/game/src/scene/perseids.ts
+++ b/packages/game/src/scene/perseids.ts
@@ -7,6 +7,11 @@ const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
 export const PERSEIDS_DENSITY_MULTIPLIER = 6;
 export const PERSEIDS_REAL_EDGE_RATE_PER_HOUR = 1;
 export const PERSEIDS_REAL_PEAK_ZHR = 100;
+export const PERSEIDS_RENDERING = {
+    depthTest: true,
+    depthWrite: false,
+    renderOrder: 29,
+};
 
 const PERSEIDS_START_MONTH_INDEX = 6;
 const PERSEIDS_START_DAY = 17;

--- a/packages/game/src/scene/perseids.ts
+++ b/packages/game/src/scene/perseids.ts
@@ -8,6 +8,7 @@ export const PERSEIDS_DENSITY_MULTIPLIER = 6;
 export const PERSEIDS_REAL_EDGE_RATE_PER_HOUR = 1;
 export const PERSEIDS_REAL_PEAK_ZHR = 100;
 export const PERSEIDS_RENDERING = {
+    backgroundNdcDepth: 1,
     depthTest: true,
     depthWrite: false,
     renderOrder: 29,

--- a/packages/game/src/scene/perseids.unit.ts
+++ b/packages/game/src/scene/perseids.unit.ts
@@ -8,9 +8,15 @@ import {
     PERSEIDS_DENSITY_MULTIPLIER,
     PERSEIDS_REAL_EDGE_RATE_PER_HOUR,
     PERSEIDS_REAL_PEAK_ZHR,
+    PERSEIDS_RENDERING,
     samplePerseidsIntervalSeconds,
     shouldRenderPerseids,
 } from './perseids';
+
+test('keeps meteors behind depth-writing garden geometry in every camera mode', () => {
+    assert.equal(PERSEIDS_RENDERING.depthTest, true);
+    assert.equal(PERSEIDS_RENDERING.depthWrite, false);
+});
 
 test('uses the recurring July 17 through August 24 activity window', () => {
     assert.equal(

--- a/packages/game/src/scene/perseids.unit.ts
+++ b/packages/game/src/scene/perseids.unit.ts
@@ -14,6 +14,7 @@ import {
 } from './perseids';
 
 test('keeps meteors behind depth-writing garden geometry in every camera mode', () => {
+    assert.equal(PERSEIDS_RENDERING.backgroundNdcDepth, 1);
     assert.equal(PERSEIDS_RENDERING.depthTest, true);
     assert.equal(PERSEIDS_RENDERING.depthWrite, false);
 });


### PR DESCRIPTION
## What changed

- keep Perseid meteor depth testing enabled in overview, FPV, and TPV
- keep meteor depth writes disabled so streaks do not affect scene depth
- centralize the rendering policy and add regression coverage

## Why

Overview mode explicitly disabled depth testing for Perseid streaks. Because the meteor mesh renders late, streaks were painted over garden blocks even when they were spatially behind them.

## Impact

Garden blocks and other depth-writing scene geometry now correctly occlude falling stars, keeping the meteor shower in the background in every camera mode.

## Validation

- `pnpm --filter @gredice/game exec tsx --test src/scene/perseids.unit.ts` (7 passed)
- `pnpm --filter @gredice/game test` (1,070 passed)
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game exec biome check src/scene/PerseidMeteorShower.tsx src/scene/perseids.ts src/scene/perseids.unit.ts`
- `git diff --check`
