### PR TITLE
fix(garden): expose notification bubbles flag

### DIFF
--- a/apps/garden/app/flags.ts
+++ b/apps/garden/app/flags.ts
@@ -76,6 +76,7 @@ export const enableRaisedBedNotificationBubblesFlag = flag<boolean>({
     key: 'enableRaisedBedNotificationBubbles',
     description:
         'Show prioritized notification bubbles above raised beds in Garden.',
-    decide: () => false,
+    adapter: vercelAdapter,
+    defaultValue: false,
     options: booleanFlagOptions,
 });

--- a/apps/garden/tests/outlet-garden-flag.spec.ts
+++ b/apps/garden/tests/outlet-garden-flag.spec.ts
@@ -43,4 +43,7 @@ test('flag discovery resolves managed Vercel provider metadata', () => {
     expect(flagsSource).toMatch(
         /enableOutletGardenCommerceFlag[\s\S]*?adapter: vercelAdapter,[\s\S]*?defaultValue: false,/u,
     );
+    expect(flagsSource).toMatch(
+        /enableRaisedBedNotificationBubblesFlag[\s\S]*?adapter: vercelAdapter,[\s\S]*?defaultValue: false,/u,
+    );
 });


### PR DESCRIPTION
## Summary

- connect `enableRaisedBedNotificationBubbles` to the managed Vercel Flags adapter
- keep the feature default-off while making it discoverable and overridable in Flags Explorer
- extend the existing discovery regression test to cover the notification flag

## Root cause

The Garden discovery endpoint now reads metadata from `@flags-sdk/vercel`, but the notification flag still used a local `decide` function. Provider discovery therefore returned only the two adapter-backed Outlet flags.

## User impact

After this deploys, `enableRaisedBedNotificationBubbles` appears in Flags Explorer and can be enabled for an individual testing session without an environment-variable flag or affecting other users.

## Validation

- `pnpm --filter garden typecheck`
- `pnpm --filter garden exec playwright test tests/outlet-garden-flag.spec.ts --project=chromium` (2 passed)
- `pnpm --filter garden exec biome check app/flags.ts tests/outlet-garden-flag.spec.ts`
- `git diff --check`