### PR TITLE
fix(game): roll beach ball over low surfaces

### DIFF
--- a/packages/game/src/entities/beachBallBounce.ts
+++ b/packages/game/src/entities/beachBallBounce.ts
@@ -55,6 +55,7 @@ const maxMotionSeconds = 5.4;
 const surfaceCellEpsilon = 0.0001;
 
 export const beachBallCollisionRadius = 0.24;
+const beachBallRollableSurfaceMaxHeight = 0.1;
 const maxMotionSubstepDistance = beachBallCollisionRadius / 2;
 
 const passableTerrainBlockNames = new Set([
@@ -135,6 +136,22 @@ function getBlockHeight(
         : null;
 }
 
+function isBeachBallRollableSurfaceBlock(
+    blockDataByName: Map<string, BeachBallBlockDataLike>,
+    blockName: string,
+) {
+    if (isBeachBallPassableTerrainBlockName(blockName)) {
+        return true;
+    }
+
+    const blockHeight = getBlockHeight(blockDataByName, blockName);
+    return (
+        blockHeight !== null &&
+        blockHeight >= 0 &&
+        blockHeight <= beachBallRollableSurfaceMaxHeight
+    );
+}
+
 function getStackSurfaceHeight({
     blockDataByName,
     movingBlockId,
@@ -152,7 +169,7 @@ function getStackSurfaceHeight({
             return height;
         }
 
-        if (!isBeachBallPassableTerrainBlockName(block.name)) {
+        if (!isBeachBallRollableSurfaceBlock(blockDataByName, block.name)) {
             break;
         }
 
@@ -314,7 +331,7 @@ export function createBeachBallBounceEnvironment({
         for (const block of stack.blocks) {
             if (
                 block.id === movingBlockId ||
-                isBeachBallPassableTerrainBlockName(block.name)
+                isBeachBallRollableSurfaceBlock(blockDataByName, block.name)
             ) {
                 continue;
             }

--- a/packages/game/src/entities/beachBallBounce.unit.ts
+++ b/packages/game/src/entities/beachBallBounce.unit.ts
@@ -217,6 +217,66 @@ describe('beach ball bounce', () => {
         );
     });
 
+    it('rolls over low ground coverings and follows their surface height', () => {
+        const environment = createBeachBallBounceEnvironment({
+            blockData: [
+                blockData('Block_Grass', 0.4),
+                blockData('MulchWood', 0.01),
+                blockData('StoneWalkway', 0.1),
+                blockData('LowBorder', 0.1001),
+            ],
+            movingBlockId: 'ball',
+            stacks: [
+                stack(0, 0, [block('Block_Grass'), block('BeachBall', 'ball')]),
+                stack(1, 0, [
+                    block('Block_Grass'),
+                    block('MulchWood', 'mulch'),
+                ]),
+                stack(2, 0, [
+                    block('Block_Grass'),
+                    block('StoneWalkway', 'walkway'),
+                ]),
+                stack(3, 0, [
+                    block('Block_Grass'),
+                    block('LowBorder', 'border'),
+                ]),
+            ],
+        });
+
+        assert.deepEqual(environment.obstacles, [{ x: 3, z: 0 }]);
+        assert.ok(
+            Math.abs(
+                getBeachBallSurfaceHeight(environment, {
+                    fallbackHeight: 0.4,
+                    worldX: 1,
+                    worldZ: 0,
+                }) - 0.41,
+            ) < 0.000_001,
+        );
+        assert.equal(
+            getBeachBallSurfaceHeight(environment, {
+                fallbackHeight: 0.4,
+                worldX: 2,
+                worldZ: 0,
+            }),
+            0.5,
+        );
+
+        const nextState = advanceBeachBallBounce(
+            activeState({ offsetX: 0.25, velocityX: 3 }),
+            environment,
+            {
+                baseX: 0,
+                baseZ: 0,
+                deltaSeconds: 0.2,
+            },
+        );
+
+        assert.ok(nextState.offsetX > 0.25);
+        assert.ok(nextState.velocityX > 0);
+        assert.equal(nextState.collisionCount, 0);
+    });
+
     it('does not use non-terrain block height as a beach ball surface', () => {
         const environment = createBeachBallBounceEnvironment({
             blockData: [


### PR DESCRIPTION
## What changed

- Treat non-negative blocks up to and including `0.1` height as rollable beach-ball surfaces.
- Add those blocks to the calculated surface height instead of the collision-obstacle map.
- Keep blocks above `0.1` as solid obstacles.
- Add regression coverage for `MulchWood` (`0.01`), `StoneWalkway` (`0.1`), and the just-over-boundary `0.1001` case.

## Why

Ground coverings and low pavers should sit under the beach ball as part of the rolling surface. They were previously classified as obstacles solely because they were not named terrain blocks.

## Validation

- `pnpm --filter @gredice/game exec tsx --test src/entities/beachBallBounce.unit.ts` — 9 passed
- `pnpm test --filter @gredice/game` — 1,085 passed
- `pnpm lint --filter @gredice/game`
- `pnpm typecheck --filter @gredice/game --filter garden --filter www`
- `git diff --check`
- Seeded local browser scene with grass + mulch + stone walkway; the ball rolled across both low surfaces, stayed above them, and its grounding shadow followed. No browser errors or framework overlay.