### PR TITLE
fix(storage): serialize signage cover images

### DIFF
--- a/packages/storage/scripts/upsertSignageBlockEntities.ts
+++ b/packages/storage/scripts/upsertSignageBlockEntities.ts
@@ -5,6 +5,7 @@ import {
     createEntity,
     entities,
     getAttributeDefinitions,
+    imageAttributeValueFromUrl,
     type SelectAttributeDefinition,
     storage,
     updateEntity,
@@ -234,7 +235,9 @@ function commonBlockAttributes({
         'attributes.type': 'decoration',
         'functions.raisedBed': 'false',
         'functions.recycler': 'false',
-        'image.cover': `https://www.gredice.com/assets/blocks/${name}.webp`,
+        'image.cover': imageAttributeValueFromUrl(
+            `https://www.gredice.com/assets/blocks/${name}.webp`,
+        ),
         'information.fullDescription': fullDescription,
         'information.label': label,
         'information.name': name,


### PR DESCRIPTION
## What changed

Serialize signage `image.cover` values with the shared image-attribute helper instead of storing a bare URL.

## Root cause

The block `image.cover` attribute uses the `image` data type and therefore expects JSON such as `{"url":"…"}`. The signage upsert wrote a plain URL, so directory expansion could not parse the cover and public block pages fell back to generic OG metadata. This broke the sitemap-driven SEO contract for the 16 colored arrow signs and the editable wooden sign.

## Impact

Rerunning the idempotent signage upsert repairs existing cover values without changing entity publication state. Public block pages then expose their actual entity-specific cover in Open Graph and Twitter metadata.

## Validation

- targeted Biome check passed
- `git diff --check` passed
- package TypeScript check has no errors in `upsertSignageBlockEntities.ts`; the package-wide command remains red on pre-existing unrelated scripts/tests
