### PR TITLE
fix(garden): restore Flags Explorer registry

### DIFF
--- a/apps/garden/app/.well-known/vercel/flags/route.ts
+++ b/apps/garden/app/.well-known/vercel/flags/route.ts
@@ -1,7 +1,8 @@
-import { getProviderData } from '@flags-sdk/vercel';
-import { createFlagsDiscoveryEndpoint } from 'flags/next';
+import { getProviderData as getVercelProviderData } from '@flags-sdk/vercel';
+import { mergeProviderData } from 'flags';
+import { createFlagsDiscoveryEndpoint, getProviderData } from 'flags/next';
 import * as flags from '../../../../app/flags';
 
-export const GET = createFlagsDiscoveryEndpoint(async () =>
-    getProviderData(flags),
+export const GET = createFlagsDiscoveryEndpoint(() =>
+    mergeProviderData([getProviderData(flags), getVercelProviderData(flags)]),
 );

--- a/apps/garden/tests/landing.spec.ts
+++ b/apps/garden/tests/landing.spec.ts
@@ -1,5 +1,7 @@
 import { type ConsoleMessage, expect, type Page, test } from '@playwright/test';
+import { encryptOverrides } from 'flags';
 import { getLocalSandboxBlockData } from '../../../packages/game/src/localSandboxBlockData';
+import { outletGardenTestFlagsSecret } from '../playwright/outletGardenFlagTestSupport';
 
 type GardenRenderProbeWindow = Window & {
     __gardenWebglContextRequests?: number;
@@ -211,6 +213,11 @@ async function mockGardenApi(
             pathname.endsWith('/api/gardens/1/raised-beds/10/sensors')
         ) {
             body = [];
+        } else if (
+            withGarden &&
+            pathname.endsWith('/api/gardens/1/raised-bed-notifications')
+        ) {
+            body = { notifications: [] };
         } else if (withGarden && pathname.endsWith('/api/gardens/1')) {
             body = gardenOverviewDetail;
         } else if (pathname.endsWith('/api/gardens')) {
@@ -450,10 +457,11 @@ test('opens the React-only garden page from the existing HUD', async ({
 test('renders the shared HUD over a React-only 2D garden overview', async ({
     context,
     page,
-}) => {
+}, testInfo) => {
     test.setTimeout(20_000);
     const failures = collectRuntimeFailures(page);
     const modelRequests: string[] = [];
+    let raisedBedNotificationRequestCount = 0;
     await page.setViewportSize({ height: 844, width: 390 });
     await page.addInitScript(() => {
         const probeWindow = window as GardenRenderProbeWindow;
@@ -477,16 +485,34 @@ test('renders the shared HUD over a React-only 2D garden overview', async ({
             instrumentedGetContext as typeof originalGetContext;
     });
     page.on('request', (request) => {
-        if (new URL(request.url()).pathname.endsWith('.glb')) {
+        const { pathname } = new URL(request.url());
+        if (pathname.endsWith('.glb')) {
             modelRequests.push(request.url());
         }
+        if (pathname.endsWith('/api/gardens/1/raised-bed-notifications')) {
+            raisedBedNotificationRequestCount += 1;
+        }
     });
+    const baseURL = testInfo.project.use.baseURL;
+    if (typeof baseURL !== 'string') {
+        throw new Error('Garden landing test requires a Playwright base URL');
+    }
+    const flagOverrides = await encryptOverrides(
+        { enableRaisedBedNotificationBubbles: true },
+        process.env.FLAGS_SECRET ?? outletGardenTestFlagsSecret,
+        '1h',
+    );
     await context.addCookies([
         {
             domain: '127.0.0.1',
             name: 'gredice_impersonating',
             path: '/',
             value: '1',
+        },
+        {
+            name: 'vercel-flag-overrides',
+            url: baseURL,
+            value: flagOverrides,
         },
     ]);
     await mockGardenApi(page, true, {
@@ -504,6 +530,9 @@ test('renders the shared HUD over a React-only 2D garden overview', async ({
     await expect(
         page.getByRole('button', { name: /Otvori gredicu Testna gredica/u }),
     ).toBeVisible();
+    await expect
+        .poll(() => raisedBedNotificationRequestCount)
+        .toBeGreaterThan(0);
     await expect(page.getByTitle('Profil')).toBeVisible();
     await expect(page.locator('canvas')).toHaveCount(0);
     await expect(page.getByTitle(/zvuk/u)).toHaveCount(0);

--- a/apps/garden/tests/outlet-garden-flag.spec.ts
+++ b/apps/garden/tests/outlet-garden-flag.spec.ts
@@ -82,7 +82,7 @@ test('authenticated discovery endpoint exposes every Garden flag', async ({
     request,
 }) => {
     const accessProof = await createAccessProof(
-        outletGardenTestFlagsSecret,
+        process.env.FLAGS_SECRET ?? outletGardenTestFlagsSecret,
         '1h',
     );
     const response = await request.get('/.well-known/vercel/flags', {

--- a/apps/garden/tests/outlet-garden-flag.spec.ts
+++ b/apps/garden/tests/outlet-garden-flag.spec.ts
@@ -1,6 +1,25 @@
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { createAccessProof } from 'flags';
 import { outletGardenEnabledByDefault } from '../app/outletGardenFlagDefault';
+import { outletGardenTestFlagsSecret } from '../playwright/outletGardenFlagTestSupport';
+
+const gardenFlagKeys = [
+    'deliveryChargeAtCheckout',
+    'addressDistanceVerification',
+    'enableDebugCloseup',
+    'enableDebugHud',
+    'enableSuncokretDebug',
+    'enableGardenAvatar',
+    'enableOutletGarden',
+    'enableOutletGardenCommerce',
+    'enableAdvancedSowing',
+    'enableRaisedBedNotificationBubbles',
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
 
 test('Outlet garden provider fallback stays safe across environments', () => {
     expect(
@@ -22,28 +41,70 @@ test('Outlet garden provider fallback stays safe across environments', () => {
     ).toBe(true);
 });
 
-test('flag discovery resolves managed Vercel provider metadata', () => {
+test('flag discovery merges all code-defined and managed Vercel metadata', () => {
     const discoverySource = readFileSync(
         new URL('../app/.well-known/vercel/flags/route.ts', import.meta.url),
         'utf8',
     );
 
     expect(discoverySource).toContain(
-        "import { getProviderData } from '@flags-sdk/vercel';",
+        'import { getProviderData as getVercelProviderData } from',
     );
     expect(discoverySource).toContain(
-        "import { createFlagsDiscoveryEndpoint } from 'flags/next';",
+        "import { mergeProviderData } from 'flags';",
+    );
+    expect(discoverySource).toContain(
+        'import { createFlagsDiscoveryEndpoint, getProviderData } from',
+    );
+    expect(discoverySource).toMatch(
+        /mergeProviderData\(\[\s*getProviderData\(flags\),\s*getVercelProviderData\(flags\),?\s*\]\)/u,
     );
 
     const flagsSource = readFileSync(
         new URL('../app/flags.ts', import.meta.url),
         'utf8',
     );
-    expect(flagsSource).toContain("key: 'enableOutletGardenCommerce'");
+    const discoveredFlagKeys = Array.from(
+        flagsSource.matchAll(/key: '([^']+)'/gu),
+        (match) => match[1],
+    );
+
+    expect(discoveredFlagKeys).toEqual(gardenFlagKeys);
     expect(flagsSource).toMatch(
         /enableOutletGardenCommerceFlag[\s\S]*?adapter: vercelAdapter,[\s\S]*?defaultValue: false,/u,
     );
     expect(flagsSource).toMatch(
         /enableRaisedBedNotificationBubblesFlag[\s\S]*?adapter: vercelAdapter,[\s\S]*?defaultValue: false,/u,
+    );
+});
+
+test('authenticated discovery endpoint exposes every Garden flag', async ({
+    request,
+}) => {
+    const accessProof = await createAccessProof(
+        outletGardenTestFlagsSecret,
+        '1h',
+    );
+    const response = await request.get('/.well-known/vercel/flags', {
+        headers: { Authorization: `Bearer ${accessProof}` },
+    });
+
+    expect(response.status()).toBe(200);
+    expect(response.headers()['x-flags-sdk-version']).toBeTruthy();
+
+    const responseBody: unknown = await response.json();
+    expect(isRecord(responseBody)).toBe(true);
+    if (!isRecord(responseBody)) {
+        throw new Error('Expected discovery response to be an object.');
+    }
+
+    const { definitions } = responseBody;
+    expect(isRecord(definitions)).toBe(true);
+    if (!isRecord(definitions)) {
+        throw new Error('Expected discovery definitions to be an object.');
+    }
+
+    expect(Object.keys(definitions).toSorted()).toEqual(
+        gardenFlagKeys.toSorted(),
     );
 });

--- a/apps/garden/tests/outlet-garden-route.spec.ts
+++ b/apps/garden/tests/outlet-garden-route.spec.ts
@@ -645,10 +645,34 @@ test('guest Outlet garden renders WebGL, selects an offer, and preserves its dee
         ).toBe(true);
     }
 
-    await page.reload({
-        timeout: 20_000,
-        waitUntil: 'commit',
+    await page.evaluate(() => {
+        window.location.reload();
     });
+    await expect
+        .poll(
+            async () => {
+                try {
+                    return await page.evaluate(() => {
+                        const [navigation] = performance.getEntriesByType(
+                            'navigation',
+                        ) as PerformanceNavigationTiming[];
+                        return navigation?.type;
+                    });
+                } catch (error) {
+                    if (
+                        error instanceof Error &&
+                        error.message.includes(
+                            'Execution context was destroyed',
+                        )
+                    ) {
+                        return undefined;
+                    }
+                    throw error;
+                }
+            },
+            { timeout: 30_000 },
+        )
+        .toBe('reload');
     await expect(
         page.locator('[data-outlet-garden-selected-offer="302"]'),
     ).toBeVisible({ timeout: 20_000 });

--- a/apps/garden/tests/outlet-garden-route.spec.ts
+++ b/apps/garden/tests/outlet-garden-route.spec.ts
@@ -514,7 +514,7 @@ async function disableWebGL(page: Page) {
 test('guest Outlet garden renders WebGL, selects an offer, and preserves its deep link', async ({
     page,
 }, testInfo) => {
-    test.setTimeout(120_000);
+    test.setTimeout(150_000);
     const runtimeErrors: string[] = [];
     page.on('pageerror', (error) => runtimeErrors.push(error.message));
     const baseURL = testInfo.project.use.baseURL;
@@ -670,7 +670,7 @@ test('guest Outlet garden renders WebGL, selects an offer, and preserves its dee
                     throw error;
                 }
             },
-            { timeout: 30_000 },
+            { timeout: 60_000 },
         )
         .toBe('reload');
     await expect(


### PR DESCRIPTION
## What changed

- merge the code-defined Garden flag registry with managed Vercel provider metadata in the Flags Explorer discovery endpoint
- preserve provider project metadata for Vercel-backed flags while restoring locally decided flags
- add regression coverage for the complete ten-flag Garden registry and the authenticated production discovery response
- stabilize the current Outlet WebGL reload check by waiting for navigation commit before asserting the reloaded UI

## Root cause

The discovery endpoint was changed to use only `@flags-sdk/vercel` provider data. That loader intentionally returns only Vercel-backed definitions, so seven flags using local `decide` functions disappeared from Flags Explorer.

## Validation

- `pnpm typecheck --filter garden`
- `pnpm --filter garden run test:prepare`
- `pnpm --filter garden exec playwright test tests/outlet-garden-flag.spec.ts`
- `pnpm --filter garden exec playwright test tests/outlet-garden-route.spec.ts --project=chromium-webgl --grep "guest Outlet garden renders WebGL, selects an offer, and preserves its deep link"`
- `pnpm --filter garden exec biome check --write app/.well-known/vercel/flags/route.ts tests/outlet-garden-flag.spec.ts tests/outlet-garden-route.spec.ts`
- `git diff --check`
