### PR TITLE
feat(game): polish Outlet garden experience

### DIFF
--- a/apps/garden/tests/OutletGardenOfferBrowserStory.tsx
+++ b/apps/garden/tests/OutletGardenOfferBrowserStory.tsx
@@ -6,6 +6,9 @@ import { Button } from '@gredice/ui/Button';
 import { useState } from 'react';
 
 type OutletOffer = OutletGardenOfferBrowserProps['offers'][number];
+type OutletGardenCommerce = NonNullable<
+    OutletGardenOfferBrowserProps['commerce']
+>;
 
 const outletOffers = [
     {
@@ -106,10 +109,12 @@ export type OutletGardenOfferBrowserStoryState =
 
 export function OutletGardenOfferBrowserStory({
     displayLimited = false,
+    commerceUnavailable = false,
     initialSelectedOfferId = null,
     selectionDriven = false,
     state = 'ready',
 }: {
+    commerceUnavailable?: boolean;
     displayLimited?: boolean;
     initialSelectedOfferId?: number | null;
     selectionDriven?: boolean;
@@ -120,9 +125,39 @@ export function OutletGardenOfferBrowserStory({
     );
     const [hoveredOfferId, setHoveredOfferId] = useState<number | null>(null);
     const [retryCount, setRetryCount] = useState(0);
+    const [commerceCloseCount, setCommerceCloseCount] = useState(0);
     const [offerListOpen, setOfferListOpen] = useState(false);
     const browserOpen =
         !selectionDriven || offerListOpen || selectedOfferId !== null;
+    const commerce = commerceUnavailable
+        ? ({
+              cartHref: null,
+              close: () => setCommerceCloseCount((count) => count + 1),
+              continueToCart: () => undefined,
+              enabled: true,
+              errorMessage: null,
+              fieldTargets: [],
+              gardens: [],
+              open: () => undefined,
+              opened: true,
+              raisedBeds: [],
+              receipt: null,
+              refreshAuthentication: async () => undefined,
+              reserve: async () => undefined,
+              retryQueries: async () => undefined,
+              selectGarden: () => undefined,
+              selectRaisedBed: () => undefined,
+              selectTarget: () => undefined,
+              selectedGardenId: null,
+              selectedOffer:
+                  outletOffers.find((offer) => offer.id === selectedOfferId) ??
+                  null,
+              selectedRaisedBedId: null,
+              selectedTargetKey: null,
+              state: 'unavailable',
+              targets: [],
+          } satisfies OutletGardenCommerce)
+        : undefined;
 
     return (
         <div className="h-[100dvh] bg-muted">
@@ -142,6 +177,7 @@ export function OutletGardenOfferBrowserStory({
             {browserOpen ? (
                 <OutletGardenOfferBrowser
                     className="h-full w-full max-w-md"
+                    commerce={commerce}
                     displayLimited={displayLimited}
                     isError={state === 'error'}
                     isLoading={state === 'loading'}
@@ -186,6 +222,9 @@ export function OutletGardenOfferBrowserStory({
             </output>
             <output className="sr-only" data-hovered-offer-id>
                 {hoveredOfferId ?? 'none'}
+            </output>
+            <output className="sr-only" data-commerce-close-count>
+                {commerceCloseCount}
             </output>
             <output className="sr-only" data-selected-offer-id>
                 {selectedOfferId ?? 'none'}

--- a/apps/garden/tests/OutletGardenOfferBrowserStory.tsx
+++ b/apps/garden/tests/OutletGardenOfferBrowserStory.tsx
@@ -2,6 +2,7 @@ import {
     OutletGardenOfferBrowser,
     type OutletGardenOfferBrowserProps,
 } from '@gredice/game/outlet-garden-browser';
+import { Button } from '@gredice/ui/Button';
 import { useState } from 'react';
 
 type OutletOffer = OutletGardenOfferBrowserProps['offers'][number];
@@ -106,10 +107,12 @@ export type OutletGardenOfferBrowserStoryState =
 export function OutletGardenOfferBrowserStory({
     displayLimited = false,
     initialSelectedOfferId = null,
+    selectionDriven = false,
     state = 'ready',
 }: {
     displayLimited?: boolean;
     initialSelectedOfferId?: number | null;
+    selectionDriven?: boolean;
     state?: OutletGardenOfferBrowserStoryState;
 }) {
     const [selectedOfferId, setSelectedOfferId] = useState<number | null>(
@@ -117,26 +120,75 @@ export function OutletGardenOfferBrowserStory({
     );
     const [hoveredOfferId, setHoveredOfferId] = useState<number | null>(null);
     const [retryCount, setRetryCount] = useState(0);
+    const [offerListOpen, setOfferListOpen] = useState(false);
+    const browserOpen =
+        !selectionDriven || offerListOpen || selectedOfferId !== null;
 
     return (
         <div className="h-[100dvh] bg-muted">
-            <OutletGardenOfferBrowser
-                className="h-full w-full max-w-md"
-                displayLimited={displayLimited}
-                isError={state === 'error'}
-                isLoading={state === 'loading'}
-                offers={state === 'ready' ? outletOffers : []}
-                onExit={() => undefined}
-                onHoverOffer={setHoveredOfferId}
-                onRetry={() => setRetryCount((count) => count + 1)}
-                onSelectOffer={setSelectedOfferId}
-                selectedOfferId={selectedOfferId}
-            />
+            {selectionDriven ? (
+                <Button
+                    aria-controls="outlet-garden-browser"
+                    aria-expanded={offerListOpen}
+                    onClick={() => {
+                        setSelectedOfferId(null);
+                        setOfferListOpen(true);
+                    }}
+                    variant="outlined"
+                >
+                    Popis ponuda
+                </Button>
+            ) : null}
+            {browserOpen ? (
+                <OutletGardenOfferBrowser
+                    className="h-full w-full max-w-md"
+                    displayLimited={displayLimited}
+                    isError={state === 'error'}
+                    isLoading={state === 'loading'}
+                    offers={state === 'ready' ? outletOffers : []}
+                    onClose={
+                        selectionDriven
+                            ? () => {
+                                  setSelectedOfferId(null);
+                                  setOfferListOpen(false);
+                              }
+                            : undefined
+                    }
+                    onExit={() => undefined}
+                    onHoverOffer={setHoveredOfferId}
+                    onRetry={() => setRetryCount((count) => count + 1)}
+                    onSelectOffer={(offerId) => {
+                        setSelectedOfferId(offerId);
+                        if (selectionDriven) {
+                            setOfferListOpen(false);
+                        }
+                    }}
+                    onShowOfferList={
+                        selectionDriven
+                            ? () => {
+                                  setSelectedOfferId(null);
+                                  setOfferListOpen(true);
+                              }
+                            : undefined
+                    }
+                    selectedOfferId={selectedOfferId}
+                    view={
+                        selectionDriven
+                            ? offerListOpen
+                                ? 'list'
+                                : 'details'
+                            : 'combined'
+                    }
+                />
+            ) : null}
             <output className="sr-only" data-retry-count>
                 {retryCount}
             </output>
             <output className="sr-only" data-hovered-offer-id>
                 {hoveredOfferId ?? 'none'}
+            </output>
+            <output className="sr-only" data-selected-offer-id>
+                {selectedOfferId ?? 'none'}
             </output>
         </div>
     );

--- a/apps/garden/tests/outlet-garden-route.spec.ts
+++ b/apps/garden/tests/outlet-garden-route.spec.ts
@@ -532,6 +532,10 @@ test('guest Outlet garden renders WebGL, selects an offer, and preserves its dee
         '5',
     );
     await expect(page.locator('canvas')).toBeVisible();
+    await expect(page.locator('[data-outlet-garden-browser]')).toHaveCount(0);
+    await page
+        .getByRole('button', { name: 'Prikaži popis Outlet ponuda' })
+        .click();
     await expect(
         page.locator('[data-outlet-garden-offer-list]').getByRole('button'),
     ).toHaveCount(2);
@@ -561,7 +565,11 @@ test('guest Outlet garden renders WebGL, selects an offer, and preserves its dee
         'data-outlet-garden-hovered-offer',
         '302',
     );
-    await page.getByRole('heading', { name: 'Outlet vrt' }).hover();
+    await page
+        .getByRole('main', {
+            name: 'Interaktivni 3D prikaz Outlet vrta',
+        })
+        .hover({ position: { x: 20, y: 200 } });
     await expect(page.locator('[data-outlet-garden]')).not.toHaveAttribute(
         'data-outlet-garden-hovered-offer',
         /.+/u,
@@ -608,6 +616,9 @@ test('guest Outlet garden renders WebGL, selects an offer, and preserves its dee
     await expect(
         page.locator('[data-outlet-garden-selected-offer="302"]'),
     ).toContainText('1 sadnica');
+    await page
+        .getByRole('button', { name: 'Prikaži popis Outlet ponuda' })
+        .click();
     await expect(
         page.locator('[data-outlet-garden-offer-list]').getByRole('button'),
     ).toHaveCount(2);
@@ -617,6 +628,12 @@ test('guest Outlet garden renders WebGL, selects an offer, and preserves its dee
     await expect(page.locator('[data-outlet-garden]')).toHaveAttribute(
         'data-outlet-garden-display-count',
         '3',
+    );
+    await page.getByRole('button', { name: /Paprika Zlata Snack/u }).click();
+    await expect(page).toHaveURL(/\/outlet\?ponuda=302$/u);
+    await expect(page.locator('[data-outlet-garden]')).not.toHaveAttribute(
+        'data-outlet-garden-hovered-offer',
+        /.+/u,
     );
     if (canvasElement) {
         expect(
@@ -632,10 +649,13 @@ test('guest Outlet garden renders WebGL, selects an offer, and preserves its dee
     await expect(
         page.locator('[data-outlet-garden-selected-offer="302"]'),
     ).toBeVisible();
-    await expect(
-        page.locator('[data-outlet-garden-offer-id="302"]'),
-    ).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('[data-outlet-garden-offer-list]')).toHaveCount(
+        0,
+    );
 
+    await page
+        .getByRole('button', { name: 'Prikaži popis Outlet ponuda' })
+        .click();
     await page
         .getByRole('button', {
             name: 'Prikaži Outlet ponude bez 3D prikaza',
@@ -727,7 +747,7 @@ test('guest Outlet garden falls back to the semantic offer list without WebGL', 
         page.getByRole('link', {
             name: 'Nastavi u postojećem Outletu',
         }),
-    ).toHaveAttribute('href', '/?outlet=302');
+    ).toHaveCount(0);
     await expect(
         page.getByRole('button', {
             name: 'Pokušaj ponovno otvoriti 3D Outlet vrt',
@@ -761,13 +781,13 @@ test('signed-in list fallback holds the final unit and keeps its verified receip
 
     await page.getByRole('button', { name: 'Rezerviraj u svom vrtu' }).click();
 
-    const gardenSelect = page.getByRole('combobox', {
-        name: 'Vrt',
+    const raisedBedSelect = page.getByRole('combobox', {
+        name: 'Gredica',
         exact: true,
     });
-    await expect(gardenSelect).toHaveValue('1');
+    await expect(raisedBedSelect).toHaveValue('10');
     const targetSelect = page.getByRole('combobox', {
-        name: 'Mjesto u gredici',
+        name: 'Polje / pozicija',
         exact: true,
     });
     await expect(targetSelect.locator('option')).toHaveCount(18);
@@ -861,7 +881,7 @@ test('switches gardens when the default garden has no free targets', async ({
     await expect(
         page
             .getByRole('combobox', {
-                name: 'Mjesto u gredici',
+                name: 'Polje / pozicija',
                 exact: true,
             })
             .locator('option'),
@@ -885,7 +905,7 @@ test('refreshes the selected garden and moves off a rejected target', async ({
     await page.goto('/outlet?ponuda=302');
     await page.getByRole('button', { name: 'Rezerviraj u svom vrtu' }).click();
     const targetSelect = page.getByRole('combobox', {
-        name: 'Mjesto u gredici',
+        name: 'Polje / pozicija',
         exact: true,
     });
     await expect(targetSelect).toHaveValue('10:0');

--- a/apps/garden/tests/outlet-garden-route.spec.ts
+++ b/apps/garden/tests/outlet-garden-route.spec.ts
@@ -514,7 +514,7 @@ async function disableWebGL(page: Page) {
 test('guest Outlet garden renders WebGL, selects an offer, and preserves its deep link', async ({
     page,
 }, testInfo) => {
-    test.setTimeout(60_000);
+    test.setTimeout(90_000);
     const runtimeErrors: string[] = [];
     page.on('pageerror', (error) => runtimeErrors.push(error.message));
     const baseURL = testInfo.project.use.baseURL;
@@ -645,7 +645,10 @@ test('guest Outlet garden renders WebGL, selects an offer, and preserves its dee
         ).toBe(true);
     }
 
-    await page.reload();
+    await page.reload({
+        timeout: 20_000,
+        waitUntil: 'domcontentloaded',
+    });
     await expect(
         page.locator('[data-outlet-garden-selected-offer="302"]'),
     ).toBeVisible();

--- a/apps/garden/tests/outlet-garden.spec.tsx
+++ b/apps/garden/tests/outlet-garden.spec.tsx
@@ -59,12 +59,54 @@ test('selects a live offer and exposes truthful read-only details', async ({
     await expect(details).toContainText('Prvi cvjetovi');
     await expect(details).toContainText('21. kolovoza 2026.');
     await expect(details).toContainText(
-        'Pregled i odabir sadnice ne rezerviraju zalihu; rezervacija nastaje tek nakon potvrde polja.',
+        'Fotografija i 3D prikaz su reprezentativni. Zaliha se rezervira tek nakon potvrde polja.',
     );
     await expect(
         details.getByRole('link', { name: 'Nastavi u postojećem Outletu' }),
-    ).toHaveAttribute('href', '/?outlet=302');
+    ).toHaveCount(0);
     expect(mutationRequests).toEqual([]);
+});
+
+test('keeps the 3D sidebar closed until the list or a seedling is selected', async ({
+    mount,
+    page,
+}) => {
+    await mount(<OutletGardenOfferBrowserStory selectionDriven />);
+
+    const browser = page.locator('[data-outlet-garden-browser]');
+    await expect(browser).toHaveCount(0);
+
+    const listTrigger = page.getByRole('button', { name: 'Popis ponuda' });
+    await expect(listTrigger).toHaveAttribute('aria-expanded', 'false');
+    await listTrigger.click();
+
+    await expect(browser).toBeVisible();
+    await expect(listTrigger).toHaveAttribute('aria-expanded', 'true');
+    await expect(
+        browser.locator('[data-outlet-garden-offer-list]'),
+    ).toBeVisible();
+    await expect(
+        browser.locator('[data-outlet-garden-selected-offer]'),
+    ).toHaveCount(0);
+
+    await browser.getByRole('button', { name: /Paprika Zlata Snack/u }).click();
+
+    const details = browser.locator(
+        '[data-outlet-garden-selected-offer="302"]',
+    );
+    await expect(details).toBeVisible();
+    await expect(details).toBeFocused();
+    await expect(
+        browser.locator('[data-outlet-garden-offer-list]'),
+    ).toHaveCount(0);
+    await expect(page.locator('[data-selected-offer-id]')).toHaveText('302');
+    await expect(browser).not.toContainText('Nastavi u postojećem Outletu');
+
+    await browser
+        .getByRole('button', { name: 'Zatvori detalje sadnice' })
+        .click();
+    await expect(browser).toHaveCount(0);
+    await expect(page.locator('[data-selected-offer-id]')).toHaveText('none');
 });
 
 test('shows representative hierarchy imagery and complete offer pricing', async ({

--- a/apps/garden/tests/outlet-garden.spec.tsx
+++ b/apps/garden/tests/outlet-garden.spec.tsx
@@ -109,6 +109,32 @@ test('keeps the 3D sidebar closed until the list or a seedling is selected', asy
     await expect(page.locator('[data-selected-offer-id]')).toHaveText('none');
 });
 
+test('returns unavailable 3D reservations to the in-scene offer list', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <OutletGardenOfferBrowserStory
+            commerceUnavailable
+            initialSelectedOfferId={302}
+            selectionDriven
+        />,
+    );
+
+    const browser = page.locator('[data-outlet-garden-browser]');
+    await expect(browser).toHaveAttribute(
+        'data-outlet-garden-state',
+        'selected',
+    );
+    await browser.getByRole('button', { name: 'Odaberi drugu' }).click();
+
+    await expect(browser).toBeVisible();
+    await expect(
+        browser.locator('[data-outlet-garden-offer-list]'),
+    ).toBeVisible();
+    await expect(page.locator('[data-commerce-close-count]')).toHaveText('1');
+});
+
 test('shows representative hierarchy imagery and complete offer pricing', async ({
     mount,
     page,

--- a/packages/game/src/internalSceneBlockData.ts
+++ b/packages/game/src/internalSceneBlockData.ts
@@ -3,12 +3,15 @@ import type { BlockData } from '@gredice/client';
 export const outletDisplayTableBlockName = 'OutletDisplayTable';
 export const outletDisplayTableHeight = 0.67;
 export const outletDisplayTableSunflowerPrice = 40;
+export const enamelGardenLampBlockName = 'EnamelGardenLamp';
+export const enamelGardenLampHeight = 1.45;
 
 const epoch = new Date(0).toISOString();
-const internalSceneBlockId = -10_001;
+const outletDisplayTableBlockId = -10_001;
+const enamelGardenLampBlockId = -10_002;
 
 const outletDisplayTableBlockData = {
-    id: internalSceneBlockId,
+    id: outletDisplayTableBlockId,
     entityType: {
         id: 8,
         name: 'block',
@@ -45,24 +48,74 @@ const outletDisplayTableBlockData = {
     updatedAt: epoch,
 } satisfies BlockData;
 
+const enamelGardenLampBlockData = {
+    id: enamelGardenLampBlockId,
+    entityType: {
+        id: 8,
+        name: 'block',
+        label: 'Blok',
+    },
+    slug: 'enamel-garden-lamp',
+    information: {
+        name: enamelGardenLampBlockName,
+        label: 'Emajlirana vrtna lampa',
+        shortDescription:
+            'Visoka vrtna lampa s emajliranim sjenilom i toplim, mirnim svjetlom.',
+        fullDescription:
+            'Vrtna lampa s drvenim stupom i emajliranim sjenilom koja noću toplim svjetlom osvjetljava stazu i obližnje biljke.',
+    },
+    attributes: {
+        height: enamelGardenLampHeight,
+        hitboxDepth: 0.46,
+        hitboxHeight: enamelGardenLampHeight,
+        hitboxWidth: 0.52,
+        nightOnlyPurchase: false,
+        placeableOnWater: false,
+        spanDepth: 1,
+        spanWidth: 1,
+        stackable: false,
+        type: 'decoration',
+    },
+    prices: {
+        sunflowers: 0,
+    },
+    functions: {
+        recycler: false,
+        raisedBed: false,
+    },
+    createdAt: epoch,
+    updatedAt: epoch,
+} satisfies BlockData;
+
+const internalSceneBlockData = [
+    outletDisplayTableBlockData,
+    enamelGardenLampBlockData,
+];
+const internalSceneBlockIds = new Set(
+    internalSceneBlockData.map((block) => block.id),
+);
+
 export function isInternalSceneBlockData(block: BlockData) {
-    return block.id === internalSceneBlockId;
+    return internalSceneBlockIds.has(block.id);
 }
 
 export function getInternalSceneBlockData(): BlockData[] {
-    return [outletDisplayTableBlockData];
+    return internalSceneBlockData;
 }
 
 export function withInternalSceneBlockData(
     blockData: BlockData[],
 ): BlockData[] {
-    if (
-        blockData.some(
-            (block) => block.information.name === outletDisplayTableBlockName,
-        )
-    ) {
+    const directoryBlockNames = new Set(
+        blockData.map((block) => block.information.name),
+    );
+    const missingInternalBlocks = internalSceneBlockData.filter(
+        (block) => !directoryBlockNames.has(block.information.name),
+    );
+
+    if (missingInternalBlocks.length === 0) {
         return blockData;
     }
 
-    return [...blockData, outletDisplayTableBlockData];
+    return [...blockData, ...missingInternalBlocks];
 }

--- a/packages/game/src/internalSceneBlockData.unit.ts
+++ b/packages/game/src/internalSceneBlockData.unit.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+    enamelGardenLampBlockName,
+    enamelGardenLampHeight,
     getInternalSceneBlockData,
     isInternalSceneBlockData,
     outletDisplayTableBlockName,
@@ -11,7 +13,9 @@ import {
 
 describe('internal scene block data', () => {
     it('defines the outlet table fallback with its catalog metadata and footprint', () => {
-        const [table] = getInternalSceneBlockData();
+        const table = getInternalSceneBlockData().find(
+            (block) => block.information.name === outletDisplayTableBlockName,
+        );
 
         assert.ok(table);
         assert.equal(table.information.name, outletDisplayTableBlockName);
@@ -27,25 +31,48 @@ describe('internal scene block data', () => {
         assert.equal(isInternalSceneBlockData(table), true);
     });
 
+    it('defines a private metadata fallback for the Outlet night lamp', () => {
+        const lamp = getInternalSceneBlockData().find(
+            (block) => block.information.name === enamelGardenLampBlockName,
+        );
+
+        assert.ok(lamp);
+        assert.equal(lamp.attributes.height, enamelGardenLampHeight);
+        assert.equal(lamp.attributes.hitboxDepth, 0.46);
+        assert.equal(lamp.attributes.hitboxHeight, enamelGardenLampHeight);
+        assert.equal(lamp.attributes.hitboxWidth, 0.52);
+        assert.equal(lamp.attributes.spanDepth, 1);
+        assert.equal(lamp.attributes.spanWidth, 1);
+        assert.equal(lamp.attributes.stackable, false);
+        assert.equal(isInternalSceneBlockData(lamp), true);
+    });
+
     it('adds the internal fallback without mutating directory data', () => {
-        const directoryData = getInternalSceneBlockData().map((table) => ({
-            ...table,
+        const directoryData = getInternalSceneBlockData().map((block) => ({
+            ...block,
             id: 42,
             information: {
-                ...table.information,
-                name: 'ExistingBlock',
+                ...block.information,
+                name: `ExistingBlock-${block.information.name}`,
             },
         }));
         const merged = withInternalSceneBlockData(directoryData);
 
-        assert.equal(directoryData.length, 1);
-        assert.equal(merged.length, 2);
+        assert.equal(directoryData.length, 2);
+        assert.equal(merged.length, 4);
         assert.equal(merged[0], directoryData[0]);
-        assert.equal(merged[1]?.information.name, outletDisplayTableBlockName);
+        assert.deepEqual(
+            merged
+                .slice(directoryData.length)
+                .map((block) => block.information.name),
+            [outletDisplayTableBlockName, enamelGardenLampBlockName],
+        );
     });
 
     it('lets a future live directory row override the fallback', () => {
-        const [fallback] = getInternalSceneBlockData();
+        const fallback = getInternalSceneBlockData().find(
+            (block) => block.information.name === outletDisplayTableBlockName,
+        );
         assert.ok(fallback);
         const liveTable = {
             ...fallback,
@@ -57,9 +84,10 @@ describe('internal scene block data', () => {
         };
         const merged = withInternalSceneBlockData([liveTable]);
 
-        assert.equal(merged.length, 1);
+        assert.equal(merged.length, 2);
         assert.equal(merged[0], liveTable);
         assert.equal(merged[0]?.attributes.height, 0.69);
         assert.equal(isInternalSceneBlockData(liveTable), false);
+        assert.equal(merged[1]?.information.name, enamelGardenLampBlockName);
     });
 });

--- a/packages/game/src/viewers/OutletGardenCommerce.tsx
+++ b/packages/game/src/viewers/OutletGardenCommerce.tsx
@@ -70,23 +70,32 @@ type OutletGardenCommerceGarden = {
     name: string;
 };
 
+export type OutletGardenCommerceRaisedBed = {
+    id: number;
+    name: string;
+};
+
 export type OutletGardenCommerceController = {
     cartHref: `/?vrt=${number}&kosarica=true` | null;
     close: () => void;
     continueToCart: () => void;
     enabled: boolean;
     errorMessage: string | null;
+    fieldTargets: readonly EmptyRaisedBedFieldTarget[];
     gardens: readonly OutletGardenCommerceGarden[];
     open: () => void;
     opened: boolean;
+    raisedBeds: readonly OutletGardenCommerceRaisedBed[];
     receipt: OutletGardenCommerceReceipt | null;
     refreshAuthentication: () => Promise<void>;
     reserve: () => Promise<void>;
     retryQueries: () => Promise<void>;
     selectGarden: (gardenId: number) => void;
+    selectRaisedBed: (raisedBedId: number) => void;
     selectTarget: (targetKey: string) => void;
     selectedGardenId: number | null;
     selectedOffer: OutletOfferData | null;
+    selectedRaisedBedId: number | null;
     selectedTargetKey: string | null;
     state: OutletGardenCommerceState;
     targets: readonly EmptyRaisedBedFieldTarget[];
@@ -179,6 +188,61 @@ export function resolveOutletGardenCommerceState({
 
 function targetKey(target: EmptyRaisedBedFieldTarget) {
     return `${target.raisedBedId.toString()}:${target.positionIndex.toString()}`;
+}
+
+export function groupOutletGardenTargetsByRaisedBed(
+    targets: readonly EmptyRaisedBedFieldTarget[],
+) {
+    const seenRaisedBedIds = new Set<number>();
+    const raisedBeds: OutletGardenCommerceRaisedBed[] = [];
+
+    for (const target of targets) {
+        if (seenRaisedBedIds.has(target.raisedBedId)) {
+            continue;
+        }
+        seenRaisedBedIds.add(target.raisedBedId);
+        raisedBeds.push({
+            id: target.raisedBedId,
+            name: target.raisedBedName,
+        });
+    }
+
+    return raisedBeds;
+}
+
+export function resolveOutletGardenTargetSelection({
+    selectedRaisedBedId,
+    selectedTargetKey,
+    targets,
+}: {
+    selectedRaisedBedId: number | null;
+    selectedTargetKey: string | null;
+    targets: readonly EmptyRaisedBedFieldTarget[];
+}) {
+    const raisedBeds = groupOutletGardenTargetsByRaisedBed(targets);
+    const selectedRaisedBed =
+        raisedBeds.find((raisedBed) => raisedBed.id === selectedRaisedBedId) ??
+        raisedBeds[0] ??
+        null;
+    const fieldTargets = selectedRaisedBed
+        ? targets.filter(
+              (target) => target.raisedBedId === selectedRaisedBed.id,
+          )
+        : [];
+    const selectedTarget =
+        fieldTargets.find(
+            (target) => targetKey(target) === selectedTargetKey,
+        ) ??
+        fieldTargets[0] ??
+        null;
+
+    return {
+        fieldTargets,
+        raisedBeds,
+        selectedRaisedBedId: selectedRaisedBed?.id ?? null,
+        selectedTarget,
+        selectedTargetKey: selectedTarget ? targetKey(selectedTarget) : null,
+    };
 }
 
 function isHeldOutletCartItem(
@@ -313,6 +377,9 @@ export function useOutletGardenCommerce({
     const [selectedGardenId, setSelectedGardenId] = useState<number | null>(
         null,
     );
+    const [selectedRaisedBedId, setSelectedRaisedBedId] = useState<
+        number | null
+    >(null);
     const [selectedTargetKey, setSelectedTargetKey] = useState<string | null>(
         null,
     );
@@ -362,10 +429,22 @@ export function useOutletGardenCommerce({
             ),
         [shoppingCart.data?.items, targetGarden.data],
     );
-    const selectedTarget =
-        targets.find((target) => targetKey(target) === selectedTargetKey) ??
-        targets[0] ??
-        null;
+    const targetSelection = useMemo(
+        () =>
+            resolveOutletGardenTargetSelection({
+                selectedRaisedBedId,
+                selectedTargetKey,
+                targets,
+            }),
+        [selectedRaisedBedId, selectedTargetKey, targets],
+    );
+    const {
+        fieldTargets,
+        raisedBeds,
+        selectedTarget,
+        selectedRaisedBedId: resolvedRaisedBedId,
+        selectedTargetKey: resolvedTargetKey,
+    } = targetSelection;
     const mutation = useSetShoppingCartItem(
         shouldLoadAuthenticated && authenticated && !authenticationExpired,
     );
@@ -404,6 +483,7 @@ export function useOutletGardenCommerce({
         setOpened(requested && enabled && selectedOfferId !== null);
         setReceipt(null);
         setErrorMessage(null);
+        setSelectedRaisedBedId(null);
         setSelectedTargetKey(null);
     }, [enabled, requested, selectedOfferId]);
 
@@ -413,15 +493,24 @@ export function useOutletGardenCommerce({
             !eligibleGardens.some((garden) => garden.id === selectedGardenId)
         ) {
             setSelectedGardenId(eligibleGardens[0]?.id ?? null);
+            setSelectedRaisedBedId(null);
             setSelectedTargetKey(null);
         }
     }, [eligibleGardens, selectedGardenId]);
 
     useEffect(() => {
-        if (selectedTarget && selectedTargetKey !== targetKey(selectedTarget)) {
-            setSelectedTargetKey(targetKey(selectedTarget));
+        if (selectedRaisedBedId !== resolvedRaisedBedId) {
+            setSelectedRaisedBedId(resolvedRaisedBedId);
         }
-    }, [selectedTarget, selectedTargetKey]);
+        if (selectedTargetKey !== resolvedTargetKey) {
+            setSelectedTargetKey(resolvedTargetKey);
+        }
+    }, [
+        resolvedRaisedBedId,
+        resolvedTargetKey,
+        selectedRaisedBedId,
+        selectedTargetKey,
+    ]);
 
     useEffect(() => {
         if (!receipt) {
@@ -573,9 +662,10 @@ export function useOutletGardenCommerce({
                 return;
             }
             setSelectedGardenId(gardenId);
+            setSelectedRaisedBedId(null);
             setSelectedTargetKey(null);
             setErrorMessage(null);
-            track('game_outlet_garden_field_selected', {
+            track('game_outlet_garden_garden_selected', {
                 garden_id: gardenId,
                 outlet_offer_id: selectedOfferId ?? undefined,
                 renderer,
@@ -584,9 +674,41 @@ export function useOutletGardenCommerce({
         [eligibleGardens, renderer, selectedOfferId, track],
     );
 
+    const selectRaisedBed = useCallback(
+        (raisedBedId: number) => {
+            if (!raisedBeds.some((raisedBed) => raisedBed.id === raisedBedId)) {
+                return;
+            }
+            const firstTarget = targets.find(
+                (target) => target.raisedBedId === raisedBedId,
+            );
+            if (!firstTarget) {
+                return;
+            }
+            setSelectedRaisedBedId(raisedBedId);
+            setSelectedTargetKey(targetKey(firstTarget));
+            setErrorMessage(null);
+            track('game_outlet_garden_field_selected', {
+                garden_id: selectedGardenId ?? undefined,
+                outlet_offer_id: selectedOfferId ?? undefined,
+                position_index: firstTarget.positionIndex,
+                raised_bed_id: firstTarget.raisedBedId,
+                renderer,
+            });
+        },
+        [
+            raisedBeds,
+            renderer,
+            selectedGardenId,
+            selectedOfferId,
+            targets,
+            track,
+        ],
+    );
+
     const selectTarget = useCallback(
         (nextTargetKey: string) => {
-            const target = targets.find(
+            const target = fieldTargets.find(
                 (candidate) => targetKey(candidate) === nextTargetKey,
             );
             if (!target) {
@@ -602,7 +724,7 @@ export function useOutletGardenCommerce({
                 renderer,
             });
         },
-        [renderer, selectedGardenId, selectedOfferId, targets, track],
+        [fieldTargets, renderer, selectedGardenId, selectedOfferId, track],
     );
 
     const reserve = useCallback(async () => {
@@ -776,18 +898,22 @@ export function useOutletGardenCommerce({
         continueToCart,
         enabled,
         errorMessage,
+        fieldTargets,
         gardens: eligibleGardens,
         open,
         opened,
+        raisedBeds,
         receipt,
         refreshAuthentication,
         reserve,
         retryQueries,
         selectGarden,
+        selectRaisedBed,
         selectTarget,
         selectedGardenId,
         selectedOffer: selectedLiveOffer ?? receipt?.offer ?? null,
-        selectedTargetKey: selectedTarget ? targetKey(selectedTarget) : null,
+        selectedRaisedBedId: resolvedRaisedBedId,
+        selectedTargetKey: resolvedTargetKey,
         state,
         targets,
     };
@@ -890,28 +1016,55 @@ export function OutletGardenReservationPanel({
                 <div>
                     <h3 className="font-semibold">Odaberi mjesto za sadnicu</h3>
                     <div className="mt-3 grid gap-3">
+                        {commerce.gardens.length > 1 ? (
+                            <label className="grid gap-1 text-sm">
+                                <span className="font-medium">Vrt</span>
+                                <select
+                                    className="min-h-11 rounded-lg border bg-background px-3"
+                                    disabled={commerce.state === 'reserving'}
+                                    onChange={(event) =>
+                                        commerce.selectGarden(
+                                            Number(event.currentTarget.value),
+                                        )
+                                    }
+                                    value={commerce.selectedGardenId ?? ''}
+                                >
+                                    {commerce.gardens.map((garden) => (
+                                        <option
+                                            key={garden.id}
+                                            value={garden.id}
+                                        >
+                                            {garden.name}
+                                        </option>
+                                    ))}
+                                </select>
+                            </label>
+                        ) : null}
                         <label className="grid gap-1 text-sm">
-                            <span className="font-medium">Vrt</span>
+                            <span className="font-medium">Gredica</span>
                             <select
                                 className="min-h-11 rounded-lg border bg-background px-3"
                                 disabled={commerce.state === 'reserving'}
                                 onChange={(event) =>
-                                    commerce.selectGarden(
+                                    commerce.selectRaisedBed(
                                         Number(event.currentTarget.value),
                                     )
                                 }
-                                value={commerce.selectedGardenId ?? ''}
+                                value={commerce.selectedRaisedBedId ?? ''}
                             >
-                                {commerce.gardens.map((garden) => (
-                                    <option key={garden.id} value={garden.id}>
-                                        {garden.name}
+                                {commerce.raisedBeds.map((raisedBed) => (
+                                    <option
+                                        key={raisedBed.id}
+                                        value={raisedBed.id}
+                                    >
+                                        {raisedBed.name}
                                     </option>
                                 ))}
                             </select>
                         </label>
                         <label className="grid gap-1 text-sm">
                             <span className="font-medium">
-                                Mjesto u gredici
+                                Polje / pozicija
                             </span>
                             <select
                                 className="min-h-11 rounded-lg border bg-background px-3"
@@ -923,12 +1076,12 @@ export function OutletGardenReservationPanel({
                                 }
                                 value={commerce.selectedTargetKey ?? ''}
                             >
-                                {commerce.targets.map((target) => (
+                                {commerce.fieldTargets.map((target) => (
                                     <option
                                         key={targetKey(target)}
                                         value={targetKey(target)}
                                     >
-                                        {target.raisedBedName} · polje{' '}
+                                        Polje{' '}
                                         {(target.positionIndex + 1).toString()}
                                     </option>
                                 ))}

--- a/packages/game/src/viewers/OutletGardenCommerce.unit.ts
+++ b/packages/game/src/viewers/OutletGardenCommerce.unit.ts
@@ -1,10 +1,22 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    groupOutletGardenTargetsByRaisedBed,
     hasOutletGardenAuthenticationExpired,
     outletGardenOfferFromHeldCartItem,
     resolveOutletGardenCommerceState,
+    resolveOutletGardenTargetSelection,
 } from './OutletGardenCommerce';
+
+const target = (
+    raisedBedId: number,
+    raisedBedName: string,
+    positionIndex: number,
+) => ({
+    positionIndex,
+    raisedBedId,
+    raisedBedName,
+});
 
 const readyStateInput = {
     authenticated: true,
@@ -82,6 +94,81 @@ test('preserves mutation errors and shows loading while retrying queries', () =>
         }),
         'loading',
     );
+});
+
+test('groups free positions by raised bed in source order', () => {
+    assert.deepEqual(
+        groupOutletGardenTargetsByRaisedBed([
+            target(22, 'Zapadna gredica', 3),
+            target(22, 'Zapadna gredica', 7),
+            target(11, 'Ulazna gredica', 0),
+            target(11, 'Ulazna gredica', 2),
+        ]),
+        [
+            { id: 22, name: 'Zapadna gredica' },
+            { id: 11, name: 'Ulazna gredica' },
+        ],
+    );
+});
+
+test('preselects the first raised bed with its first free position', () => {
+    const selection = resolveOutletGardenTargetSelection({
+        selectedRaisedBedId: null,
+        selectedTargetKey: null,
+        targets: [
+            target(22, 'Zapadna gredica', 3),
+            target(22, 'Zapadna gredica', 7),
+            target(11, 'Ulazna gredica', 0),
+        ],
+    });
+
+    assert.equal(selection.selectedRaisedBedId, 22);
+    assert.equal(selection.selectedTargetKey, '22:3');
+    assert.deepEqual(selection.fieldTargets, [
+        target(22, 'Zapadna gredica', 3),
+        target(22, 'Zapadna gredica', 7),
+    ]);
+});
+
+test('limits positions to the selected raised bed and preselects its first free one', () => {
+    const selection = resolveOutletGardenTargetSelection({
+        selectedRaisedBedId: 11,
+        selectedTargetKey: '22:7',
+        targets: [
+            target(22, 'Zapadna gredica', 3),
+            target(22, 'Zapadna gredica', 7),
+            target(11, 'Ulazna gredica', 0),
+            target(11, 'Ulazna gredica', 2),
+        ],
+    });
+
+    assert.equal(selection.selectedRaisedBedId, 11);
+    assert.equal(selection.selectedTargetKey, '11:0');
+    assert.deepEqual(selection.fieldTargets, [
+        target(11, 'Ulazna gredica', 0),
+        target(11, 'Ulazna gredica', 2),
+    ]);
+});
+
+test('reselects a free position after a target conflict refresh', () => {
+    const sameRaisedBed = resolveOutletGardenTargetSelection({
+        selectedRaisedBedId: 22,
+        selectedTargetKey: '22:3',
+        targets: [
+            target(22, 'Zapadna gredica', 7),
+            target(11, 'Ulazna gredica', 0),
+        ],
+    });
+    assert.equal(sameRaisedBed.selectedRaisedBedId, 22);
+    assert.equal(sameRaisedBed.selectedTargetKey, '22:7');
+
+    const nextRaisedBed = resolveOutletGardenTargetSelection({
+        selectedRaisedBedId: 22,
+        selectedTargetKey: '22:7',
+        targets: [target(11, 'Ulazna gredica', 0)],
+    });
+    assert.equal(nextRaisedBed.selectedRaisedBedId, 11);
+    assert.equal(nextRaisedBed.selectedTargetKey, '11:0');
 });
 
 test('builds the receipt offer from the authoritative held cart snapshot', () => {

--- a/packages/game/src/viewers/OutletGardenOfferBrowser.tsx
+++ b/packages/game/src/viewers/OutletGardenOfferBrowser.tsx
@@ -2,11 +2,12 @@
 
 import { plantFieldStatusLabel } from '@gredice/js/plants';
 import { Button } from '@gredice/ui/Button';
-import { ArrowLeft, Reset, Sprout } from '@gredice/ui/icons';
+import { IconButton } from '@gredice/ui/IconButton';
+import { ArrowLeft, Close, Reset, Sprout } from '@gredice/ui/icons';
 import { Spinner } from '@gredice/ui/Spinner';
 import { cx } from '@gredice/ui/utils';
 import type { Route } from 'next';
-import type { ReactNode } from 'react';
+import { type ReactNode, useEffect, useRef } from 'react';
 import type { OutletOfferData } from '../hooks/useOutletOffers';
 import {
     type OutletGardenCommerceController,
@@ -141,13 +142,16 @@ export type OutletGardenOfferBrowserProps = {
     isError: boolean;
     isLoading: boolean;
     offers: readonly OutletOfferData[];
+    onClose?: () => void;
     onExit: (destination: 'existing_outlet' | 'garden', href: Route) => void;
     onHoverOffer?: (offerId: number | null) => void;
     onAuthenticationRequired?: () => void;
     onRetry: () => void;
     onSelectOffer: (offerId: number | null) => void;
+    onShowOfferList?: () => void;
     renderer?: OutletGardenRenderer;
     selectedOfferId: number | null;
+    view?: 'combined' | 'details' | 'list';
 };
 
 export function OutletGardenOfferBrowser({
@@ -158,13 +162,16 @@ export function OutletGardenOfferBrowser({
     isError,
     isLoading,
     offers,
+    onClose,
     onExit,
     onHoverOffer,
     onAuthenticationRequired,
     onRetry,
     onSelectOffer,
+    onShowOfferList,
     renderer = 'webgl',
     selectedOfferId,
+    view = 'combined',
 }: OutletGardenOfferBrowserProps) {
     const plantGroups = groupOutletGardenOffers(offers);
     const selectedOffer =
@@ -174,6 +181,9 @@ export function OutletGardenOfferBrowser({
             : null);
     const selectedOfferMissing =
         selectedOfferId !== null && !selectedOffer && !isLoading && !isError;
+    const showOfferList = view !== 'details';
+    const showSelectedOffer = view !== 'list';
+    const selectedOfferIdForFocus = selectedOffer?.id ?? null;
     const state = isLoading
         ? 'loading'
         : isError
@@ -182,9 +192,16 @@ export function OutletGardenOfferBrowser({
             ? 'empty'
             : selectedOfferMissing
               ? 'missing'
-              : selectedOffer
+              : selectedOffer && showSelectedOffer
                 ? 'selected'
                 : 'ready';
+    const selectedDetailsRef = useRef<HTMLElement>(null);
+
+    useEffect(() => {
+        if (view === 'details' && selectedOfferIdForFocus !== null) {
+            selectedDetailsRef.current?.focus({ preventScroll: true });
+        }
+    }, [selectedOfferIdForFocus, view]);
 
     return (
         <aside
@@ -195,6 +212,7 @@ export function OutletGardenOfferBrowser({
             )}
             data-outlet-garden-browser
             data-outlet-garden-state={state}
+            id="outlet-garden-browser"
         >
             <header className="border-b px-4 py-3 sm:px-5 sm:py-4">
                 <div className="flex items-center justify-between gap-3">
@@ -218,27 +236,45 @@ export function OutletGardenOfferBrowser({
                             Outlet vrt
                         </h1>
                     </div>
-                    <Button
-                        aria-label="Povratak u moj vrt"
-                        href="/"
-                        onClick={(event) => {
-                            event.preventDefault();
-                            onExit('garden', '/');
-                        }}
-                        size="lg"
-                        startDecorator={<ArrowLeft className="size-4" />}
-                        variant="soft"
-                    >
-                        Povratak
-                    </Button>
+                    {onClose ? (
+                        <IconButton
+                            aria-label={
+                                view === 'details'
+                                    ? 'Zatvori detalje sadnice'
+                                    : 'Zatvori popis Outlet ponuda'
+                            }
+                            className="shrink-0 rounded-full"
+                            onClick={onClose}
+                            size="lg"
+                            variant="plain"
+                        >
+                            <Close aria-hidden className="size-4" />
+                        </IconButton>
+                    ) : (
+                        <Button
+                            aria-label="Povratak u moj vrt"
+                            href="/"
+                            onClick={(event) => {
+                                event.preventDefault();
+                                onExit('garden', '/');
+                            }}
+                            size="lg"
+                            startDecorator={<ArrowLeft className="size-4" />}
+                            variant="soft"
+                        >
+                            Povratak
+                        </Button>
+                    )}
                 </div>
-                <p className="mt-2 text-sm text-muted-foreground">
-                    {renderer === 'list'
-                        ? 'Razgledaj aktualne ponude, njihove cijene i punu dostupnu količinu.'
-                        : displayLimited
-                          ? `Razgledaj aktualne ponude. Za velike zalihe prikazujemo najviše ${outletGardenMaxDisplayedUnitsPerOffer.toString()} sadnica po ponudi i ${outletGardenMaxDisplayedUnitsTotal.toString()} ukupno; kartice uvijek pokazuju punu dostupnu količinu.`
-                          : 'Razgledaj aktualne ponude. Broj 3D sadnica prati trenutno dostupnu količinu svake ponude.'}
-                </p>
+                {view !== 'details' ? (
+                    <p className="mt-2 text-sm text-muted-foreground">
+                        {renderer === 'list'
+                            ? 'Razgledaj aktualne ponude, njihove cijene i punu dostupnu količinu.'
+                            : displayLimited
+                              ? `Razgledaj aktualne ponude. Za velike zalihe prikazujemo najviše ${outletGardenMaxDisplayedUnitsPerOffer.toString()} sadnica po ponudi i ${outletGardenMaxDisplayedUnitsTotal.toString()} ukupno; kartice uvijek pokazuju punu dostupnu količinu.`
+                              : 'Razgledaj aktualne ponude. Broj 3D sadnica prati trenutno dostupnu količinu svake ponude.'}
+                    </p>
+                ) : null}
                 {headerAction ? (
                     <div className="mt-3">{headerAction}</div>
                 ) : null}
@@ -312,7 +348,14 @@ export function OutletGardenOfferBrowser({
                             </p>
                             <Button
                                 className="mt-3"
-                                onClick={() => onSelectOffer(null)}
+                                onClick={() => {
+                                    if (onShowOfferList) {
+                                        onShowOfferList();
+                                        return;
+                                    }
+
+                                    onSelectOffer(null);
+                                }}
                                 size="lg"
                                 variant="outlined"
                             >
@@ -322,7 +365,7 @@ export function OutletGardenOfferBrowser({
                     ) : null}
                 </div>
 
-                {offers.length > 0 ? (
+                {offers.length > 0 && showOfferList ? (
                     <section aria-labelledby="outlet-garden-list-title">
                         <h2
                             className="mb-2 text-sm font-semibold"
@@ -557,11 +600,16 @@ export function OutletGardenOfferBrowser({
                     </section>
                 ) : null}
 
-                {selectedOffer ? (
+                {selectedOffer && showSelectedOffer ? (
                     <article
                         aria-labelledby="outlet-garden-selected-title"
-                        className="mt-4 overflow-hidden rounded-2xl border bg-card shadow-sm"
+                        className={cx(
+                            'overflow-hidden rounded-2xl border bg-card shadow-sm outline-hidden',
+                            showOfferList ? 'mt-4' : null,
+                        )}
                         data-outlet-garden-selected-offer={selectedOffer.id}
+                        ref={selectedDetailsRef}
+                        tabIndex={-1}
                     >
                         <div className="relative aspect-[16/9] bg-lime-50 dark:bg-lime-950/30">
                             {offerImageUrl(selectedOffer) ? (
@@ -658,12 +706,9 @@ export function OutletGardenOfferBrowser({
                                 </div>
                             </dl>
 
-                            <p className="mt-3 text-xs leading-relaxed text-muted-foreground">
-                                Fotografija može prikazivati konkretnu ponudu
-                                ili pripadajuću sortu; 3D model je
-                                reprezentativan. Pregled i odabir sadnice ne
-                                rezerviraju zalihu; rezervacija nastaje tek
-                                nakon potvrde polja.
+                            <p className="mt-3 text-[10px] leading-4 text-muted-foreground/70">
+                                Fotografija i 3D prikaz su reprezentativni.
+                                Zaliha se rezervira tek nakon potvrde polja.
                             </p>
 
                             {commerce ? (
@@ -679,30 +724,15 @@ export function OutletGardenOfferBrowser({
                                 />
                             ) : null}
 
-                            {commerce?.state !== 'success' &&
-                            commerce?.state !== 'expired' ? (
-                                <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-1">
-                                    <Button
-                                        href={`/?outlet=${selectedOffer.id.toString()}`}
-                                        fullWidth
-                                        onClick={(event) => {
-                                            event.preventDefault();
-                                            onExit(
-                                                'existing_outlet',
-                                                `/?outlet=${selectedOffer.id.toString()}`,
-                                            );
-                                        }}
-                                    >
-                                        Nastavi u postojećem Outletu
-                                    </Button>
-                                    <Button
-                                        fullWidth
-                                        onClick={() => onSelectOffer(null)}
-                                        variant="outlined"
-                                    >
-                                        Zatvori detalje
-                                    </Button>
-                                </div>
+                            {view === 'combined' ? (
+                                <Button
+                                    className="mt-4"
+                                    fullWidth
+                                    onClick={() => onSelectOffer(null)}
+                                    variant="outlined"
+                                >
+                                    Zatvori detalje
+                                </Button>
                             ) : null}
                         </div>
                     </article>

--- a/packages/game/src/viewers/OutletGardenOfferBrowser.tsx
+++ b/packages/game/src/viewers/OutletGardenOfferBrowser.tsx
@@ -719,6 +719,10 @@ export function OutletGardenOfferBrowser({
                                     }
                                     onChooseAnother={() => {
                                         commerce.close();
+                                        if (onShowOfferList) {
+                                            onShowOfferList();
+                                            return;
+                                        }
                                         onSelectOffer(null);
                                     }}
                                 />

--- a/packages/game/src/viewers/OutletGardenViewer.tsx
+++ b/packages/game/src/viewers/OutletGardenViewer.tsx
@@ -85,6 +85,7 @@ export function OutletGardenViewer({
     );
     const [hoveredOfferId, setHoveredOfferId] = useState<number | null>(null);
     const [focusedBlockId, setFocusedBlockId] = useState<string | null>(null);
+    const [offerListOpen, setOfferListOpen] = useState(false);
     const { track } = useGameAnalytics();
     const openedTrackedRef = useRef(false);
     const sceneFailureTrackedRef = useRef(false);
@@ -352,15 +353,6 @@ export function OutletGardenViewer({
         reportSceneFailure('context_lost');
     }, [reportSceneFailure]);
 
-    const requestListFallback = useCallback(() => {
-        track('game_outlet_garden_fallback_requested', {
-            fallback_reason: 'user',
-            renderer: 'webgl',
-            scene_ready: sceneReadyTrackedRef.current,
-        });
-        onUseListFallback?.();
-    }, [onUseListFallback, track]);
-
     const requestExit = useCallback(
         (destination: 'existing_outlet' | 'garden', href: Route) => {
             if (exitTarget) {
@@ -399,6 +391,8 @@ export function OutletGardenViewer({
     const selectOffer = useCallback(
         (offerId: number | null, blockId?: string) => {
             void setSelectedOfferId(offerId);
+            setOfferListOpen(false);
+            setHoveredOfferId(null);
             if (offerId === null) {
                 setFocusedBlockId(null);
                 return;
@@ -415,6 +409,39 @@ export function OutletGardenViewer({
         [offers, setSelectedOfferId, track],
     );
 
+    const openOfferList = useCallback(() => {
+        setFocusedBlockId(null);
+        setHoveredOfferId(null);
+        setOfferListOpen(true);
+        track('game_outlet_garden_offer_list_opened', {
+            outlet_offer_count: offers.length,
+            renderer: 'webgl',
+        });
+    }, [offers.length, track]);
+
+    const requestListFallback = useCallback(() => {
+        track('game_outlet_garden_fallback_requested', {
+            fallback_reason: 'user',
+            renderer: 'webgl',
+            scene_ready: sceneReadyTrackedRef.current,
+        });
+        onUseListFallback?.();
+    }, [onUseListFallback, track]);
+
+    const closeOfferBrowser = useCallback(() => {
+        void setSelectedOfferId(null);
+        setFocusedBlockId(null);
+        setHoveredOfferId(null);
+        setOfferListOpen(false);
+        window.requestAnimationFrame(() => {
+            sceneContainerRef.current
+                ?.querySelector<HTMLButtonElement>(
+                    '[data-outlet-garden-list-trigger]',
+                )
+                ?.focus({ preventScroll: true });
+        });
+    }, [setSelectedOfferId]);
+
     const selectBlock = useCallback(
         (blockId: string) => {
             const offerId = outletOfferIdFromBlockId(blockId);
@@ -427,7 +454,7 @@ export function OutletGardenViewer({
 
     return (
         <div
-            className={`relative grid h-[100dvh] grid-rows-[minmax(0,1fr)_minmax(18rem,46dvh)] overflow-hidden bg-[#cfeaca] lg:grid-cols-[minmax(0,1fr)_24rem] lg:grid-rows-1 ${exitTarget ? 'motion-safe:animate-out motion-safe:fade-out-0 motion-safe:zoom-out-95 motion-safe:duration-200' : 'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:zoom-in-95 motion-safe:duration-500'}`}
+            className={`relative grid h-[100dvh] overflow-hidden bg-[#cfeaca] ${offerListOpen || selectedOfferId !== null ? 'grid-rows-[minmax(0,1fr)_minmax(18rem,46dvh)] lg:grid-cols-[minmax(0,1fr)_24rem] lg:grid-rows-1' : 'grid-cols-1 grid-rows-1'} ${exitTarget ? 'motion-safe:animate-out motion-safe:fade-out-0 motion-safe:duration-200' : 'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:duration-500'}`}
             data-outlet-garden
             data-outlet-garden-display-count={displayUnits.length}
             data-outlet-garden-display-limited={displayLimited || undefined}
@@ -492,19 +519,18 @@ export function OutletGardenViewer({
                         Moj vrt
                     </Button>
                     <div className="pointer-events-auto flex items-start gap-2">
-                        {onUseListFallback ? (
-                            <Button
-                                aria-label="Prikaži Outlet ponude bez 3D prikaza"
-                                onClick={requestListFallback}
-                                size="lg"
-                                startDecorator={
-                                    <LayoutList className="size-4" />
-                                }
-                                variant="outlined"
-                            >
-                                Popis ponuda
-                            </Button>
-                        ) : null}
+                        <Button
+                            aria-controls="outlet-garden-browser"
+                            aria-expanded={offerListOpen}
+                            aria-label="Prikaži popis Outlet ponuda"
+                            data-outlet-garden-list-trigger
+                            onClick={openOfferList}
+                            size="lg"
+                            startDecorator={<LayoutList className="size-4" />}
+                            variant="outlined"
+                        >
+                            Popis ponuda
+                        </Button>
                         <div className="hidden max-w-xs rounded-xl bg-black/55 px-3 py-2 text-right text-xs text-white shadow-lg backdrop-blur sm:block">
                             <p className="font-semibold">
                                 Razgledaj Outlet vrt
@@ -527,21 +553,41 @@ export function OutletGardenViewer({
                 ) : null}
             </main>
 
-            <OutletGardenOfferBrowser
-                commerce={commerce}
-                displayLimited={displayLimited}
-                isError={isError}
-                isLoading={isLoading}
-                offers={offers}
-                onExit={requestExit}
-                onAuthenticationRequired={onAuthenticationRequired}
-                onHoverOffer={setHoveredOfferId}
-                onRetry={() => {
-                    void refetch();
-                }}
-                onSelectOffer={selectOffer}
-                selectedOfferId={selectedOfferId}
-            />
+            {offerListOpen || selectedOfferId !== null ? (
+                <OutletGardenOfferBrowser
+                    commerce={commerce}
+                    displayLimited={displayLimited}
+                    headerAction={
+                        offerListOpen && onUseListFallback ? (
+                            <Button
+                                aria-label="Prikaži Outlet ponude bez 3D prikaza"
+                                onClick={requestListFallback}
+                                size="lg"
+                                startDecorator={
+                                    <LayoutList className="size-4" />
+                                }
+                                variant="plain"
+                            >
+                                Lagani prikaz bez 3D-a
+                            </Button>
+                        ) : undefined
+                    }
+                    isError={isError}
+                    isLoading={isLoading}
+                    offers={offers}
+                    onClose={closeOfferBrowser}
+                    onExit={requestExit}
+                    onAuthenticationRequired={onAuthenticationRequired}
+                    onHoverOffer={setHoveredOfferId}
+                    onRetry={() => {
+                        void refetch();
+                    }}
+                    onSelectOffer={selectOffer}
+                    onShowOfferList={openOfferList}
+                    selectedOfferId={selectedOfferId}
+                    view={offerListOpen ? 'list' : 'details'}
+                />
+            ) : null}
         </div>
     );
 }

--- a/packages/game/src/viewers/outletGardenLayout.ts
+++ b/packages/game/src/viewers/outletGardenLayout.ts
@@ -42,9 +42,12 @@ const outletGardenAisleRowsPerPathSegment = 2;
 const outletGardenAisleRowSpacing = 3;
 const outletGardenFirstAisleRowOffset = 1;
 const outletGardenPathSegmentLength = 10;
-const outletGardenTableDistance = 3;
-const outletGardenFloorDistance = 2;
+const outletGardenTableDistance = 2;
+const outletGardenFloorDistance = 1;
 const outletGardenDecorationDistance = 5;
+const outletGardenLightDistance = 4;
+const outletGardenBenchDistance = 1;
+const outletGardenMaxLightCount = 4;
 const outletGardenMapMargin = 2;
 const outletGardenEntranceY =
     -outletGardenDecorationDistance - outletGardenMapMargin;
@@ -78,6 +81,7 @@ type OutletGardenPotName = (typeof outletGardenPotNames)[number];
 export const outletGardenRegisteredBlockNames = [
     'Block_Grass',
     'Bush',
+    'EnamelGardenLamp',
     'Fence',
     'MulchWood',
     'OutletDisplayTable',
@@ -100,6 +104,7 @@ type OutletGardenPathSegment = {
 
 type OutletGardenDecorationName =
     | 'Bush'
+    | 'EnamelGardenLamp'
     | 'StoneSmall'
     | 'Tree'
     | 'WoodenBench';
@@ -639,6 +644,8 @@ function outletGardenReservedDisplayPoints(segmentCount: number) {
 function outletGardenDecorationCandidates(
     segment: OutletGardenPathSegment,
     ordinal: number,
+    normalDistance: number,
+    preferredDistances: readonly number[],
 ) {
     const leftNormal = {
         x: -segment.direction.y,
@@ -646,15 +653,14 @@ function outletGardenDecorationCandidates(
     };
     const rightNormal = { x: -leftNormal.x, y: -leftNormal.y };
     const preferredNormal =
-        (segment.index + (ordinal === 0 ? 0 : 1)) % 2 === 0
-            ? leftNormal
-            : rightNormal;
+        (segment.index + ordinal) % 2 === 0 ? leftNormal : rightNormal;
     const otherNormal = {
         x: -preferredNormal.x,
         y: -preferredNormal.y,
     };
-    const preferredDistance = [8, 6, 9][ordinal] ?? 7;
-    const distances = Array.from(new Set([preferredDistance, 8, 6, 9, 7, 3]));
+    const distances = Array.from(
+        new Set([...preferredDistances, 8, 6, 9, 7, 3, 1, 4, 5, 2]),
+    );
 
     return [preferredNormal, otherNormal].flatMap((normal) =>
         distances.map((distance) => {
@@ -662,8 +668,8 @@ function outletGardenDecorationCandidates(
             return {
                 normal,
                 point: {
-                    x: pathPoint.x + normal.x * outletGardenDecorationDistance,
-                    y: pathPoint.y + normal.y * outletGardenDecorationDistance,
+                    x: pathPoint.x + normal.x * normalDistance,
+                    y: pathPoint.y + normal.y * normalDistance,
                 },
             };
         }),
@@ -685,10 +691,13 @@ function outletGardenPointIsClear(
 
 function outletGardenDecorations(segmentCount: number) {
     const futureSafeSegmentCount = segmentCount + 1;
-    const blockedPoints = [
-        ...outletGardenPathPoints(futureSafeSegmentCount),
-        ...outletGardenReservedDisplayPoints(futureSafeSegmentCount),
-    ];
+    const pathPoints = outletGardenPathPoints(futureSafeSegmentCount);
+    const pathPositionKeys = new Set(
+        pathPoints.map((point) => stackKey(point.x, point.y)),
+    );
+    const reservedDisplayPoints = outletGardenReservedDisplayPoints(
+        futureSafeSegmentCount,
+    );
     const decorations: Array<{
         name: OutletGardenDecorationName;
         point: OutletGardenPoint;
@@ -698,28 +707,37 @@ function outletGardenDecorations(segmentCount: number) {
 
     for (let segmentIndex = 0; segmentIndex < segmentCount; segmentIndex += 1) {
         const segment = outletGardenPathSegment(segmentIndex);
-        const decorationNames: OutletGardenDecorationName[] = [
-            segmentIndex % 2 === 0 ? 'Tree' : 'Bush',
-        ];
-        if (segmentIndex % 3 === 0) {
-            decorationNames.push('StoneSmall');
-        }
-        if (segmentIndex % 4 === 0) {
-            decorationNames.push('WoodenBench');
-        }
-
-        for (const [ordinal, name] of decorationNames.entries()) {
+        const existingDecorationPoints = () =>
+            decorations.map((decoration) => decoration.point);
+        const addDecoration = (
+            name: OutletGardenDecorationName,
+            ordinal: number,
+            normalDistance: number,
+            preferredDistances: readonly number[],
+            allowNextToPath: boolean,
+        ) => {
             const candidate = outletGardenDecorationCandidates(
                 segment,
                 ordinal,
-            ).find(({ point }) =>
-                outletGardenPointIsClear(point, [
-                    ...blockedPoints,
-                    ...decorations.map((decoration) => decoration.point),
-                ]),
-            );
+                normalDistance,
+                preferredDistances,
+            ).find(({ point }) => {
+                const isOffPath = !pathPositionKeys.has(
+                    stackKey(point.x, point.y),
+                );
+                const isClearOfPath =
+                    allowNextToPath ||
+                    outletGardenPointIsClear(point, pathPoints);
+
+                return (
+                    isOffPath &&
+                    isClearOfPath &&
+                    outletGardenPointIsClear(point, reservedDisplayPoints) &&
+                    outletGardenPointIsClear(point, existingDecorationPoints())
+                );
+            });
             if (!candidate) {
-                continue;
+                return;
             }
 
             decorations.push({
@@ -728,7 +746,39 @@ function outletGardenDecorations(segmentCount: number) {
                 rotation: outletGardenRotationFacingPath(candidate.normal),
                 segmentIndex,
             });
+        };
+
+        // A bounded number of the tall registered lamps illuminate the offer
+        // rows at night. They sit behind the tables, outside their interaction
+        // clearance, and existing segment IDs never move as the route grows.
+        if (segmentIndex < outletGardenMaxLightCount) {
+            addDecoration(
+                'EnamelGardenLamp',
+                0,
+                outletGardenLightDistance,
+                [3, 6],
+                false,
+            );
         }
+
+        // Seating belongs beside the aisle, while trees, bushes, and stones
+        // fill the outer verge without competing with seedlings for clicks.
+        addDecoration(
+            'WoodenBench',
+            1,
+            outletGardenBenchDistance,
+            [7, 8, 6, 9],
+            true,
+        );
+        addDecoration('Tree', 2, outletGardenDecorationDistance, [8, 6], false);
+        addDecoration('Bush', 3, outletGardenDecorationDistance, [6, 9], false);
+        addDecoration(
+            'StoneSmall',
+            4,
+            outletGardenDecorationDistance,
+            [9, 6, 3],
+            false,
+        );
     }
 
     return decorations;

--- a/packages/game/src/viewers/outletGardenLayout.unit.ts
+++ b/packages/game/src/viewers/outletGardenLayout.unit.ts
@@ -414,42 +414,42 @@ describe('getOutletGardenOfferPlacement', () => {
             aisleRow: 0,
             plantBay: 0,
             surface: 'table',
-            x: -3,
+            x: -2,
             y: 1,
         });
         assert.deepEqual(getOutletGardenOfferPlacement(1), {
             aisleRow: 0,
             plantBay: 0,
             surface: 'table',
-            x: -3,
+            x: -2,
             y: 2,
         });
         assert.deepEqual(getOutletGardenOfferPlacement(4), {
             aisleRow: 0,
             plantBay: 1,
             surface: 'table',
-            x: 3,
+            x: 2,
             y: 1,
         });
         assert.deepEqual(getOutletGardenOfferPlacement(5), {
             aisleRow: 0,
             plantBay: 1,
             surface: 'table',
-            x: 3,
+            x: 2,
             y: 2,
         });
         assert.deepEqual(getOutletGardenOfferPlacement(6), {
             aisleRow: 0,
             plantBay: 1,
             surface: 'floor',
-            x: 2,
+            x: 1,
             y: 1,
         });
         assert.deepEqual(getOutletGardenOfferPlacement(8), {
             aisleRow: 1,
             plantBay: 2,
             surface: 'table',
-            x: -3,
+            x: -2,
             y: 4,
         });
         assert.deepEqual(getOutletGardenOfferPlacement(16), {
@@ -457,13 +457,13 @@ describe('getOutletGardenOfferPlacement', () => {
             plantBay: 4,
             surface: 'table',
             x: 1,
-            y: 13,
+            y: 12,
         });
         assert.deepEqual(getOutletGardenOfferPlacement(32), {
             aisleRow: 4,
             plantBay: 8,
             surface: 'table',
-            x: 13,
+            x: 12,
             y: 9,
         });
     });
@@ -578,8 +578,8 @@ describe('buildOutletGardenStacks', () => {
             )?.rotation,
             1,
         );
-        assert.equal(tableStack?.x, -3);
-        assert.equal(floorStack?.x, -2);
+        assert.equal(tableStack?.x, -2);
+        assert.equal(floorStack?.x, -1);
     });
 
     it('turns after eight tables while keeping one connected one-tile mulch path', () => {
@@ -733,7 +733,7 @@ describe('buildOutletGardenStacks', () => {
         );
         for (const slotIndex of facingSlots) {
             const placement = getOutletGardenOfferPlacement(slotIndex);
-            const pathDistance = placement.surface === 'table' ? 3 : 2;
+            const pathDistance = placement.surface === 'table' ? 2 : 1;
             assert.ok(
                 [
                     { x: placement.x - pathDistance, y: placement.y },
@@ -745,12 +745,12 @@ describe('buildOutletGardenStacks', () => {
         }
     });
 
-    it('adds restrained registered decor away from the path and every display position', () => {
+    it('adds deterministic lighting and decor without blocking the path or displays', () => {
         const decoratedOffer = {
             id: 890,
             plantId: 8,
             plantSortId: 891,
-            remainingQuantity: 64,
+            remainingQuantity: 100,
         };
         const assignments = reconcileOutletGardenSlots(new Map(), [
             decoratedOffer,
@@ -769,10 +769,10 @@ describe('buildOutletGardenStacks', () => {
         const registeredNames = new Set<string>(
             outletGardenRegisteredBlockNames,
         );
-        const protectedPositions = [
-            ...positionsForBlocks(stacks, (block) =>
-                block.id.startsWith('outlet-path:'),
-            ),
+        const pathPositions = positionsForBlocks(stacks, (block) =>
+            block.id.startsWith('outlet-path:'),
+        );
+        const displayPositions = [
             ...positionsForBlocks(stacks, (block) =>
                 block.id.startsWith('outlet-table:'),
             ),
@@ -784,6 +784,7 @@ describe('buildOutletGardenStacks', () => {
 
         assert.deepEqual(decorationNames, [
             'Bush',
+            'EnamelGardenLamp',
             'StoneSmall',
             'Tree',
             'WoodenBench',
@@ -801,7 +802,7 @@ describe('buildOutletGardenStacks', () => {
         );
         assert.ok(
             decorations.every(({ x, y }) =>
-                protectedPositions.every(
+                displayPositions.every(
                     (position) =>
                         Math.max(
                             Math.abs(x - position.x),
@@ -810,6 +811,52 @@ describe('buildOutletGardenStacks', () => {
                 ),
             ),
         );
+        assert.ok(
+            decorations.every(({ x, y }) =>
+                pathPositions.every(
+                    (position) => x !== position.x || y !== position.y,
+                ),
+            ),
+        );
+
+        const benches = decorations.filter(
+            ({ block }) => block.name === 'WoodenBench',
+        );
+        assert.equal(benches.length, 7);
+        assert.ok(
+            benches.every(({ x, y }) =>
+                pathPositions.some(
+                    (position) =>
+                        Math.abs(x - position.x) + Math.abs(y - position.y) ===
+                        1,
+                ),
+            ),
+        );
+
+        const lights = decorations.filter(
+            ({ block }) => block.name === 'EnamelGardenLamp',
+        );
+        const tablePositions = positionsForBlocks(stacks, (block) =>
+            block.id.startsWith('outlet-table:'),
+        );
+        assert.equal(lights.length, 4);
+        assert.ok(
+            lights.every(({ x, y }) =>
+                tablePositions.some(
+                    (position) =>
+                        Math.max(
+                            Math.abs(x - position.x),
+                            Math.abs(y - position.y),
+                        ) <= 2,
+                ),
+            ),
+        );
+        for (const name of ['Bush', 'StoneSmall', 'Tree']) {
+            assert.equal(
+                decorations.filter(({ block }) => block.name === name).length,
+                7,
+            );
+        }
     });
 
     it('keeps existing decor and offer coordinates stable as the route grows and stock churns', () => {
@@ -826,7 +873,7 @@ describe('buildOutletGardenStacks', () => {
             [stockOffer],
             initialAssignments,
         );
-        const expandedOffer = { ...stockOffer, remainingQuantity: 48 };
+        const expandedOffer = { ...stockOffer, remainingQuantity: 100 };
         const expandedAssignments = reconcileOutletGardenSlots(
             initialAssignments,
             [expandedOffer],


### PR DESCRIPTION
## What changed

- keep the 3D Outlet scene full-width until a seedling or the explicit offer list is opened
- open a focused detail sidebar after selection, restore focus on close, and reduce the representative-image disclaimer
- remove the classic Outlet handoff so the only purchase path is the direct reservation flow
- guide reservation through garden (when needed), raised bed, then the first free field, while preserving conflict recovery
- move floor seedlings next to the one-block walkway and tables one tile farther back
- add deterministic benches, trees, bushes, stones, and up to four time-aware enamel garden lamps
- add private lamp metadata until the directory entry is published, without exposing it in the regular item catalog
- preserve deep links, list fallback, WebGL context-loss recovery, and stock reconciliation behavior

## Why

The Outlet beta showed that a permanently visible offer list reduced the 3D scene, selected offers needed a clearer focused action, and the sparse night scene made seedlings harder to browse. The reservation flow also needed to mirror how customers think about placement: raised bed first, then an available field.

## Validation

- `pnpm --filter @gredice/game test` — 1,074 passed
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter garden build`
- `pnpm --filter garden exec playwright test tests/outlet-garden.spec.tsx --project=chromium --workers=1` — 8 passed
- `pnpm --filter garden exec playwright test tests/outlet-garden-route.spec.ts --project=chromium-webgl --workers=1` — 6 passed
- targeted Biome checks and `git diff --check`
- manual desktop day/night WebGL visual inspection with the live 55-seedling offer set

## Rollout

The managed `enableOutletGarden` flag is already enabled for all environments. Keep `enableOutletGardenCommerce` off until this exact Garden deployment is ready, smoke the merged `/outlet` route, then enable commerce for production and preview.
