### PR TITLE
fix(game): streamline wooden sign editing

### DIFF
--- a/apps/garden/tests/wooden-sign-modal.spec.tsx
+++ b/apps/garden/tests/wooden-sign-modal.spec.tsx
@@ -90,7 +90,7 @@ async function mockWoodenSignRequests(
     return updatePayloads;
 }
 
-test('shows the existing two-row inscription and its grapheme counter', async ({
+test('shows the inscription without a visible card header, counter, or disclaimer', async ({
     mount,
     page,
 }) => {
@@ -103,10 +103,18 @@ test('shows the existing two-row inscription and its grapheme counter', async ({
 
     await expect(dialog).toBeVisible();
     await expect(editor).toHaveValue(woodenSignInitialMessage);
-    await expect(dialog.getByText('12/24', { exact: true })).toBeVisible();
+    await expect(dialog.locator('h2:not(.sr-only)')).toHaveCount(0);
+    await expect(dialog.locator('#wooden-sign-counter')).toHaveCount(0);
+    await expect(dialog.locator('#wooden-sign-help')).toHaveCount(0);
+    await expect(editor).not.toHaveAttribute('aria-describedby');
+
+    const saveButton = dialog.getByRole('button', { name: 'Spremi natpis' });
+    await expect(saveButton).toHaveClass(/bg-primary/u);
+    await expect(saveButton).toHaveClass(/text-primary-foreground/u);
+    await expect(saveButton).toHaveCSS('background-color', 'rgb(42, 28, 15)');
 });
 
-test('keeps one Unicode grapheme intact while rejecting the thirteenth character', async ({
+test('automatically wraps continuous typing onto the second row in order', async ({
     mount,
     page,
 }) => {
@@ -117,13 +125,13 @@ test('keeps one Unicode grapheme intact while rejecting the thirteenth character
     });
     const editor = dialog.getByLabel('Tekst na drvenom natpisu');
 
-    await editor.fill('12345678901👩‍🌾A');
+    await editor.fill('');
+    await editor.pressSequentially('ABCDEFGHIJKLMNOPQRSTUVWX');
 
-    await expect(editor).toHaveValue('12345678901👩‍🌾');
-    await expect(dialog.getByText('12/12', { exact: true })).toBeVisible();
+    await expect(editor).toHaveValue('ABCDEFGHIJKL\nMNOPQRSTUVWX');
 });
 
-test('allows twelve Unicode graphemes on each row and rejects the thirteenth per row', async ({
+test('wraps pasted Unicode text and caps the message at two twelve-character rows', async ({
     mount,
     page,
 }) => {
@@ -134,10 +142,9 @@ test('allows twelve Unicode graphemes on each row and rejects the thirteenth per
     });
     const editor = dialog.getByLabel('Tekst na drvenom natpisu');
 
-    await editor.fill('12345678901👩‍🌾A\nABCDEFGHIJKLZ');
+    await editor.fill(`12345678901👩‍🌾ABCDEFGHIJKLZ`);
 
-    await expect(editor).toHaveValue('12345678901👩‍🌾\nABCDEFGHIJKL');
-    await expect(dialog.getByText('24/24', { exact: true })).toBeVisible();
+    await expect(editor).toHaveValue(`12345678901👩‍🌾\nABCDEFGHIJKL`);
 });
 
 test('optimistically updates the sign, sends the exact payload, and closes after success', async ({

--- a/packages/game/src/modals/WoodenSignModal.tsx
+++ b/packages/game/src/modals/WoodenSignModal.tsx
@@ -2,7 +2,6 @@
 
 import {
     countWoodenSignMessageGraphemes,
-    getWoodenSignMessageGraphemeLimit,
     normalizeWoodenSignMessage,
     sanitizeWoodenSignDraft,
     woodenSignBlockName,
@@ -31,7 +30,6 @@ function WoodenSignEditor({
     const updateMessage = useBlockMessage();
     const { track } = useGameAnalytics();
     const characterCount = countWoodenSignMessageGraphemes(draft);
-    const characterLimit = getWoodenSignMessageGraphemeLimit(draft);
 
     const handleSubmit = async (event: SubmitEvent<HTMLFormElement>) => {
         event.preventDefault();
@@ -69,20 +67,6 @@ function WoodenSignEditor({
                         updateMessage.reset();
                     }}
                 />
-                <div className="flex items-start justify-between gap-4">
-                    <Typography id="wooden-sign-help" level="body2" secondary>
-                        Upiši najviše 12 znakova po redu, u najviše dva reda.
-                        Natpis će vidjeti svi koji mogu vidjeti vrt.
-                    </Typography>
-                    <Typography
-                        id="wooden-sign-counter"
-                        level="body2"
-                        className="shrink-0 tabular-nums"
-                        aria-live="polite"
-                    >
-                        {characterCount}/{characterLimit}
-                    </Typography>
-                </div>
                 {errorMessage ? (
                     <Typography
                         level="body2"
@@ -101,11 +85,7 @@ function WoodenSignEditor({
                     >
                         Odustani
                     </Button>
-                    <Button
-                        type="submit"
-                        variant="solid"
-                        loading={updateMessage.isPending}
-                    >
+                    <Button type="submit" loading={updateMessage.isPending}>
                         Spremi natpis
                     </Button>
                 </div>
@@ -142,7 +122,6 @@ export function WoodenSignModal() {
             title="Uredi drveni natpis"
             description="Upiši tekst koji će se prikazati na drvenom natpisu u vrtu."
             className="md:max-w-xl"
-            showHeader
         >
             {block?.name === woodenSignBlockName ? (
                 <WoodenSignEditor

--- a/packages/game/src/modals/WoodenSignPreview.tsx
+++ b/packages/game/src/modals/WoodenSignPreview.tsx
@@ -23,7 +23,6 @@ export function WoodenSignPreview({ onChange, value }: WoodenSignPreviewProps) {
                 <textarea
                     id="wooden-sign-message"
                     name="woodenSignMessage"
-                    aria-describedby="wooden-sign-help wooden-sign-counter"
                     autoComplete="off"
                     className="relative z-10 block h-28 w-full resize-none overflow-hidden rounded-md border border-[#98683e]/70 bg-[#e2bf8e]/90 px-3 py-3 text-center font-bold text-2xl leading-10 text-[#3f2a1d] caret-[#3f2a1d] outline-hidden placeholder:text-[#7f6045]/55 focus:border-[#6d4527] focus:ring-2 focus:ring-[#6d4527]/35 sm:h-32 sm:py-5 sm:text-3xl sm:leading-10"
                     onChange={onChange}

--- a/packages/js/src/woodenSign/index.ts
+++ b/packages/js/src/woodenSign/index.ts
@@ -82,14 +82,6 @@ export function countWoodenSignMessageGraphemes(value: string): number {
     return graphemes(normalizeUnicode(value).replaceAll('\n', '')).length;
 }
 
-export function getWoodenSignMessageGraphemeLimit(value: string): number {
-    const lineCount = Math.min(
-        normalizeLineEndings(value).split('\n').length,
-        woodenSignMessageMaxLines,
-    );
-    return lineCount * woodenSignMessageMaxGraphemesPerLine;
-}
-
 export function normalizeWoodenSignMessage(value: string): string | null {
     if (value.length > woodenSignMessageMaxRawLength) {
         throw new WoodenSignMessageValidationError('raw_too_long');
@@ -138,14 +130,19 @@ export function sanitizeWoodenSignDraft(value: string): string {
     const rows = stripUnsupportedControlCharacters(normalized)
         .split('\n')
         .slice(0, woodenSignMessageMaxLines);
+    const firstRowGraphemes = graphemes(rows[0] ?? '');
+    const firstRow = firstRowGraphemes
+        .slice(0, woodenSignMessageMaxGraphemesPerLine)
+        .join('');
+    const overflow = firstRowGraphemes.slice(
+        woodenSignMessageMaxGraphemesPerLine,
+    );
+    const secondRow = [...overflow, ...graphemes(rows[1] ?? '')]
+        .slice(0, woodenSignMessageMaxGraphemesPerLine)
+        .join('');
+    const hasSecondRow = rows.length > 1 || overflow.length > 0;
 
-    return rows
-        .map((row) =>
-            graphemes(row)
-                .slice(0, woodenSignMessageMaxGraphemesPerLine)
-                .join(''),
-        )
-        .join('\n');
+    return hasSecondRow ? `${firstRow}\n${secondRow}` : firstRow;
 }
 
 export function isValidWoodenSignMessage(value: string | null): boolean {

--- a/packages/js/src/woodenSign/index.unit.ts
+++ b/packages/js/src/woodenSign/index.unit.ts
@@ -4,7 +4,6 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
     countWoodenSignMessageGraphemes,
-    getWoodenSignMessageGraphemeLimit,
     isValidWoodenSignMessage,
     normalizeWoodenSignMessage,
     sanitizeWoodenSignDraft,
@@ -24,14 +23,6 @@ describe('countWoodenSignMessageGraphemes', () => {
             ),
             2,
         );
-    });
-});
-
-describe('getWoodenSignMessageGraphemeLimit', () => {
-    it('doubles the character allowance when a second row is drawn', () => {
-        assert.equal(getWoodenSignMessageGraphemeLimit('MOJ VRT'), 12);
-        assert.equal(getWoodenSignMessageGraphemeLimit('MOJ\nVRT'), 24);
-        assert.equal(getWoodenSignMessageGraphemeLimit('MOJ\r\nVRT'), 24);
     });
 });
 
@@ -125,14 +116,32 @@ describe('normalizeWoodenSignMessage', () => {
 });
 
 describe('sanitizeWoodenSignDraft', () => {
-    it('produces an NFC, control-free two-row draft capped at twelve graphemes per row', () => {
+    it('automatically wraps continuous text after twelve graphemes', () => {
+        assert.equal(
+            sanitizeWoodenSignDraft('ABCDEFGHIJKLMNOPQRSTUVWX'),
+            'ABCDEFGHIJKL\nMNOPQRSTUVWX',
+        );
+        assert.equal(
+            sanitizeWoodenSignDraft(`12345678901👩‍🌾A`),
+            `12345678901👩‍🌾\nA`,
+        );
+    });
+
+    it('preserves a manual second row and flows first-row overflow into it', () => {
         assert.equal(
             sanitizeWoodenSignDraft(
                 'ABCDEFGHIJKLM\r\nNOPQRSTUVWXYZ\nignored\t',
             ),
-            'ABCDEFGHIJKL\nNOPQRSTUVWXY',
+            'ABCDEFGHIJKL\nMNOPQRSTUVWX',
         );
+    });
+
+    it('produces an NFC, control-free draft capped at two rows', () => {
         assert.equal(sanitizeWoodenSignDraft('C\u030C'), 'Č');
+        assert.equal(
+            sanitizeWoodenSignDraft('PRVI\t\nDRUGI\nTREĆI'),
+            'PRVI\nDRUGI',
+        );
     });
 });
 


### PR DESCRIPTION
## Summary

- automatically wrap wooden-sign input after 12 Unicode graphemes and preserve up to two rows
- remove the visible modal header, character counter, and disclaimer
- use the shared Garden primary button styling for the dark-brown Save action
- cover sequential typing, Unicode paste, modal chrome, theme color, save, error, cancel, and clear behavior

## Validation

- `pnpm --filter @gredice/js test` — 46 passed
- `pnpm --dir packages/game test` — 1,069 passed
- `pnpm --dir packages/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `GREDICE_GARDEN_TEST_PORT=3301 GREDICE_GARDEN_START_PORT=3301 GREDICE_GARDEN_CT_PORT=3401 pnpm --dir apps/garden exec playwright test tests/wooden-sign-modal.spec.tsx --config playwright.config.ts --workers=1` — 7 passed
- scoped Biome checks
- `git diff --check`