### PR TITLE
fix(game): allow beach ball pickup

### DIFF
--- a/packages/game/src/entities/BeachBall.tsx
+++ b/packages/game/src/entities/BeachBall.tsx
@@ -2,6 +2,7 @@ import { animated } from '@react-spring/three';
 import { type ThreeEvent, useFrame } from '@react-three/fiber';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Group } from 'three';
+import { areBlockInteractionsSuppressed } from '../controls/blockInteractionSuppression';
 import { useBlockData } from '../hooks/useBlockData';
 import type { GLTFResult } from '../models/GameAssets';
 import { RainWetOverlay } from '../rain/RainWetOverlay';
@@ -233,16 +234,22 @@ export function BeachBall({
         motionGroup.rotation.z -= movementX / beachBallCollisionRadius;
     });
 
-    function handlePointerDown(event: ThreeEvent<PointerEvent>) {
+    function handlePointerUp(event: ThreeEvent<PointerEvent>) {
         if (event.button !== 0) {
             return;
         }
 
+        // Pickup starts in the parent on pointer down. Keep pointer up from
+        // also turning a beach-ball tap into the parent's rotate gesture.
         event.stopPropagation();
     }
 
     function handleClick(event: ThreeEvent<MouseEvent>) {
         event.stopPropagation();
+
+        if (areBlockInteractionsSuppressed()) {
+            return;
+        }
 
         const currentState = bounceStateRef.current;
         if (
@@ -308,9 +315,9 @@ export function BeachBall({
                 <group
                     ref={motionGroupRef}
                     onClick={handleClick}
-                    onPointerDown={handlePointerDown}
                     onPointerEnter={handlePointerEnter}
                     onPointerLeave={handlePointerLeave}
+                    onPointerUp={handlePointerUp}
                 >
                     <group scale={beachBallScale}>
                         {beachBallNodeNames.map((nodeName) => (


### PR DESCRIPTION
## Summary

- let beach-ball pointer-down events reach the existing hold-to-pick-up controller
- keep the click-to-bounce interaction intact
- prevent pointer-up from also triggering rotation and ignore the click emitted after a completed pickup

## Root cause

The beach ball stopped propagation on primary pointer down so its bounce interaction always won before the parent `PickableGroup` could start the hold-to-pick-up gesture.

## User impact

Players can now hold the beach ball to pick it up and move it, while a normal click or tap still kicks it around the garden.

## Validation

- `pnpm --filter @gredice/game exec biome check src/entities/BeachBall.tsx`
- `pnpm test --filter @gredice/game` (1,070 tests passed)
- `pnpm typecheck --filter @gredice/game --filter garden --filter www`
- `git diff --check`