### PR TITLE
fix(observability): reduce duplicate telemetry events

### DIFF
--- a/apps/api/app/layout.tsx
+++ b/apps/api/app/layout.tsx
@@ -1,3 +1,4 @@
+import { shouldInjectVercelAnalytics } from '@gredice/js/observability';
 import { Stack } from '@gredice/ui/Stack';
 import { PostHogPageView, PostHogProvider } from '@posthog/next';
 import { Analytics } from '@vercel/analytics/react';
@@ -29,6 +30,9 @@ export default function RootLayout({
 }: Readonly<{
     children: ReactNode;
 }>) {
+    const injectVercelAnalytics = shouldInjectVercelAnalytics(
+        process.env.VERCEL,
+    );
     const postHogApiKey =
         process.env.NODE_ENV === 'development'
             ? undefined
@@ -55,7 +59,7 @@ export default function RootLayout({
                 </header>
                 {children}
             </Stack>
-            <Analytics />
+            {injectVercelAnalytics && <Analytics />}
         </>
     );
 

--- a/apps/api/lib/posthog-server.ts
+++ b/apps/api/lib/posthog-server.ts
@@ -1,3 +1,4 @@
+import { shouldForwardPostHogConsoleMethod } from '@gredice/js/observability';
 import { type Logger, logs, SeverityNumber } from '@opentelemetry/api-logs';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { resourceFromAttributes } from '@opentelemetry/resources';
@@ -144,6 +145,10 @@ export function registerPostHogConsoleForwarding(): void {
         severityNumber: SeverityNumber,
         severityText: string,
     ) => {
+        if (!shouldForwardPostHogConsoleMethod(method)) {
+            return;
+        }
+
         const originalMethod = originalConsole[method];
 
         console[method] = (...args: unknown[]) => {

--- a/apps/api/proxy.ts
+++ b/apps/api/proxy.ts
@@ -1,3 +1,4 @@
+import { shouldLogPostHogProxyRequest } from '@gredice/js/observability';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { postHogMiddleware } from '@posthog/next';
 import {
@@ -67,15 +68,22 @@ const proxyHandler: NextProxy = async (
 ) => {
     const response =
         (await baseProxyHandler(request, event)) ?? NextResponse.next();
+    const proxyAttributes = getProxyAttributes(response);
 
-    if (isPostHogLoggingEnabled()) {
+    if (
+        isPostHogLoggingEnabled() &&
+        shouldLogPostHogProxyRequest({
+            pathname: request.nextUrl.pathname,
+            proxyResult: proxyAttributes['next.proxy_result'],
+        })
+    ) {
         requestLogger.emit({
             attributes: {
                 'http.method': request.method,
                 'posthog.log_type': 'request',
                 'server.address': request.nextUrl.hostname,
                 'url.path': request.nextUrl.pathname,
-                ...getProxyAttributes(response),
+                ...proxyAttributes,
                 ...(request.headers.get('referer')
                     ? {
                           'http.request.header.referer':
@@ -105,6 +113,6 @@ export default proxyHandler;
 export const config = {
     matcher: [
         '/api/mcp/:path*',
-        '/((?!_next/static|_next/image|favicon.ico|assets|api).*)',
+        '/((?!_next/static|_next/image|_vercel|favicon.ico|assets|api).*)',
     ],
 };

--- a/apps/api/turbo.json
+++ b/apps/api/turbo.json
@@ -67,6 +67,7 @@
                 "SOCIAL_PUBLISHING_QUEUE_SECRET",
                 "STRIPE_SECRETKEY",
                 "STRIPE_WEBHOOK_SECRET",
+                "VERCEL",
                 "VERCEL_OIDC_TOKEN"
             ]
         }

--- a/apps/app/app/layout.tsx
+++ b/apps/app/app/layout.tsx
@@ -1,3 +1,4 @@
+import { shouldInjectVercelAnalytics } from '@gredice/js/observability';
 import { ImpersonationBanner } from '@gredice/ui/ImpersonationBanner';
 import { PostHogPageView, PostHogProvider } from '@posthog/next';
 import { Analytics } from '@vercel/analytics/react';
@@ -31,6 +32,9 @@ export default function RootLayout({
 }: Readonly<{
     children: ReactNode;
 }>) {
+    const injectVercelAnalytics = shouldInjectVercelAnalytics(
+        process.env.VERCEL,
+    );
     const postHogApiKey =
         process.env.NODE_ENV === 'development'
             ? undefined
@@ -46,7 +50,7 @@ export default function RootLayout({
                 <ImpersonationBanner />
                 {children}
             </ClientAppProvider>
-            <Analytics />
+            {injectVercelAnalytics && <Analytics />}
         </>
     );
 

--- a/apps/app/lib/posthog-server.ts
+++ b/apps/app/lib/posthog-server.ts
@@ -1,3 +1,4 @@
+import { shouldForwardPostHogConsoleMethod } from '@gredice/js/observability';
 import { type Logger, logs, SeverityNumber } from '@opentelemetry/api-logs';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { resourceFromAttributes } from '@opentelemetry/resources';
@@ -144,6 +145,10 @@ export function registerPostHogConsoleForwarding(): void {
         severityNumber: SeverityNumber,
         severityText: string,
     ) => {
+        if (!shouldForwardPostHogConsoleMethod(method)) {
+            return;
+        }
+
         const originalMethod = originalConsole[method];
 
         console[method] = (...args: unknown[]) => {

--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -1,3 +1,4 @@
+import { shouldLogPostHogProxyRequest } from '@gredice/js/observability';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { postHogMiddleware } from '@posthog/next';
 import {
@@ -67,15 +68,22 @@ const proxyHandler: NextProxy = async (
 ) => {
     const response =
         (await baseProxyHandler(request, event)) ?? NextResponse.next();
+    const proxyAttributes = getProxyAttributes(response);
 
-    if (isPostHogLoggingEnabled()) {
+    if (
+        isPostHogLoggingEnabled() &&
+        shouldLogPostHogProxyRequest({
+            pathname: request.nextUrl.pathname,
+            proxyResult: proxyAttributes['next.proxy_result'],
+        })
+    ) {
         requestLogger.emit({
             attributes: {
                 'http.method': request.method,
                 'posthog.log_type': 'request',
                 'server.address': request.nextUrl.hostname,
                 'url.path': request.nextUrl.pathname,
-                ...getProxyAttributes(response),
+                ...proxyAttributes,
                 ...(request.headers.get('referer')
                     ? {
                           'http.request.header.referer':
@@ -103,5 +111,5 @@ const proxyHandler: NextProxy = async (
 export default proxyHandler;
 
 export const config = {
-    matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+    matcher: ['/((?!_next/static|_next/image|_vercel|favicon.ico).*)'],
 };

--- a/apps/app/turbo.json
+++ b/apps/app/turbo.json
@@ -53,6 +53,7 @@
                 "POSTHOG_SERVER_HOST",
                 "SIGNALCO_API_KEY",
                 "SLACK_BOT_TOKEN",
+                "VERCEL",
                 "VERCEL_ENV",
                 "VERCEL_OIDC_TOKEN"
             ]

--- a/apps/farm/app/layout.tsx
+++ b/apps/farm/app/layout.tsx
@@ -1,3 +1,4 @@
+import { shouldInjectVercelAnalytics } from '@gredice/js/observability';
 import { ImpersonationBanner } from '@gredice/ui/ImpersonationBanner';
 import { VercelToolbar } from '@vercel/toolbar/next';
 import type { Metadata, Viewport } from 'next';
@@ -30,6 +31,9 @@ export default function RootLayout({
 }: Readonly<{
     children: ReactNode;
 }>) {
+    const injectVercelAnalytics = shouldInjectVercelAnalytics(
+        process.env.VERCEL,
+    );
     const shouldInjectToolbar = process.env.NODE_ENV === 'development';
     const postHogApiKey =
         process.env.NODE_ENV === 'development'
@@ -50,7 +54,7 @@ export default function RootLayout({
                     </FarmAnalyticsProvider>
                 </AuthAppProvider>
             </ClientAppProvider>
-            <FarmWebAnalytics />
+            {injectVercelAnalytics && <FarmWebAnalytics />}
             {shouldInjectToolbar && <VercelToolbar />}
         </>
     );

--- a/apps/farm/lib/posthog-server.ts
+++ b/apps/farm/lib/posthog-server.ts
@@ -1,3 +1,4 @@
+import { shouldForwardPostHogConsoleMethod } from '@gredice/js/observability';
 import { type Logger, logs, SeverityNumber } from '@opentelemetry/api-logs';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { resourceFromAttributes } from '@opentelemetry/resources';
@@ -144,6 +145,10 @@ export function registerPostHogConsoleForwarding(): void {
         severityNumber: SeverityNumber,
         severityText: string,
     ) => {
+        if (!shouldForwardPostHogConsoleMethod(method)) {
+            return;
+        }
+
         const originalMethod = originalConsole[method];
 
         console[method] = (...args: unknown[]) => {

--- a/apps/farm/proxy.ts
+++ b/apps/farm/proxy.ts
@@ -1,3 +1,4 @@
+import { shouldLogPostHogProxyRequest } from '@gredice/js/observability';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { postHogMiddleware } from '@posthog/next';
 import {
@@ -67,15 +68,22 @@ const proxyHandler: NextProxy = async (
 ) => {
     const response =
         (await baseProxyHandler(request, event)) ?? NextResponse.next();
+    const proxyAttributes = getProxyAttributes(response);
 
-    if (isPostHogLoggingEnabled()) {
+    if (
+        isPostHogLoggingEnabled() &&
+        shouldLogPostHogProxyRequest({
+            pathname: request.nextUrl.pathname,
+            proxyResult: proxyAttributes['next.proxy_result'],
+        })
+    ) {
         requestLogger.emit({
             attributes: {
                 'http.method': request.method,
                 'posthog.log_type': 'request',
                 'server.address': request.nextUrl.hostname,
                 'url.path': request.nextUrl.pathname,
-                ...getProxyAttributes(response),
+                ...proxyAttributes,
                 ...(request.headers.get('referer')
                     ? {
                           'http.request.header.referer':
@@ -103,5 +111,5 @@ const proxyHandler: NextProxy = async (
 export default proxyHandler;
 
 export const config = {
-    matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+    matcher: ['/((?!_next/static|_next/image|_vercel|favicon.ico).*)'],
 };

--- a/apps/farm/turbo.json
+++ b/apps/farm/turbo.json
@@ -33,6 +33,7 @@
                 "POSTGRES_USER",
                 "POSTHOG_SERVER_HOST",
                 "SLACK_BOT_TOKEN",
+                "VERCEL",
                 "VERCEL_OIDC_TOKEN"
             ]
         }

--- a/apps/garden/app/layout.tsx
+++ b/apps/garden/app/layout.tsx
@@ -1,3 +1,4 @@
+import { shouldInjectVercelAnalytics } from '@gredice/js/observability';
 import { ImpersonationBanner } from '@gredice/ui/ImpersonationBanner';
 import { PostHogPageView, PostHogProvider } from '@posthog/next';
 import { Analytics } from '@vercel/analytics/react';
@@ -36,6 +37,9 @@ export default function RootLayout({
 }: Readonly<{
     children: ReactNode;
 }>) {
+    const injectVercelAnalytics = shouldInjectVercelAnalytics(
+        process.env.VERCEL,
+    );
     const shouldInjectToolbar = process.env.NODE_ENV === 'development';
     const postHogApiKey =
         process.env.NODE_ENV === 'development'
@@ -52,7 +56,7 @@ export default function RootLayout({
                 <ImpersonationBanner />
                 {children}
             </ClientAppProvider>
-            <Analytics />
+            {injectVercelAnalytics && <Analytics />}
             {shouldInjectToolbar && <VercelToolbar />}
         </>
     );

--- a/apps/garden/lib/posthog-server.ts
+++ b/apps/garden/lib/posthog-server.ts
@@ -1,3 +1,4 @@
+import { shouldForwardPostHogConsoleMethod } from '@gredice/js/observability';
 import { type Logger, logs, SeverityNumber } from '@opentelemetry/api-logs';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { resourceFromAttributes } from '@opentelemetry/resources';
@@ -144,6 +145,10 @@ export function registerPostHogConsoleForwarding(): void {
         severityNumber: SeverityNumber,
         severityText: string,
     ) => {
+        if (!shouldForwardPostHogConsoleMethod(method)) {
+            return;
+        }
+
         const originalMethod = originalConsole[method];
 
         console[method] = (...args: unknown[]) => {

--- a/apps/garden/proxy.ts
+++ b/apps/garden/proxy.ts
@@ -1,3 +1,4 @@
+import { shouldLogPostHogProxyRequest } from '@gredice/js/observability';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { postHogMiddleware } from '@posthog/next';
 import {
@@ -67,15 +68,22 @@ const proxyHandler: NextProxy = async (
 ) => {
     const response =
         (await baseProxyHandler(request, event)) ?? NextResponse.next();
+    const proxyAttributes = getProxyAttributes(response);
 
-    if (isPostHogLoggingEnabled()) {
+    if (
+        isPostHogLoggingEnabled() &&
+        shouldLogPostHogProxyRequest({
+            pathname: request.nextUrl.pathname,
+            proxyResult: proxyAttributes['next.proxy_result'],
+        })
+    ) {
         requestLogger.emit({
             attributes: {
                 'http.method': request.method,
                 'posthog.log_type': 'request',
                 'server.address': request.nextUrl.hostname,
                 'url.path': request.nextUrl.pathname,
-                ...getProxyAttributes(response),
+                ...proxyAttributes,
                 ...(request.headers.get('referer')
                     ? {
                           'http.request.header.referer':
@@ -104,6 +112,6 @@ export default proxyHandler;
 
 export const config = {
     matcher: [
-        '/((?!_next/static|_next/image|favicon.ico|assets|api/gredice).*)',
+        '/((?!_next/static|_next/image|_vercel|favicon.ico|assets|api/gredice).*)',
     ],
 };

--- a/apps/garden/turbo.json
+++ b/apps/garden/turbo.json
@@ -40,6 +40,7 @@
                 "POSTHOG_SERVER_HOST",
                 "RESEND_API_KEY",
                 "STRIPE_SECRETKEY",
+                "VERCEL",
                 "VERCEL_OIDC_TOKEN"
             ]
         }

--- a/apps/www/app/[...slug]/cmsPageRouteUtils.ts
+++ b/apps/www/app/[...slug]/cmsPageRouteUtils.ts
@@ -58,6 +58,7 @@ export function parseCmsPageRenderMaxWidth(
 }
 
 const reservedFirstSegments = new Set([
+    '_vercel',
     'biljke',
     'bolesti',
     'blokovi',

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -1,3 +1,4 @@
+import { shouldInjectVercelAnalytics } from '@gredice/js/observability';
 import { ImpersonationBanner } from '@gredice/ui/ImpersonationBanner';
 import { Analytics } from '@vercel/analytics/react';
 import type { Metadata, Viewport } from 'next';
@@ -93,6 +94,9 @@ export default async function RootLayout({
 }: Readonly<{
     children: ReactNode;
 }>) {
+    const injectVercelAnalytics = shouldInjectVercelAnalytics(
+        process.env.VERCEL,
+    );
     const shouldInjectToolbar = process.env.NODE_ENV === 'development';
     const postHogApiKey =
         process.env.NODE_ENV === 'development'
@@ -113,7 +117,7 @@ export default async function RootLayout({
                 </main>
                 <PublicFooter />
             </Stack>
-            <Analytics />
+            {injectVercelAnalytics && <Analytics />}
             <PageViewTracker />
             {shouldInjectToolbar && <VercelToolbar />}
         </ClientAppProvider>

--- a/apps/www/lib/posthog-server.ts
+++ b/apps/www/lib/posthog-server.ts
@@ -1,3 +1,4 @@
+import { shouldForwardPostHogConsoleMethod } from '@gredice/js/observability';
 import { type Logger, logs, SeverityNumber } from '@opentelemetry/api-logs';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { resourceFromAttributes } from '@opentelemetry/resources';
@@ -144,6 +145,10 @@ export function registerPostHogConsoleForwarding(): void {
         severityNumber: SeverityNumber,
         severityText: string,
     ) => {
+        if (!shouldForwardPostHogConsoleMethod(method)) {
+            return;
+        }
+
         const originalMethod = originalConsole[method];
 
         console[method] = (...args: unknown[]) => {

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -12,7 +12,7 @@
         "build": "next build",
         "postbuild": "tsx --conditions=react-server ./node_modules/next-sitemap/bin/next-sitemap.mjs --config next-sitemap.config.ts",
         "start": "node ../../scripts/run-app-command.mjs start",
-        "test": "pnpm run test:pricing && pnpm run test:plant-sowing-price && pnpm run test:preview-backfill && pnpm run test:wallpapers && pnpm run test:plant-operation-stages && pnpm run test:seeds && pnpm run test:static-data && pnpm run test:canonical-urls && pnpm run test:seo && pnpm run test:prepare:routes && pnpm run test:run",
+        "test": "pnpm run test:pricing && pnpm run test:plant-sowing-price && pnpm run test:preview-backfill && pnpm run test:wallpapers && pnpm run test:plant-operation-stages && pnpm run test:seeds && pnpm run test:static-data && pnpm run test:canonical-urls && pnpm run test:seo && pnpm run test:cms-pages && pnpm run test:prepare:routes && pnpm run test:run",
         "test:prepare": "turbo build --filter=www && pnpm run test:prepare:routes",
         "test:prepare:routes": "node --experimental-strip-types ./tests/populate-test-cases.ts",
         "test:run": "playwright test --project=chromium",

--- a/apps/www/proxy.ts
+++ b/apps/www/proxy.ts
@@ -1,3 +1,4 @@
+import { shouldLogPostHogProxyRequest } from '@gredice/js/observability';
 import { decodeRouteParam } from '@gredice/js/uri';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { postHogMiddleware } from '@posthog/next';
@@ -159,15 +160,22 @@ const proxyHandler: NextProxy = async (
         response =
             (await baseProxyHandler(request, event)) ?? NextResponse.next();
     }
+    const proxyAttributes = getProxyAttributes(response);
 
-    if (isPostHogLoggingEnabled()) {
+    if (
+        isPostHogLoggingEnabled() &&
+        shouldLogPostHogProxyRequest({
+            pathname: request.nextUrl.pathname,
+            proxyResult: proxyAttributes['next.proxy_result'],
+        })
+    ) {
         requestLogger.emit({
             attributes: {
                 'http.method': request.method,
                 'posthog.log_type': 'request',
                 'server.address': request.nextUrl.hostname,
                 'url.path': request.nextUrl.pathname,
-                ...getProxyAttributes(response),
+                ...proxyAttributes,
                 ...(request.headers.get('referer')
                     ? {
                           'http.request.header.referer':
@@ -196,6 +204,6 @@ export default proxyHandler;
 
 export const config = {
     matcher: [
-        '/((?!_next/static|_next/image|favicon.ico|assets|api/gredice).*)',
+        '/((?!_next/static|_next/image|_vercel|favicon.ico|assets|api/gredice).*)',
     ],
 };

--- a/apps/www/tests/cmsPages.node.spec.ts
+++ b/apps/www/tests/cmsPages.node.spec.ts
@@ -78,6 +78,10 @@ test('public CMS catch-all keeps wallpaper studio route reserved', () => {
     assert.equal(hasReservedFirstSegment('pozadine'), true);
 });
 
+test('public CMS catch-all keeps Vercel platform routes reserved', () => {
+    assert.equal(hasReservedFirstSegment('_vercel/insights/script.js'), true);
+});
+
 test('quality harvest safety source CMS page has real content sections', () => {
     const components = qualityHarvestSafetyCmsPage.content.map(
         (section) => section.component,

--- a/apps/www/turbo.json
+++ b/apps/www/turbo.json
@@ -35,6 +35,7 @@
                 "POSTGRES_URL_NO_SSL",
                 "POSTGRES_USER",
                 "POSTHOG_SERVER_HOST",
+                "VERCEL",
                 "VERCEL_ENV",
                 "VERCEL_OIDC_TOKEN"
             ]

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,44 @@
+# Observability event budget
+
+Vercel records separate Observability events for the request, Proxy, Function,
+and outgoing API stages of one product action. Gredice keeps those layers when
+they provide required routing, authentication, or operational reliability and
+avoids producing additional telemetry about routine telemetry.
+
+## Vercel Web Analytics
+
+The app layouts render `@vercel/analytics` only when `VERCEL=1`. Local and CI
+production builds therefore do not request Vercel's reserved
+`/_vercel/insights/*` resources. The WWW CMS catch-all also reserves the
+`_vercel` first segment, so a missing platform resource can never become a CMS
+directory API lookup.
+
+Proxy matchers exclude `/_vercel/*`. Vercel serves those platform resources
+without running Gredice PostHog Proxy logic.
+
+## PostHog
+
+The `/ingest` reverse proxy remains enabled so browser analytics keep their
+first-party endpoint and shared anonymous identity. It does not emit a second
+PostHog request log for its own traffic.
+
+Routine Proxy pass-through requests are available in Vercel Observability and
+are not copied to PostHog logs. PostHog request logs are reserved for:
+
+- the public `/api/mcp` contract;
+- redirects; and
+- rewrites other than PostHog ingestion.
+
+Vercel retains normal `console.info`, `console.log`, and `console.debug` runtime
+logs. PostHog receives only `console.warn`, `console.error`, unhandled request
+errors, and the explicit high-signal request logs above. This prevents routine
+cron completion and health records from forcing an outgoing OTLP request every
+minute while retaining operational failures.
+
+## Cron schedules
+
+Do not reduce one-minute schedules from event counts alone. Checkout outboxes,
+delivery tracking privacy cleanup, delivery notification reconciliation, and
+automations have documented latency or recovery contracts. Inspect aggregate
+worker results and empty-run ratios over a representative production window
+before changing cadence.

--- a/packages/js/src/observability/index.ts
+++ b/packages/js/src/observability/index.ts
@@ -1,0 +1,32 @@
+const postHogIngestPath = '/ingest';
+const publicMcpPath = '/api/mcp';
+
+function matchesPathSegment(pathname: string, path: string) {
+    return pathname === path || pathname.startsWith(`${path}/`);
+}
+
+export function shouldInjectVercelAnalytics(vercelRuntime: string | undefined) {
+    return vercelRuntime === '1';
+}
+
+export function shouldForwardPostHogConsoleMethod(method: string) {
+    return method === 'warn' || method === 'error';
+}
+
+export function shouldLogPostHogProxyRequest({
+    pathname,
+    proxyResult,
+}: {
+    pathname: string;
+    proxyResult: string;
+}) {
+    if (matchesPathSegment(pathname, postHogIngestPath)) {
+        return false;
+    }
+
+    if (matchesPathSegment(pathname, publicMcpPath)) {
+        return true;
+    }
+
+    return proxyResult === 'redirect' || proxyResult === 'rewrite';
+}

--- a/packages/js/src/observability/index.unit.ts
+++ b/packages/js/src/observability/index.unit.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    shouldForwardPostHogConsoleMethod,
+    shouldInjectVercelAnalytics,
+    shouldLogPostHogProxyRequest,
+} from './index';
+
+test('Vercel Analytics is injected only in an actual Vercel runtime', () => {
+    assert.equal(shouldInjectVercelAnalytics('1'), true);
+    assert.equal(shouldInjectVercelAnalytics('0'), false);
+    assert.equal(shouldInjectVercelAnalytics(undefined), false);
+});
+
+test('PostHog forwards warning and error console records only', () => {
+    assert.equal(shouldForwardPostHogConsoleMethod('debug'), false);
+    assert.equal(shouldForwardPostHogConsoleMethod('log'), false);
+    assert.equal(shouldForwardPostHogConsoleMethod('info'), false);
+    assert.equal(shouldForwardPostHogConsoleMethod('warn'), true);
+    assert.equal(shouldForwardPostHogConsoleMethod('error'), true);
+});
+
+test('PostHog ingest traffic does not log telemetry about itself', () => {
+    assert.equal(
+        shouldLogPostHogProxyRequest({
+            pathname: '/ingest',
+            proxyResult: 'rewrite',
+        }),
+        false,
+    );
+    assert.equal(
+        shouldLogPostHogProxyRequest({
+            pathname: '/ingest/e',
+            proxyResult: 'rewrite',
+        }),
+        false,
+    );
+});
+
+test('routine proxy requests are omitted while redirects and rewrites remain visible', () => {
+    assert.equal(
+        shouldLogPostHogProxyRequest({
+            pathname: '/biljke/rajcica',
+            proxyResult: 'next',
+        }),
+        false,
+    );
+    assert.equal(
+        shouldLogPostHogProxyRequest({
+            pathname: '/biljke/Rajcica',
+            proxyResult: 'redirect',
+        }),
+        true,
+    );
+    assert.equal(
+        shouldLogPostHogProxyRequest({
+            pathname: '/legacy',
+            proxyResult: 'rewrite',
+        }),
+        true,
+    );
+});
+
+test('public MCP requests retain explicit request logging', () => {
+    assert.equal(
+        shouldLogPostHogProxyRequest({
+            pathname: '/api/mcp',
+            proxyResult: 'next',
+        }),
+        true,
+    );
+    assert.equal(
+        shouldLogPostHogProxyRequest({
+            pathname: '/api/mcp/tools',
+            proxyResult: 'next',
+        }),
+        true,
+    );
+    assert.equal(
+        shouldLogPostHogProxyRequest({
+            pathname: '/api/mcproxy',
+            proxyResult: 'next',
+        }),
+        false,
+    );
+});


### PR DESCRIPTION
## What changed
- render Vercel Web Analytics only inside an actual Vercel deployment
- reserve `/_vercel/*` from the WWW CMS catch-all and Proxy matchers
- stop PostHog from logging its own `/ingest` traffic or routine pass-through requests
- keep warnings, errors, redirects/rewrites, and public MCP request logging
- document the event-budget policy and add regression coverage

## Why
A local/CI request for `/_vercel/insights/script.js` was falling through to the WWW CMS catch-all, producing tens of thousands of production API 404s and additional Vercel events. Routine Proxy and console-info forwarding also generated OTLP requests about telemetry itself.

## Impact
This removes the confirmed CI amplification and reduces secondary PostHog OTLP traffic without changing business analytics, required public MCP logging, cron cadence, or project-level Observability coverage.

## Validation
- `pnpm lint --filter @gredice/js --filter api --filter app --filter garden --filter farm --filter www`
- `pnpm --filter @gredice/js test`
- `pnpm --filter www test:cms-pages`
- `pnpm typecheck --filter garden --filter www`
- `pnpm build --filter api --filter app --filter garden --filter farm --filter www`
- `pnpm mcp:smoke:public`
- local production smoke for analytics injection and `/_vercel/insights/script.js`