### PR TITLE
fix(game): keep stone walkway above terrain

### DIFF
--- a/apps/garden/tests/landing.spec.ts
+++ b/apps/garden/tests/landing.spec.ts
@@ -304,6 +304,10 @@ async function mockGardenApi(
             body = { devices: [] };
         } else if (pathname.endsWith('/api/notifications/push-status')) {
             body = { hasDevices: false, status: 'unsubscribed' };
+        } else if (
+            /\/api\/gardens\/\d+\/raised-bed-notifications$/u.test(pathname)
+        ) {
+            body = { notifications: [] };
         } else if (pathname.endsWith('/api/notifications')) {
             body = [];
         }

--- a/packages/game/src/entities/walkwayPlacement.ts
+++ b/packages/game/src/entities/walkwayPlacement.ts
@@ -15,7 +15,9 @@ export function getWalkwayPlacementYOffset(
     const walkwayIndex = stack.blocks.indexOf(block);
     const supportBlock = stack.blocks[walkwayIndex - 1];
 
-    return supportBlock?.name.startsWith(terrainBlockPrefix)
-        ? -waterBlockBottomOverlap
-        : 0;
+    if (!supportBlock?.name.startsWith(terrainBlockPrefix)) {
+        return 0;
+    }
+
+    return block.name === 'WoodenWalkway' ? -waterBlockBottomOverlap : 0;
 }

--- a/packages/game/src/entities/walkwayPlacement.unit.ts
+++ b/packages/game/src/entities/walkwayPlacement.unit.ts
@@ -15,27 +15,34 @@ function stack(blocks: Block[]): Stack {
 }
 
 describe('getWalkwayPlacementYOffset', () => {
+    for (const terrainName of [
+        'Block_Grass',
+        'Block_Ground',
+        'Block_Snow',
+        'Block_Water',
+    ]) {
+        it(`keeps WoodenWalkway supports embedded in ${terrainName}`, () => {
+            const terrain = block('terrain', terrainName);
+            const walkway = block('walkway', 'WoodenWalkway');
+
+            assert.equal(
+                getWalkwayPlacementYOffset(stack([terrain, walkway]), walkway),
+                -waterBlockBottomOverlap,
+            );
+        });
+
+        it(`keeps StoneWalkway above the ${terrainName} surface`, () => {
+            const terrain = block('terrain', terrainName);
+            const walkway = block('walkway', 'StoneWalkway');
+
+            assert.equal(
+                getWalkwayPlacementYOffset(stack([terrain, walkway]), walkway),
+                0,
+            );
+        });
+    }
+
     for (const walkwayName of ['WoodenWalkway', 'StoneWalkway']) {
-        for (const terrainName of [
-            'Block_Grass',
-            'Block_Ground',
-            'Block_Snow',
-            'Block_Water',
-        ]) {
-            it(`keeps ${walkwayName} continuous on ${terrainName}`, () => {
-                const terrain = block('terrain', terrainName);
-                const walkway = block('walkway', walkwayName);
-
-                assert.equal(
-                    getWalkwayPlacementYOffset(
-                        stack([terrain, walkway]),
-                        walkway,
-                    ),
-                    -waterBlockBottomOverlap,
-                );
-            });
-        }
-
         it(`keeps the ${walkwayName} origin unchanged without terrain support`, () => {
             const walkway = block('walkway', walkwayName);
 


### PR DESCRIPTION
## What changed
- stop applying the wooden walkway's terrain-embedding offset to `StoneWalkway`
- keep the wooden support structure embedded as before
- cover stone and wooden placement independently across grass, ground, snow, and water
- include the shared four-line Garden landing mock fix from #4515 so current notification requests do not fail unrelated CI

## Root cause
The original stone walkway used underside supports, so it shared a `-0.06` placement offset with the wooden walkway. After the supports were removed, that offset left only about `0.004` units of stone above the terrain surface, causing depth fighting and soil bleed-through.

## Validation
- 1,077 `@gredice/game` tests pass
- exact previously failing 2D landing test passes
- `pnpm lint --filter @gredice/game`
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter garden`
- `pnpm build --filter garden --output-logs=errors-only`
- real `/debug/sandbox` WebGL scene with alternating 0°/90° stone tiles; no error overlay and no terrain bleed-through