### PR TITLE
fix(game): align beach ball collisions and shadow

### DIFF
--- a/packages/game/src/entities/BeachBall.tsx
+++ b/packages/game/src/entities/BeachBall.tsx
@@ -10,6 +10,7 @@ import { SnowOverlay } from '../snow/SnowOverlay';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
 import { useStackHeight } from '../utils/getStackHeight';
 import { useGameGLTF } from '../utils/useGameGLTF';
+import { useActorGroundingShadow } from './animals/ActorGroundingShadows';
 import {
     advanceBeachBallBounce,
     beachBallCollisionRadius,
@@ -57,7 +58,7 @@ const beachBallNodeNames = [
 function BeachBallPart({ node }: { node: BeachBallNode }) {
     return (
         <mesh
-            castShadow
+            castShadow={false}
             receiveShadow
             geometry={node.geometry}
             material={node.material}
@@ -150,6 +151,11 @@ export function BeachBall({
     const visualBounceRef = useRef(createBeachBallVisualBounce());
     const clickCountRef = useRef(0);
     const [hovered, setHovered] = useState(false);
+    const updateGroundingShadow = useActorGroundingShadow({
+        id: `beach-ball:${block.id}`,
+        primaryCasterCount: 0,
+        species: 'beachBall',
+    });
     const bounceEnvironment = useMemo(
         () =>
             createBeachBallBounceEnvironment({
@@ -195,6 +201,14 @@ export function BeachBall({
                 surfaceHeight - currentStackHeight + bounceY,
                 state.offsetZ,
             );
+            updateGroundingShadow?.({
+                actorY: surfaceHeight + bounceY,
+                receiverY: surfaceHeight,
+                visible: motionGroup.visible,
+                x: stack.position.x + state.offsetX,
+                yaw: 0,
+                z: stack.position.z + state.offsetZ,
+            });
         };
 
         if (!currentState.active) {
@@ -305,12 +319,7 @@ export function BeachBall({
 
     return (
         <HoverOutline color="white" hovered={hovered} thickness={7}>
-            <animated.group
-                position={position}
-                rotation={
-                    animatedRotation as unknown as [number, number, number]
-                }
-            >
+            <group position={position}>
                 {/* biome-ignore lint/a11y/noStaticElementInteractions: Three.js group uses raycast picking for the clickable beach ball. */}
                 <group
                     ref={motionGroupRef}
@@ -319,16 +328,26 @@ export function BeachBall({
                     onPointerLeave={handlePointerLeave}
                     onPointerUp={handlePointerUp}
                 >
-                    <group scale={beachBallScale}>
-                        {beachBallNodeNames.map((nodeName) => (
-                            <BeachBallPart
-                                key={nodeName}
-                                node={nodes[nodeName]}
-                            />
-                        ))}
-                    </group>
+                    <animated.group
+                        rotation={
+                            animatedRotation as unknown as [
+                                number,
+                                number,
+                                number,
+                            ]
+                        }
+                    >
+                        <group scale={beachBallScale}>
+                            {beachBallNodeNames.map((nodeName) => (
+                                <BeachBallPart
+                                    key={nodeName}
+                                    node={nodes[nodeName]}
+                                />
+                            ))}
+                        </group>
+                    </animated.group>
                 </group>
-            </animated.group>
+            </group>
         </HoverOutline>
     );
 }

--- a/packages/game/src/entities/animals/actorGroundingShadowRegistry.ts
+++ b/packages/game/src/entities/animals/actorGroundingShadowRegistry.ts
@@ -1,5 +1,6 @@
 export type ActorGroundingShadowSpecies =
     | 'avatar'
+    | 'beachBall'
     | 'bee'
     | 'bird'
     | 'cat'
@@ -76,6 +77,13 @@ export const actorGroundingShadowProfiles = {
         baseOpacity: 0.32,
         cutoffHeight: 2,
         maxFootprintScale: 1.7,
+    },
+    beachBall: {
+        baseHalfLength: 0.23,
+        baseHalfWidth: 0.23,
+        baseOpacity: 0.28,
+        cutoffHeight: 0.42,
+        maxFootprintScale: 1.3,
     },
     bee: {
         baseHalfLength: 0.055,

--- a/packages/game/src/entities/animals/actorGroundingShadowRegistry.unit.ts
+++ b/packages/game/src/entities/animals/actorGroundingShadowRegistry.unit.ts
@@ -55,6 +55,30 @@ describe('actor grounding-shadow projection', () => {
         assert.equal(resolved.opacity, profile.baseOpacity * 0.25);
     });
 
+    it('keeps the beach ball shadow centered below its bounce', () => {
+        const profile = actorGroundingShadowProfiles.beachBall;
+        const bounceHeight = profile.cutoffHeight / 4;
+        const resolved = resolveActorGroundingShadow({
+            snowCoverage: 0,
+            species: 'beachBall',
+            state: {
+                ...groundedState,
+                actorY: groundedState.receiverY + bounceHeight,
+            },
+        });
+        const expectedScale = 1 + (profile.maxFootprintScale - 1) * (1 / 4);
+
+        assert.equal(resolved.visible, true);
+        assert.equal(resolved.x, groundedState.x);
+        assert.equal(resolved.z, groundedState.z);
+        assert.equal(
+            resolved.halfLength,
+            profile.baseHalfLength * expectedScale,
+        );
+        assert.equal(resolved.halfWidth, profile.baseHalfWidth * expectedScale);
+        assert.equal(resolved.opacity, profile.baseOpacity * (3 / 4) ** 2);
+    });
+
     it('cuts the projection off at the species flight height', () => {
         const profile = actorGroundingShadowProfiles.bee;
         const resolved = resolveActorGroundingShadow({

--- a/packages/game/src/entities/beachBallBounce.ts
+++ b/packages/game/src/entities/beachBallBounce.ts
@@ -55,6 +55,7 @@ const maxMotionSeconds = 5.4;
 const surfaceCellEpsilon = 0.0001;
 
 export const beachBallCollisionRadius = 0.24;
+const maxMotionSubstepDistance = beachBallCollisionRadius / 2;
 
 const passableTerrainBlockNames = new Set([
     'Block_Ground',
@@ -388,38 +389,47 @@ export function advanceBeachBallBounce(
     let velocityZ = state.velocityZ;
     let collisionCount = state.collisionCount;
 
-    const xMotion = resolveAxisMotion({
-        axis: 'x',
-        baseX: options.baseX,
-        baseZ: options.baseZ,
-        currentOffsetX: offsetX,
-        currentOffsetZ: offsetZ,
-        deltaSeconds,
-        environment,
-        nextOffset: offsetX + velocityX * deltaSeconds,
-        velocity: velocityX,
-    });
-    offsetX = xMotion.offset;
-    velocityX = xMotion.velocity;
-    if (xMotion.collided) {
-        collisionCount += 1;
-    }
+    const motionDistance = Math.hypot(velocityX, velocityZ) * deltaSeconds;
+    const motionStepCount = Math.max(
+        1,
+        Math.ceil(motionDistance / maxMotionSubstepDistance),
+    );
+    const motionStepSeconds = deltaSeconds / motionStepCount;
 
-    const zMotion = resolveAxisMotion({
-        axis: 'z',
-        baseX: options.baseX,
-        baseZ: options.baseZ,
-        currentOffsetX: offsetX,
-        currentOffsetZ: offsetZ,
-        deltaSeconds,
-        environment,
-        nextOffset: offsetZ + velocityZ * deltaSeconds,
-        velocity: velocityZ,
-    });
-    offsetZ = zMotion.offset;
-    velocityZ = zMotion.velocity;
-    if (zMotion.collided) {
-        collisionCount += 1;
+    for (let step = 0; step < motionStepCount; step += 1) {
+        const xMotion = resolveAxisMotion({
+            axis: 'x',
+            baseX: options.baseX,
+            baseZ: options.baseZ,
+            currentOffsetX: offsetX,
+            currentOffsetZ: offsetZ,
+            deltaSeconds: motionStepSeconds,
+            environment,
+            nextOffset: offsetX + velocityX * motionStepSeconds,
+            velocity: velocityX,
+        });
+        offsetX = xMotion.offset;
+        velocityX = xMotion.velocity;
+        if (xMotion.collided) {
+            collisionCount += 1;
+        }
+
+        const zMotion = resolveAxisMotion({
+            axis: 'z',
+            baseX: options.baseX,
+            baseZ: options.baseZ,
+            currentOffsetX: offsetX,
+            currentOffsetZ: offsetZ,
+            deltaSeconds: motionStepSeconds,
+            environment,
+            nextOffset: offsetZ + velocityZ * motionStepSeconds,
+            velocity: velocityZ,
+        });
+        offsetZ = zMotion.offset;
+        velocityZ = zMotion.velocity;
+        if (zMotion.collided) {
+            collisionCount += 1;
+        }
     }
 
     const damping = velocityDampingPerSecond ** deltaSeconds;

--- a/packages/game/src/entities/beachBallBounce.unit.ts
+++ b/packages/game/src/entities/beachBallBounce.unit.ts
@@ -110,6 +110,34 @@ describe('beach ball bounce', () => {
         assert.equal(nextState.collisionCount, 1);
     });
 
+    it('cannot tunnel through an occupied cell during a fast frame', () => {
+        const environment = createBeachBallBounceEnvironment({
+            movingBlockId: 'ball',
+            stacks: [
+                stack(0, 0, [block('Block_Grass'), block('BeachBall', 'ball')]),
+                stack(1, 0, [
+                    block('Block_Grass'),
+                    block('Raised_Bed', 'raised-bed'),
+                ]),
+                stack(2, 0, [block('Block_Grass')]),
+            ],
+        });
+
+        const nextState = advanceBeachBallBounce(
+            activeState({ velocityX: 40 }),
+            environment,
+            {
+                baseX: 0,
+                baseZ: 0,
+                deltaSeconds: 0.2,
+            },
+        );
+
+        assert.ok(nextState.offsetX < 0.25);
+        assert.ok(nextState.velocityX < 0);
+        assert.ok(nextState.collisionCount >= 1);
+    });
+
     it('uses multi-block footprint spans for obstacle cells', () => {
         const environment = createBeachBallBounceEnvironment({
             blockData: [


### PR DESCRIPTION
## Summary

- Keep beach-ball movement in world space so placement rotation cannot rotate the rendered ball away from its collision path.
- Subdivide fast motion frames so the ball cannot tunnel through occupied cells or garden bounds.
- Replace the beach ball's cached real-time shadow with the shared lightweight grounding shadow, updated from the ball's live world position and bounce height.
- Add focused regression coverage for collision tunneling and the beach-ball shadow profile.

## Root cause

The motion group inherited the block's placement rotation while the collision solver continued to use unrotated world offsets. A rotated ball could therefore render along a different path than the collider. The meshes also relied on the scene's cached directional shadow map, which is not refreshed for every ball movement.

## User impact

Beach balls now rebound from placed blocks consistently at every rotation, and their simpler blob shadow follows the ball as it rolls and bounces.

## Validation

- `pnpm lint --filter @gredice/game`
- `pnpm test --filter @gredice/game` (1,079 tests)
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
- Browser verification on `/debug/entities/BeachBall?rotation=1`: kicked the rotated ball into a raised bed, observed it reverse away, and confirmed the grounding shadow followed at collision and after the bounce; no framework overlay or browser page errors.
