### PR TITLE
fix(game): complete raised-bed notification interactions

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -63,6 +63,7 @@ import {
     getGardenStack,
     getGardenStackForUpdate,
     getGardenVisitState,
+    getNotification,
     getOperationsByIds,
     getOperationsPage,
     getPreviousPlantStatusChangedAtForUpdate,
@@ -79,6 +80,7 @@ import {
     getRaisedBedsForGardens,
     getSandboxGardenDeletionCandidate,
     getUnreadNotificationsByType,
+    getUnreadRaisedBedImageNotificationIdsForGarden,
     getUnreadRaisedBedNotificationsForGarden,
     getUserLikedGardenIds,
     isPlantStatusEffectiveDateAllowed,
@@ -217,6 +219,12 @@ const detailedInspectionReportsSeenBodySchema = z
             .array(z.string().min(1))
             .min(1)
             .max(maxNotificationReadBatchSize),
+    })
+    .strict();
+
+const raisedBedNotificationDismissBodySchema = z
+    .object({
+        scope: z.enum(['selected', 'raised_bed_images']),
     })
     .strict();
 
@@ -1385,6 +1393,105 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     notifications: notifications.map(
                         serializeRaisedBedGardenNotification,
                     ),
+                },
+                200,
+            );
+        },
+    )
+    .put(
+        '/:gardenId/raised-bed-notifications/:notificationId/dismiss',
+        describeRoute({
+            description:
+                'Dismiss one unread raised-bed notification, or every unread image notification for the same raised bed, for the current user in an owned garden.',
+            security: authSecurity,
+        }),
+        zValidator(
+            'param',
+            z.object({
+                gardenId: z.string(),
+                notificationId: z.string().min(1),
+            }),
+        ),
+        zValidator('json', raisedBedNotificationDismissBodySchema),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { gardenId, notificationId } = context.req.valid('param');
+            const { scope } = context.req.valid('json');
+            const gardenIdNumber = Number.parseInt(gardenId, 10);
+            if (Number.isNaN(gardenIdNumber)) {
+                return context.json({ error: 'Invalid garden ID' }, 400);
+            }
+
+            const { accountId, userId } = context.get('authContext');
+            const garden = await getGarden(gardenIdNumber);
+            if (!garden || garden.accountId !== accountId) {
+                return context.json({ error: 'Garden not found' }, 404);
+            }
+
+            const notification = await getNotification(notificationId);
+            if (
+                !notification ||
+                notification.accountId !== accountId ||
+                (notification.userId !== null &&
+                    notification.userId !== userId) ||
+                notification.gardenId !== gardenIdNumber ||
+                notification.raisedBedId === null ||
+                notification.type ===
+                    detailedRaisedBedInspectionNotificationType
+            ) {
+                return context.json(
+                    { error: 'Raised-bed notification not found' },
+                    404,
+                );
+            }
+
+            const dismissedNotificationIds: string[] = [];
+            const dismissBatch = async (notificationIds: string[]) => {
+                await setAllNotificationsRead(
+                    accountId,
+                    userId,
+                    notificationIds,
+                    true,
+                    'game_raised_bed_bubble',
+                );
+                dismissedNotificationIds.push(...notificationIds);
+                return notificationIds.length;
+            };
+
+            if (
+                scope === 'raised_bed_images' &&
+                notification.imageUrl?.trim()
+            ) {
+                while (true) {
+                    const notificationIds =
+                        await getUnreadRaisedBedImageNotificationIdsForGarden({
+                            accountId,
+                            gardenId: gardenIdNumber,
+                            limit: maxNotificationReadBatchSize,
+                            raisedBedId: notification.raisedBedId,
+                            userId,
+                        });
+                    if (notificationIds.length === 0) {
+                        break;
+                    }
+
+                    const dismissedCount = await dismissBatch(notificationIds);
+                    if (
+                        dismissedCount === 0 ||
+                        notificationIds.length < maxNotificationReadBatchSize
+                    ) {
+                        break;
+                    }
+                }
+            } else {
+                await dismissBatch([notification.id]);
+            }
+
+            return context.json(
+                {
+                    dismissedNotificationIds: [
+                        ...new Set(dismissedNotificationIds),
+                    ],
                 },
                 200,
             );

--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -117,7 +117,9 @@ function buildRaisedBedNotificationLink(
 
     return getRaisedBedCloseupUrl(
         raisedBedName,
-        typeof positionIndex === 'number' ? { positionIndex } : undefined,
+        typeof positionIndex === 'number'
+            ? { fieldTab: 'diary', positionIndex }
+            : undefined,
     );
 }
 

--- a/apps/garden/tests/RaisedBedFieldHudStory.tsx
+++ b/apps/garden/tests/RaisedBedFieldHudStory.tsx
@@ -168,12 +168,14 @@ function createScenarioQueryClient(
 type ProvidersProps = PropsWithChildren<{
     favorites?: FavoriteItem[];
     scenario: RaisedBedScenario;
+    searchParams?: string;
 }>;
 
 function RaisedBedHudTestProviders({
     children,
     scenario,
     favorites = [],
+    searchParams,
 }: ProvidersProps) {
     const queryClient = useMemo(
         () => createScenarioQueryClient(scenario, favorites),
@@ -191,7 +193,7 @@ function RaisedBedHudTestProviders({
     );
 
     return (
-        <NuqsTestingAdapter>
+        <NuqsTestingAdapter hasMemory searchParams={searchParams}>
             <ReactQuery.QueryClientProvider client={queryClient}>
                 <GameStateContext.Provider value={gameStore}>
                     <GameFlagsContext.Provider value={{}}>
@@ -226,18 +228,24 @@ export function RaisedBedFieldHudStory({
     positionIndex,
     favorites = [],
     cellSize = 80,
+    searchParams,
 }: {
     scenario: RaisedBedScenario;
     positionIndex: number;
     favorites?: FavoriteItem[];
     cellSize?: number;
+    searchParams?: string;
 }) {
     const cartItem =
         scenario.cartItems?.find(
             (item) => item.positionIndex === positionIndex,
         ) ?? null;
     return (
-        <RaisedBedHudTestProviders scenario={scenario} favorites={favorites}>
+        <RaisedBedHudTestProviders
+            scenario={scenario}
+            favorites={favorites}
+            searchParams={searchParams}
+        >
             <div
                 data-testid="hud-cell"
                 className="relative"

--- a/apps/garden/tests/RaisedBedNotificationBubbleFixture.tsx
+++ b/apps/garden/tests/RaisedBedNotificationBubbleFixture.tsx
@@ -15,16 +15,20 @@ const notificationImage =
     'data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%22280%22 height=%22200%22 viewBox=%220 0 280 200%22%3E%3Crect width=%22280%22 height=%22200%22 fill=%22%23589b47%22/%3E%3Cpath d=%22M20 145L90 80l45 42 38-30 87 67H20z%22 fill=%22%23d9efad%22/%3E%3C/svg%3E';
 
 function fixtureNotification({
+    content,
     imageUrl = notificationImage,
 }: {
+    content?: string;
     imageUrl?: string | null;
 } = {}): SelectedRaisedBedGardenNotification {
     const timestamp = new Date('2026-08-11T12:00:00.000Z');
     return {
         category: 'garden',
-        content: imageUrl
-            ? 'Stigla je nova fotografija gredice.'
-            : 'Danas je na gredici **Sjever** odrađena **Održavajuća rezidba**.',
+        content:
+            content ??
+            (imageUrl
+                ? 'Stigla je nova fotografija gredice.'
+                : 'Danas je na gredici **Sjever** odrađena **Održavajuća rezidba**.'),
         createdAt: timestamp,
         gardenId: 8,
         header: imageUrl
@@ -47,8 +51,10 @@ function fixtureNotification({
 }
 
 export function RaisedBedNotificationBubbleFixture({
+    content,
     imageUrl,
 }: {
+    content?: string;
     imageUrl?: string | null;
 }) {
     const [ready, setReady] = useState(false);
@@ -60,7 +66,7 @@ export function RaisedBedNotificationBubbleFixture({
     const [visible, setVisible] = useState(true);
     const [viewerImage, setViewerImage] =
         useState<RaisedBedNotificationViewerImage | null>(null);
-    const notification = fixtureNotification({ imageUrl });
+    const notification = fixtureNotification({ content, imageUrl });
 
     return (
         <div

--- a/apps/garden/tests/RaisedBedNotificationBubbleFixture.tsx
+++ b/apps/garden/tests/RaisedBedNotificationBubbleFixture.tsx
@@ -4,7 +4,11 @@ import {
 } from '@gredice/js/notifications';
 import { Canvas } from '@react-three/fiber';
 import { useState } from 'react';
-import { RaisedBedNotificationBubble } from '../../../packages/game/src/hud/RaisedBedNotificationBubbles';
+import {
+    RaisedBedNotificationBubble,
+    RaisedBedNotificationImageViewer,
+} from '../../../packages/game/src/hud/RaisedBedNotificationBubbles';
+import type { RaisedBedNotificationViewerImage } from '../../../packages/game/src/hud/RaisedBedNotificationSurface';
 import type { SelectedRaisedBedGardenNotification } from '../../../packages/game/src/raisedBedNotifications';
 
 const notificationImage =
@@ -18,10 +22,14 @@ function fixtureNotification({
     const timestamp = new Date('2026-08-11T12:00:00.000Z');
     return {
         category: 'garden',
-        content: 'Stigla je nova fotografija gredice.',
+        content: imageUrl
+            ? 'Stigla je nova fotografija gredice.'
+            : 'Danas je na gredici **Sjever** odrađena **Održavajuća rezidba**.',
         createdAt: timestamp,
         gardenId: 8,
-        header: 'Nova fotografija gredice Sjever',
+        header: imageUrl
+            ? 'Nova fotografija gredice Sjever'
+            : 'Održavajuća rezidba',
         iconUrl: null,
         id: 'raised-bed-photo-notification',
         imageUrl,
@@ -45,14 +53,20 @@ export function RaisedBedNotificationBubbleFixture({
 }) {
     const [ready, setReady] = useState(false);
     const [bubbleOpenCount, setBubbleOpenCount] = useState(0);
+    const [dismissCount, setDismissCount] = useState(0);
+    const [imageOpenCount, setImageOpenCount] = useState(0);
     const [raisedBedClickCount, setRaisedBedClickCount] = useState(0);
     const [positionX, setPositionX] = useState(0);
     const [visible, setVisible] = useState(true);
+    const [viewerImage, setViewerImage] =
+        useState<RaisedBedNotificationViewerImage | null>(null);
     const notification = fixtureNotification({ imageUrl });
 
     return (
         <div
             data-bubble-open-count={bubbleOpenCount}
+            data-dismiss-count={dismissCount}
+            data-image-open-count={imageOpenCount}
             data-position-x={positionX}
             data-raised-bed-click-count={raisedBedClickCount}
             data-render-ready={ready ? 'true' : 'false'}
@@ -85,14 +99,30 @@ export function RaisedBedNotificationBubbleFixture({
                 {visible ? (
                     <RaisedBedNotificationBubble
                         notification={notification}
+                        onDismiss={() => {
+                            setDismissCount((count) => count + 1);
+                            setVisible(false);
+                        }}
                         onOpen={() => {
                             setBubbleOpenCount((count) => count + 1);
+                            setVisible(false);
+                        }}
+                        onOpenImage={(_, imageUrl) => {
+                            setImageOpenCount((count) => count + 1);
+                            setViewerImage({
+                                alt: notification.header,
+                                src: imageUrl,
+                            });
                             setVisible(false);
                         }}
                         position={[positionX, 0.25, 0]}
                     />
                 ) : null}
             </Canvas>
+            <RaisedBedNotificationImageViewer
+                image={viewerImage}
+                onClose={() => setViewerImage(null)}
+            />
         </div>
     );
 }

--- a/apps/garden/tests/landing.spec.ts
+++ b/apps/garden/tests/landing.spec.ts
@@ -304,6 +304,10 @@ async function mockGardenApi(
             body = { devices: [] };
         } else if (pathname.endsWith('/api/notifications/push-status')) {
             body = { hasDevices: false, status: 'unsubscribed' };
+        } else if (
+            /\/api\/gardens\/\d+\/raised-bed-notifications$/u.test(pathname)
+        ) {
+            body = { notifications: [] };
         } else if (pathname.endsWith('/api/notifications')) {
             body = [];
         }

--- a/apps/garden/tests/outlet-garden-route.spec.ts
+++ b/apps/garden/tests/outlet-garden-route.spec.ts
@@ -514,7 +514,7 @@ async function disableWebGL(page: Page) {
 test('guest Outlet garden renders WebGL, selects an offer, and preserves its deep link', async ({
     page,
 }, testInfo) => {
-    test.setTimeout(90_000);
+    test.setTimeout(120_000);
     const runtimeErrors: string[] = [];
     page.on('pageerror', (error) => runtimeErrors.push(error.message));
     const baseURL = testInfo.project.use.baseURL;
@@ -647,11 +647,11 @@ test('guest Outlet garden renders WebGL, selects an offer, and preserves its dee
 
     await page.reload({
         timeout: 20_000,
-        waitUntil: 'domcontentloaded',
+        waitUntil: 'commit',
     });
     await expect(
         page.locator('[data-outlet-garden-selected-offer="302"]'),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 20_000 });
     await expect(page.locator('[data-outlet-garden-offer-list]')).toHaveCount(
         0,
     );

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -785,6 +785,25 @@ function daysFromNowIso(days: number): string {
 test.describe('RaisedBedFieldItem HUD (desktop)', () => {
     test.use({ viewport: DESKTOP_VIEWPORT });
 
+    test('opens the plant details modal on the Dnevnik tab from a field deep link', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedGrowingScenario()}
+                positionIndex={0}
+                searchParams="polje=1&polje-kartica=diary"
+            />,
+        );
+
+        const dialog = page.getByRole('dialog');
+        await expect(dialog).toBeVisible();
+        await expect(
+            dialog.getByRole('tab', { name: /Dnevnik/ }),
+        ).toHaveAttribute('aria-selected', 'true');
+    });
+
     test('empty field shows sowing seed icon and no indicator stack', async ({
         mount,
         page,

--- a/apps/garden/tests/raised-bed-notification-bubble.spec.tsx
+++ b/apps/garden/tests/raised-bed-notification-bubble.spec.tsx
@@ -14,6 +14,9 @@ test('renders notification media edge-to-edge and follows its raised-bed anchor'
     await expect(image).toBeVisible();
     await expect(bubble).toHaveCSS('padding', '0px');
     await expect(image).toHaveCSS('object-fit', 'cover');
+    await expect(
+        fixture.locator('[data-raised-bed-notification-arrow] path'),
+    ).toHaveAttribute('d', 'M1 0.5h18L10 9.5Z');
 
     const bubbleBox = await bubble.boundingBox();
     const imageBox = await image.boundingBox();
@@ -32,7 +35,7 @@ test('renders notification media edge-to-edge and follows its raised-bed anchor'
         .toBeGreaterThan(bubbleBox.x + 40);
 });
 
-test('keeps the bubble tappable and dismisses only after opening it', async ({
+test('opens notification images in the viewer, clears the bubble, and does not activate the bed', async ({
     mount,
     page,
 }) => {
@@ -45,19 +48,47 @@ test('keeps the bubble tappable and dismisses only after opening it', async ({
 
     const topElementIsBubble = await bubble.evaluate((element) => {
         const bounds = element.getBoundingClientRect();
-        return (
+        return Boolean(
             document
                 .elementFromPoint(
                     bounds.left + bounds.width / 2,
                     bounds.top + bounds.height / 2,
                 )
-                ?.closest('[data-raised-bed-notification-bubble]') === element
+                ?.closest('[data-raised-bed-notification-bubble]'),
         );
     });
     expect(topElementIsBubble).toBe(true);
 
     await bubble.click();
-    await expect(fixture).toHaveAttribute('data-bubble-open-count', '1');
+    await expect(fixture).toHaveAttribute('data-image-open-count', '1');
+    await expect(fixture).toHaveAttribute('data-bubble-open-count', '0');
+    await expect(fixture).toHaveAttribute('data-raised-bed-click-count', '0');
+    await expect(bubble).toHaveCount(0);
+    await expect(
+        page.getByRole('dialog', { name: 'Pregled slike' }),
+    ).toBeVisible();
+});
+
+test('shows operation context and dismisses from the small close control without opening', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 400, height: 320 });
+    const fixture = await mount(
+        <RaisedBedNotificationBubbleFixture imageUrl={null} />,
+    );
+    await expect(fixture).toHaveAttribute('data-render-ready', 'true');
+    const bubble = fixture.locator('[data-raised-bed-notification-bubble]');
+    await expect(bubble).toContainText('Održavajuća rezidba');
+    await expect(bubble).toContainText('Danas je na gredici Sjever odrađena');
+
+    const dismissButton = fixture.getByRole('button', {
+        name: 'Odbaci obavijest: Održavajuća rezidba',
+    });
+    await dismissButton.click();
+
+    await expect(fixture).toHaveAttribute('data-dismiss-count', '1');
+    await expect(fixture).toHaveAttribute('data-bubble-open-count', '0');
     await expect(fixture).toHaveAttribute('data-raised-bed-click-count', '0');
     await expect(bubble).toHaveCount(0);
 });

--- a/apps/garden/tests/raised-bed-notification-bubble.spec.tsx
+++ b/apps/garden/tests/raised-bed-notification-bubble.spec.tsx
@@ -93,6 +93,41 @@ test('shows operation context and dismisses from the small close control without
     await expect(bubble).toHaveCount(0);
 });
 
+test('bounds long operation context so the dismiss control stays on screen', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 400, height: 320 });
+    const fixture = await mount(
+        <RaisedBedNotificationBubbleFixture
+            content={`Danas je na gredici Sjever odrađena Održavajuća rezidba. ${'Vrlo duga napomena uz otkazivanje operacije. '.repeat(20)}`}
+            imageUrl={null}
+        />,
+    );
+    await expect(fixture).toHaveAttribute('data-render-ready', 'true');
+
+    const bubble = fixture.locator('[data-raised-bed-notification-bubble]');
+    const dismissButton = fixture.getByRole('button', {
+        name: 'Odbaci obavijest: Održavajuća rezidba',
+    });
+    const content = bubble.locator('.line-clamp-3');
+
+    await expect(content).toHaveCSS('-webkit-line-clamp', '3');
+    const bubbleBox = await bubble.boundingBox();
+    const dismissBox = await dismissButton.boundingBox();
+    expect(bubbleBox).not.toBeNull();
+    expect(dismissBox).not.toBeNull();
+    if (!bubbleBox || !dismissBox) {
+        return;
+    }
+
+    expect(bubbleBox.height).toBeLessThan(130);
+    expect(dismissBox.y).toBeGreaterThanOrEqual(bubbleBox.y);
+    expect(dismissBox.y + dismissBox.height).toBeLessThanOrEqual(
+        bubbleBox.y + bubbleBox.height,
+    );
+});
+
 test('falls back to a readable text bubble when notification media fails', async ({
     mount,
 }) => {

--- a/packages/game/src/GardenOverview2DMap.tsx
+++ b/packages/game/src/GardenOverview2DMap.tsx
@@ -21,6 +21,7 @@ import {
 import type { CurrentGarden } from './hooks/useCurrentGarden';
 import {
     RaisedBedNotificationBubbleContent,
+    RaisedBedNotificationImageViewer,
     useRaisedBedNotificationSurface,
 } from './hud/RaisedBedNotificationSurface';
 import { getSolarEclipseVisualScales } from './scene/solarEclipse';
@@ -74,8 +75,12 @@ export function GardenOverview2DMap({
     const hudPlacementDrag = useGameState((state) => state.hudPlacementDrag);
     const { mutate: openRaisedBed } = useSetRaisedBedCloseupParam();
     const {
+        closeImageViewer: closeRaisedBedNotificationImageViewer,
+        dismissNotification: dismissRaisedBedNotification,
         notifications: raisedBedNotifications,
+        openImageNotification: openRaisedBedNotificationImage,
         openNotification: openRaisedBedNotification,
+        viewerImage: raisedBedNotificationViewerImage,
     } = useRaisedBedNotificationSurface(garden);
     const layout = useMemo(
         () =>
@@ -435,7 +440,13 @@ export function GardenOverview2DMap({
                                       <div className="pointer-events-auto absolute bottom-[calc(100%+0.5rem)] left-1/2 -translate-x-1/2">
                                           <RaisedBedNotificationBubbleContent
                                               notification={notification}
+                                              onDismiss={
+                                                  dismissRaisedBedNotification
+                                              }
                                               onOpen={openRaisedBedNotification}
+                                              onOpenImage={
+                                                  openRaisedBedNotificationImage
+                                              }
                                           />
                                       </div>
                                   </div>
@@ -473,6 +484,10 @@ export function GardenOverview2DMap({
                     ) : null}
                 </section>
             </div>
+            <RaisedBedNotificationImageViewer
+                image={raisedBedNotificationViewerImage}
+                onClose={closeRaisedBedNotificationImageViewer}
+            />
         </section>
     );
 }

--- a/packages/game/src/hooks/useDismissRaisedBedNotification.ts
+++ b/packages/game/src/hooks/useDismissRaisedBedNotification.ts
@@ -1,0 +1,77 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { notificationsQueryKey } from './useNotifications';
+
+export type RaisedBedNotificationDismissScope =
+    | 'selected'
+    | 'raised_bed_images';
+
+export function useDismissRaisedBedNotification() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({
+            gardenId,
+            notificationId,
+            scope,
+        }: {
+            gardenId: number;
+            notificationId: string;
+            scope: RaisedBedNotificationDismissScope;
+        }) => {
+            const response = await clientAuthenticated().api.gardens[
+                ':gardenId'
+            ]['raised-bed-notifications'][':notificationId'].dismiss.$put({
+                param: {
+                    gardenId: gardenId.toString(),
+                    notificationId,
+                },
+                json: { scope },
+            });
+            if (!response.ok) {
+                throw new Error('Failed to dismiss raised-bed notification');
+            }
+            return await response.json();
+        },
+        onMutate: async ({ notificationId }) => {
+            await queryClient.cancelQueries({
+                queryKey: notificationsQueryKey,
+            });
+            const previousQueries = new Map<readonly unknown[], unknown>();
+            const queries = queryClient.getQueriesData({
+                queryKey: notificationsQueryKey,
+            });
+            for (const [queryKey, data] of queries) {
+                previousQueries.set(queryKey, data);
+                if (!Array.isArray(data)) continue;
+
+                queryClient.setQueryData(
+                    queryKey,
+                    data.map((notification) => {
+                        if (
+                            notification &&
+                            typeof notification === 'object' &&
+                            'id' in notification &&
+                            notification.id === notificationId
+                        ) {
+                            return {
+                                ...notification,
+                                readAt: new Date(),
+                            };
+                        }
+                        return notification;
+                    }),
+                );
+            }
+            return { previousQueries };
+        },
+        onError: (_error, _variables, context) => {
+            context?.previousQueries.forEach((data, queryKey) => {
+                queryClient.setQueryData(queryKey, data);
+            });
+        },
+        onSettled: () => {
+            queryClient.invalidateQueries({ queryKey: notificationsQueryKey });
+        },
+    });
+}

--- a/packages/game/src/hud/RaisedBedNotificationBubbles.tsx
+++ b/packages/game/src/hud/RaisedBedNotificationBubbles.tsx
@@ -9,12 +9,14 @@ import { getRaisedBedBlockIds } from '../utils/raisedBedBlocks';
 import { getStackHeight } from '../utils/stackHeightCore';
 import {
     RaisedBedNotificationBubbleContent,
+    RaisedBedNotificationImageViewer,
     type SelectedRaisedBedGardenNotification,
     useRaisedBedNotificationSurface,
 } from './RaisedBedNotificationSurface';
 
 export {
     RaisedBedNotificationBubbleContent,
+    RaisedBedNotificationImageViewer,
     useRaisedBedNotificationSurface,
 } from './RaisedBedNotificationSurface';
 
@@ -86,11 +88,18 @@ export function getRaisedBedNotificationAnchor(
 
 export function RaisedBedNotificationBubble({
     notification,
+    onDismiss,
     onOpen,
+    onOpenImage,
     position,
 }: {
     notification: SelectedRaisedBedGardenNotification;
+    onDismiss: (notification: SelectedRaisedBedGardenNotification) => void;
     onOpen: (notification: SelectedRaisedBedGardenNotification) => void;
+    onOpenImage: (
+        notification: SelectedRaisedBedGardenNotification,
+        imageUrl: string,
+    ) => void;
     position: [x: number, y: number, z: number];
 }) {
     return (
@@ -98,7 +107,9 @@ export function RaisedBedNotificationBubble({
             <div className="-translate-x-1/2 -translate-y-[calc(100%+0.5rem)]">
                 <RaisedBedNotificationBubbleContent
                     notification={notification}
+                    onDismiss={onDismiss}
                     onOpen={onOpen}
+                    onOpenImage={onOpenImage}
                 />
             </div>
         </Html>
@@ -120,26 +131,46 @@ export function RaisedBedNotificationBubbles({
             state.activeDragPreview !== null ||
             state.hudPlacementDrag !== null,
     );
-    const { notifications, openNotification } =
-        useRaisedBedNotificationSurface(garden);
+    const {
+        closeImageViewer,
+        dismissNotification,
+        notifications,
+        openImageNotification,
+        openNotification,
+        viewerImage,
+    } = useRaisedBedNotificationSurface(garden);
 
     if (!garden || view === 'closeup' || hasActivePlacement) {
         return null;
     }
 
-    return notifications.map((notification) => {
-        const position = getRaisedBedNotificationAnchor(
-            blockData,
-            garden,
-            notification.raisedBedId,
-        );
-        return position ? (
-            <RaisedBedNotificationBubble
-                key={notification.id}
-                notification={notification}
-                onOpen={openNotification}
-                position={position}
-            />
-        ) : null;
-    });
+    return (
+        <>
+            {notifications.map((notification) => {
+                const position = getRaisedBedNotificationAnchor(
+                    blockData,
+                    garden,
+                    notification.raisedBedId,
+                );
+                return position ? (
+                    <RaisedBedNotificationBubble
+                        key={notification.id}
+                        notification={notification}
+                        onDismiss={dismissNotification}
+                        onOpen={openNotification}
+                        onOpenImage={openImageNotification}
+                        position={position}
+                    />
+                ) : null;
+            })}
+            {viewerImage ? (
+                <Html position={[0, 0, 0]} zIndexRange={[100, 100]}>
+                    <RaisedBedNotificationImageViewer
+                        image={viewerImage}
+                        onClose={closeImageViewer}
+                    />
+                </Html>
+            ) : null}
+        </>
+    );
 }

--- a/packages/game/src/hud/RaisedBedNotificationSurface.tsx
+++ b/packages/game/src/hud/RaisedBedNotificationSurface.tsx
@@ -142,11 +142,11 @@ export function RaisedBedNotificationBubbleContent({
                     </span>
                 ) : (
                     <span className="block px-3 py-2.5 pr-9">
-                        <span className="block font-semibold">
+                        <span className="line-clamp-2 break-words font-semibold">
                             {notification.header}
                         </span>
                         {showContent ? (
-                            <span className="mt-1 block text-xs font-normal text-emerald-900/80 dark:text-emerald-100/80">
+                            <span className="mt-1 line-clamp-3 break-words text-xs font-normal text-emerald-900/80 dark:text-emerald-100/80">
                                 {content}
                             </span>
                         ) : null}

--- a/packages/game/src/hud/RaisedBedNotificationSurface.tsx
+++ b/packages/game/src/hud/RaisedBedNotificationSurface.tsx
@@ -1,5 +1,11 @@
 'use client';
 
+import {
+    operationCanceledNotificationType,
+    operationCompletedNotificationType,
+} from '@gredice/js/notifications';
+import { ImageViewer } from '@gredice/ui/ImageViewer';
+import { Close } from '@gredice/ui/icons';
 import { cx } from '@gredice/ui/utils';
 import type { Route } from 'next';
 import { useRouter } from 'next/navigation';
@@ -13,10 +19,11 @@ import {
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useGameFlags } from '../GameFlagsContext';
 import type { CurrentGarden } from '../hooks/useCurrentGarden';
+import { useDismissRaisedBedNotification } from '../hooks/useDismissRaisedBedNotification';
 import { useRaisedBedGardenNotifications } from '../hooks/useRaisedBedGardenNotifications';
-import { useSetNotificationRead } from '../hooks/useSetNotificationRead';
 import {
     type RaisedBedGardenNotification,
+    raisedBedNotificationDisplayContent,
     selectRaisedBedGardenNotifications,
 } from '../raisedBedNotifications';
 import { useGameState } from '../useGameState';
@@ -34,6 +41,11 @@ export type SelectedRaisedBedGardenNotification = ReturnType<
     typeof selectRaisedBedGardenNotifications
 >[number];
 
+export type RaisedBedNotificationViewerImage = {
+    alt: string;
+    src: string;
+};
+
 function notificationMediaUrls(notification: RaisedBedGardenNotification) {
     return [notification.imageUrl, notification.iconUrl].flatMap((url) => {
         const normalizedUrl = url?.trim();
@@ -43,10 +55,17 @@ function notificationMediaUrls(notification: RaisedBedGardenNotification) {
 
 export function RaisedBedNotificationBubbleContent({
     notification,
+    onDismiss,
     onOpen,
+    onOpenImage,
 }: {
     notification: SelectedRaisedBedGardenNotification;
+    onDismiss: (notification: SelectedRaisedBedGardenNotification) => void;
     onOpen: (notification: SelectedRaisedBedGardenNotification) => void;
+    onOpenImage: (
+        notification: SelectedRaisedBedGardenNotification,
+        imageUrl: string,
+    ) => void;
 }) {
     const [failedMediaUrls, setFailedMediaUrls] = useState<string[]>([]);
     const mediaUrl = notificationMediaUrls(notification).find(
@@ -54,6 +73,12 @@ export function RaisedBedNotificationBubbleContent({
     );
     const showMedia = Boolean(mediaUrl);
     const actionLabel = `Otvori obavijest za gredicu: ${notification.header}`;
+    const dismissLabel = `Odbaci obavijest: ${notification.header}`;
+    const notificationImageUrl = notification.imageUrl?.trim();
+    const opensImageViewer =
+        Boolean(mediaUrl) && mediaUrl === notificationImageUrl;
+    const content = raisedBedNotificationDisplayContent(notification.content);
+    const showContent = content && content !== notification.header.trim();
 
     function stopPointerEvent(event: PointerEvent<HTMLButtonElement>) {
         event.stopPropagation();
@@ -61,54 +86,124 @@ export function RaisedBedNotificationBubbleContent({
 
     function handleOpen(event: MouseEvent<HTMLButtonElement>) {
         event.stopPropagation();
-        onOpen(notification);
+        if (mediaUrl && opensImageViewer) {
+            onOpenImage(notification, mediaUrl);
+        } else {
+            onOpen(notification);
+        }
+    }
+
+    function handleDismiss(event: MouseEvent<HTMLButtonElement>) {
+        event.stopPropagation();
+        onDismiss(notification);
     }
 
     return (
-        <button
-            type="button"
-            aria-label={actionLabel}
+        <div
             aria-live="polite"
             className={cx(
-                'group relative block touch-manipulation overflow-visible rounded-xl border border-emerald-200 bg-white/95 p-0 text-center text-sm font-semibold leading-snug text-emerald-950 shadow-xl backdrop-blur-sm transition-transform hover:scale-105 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 dark:border-emerald-800/80 dark:bg-neutral-950/95 dark:text-emerald-50',
-                showMedia ? 'h-20 w-28' : 'max-w-[min(15rem,75vw)]',
+                'group relative block overflow-visible rounded-xl border border-emerald-200 bg-white/95 p-0 text-sm leading-snug text-emerald-950 shadow-xl backdrop-blur-sm transition-transform hover:scale-105 dark:border-emerald-800/80 dark:bg-neutral-950/95 dark:text-emerald-50',
+                showMedia ? 'h-20 w-28' : 'w-60 max-w-[80vw]',
             )}
             data-raised-bed-notification-bubble
             data-notification-id={notification.id}
             data-notification-kind={notification.kind}
-            onClick={handleOpen}
-            onPointerDown={stopPointerEvent}
-            onPointerUp={stopPointerEvent}
         >
-            {showMedia ? (
-                <span className="block size-full overflow-hidden rounded-[calc(0.75rem-1px)]">
-                    {/** biome-ignore lint/performance/noImgElement: Notification media uses runtime URLs from the authenticated API. */}
-                    <img
-                        alt={notification.header}
-                        className="size-full object-cover"
-                        data-raised-bed-notification-image
-                        draggable={false}
-                        onError={() => {
-                            if (mediaUrl) {
-                                setFailedMediaUrls((current) =>
-                                    current.includes(mediaUrl)
-                                        ? current
-                                        : [...current, mediaUrl],
-                                );
-                            }
-                        }}
-                        src={mediaUrl}
-                    />
-                </span>
-            ) : (
-                <span className="block px-3 py-2.5">{notification.header}</span>
-            )}
-            <span
+            <button
+                type="button"
+                aria-label={actionLabel}
+                className={cx(
+                    'block size-full touch-manipulation overflow-hidden rounded-[calc(0.75rem-1px)] p-0 text-inherit focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2',
+                    showMedia ? 'text-center' : 'text-left',
+                )}
+                onClick={handleOpen}
+                onPointerDown={stopPointerEvent}
+                onPointerUp={stopPointerEvent}
+            >
+                {showMedia ? (
+                    <span className="block size-full overflow-hidden">
+                        {/** biome-ignore lint/performance/noImgElement: Notification media uses runtime URLs from the authenticated API. */}
+                        <img
+                            alt={notification.header}
+                            className="size-full object-cover"
+                            data-raised-bed-notification-image
+                            draggable={false}
+                            onError={() => {
+                                if (mediaUrl) {
+                                    setFailedMediaUrls((current) =>
+                                        current.includes(mediaUrl)
+                                            ? current
+                                            : [...current, mediaUrl],
+                                    );
+                                }
+                            }}
+                            src={mediaUrl}
+                        />
+                    </span>
+                ) : (
+                    <span className="block px-3 py-2.5 pr-9">
+                        <span className="block font-semibold">
+                            {notification.header}
+                        </span>
+                        {showContent ? (
+                            <span className="mt-1 block text-xs font-normal text-emerald-900/80 dark:text-emerald-100/80">
+                                {content}
+                            </span>
+                        ) : null}
+                    </span>
+                )}
+            </button>
+            <button
+                type="button"
+                aria-label={dismissLabel}
+                title="Odbaci"
+                className={cx(
+                    'absolute right-1 top-1 z-10 inline-flex size-6 touch-manipulation items-center justify-center rounded-full border-0 p-0 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-1',
+                    showMedia
+                        ? 'bg-black/65 text-white hover:bg-black/80'
+                        : 'bg-white/80 text-emerald-950 hover:bg-emerald-50 dark:bg-neutral-950/80 dark:text-emerald-50 dark:hover:bg-neutral-900',
+                )}
+                data-raised-bed-notification-dismiss
+                onClick={handleDismiss}
+                onPointerDown={stopPointerEvent}
+                onPointerUp={stopPointerEvent}
+            >
+                <Close className="size-3.5" />
+            </button>
+            <svg
                 aria-hidden="true"
-                className="absolute top-full left-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rotate-45 border-r border-b border-emerald-200 bg-white/95 dark:border-emerald-800/80 dark:bg-neutral-950/95"
-            />
-        </button>
+                className="pointer-events-none absolute left-1/2 top-full h-2.5 w-5 -translate-x-1/2 overflow-visible"
+                data-raised-bed-notification-arrow
+                viewBox="0 0 20 10"
+            >
+                <path
+                    className="fill-white/95 stroke-emerald-200 dark:fill-neutral-950/95 dark:stroke-emerald-800/80"
+                    d="M1 0.5h18L10 9.5Z"
+                    strokeLinejoin="round"
+                />
+            </svg>
+        </div>
     );
+}
+
+export function RaisedBedNotificationImageViewer({
+    image,
+    onClose,
+}: {
+    image: RaisedBedNotificationViewerImage | null;
+    onClose: () => void;
+}) {
+    return image ? (
+        <ImageViewer
+            alt={image.alt}
+            onOpenChange={(open) => {
+                if (!open) onClose();
+            }}
+            open
+            showPreview={false}
+            src={image.src}
+        />
+    ) : null;
 }
 
 export function useRaisedBedNotificationSurface(
@@ -126,7 +221,9 @@ export function useRaisedBedNotificationSurface(
     const notificationsQuery = useRaisedBedGardenNotifications(
         notificationSurfaceEnabled ? garden?.id : undefined,
     );
-    const setNotificationRead = useSetNotificationRead();
+    const dismissRaisedBedNotification = useDismissRaisedBedNotification();
+    const [viewerImage, setViewerImage] =
+        useState<RaisedBedNotificationViewerImage | null>(null);
     const selectedNotifications = useMemo(
         () =>
             garden && notificationSurfaceEnabled
@@ -146,20 +243,24 @@ export function useRaisedBedNotificationSurface(
             const raisedBed = garden?.raisedBeds.find(
                 (candidate) => candidate.id === notification.raisedBedId,
             );
+            const isOperation =
+                notification.type === operationCompletedNotificationType ||
+                notification.type === operationCanceledNotificationType;
             const href = resolveRaisedBedNotificationHref({
                 currentOrigin: window.location.origin,
+                fieldTab: isOperation ? 'diary' : undefined,
                 linkUrl: notification.linkUrl,
                 raisedBedName: raisedBed?.name,
             });
-            if (!href) {
+            if (!href || !garden) {
                 return;
             }
 
             try {
-                await setNotificationRead.mutateAsync({
-                    id: notification.id,
-                    read: true,
-                    readWhere: 'game_raised_bed_bubble',
+                await dismissRaisedBedNotification.mutateAsync({
+                    gardenId: garden.id,
+                    notificationId: notification.id,
+                    scope: 'selected',
                 });
             } catch {
                 return;
@@ -178,11 +279,60 @@ export function useRaisedBedNotificationSurface(
                 push: (url) => router.push(url as Route),
             });
         },
-        [garden?.raisedBeds, router, setNotificationRead, track],
+        [dismissRaisedBedNotification, garden, router, track],
+    );
+
+    const openImageNotification = useCallback(
+        (
+            notification: SelectedRaisedBedGardenNotification,
+            imageUrl: string,
+        ) => {
+            if (!garden) return;
+
+            setViewerImage({ alt: notification.header, src: imageUrl });
+            track('game_raised_bed_notification_opened', {
+                has_link: false,
+                notification_id: notification.id,
+                notification_kind: notification.kind,
+                raised_bed_id: notification.raisedBedId,
+            });
+            void dismissRaisedBedNotification
+                .mutateAsync({
+                    gardenId: garden.id,
+                    notificationId: notification.id,
+                    scope: 'raised_bed_images',
+                })
+                .catch(() => undefined);
+        },
+        [dismissRaisedBedNotification, garden, track],
+    );
+
+    const dismissNotification = useCallback(
+        (notification: SelectedRaisedBedGardenNotification) => {
+            if (!garden) return;
+
+            track('game_raised_bed_notification_dismissed', {
+                notification_id: notification.id,
+                notification_kind: notification.kind,
+                raised_bed_id: notification.raisedBedId,
+            });
+            void dismissRaisedBedNotification
+                .mutateAsync({
+                    gardenId: garden.id,
+                    notificationId: notification.id,
+                    scope: 'selected',
+                })
+                .catch(() => undefined);
+        },
+        [dismissRaisedBedNotification, garden, track],
     );
 
     return {
+        closeImageViewer: () => setViewerImage(null),
+        dismissNotification,
         notifications: selectedNotifications,
+        openImageNotification,
         openNotification,
+        viewerImage,
     };
 }

--- a/packages/game/src/hud/notificationNavigation.ts
+++ b/packages/game/src/hud/notificationNavigation.ts
@@ -17,10 +17,12 @@ type NavigateNotificationLinkOptions = {
 
 export function resolveRaisedBedNotificationHref({
     currentOrigin,
+    fieldTab,
     linkUrl,
     raisedBedName,
 }: {
     currentOrigin: string;
+    fieldTab?: 'diary' | 'lifecycle' | 'operations';
     linkUrl: string | null | undefined;
     raisedBedName: string | null | undefined;
 }) {
@@ -31,7 +33,11 @@ export function resolveRaisedBedNotificationHref({
             currentOrigin,
         );
         if (resolvedNotificationHref) {
-            return resolvedNotificationHref;
+            return addRaisedBedFieldTab(
+                resolvedNotificationHref,
+                currentOrigin,
+                fieldTab,
+            );
         }
     }
 
@@ -41,6 +47,28 @@ export function resolveRaisedBedNotificationHref({
               currentOrigin,
           )
         : null;
+}
+
+function addRaisedBedFieldTab(
+    href: string,
+    currentOrigin: string,
+    fieldTab: 'diary' | 'lifecycle' | 'operations' | undefined,
+) {
+    if (!fieldTab) return href;
+
+    try {
+        const targetUrl = new URL(href, currentOrigin);
+        const fieldNumber = Number(targetUrl.searchParams.get('polje'));
+        if (!Number.isSafeInteger(fieldNumber) || fieldNumber <= 0) {
+            return href;
+        }
+        targetUrl.searchParams.set('polje-kartica', fieldTab);
+        return href.startsWith('http')
+            ? targetUrl.toString()
+            : `${targetUrl.pathname}${targetUrl.search}${targetUrl.hash}`;
+    } catch {
+        return href;
+    }
 }
 
 function hasExplicitPort(rawUrl: string) {

--- a/packages/game/src/hud/notificationNavigation.unit.ts
+++ b/packages/game/src/hud/notificationNavigation.unit.ts
@@ -60,6 +60,18 @@ test('falls back to the raised-bed closeup for a blank notification link', () =>
     );
 });
 
+test('adds the diary tab to operation field links while preserving the target', () => {
+    assert.equal(
+        resolveRaisedBedNotificationHref({
+            currentOrigin,
+            fieldTab: 'diary',
+            linkUrl: 'https://vrt.gredice.com/?gredica=Moja%20gredica&polje=3',
+            raisedBedName: 'Moja gredica',
+        }),
+        '/?gredica=Moja+gredica&polje=3&polje-kartica=diary',
+    );
+});
+
 test('uses router navigation for relative and absolute same-origin links', () => {
     const harness = createHarness();
 

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItem.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItem.tsx
@@ -1,7 +1,10 @@
 import { useEffect } from 'react';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import type { ShoppingCartItemData } from '../../hooks/useShoppingCart';
-import { useRaisedBedFieldDetailsParam } from '../../useUrlState';
+import {
+    normalizeRaisedBedFieldTab,
+    useRaisedBedCloseupParams,
+} from '../../useUrlState';
 import {
     findRaisedBedOccupiedField,
     getRaisedBedFieldPlantHistory,
@@ -28,8 +31,9 @@ export function RaisedBedFieldItem({
     isDragging?: boolean;
 }) {
     const { data: garden, isLoading: isGardenLoading } = useCurrentGarden();
-    const [fieldDetailsParam, setFieldDetailsParam] =
-        useRaisedBedFieldDetailsParam();
+    const [fieldDetailsParams, setFieldDetailsParams] =
+        useRaisedBedCloseupParams();
+    const fieldDetailsParam = fieldDetailsParams.polje;
     const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
 
     const field = findRaisedBedOccupiedField(raisedBed?.fields, positionIndex);
@@ -59,18 +63,24 @@ export function RaisedBedFieldItem({
             return;
         }
 
-        void setFieldDetailsParam(null);
+        void setFieldDetailsParams({
+            polje: null,
+            'polje-kartica': null,
+        });
     }, [
         focusedHistoryEntry,
         hasField,
         isFieldDetailsFocused,
         isGardenLoading,
-        setFieldDetailsParam,
+        setFieldDetailsParams,
     ]);
 
     function handleFieldDetailsOpenChange(open: boolean) {
         if (!open && isFieldDetailsFocused) {
-            void setFieldDetailsParam(null);
+            void setFieldDetailsParams({
+                polje: null,
+                'polje-kartica': null,
+            });
         }
     }
 
@@ -105,6 +115,9 @@ export function RaisedBedFieldItem({
                         isHistorical
                         onOpenChange={handleFieldDetailsOpenChange}
                         open
+                        requestedTab={normalizeRaisedBedFieldTab(
+                            fieldDetailsParams['polje-kartica'],
+                        )}
                         positionIndex={positionIndex}
                         raisedBedId={raisedBedId}
                         triggerOverride={null}
@@ -121,6 +134,13 @@ export function RaisedBedFieldItem({
                 isFieldDetailsFocused ? handleFieldDetailsOpenChange : undefined
             }
             open={isFieldDetailsFocused ? true : undefined}
+            requestedTab={
+                isFieldDetailsFocused
+                    ? normalizeRaisedBedFieldTab(
+                          fieldDetailsParams['polje-kartica'],
+                      )
+                    : undefined
+            }
             plantHistory={visiblePlantHistory}
             raisedBedId={raisedBedId}
             positionIndex={positionIndex}

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -21,12 +21,13 @@ import { SegmentedCircularProgress } from '@gredice/ui/SegmentedCircularProgress
 import { Stack } from '@gredice/ui/Stack';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import { Typography } from '@gredice/ui/Typography';
-import { type ReactElement, useState } from 'react';
+import { type ReactElement, useEffect, useState } from 'react';
 import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { usePlantSort } from '../../hooks/usePlantSorts';
 import { KnownPages } from '../../knownPages';
 import { GameModal } from '../../shared-ui/game-modal';
+import type { RaisedBedFieldTabValue } from '../../useUrlState';
 import {
     findRaisedBedFieldWithPlant,
     findRaisedBedOccupiedField,
@@ -60,14 +61,13 @@ import {
     ScheduledSowingDateBadge,
 } from './ScheduledSowingDateBadge';
 
-type RaisedBedFieldTabValue = 'lifecycle' | 'diary' | 'operations';
-
 export function RaisedBedFieldItemPlanted({
     raisedBedId,
     positionIndex,
     fieldOverride,
     onOpenChange,
     open: openProp,
+    requestedTab,
     plantHistory = [],
     isHistorical = false,
     triggerOverride,
@@ -78,6 +78,7 @@ export function RaisedBedFieldItemPlanted({
     fieldOverride?: RaisedBedFieldPlantHistoryEntry;
     onOpenChange?: (open: boolean) => void;
     open?: boolean;
+    requestedTab?: RaisedBedFieldTabValue;
     plantHistory?: RaisedBedFieldPlantHistoryEntry[];
     isHistorical?: boolean;
     triggerOverride?: ReactElement | null;
@@ -125,6 +126,12 @@ export function RaisedBedFieldItemPlanted({
     };
     const isOpenControlled = openProp !== undefined;
     const open = openProp ?? internalOpen;
+
+    useEffect(() => {
+        if (open && requestedTab) {
+            setActiveTab(requestedTab);
+        }
+    }, [open, requestedTab]);
 
     if (!raisedBed) {
         return null;

--- a/packages/game/src/raisedBedNotifications.ts
+++ b/packages/game/src/raisedBedNotifications.ts
@@ -45,6 +45,15 @@ export type SelectedRaisedBedGardenNotification = Omit<
     raisedBedId: number;
 };
 
+export function raisedBedNotificationDisplayContent(content: string) {
+    return content
+        .replace(/!\[([^\]]*)\]\([^)]*\)/gu, '$1')
+        .replace(/\[([^\]]+)\]\([^)]*\)/gu, '$1')
+        .replace(/[*_`#]+/gu, '')
+        .replace(/\s+/gu, ' ')
+        .trim();
+}
+
 const kindPriority: Record<RaisedBedGardenNotificationKind, number> = {
     raisedBedPhoto: 0,
     raisedBedFieldPhoto: 1,

--- a/packages/game/src/raisedBedNotifications.unit.ts
+++ b/packages/game/src/raisedBedNotifications.unit.ts
@@ -9,8 +9,20 @@ import {
 } from '@gredice/js/notifications';
 import {
     type RaisedBedGardenNotification,
+    raisedBedNotificationDisplayContent,
     selectRaisedBedGardenNotifications,
 } from './raisedBedNotifications';
+
+describe('raisedBedNotificationDisplayContent', () => {
+    it('shows compact context without exposing markdown syntax', () => {
+        assert.equal(
+            raisedBedNotificationDisplayContent(
+                'Danas je na **gredici Sjever** odrađena [rezidba](https://example.com).',
+            ),
+            'Danas je na gredici Sjever odrađena rezidba.',
+        );
+    });
+});
 
 const baseTimestamp = new Date('2026-08-11T08:00:00.000Z');
 

--- a/packages/game/src/useRaisedBedCloseup.tsx
+++ b/packages/game/src/useRaisedBedCloseup.tsx
@@ -11,6 +11,7 @@ export function useRemoveRaisedBedCloseupParam() {
             setRaisedBedCloseupParams({
                 gredica: null,
                 polje: null,
+                'polje-kartica': null,
             }),
         [setRaisedBedCloseupParams],
     );
@@ -30,6 +31,7 @@ export function useSetRaisedBedCloseupParam() {
                     typeof positionIndex === 'number'
                         ? positionIndex + 1
                         : null,
+                'polje-kartica': null,
             }),
         [setRaisedBedCloseupParams],
     );
@@ -70,6 +72,7 @@ export function useRaisedBedCloseup() {
             void setRaisedBedCloseupParams({
                 gredica: null,
                 polje: null,
+                'polje-kartica': null,
             });
             return;
         }
@@ -102,6 +105,7 @@ export function useRaisedBedCloseup() {
             void setRaisedBedCloseupParams({
                 gredica: null,
                 polje: null,
+                'polje-kartica': null,
             });
             return;
         }
@@ -117,6 +121,7 @@ export function useRaisedBedCloseup() {
             void setRaisedBedCloseupParams({
                 gredica: null,
                 polje: null,
+                'polje-kartica': null,
             });
             return;
         }

--- a/packages/game/src/useUrlState.tsx
+++ b/packages/game/src/useUrlState.tsx
@@ -62,6 +62,7 @@ export function useRaisedBedCloseupParam() {
 const raisedBedCloseupParamParsers = {
     gredica: parseAsString,
     polje: parseAsInteger,
+    'polje-kartica': parseAsString,
 };
 
 export function useRaisedBedCloseupParams() {
@@ -71,6 +72,19 @@ export function useRaisedBedCloseupParams() {
 // Raised bed field details parameter (Croatian: "polje" = field)
 export function useRaisedBedFieldDetailsParam() {
     return useQueryState('polje', parseAsInteger);
+}
+
+export const raisedBedFieldTabValues = [
+    'lifecycle',
+    'diary',
+    'operations',
+] as const;
+export type RaisedBedFieldTabValue = (typeof raisedBedFieldTabValues)[number];
+
+export function normalizeRaisedBedFieldTab(
+    value: string | null | undefined,
+): RaisedBedFieldTabValue {
+    return raisedBedFieldTabValues.find((tab) => tab === value) ?? 'lifecycle';
 }
 
 // Gift box modal parameter (Croatian: "poklon-kutija" = gift box)
@@ -102,6 +116,7 @@ export const urlStateSerializer = createSerializer({
     'ruksak-kartica': parseAsString,
     gredica: parseAsString,
     polje: parseAsInteger,
+    'polje-kartica': parseAsString,
     'poklon-kutija': parseAsString,
     natpis: parseAsString,
     vrt: parseAsInteger,

--- a/packages/js/src/urls/gardenUrls.ts
+++ b/packages/js/src/urls/gardenUrls.ts
@@ -40,7 +40,10 @@ export function getGardenBaseUrl(): string {
  */
 export function getRaisedBedCloseupUrl(
     raisedBedName: string,
-    options?: { positionIndex?: number | null },
+    options?: {
+        fieldTab?: 'diary' | 'lifecycle' | 'operations';
+        positionIndex?: number | null;
+    },
 ): string {
     const params = [`gredica=${encodeURIComponent(raisedBedName)}`];
     if (
@@ -49,6 +52,9 @@ export function getRaisedBedCloseupUrl(
         options.positionIndex >= 0
     ) {
         params.push(`polje=${(options.positionIndex + 1).toString()}`);
+        if (options.fieldTab) {
+            params.push(`polje-kartica=${options.fieldTab}`);
+        }
     }
 
     return `${getGardenBaseUrl()}?${params.join('&')}`;

--- a/packages/js/src/urls/gardenUrls.unit.ts
+++ b/packages/js/src/urls/gardenUrls.unit.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getRaisedBedCloseupUrl } from './gardenUrls';
+
+test('builds a raised-bed field deep link with the requested plant-details tab', () => {
+    assert.match(
+        getRaisedBedCloseupUrl('Moja gredica', {
+            fieldTab: 'diary',
+            positionIndex: 2,
+        }),
+        /\?gredica=Moja%20gredica&polje=3&polje-kartica=diary$/u,
+    );
+});
+
+test('does not add a field tab without a valid field position', () => {
+    assert.doesNotMatch(
+        getRaisedBedCloseupUrl('Moja gredica', { fieldTab: 'diary' }),
+        /polje-kartica/u,
+    );
+});

--- a/packages/storage/src/repositories/notificationsRepo.ts
+++ b/packages/storage/src/repositories/notificationsRepo.ts
@@ -4408,6 +4408,53 @@ export async function getUnreadRaisedBedNotificationsForGarden({
     );
 }
 
+export async function getUnreadRaisedBedImageNotificationIdsForGarden({
+    accountId,
+    gardenId,
+    limit = maxNotificationReadBatchSize,
+    raisedBedId,
+    userId,
+}: {
+    accountId: string;
+    gardenId: number;
+    limit?: number;
+    raisedBedId: number;
+    userId: string;
+}) {
+    const boundedLimit = Math.min(
+        Math.max(Number.isSafeInteger(limit) ? limit : 1, 1),
+        maxNotificationReadBatchSize,
+    );
+    const rows = await storage()
+        .select({ id: notifications.id })
+        .from(notifications)
+        .where(
+            and(
+                eq(notifications.accountId, accountId),
+                or(
+                    eq(notifications.userId, userId),
+                    isNull(notifications.userId),
+                ),
+                eq(notifications.gardenId, gardenId),
+                eq(notifications.raisedBedId, raisedBedId),
+                isNull(notifications.readAt),
+                ne(
+                    notifications.type,
+                    detailedRaisedBedInspectionNotificationType,
+                ),
+                raisedBedNotificationHasImage,
+            ),
+        )
+        .orderBy(
+            desc(notifications.timestamp),
+            desc(notifications.createdAt),
+            desc(notifications.id),
+        )
+        .limit(boundedLimit);
+
+    return rows.map(({ id }) => id);
+}
+
 export function getNotifications(page: number, limit: number) {
     return storage().query.notifications.findMany({
         orderBy: desc(notifications.timestamp),

--- a/packages/storage/tests/notificationsRepo.node.spec.ts
+++ b/packages/storage/tests/notificationsRepo.node.spec.ts
@@ -29,6 +29,7 @@ import {
     getNotificationDeliverySummary,
     getNotificationsByAccount,
     getNotificationsForCenter,
+    getUnreadRaisedBedImageNotificationIdsForGarden,
     getUnreadRaisedBedNotificationsForGarden,
     getUser,
     markDeliveryLifecycleEmailAttemptFailed,
@@ -1464,6 +1465,106 @@ test('garden raised-bed notifications select visual kind before priority and rec
     assert.deepEqual(
         result.map(({ id }) => id),
         [ids.fullBed],
+    );
+});
+
+test('garden raised-bed image notification dismissal targets only unread images for one bed and recipient', async () => {
+    createTestDb();
+    const farmId = await ensureFarmId();
+    const userId = await createUserWithPassword(
+        `raised-bed-image-dismiss-${randomUUID()}@example.com`,
+        'password',
+    );
+    const user = await getUser(userId);
+    assert.ok(user);
+    const accountId = user.accounts[0]?.accountId;
+    assert.ok(accountId);
+    const foreignUserId = await createUserWithPassword(
+        `raised-bed-image-dismiss-foreign-${randomUUID()}@example.com`,
+        'password',
+    );
+    await storage()
+        .insert(accountUsers)
+        .values({ accountId, userId: foreignUserId });
+
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const raisedBedId = await createTestRaisedBed(
+        gardenId,
+        accountId,
+        await createTestBlock(gardenId, 'Raised_Bed'),
+    );
+    const otherRaisedBedId = await createTestRaisedBed(
+        gardenId,
+        accountId,
+        await createTestBlock(gardenId, 'Raised_Bed'),
+    );
+    const idPrefix = `raised-bed-image-dismiss-${randomUUID()}`;
+    const visibleAccountImageId = `${idPrefix}-account-image`;
+    const visibleUserImageId = `${idPrefix}-user-image`;
+    const row = ({
+        id,
+        imageUrl = 'https://cdn.example.com/raised-bed.jpg',
+        readAt,
+        targetRaisedBedId = raisedBedId,
+        targetUserId,
+        type,
+    }: {
+        id: string;
+        imageUrl?: string | null;
+        readAt?: Date;
+        targetRaisedBedId?: number;
+        targetUserId?: string;
+        type?: string;
+    }) => ({
+        id,
+        accountId,
+        category: 'garden',
+        content: id,
+        gardenId,
+        header: id,
+        imageUrl,
+        raisedBedId: targetRaisedBedId,
+        readAt,
+        timestamp: new Date('2026-08-12T10:00:00.000Z'),
+        type,
+        userId: targetUserId,
+    });
+
+    await storage()
+        .insert(notifications)
+        .values([
+            row({ id: visibleAccountImageId }),
+            row({ id: visibleUserImageId, targetUserId: userId }),
+            row({ id: `${idPrefix}-text`, imageUrl: null }),
+            row({
+                id: `${idPrefix}-other-bed`,
+                targetRaisedBedId: otherRaisedBedId,
+            }),
+            row({
+                id: `${idPrefix}-foreign-user`,
+                targetUserId: foreignUserId,
+            }),
+            row({
+                id: `${idPrefix}-read`,
+                readAt: new Date('2026-08-12T10:01:00.000Z'),
+            }),
+            row({
+                id: `${idPrefix}-inspection`,
+                type: detailedRaisedBedInspectionNotificationType,
+            }),
+            row({ id: `${idPrefix}-blank`, imageUrl: '   ' }),
+        ]);
+
+    const result = await getUnreadRaisedBedImageNotificationIdsForGarden({
+        accountId,
+        gardenId,
+        raisedBedId,
+        userId,
+    });
+
+    assert.deepEqual(
+        new Set(result),
+        new Set([visibleAccountImageId, visibleUserImageId]),
     );
 });
 

--- a/packages/ui/src/ImageViewer/ImageViewer.tsx
+++ b/packages/ui/src/ImageViewer/ImageViewer.tsx
@@ -13,6 +13,8 @@ import { cx } from '../utils';
 interface ImageViewerProps {
     src: string;
     alt: string;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
     previewWidth?: number;
     previewHeight?: number;
     /**
@@ -20,19 +22,24 @@ interface ImageViewerProps {
      * Use "div" when ImageViewer is placed inside another <button> to avoid invalid HTML.
      */
     previewAs?: 'button' | 'div';
+    /** Keep the full-screen viewer mounted without rendering its preview. */
+    showPreview?: boolean;
 }
 
 export function ImageViewer({
     src,
     alt,
+    open: openProp,
+    onOpenChange,
     previewWidth = 300,
     previewHeight = 200,
     previewAs = 'button',
+    showPreview = true,
 }: ImageViewerProps) {
     const resolvedAlt = alt?.trim() || 'Slika';
     const imageInstructionsId = useId();
     const lastFocusedElementRef = useRef<Element | null>(null);
-    const [isExpanded, setIsExpanded] = useState(false);
+    const [internalExpanded, setInternalExpanded] = useState(false);
     const [position, setPosition] = useState({ x: 0, y: 0 });
     const [isDragging, setIsDragging] = useState(false);
     const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
@@ -46,7 +53,17 @@ export function ImageViewer({
         setZoomLevel,
         viewerRef: imageRef,
         zoomLevel,
-    } = useImageFitZoom<HTMLButtonElement>(isExpanded, src);
+    } = useImageFitZoom<HTMLButtonElement>(openProp ?? internalExpanded, src);
+    const isExpanded = openProp ?? internalExpanded;
+    const setIsExpanded = useCallback(
+        (open: boolean) => {
+            if (openProp === undefined) {
+                setInternalExpanded(open);
+            }
+            onOpenChange?.(open);
+        },
+        [onOpenChange, openProp],
+    );
 
     const resetTransform = useCallback(() => {
         resetZoomLevel();
@@ -89,7 +106,7 @@ export function ImageViewer({
             resetTransform();
             restoreFocusedElement();
         },
-        [resetTransform, restoreFocusedElement],
+        [resetTransform, restoreFocusedElement, setIsExpanded],
     );
 
     const getTouchDistance = (touch1: React.Touch, touch2: React.Touch) => {
@@ -291,40 +308,42 @@ export function ImageViewer({
 
     return (
         <>
-            <PreviewComponent
-                {...(previewAs === 'button'
-                    ? { type: 'button' as const }
-                    : {
-                          role: 'button' as const,
-                          tabIndex: 0,
-                      })}
-                aria-label={`Otvori sliku u punoj veličini: ${resolvedAlt}`}
-                title="Otvori u punoj veličini"
-                className="group relative hover:cursor-zoom-in flex items-center justify-center overflow-hidden rounded-lg shadow-md bg-muted hover:shadow-lg transition-shadow duration-200"
-                style={{ width: previewWidth, height: previewHeight }}
-                onClick={(event: React.MouseEvent) => {
-                    event.stopPropagation();
-                    openExpanded(event.currentTarget);
-                }}
-                onKeyDown={(event: React.KeyboardEvent) => {
-                    if (previewAs === 'button') return;
-                    event.stopPropagation();
-                    if (event.key === 'Enter' || event.key === ' ') {
-                        event.preventDefault();
+            {showPreview ? (
+                <PreviewComponent
+                    {...(previewAs === 'button'
+                        ? { type: 'button' as const }
+                        : {
+                              role: 'button' as const,
+                              tabIndex: 0,
+                          })}
+                    aria-label={`Otvori sliku u punoj veličini: ${resolvedAlt}`}
+                    title="Otvori u punoj veličini"
+                    className="group relative hover:cursor-zoom-in flex items-center justify-center overflow-hidden rounded-lg shadow-md bg-muted hover:shadow-lg transition-shadow duration-200"
+                    style={{ width: previewWidth, height: previewHeight }}
+                    onClick={(event: React.MouseEvent) => {
+                        event.stopPropagation();
                         openExpanded(event.currentTarget);
-                    }
-                }}
-            >
-                <Image
-                    src={src}
-                    alt={resolvedAlt}
-                    fill
-                    sizes={`${previewWidth}px`}
-                    className="h-full w-full object-cover"
-                />
-                <div className="absolute inset-0 bg-white/40 opacity-0 group-hover:opacity-50 transition-opacity"></div>
-                <Search className="stroke-white group-hover:scale-110 size-4 shrink-0 absolute bottom-1 right-1" />
-            </PreviewComponent>
+                    }}
+                    onKeyDown={(event: React.KeyboardEvent) => {
+                        if (previewAs === 'button') return;
+                        event.stopPropagation();
+                        if (event.key === 'Enter' || event.key === ' ') {
+                            event.preventDefault();
+                            openExpanded(event.currentTarget);
+                        }
+                    }}
+                >
+                    <Image
+                        src={src}
+                        alt={resolvedAlt}
+                        fill
+                        sizes={`${previewWidth}px`}
+                        className="h-full w-full object-cover"
+                    />
+                    <div className="absolute inset-0 bg-white/40 opacity-0 group-hover:opacity-50 transition-opacity"></div>
+                    <Search className="stroke-white group-hover:scale-110 size-4 shrink-0 absolute bottom-1 right-1" />
+                </PreviewComponent>
+            ) : null}
 
             <Modal
                 open={isExpanded}


### PR DESCRIPTION
## Summary

- replace the rotated-square bubble pointer with a standard downward pointer, show contextual notification content, and add an accessible dismiss control
- open image notifications in the full-screen image viewer and dismiss all unread images for that raised bed
- mark operation notifications read through a garden-scoped endpoint before navigating to the plant modal on its Dnevnik tab
- add URL support for deep-linking plant details tabs and retain the existing feature flag

## Root cause

The first bubble implementation reused one generic link-and-read action for every notification. Its visual pointer was a rotated square, text bubbles rendered only the header, media did not have a persistent viewer, and the generic single-row read path could navigate without the grouped semantics required by the garden surface.

## Validation

- `pnpm typecheck` in `@gredice/game`, `@gredice/ui`, `garden`, and `www`
- `pnpm test` in `@gredice/game` (1,071 passing)
- `pnpm test` in `@gredice/js` (47 passing)
- `pnpm test:node` in `api` (537 passing)
- focused operation notification tests in `app` (5 passing)
- focused notification repository suite in `@gredice/storage` (58 passing)
- raised-bed notification Playwright component suite (4 passing)
- Dnevnik deep-link Playwright interaction (1 passing)