### PR TITLE
fix(game): keep failed block placements silent

### DIFF
--- a/packages/game/src/hud/ItemsHud.tsx
+++ b/packages/game/src/hud/ItemsHud.tsx
@@ -747,9 +747,6 @@ function PlaceEntityButton({
 
     if (!isPlaceable && simple) return null;
 
-    const errorMessage =
-        placeBlock.error instanceof Error ? placeBlock.error.message : null;
-
     return (
         <Stack spacing={1}>
             <Button
@@ -791,11 +788,6 @@ function PlaceEntityButton({
             {insufficientSunflowersMessage && !simple && (
                 <Typography level="body3" className="text-muted-foreground">
                     {insufficientSunflowersMessage}
-                </Typography>
-            )}
-            {errorMessage && (
-                <Typography level="body3" className="text-red-600">
-                    {errorMessage}
                 </Typography>
             )}
         </Stack>


### PR DESCRIPTION
## What changed

- stop rendering raw block-placement mutation errors inside the Blocks item grid
- keep existing optimistic rollback, sunflower restoration, and authoritative query refresh behavior
- preserve availability and insufficient-sunflower guidance

## Why

A rejected placement currently inserts the API error text into the Blocks grid, expanding the item row and breaking the HUD layout. Failed placements should simply disappear after rollback.

## Validation

- `pnpm lint --filter @gredice/game`
- `pnpm test --filter @gredice/game`
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`