### PR TITLE
feat(game): group garden store items

### DIFF
--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -34,6 +34,7 @@ const newBlockCatalogItems = [
 ] as const;
 
 async function dragLocatorByMouse(page: Page, locator: Locator) {
+    await locator.hover();
     const box = await locator.boundingBox();
     expect(box).not.toBeNull();
 
@@ -410,6 +411,96 @@ test('trees are listed under the decoration tree picker', async ({
     await expect(page.getByRole('button', { name: 'PalmTree' })).toBeVisible();
 });
 
+test('decorations are grouped into summer, furniture, pets, and signs', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(TABLET_VIEWPORT);
+    await mount(<ItemsHudAlignmentStory />);
+
+    await page.getByRole('button', { name: 'Dekoracija' }).click();
+
+    for (const label of ['Ljeto', 'Namještaj', 'Ljubimci', 'Znakovi']) {
+        await expect(
+            page.getByRole('button', { name: label, exact: true }),
+        ).toBeVisible();
+    }
+    await expect(page.getByRole('button', { name: 'Putokazi' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'WoodenSign' })).toHaveCount(
+        0,
+    );
+
+    await page.getByRole('button', { name: 'Ljeto' }).click();
+    await expect(
+        page.getByRole('button', { name: 'BeachUmbrella' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'LemonadeStand' }),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Natrag' }).click();
+
+    await page.getByRole('button', { name: 'Namještaj' }).click();
+    await expect(
+        page.getByRole('button', { name: 'WoodenBench' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Drveni izložbeni stol' }),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Natrag' }).click();
+
+    await page.getByRole('button', { name: 'Ljubimci' }).click();
+    await expect(page.getByRole('button', { name: 'BirdHouse' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'DogHouse' })).toBeVisible();
+    await page.getByRole('button', { name: 'Natrag' }).click();
+
+    await page.getByRole('button', { name: 'Znakovi' }).click();
+    await expect(
+        page.getByRole('button', { name: 'ArrowSignWhiteRight' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'WoodenSign' }),
+    ).toBeVisible();
+});
+
+test('terrain blocks are grouped by biome or material type', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(TABLET_VIEWPORT);
+    await mount(<ItemsHudAlignmentStory />);
+
+    await page.getByRole('button', { name: 'Blokovi' }).click();
+
+    const groups = [
+        ['Trava', 'Block Grass Angle'],
+        ['Zemlja', 'Block Ground Corner'],
+        ['Suha zemlja', 'Suha zemlja rub'],
+        ['Močvara', 'Močvarna voda'],
+        ['Kamen', 'Kutne kamene stube'],
+        ['Polirani kamen', 'Kutne polirane kamene stube'],
+        ['Šljunak', 'Šljunak rub'],
+        ['Pijesak', 'Block Sand Reverse Corner'],
+        ['Snijeg', 'Block Snow Reverse Corner'],
+        ['Voda', 'Block Water'],
+    ];
+
+    for (const [groupLabel, representativeItemLabel] of groups) {
+        await expect(
+            page.getByRole('button', { name: groupLabel, exact: true }),
+        ).toBeVisible();
+        await page
+            .getByRole('button', { name: groupLabel, exact: true })
+            .click();
+        await expect(
+            page.getByRole('button', {
+                name: representativeItemLabel,
+                exact: true,
+            }),
+        ).toBeVisible();
+        await page.getByRole('button', { name: 'Natrag' }).click();
+    }
+});
+
 test('tool picker lists functional garden boxes outside sandbox', async ({
     mount,
     page,
@@ -458,9 +549,11 @@ test('sandbox decoration picker includes special blocks', async ({
     await expect(
         page.getByRole('button', { name: 'Mali drveni most' }),
     ).toBeVisible();
+    await page.getByRole('button', { name: 'Namještaj' }).click();
     await expect(
         page.getByRole('button', { name: 'Drveni izložbeni stol' }),
     ).toBeVisible();
+    await page.getByRole('button', { name: 'Natrag' }).click();
     await expect(
         page
             .locator('[data-items-picker-group-label]')
@@ -521,6 +614,7 @@ test('stackable display table is offered at its catalog price', async ({
     await mount(<ItemsHudAlignmentStory />);
 
     await page.getByRole('button', { name: 'Dekoracija' }).click();
+    await page.getByRole('button', { name: 'Namještaj' }).click();
     await page.getByRole('button', { name: 'Drveni izložbeni stol' }).click();
     await expect(
         page.getByRole('button', { name: /Postavi.*40/u }),
@@ -587,9 +681,11 @@ test('local sandbox decoration picker includes sunflower and mulch', async ({
     await expect(
         page.getByRole('button', { name: 'SmallWoodenBridge' }),
     ).toBeVisible();
+    await page.getByRole('button', { name: 'Namještaj' }).click();
     await expect(
         page.getByRole('button', { name: 'Drveni izložbeni stol' }),
     ).toBeVisible();
+    await page.getByRole('button', { name: 'Natrag' }).click();
     await expect(
         page.getByRole('button', { name: 'WoodenWalkway' }),
     ).toBeVisible();
@@ -668,12 +764,12 @@ test('dragging an affordable picker item requests a scene drop without opening d
 
     await page.getByRole('button', { name: 'Dekoracija' }).click();
 
-    const stoolButton = page.getByRole('button', { name: 'Stool' });
-    await dragLocatorByMouse(page, stoolButton);
+    const fenceButton = page.getByRole('button', { name: 'Fence' });
+    await dragLocatorByMouse(page, fenceButton);
 
-    await expect(dragState).toHaveText('Stool:drag');
+    await expect(dragState).toHaveText('Fence:drag');
     await page.mouse.up();
-    await expect(dragState).toHaveText('Stool:drop');
+    await expect(dragState).toHaveText('Fence:drop');
     await expect(
         page.getByText('Mock block for HUD layout tests.'),
     ).toHaveCount(0);
@@ -765,6 +861,7 @@ test('touch drag cancellation clears HUD item placement', async ({
     await mount(<ItemsHudDragStateStory />);
 
     await page.getByRole('button', { name: 'Dekoracija' }).click();
+    await page.getByRole('button', { name: 'Namještaj' }).click();
 
     const stoolButton = page.getByRole('button', { name: 'Stool' });
     await dispatchTouchDrag({
@@ -804,6 +901,7 @@ test('item details place button keeps the soft color treatment', async ({
     await mount(<ItemsHudAlignmentStory />);
 
     await page.getByRole('button', { name: 'Dekoracija' }).click();
+    await page.getByRole('button', { name: 'Namještaj' }).click();
     await page.getByRole('button', { name: 'Stool' }).click();
 
     const placeButton = page.getByRole('button', { name: /Postavi.*10/u });
@@ -844,6 +942,7 @@ test('item placement starts near the current camera target', async ({
     await mount(<ItemsHudCameraTargetStory />);
 
     await page.getByRole('button', { name: 'Dekoracija' }).click();
+    await page.getByRole('button', { name: 'Namještaj' }).click();
     await page.getByRole('button', { name: 'Stool' }).click();
     await page.getByRole('button', { name: /Postavi.*10/u }).click();
 
@@ -887,6 +986,7 @@ test('item placement reserves local positions while requests are pending', async
     await mount(<ItemsHudAlignmentStory />);
 
     await page.getByRole('button', { name: 'Blokovi' }).click();
+    await page.getByRole('button', { name: 'Trava' }).click();
     await page
         .getByRole('button', { name: 'Block Grass', exact: true })
         .click();
@@ -940,6 +1040,7 @@ test('item placement subtracts pending sunflower spends before enabling more pur
     await mount(<LowSunflowerBalanceItemsHudStory />);
 
     await page.getByRole('button', { name: 'Blokovi' }).click();
+    await page.getByRole('button', { name: 'Trava' }).click();
     await page
         .getByRole('button', { name: 'Block Grass', exact: true })
         .click();

--- a/packages/game/src/hud/ItemsHud.tsx
+++ b/packages/game/src/hud/ItemsHud.tsx
@@ -89,10 +89,13 @@ const treeItems: HudItemEntity[] = [
     { type: 'entity', name: 'DeadTreeStump' },
 ];
 
-const arrowSignItems: HudItemEntity[] = arrowSignNames.map((name) => ({
-    type: 'entity',
-    name,
-}));
+const signItems: HudItemEntity[] = [
+    ...arrowSignNames.map<HudItemEntity>((name) => ({
+        type: 'entity',
+        name,
+    })),
+    { type: 'entity', name: 'WoodenSign' },
+];
 
 const lightingItems: HudItemEntity[] = [
     { type: 'entity', name: 'FireflyJar' },
@@ -103,6 +106,139 @@ const lightingItems: HudItemEntity[] = [
     { type: 'entity', name: 'WickerGardenLantern' },
     { type: 'entity', name: 'WoodenHandLantern' },
     { type: 'entity', name: 'MoonRainBarrel' },
+];
+
+const summerItems: HudItemEntity[] = [
+    { type: 'entity', name: 'Shade' },
+    { type: 'entity', name: 'BeachUmbrella' },
+    { type: 'entity', name: 'LemonadeStand' },
+    { type: 'entity', name: 'IceCreamCart' },
+    { type: 'entity', name: 'SummerHat' },
+    { type: 'entity', name: 'BeachTowelStriped' },
+    { type: 'entity', name: 'InflatablePoolSmall' },
+    { type: 'entity', name: 'BeachChair' },
+    { type: 'entity', name: 'BeachBall' },
+    { type: 'entity', name: 'SandcastleSmallA' },
+];
+
+const furnitureItems: HudItemEntity[] = [
+    { type: 'entity', name: 'Stool' },
+    { type: 'entity', name: 'WoodenBench' },
+    { type: 'entity', name: 'OutletDisplayTable' },
+];
+
+const petItems: HudItemEntity[] = [
+    { type: 'entity', name: 'BirdHouse' },
+    { type: 'entity', name: 'CatPillow' },
+    { type: 'entity', name: 'DogHouse' },
+];
+
+const terrainItems: HudItemPicker[] = [
+    {
+        type: 'picker',
+        label: 'Trava',
+        imageSrc: 'https://www.gredice.com/assets/blocks/Block_Grass.webp',
+        items: [
+            { type: 'entity', name: 'Block_Grass' },
+            { type: 'entity', name: 'Block_Grass_Angle' },
+            { type: 'entity', name: 'Block_Grass_Corner' },
+            { type: 'entity', name: 'Block_Grass_Reverse_Corner' },
+        ],
+    },
+    {
+        type: 'picker',
+        label: 'Zemlja',
+        imageSrc: 'https://www.gredice.com/assets/blocks/Block_Ground.webp',
+        items: [
+            { type: 'entity', name: 'Block_Ground' },
+            { type: 'entity', name: 'Block_Ground_Angle' },
+            { type: 'entity', name: 'Block_Ground_Corner' },
+            { type: 'entity', name: 'Block_Ground_Reverse_Corner' },
+        ],
+    },
+    {
+        type: 'picker',
+        label: 'Suha zemlja',
+        imageSrc: 'https://www.gredice.com/assets/blocks/Block_Dry_Ground.webp',
+        items: [
+            { type: 'entity', name: 'Block_Dry_Ground' },
+            { type: 'entity', name: 'Block_Dry_Ground_Angle' },
+        ],
+    },
+    {
+        type: 'picker',
+        label: 'Močvara',
+        imageSrc:
+            'https://www.gredice.com/assets/blocks/Block_Swamp_Ground.webp',
+        items: [
+            { type: 'entity', name: 'Block_Swamp_Ground' },
+            { type: 'entity', name: 'Block_Swamp_Ground_Angle' },
+            { type: 'entity', name: 'Block_Swamp_Water' },
+        ],
+    },
+    {
+        type: 'picker',
+        label: 'Kamen',
+        imageSrc: 'https://www.gredice.com/assets/blocks/Block_Stone.webp',
+        items: [
+            { type: 'entity', name: 'Block_Stone' },
+            { type: 'entity', name: 'Block_Stone_Angle' },
+            { type: 'entity', name: 'Block_Stone_Stairs' },
+            { type: 'entity', name: 'Block_Stone_Stairs_Corner' },
+        ],
+    },
+    {
+        type: 'picker',
+        label: 'Polirani kamen',
+        imageSrc:
+            'https://www.gredice.com/assets/blocks/Block_Polished_Stone.webp',
+        items: [
+            { type: 'entity', name: 'Block_Polished_Stone' },
+            { type: 'entity', name: 'Block_Polished_Stone_Angle' },
+            { type: 'entity', name: 'Block_Polished_Stone_Stairs' },
+            {
+                type: 'entity',
+                name: 'Block_Polished_Stone_Stairs_Corner',
+            },
+        ],
+    },
+    {
+        type: 'picker',
+        label: 'Šljunak',
+        imageSrc: 'https://www.gredice.com/assets/blocks/Block_Gravel.webp',
+        items: [
+            { type: 'entity', name: 'Block_Gravel' },
+            { type: 'entity', name: 'Block_Gravel_Angle' },
+        ],
+    },
+    {
+        type: 'picker',
+        label: 'Pijesak',
+        imageSrc: 'https://www.gredice.com/assets/blocks/Block_Sand.webp',
+        items: [
+            { type: 'entity', name: 'Block_Sand' },
+            { type: 'entity', name: 'Block_Sand_Angle' },
+            { type: 'entity', name: 'Block_Sand_Corner' },
+            { type: 'entity', name: 'Block_Sand_Reverse_Corner' },
+        ],
+    },
+    {
+        type: 'picker',
+        label: 'Snijeg',
+        imageSrc: 'https://www.gredice.com/assets/blocks/Block_Snow.webp',
+        items: [
+            { type: 'entity', name: 'Block_Snow' },
+            { type: 'entity', name: 'Block_Snow_Angle' },
+            { type: 'entity', name: 'Block_Snow_Corner' },
+            { type: 'entity', name: 'Block_Snow_Reverse_Corner' },
+        ],
+    },
+    {
+        type: 'picker',
+        label: 'Voda',
+        imageSrc: 'https://www.gredice.com/assets/blocks/Block_Water.webp',
+        items: [{ type: 'entity', name: 'Block_Water' }],
+    },
 ];
 
 const treeGroupEntityNames = new Set([
@@ -171,12 +307,11 @@ const items: HudItem[] = [
             },
             {
                 type: 'picker',
-                label: 'Putokazi',
+                label: 'Znakovi',
                 imageSrc:
                     'https://www.gredice.com/assets/blocks/ArrowSignWhiteRight.webp',
-                items: arrowSignItems,
+                items: signItems,
             },
-            { type: 'entity', name: 'WoodenSign' },
             {
                 type: 'picker',
                 label: 'Rasvjeta',
@@ -184,28 +319,32 @@ const items: HudItem[] = [
                     'https://www.gredice.com/assets/blocks/FireflyJar.webp',
                 items: lightingItems,
             },
-            { type: 'entity', name: 'Shade' },
-            { type: 'entity', name: 'BeachUmbrella' },
-            { type: 'entity', name: 'Stool' },
-            { type: 'entity', name: 'WoodenBench' },
-            { type: 'entity', name: 'OutletDisplayTable' },
+            {
+                type: 'picker',
+                label: 'Ljeto',
+                imageSrc:
+                    'https://www.gredice.com/assets/blocks/BeachUmbrella.webp',
+                items: summerItems,
+            },
+            {
+                type: 'picker',
+                label: 'Namještaj',
+                imageSrc:
+                    'https://www.gredice.com/assets/blocks/WoodenBench.webp',
+                items: furnitureItems,
+            },
+            {
+                type: 'picker',
+                label: 'Ljubimci',
+                imageSrc: 'https://www.gredice.com/assets/blocks/DogHouse.webp',
+                items: petItems,
+            },
             { type: 'entity', name: 'Fence' },
             { type: 'entity', name: 'SmallWoodenBridge' },
             { type: 'entity', name: 'WoodenWalkway' },
             { type: 'entity', name: 'StoneWalkway' },
             { type: 'entity', name: 'FishingBoat' },
             { type: 'entity', name: 'WaterWell' },
-            { type: 'entity', name: 'LemonadeStand' },
-            { type: 'entity', name: 'IceCreamCart' },
-            { type: 'entity', name: 'SummerHat' },
-            { type: 'entity', name: 'BeachTowelStriped' },
-            { type: 'entity', name: 'InflatablePoolSmall' },
-            { type: 'entity', name: 'BeachChair' },
-            { type: 'entity', name: 'BeachBall' },
-            { type: 'entity', name: 'SandcastleSmallA' },
-            { type: 'entity', name: 'BirdHouse' },
-            { type: 'entity', name: 'CatPillow' },
-            { type: 'entity', name: 'DogHouse' },
             { type: 'entity', name: 'Bush' },
             { type: 'entity', name: 'Tulip' },
             { type: 'entity', name: 'Sunflower' },
@@ -219,43 +358,7 @@ const items: HudItem[] = [
         label: 'Blokovi',
         imageSrc:
             'https://www.gredice.com/assets/blocks/Block_Icon_GroundOverGrass.webp',
-        items: [
-            { type: 'entity', name: 'Block_Grass' },
-            { type: 'entity', name: 'Block_Ground' },
-            { type: 'entity', name: 'Block_Dry_Ground' },
-            { type: 'entity', name: 'Block_Swamp_Ground' },
-            { type: 'entity', name: 'Block_Stone' },
-            { type: 'entity', name: 'Block_Polished_Stone' },
-            { type: 'entity', name: 'Block_Gravel' },
-            { type: 'entity', name: 'Block_Sand' },
-            { type: 'entity', name: 'Block_Snow' },
-            { type: 'entity', name: 'Block_Water' },
-            { type: 'entity', name: 'Block_Swamp_Water' },
-            { type: 'entity', name: 'Block_Grass_Angle' },
-            { type: 'entity', name: 'Block_Ground_Angle' },
-            { type: 'entity', name: 'Block_Dry_Ground_Angle' },
-            { type: 'entity', name: 'Block_Swamp_Ground_Angle' },
-            { type: 'entity', name: 'Block_Stone_Angle' },
-            { type: 'entity', name: 'Block_Polished_Stone_Angle' },
-            { type: 'entity', name: 'Block_Gravel_Angle' },
-            { type: 'entity', name: 'Block_Sand_Angle' },
-            { type: 'entity', name: 'Block_Snow_Angle' },
-            { type: 'entity', name: 'Block_Stone_Stairs' },
-            { type: 'entity', name: 'Block_Stone_Stairs_Corner' },
-            { type: 'entity', name: 'Block_Polished_Stone_Stairs' },
-            {
-                type: 'entity',
-                name: 'Block_Polished_Stone_Stairs_Corner',
-            },
-            { type: 'entity', name: 'Block_Grass_Corner' },
-            { type: 'entity', name: 'Block_Ground_Corner' },
-            { type: 'entity', name: 'Block_Sand_Corner' },
-            { type: 'entity', name: 'Block_Snow_Corner' },
-            { type: 'entity', name: 'Block_Grass_Reverse_Corner' },
-            { type: 'entity', name: 'Block_Ground_Reverse_Corner' },
-            { type: 'entity', name: 'Block_Sand_Reverse_Corner' },
-            { type: 'entity', name: 'Block_Snow_Reverse_Corner' },
-        ],
+        items: terrainItems,
     },
 ];
 


### PR DESCRIPTION
## Summary

- group terrain blocks by biome and material type in the Garden items store HUD
- group decorations into Ljeto, Namještaj, and Ljubimci
- rename Putokazi to Znakovi and include the editable wooden sign with arrow signs
- update HUD interaction coverage for nested category navigation and drag behavior

## User impact

Garden store items are easier to scan and find without scrolling through one long flat list.

## Validation

- `pnpm lint --filter @gredice/game --filter garden`
- `pnpm typecheck --filter @gredice/game --filter garden`
- `pnpm --filter garden test:prepare`
- `pnpm --filter garden exec playwright test tests/items-hud.spec.tsx --project=chromium` (41 passed)